### PR TITLE
Included $resolution for generating the Config Hash of the Visitor

### DIFF
--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -1038,7 +1038,7 @@ class Visit implements Tracker\VisitInterface
      */
     protected function getConfigHash($os, $browserName, $browserVersion, $resolution, $plugin_Flash, $plugin_Java, $plugin_Director, $plugin_Quicktime, $plugin_RealPlayer, $plugin_PDF, $plugin_WindowsMedia, $plugin_Gears, $plugin_Silverlight, $plugin_Cookie, $ip, $browserLang)
     {
-        $hash = md5($os . $browserName . $browserVersion . $plugin_Flash . $plugin_Java . $plugin_Director . $plugin_Quicktime . $plugin_RealPlayer . $plugin_PDF . $plugin_WindowsMedia . $plugin_Gears . $plugin_Silverlight . $plugin_Cookie . $ip . $browserLang, $raw_output = true);
+        $hash = md5($os . $browserName . $browserVersion . $resolution . $plugin_Flash . $plugin_Java . $plugin_Director . $plugin_Quicktime . $plugin_RealPlayer . $plugin_PDF . $plugin_WindowsMedia . $plugin_Gears . $plugin_Silverlight . $plugin_Cookie . $ip . $browserLang, $raw_output = true);
         return Common::substr($hash, 0, Tracker::LENGTH_BINARY_ID);
     }
 


### PR DESCRIPTION
The $resolution on the function getConfigHash seem to have been ignored for generating the visitors configuation settings hash. Added that to the md5 function.
