### PR TITLE
Bug Fix for bug 4063.

### DIFF
--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -322,6 +322,17 @@ class Csv extends Renderer
      */
     protected function formatValue($value)
     {
+        // Some custom variables are received as an array, we need to convert them into a string first
+        // Then we can handle it normally
+        if (is_array($value)) {
+            $str = "";
+            foreach ($value as $customVariable => $customValues){
+                foreach ($customValues as $customVariableName => $data) {
+                    $str .= "$customVariableName: $data ";
+                }
+            }
+            $value = $str;
+        }
         if (is_string($value)
             && !is_numeric($value)
         ) {


### PR DESCRIPTION
This is a bug fix for 4063. "Notice: Array to string conversion" when downloading CSV or TSV files from Visitor Log in 1.12. 

Some custom variables are in the $csv array as arrays themselves. Line 283 was trying to handle this array as a string and was throwing the error. This fix parses the array into a string prior to the string formatting step. The csv will successfully download with this fix. Tested on PHP 5.4.13. 

Pull request for master. 

The bug is reproducible with a clean install and generated data using the plugin. The route is address to get the bug is:

index.php?module=API&method=Live.getLastVisitsDetails&format=CSV&idSite=1&period=day&date=yesterday&expanded=1&translateColumnNames=1&language=en&filter_limit=100
