### PR TITLE
Update import_logs.py

### DIFF
--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -179,6 +179,9 @@ _S3_LOG_FORMAT = (
     '\S+ \S+ \S+ \S+ "\S+ (?P<path>.*?) \S+" (?P<status>\S+) \S+ (?P<length>\S+) '
     '\S+ \S+ \S+ "(?P<referrer>.*?)" "(?P<user_agent>.*?)"'
 )
+_ICECAST2_LOG_FORMAT = ( _NCSA_EXTENDED_LOG_FORMAT +
+    ' (?P<session_time>\S+)'
+)
 
 FORMATS = {
     'common': RegexFormat('common', _COMMON_LOG_FORMAT),
@@ -187,6 +190,7 @@ FORMATS = {
     'common_complete': RegexFormat('common_complete', _HOST_PREFIX + _NCSA_EXTENDED_LOG_FORMAT),
     'iis': IisFormat(),
     's3': RegexFormat('s3', _S3_LOG_FORMAT),
+    'icecast2': RegexFormat('icecast2', _ICECAST2_LOG_FORMAT),
 }
 
 


### PR DESCRIPTION
Added support to Icecast2 HTTP logs format. NCSA_EXTENDED + SessionTime

*SessionTime is expresed on seconds

I have request this feature a few months ago into this ticket:
http://dev.piwik.org/trac/ticket/3233

Now after some research I have integrated the change, will be great if can merge this into the official release.

I have tested with one logs file with more than

501600 lines parsed, 499714 lines recorded, 213 records/sec (avg), 378 records/sec (current)

Here one screenshot how the stats widget look, after process this log file:

![image](https://f.cloud.github.com/assets/1087447/423589/d251f1b8-ad63-11e2-81bc-39958d732587.png)
