### PR TITLE
IE browser detection improvement

### DIFF
--- a/plugins/DevicesDetection/UserAgentParserEnhanced/regexes/browsers.yml
+++ b/plugins/DevicesDetection/UserAgentParserEnhanced/regexes/browsers.yml
@@ -264,6 +264,18 @@
 - regex: 'IEMobile[ /](\d+\.\d+)'
   name: IE Mobile
   version: '$1'
+- regex: 'MSIE.*Trident/4.0'
+  name: Internet Explorer
+  version: 8.0
+- regex: 'MSIE.*Trident/5.0'
+  name: Internet Explorer
+  version: 9.0
+- regex: 'MSIE.*Trident/6.0'
+  name: Internet Explorer
+  version: 10.0
+- regex: 'MSIE.*Trident/7.0'
+  name: Internet Explorer
+  version: 11.0
 - regex: 'MSIE (\d+\.\d+).*XBLWP7'
   name: IE Mobile
   version: '$1'


### PR DESCRIPTION
IE browsers from version 8.0 up, are identified by used Trident engine version, rather than MSIE X.X number. This change allows to recognize those versions regardless compatibility mode activated.
