### PR TITLE
Add CloudFlare location provider

### DIFF
--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -15,6 +15,11 @@
 require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/LocationProvider/Default.php';
 
 /**
+ * @see plugins/UserCountry/LocationProvider/CloudFlare.php
+ */
+require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/LocationProvider/CloudFlare.php';
+
+/**
  * @see plugins/UserCountry/LocationProvider/GeoIp.php
  */
 require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/LocationProvider/GeoIp.php';

--- a/plugins/UserCountry/LocationProvider/CloudFlare.php
+++ b/plugins/UserCountry/LocationProvider/CloudFlare.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Piwik - Open source web analytics
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ * @category Piwik_Plugins
+ * @package Piwik_UserCountry
+ */
+
+/**
+ * This LocationProvider uses the HTTP_CF_IPCOUNTRY header provided by
+ * CloudFlare to determine the user's location. It only works if your Piwik
+ * installation runs behind CloudFlare.
+ *
+ * @author Gabriel Bauman <gabe@codehaus.org>
+ * @package Piwik_UserCountry
+ */
+class Piwik_UserCountry_LocationProvider_CloudFlare extends Piwik_UserCountry_LocationProvider
+{
+    const ID = 'cloudflare';
+    const TITLE = 'CloudFlare';
+
+    /**
+     * Uses the CloudFlare-provided HTTP header HTTP_CF_IPCOUNTRY to determine
+     * the user's IP address.
+     *
+     * @param array $info Contains 'ip' & 'lang' keys.
+     * @return array Contains the guessed country code mapped to LocationProvider::COUNTRY_CODE_KEY.
+     */
+    public function getLocation($info)
+    {
+        return array(parent::COUNTRY_CODE_KEY => $_SERVER["HTTP_CF_IPCOUNTRY"]);
+    }
+
+    /**
+     * Returns whether this location provider is available.
+     *
+     * This implementation is only available if Piwik is behind CloudFlare.
+     *
+     * @return true
+     */
+    public function isAvailable()
+    {
+        return isset($_SERVER["HTTP_CF_IPCOUNTRY"]);
+    }
+
+    /**
+     * Returns whether this location provider is working correctly.
+     *
+     * This implementation is always working correctly.
+     *
+     * @return true
+     */
+    public function isWorking()
+    {
+        return true;
+    }
+
+    /**
+     * Returns an array describing the types of location information this provider will
+     * return.
+     *
+     * This provider supports the following types of location info:
+     * - country code
+     *
+     * @return array
+     */
+    public function getSupportedLocationInfo()
+    {
+        return array(self::COUNTRY_CODE_KEY   => true);
+    }
+
+    /**
+     * Returns information about this location provider. Contains an id, title & description:
+     *
+     * array(
+     *     'id' => 'default',
+     *     'title' => '...',
+     *     'description' => '...'
+     * );
+     *
+     * @return array
+     */
+    public function getInfo()
+    {
+        $desc = 'This provider uses HTTP headers sent by CloudFlare to determine visitor location.';
+        return array('id' => self::ID, 'title' => self::TITLE, 'description' => $desc);
+    }
+}
+


### PR DESCRIPTION
Hi there,

This pull request adds a CloudFlare location provider to the UserCountry plugin. 

If Piwik is behind a CloudFlare proxy, all requests have a HTTP_CF_IPCOUNTRY header containing the country code of the visitor as looked up by CloudFlare. This LocationProvider simply uses that value.

I am not sure how to get things set up for internationalization or what your requirements are on that front, so I have just hardcoded English strings for now. If you let me know what needs to be done, I will do it.
