### PR TITLE
Fixed 'rec' param value when replay-tracking enabled

### DIFF
--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1120,6 +1120,9 @@ class Recorder(object):
             'dp': '0' if config.options.reverse_dns else '1',
             'ua': hit.user_agent.encode('utf8'),
         }
+        if not hit.args.get('rec'):
+            # prevent request to be force recorded when option replay-tracking
+            args['rec'] = '0'
         args.update(hit.args)
 
         if hit.is_download:

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1120,7 +1120,7 @@ class Recorder(object):
             'dp': '0' if config.options.reverse_dns else '1',
             'ua': hit.user_agent.encode('utf8'),
         }
-        if not hit.args.get('rec'):
+        if config.options.replay_tracking:
             # prevent request to be force recorded when option replay-tracking
             args['rec'] = '0'
         args.update(hit.args)


### PR DESCRIPTION
When `--replay-tracking` is enabled, we can't set `query_arguments['rec']` to `1`, because we don't want to force the request to be recorded (according to: http://piwik.org/docs/tracking-api/#toc-two-tracking-methods-image-tracking-or-using-the-api).
