### PR TITLE
ClearCache plugin

### DIFF
--- a/plugins/ClearCache/ClearCache.php
+++ b/plugins/ClearCache/ClearCache.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Piwik - Open source web analytics
+ * 
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @version $Id: ExamplePlugin.php 6427 2012-05-31 23:26:11Z matt $
+ * 
+ * @category Piwik_Plugins
+ * @package Piwik_ClearCache
+ */
+
+/**
+ *
+ * @package Piwik_ClearCache
+ */
+class Piwik_ClearCache extends Piwik_Plugin
+{
+	public function getInformation()
+	{
+		$info = array(
+			'description' => Piwik_Translate('ClearCache_PluginDescription'),
+			'author' => 'Spherexx.com',
+			'author_homepage' => 'http://spherexx.com/',
+			'version' => '1.0',
+			'translationAvailable' => true
+		);
+		return $info;
+	}
+
+	function getListHooksRegistered()
+	{
+		return array( 
+			'TopMenu.add' => 'addTopMenu',
+		);
+	}
+
+	public function addTopMenu()
+	{
+		If(Piwik::isUserIsSuperUser())
+		{
+			$tooltip = false;
+			try
+			{
+				$idSite = Piwik_Common::getRequestVar('idSite');
+				$tooltip = Piwik_Translate('ClearCache_PluginDescription', Piwik_Site::getNameFor($idSite));
+			}
+			catch (Exception $ex)
+			{
+				// if no idSite parameter, show no tooltip
+			}
+			
+			$urlParams = array('module' => 'ClearCache', 'action' => 'index');
+			Piwik_AddTopMenu('ClearCache', $urlParams, true, 8, $isHTML = false, $tooltip);
+		}
+	}
+}

--- a/plugins/ClearCache/Controller.php
+++ b/plugins/ClearCache/Controller.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Piwik - Open source web analytics
+ * 
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @version $Id: Controller.php 4451 2011-04-14 19:00:39Z vipsoft $
+ *
+ * @category Piwik_Plugins
+ * @package Piwik_ClearCache
+ */
+
+/**
+ * @package Piwik_ClearCache
+ */
+class Piwik_ClearCache_Controller extends Piwik_Controller_Admin
+{
+	function index()
+	{
+		$pwd = explode('\\', $_SERVER['SCRIPT_FILENAME']);
+		$pwd = $pwd[0]."\\".$pwd[1]."\\".$pwd[2];
+		$directories = glob($pwd."\\tmp\*" , GLOB_ONLYDIR);
+
+		for($i=0; $i < sizeof($directories); $i++)
+		{
+			if(strstr($_SERVER['OS'], "Windows"))
+			{
+				system("rmdir ".$directories[$i]." /s /q");
+			} else {
+				system("rm -rf ".$directories[$i]);
+			}
+		}
+		Piwik_Url::redirectToReferer();
+	}
+}

--- a/plugins/ClearCache/lang/en.php
+++ b/plugins/ClearCache/lang/en.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Piwik - Open source web analytics
+ * 
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+$translations = array(
+	'ClearCache_PluginName' => 'Clear Cache',
+	'ClearCache_PluginDescription' => "Clears the Piwik cache by deleting all folders in the /tmp directory",
+);


### PR DESCRIPTION
Plugin that allows SuperUsers to clear the /tmp cache. Very useful when
developing new plugins and old code is hanging around.
