### PR TITLE
refs #3882 Use table instead of tableGoals on Visits-Days to Conversion reports

### DIFF
--- a/plugins/Goals/Controller.php
+++ b/plugins/Goals/Controller.php
@@ -359,11 +359,11 @@ class Piwik_Goals_Controller extends Piwik_Controller
         $topDimensions = array();
         foreach ($topDimensionsToLoad as $dimensionName => $apiMethod) {
             $request = new Piwik_API_Request("method=$apiMethod
-                                &format=original
-                                &filter_update_columns_when_show_all_goals=1
-                                &idGoal=" . Piwik_DataTable_Filter_AddColumnsProcessedMetricsGoal::GOALS_FULL_TABLE . "
-                                &filter_sort_order=desc
-                                &filter_sort_column=$columnNbConversions" .
+                &format=original
+                &filter_update_columns_when_show_all_goals=1
+                &idGoal=" . Piwik_DataTable_Filter_AddColumnsProcessedMetricsGoal::GOALS_FULL_TABLE . "
+                &filter_sort_order=desc
+                &filter_sort_column=$columnNbConversions" .
                 // select a couple more in case some are not valid (ie. conversions==0 or they are "Keyword not defined")
                 "&filter_limit=" . (self::COUNT_TOP_ROWS_TO_DISPLAY + 2));
             $datatable = $request->process();

--- a/plugins/Goals/Controller.php
+++ b/plugins/Goals/Controller.php
@@ -359,11 +359,11 @@ class Piwik_Goals_Controller extends Piwik_Controller
         $topDimensions = array();
         foreach ($topDimensionsToLoad as $dimensionName => $apiMethod) {
             $request = new Piwik_API_Request("method=$apiMethod
-								&format=original
-								&filter_update_columns_when_show_all_goals=1
-								&idGoal=" . Piwik_DataTable_Filter_AddColumnsProcessedMetricsGoal::GOALS_FULL_TABLE . "
-								&filter_sort_order=desc
-								&filter_sort_column=$columnNbConversions" .
+                                &format=original
+                                &filter_update_columns_when_show_all_goals=1
+                                &idGoal=" . Piwik_DataTable_Filter_AddColumnsProcessedMetricsGoal::GOALS_FULL_TABLE . "
+                                &filter_sort_order=desc
+                                &filter_sort_column=$columnNbConversions" .
                 // select a couple more in case some are not valid (ie. conversions==0 or they are "Keyword not defined")
                 "&filter_limit=" . (self::COUNT_TOP_ROWS_TO_DISPLAY + 2));
             $datatable = $request->process();
@@ -522,6 +522,9 @@ class Piwik_Goals_Controller extends Piwik_Controller
             foreach ($allReports as $category => $reports) {
                 $categoryText = Piwik_Translate('Goals_ViewGoalsBy', $category);
                 foreach ($reports as $report) {
+                    if ($report['module'] == 'Goals') {
+                        $customParams['viewDataTable'] = 'table';
+                    }
                     $goalReportsByDimension->addReport(
                         $categoryText, $report['name'], $report['module'] . '.' . $report['action'], $customParams);
                 }


### PR DESCRIPTION
Use "table" instead of "tableGoals" on reports from Goals plugin
