### PR TITLE
[#3327] Add show_related_reports request parameter

### DIFF
--- a/core/ViewDataTable.php
+++ b/core/ViewDataTable.php
@@ -302,9 +302,11 @@ abstract class Piwik_ViewDataTable
 		$this->viewProperties['show_pagination_control'] = Piwik_Common::getRequestVar('show_pagination_control', true);
 		$this->viewProperties['show_footer'] = Piwik_Common::getRequestVar('show_footer', true);
 		$this->viewProperties['show_footer_icons'] = ($this->idSubtable == false);
+		$this->viewProperties['show_related_reports'] = Piwik_Common::getRequestVar('show_related_reports', true);
 		$this->viewProperties['apiMethodToRequestDataTable'] = $this->apiMethodToRequestDataTable;
 		$this->viewProperties['uniqueId'] = $this->getUniqueIdViewDataTable();
 		$this->viewProperties['exportLimit'] = Piwik_Config::getInstance()->General['API_datatable_default_limit'];
+
 		$this->viewProperties['highlight_summary_row'] = false;
 		$this->viewProperties['metadata'] = array();
 		
@@ -972,6 +974,14 @@ abstract class Piwik_ViewDataTable
 	public function disableTagCloud()
 	{
 		$this->viewProperties['show_tag_cloud'] = false;
+	}
+
+	/**
+	 * Whether or not to show related reports in the footer
+	 */
+	public function disableShowRelatedReports()
+	{
+		$this->viewProperties['show_related_reports'] = false;
 	}
 
 	/**

--- a/plugins/CoreHome/templates/datatable_footer.tpl
+++ b/plugins/CoreHome/templates/datatable_footer.tpl
@@ -99,7 +99,7 @@
 {/if}
 
 <div class="datatableRelatedReports">
-	{if !empty($properties.relatedReports) && (!empty($arrayDataTable) || !empty($cloudValues) || (isset($isDataAvailable) && $isDataAvailable))}
+	{if !empty($properties.relatedReports) && (!empty($arrayDataTable) || !empty($cloudValues) || (isset($isDataAvailable) && $isDataAvailable)) && $properties.show_related_reports}
 		{if count($properties.relatedReports) == 1}{'General_RelatedReport'|translate}{else}{'General_RelatedReports'|translate}{/if}:
 		<ul style="list-style:none;{if count($properties.relatedReports) == 1}display:inline-block;{/if}">
 			<li><span href="{$properties.self_url}" style="display:none;">{$properties.title}</span></li>


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Tests pass: -
Fixes the following tickets: #3327
Todo: -
License of the code: MIT

There are widget types like MobileVsDesktop which add related reports. This patch adds a show_related_reports parameter which is set to true by default to not break current behavior. If widgets are requested related reports can be deactivated by passing show_related_reports=0 request parameter.

It allows to further customize requested widgets.
