### PR TITLE
adding support for windows phone 7 version 7.5

### DIFF
--- a/libs/UserAgentParser/UserAgentParser.php
+++ b/libs/UserAgentParser/UserAgentParser.php
@@ -243,7 +243,7 @@ class UserAgentParser
 			'Windows 95'			=> 'W95',
 
 			'Windows Phone OS 7.0'	=> 'WP7',
-            'Windows Phone OS 7.5'	=> 'WP7',
+			'Windows Phone OS 7.5'	=> 'WP7',
 			'Windows Mobile 6.5'	=> 'W65',
 			'Windows Mobile 6.1'	=> 'W61',
 			'Windows CE'			=> 'WCE',

--- a/libs/UserAgentParser/UserAgentParser.php
+++ b/libs/UserAgentParser/UserAgentParser.php
@@ -243,6 +243,7 @@ class UserAgentParser
 			'Windows 95'			=> 'W95',
 
 			'Windows Phone OS 7.0'	=> 'WP7',
+            'Windows Phone OS 7.5'	=> 'WP7',
 			'Windows Mobile 6.5'	=> 'W65',
 			'Windows Mobile 6.1'	=> 'W61',
 			'Windows CE'			=> 'WCE',


### PR DESCRIPTION
UserAgentClass fails to return an OS for 7.5 user agent strings.
