### PR TITLE
[#3317] export_as_image_icon setting has no effect on widget

### DIFF
--- a/core/ViewDataTable/GenerateGraphHTML.php
+++ b/core/ViewDataTable/GenerateGraphHTML.php
@@ -68,7 +68,11 @@ abstract class Piwik_ViewDataTable_GenerateGraphHTML extends Piwik_ViewDataTable
 	
 	public function enableShowExportAsImageIcon()
 	{
-		$this->viewProperties['show_export_as_image_icon'] = true;
+		// If user passed 0 or 1 in request, value is not overwritten. false is default
+		if (false === $this->viewProperties['show_export_as_image_icon'])
+		{
+			$this->viewProperties['show_export_as_image_icon'] = true;
+		}
 	}
 	
 	public function addRowEvolutionSeriesToggle($initiallyShowAllMetrics) {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Tests pass: -
Fixes the following tickets: #3317
Todo: -
License of the code: MIT

Use case:

Using Widgetize-Plugin to display certain widgets on a website:

```
<div id="widgetIframe">
<iframe width="100%" 
    height="350" 
    src="http://host/piwik/index.php?module=Widgetize&action=iframe&columns[]=nb_visits,nb_pageviews&moduleToWidgetize=VisitsSummary&actionToWidgetize=getEvolutionGraph&idSite=1&period=month&date=today&disableLink=1&widget=1&show_export_as_image_icon=0" 
    scrolling="no" 
    frameborder="0" 
    marginheight="0" 
    marginwidth="0" 
    id="visitssum"></iframe>
</div>
```

The show_export_as_image_icon setting has no effect, because the value (first set in parent class from request parameters) is overwritten in core/ViewDataTable/GenerateGraphHTML.php

I don't see why this shouldn't be allowed here. The patch fixes this problem.
