### PR TITLE
Fix typo DbHelperS

### DIFF
--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -715,7 +715,7 @@ class Controller extends \Piwik\Controller\Admin
 
         $directoriesToCheck = array();
 
-        if (!DbHelperS::isInstalled()) {
+        if (!DbHelper::isInstalled()) {
             // at install, need /config to be writable (so we can create config.ini.php)
             $directoriesToCheck[] = '/config/';
         }


### PR DESCRIPTION
Fatal error: Class 'Piwik\Plugins\Installation\DbHelperS' not found in /srv/www/piwik/plugins/Installation/Controller.php on line 718
