### PR TITLE
Refs #3697 Prettify ISP names

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -1023,6 +1023,21 @@ class Piwik_Common
 		return $searchEngines;
 	}
 
+	/**
+	 * Returns list of provider names
+	 *
+	 * @see core/DataFiles/Providers.php
+	 *
+	 * @return array  Array of ( dnsName => providerName )
+	 */
+	static public function getProviderNames()
+	{
+		require_once PIWIK_INCLUDE_PATH . '/core/DataFiles/Providers.php';
+
+		$providers = $GLOBALS['Piwik_ProviderNames'];
+		return $providers;
+	}
+
 /*
  * Language, country, continent
  */

--- a/core/DataFiles/Providers.php
+++ b/core/DataFiles/Providers.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Piwik - Open source web analytics
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ * @category Piwik
+ * @package DataFiles
+ */
+
+/**
+ * Providers names
+ */
+if(!isset($GLOBALS['Piwik_ProviderNames']))
+{
+	$GLOBALS['Piwik_ProviderNames'] = array(
+			// France
+			"wanadoo"		=> "Orange",
+			"proxad"		=> "Free",
+			"bbox"			=> "Bouygues Telecom",
+			"bouyguestelecom"	=> "Bouygues Telecom",
+			"coucou-networks"	=> "Free Mobile",
+			"sfr"			=> "SFR",               //Acronym, keep in uppercase
+			"univ-metz"		=> "Université de Lorraine",
+			"unilim"		=> "Université de Limoges",
+			"univ-paris5"		=> "Université Paris Descartes",
+			
+			// US
+			"rr"			=> "Time Warner Cable Internet", // Not sure
+		);
+}

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -497,7 +497,7 @@ class Piwik_Live_Visitor
 
 	function getProvider()
 	{
-		return Piwik_getHostnameName( @$this->details['location_provider']);
+		return Piwik_Provider_getPrettyProviderName( @$this->details['location_provider']);
 	}
 
 	function getProviderUrl()

--- a/plugins/Provider/API.php
+++ b/plugins/Provider/API.php
@@ -39,7 +39,7 @@ class Piwik_Provider_API
 		$dataTable = $archive->getDataTable('Provider_hostnameExt');
 		$dataTable->filter('Sort', array(Piwik_Archive::INDEX_NB_VISITS));
 		$dataTable->queueFilter('ColumnCallbackAddMetadata', array('label', 'url', 'Piwik_getHostnameUrl'));
-		$dataTable->queueFilter('ColumnCallbackReplace', array('label', 'Piwik_getHostnameName'));
+		$dataTable->queueFilter('ColumnCallbackReplace', array('label', 'Piwik_Provider_getPrettyProviderName'));
 		$dataTable->queueFilter('ReplaceColumnNames');
 		$dataTable->queueFilter('ReplaceSummaryRowLabel');
 		return $dataTable;

--- a/plugins/Provider/functions.php
+++ b/plugins/Provider/functions.php
@@ -61,3 +61,37 @@ function Piwik_getHostnameUrl($in)
 		return "https://startpage.com/do/search?q=".urlencode($in);
 	}
 }
+
+/**
+ * Return a pretty provider name for a given domain name
+ *
+ * @param string $in hostname
+ * @return string Real ISP name, IP (if IP address didn't resolve), or Unknown
+ */
+function Piwik_Provider_getPrettyProviderName( $in )
+{
+	$providerName = Piwik_getHostnameName($in);
+
+	$prettyNames = array( //List to be completed
+		// France
+		"wanadoo" 		=> "Orange",
+		"proxad" 		=> "Free",
+		"bbox"	 		=> "Bouygues Telecom",
+		"bouyguestelecom"	=> "Bouygues Telecom",
+		"coucou-networks" 	=> "Free Mobile",
+		"sfr"			=> "SFR",		//Acronym, keep in uppercase
+		"univ-metz"		=> "Université de Lorraine",
+		"unilim"		=> "Université de Limoges",
+		"univ-paris5"		=> "Université Paris Descartes",
+
+		// US
+		"rr"			=> "Time Warner Cable Internet", // Not sure
+	);
+
+	if(array_key_exists(strtolower($providerName), $prettyNames))
+	{
+		$providerName = $prettyNames[strtolower($providerName)];
+	}
+
+	return $providerName;
+}

--- a/plugins/Provider/functions.php
+++ b/plugins/Provider/functions.php
@@ -74,7 +74,8 @@ function Piwik_Provider_getPrettyProviderName( $in )
 
 	$prettyNames = Piwik_Common::getProviderNames();
 
-	if(array_key_exists(strtolower($providerName), $prettyNames))
+	if(is_array($prettyNames)
+		&& array_key_exists(strtolower($providerName), $prettyNames))
 	{
 		$providerName = $prettyNames[strtolower($providerName)];
 	}

--- a/plugins/Provider/functions.php
+++ b/plugins/Provider/functions.php
@@ -72,21 +72,7 @@ function Piwik_Provider_getPrettyProviderName( $in )
 {
 	$providerName = Piwik_getHostnameName($in);
 
-	$prettyNames = array( //List to be completed
-		// France
-		"wanadoo" 		=> "Orange",
-		"proxad" 		=> "Free",
-		"bbox"	 		=> "Bouygues Telecom",
-		"bouyguestelecom"	=> "Bouygues Telecom",
-		"coucou-networks" 	=> "Free Mobile",
-		"sfr"			=> "SFR",		//Acronym, keep in uppercase
-		"univ-metz"		=> "Université de Lorraine",
-		"unilim"		=> "Université de Limoges",
-		"univ-paris5"		=> "Université Paris Descartes",
-
-		// US
-		"rr"			=> "Time Warner Cable Internet", // Not sure
-	);
+	$prettyNames = Piwik_Common::getProviderNames();
 
 	if(array_key_exists(strtolower($providerName), $prettyNames))
 	{

--- a/tests/PHPUnit/IntegrationTestCase.php
+++ b/tests/PHPUnit/IntegrationTestCase.php
@@ -123,6 +123,7 @@ abstract class IntegrationTestCase extends PHPUnit_Framework_TestCase
         include "DataFiles/Countries.php";
         include "DataFiles/Currencies.php";
         include "DataFiles/LanguageToCountry.php";
+        include "DataFiles/Providers.php";
 
         Piwik::createAccessObject();
         Piwik_PostEvent('FrontController.initAuthenticationObject');


### PR DESCRIPTION
A first implementation of the new feature requested in #3697.
It might be better to export the array of ISP names in a separate file (in the core/DataFiles folder, as it's done for search engines or countries for example), what do you think about it?

Note that I'm the same person as "bugmenot" (the author of the ticket), but with a new github account and my real name this time ;-)
