### PR TITLE
[#3316] Add request parameter option to disable seriesPicker on jqplot

### DIFF
--- a/core/ViewDataTable/GenerateGraphData.php
+++ b/core/ViewDataTable/GenerateGraphData.php
@@ -91,7 +91,14 @@ abstract class Piwik_ViewDataTable_GenerateGraphData extends Piwik_ViewDataTable
 	{
 		// the array contains values if enableShowGoals() has been used
 		// add $columnsNames to the beginning of the array
-		$this->selectableColumns = array_merge($columnsNames, $this->selectableColumns);
+		if (Piwik_Common::getRequestVar('seriesPicker', true))
+		{
+			$this->selectableColumns = array_merge($columnsNames, $this->selectableColumns);
+		}
+		else
+		{
+			$this->selectableColumns = array();
+		}
 	}
 	
 	/**


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Tests pass: -
Fixes the following tickets: #3316
Todo: -
License of the code: MIT

Use case: Using Widgetize-Plugin to display certain widgets on a website:

```
<div id="widgetIframe">
<iframe width="100%" 
    height="350" 
    src="http://host/piwik/index.php?module=Widgetize&action=iframe&columns[]=nb_visits,nb_pageviews&moduleToWidgetize=VisitsSummary&actionToWidgetize=getEvolutionGraph&idSite=1&period=month&date=today&disableLink=1&widget=1&seriesPicker=0" 
    scrolling="no" 
    frameborder="0" 
    marginheight="0" 
    marginwidth="0" 
    id="visitssum"></iframe>
</div>
```

This widget should be a limited version of the real piwik widgets, so you want to disable other series for the graph. Currently there is no option to disable the series picker in jqPlot, it is always activated as long as there are other series types for the requested graph.

I am aware of the fact that the URL can be manipulated to show other graph types. This is not important as the end user is assumed to not be able to do it. On the other hand, this could be prevented by apache rules for example.

This patch allows to set request parameter "seriesPicker" to 0 to disable the seriesPicker.
