### PR TITLE
[#3163] Update misc/log-analytics/import_logs.py to handle empty log files

### DIFF
--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1235,6 +1235,9 @@ class Parser(object):
             if not os.path.exists(filename):
                 print >> sys.stderr, 'File %s does not exist' % filename
                 return
+            elif os.path.getsize(filename) == 0:
+                print 'File %s is empty' % filename
+                return
             else:
                 if filename.endswith('.bz2'):
                     open_func = bz2.BZ2File


### PR DESCRIPTION
For empty logfiles merely print a message and skip. Previously empty logfiles would require an explicit log format because otherwise detection would fail with the following message:
"Fatal error: Cannot guess the logs format. Please give one using either the --log-format-name or --log-format-regex option"

See also: http://dev.piwik.org/trac/ticket/3163#comment:81

Might need to verify that this does not break using stdin as input file.
