### PR TITLE
[#3341] Add possibility to pass custom plot properties in request eg. canvasLegend

### DIFF
--- a/core/ViewDataTable.php
+++ b/core/ViewDataTable.php
@@ -67,6 +67,14 @@ abstract class Piwik_ViewDataTable
 	 * @var array
 	 */
 	protected $viewProperties = array();
+
+	/**
+	 * Array of properties that override default plot properties
+	 * Used to manipulate plot parameters, eg. canvasLegend
+	 *
+	 * @var array
+	 */
+	protected $plotProperties = array();
 	
 	/**
 	 * If the current dataTable refers to a subDataTable (eg. keywordsBySearchEngineId for id=X) this variable is set to the Id
@@ -312,6 +320,9 @@ abstract class Piwik_ViewDataTable
 		$this->viewProperties['title'] = 'unknown';
 		$this->viewProperties['self_url'] = $this->getBaseReportUrl($currentControllerName, $currentControllerAction);
 		$this->viewProperties['tooltip_metadata_name'] = false;
+
+		// Read plot properties
+		$this->plotProperties['canvasLegend']['show'] = (bool) Piwik_Common::getRequestVar('show_canvas_legend', true);
 		
 		$standardColumnNameToTranslation = array_merge(
 			Piwik_API_API::getInstance()->getDefaultMetrics(),

--- a/core/ViewDataTable/GenerateGraphData.php
+++ b/core/ViewDataTable/GenerateGraphData.php
@@ -231,6 +231,7 @@ abstract class Piwik_ViewDataTable_GenerateGraphData extends Piwik_ViewDataTable
 		$this->view->setAxisYLabels($columnNameToTranslation);
 		$this->view->setAxisYUnit($this->yAxisUnit);
 		$this->view->setDisplayPercentageInTooltip($this->displayPercentageInTooltip);
+		$this->view->setCustomPlotProperties($this->plotProperties);
 		
 		// show_all_ticks is not real query param, it is set by GenerateGraphHTML.
 		if (Piwik_Common::getRequestVar('show_all_ticks', 0) == 1)

--- a/core/Visualization/Chart.php
+++ b/core/Visualization/Chart.php
@@ -27,6 +27,9 @@ abstract class Piwik_Visualization_Chart implements Piwik_View_Interface
 	protected $tooltip = array();
 	protected $seriesColors = array('#000000');
 	protected $seriesPicker = array();
+
+	// additional jqplot properties that can be customized via request parameter
+	protected $customPlotProperties = array();
 	
 	// other attributes (not directly used for jqplot)
 	protected $maxValue;
@@ -160,16 +163,23 @@ abstract class Piwik_Visualization_Chart implements Piwik_View_Interface
 		$this->showAllTicks = true;
 	}
 
+	public function setCustomPlotProperties($plotProperties)
+	{
+		$this->customPlotProperties = $plotProperties;
+	}
+
 	public function render()
 	{
 		Piwik::overrideCacheControlHeaders();
 		
-		$data = array(
-			'params' => array(
+		$params = array_merge(
+			array(
 				'axes' => &$this->axes,
 				'series' => &$this->series,
-				'seriesColors' => &$this->seriesColors
-			),
+				'seriesColors' => &$this->seriesColors,
+			), $this->customPlotProperties);
+		$data = array(
+			'params' => $params,
 			'data' => &$this->data,
 			'tooltip' => &$this->tooltip,
 			'seriesPicker' => &$this->seriesPicker

--- a/plugins/CoreHome/templates/jqplot.js
+++ b/plugins/CoreHome/templates/jqplot.js
@@ -330,9 +330,10 @@ JQPlot.prototype = {
 		this.params.legend = {
 			show: false
 		};
-		this.params.canvasLegend = {
+		var canvasLegend = {
 			show: true
 		};
+		this.params.canvasLegend = $.extend({}, canvasLegend, this.params.canvasLegend);
 	},
 	
 	showEvolutionChartTooltip: function(i) {
@@ -383,10 +384,12 @@ JQPlot.prototype = {
 		this.params.pieLegend = {
 			show: true
 		};
-		this.params.canvasLegend = {
+
+		var canvasLegend = {
 			show: true,
 			singleMetric: true
 		};
+		this.params.canvasLegend = $.extend({}, canvasLegend, this.params.canvasLegend);
 		
 		// pie charts have a different data format
 		if (!(this.data[0][0] instanceof Array)) { // check if already in different format
@@ -438,9 +441,10 @@ JQPlot.prototype = {
 			showGridline: false
 		};
 		
-		this.params.canvasLegend = {
+		var canvasLegend = {
 			show: true
 		};
+		this.params.canvasLegend = $.extend({}, canvasLegend, this.params.canvasLegend);
 	},
 	
 	showBarChartTooltip: function(s, i) {


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Tests pass: -
Fixes the following tickets: #3341
Todo: -
License of the code: MIT

Use case: The canvas legend of pie charts doesn't make sense, actually. Currently a canvas legend with the word "visits" is shown. This patch prepares piwik to customize plot parameters. Plot parameters that should be allowed to be customized need to be added to Piwik_ViewDataTable::init() to the protected $plotProperties variable. Plot options are then fully under control of PIWIK and if desires arise to customize other parameters as well, they can easily be added. Of course modifications to jqplot.js are unavoidable to $.extend() the default settings.

Please review and tell if you can think of better implementations. This one seems pretty straight forward and transparent to me.
