### PR TITLE
Remove ids

### DIFF
--- a/core/API/DataTableGenericFilter.php
+++ b/core/API/DataTableGenericFilter.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/API/DataTableManipulator.php
+++ b/core/API/DataTableManipulator.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/API/DataTableManipulator/Flattener.php
+++ b/core/API/DataTableManipulator/Flattener.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/API/DataTableManipulator/LabelFilter.php
+++ b/core/API/DataTableManipulator/LabelFilter.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Access.php
+++ b/core/Access.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Archive/Array.php
+++ b/core/Archive/Array.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Archive/Array/IndexedByDate.php
+++ b/core/Archive/Array/IndexedByDate.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Archive/Array/IndexedBySite.php
+++ b/core/Archive/Array/IndexedBySite.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Archive/Single.php
+++ b/core/Archive/Single.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * 
  * @category Piwik

--- a/core/ArchiveProcessing.php
+++ b/core/ArchiveProcessing.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ArchiveProcessing/Day.php
+++ b/core/ArchiveProcessing/Day.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ArchiveProcessing/Period.php
+++ b/core/ArchiveProcessing/Period.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/AssetManager.php
+++ b/core/AssetManager.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Auth.php
+++ b/core/Auth.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/CacheFile.php
+++ b/core/CacheFile.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Common.php
+++ b/core/Common.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Config.php
+++ b/core/Config.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Config/Compat.php
+++ b/core/Config/Compat.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Controller.php
+++ b/core/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Controller/Admin.php
+++ b/core/Controller/Admin.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/DataFiles/Countries.php
+++ b/core/DataFiles/Countries.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package DataFiles

--- a/core/DataFiles/Currencies.php
+++ b/core/DataFiles/Currencies.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package DataFiles

--- a/core/DataFiles/LanguageToCountry.php
+++ b/core/DataFiles/LanguageToCountry.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package DataFiles

--- a/core/DataFiles/Languages.php
+++ b/core/DataFiles/Languages.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package DataFiles

--- a/core/DataFiles/SearchEngines.php
+++ b/core/DataFiles/SearchEngines.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package DataFiles

--- a/core/DataFiles/Socials.php
+++ b/core/DataFiles/Socials.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package DataFiles

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Array.php
+++ b/core/DataTable/Array.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter.php
+++ b/core/DataTable/Filter.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/AddColumnsProcessedMetrics.php
+++ b/core/DataTable/Filter/AddColumnsProcessedMetrics.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/AddColumnsProcessedMetricsGoal.php
+++ b/core/DataTable/Filter/AddColumnsProcessedMetricsGoal.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/AddConstantMetadata.php
+++ b/core/DataTable/Filter/AddConstantMetadata.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/AddSummaryRow.php
+++ b/core/DataTable/Filter/AddSummaryRow.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/BeautifyRangeLabels.php
+++ b/core/DataTable/Filter/BeautifyRangeLabels.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/BeautifyTimeRangeLabels.php
+++ b/core/DataTable/Filter/BeautifyTimeRangeLabels.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/CalculateEvolutionFilter.php
+++ b/core/DataTable/Filter/CalculateEvolutionFilter.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: CalculateEvolutionFilter.php$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ColumnCallbackAddColumn.php
+++ b/core/DataTable/Filter/ColumnCallbackAddColumn.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: ColumnCallbackAddColumn.php $
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ColumnCallbackAddColumnPercentage.php
+++ b/core/DataTable/Filter/ColumnCallbackAddColumnPercentage.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ColumnCallbackAddColumnQuotient.php
+++ b/core/DataTable/Filter/ColumnCallbackAddColumnQuotient.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ColumnCallbackAddMetadata.php
+++ b/core/DataTable/Filter/ColumnCallbackAddMetadata.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ColumnCallbackDeleteRow.php
+++ b/core/DataTable/Filter/ColumnCallbackDeleteRow.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ColumnCallbackReplace.php
+++ b/core/DataTable/Filter/ColumnCallbackReplace.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ColumnDelete.php
+++ b/core/DataTable/Filter/ColumnDelete.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ExcludeLowPopulation.php
+++ b/core/DataTable/Filter/ExcludeLowPopulation.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/GroupBy.php
+++ b/core/DataTable/Filter/GroupBy.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: GroupBy.php $
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/Limit.php
+++ b/core/DataTable/Filter/Limit.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/MetadataCallbackAddMetadata.php
+++ b/core/DataTable/Filter/MetadataCallbackAddMetadata.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/MetadataCallbackReplace.php
+++ b/core/DataTable/Filter/MetadataCallbackReplace.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/Null.php
+++ b/core/DataTable/Filter/Null.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/Pattern.php
+++ b/core/DataTable/Filter/Pattern.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/PatternRecursive.php
+++ b/core/DataTable/Filter/PatternRecursive.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/RangeCheck.php
+++ b/core/DataTable/Filter/RangeCheck.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: RangeCheck.php 5791 2012-02-09 05:58:45Z matt $
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ReplaceColumnNames.php
+++ b/core/DataTable/Filter/ReplaceColumnNames.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/ReplaceSummaryRowLabel.php
+++ b/core/DataTable/Filter/ReplaceSummaryRowLabel.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/SafeDecodeLabel.php
+++ b/core/DataTable/Filter/SafeDecodeLabel.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/Sort.php
+++ b/core/DataTable/Filter/Sort.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Filter/Truncate.php
+++ b/core/DataTable/Filter/Truncate.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Manager.php
+++ b/core/DataTable/Manager.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Renderer.php
+++ b/core/DataTable/Renderer.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Renderer/Console.php
+++ b/core/DataTable/Renderer/Console.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Renderer/Html.php
+++ b/core/DataTable/Renderer/Html.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Renderer/Json.php
+++ b/core/DataTable/Renderer/Json.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Renderer/Php.php
+++ b/core/DataTable/Renderer/Php.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Renderer/Rss.php
+++ b/core/DataTable/Renderer/Rss.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Renderer/Tsv.php
+++ b/core/DataTable/Renderer/Tsv.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Renderer/Xml.php
+++ b/core/DataTable/Renderer/Xml.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Row/DataTableSummary.php
+++ b/core/DataTable/Row/DataTableSummary.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/DataTable/Simple.php
+++ b/core/DataTable/Simple.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Date.php
+++ b/core/Date.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Db/Adapter/Interface.php
+++ b/core/Db/Adapter/Interface.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Db/Adapter/Pdo/Mssql.php
+++ b/core/Db/Adapter/Pdo/Mssql.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Db/Adapter/Pdo/Pgsql.php
+++ b/core/Db/Adapter/Pdo/Pgsql.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Db/Schema.php
+++ b/core/Db/Schema.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Db/Schema/Interface.php
+++ b/core/Db/Schema/Interface.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Db/Schema/Myisam.php
+++ b/core/Db/Schema/Myisam.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/HTMLPurifier.php
+++ b/core/HTMLPurifier.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Http.php
+++ b/core/Http.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/IP.php
+++ b/core/IP.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Loader.php
+++ b/core/Loader.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Log.php
+++ b/core/Log.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Log/APICall.php
+++ b/core/Log/APICall.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Log/Error.php
+++ b/core/Log/Error.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Log/Exception.php
+++ b/core/Log/Exception.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Log/Message.php
+++ b/core/Log/Message.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Mail.php
+++ b/core/Mail.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Menu/Abstract.php
+++ b/core/Menu/Abstract.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik_Menu

--- a/core/Menu/Admin.php
+++ b/core/Menu/Admin.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik_Menu

--- a/core/Menu/Main.php
+++ b/core/Menu/Main.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik_Menu

--- a/core/Menu/Top.php
+++ b/core/Menu/Top.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik_Menu

--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Option.php
+++ b/core/Option.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Period.php
+++ b/core/Period.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Period/Day.php
+++ b/core/Period/Day.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Period/Month.php
+++ b/core/Period/Month.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Period/Week.php
+++ b/core/Period/Week.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Period/Year.php
+++ b/core/Period/Year.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Plugin/Config.php
+++ b/core/Plugin/Config.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/PluginsFunctions/Sql.php
+++ b/core/PluginsFunctions/Sql.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package PluginsFunctions

--- a/core/PluginsFunctions/WidgetsList.php
+++ b/core/PluginsFunctions/WidgetsList.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package PluginsFunctions

--- a/core/PluginsManager.php
+++ b/core/PluginsManager.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ProxyHeaders.php
+++ b/core/ProxyHeaders.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/QuickForm2.php
+++ b/core/QuickForm2.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/RankingQuery.php
+++ b/core/RankingQuery.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ReportRenderer/Html.php
+++ b/core/ReportRenderer/Html.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik_ReportRenderer

--- a/core/ReportRenderer/Pdf.php
+++ b/core/ReportRenderer/Pdf.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik_ReportRenderer

--- a/core/ScheduledTask.php
+++ b/core/ScheduledTask.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ScheduledTime.php
+++ b/core/ScheduledTime.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ScheduledTime/Daily.php
+++ b/core/ScheduledTime/Daily.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ScheduledTime/Hourly.php
+++ b/core/ScheduledTime/Hourly.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ScheduledTime/Monthly.php
+++ b/core/ScheduledTime/Monthly.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ScheduledTime/Weekly.php
+++ b/core/ScheduledTime/Weekly.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/SegmentExpression.php
+++ b/core/SegmentExpression.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Session.php
+++ b/core/Session.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Session/Namespace.php
+++ b/core/Session/Namespace.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Session/SaveHandler/DbTable.php
+++ b/core/Session/SaveHandler/DbTable.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Site.php
+++ b/core/Site.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Smarty.php
+++ b/core/Smarty.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/SmartyPlugins/block.purify.php
+++ b/core/SmartyPlugins/block.purify.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.ajaxErrorDiv.php
+++ b/core/SmartyPlugins/function.ajaxErrorDiv.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.ajaxLoadingDiv.php
+++ b/core/SmartyPlugins/function.ajaxLoadingDiv.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.ajaxRequestErrorDiv.php
+++ b/core/SmartyPlugins/function.ajaxRequestErrorDiv.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.hiddenurl.php
+++ b/core/SmartyPlugins/function.hiddenurl.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.includeAssets.php
+++ b/core/SmartyPlugins/function.includeAssets.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.loadJavascriptTranslations.php
+++ b/core/SmartyPlugins/function.loadJavascriptTranslations.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.logoHtml.php
+++ b/core/SmartyPlugins/function.logoHtml.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.postEvent.php
+++ b/core/SmartyPlugins/function.postEvent.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.sparkline.php
+++ b/core/SmartyPlugins/function.sparkline.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/function.url.php
+++ b/core/SmartyPlugins/function.url.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/modifier.inlineHelp.php
+++ b/core/SmartyPlugins/modifier.inlineHelp.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/modifier.money.php
+++ b/core/SmartyPlugins/modifier.money.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/modifier.stripeol.php
+++ b/core/SmartyPlugins/modifier.stripeol.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/modifier.sumtime.php
+++ b/core/SmartyPlugins/modifier.sumtime.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/modifier.translate.php
+++ b/core/SmartyPlugins/modifier.translate.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/modifier.unescape.php
+++ b/core/SmartyPlugins/modifier.unescape.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/modifier.urlRewriteBasicView.php
+++ b/core/SmartyPlugins/modifier.urlRewriteBasicView.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/modifier.urlRewriteWithParameters.php
+++ b/core/SmartyPlugins/modifier.urlRewriteWithParameters.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/outputfilter.ajaxcdn.php
+++ b/core/SmartyPlugins/outputfilter.ajaxcdn.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/SmartyPlugins/outputfilter.cachebuster.php
+++ b/core/SmartyPlugins/outputfilter.cachebuster.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/TCPDF.php
+++ b/core/TCPDF.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/TablePartitioning.php
+++ b/core/TablePartitioning.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/TaskScheduler.php
+++ b/core/TaskScheduler.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Timer.php
+++ b/core/Timer.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/Action.php
+++ b/core/Tracker/Action.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/Config.php
+++ b/core/Tracker/Config.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/Db.php
+++ b/core/Tracker/Db.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/Db/Exception.php
+++ b/core/Tracker/Db/Exception.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/Db/Mysqli.php
+++ b/core/Tracker/Db/Mysqli.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/Db/Pdo/Pgsql.php
+++ b/core/Tracker/Db/Pdo/Pgsql.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/IgnoreCookie.php
+++ b/core/Tracker/IgnoreCookie.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Translate.php
+++ b/core/Translate.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/TranslationWriter.php
+++ b/core/TranslationWriter.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Unzip.php
+++ b/core/Unzip.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Unzip/Gzip.php
+++ b/core/Unzip/Gzip.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Unzip/Interface.php
+++ b/core/Unzip/Interface.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Unzip/PclZip.php
+++ b/core/Unzip/PclZip.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Unzip/Tar.php
+++ b/core/Unzip/Tar.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Unzip/ZipArchive.php
+++ b/core/Unzip/ZipArchive.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/UpdateCheck.php
+++ b/core/UpdateCheck.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Updates.php
+++ b/core/Updates.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Updates/0.2.10.php
+++ b/core/Updates/0.2.10.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.2.12.php
+++ b/core/Updates/0.2.12.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.2.13.php
+++ b/core/Updates/0.2.13.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.2.24.php
+++ b/core/Updates/0.2.24.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.2.27.php
+++ b/core/Updates/0.2.27.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.2.32.php
+++ b/core/Updates/0.2.32.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.2.33.php
+++ b/core/Updates/0.2.33.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.2.34.php
+++ b/core/Updates/0.2.34.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.2.35.php
+++ b/core/Updates/0.2.35.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.2.37.php
+++ b/core/Updates/0.2.37.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.4.1.php
+++ b/core/Updates/0.4.1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.4.2.php
+++ b/core/Updates/0.4.2.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.4.4.php
+++ b/core/Updates/0.4.4.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.4.php
+++ b/core/Updates/0.4.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.5.4.php
+++ b/core/Updates/0.5.4.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.5.5.php
+++ b/core/Updates/0.5.5.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.5.php
+++ b/core/Updates/0.5.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.6-rc1.php
+++ b/core/Updates/0.6-rc1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.6.2.php
+++ b/core/Updates/0.6.2.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.6.3.php
+++ b/core/Updates/0.6.3.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.7.php
+++ b/core/Updates/0.7.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/0.9.1.php
+++ b/core/Updates/0.9.1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.1.php
+++ b/core/Updates/1.1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.10-b4.php
+++ b/core/Updates/1.10-b4.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.10.1.php
+++ b/core/Updates/1.10.1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.10.2-b1.php
+++ b/core/Updates/1.10.2-b1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.2-rc1.php
+++ b/core/Updates/1.2-rc1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.2-rc2.php
+++ b/core/Updates/1.2-rc2.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.2.3.php
+++ b/core/Updates/1.2.3.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.2.5-rc1.php
+++ b/core/Updates/1.2.5-rc1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.2.5-rc7.php
+++ b/core/Updates/1.2.5-rc7.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.4-rc1.php
+++ b/core/Updates/1.4-rc1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.4-rc2.php
+++ b/core/Updates/1.4-rc2.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.5-b1.php
+++ b/core/Updates/1.5-b1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.5-b2.php
+++ b/core/Updates/1.5-b2.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.5-b3.php
+++ b/core/Updates/1.5-b3.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.5-b4.php
+++ b/core/Updates/1.5-b4.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.5-b5.php
+++ b/core/Updates/1.5-b5.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.5-rc6.php
+++ b/core/Updates/1.5-rc6.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.6-b1.php
+++ b/core/Updates/1.6-b1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.6-rc1.php
+++ b/core/Updates/1.6-rc1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.7-b1.php
+++ b/core/Updates/1.7-b1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.7.2-rc5.php
+++ b/core/Updates/1.7.2-rc5.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.7.2-rc7.php
+++ b/core/Updates/1.7.2-rc7.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.8.3-b1.php
+++ b/core/Updates/1.8.3-b1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik‚
  * @package Updates

--- a/core/Updates/1.8.4-b1.php
+++ b/core/Updates/1.8.4-b1.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.9-b16.php
+++ b/core/Updates/1.9-b16.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.9-b19.php
+++ b/core/Updates/1.9-b19.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.9-b9.php
+++ b/core/Updates/1.9-b9.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.9.1-b2.php
+++ b/core/Updates/1.9.1-b2.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.9.3-b10.php
+++ b/core/Updates/1.9.3-b10.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.9.3-b3.php
+++ b/core/Updates/1.9.3-b3.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Updates/1.9.3-b8.php
+++ b/core/Updates/1.9.3-b8.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Updates

--- a/core/Url.php
+++ b/core/Url.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Version.php
+++ b/core/Version.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/View.php
+++ b/core/View.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/View/Interface.php
+++ b/core/View/Interface.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/View/OneClickDone.php
+++ b/core/View/OneClickDone.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/View/ReportsByDimension.php
+++ b/core/View/ReportsByDimension.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package SmartyPlugins

--- a/core/ViewDataTable.php
+++ b/core/ViewDataTable.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/Cloud.php
+++ b/core/ViewDataTable/Cloud.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/GenerateGraphData.php
+++ b/core/ViewDataTable/GenerateGraphData.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/GenerateGraphData/ChartEvolution.php
+++ b/core/ViewDataTable/GenerateGraphData/ChartEvolution.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/GenerateGraphData/ChartPie.php
+++ b/core/ViewDataTable/GenerateGraphData/ChartPie.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/GenerateGraphData/ChartVerticalBar.php
+++ b/core/ViewDataTable/GenerateGraphData/ChartVerticalBar.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/GenerateGraphHTML.php
+++ b/core/ViewDataTable/GenerateGraphHTML.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/GenerateGraphHTML/ChartEvolution.php
+++ b/core/ViewDataTable/GenerateGraphHTML/ChartEvolution.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/GenerateGraphHTML/ChartPie.php
+++ b/core/ViewDataTable/GenerateGraphHTML/ChartPie.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/GenerateGraphHTML/ChartVerticalBar.php
+++ b/core/ViewDataTable/GenerateGraphHTML/ChartVerticalBar.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/HtmlTable.php
+++ b/core/ViewDataTable/HtmlTable.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/HtmlTable/AllColumns.php
+++ b/core/ViewDataTable/HtmlTable/AllColumns.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/HtmlTable/Goals.php
+++ b/core/ViewDataTable/HtmlTable/Goals.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/ViewDataTable/Sparkline.php
+++ b/core/ViewDataTable/Sparkline.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/core/Visualization/Chart.php
+++ b/core/Visualization/Chart.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Visualization/Chart/Evolution.php
+++ b/core/Visualization/Chart/Evolution.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Visualization/Chart/Pie.php
+++ b/core/Visualization/Chart/Pie.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Visualization/Chart/VerticalBar.php
+++ b/core/Visualization/Chart/VerticalBar.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Visualization/Cloud.php
+++ b/core/Visualization/Cloud.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/Visualization/Sparkline.php
+++ b/core/Visualization/Sparkline.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik
  * @package Piwik

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik
  * @package Piwik

--- a/index.php
+++ b/index.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @package Piwik
  */

--- a/js/index.php
+++ b/js/index.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -11,7 +11,6 @@
  *  - CURL or STREAM extensions (to issue the http request to Piwik)
  *
  * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
- * @version $Id$
  * @link http://piwik.org/docs/tracking-api/
  *
  * @category Piwik

--- a/libs/PiwikTracker/java/src/main/java/org/piwik/EBrowserPlugins.java
+++ b/libs/PiwikTracker/java/src/main/java/org/piwik/EBrowserPlugins.java
@@ -2,7 +2,6 @@
  * Piwik - Open source web analytics
  * 
  * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
- * @version $Id$
  * @link http://piwik.org/docs/tracking-api/
  *
  * @category Piwik

--- a/libs/PiwikTracker/java/src/main/java/org/piwik/IPiwikTracker.java
+++ b/libs/PiwikTracker/java/src/main/java/org/piwik/IPiwikTracker.java
@@ -2,7 +2,6 @@
  * Piwik - Open source web analytics
  * 
  * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
- * @version $Id$
  * @link http://piwik.org/docs/tracking-api/
  *
  * @category Piwik

--- a/libs/PiwikTracker/java/src/main/java/org/piwik/PiwikException.java
+++ b/libs/PiwikTracker/java/src/main/java/org/piwik/PiwikException.java
@@ -2,7 +2,6 @@
  * Piwik - Open source web analytics
  * 
  * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
- * @version $Id$
  * @link http://piwik.org/docs/tracking-api/
  *
  * @category Piwik

--- a/libs/PiwikTracker/java/src/main/java/org/piwik/ResponseData.java
+++ b/libs/PiwikTracker/java/src/main/java/org/piwik/ResponseData.java
@@ -2,7 +2,6 @@
  * Piwik - Open source web analytics
  * 
  * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
- * @version $Id$
  * @link http://piwik.org/docs/tracking-api/
  *
  * @category Piwik

--- a/libs/PiwikTracker/java/src/main/java/org/piwik/SimplePiwikTracker.java
+++ b/libs/PiwikTracker/java/src/main/java/org/piwik/SimplePiwikTracker.java
@@ -2,7 +2,6 @@
  * Piwik - Open source web analytics
  * 
  * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
- * @version $Id$
  * @link http://piwik.org/docs/tracking-api/
  *
  * @category Piwik

--- a/libs/PiwikTracker/java/src/test/java/org/piwik/SimplePiwikTrackerTest.java
+++ b/libs/PiwikTracker/java/src/test/java/org/piwik/SimplePiwikTrackerTest.java
@@ -2,7 +2,6 @@
  * Piwik - Open source web analytics
  * 
  * @license released under BSD License http://www.opensource.org/licenses/bsd-license.php
- * @version $Id$
  * @link http://piwik.org/docs/tracking-api/
  *
  * @category Piwik

--- a/piwik.php
+++ b/piwik.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @package Piwik
  */

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -5,7 +5,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_API

--- a/plugins/API/Controller.php
+++ b/plugins/API/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_API

--- a/plugins/Actions/API.php
+++ b/plugins/Actions/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Actions

--- a/plugins/Actions/Actions.php
+++ b/plugins/Actions/Actions.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Actions

--- a/plugins/Actions/Archiving.php
+++ b/plugins/Actions/Archiving.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: Actions.php 6986 2012-09-15 03:42:26Z capedfuzz $
  *
  * @category Piwik_Plugins
  * @package Piwik_Actions

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: Actions.php 6986 2012-09-15 03:42:26Z capedfuzz $
  *
  * @category Piwik_Plugins
  * @package Piwik_Actions

--- a/plugins/Actions/Controller.php
+++ b/plugins/Actions/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Actions

--- a/plugins/Annotations/API.php
+++ b/plugins/Annotations/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Annotations

--- a/plugins/Annotations/AnnotationList.php
+++ b/plugins/Annotations/AnnotationList.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Annotations

--- a/plugins/Annotations/Annotations.php
+++ b/plugins/Annotations/Annotations.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Annotations

--- a/plugins/Annotations/Controller.php
+++ b/plugins/Annotations/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Annotations

--- a/plugins/AnonymizeIP/AnonymizeIP.php
+++ b/plugins/AnonymizeIP/AnonymizeIP.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_AnonymizeIP

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_CoreAdminHome

--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_CoreAdminHome

--- a/plugins/CoreAdminHome/CoreAdminHome.php
+++ b/plugins/CoreAdminHome/CoreAdminHome.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_CoreAdminHome

--- a/plugins/CoreHome/Controller.php
+++ b/plugins/CoreHome/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_CoreHome

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_CoreHome

--- a/plugins/CoreHome/DataTableRowAction/MultiRowEvolution.php
+++ b/plugins/CoreHome/DataTableRowAction/MultiRowEvolution.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_CoreHome

--- a/plugins/CoreHome/DataTableRowAction/RowEvolution.php
+++ b/plugins/CoreHome/DataTableRowAction/RowEvolution.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_CoreHome

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_CorePluginsAdmin

--- a/plugins/CorePluginsAdmin/CorePluginsAdmin.php
+++ b/plugins/CorePluginsAdmin/CorePluginsAdmin.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_CorePluginsAdmin

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_CoreUpdater

--- a/plugins/CoreUpdater/CoreUpdater.php
+++ b/plugins/CoreUpdater/CoreUpdater.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_CoreUpdater

--- a/plugins/CustomVariables/API.php
+++ b/plugins/CustomVariables/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_CustomVariables

--- a/plugins/CustomVariables/Controller.php
+++ b/plugins/CustomVariables/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_CustomVariables

--- a/plugins/CustomVariables/CustomVariables.php
+++ b/plugins/CustomVariables/CustomVariables.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_CustomVariables

--- a/plugins/DBStats/API.php
+++ b/plugins/DBStats/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_DBStats

--- a/plugins/DBStats/Controller.php
+++ b/plugins/DBStats/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_DBStats

--- a/plugins/DBStats/DBStats.php
+++ b/plugins/DBStats/DBStats.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_DBStats

--- a/plugins/DBStats/MySQLMetadataProvider.php
+++ b/plugins/DBStats/MySQLMetadataProvider.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: MySQLMetadataProvider.php $
  * 
  * @category Piwik_Plugins
  * @package Piwik_DBStats

--- a/plugins/Dashboard/Controller.php
+++ b/plugins/Dashboard/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link     http://piwik.org
  * @license  http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version  $Id$
  * @category Piwik_Plugins
  * @package  Piwik_Dashboard
  */

--- a/plugins/Dashboard/Dashboard.php
+++ b/plugins/Dashboard/Dashboard.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Dashboard

--- a/plugins/DoNotTrack/DoNotTrack.php
+++ b/plugins/DoNotTrack/DoNotTrack.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_DoNotTrack

--- a/plugins/ExampleAPI/API.php
+++ b/plugins/ExampleAPI/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ExampleAPI

--- a/plugins/ExampleAPI/ExampleAPI.php
+++ b/plugins/ExampleAPI/ExampleAPI.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ExampleAPI

--- a/plugins/ExamplePlugin/Controller.php
+++ b/plugins/ExamplePlugin/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ExamplePlugin

--- a/plugins/ExamplePlugin/ExamplePlugin.php
+++ b/plugins/ExamplePlugin/ExamplePlugin.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ExamplePlugin

--- a/plugins/ExamplePlugin/lang/en.php
+++ b/plugins/ExamplePlugin/lang/en.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ExamplePlugin

--- a/plugins/ExampleRssWidget/ExampleRssWidget.php
+++ b/plugins/ExampleRssWidget/ExampleRssWidget.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ExampleRssWidget

--- a/plugins/ExampleUI/API.php
+++ b/plugins/ExampleUI/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ExampleUI

--- a/plugins/ExampleUI/Controller.php
+++ b/plugins/ExampleUI/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ExampleUI

--- a/plugins/ExampleUI/ExampleUI.php
+++ b/plugins/ExampleUI/ExampleUI.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ExampleUI

--- a/plugins/Feedback/Controller.php
+++ b/plugins/Feedback/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Feedback

--- a/plugins/Feedback/Feedback.php
+++ b/plugins/Feedback/Feedback.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Feedback

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Goals

--- a/plugins/Goals/Controller.php
+++ b/plugins/Goals/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Goals

--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Goals

--- a/plugins/ImageGraph/API.php
+++ b/plugins/ImageGraph/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph

--- a/plugins/ImageGraph/Controller.php
+++ b/plugins/ImageGraph/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph

--- a/plugins/ImageGraph/ImageGraph.php
+++ b/plugins/ImageGraph/ImageGraph.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph

--- a/plugins/ImageGraph/StaticGraph.php
+++ b/plugins/ImageGraph/StaticGraph.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph

--- a/plugins/ImageGraph/StaticGraph/3DPie.php
+++ b/plugins/ImageGraph/StaticGraph/3DPie.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph_StaticGraph

--- a/plugins/ImageGraph/StaticGraph/Evolution.php
+++ b/plugins/ImageGraph/StaticGraph/Evolution.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph_StaticGraph

--- a/plugins/ImageGraph/StaticGraph/Exception.php
+++ b/plugins/ImageGraph/StaticGraph/Exception.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph_StaticGraph

--- a/plugins/ImageGraph/StaticGraph/GridGraph.php
+++ b/plugins/ImageGraph/StaticGraph/GridGraph.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph_StaticGraph

--- a/plugins/ImageGraph/StaticGraph/HorizontalBar.php
+++ b/plugins/ImageGraph/StaticGraph/HorizontalBar.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph_StaticGraph

--- a/plugins/ImageGraph/StaticGraph/Pie.php
+++ b/plugins/ImageGraph/StaticGraph/Pie.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph_StaticGraph

--- a/plugins/ImageGraph/StaticGraph/PieGraph.php
+++ b/plugins/ImageGraph/StaticGraph/PieGraph.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph_StaticGraph

--- a/plugins/ImageGraph/StaticGraph/VerticalBar.php
+++ b/plugins/ImageGraph/StaticGraph/VerticalBar.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_ImageGraph_StaticGraph

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Installation

--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Installation

--- a/plugins/Installation/FormFirstWebsiteSetup.php
+++ b/plugins/Installation/FormFirstWebsiteSetup.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Installation

--- a/plugins/Installation/FormGeneralSetup.php
+++ b/plugins/Installation/FormGeneralSetup.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Installation

--- a/plugins/Installation/Installation.php
+++ b/plugins/Installation/Installation.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Installation

--- a/plugins/Installation/View.php
+++ b/plugins/Installation/View.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Installation

--- a/plugins/LanguagesManager/API.php
+++ b/plugins/LanguagesManager/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_LanguagesManager

--- a/plugins/LanguagesManager/Controller.php
+++ b/plugins/LanguagesManager/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_LanguagesManager

--- a/plugins/LanguagesManager/LanguagesManager.php
+++ b/plugins/LanguagesManager/LanguagesManager.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_LanguagesManager

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Live

--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Live

--- a/plugins/Live/Live.php
+++ b/plugins/Live/Live.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Live

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Live

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Login

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Login

--- a/plugins/Login/FormLogin.php
+++ b/plugins/Login/FormLogin.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Login

--- a/plugins/Login/FormResetPassword.php
+++ b/plugins/Login/FormResetPassword.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Login

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Login

--- a/plugins/MobileMessaging/API.php
+++ b/plugins/MobileMessaging/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging

--- a/plugins/MobileMessaging/APIException.php
+++ b/plugins/MobileMessaging/APIException.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging

--- a/plugins/MobileMessaging/Controller.php
+++ b/plugins/MobileMessaging/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging

--- a/plugins/MobileMessaging/CountryCallingCodes.php
+++ b/plugins/MobileMessaging/CountryCallingCodes.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging

--- a/plugins/MobileMessaging/GSMCharset.php
+++ b/plugins/MobileMessaging/GSMCharset.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging

--- a/plugins/MobileMessaging/MobileMessaging.php
+++ b/plugins/MobileMessaging/MobileMessaging.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging

--- a/plugins/MobileMessaging/ReportRenderer/Exception.php
+++ b/plugins/MobileMessaging/ReportRenderer/Exception.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging_ReportRenderer

--- a/plugins/MobileMessaging/ReportRenderer/Sms.php
+++ b/plugins/MobileMessaging/ReportRenderer/Sms.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging_ReportRenderer

--- a/plugins/MobileMessaging/SMSProvider.php
+++ b/plugins/MobileMessaging/SMSProvider.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging

--- a/plugins/MobileMessaging/SMSProvider/Clockwork.php
+++ b/plugins/MobileMessaging/SMSProvider/Clockwork.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging_SMSProvider

--- a/plugins/MobileMessaging/SMSProvider/StubbedProvider.php
+++ b/plugins/MobileMessaging/SMSProvider/StubbedProvider.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MobileMessaging_SMSProvider

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: API.php$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Goals

--- a/plugins/MultiSites/CalculateEvolutionFilter.php
+++ b/plugins/MultiSites/CalculateEvolutionFilter.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: CalculateEvolutionFilter.php$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Goals

--- a/plugins/MultiSites/Controller.php
+++ b/plugins/MultiSites/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_MultiSites

--- a/plugins/MultiSites/MultiSites.php
+++ b/plugins/MultiSites/MultiSites.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_MultiSites

--- a/plugins/Overlay/API.php
+++ b/plugins/Overlay/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Overlay

--- a/plugins/Overlay/Controller.php
+++ b/plugins/Overlay/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Overlay

--- a/plugins/Overlay/Overlay.php
+++ b/plugins/Overlay/Overlay.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Overlay

--- a/plugins/PDFReports/API.php
+++ b/plugins/PDFReports/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_PDFReports

--- a/plugins/PDFReports/Controller.php
+++ b/plugins/PDFReports/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_PDFReports

--- a/plugins/PDFReports/PDFReports.php
+++ b/plugins/PDFReports/PDFReports.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_PDFReports

--- a/plugins/PDFReports/config/tcpdf_config.php
+++ b/plugins/PDFReports/config/tcpdf_config.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_PDFReports

--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_PrivacyManager

--- a/plugins/PrivacyManager/LogDataPurger.php
+++ b/plugins/PrivacyManager/LogDataPurger.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: $
  *
  * @category Piwik_Plugins
  * @package Piwik_PrivacyManager

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_PrivacyManager

--- a/plugins/PrivacyManager/ReportsPurger.php
+++ b/plugins/PrivacyManager/ReportsPurger.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: $
  *
  * @category Piwik_Plugins
  * @package Piwik_PrivacyManager

--- a/plugins/Provider/API.php
+++ b/plugins/Provider/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Provider

--- a/plugins/Provider/Controller.php
+++ b/plugins/Provider/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Provider

--- a/plugins/Provider/Provider.php
+++ b/plugins/Provider/Provider.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Provider

--- a/plugins/Provider/functions.php
+++ b/plugins/Provider/functions.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Provider

--- a/plugins/Proxy/Controller.php
+++ b/plugins/Proxy/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Proxy

--- a/plugins/Proxy/Proxy.php
+++ b/plugins/Proxy/Proxy.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Proxy

--- a/plugins/Referers/API.php
+++ b/plugins/Referers/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Referers

--- a/plugins/Referers/Controller.php
+++ b/plugins/Referers/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Referers

--- a/plugins/Referers/Referers.php
+++ b/plugins/Referers/Referers.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Referers

--- a/plugins/Referers/functions.php
+++ b/plugins/Referers/functions.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Referers

--- a/plugins/SEO/API.php
+++ b/plugins/SEO/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_SEO

--- a/plugins/SEO/Controller.php
+++ b/plugins/SEO/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_SEO

--- a/plugins/SEO/RankChecker.php
+++ b/plugins/SEO/RankChecker.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_SEO

--- a/plugins/SEO/SEO.php
+++ b/plugins/SEO/SEO.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_SEO

--- a/plugins/SecurityInfo/Controller.php
+++ b/plugins/SecurityInfo/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_SecurityInfo

--- a/plugins/SecurityInfo/SecurityInfo.php
+++ b/plugins/SecurityInfo/SecurityInfo.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_SecurityInfo

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_SitesManager

--- a/plugins/SitesManager/Controller.php
+++ b/plugins/SitesManager/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_SitesManager

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_SitesManager

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Transitions

--- a/plugins/Transitions/Controller.php
+++ b/plugins/Transitions/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Transitions

--- a/plugins/Transitions/Transitions.php
+++ b/plugins/Transitions/Transitions.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_Transitions

--- a/plugins/UserCountry/API.php
+++ b/plugins/UserCountry/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/Controller.php
+++ b/plugins/UserCountry/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/GeoIPAutoUpdater.php
+++ b/plugins/UserCountry/GeoIPAutoUpdater.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/LocationProvider/Default.php
+++ b/plugins/UserCountry/LocationProvider/Default.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/LocationProvider/GeoIp.php
+++ b/plugins/UserCountry/LocationProvider/GeoIp.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/LocationProvider/GeoIp/Pecl.php
+++ b/plugins/UserCountry/LocationProvider/GeoIp/Pecl.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/LocationProvider/GeoIp/Php.php
+++ b/plugins/UserCountry/LocationProvider/GeoIp/Php.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/LocationProvider/GeoIp/ServerBased.php
+++ b/plugins/UserCountry/LocationProvider/GeoIp/ServerBased.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/UserCountry.php
+++ b/plugins/UserCountry/UserCountry.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountry/functions.php
+++ b/plugins/UserCountry/functions.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserCountry

--- a/plugins/UserCountryMap/Controller.php
+++ b/plugins/UserCountryMap/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: $
  *
  * @category Piwik_Plugins
  * @package Piwik_UserCountryMap

--- a/plugins/UserCountryMap/UserCountryMap.php
+++ b/plugins/UserCountryMap/UserCountryMap.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: $
  *
  * @category Piwik_Plugins
  * @package Piwik_UserCountryMap

--- a/plugins/UserSettings/API.php
+++ b/plugins/UserSettings/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_UserSettings

--- a/plugins/UserSettings/Controller.php
+++ b/plugins/UserSettings/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserSettings

--- a/plugins/UserSettings/UserSettings.php
+++ b/plugins/UserSettings/UserSettings.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_UserSettings

--- a/plugins/UserSettings/functions.php
+++ b/plugins/UserSettings/functions.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UserSettings

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UsersManager

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UsersManager
@@ -30,12 +29,9 @@ class Piwik_UsersManager_Controller extends Piwik_Controller_Admin
 
 		$view = Piwik_View::factory('UsersManager');
 		
-		$IdSitesAdmin = Piwik_SitesManager_API::getInstance()->getSitesIdWithAdminAccess();
 		$idSiteSelected = 1;
 		
-		if(count($IdSitesAdmin) > 0)
 		{
-			$defaultWebsiteId = $IdSitesAdmin[0];
 			$idSiteSelected = Piwik_Common::getRequestVar('idSite', $defaultWebsiteId);
 		}
 		

--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_UsersManager

--- a/plugins/VisitFrequency/API.php
+++ b/plugins/VisitFrequency/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_VisitFrequency

--- a/plugins/VisitFrequency/Controller.php
+++ b/plugins/VisitFrequency/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_VisitFrequency

--- a/plugins/VisitFrequency/VisitFrequency.php
+++ b/plugins/VisitFrequency/VisitFrequency.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_VisitFrequency

--- a/plugins/VisitTime/API.php
+++ b/plugins/VisitTime/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_VisitTime

--- a/plugins/VisitTime/Controller.php
+++ b/plugins/VisitTime/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_VisitTime

--- a/plugins/VisitTime/VisitTime.php
+++ b/plugins/VisitTime/VisitTime.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_VisitTime

--- a/plugins/VisitorGenerator/Controller.php
+++ b/plugins/VisitorGenerator/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_VisitorGenerator

--- a/plugins/VisitorGenerator/VisitorGenerator.php
+++ b/plugins/VisitorGenerator/VisitorGenerator.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_VisitorGenerator

--- a/plugins/VisitorInterest/API.php
+++ b/plugins/VisitorInterest/API.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_VisitorInterest

--- a/plugins/VisitorInterest/Controller.php
+++ b/plugins/VisitorInterest/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_VisitorInterest

--- a/plugins/VisitorInterest/VisitorInterest.php
+++ b/plugins/VisitorInterest/VisitorInterest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_VisitorInterest

--- a/plugins/VisitsSummary/API.php
+++ b/plugins/VisitsSummary/API.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_VisitsSummary

--- a/plugins/VisitsSummary/Controller.php
+++ b/plugins/VisitsSummary/Controller.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_VisitsSummary

--- a/plugins/VisitsSummary/VisitsSummary.php
+++ b/plugins/VisitsSummary/VisitsSummary.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  *
  * @category Piwik_Plugins
  * @package Piwik_VisitsSummary

--- a/plugins/Widgetize/Controller.php
+++ b/plugins/Widgetize/Controller.php
@@ -4,7 +4,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Widgetize

--- a/plugins/Widgetize/Widgetize.php
+++ b/plugins/Widgetize/Widgetize.php
@@ -5,7 +5,6 @@
  * 
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  * 
  * @category Piwik_Plugins
  * @package Piwik_Widgetize

--- a/tests/PHPUnit/BenchmarkTestCase.php
+++ b/tests/PHPUnit/BenchmarkTestCase.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/IntegrationTestCase.php';
 require_once PIWIK_INCLUDE_PATH . '/tests/LocalTracker.php';

--- a/tests/PHPUnit/Benchmarks/ArchivingProcessBenchmark.php
+++ b/tests/PHPUnit/Benchmarks/ArchivingProcessBenchmark.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/BenchmarkTestCase.php';
 

--- a/tests/PHPUnit/Benchmarks/Fixtures/OneSiteTwelveThousandVisitsOneYear.php
+++ b/tests/PHPUnit/Benchmarks/Fixtures/OneSiteTwelveThousandVisitsOneYear.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Benchmarks/Fixtures/SqlDump.php
+++ b/tests/PHPUnit/Benchmarks/Fixtures/SqlDump.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Benchmarks/Fixtures/ThousandSitesTwelveVisitsEachOneDay.php
+++ b/tests/PHPUnit/Benchmarks/Fixtures/ThousandSitesTwelveVisitsEachOneDay.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Benchmarks/TrackerBenchmark.php
+++ b/tests/PHPUnit/Benchmarks/TrackerBenchmark.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/BenchmarkTestCase.php';
 

--- a/tests/PHPUnit/Core/API/ResponseBuilderTest.php
+++ b/tests/PHPUnit/Core/API/ResponseBuilderTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class API_ResponseBuilderTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/AccessTest.php
+++ b/tests/PHPUnit/Core/AccessTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: $
  */
 class AccessTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Core/ArchiveProcessing/DayTest.php
+++ b/tests/PHPUnit/Core/ArchiveProcessing/DayTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class ArchiveProcessing_DayTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/ArchiveProcessingTest.php
+++ b/tests/PHPUnit/Core/ArchiveProcessingTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class ArchiveProcessingTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Core/AssetManagerTest.php
+++ b/tests/PHPUnit/Core/AssetManagerTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class AssetManagerTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/CommonTest.php
+++ b/tests/PHPUnit/Core/CommonTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class Core_CommonTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/ConfigTest.php
+++ b/tests/PHPUnit/Core/ConfigTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class ConfigTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/CookieTest.php
+++ b/tests/PHPUnit/Core/CookieTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class CookieTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Filter/AddSummaryRowTest.php
+++ b/tests/PHPUnit/Core/DataTable/Filter/AddSummaryRowTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Filter_AddSummaryRowTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Filter/ExcludeLowPopulationTest.php
+++ b/tests/PHPUnit/Core/DataTable/Filter/ExcludeLowPopulationTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Filter_ExcludeLowPopulationTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Filter/LimitTest.php
+++ b/tests/PHPUnit/Core/DataTable/Filter/LimitTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Filter_LimitTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Filter/PatternRecursiveTest.php
+++ b/tests/PHPUnit/Core/DataTable/Filter/PatternRecursiveTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Filter_PatternRecursiveTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Filter/PatternTest.php
+++ b/tests/PHPUnit/Core/DataTable/Filter/PatternTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Filter_PatternTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Filter/RangeCheckTest.php
+++ b/tests/PHPUnit/Core/DataTable/Filter/RangeCheckTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Filter_RangeCheckTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Filter/SortTest.php
+++ b/tests/PHPUnit/Core/DataTable/Filter/SortTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Filter_SortTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Filter/TruncateTest.php
+++ b/tests/PHPUnit/Core/DataTable/Filter/TruncateTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Filter_TruncateTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Renderer/CSVTest.php
+++ b/tests/PHPUnit/Core/DataTable/Renderer/CSVTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Renderer_CSVTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Renderer/ConsoleTest.php
+++ b/tests/PHPUnit/Core/DataTable/Renderer/ConsoleTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Renderer_ConsoleTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Renderer/JSONTest.php
+++ b/tests/PHPUnit/Core/DataTable/Renderer/JSONTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Renderer_JSONTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Renderer/PHPTest.php
+++ b/tests/PHPUnit/Core/DataTable/Renderer/PHPTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Renderer_PHPTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/Renderer/XMLTest.php
+++ b/tests/PHPUnit/Core/DataTable/Renderer/XMLTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTable_Renderer_XMLTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTable/RowTest.php
+++ b/tests/PHPUnit/Core/DataTable/RowTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class RowTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DataTableTest.php
+++ b/tests/PHPUnit/Core/DataTableTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DataTableTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/DateTest.php
+++ b/tests/PHPUnit/Core/DateTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class DateTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/HttpTest.php
+++ b/tests/PHPUnit/Core/HttpTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class HttpTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/IPTest.php
+++ b/tests/PHPUnit/Core/IPTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class IPTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/NonceTest.php
+++ b/tests/PHPUnit/Core/NonceTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class NonceTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/OptionTest.php
+++ b/tests/PHPUnit/Core/OptionTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once "Option.php";
 

--- a/tests/PHPUnit/Core/Period/DayTest.php
+++ b/tests/PHPUnit/Core/Period/DayTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 /**
  * Testing Period_Day

--- a/tests/PHPUnit/Core/Period/MonthTest.php
+++ b/tests/PHPUnit/Core/Period/MonthTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 /**
  * Testing Period_Month

--- a/tests/PHPUnit/Core/Period/RangeTest.php
+++ b/tests/PHPUnit/Core/Period/RangeTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class Period_RangeTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/Period/WeekTest.php
+++ b/tests/PHPUnit/Core/Period/WeekTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 /**
  * Testing Period_Week

--- a/tests/PHPUnit/Core/Period/YearTest.php
+++ b/tests/PHPUnit/Core/Period/YearTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 /**
  * Testing Period_Year

--- a/tests/PHPUnit/Core/PeriodTest.php
+++ b/tests/PHPUnit/Core/PeriodTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class PeriodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/PiwikTest.php
+++ b/tests/PHPUnit/Core/PiwikTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class PiwikTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Core/Plugin/ConfigTest.php
+++ b/tests/PHPUnit/Core/Plugin/ConfigTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class Plugin_ConfigTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/PluginsFunctions/WidgetsListTest.php
+++ b/tests/PHPUnit/Core/PluginsFunctions/WidgetsListTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 class WidgetsListTest extends DatabaseTestCase

--- a/tests/PHPUnit/Core/RankingQueryTest.php
+++ b/tests/PHPUnit/Core/RankingQueryTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 class RankingQueryTest extends PHPUnit_Framework_TestCase

--- a/tests/PHPUnit/Core/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Core/ReleaseCheckListTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class ReleaseCheckListTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/ScheduledTaskTest.php
+++ b/tests/PHPUnit/Core/ScheduledTaskTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once PIWIK_INCLUDE_PATH . '/plugins/PDFReports/PDFReports.php';
 

--- a/tests/PHPUnit/Core/ScheduledTime/DailyTest.php
+++ b/tests/PHPUnit/Core/ScheduledTime/DailyTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class ScheduledTime_DailyTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/ScheduledTime/HourlyTest.php
+++ b/tests/PHPUnit/Core/ScheduledTime/HourlyTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class ScheduledTime_HourlyTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/ScheduledTime/MonthlyTest.php
+++ b/tests/PHPUnit/Core/ScheduledTime/MonthlyTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class ScheduledTime_MonthlyTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/ScheduledTime/WeeklyTest.php
+++ b/tests/PHPUnit/Core/ScheduledTime/WeeklyTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class ScheduledTime_WeeklyTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/SegmentExpressionTest.php
+++ b/tests/PHPUnit/Core/SegmentExpressionTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class SegmentExpressionTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/SegmentTest.php
+++ b/tests/PHPUnit/Core/SegmentTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class SegmentTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/SqlTest.php
+++ b/tests/PHPUnit/Core/SqlTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class SqlTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Core/TablePartitioningTest.php
+++ b/tests/PHPUnit/Core/TablePartitioningTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class TablePartitioningTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Core/TaskSchedulerTest.php
+++ b/tests/PHPUnit/Core/TaskSchedulerTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class TaskSchedulerTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Core/Tracker/ActionTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class Tracker_ActionTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Core/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Core/Tracker/VisitTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class Tracker_VisitTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Core/TranslationWriterTest.php
+++ b/tests/PHPUnit/Core/TranslationWriterTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class TranslationWriterTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/UnzipTest.php
+++ b/tests/PHPUnit/Core/UnzipTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class UnzipTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Core/UpdaterTest.php
+++ b/tests/PHPUnit/Core/UpdaterTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class UpdaterTest extends DatabaseTestCase 
 {

--- a/tests/PHPUnit/Core/UrlTest.php
+++ b/tests/PHPUnit/Core/UrlTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class UrlTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/DatabaseTestCase.php
+++ b/tests/PHPUnit/DatabaseTestCase.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 /**
  * Tests extending DatabaseTestCase are much slower to run: the setUp will

--- a/tests/PHPUnit/FakeAccess.php
+++ b/tests/PHPUnit/FakeAccess.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 /**
  * FakeAccess for UnitTests

--- a/tests/PHPUnit/Integration/AnnotationsTest.php
+++ b/tests/PHPUnit/Integration/AnnotationsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 class AnnotationsTest extends IntegrationTestCase

--- a/tests/PHPUnit/Integration/ApiGetReportMetadataTest.php
+++ b/tests/PHPUnit/Integration/ApiGetReportMetadataTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/ApiGetReportMetadata_yearTest.php
+++ b/tests/PHPUnit/Integration/ApiGetReportMetadata_yearTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/Integration/BlobReportLimitingTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/MockLocationProvider.php';

--- a/tests/PHPUnit/Integration/CsvExportTest.php
+++ b/tests/PHPUnit/Integration/CsvExportTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/EcommerceOrderWithItemsTest.php
+++ b/tests/PHPUnit/Integration/EcommerceOrderWithItemsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/FlattenReportsTest.php
+++ b/tests/PHPUnit/Integration/FlattenReportsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/ImportLogsTest.php
+++ b/tests/PHPUnit/Integration/ImportLogsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: $
  */
 
 /**

--- a/tests/PHPUnit/Integration/LabelFilterTest.php
+++ b/tests/PHPUnit/Integration/LabelFilterTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/ManyVisitorsOneWebsiteTest.php
+++ b/tests/PHPUnit/Integration/ManyVisitorsOneWebsiteTest.php
@@ -4,7 +4,6 @@
  *
  * @link	http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/MockLocationProvider.php';

--- a/tests/PHPUnit/Integration/NoVisitTest.php
+++ b/tests/PHPUnit/Integration/NoVisitTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/NonUnicodeTest.php
+++ b/tests/PHPUnit/Integration/NonUnicodeTest.php
@@ -4,7 +4,6 @@
  *
  * @link	http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/OneVisitorOneWebsite_SeveralDaysDateRangeTest.php
+++ b/tests/PHPUnit/Integration/OneVisitorOneWebsite_SeveralDaysDateRangeTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/OneVisitorOneWebsite_SeveralDaysDateRange_ArchivingTestsTest.php
+++ b/tests/PHPUnit/Integration/OneVisitorOneWebsite_SeveralDaysDateRange_ArchivingTestsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/OneVisitorTwoVisitsTest.php
+++ b/tests/PHPUnit/Integration/OneVisitorTwoVisitsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/OneVisitorTwoVisits_withCookieSupportTest.php
+++ b/tests/PHPUnit/Integration/OneVisitorTwoVisits_withCookieSupportTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/OneVisitor_LongUrlsTruncatedTest.php
+++ b/tests/PHPUnit/Integration/OneVisitor_LongUrlsTruncatedTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 /**
  * Tests that filter_truncate works recursively in Page URLs report AND in the case there are 2 different data Keywords -> search engine

--- a/tests/PHPUnit/Integration/OneVisitor_NoKeywordSpecifiedTest.php
+++ b/tests/PHPUnit/Integration/OneVisitor_NoKeywordSpecifiedTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/PeriodIsRange_DateIsLastN_MetadataAndNormalAPITest.php
+++ b/tests/PHPUnit/Integration/PeriodIsRange_DateIsLastN_MetadataAndNormalAPITest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/RowEvolutionTest.php
+++ b/tests/PHPUnit/Integration/RowEvolutionTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/SiteSearchTest.php
+++ b/tests/PHPUnit/Integration/SiteSearchTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/TrackCustomVariablesAndCampaigns_ForceUsingVisitIdNotHeuristicsTest.php
+++ b/tests/PHPUnit/Integration/TrackCustomVariablesAndCampaigns_ForceUsingVisitIdNotHeuristicsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/TrackGoals_AllowMultipleConversionsPerVisitTest.php
+++ b/tests/PHPUnit/Integration/TrackGoals_AllowMultipleConversionsPerVisitTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/TwoVisitors_TwoWebsites_DifferentDaysTest.php
+++ b/tests/PHPUnit/Integration/TwoVisitors_TwoWebsites_DifferentDaysTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/TwoVisitors_TwoWebsites_DifferentDays_ArchivingDisabledTest.php
+++ b/tests/PHPUnit/Integration/TwoVisitors_TwoWebsites_DifferentDays_ArchivingDisabledTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/TwoVisitors_TwoWebsites_DifferentDays_ConversionsTest.php
+++ b/tests/PHPUnit/Integration/TwoVisitors_TwoWebsites_DifferentDays_ConversionsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 require_once 'Goals/Goals.php';

--- a/tests/PHPUnit/Integration/TwoVisitsWithCustomVariablesTest.php
+++ b/tests/PHPUnit/Integration/TwoVisitsWithCustomVariablesTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/TwoVisitsWithCustomVariables_SegmentContainsTest.php
+++ b/tests/PHPUnit/Integration/TwoVisitsWithCustomVariables_SegmentContainsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/TwoVisitsWithCustomVariables_SegmentMatchALL_NoGoalDataTest.php
+++ b/tests/PHPUnit/Integration/TwoVisitsWithCustomVariables_SegmentMatchALL_NoGoalDataTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 class Test_Piwik_Integration_TwoVisitsWithCustomVariables_SegmentMatchALL_NoGoalData extends IntegrationTestCase

--- a/tests/PHPUnit/Integration/TwoVisitsWithCustomVariables_SegmentMatchNONETest.php
+++ b/tests/PHPUnit/Integration/TwoVisitsWithCustomVariables_SegmentMatchNONETest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/TwoVisitsWithCustomVariables_SegmentMatchVisitorTypeTest.php
+++ b/tests/PHPUnit/Integration/TwoVisitsWithCustomVariables_SegmentMatchVisitorTypeTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/Integration/VisitsInPast_InvalidateOldReportsTest.php
+++ b/tests/PHPUnit/Integration/VisitsInPast_InvalidateOldReportsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 /**

--- a/tests/PHPUnit/IntegrationTestCase.php
+++ b/tests/PHPUnit/IntegrationTestCase.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once PIWIK_INCLUDE_PATH . '/libs/PiwikTracker/PiwikTracker.php';
 

--- a/tests/PHPUnit/MockEventDispatcher.php
+++ b/tests/PHPUnit/MockEventDispatcher.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class MockEventDispatcher extends Event_Dispatcher
 {

--- a/tests/PHPUnit/MockLocationProvider.php
+++ b/tests/PHPUnit/MockLocationProvider.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 class MockLocationProvider extends Piwik_UserCountry_LocationProvider

--- a/tests/PHPUnit/MockPiwikOption.php
+++ b/tests/PHPUnit/MockPiwikOption.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class MockPiwikOption extends Piwik_Option
 {

--- a/tests/PHPUnit/Plugins/ActionsTest.php
+++ b/tests/PHPUnit/Plugins/ActionsTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once 'Actions/Actions.php';
 

--- a/tests/PHPUnit/Plugins/AnonymizeIPTest.php
+++ b/tests/PHPUnit/Plugins/AnonymizeIPTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once 'AnonymizeIP/AnonymizeIP.php';
 

--- a/tests/PHPUnit/Plugins/LanguagesManagerTest.php
+++ b/tests/PHPUnit/Plugins/LanguagesManagerTest.php
@@ -4,7 +4,6 @@
  *
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once 'LanguagesManager/API.php';
 

--- a/tests/PHPUnit/Plugins/LoginTest.php
+++ b/tests/PHPUnit/Plugins/LoginTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once 'Login/Auth.php';
 

--- a/tests/PHPUnit/Plugins/MobileMessagingTest.php
+++ b/tests/PHPUnit/Plugins/MobileMessagingTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 class MobileMessagingTest extends DatabaseTestCase

--- a/tests/PHPUnit/Plugins/MultiSitesTest.php
+++ b/tests/PHPUnit/Plugins/MultiSitesTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 
 class MultiSitesTest extends DatabaseTestCase

--- a/tests/PHPUnit/Plugins/PDFReportsTest.php
+++ b/tests/PHPUnit/Plugins/PDFReportsTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once 'PDFReports/PDFReports.php';
 

--- a/tests/PHPUnit/Plugins/PrivacyManagerTest.php
+++ b/tests/PHPUnit/Plugins/PrivacyManagerTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once 'PrivacyManager/PrivacyManager.php';
 

--- a/tests/PHPUnit/Plugins/ProxyTest.php
+++ b/tests/PHPUnit/Plugins/ProxyTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class ProxyTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Plugins/ReferersTest.php
+++ b/tests/PHPUnit/Plugins/ReferersTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once 'Referers/Referers.php';
 

--- a/tests/PHPUnit/Plugins/SEOTest.php
+++ b/tests/PHPUnit/Plugins/SEOTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class SEOTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Plugins/SitesManagerTest.php
+++ b/tests/PHPUnit/Plugins/SitesManagerTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class SitesManagerTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Plugins/UserCountryTest.php
+++ b/tests/PHPUnit/Plugins/UserCountryTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once PIWIK_INCLUDE_PATH.'/plugins/UserCountry/UserCountry.php';
 require_once 'UserCountry/functions.php';

--- a/tests/PHPUnit/Plugins/UserSettingsTest.php
+++ b/tests/PHPUnit/Plugins/UserSettingsTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 require_once 'UserSettings/UserSettings.php';
 require_once 'UserSettings/functions.php';

--- a/tests/PHPUnit/Plugins/UsersManagerTest.php
+++ b/tests/PHPUnit/Plugins/UsersManagerTest.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id$
  */
 class UsersManagerTest extends DatabaseTestCase
 {

--- a/tests/javascript/SQLite.php
+++ b/tests/javascript/SQLite.php
@@ -6,7 +6,6 @@
  *
  * @link http://piwik.org
  * @source http://dev.piwik.org/trac/browser/trunk/tests/javascript/SQLite.php
- * @version $Id$
  * @license http://www.opensource.org/licenses/bsd-license.php Simplified BSD
  */
 if (class_exists('SQLite3'))

--- a/tests/javascript/jash/Jash.css
+++ b/tests/javascript/jash/Jash.css
@@ -1,5 +1,4 @@
 /**
-* $Id: Jash.css,v 1.2 2007/07/13 04:38:41 billyreisinger Exp $
 *
 * Jash - JavaScript Shell
 * Copyright: 2007, Billy Reisinger

--- a/tests/javascript/piwiktest.js
+++ b/tests/javascript/piwiktest.js
@@ -3,7 +3,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- * @version $Id: $
  */
 
 /*global Piwik getToken */


### PR DESCRIPTION
I ran a script to automatically remove all appearances of `@version: $Id$` since Git does not allow auto property expansion like SVN and they are useless now.

Thanks to the guys at Typo3 for the script (http://bugs.typo3.org/view.php?id=18016).
