### PR TITLE
Set client cookies from PiwikTracker.php

### DIFF
--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -403,7 +403,7 @@ class PiwikTracker
     function getCookieName($baseName) {
         // NOTE: If the cookie name is changed, we must also update the method in piwik.js with
         // the same name.
-        $hash = substr( sha1( ($this->clientCookieDomain == '' ? self::getCurrentHost() : self::domainFixup($this->clientCookieDomain))  . '/' ), 0, 4);
+        $hash = substr( sha1( ($this->clientCookieDomain == '' ? self::getCurrentHost() : $this->clientCookieDomain)  . '/' ), 0, 4);
         return '_pk_' . $baseName . '.' . $this->idSite . '.' . $hash;
     }
      
@@ -416,7 +416,7 @@ class PiwikTracker
      */
     protected function setVisitorIdCookie($visitorId, $createTs, $visitCount, $nowTs, $lastVisitTs, $lastEcommerceOrderTs = '')
     {
-        return setcookie( $this->getCookieName('id'), visitorId . '.' . $createTs . '.' . $visitCount . '.' . $nowTs . '.' . $lastVisitTs . '.' . $lastEcommerceOrderTs, $nowTs + $this->configVisitorCookieTimeout / 1000, '/', $this->clientCookieDomain );
+        return setcookie( $this->getCookieName('id'), $visitorId . '.' . $createTs . '.' . $visitCount . '.' . $nowTs . '.' . $lastVisitTs . '.' . $lastEcommerceOrderTs, $nowTs + $this->configVisitorCookieTimeout / 1000, '/', $this->clientCookieDomain );
     }
 
     /**

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -362,55 +362,55 @@ class PiwikTracker
         $this->doBulkRequests = true;
     }
 
-	/**
-	 * Enable Cookie Creation - this will cause a first party VisitorId cookie to be set when the VisitorId is set or reset
-	 *
-	 * @param bool $create determines whether or not client cookies will be updated
-	 * $param string $domain sets the domain under which the cookie will be placed (primarily used to create domain wildcard cookies)
-	 */
-	public function setUpdateClientCookies( $create, $domain = '' )
-	{
-		$this->updateClientCookies = $create;
-		$this->clientCookieDomain = $domain;
-	}
+    /**
+     * Enable Cookie Creation - this will cause a first party VisitorId cookie to be set when the VisitorId is set or reset
+     *
+     * @param bool $create determines whether or not client cookies will be updated
+     * $param string $domain sets the domain under which the cookie will be placed (primarily used to create domain wildcard cookies)
+     */
+    public function setUpdateClientCookies( $create, $domain = '' )
+    {
+        $this->updateClientCookies = $create;
+        $this->clientCookieDomain = $domain;
+    }
 
-	/*
-	 * Fix-up domain
-	 */
+    /*
+     * Fix-up domain
+     */
     static protected function domainFixup($domain) {
-		$dl = strlen($domain);
-		// remove trailing '.'
-		if ($domain{--$dl} === '.') {
-			$domain = substr($domain, 0, $dl);
-		}
-		// remove leading '*'
-		if (substr($domain, 0, 2) === '*.') {
-			$domain = substr($domain, 1);
-		}
-		return $domain;
-	}
-	
-	/**
-	 * Get cookie name with prefix and domain hash
-	 */
-	function getCookieName($baseName) {
-		// NOTE: If the cookie name is changed, we must also update the method in piwik.js with
-		// the same name.
-		$hash = substr( sha1( ($this->clientCookieDomain == '' ? self::getCurrentHost() : self::domainFixup($this->clientCookieDomain))  . '/' ), 0, 4);
-		return '_pk_' . $baseName . '.' . $this->idSite . '.' . $hash;
-	}
-	 
-	/**
-	 * Sets a first party cookie.  This is useful when using the PHP Tracking API along with the Javascript Tracking API.
-	 *
-	 * @param string $baseName value will be combined with prefix and domain hash to determine the cookie name
-	 * $param string $value indicates the value of the cookie to be stored on the client's computer
-	 * @return bool
-	 */
-	protected function setFirstPartyCookie($baseName, $value)
-	{
-		$name = $this->getCookieName($baseName);
-		return setcookie( $name, $value, null, '/', $this->clientCookieDomain );
+        $dl = strlen($domain);
+        // remove trailing '.'
+        if ($domain{--$dl} === '.') {
+            $domain = substr($domain, 0, $dl);
+        }
+        // remove leading '*'
+        if (substr($domain, 0, 2) === '*.') {
+            $domain = substr($domain, 1);
+        }
+        return $domain;
+    }
+    
+    /**
+     * Get cookie name with prefix and domain hash
+     */
+    function getCookieName($baseName) {
+        // NOTE: If the cookie name is changed, we must also update the method in piwik.js with
+        // the same name.
+        $hash = substr( sha1( ($this->clientCookieDomain == '' ? self::getCurrentHost() : self::domainFixup($this->clientCookieDomain))  . '/' ), 0, 4);
+        return '_pk_' . $baseName . '.' . $this->idSite . '.' . $hash;
+    }
+     
+    /**
+     * Sets a first party cookie.  This is useful when using the PHP Tracking API along with the Javascript Tracking API.
+     *
+     * @param string $baseName value will be combined with prefix and domain hash to determine the cookie name
+     * $param string $value indicates the value of the cookie to be stored on the client's computer
+     * @return bool
+     */
+    protected function setFirstPartyCookie($baseName, $value)
+    {
+        $name = $this->getCookieName($baseName);
+        return setcookie( $name, $value, null, '/', $this->clientCookieDomain );
     }
 
     /**
@@ -816,60 +816,60 @@ class PiwikTracker
     public function getVisitorId()
     {
         if (!empty($this->forcedVisitorId)) {
-			return $this->forcedVisitorId;
-		} else if ($this->loadVisitorIdCookie()) {
-			return $this->CookieVisitorId;
+            return $this->forcedVisitorId;
+        } else if ($this->loadVisitorIdCookie()) {
+            return $this->CookieVisitorId;
         } else {
-			return $this->visitorId;
-		}
+            return $this->visitorId;
+        }
     }
 
-	/**
-	 * Loads values from the VisitorId Cookie
-	 * 
-	 * @return bool True if cookie exists and is valid, False otherwise
-	 */
-	protected function loadVisitorIdCookie() 
-	{
+    /**
+     * Loads values from the VisitorId Cookie
+     * 
+     * @return bool True if cookie exists and is valid, False otherwise
+     */
+    protected function loadVisitorIdCookie() 
+    {
         $idCookieName = $this->getCookieName('id');
         $idCookie = $this->getCookieMatchingName($idCookieName);
         if ($idCookie !== false) {
-			$parts = explode('.',$idCookie);
+            $parts = explode('.',$idCookie);
             if (strlen($parts[0]) == self::LENGTH_VISITOR_ID) {
-				$this->CookieVisitorId = $parts[0]; // provides backward compatibility since getVisitorId() didn't change any existing VisitorId value
-				$this->createTs = $parts[1];
-				$this->visitCount = $parts[2];
-				$this->currentVisitTs = $parts[3];
-				$this->lastVisitTs = $parts[4];
-				if (count($parts)>5) {
-					$this->lastEcommerceOrderTs = $parts[5];
-				} else {
-					$this->lastEcommerceOrderTs = false;
-				}
+                $this->CookieVisitorId = $parts[0]; // provides backward compatibility since getVisitorId() didn't change any existing VisitorId value
+                $this->createTs = $parts[1];
+                $this->visitCount = $parts[2];
+                $this->currentVisitTs = $parts[3];
+                $this->lastVisitTs = $parts[4];
+                if (count($parts)>5) {
+                    $this->lastEcommerceOrderTs = $parts[5];
+                } else {
+                    $this->lastEcommerceOrderTs = false;
+                }
                 return true;
             }
         }
-		return false;
-	}
-	
-	/**
-	 * Deletes all cookies from client
-	 * 
-	 */
-	protected function deleteCookies() 
-	{
-		$savedConfigCookiesDisabled = $configCookiesDisabled;
+        return false;
+    }
+    
+    /**
+     * Deletes all cookies from client
+     * 
+     */
+    protected function deleteCookies() 
+    {
+        $savedConfigCookiesDisabled = $configCookiesDisabled;
 
-		// Temporarily allow cookies just to delete the existing ones
-		$configCookiesDisabled = false;
-		setCookie($this->getCookieName('id'), '', -86400, configCookiePath, configCookieDomain);
-		setCookie($this->getCookieName('ses'), '', -86400, configCookiePath, configCookieDomain);
-		setCookie($this->getCookieName('cvar'), '', -86400, configCookiePath, configCookieDomain);
-		setCookie($this->getCookieName('ref'), '', -86400, configCookiePath, configCookieDomain);
+        // Temporarily allow cookies just to delete the existing ones
+        $configCookiesDisabled = false;
+        setCookie($this->getCookieName('id'), '', -86400, configCookiePath, configCookieDomain);
+        setCookie($this->getCookieName('ses'), '', -86400, configCookiePath, configCookieDomain);
+        setCookie($this->getCookieName('cvar'), '', -86400, configCookiePath, configCookieDomain);
+        setCookie($this->getCookieName('ref'), '', -86400, configCookiePath, configCookieDomain);
 
-		$configCookiesDisabled = $savedConfigCookiesDisabled;
-	}
-	
+        $configCookiesDisabled = $savedConfigCookiesDisabled;
+    }
+    
     /**
      * Returns the currently assigned Attribution Information stored in a first party cookie.
      *
@@ -1190,14 +1190,14 @@ class PiwikTracker
         // Reset page level custom variables after this page view
         $this->pageCustomVar = false;
 
-		// Update client cookies in getRequest to parallel piwik.js logic
-		if ($this->updateClientCookies) {
-			if ($visitorId != $this->visitorId || !$currentVisitTs) {
-				$this->setFirstPartyCookie('id', $visitorId . '.' . $this->currentTs . '.1.' . $this->currentTs . '.' . $this->currentTs ); 
-			} else {
-				$this->setFirstPartyCookie('id', $visitorId . '.' . $this->currentTs . '.1.' . $this->currentTs . '.' . $this->currentTs ); 
-			}
-		}
+        // Update client cookies in getRequest to parallel piwik.js logic
+        if ($this->updateClientCookies) {
+            if ($visitorId != $this->visitorId || !$currentVisitTs) {
+                $this->setFirstPartyCookie('id', $visitorId . '.' . $this->currentTs . '.1.' . $this->currentTs . '.' . $this->currentTs ); 
+            } else {
+                $this->setFirstPartyCookie('id', $visitorId . '.' . $this->currentTs . '.1.' . $this->currentTs . '.' . $this->currentTs ); 
+            }
+        }
 
         return $url;
     }

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -90,7 +90,7 @@ class PiwikTracker
         $this->requestCookie = '';
         $this->updateClientCookies = false;
         $this->clientCookieDomain = ''; 
-        $this->CookieVisitorId;
+        $this->cookieVisitorId;
         $this->createTs = false;
         $this->visitCount = false;
         $this->currentVisitTs = false;
@@ -822,7 +822,7 @@ class PiwikTracker
         if (!empty($this->forcedVisitorId)) {
             return $this->forcedVisitorId;
         } else if ($this->loadVisitorIdCookie()) {
-            return $this->CookieVisitorId;
+            return $this->cookieVisitorId;
         } else {
             return $this->visitorId;
         }
@@ -840,7 +840,7 @@ class PiwikTracker
         if ($idCookie !== false) {
             $parts = explode('.',$idCookie);
             if (strlen($parts[0]) == self::LENGTH_VISITOR_ID) {
-                $this->CookieVisitorId = $parts[0]; // provides backward compatibility since getVisitorId() didn't change any existing VisitorId value
+                $this->cookieVisitorId = $parts[0]; // provides backward compatibility since getVisitorId() didn't change any existing VisitorId value
                 $this->createTs = $parts[1];
                 $this->visitCount = $parts[2];
                 $this->currentVisitTs = $parts[3];

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -1200,7 +1200,7 @@ class PiwikTracker
 
         // Update client cookies in getRequest to parallel piwik.js logic
         if ($this->updateClientCookies) {
-			if (!$this->lastVisitTs) 
+			if (!$this->lastVisitTs) {
 				// Initialize cookie data if it's still defaulted to false
 				$this->loadVisitorIdCookie();
 			}

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -410,8 +410,6 @@ class PiwikTracker
     /**
      * Sets a first party cookie.  This is useful when using the PHP Tracking API along with the Javascript Tracking API.
      *
-     * @param string $baseName value will be combined with prefix and domain hash to determine the cookie name
-     * $param string $value indicates the value of the cookie to be stored on the client's computer
      * @return bool
      */
     protected function setVisitorIdCookie($visitorId, $createTs, $visitCount, $nowTs, $lastVisitTs, $lastEcommerceOrderTs = '')
@@ -1200,8 +1198,8 @@ class PiwikTracker
 
         // Update client cookies in getRequest to parallel piwik.js logic
         if ($this->updateClientCookies) {
+            // Initialize cookie data if it's still defaulted to false
             if (!$this->lastVisitTs) {
-                // Initialize cookie data if it's still defaulted to false
                 $this->loadVisitorIdCookie();
             }
             $sesname = $this->getCookieName('ses');

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -1144,14 +1144,23 @@ class PiwikTracker
             if (empty($this->lastVisitTs)) {
                 $this->loadVisitorIdCookie();
             }
+			// Set the id cookie
+            $this->setVisitorIdCookie($this->getVisitorId(), $this->createTs, $this->visitCount, $this->currentTs, $this->lastVisitTs, $this->lastEcommerceOrderTs); 
+			
+			// Set/update the session cookie
             $sesname = $this->getCookieName('ses');
             if (!$this->getCookieMatchingName($sesname)) {
                 // new session (new visit)
                 $this->visitCount++;
                 $this->lastVisitTs = $this->currentVisitTs;
             }
-            $this->setVisitorIdCookie($this->getVisitorId(), $this->createTs, $this->visitCount, $this->currentTs, $this->lastVisitTs, $this->lastEcommerceOrderTs); 
             setrawcookie($sesname, '*', $this->currentTs + $this->configSessionCookieTimeout / 1000, $this->clientCookiePath, $this->clientCookieDomain);
+			
+			// Set the custom variable cookie if custom variables have been set
+			if (!empty($this->visitorCustomVar)) {
+				$cvarame = $this->getCookieName('cvar');
+				setcookie($cvarname, json_encode($this->visitorCustomVar), $this->currentTs + $this->configSessionCookieTimeout / 1000, $this->clientCookiePath, $this->clientCookieDomain);
+			}
         }
 
         $url = $this->getBaseUrl() .

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -256,7 +256,7 @@ class PiwikTracker
 		
 		if ($this->updateClientCookies) {
 			$ts = time(); 
-			$this->setFirstPartyCookie('id', $visitorId . '.' . $ts . '.1.' . $ts . '.' . $ts ); 
+			$this->setFirstPartyCookie('id', $this->visitorId . '.' . $ts . '.1.' . $ts . '.' . $ts ); 
 		}
     }
 

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -109,13 +109,13 @@ class PiwikTracker
         }
         $this->setNewVisitorId();
 
-		// Life of the visitor cookie (in milliseconds)
-		$this->configVisitorCookieTimeout = 63072000000; // 2 years
-		// Life of the session cookie (in milliseconds)
-		$this->configSessionCookieTimeout = 1800000; // 30 minutes
-		// Life of the referral cookie (in milliseconds)
-		$this->configReferralCookieTimeout = 15768000000; // 6 months
-		
+        // Life of the visitor cookie (in milliseconds)
+        $this->configVisitorCookieTimeout = 63072000000; // 2 years
+        // Life of the session cookie (in milliseconds)
+        $this->configSessionCookieTimeout = 1800000; // 30 minutes
+        // Life of the referral cookie (in milliseconds)
+        $this->configReferralCookieTimeout = 15768000000; // 6 months
+        
         // Allow debug while blocking the request
         $this->requestTimeout = 600;
         $this->doBulkRequests = false;
@@ -850,18 +850,18 @@ class PiwikTracker
                 if (count($parts)>5) {
                     $this->lastEcommerceOrderTs = $parts[5];
                 } else {
-					$this->lastEcommerceOrderTs = '';
+                    $this->lastEcommerceOrderTs = '';
                 }
                 return true;
             }
         }
-		// If we didn't return true already, the cookie didn't exist or was invalid.
-		// Initialize default values
-		$this->createTs = $this->currentTs;
-		$this->visitCount = 1;
-		$this->currentVisitTs = $this->currentTs;
-		$this->lastVisitTs = $this->currentTs;
-		$this->lastEcommerceOrderTs = '';
+        // If we didn't return true already, the cookie didn't exist or was invalid.
+        // Initialize default values
+        $this->createTs = $this->currentTs;
+        $this->visitCount = 1;
+        $this->currentVisitTs = $this->currentTs;
+        $this->lastVisitTs = $this->currentTs;
+        $this->lastEcommerceOrderTs = '';
         return false;
     }
     
@@ -871,12 +871,12 @@ class PiwikTracker
      */
     public function deleteCookies() 
     {
-		return 
+        return 
         setcookie($this->getCookieName('id'), '', $this->currentTs - 86400, '/', $this->clientCookieDomain) && 
         setcookie($this->getCookieName('ses'), '', $this->currentTs - 86400, '/', $this->clientCookieDomain) &&
         setcookie($this->getCookieName('cvar'), '', $this->currentTs - 86400, '/', $this->clientCookieDomain) &&
         setcookie($this->getCookieName('ref'), '', $this->currentTs - 86400, '/', $this->clientCookieDomain);
-	}
+    }
     
     /**
      * Returns the currently assigned Attribution Information stored in a first party cookie.
@@ -1200,18 +1200,18 @@ class PiwikTracker
 
         // Update client cookies in getRequest to parallel piwik.js logic
         if ($this->updateClientCookies) {
-			if (!$this->lastVisitTs) {
-				// Initialize cookie data if it's still defaulted to false
-				$this->loadVisitorIdCookie();
-			}
-			$sesname = $this->getCookieName('ses');
-			if (!$this->getCookieMatchingName($sesname)) {
-				// new session (new visit)
-				$this->visitCount++;
-				$this->lastVisitTs = $this->currentVisitTs;
-			}
-			$this->setVisitorIdCookie($this->getVisitorId(), $this->createTs, $this->visitCount, $this->currentTs, $this->lastVisitTs, $this->lastEcommerceOrderTs); 
-			setcookie($sesname, '*', $this->currentTs + $this->configSessionCookieTimeout / 1000, '/', $this->clientCookieDomain);
+            if (!$this->lastVisitTs) {
+                // Initialize cookie data if it's still defaulted to false
+                $this->loadVisitorIdCookie();
+            }
+            $sesname = $this->getCookieName('ses');
+            if (!$this->getCookieMatchingName($sesname)) {
+                // new session (new visit)
+                $this->visitCount++;
+                $this->lastVisitTs = $this->currentVisitTs;
+            }
+            $this->setVisitorIdCookie($this->getVisitorId(), $this->createTs, $this->visitCount, $this->currentTs, $this->lastVisitTs, $this->lastEcommerceOrderTs); 
+            setcookie($sesname, '*', $this->currentTs + $this->configSessionCookieTimeout / 1000, '/', $this->clientCookieDomain);
         }
         return $url;
     }

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -858,17 +858,11 @@ class PiwikTracker
      */
     protected function deleteCookies() 
     {
-        $savedConfigCookiesDisabled = $configCookiesDisabled;
-
-        // Temporarily allow cookies just to delete the existing ones
-        $configCookiesDisabled = false;
-        setCookie($this->getCookieName('id'), '', -86400, configCookiePath, configCookieDomain);
-        setCookie($this->getCookieName('ses'), '', -86400, configCookiePath, configCookieDomain);
-        setCookie($this->getCookieName('cvar'), '', -86400, configCookiePath, configCookieDomain);
-        setCookie($this->getCookieName('ref'), '', -86400, configCookiePath, configCookieDomain);
-
-        $configCookiesDisabled = $savedConfigCookiesDisabled;
-    }
+        setcookie($this->getCookieName('id'), '', -86400, '', $this->clientCookieDomain);
+        setcookie($this->getCookieName('ses'), '', -86400, '', $this->clientCookieDomain);
+        setcookie($this->getCookieName('cvar'), '', -86400, '', $this->clientCookieDomain);
+        setcookie($this->getCookieName('ref'), '', -86400, '', $this->clientCookieDomain);
+   }
     
     /**
      * Returns the currently assigned Attribution Information stored in a first party cookie.

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -1146,7 +1146,7 @@ class PiwikTracker
                 $this->lastVisitTs = $this->currentVisitTs;
             }
             $this->setVisitorIdCookie($this->getVisitorId(), $this->createTs, $this->visitCount, $this->currentTs, $this->lastVisitTs, $this->lastEcommerceOrderTs); 
-            setcookie($sesname, '*', $this->currentTs + $this->configSessionCookieTimeout / 1000, '/', $this->clientCookieDomain);
+            setrawcookie($sesname, '*', $this->currentTs + $this->configSessionCookieTimeout / 1000, '/', $this->clientCookieDomain);
         }
 
         $url = $this->getBaseUrl() .

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -92,7 +92,7 @@ class PiwikTracker
         $this->clientCookiePath = '/';
         $this->clientCookieDomain = ''; 
         $this->newVisitor = 1;
-        $this->cookieVisitorId;
+        $this->cookieVisitorId = '';
         $this->currentTs = time();
         $this->createTs = $this->currentTs;
         $this->visitCount = 0;

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -95,7 +95,7 @@ class PiwikTracker
         $this->cookieVisitorId;
         $this->currentTs = time();
         $this->createTs = $this->currentTs;
-        $this->visitCount = 1;
+        $this->visitCount = 0;
         $this->currentVisitTs = '';
         $this->lastVisitTs = '';
         $this->lastEcommerceOrderTs = '';

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -89,9 +89,9 @@ class PiwikTracker
 
         $this->requestCookie = '';
         $this->updateClientCookies = false;
-		$this->clientCookiePath = '/';
+        $this->clientCookiePath = '/';
         $this->clientCookieDomain = ''; 
-		$this->newVisitor = 1;
+        $this->newVisitor = 1;
         $this->cookieVisitorId;
         $this->currentTs = time();
         $this->createTs = $this->currentTs;
@@ -381,7 +381,7 @@ class PiwikTracker
     {
         $this->updateClientCookies = $create;
         $this->clientCookieDomain = self::domainFixup($domain);
-		$this->clientCookiePath = $path;
+        $this->clientCookiePath = $path;
     }
 
     /*
@@ -843,7 +843,7 @@ class PiwikTracker
         if ($idCookie !== false) {
             $parts = explode('.',$idCookie);
             if (strlen($parts[0]) == self::LENGTH_VISITOR_ID) {
-				$this->newVisitor = 0;
+                $this->newVisitor = 0;
                 $this->cookieVisitorId = $parts[0]; // provides backward compatibility since getVisitorId() didn't change any existing VisitorId value
                 $this->createTs = $parts[1];
                 $this->visitCount = $parts[2];
@@ -1140,14 +1140,14 @@ class PiwikTracker
         // Update client cookies in getRequest to parallel piwik.js logic
         if ($this->updateClientCookies) {
             // If we're setting cookies, we want to make sure we've loaded prevoius cookies
-			// Initialize cookie data if it's still defaulted to false
+            // Initialize cookie data if it's still defaulted to false
             if (empty($this->lastVisitTs)) {
                 $this->loadVisitorIdCookie();
             }
-			// Set the id cookie
+            // Set the id cookie
             $this->setVisitorIdCookie($this->getVisitorId(), $this->createTs, $this->visitCount, $this->currentTs, $this->lastVisitTs, $this->lastEcommerceOrderTs); 
-			
-			// Set/update the session cookie
+            
+            // Set/update the session cookie
             $sesname = $this->getCookieName('ses');
             if (!$this->getCookieMatchingName($sesname)) {
                 // new session (new visit)
@@ -1155,12 +1155,12 @@ class PiwikTracker
                 $this->lastVisitTs = $this->currentVisitTs;
             }
             setrawcookie($sesname, '*', $this->currentTs + $this->configSessionCookieTimeout / 1000, $this->clientCookiePath, $this->clientCookieDomain);
-			
-			// Set the custom variable cookie if custom variables have been set
-			if (!empty($this->visitorCustomVar)) {
-				$cvarame = $this->getCookieName('cvar');
-				setcookie($cvarname, json_encode($this->visitorCustomVar), $this->currentTs + $this->configSessionCookieTimeout / 1000, $this->clientCookiePath, $this->clientCookieDomain);
-			}
+            
+            // Set the custom variable cookie if custom variables have been set
+            if (!empty($this->visitorCustomVar)) {
+                $cvarame = $this->getCookieName('cvar');
+                setcookie($cvarname, json_encode($this->visitorCustomVar), $this->currentTs + $this->configSessionCookieTimeout / 1000, $this->clientCookiePath, $this->clientCookieDomain);
+            }
         }
 
         $url = $this->getBaseUrl() .
@@ -1179,13 +1179,13 @@ class PiwikTracker
             (!empty($this->forcedDatetime) ? '&cdt=' . urlencode($this->forcedDatetime) : '') .
             ((!empty($this->token_auth) && !$this->doBulkRequests) ? '&token_auth=' . urlencode($this->token_auth) : '') .
 
-			// Values collected from cookie
-			'&_idts=' . $this->createTs .
-			'&_idvc=' . $this->visitCount .
-			'&_idn=' . $this->newVisitor . // currently unused
-			(!empty($this->lastVisitTs) ? '&_viewts=' . $this->lastVisitTs : '' ) . // note that piwik.js sends an empty value instead of skipping
-			(!empty($this->lastEcommerceOrderTs) ? '&_ects=' . $this->lastEcommerceOrderTs : '' ) .
-			
+            // Values collected from cookie
+            '&_idts=' . $this->createTs .
+            '&_idvc=' . $this->visitCount .
+            '&_idn=' . $this->newVisitor . // currently unused
+            (!empty($this->lastVisitTs) ? '&_viewts=' . $this->lastVisitTs : '' ) . // note that piwik.js sends an empty value instead of skipping
+            (!empty($this->lastEcommerceOrderTs) ? '&_ects=' . $this->lastEcommerceOrderTs : '' ) .
+            
             // These parameters are set by the JS, but optional when using API
             (!empty($this->plugins) ? $this->plugins : '') .
             (($this->localHour !== false && $this->localMinute !== false && $this->localSecond !== false) ? '&h=' . $this->localHour . '&m=' . $this->localMinute . '&s=' . $this->localSecond : '') .

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -1160,12 +1160,6 @@ class PiwikTracker
             '&apiv=' . self::VERSION .
             '&r=' . substr(strval(mt_rand()), 2, 6) .
 
-			// Values collected from cookie
-			'&_idts=' . $this->createTs .
-			'&_idvc=' . $this->visitCount .
-			(!empty($this->lastVisitTs) ? '&_viewts=' . $this->lastVisitTs : '' ) . // note that piwik.js sends an empty value instead of skipping
-			(!empty($this->lastEcommerceOrderTs) ? '&_ects=' . $this->lastEcommerceOrderTs : '' ) .
-			
             // XDEBUG_SESSIONS_START and KEY are related to the PHP Debugger, this can be ignored in other languages
             (!empty($_GET['XDEBUG_SESSION_START']) ? '&XDEBUG_SESSION_START=' . @urlencode($_GET['XDEBUG_SESSION_START']) : '') .
             (!empty($_GET['KEY']) ? '&KEY=' . @urlencode($_GET['KEY']) : '') .
@@ -1176,6 +1170,13 @@ class PiwikTracker
             (!empty($this->forcedDatetime) ? '&cdt=' . urlencode($this->forcedDatetime) : '') .
             ((!empty($this->token_auth) && !$this->doBulkRequests) ? '&token_auth=' . urlencode($this->token_auth) : '') .
 
+			// Values collected from cookie
+			'&_idts=' . $this->createTs .
+			'&_idvc=' . $this->visitCount .
+			'&_idn=' . $this->newVisitor . // currently unused
+			(!empty($this->lastVisitTs) ? '&_viewts=' . $this->lastVisitTs : '' ) . // note that piwik.js sends an empty value instead of skipping
+			(!empty($this->lastEcommerceOrderTs) ? '&_ects=' . $this->lastEcommerceOrderTs : '' ) .
+			
             // These parameters are set by the JS, but optional when using API
             (!empty($this->plugins) ? $this->plugins : '') .
             (($this->localHour !== false && $this->localMinute !== false && $this->localSecond !== false) ? '&h=' . $this->localHour . '&m=' . $this->localMinute . '&s=' . $this->localSecond : '') .

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -89,6 +89,7 @@ class PiwikTracker
 
         $this->requestCookie = '';
         $this->updateClientCookies = false;
+		$this->clientCookiePath = '/';
         $this->clientCookieDomain = ''; 
         $this->cookieVisitorId;
         $this->currentTs = time();
@@ -375,10 +376,11 @@ class PiwikTracker
      * @param bool $create determines whether or not client cookies will be updated
      * $param string $domain sets the domain under which the cookie will be placed (primarily used to create domain wildcard cookies)
      */
-    public function setUpdateClientCookies( $create, $domain = '' )
+    public function setUpdateClientCookies( $create, $domain = '', $path = '/' )
     {
         $this->updateClientCookies = $create;
         $this->clientCookieDomain = self::domainFixup($domain);
+		$this->clientCookiePath = $path;
     }
 
     /*
@@ -403,7 +405,7 @@ class PiwikTracker
     function getCookieName($baseName) {
         // NOTE: If the cookie name is changed, we must also update the method in piwik.js with
         // the same name.
-        $hash = substr( sha1( ($this->clientCookieDomain == '' ? self::getCurrentHost() : $this->clientCookieDomain)  . '/' ), 0, 4);
+        $hash = substr( sha1( ($this->clientCookieDomain == '' ? self::getCurrentHost() : $this->clientCookieDomain)  . $this->clientCookiePath ), 0, 4);
         return '_pk_' . $baseName . '.' . $this->idSite . '.' . $hash;
     }
      
@@ -414,7 +416,7 @@ class PiwikTracker
      */
     protected function setVisitorIdCookie($visitorId, $createTs, $visitCount, $nowTs, $lastVisitTs, $lastEcommerceOrderTs = '')
     {
-        return setcookie( $this->getCookieName('id'), $visitorId . '.' . $createTs . '.' . $visitCount . '.' . $nowTs . '.' . $lastVisitTs . '.' . $lastEcommerceOrderTs, $nowTs + $this->configVisitorCookieTimeout / 1000, '/', $this->clientCookieDomain );
+        return setcookie( $this->getCookieName('id'), $visitorId . '.' . $createTs . '.' . $visitCount . '.' . $nowTs . '.' . $lastVisitTs . '.' . $lastEcommerceOrderTs, $nowTs + $this->configVisitorCookieTimeout / 1000, $this->clientCookiePath, $this->clientCookieDomain );
     }
 
     /**
@@ -863,10 +865,10 @@ class PiwikTracker
     public function deleteCookies() 
     {
         return 
-        setcookie($this->getCookieName('id'), '', $this->currentTs - 86400, '/', $this->clientCookieDomain) && 
-        setcookie($this->getCookieName('ses'), '', $this->currentTs - 86400, '/', $this->clientCookieDomain) &&
-        setcookie($this->getCookieName('cvar'), '', $this->currentTs - 86400, '/', $this->clientCookieDomain) &&
-        setcookie($this->getCookieName('ref'), '', $this->currentTs - 86400, '/', $this->clientCookieDomain);
+        setcookie($this->getCookieName('id'), '', $this->currentTs - 86400, $this->clientCookiePath, $this->clientCookieDomain) && 
+        setcookie($this->getCookieName('ses'), '', $this->currentTs - 86400, $this->clientCookiePath, $this->clientCookieDomain) &&
+        setcookie($this->getCookieName('cvar'), '', $this->currentTs - 86400, $this->clientCookiePath, $this->clientCookieDomain) &&
+        setcookie($this->getCookieName('ref'), '', $this->currentTs - 86400, $this->clientCookiePath, $this->clientCookieDomain);
     }
     
     /**
@@ -1146,7 +1148,7 @@ class PiwikTracker
                 $this->lastVisitTs = $this->currentVisitTs;
             }
             $this->setVisitorIdCookie($this->getVisitorId(), $this->createTs, $this->visitCount, $this->currentTs, $this->lastVisitTs, $this->lastEcommerceOrderTs); 
-            setrawcookie($sesname, '*', $this->currentTs + $this->configSessionCookieTimeout / 1000, '/', $this->clientCookieDomain);
+            setrawcookie($sesname, '*', $this->currentTs + $this->configSessionCookieTimeout / 1000, $this->clientCookiePath, $this->clientCookieDomain);
         }
 
         $url = $this->getBaseUrl() .


### PR DESCRIPTION
This pull request adds variables, functions, and logic so PiwikTracker can update client cookies and may suffice to meet the request in ticket #3239 (http://dev.piwik.org/trac/ticket/3239).  The code was originally derived from the patch submitted (and ultimately not-accepted) in ticket #2699 (http://dev.piwik.org/trac/ticket/2699).  Deeper research showed that the logic inside this patch was incomplete and differed greatly from piwik.js.  In response, functions in Piwik.js were copied over and translated into PHP, refactoring existing code to leverage these functions.
