### PR TITLE
Fixed Bug 4063 in 1.X

### DIFF
--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -312,6 +312,17 @@ class Piwik_DataTable_Renderer_Csv extends Piwik_DataTable_Renderer
      */
     protected function formatValue($value)
     {
+        // Some custom variables are received as an array, we need to convert them into a string first
+        // Then we can handle it normally
+        if (is_array($value)) {
+            $str = "";
+            foreach ($value as $customVariable => $customValues){
+                foreach ($customValues as $customVariableName => $data) {
+                    $str .= "$customVariableName: $data ";
+                }
+            }
+            $value = $str;
+        }
         if (is_string($value)
             && !is_numeric($value)
         ) {


### PR DESCRIPTION
This is a bug fix for 4063. "Notice: Array to string conversion" when downloading CSV or TSV files from Visitor Log in 1.12. 

Some custom variables are in the $csv array as arrays themselves. Line 283 was trying to handle this array as a string and was throwing the error. This fix parses the array into a string prior to the string formatting step. The csv will successfully download with this fix. Tested on PHP 5.4.13. 
