### PR TITLE
Removed PSR-0 statement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,5 @@
         "php": ">=5.3.0",
         "twig/twig": "1.*",
         "leafo/lessphp": "0.3.*"
-    },
-    "autoload": {
-        "psr-0": {
-            "Piwik\\Core\\": "core/",
-            "Piwik\\Plugins\\": "plugins/"
-        }
     }
 }


### PR DESCRIPTION
Since Piwik does NOT follow PSR-0, composer makes unnecessary file system calls for every single class. Piwik's own autoloader knows how to load Piwik's classes.
