### PR TITLE
Add parameters to getJavascriptTag API call

### DIFF
--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -125,19 +125,19 @@ class Piwik
      * @param string $piwikUrl http://path/to/piwik/directory/
      * @return string
      */
-    static public function getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains = false, $groupPageTitlesByDomain = false, $mergeAliasUrls = false)
+    static public function getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains = false, $groupPageTitlesByDomain = false, $mergeAliasUrls = false, $visitorCustomVariables = false, $pageCustomVariables = false, $customCampaignNameQueryParam = false, $customCampaignKeywordParam = false, $doNotTrack = false)
     {
+		// changes made to this code should be mirrored in plugins/CoreAdminHome/javascripts/jsTrackingGenerator.js var generateJsCode
         $jsCode = file_get_contents(PIWIK_INCLUDE_PATH . "/plugins/Zeitgeist/templates/javascriptCode.tpl");
         $jsCode = htmlentities($jsCode);
         preg_match('~^(http|https)://(.*)$~D', $piwikUrl, $matches);
         $piwikUrl = @$matches[2];
         $jsCode = str_replace('{$idSite}', $idSite, $jsCode);
         $jsCode = str_replace('{$piwikUrl}', Common::sanitizeInputValue($piwikUrl), $jsCode);
-        $subdomainText = '';
-        $prependText = '';
-        $aliasText = '';
+		// Build optional parameters to be added to text
+        $options = '';
         if ($groupPageTitlesByDomain) {
-            $prependText = PHP_EOL . '  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);';
+            $options .= PHP_EOL . '  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);' . PHP_EOL;
         }
         if ($mergeSubdomains || $mergeAliasUrls) {
             // Both flags need URL data
@@ -150,15 +150,36 @@ class Piwik
             }
         }
         if ($mergeSubdomains) {
-            $subdomainText = PHP_EOL . '  _paq.push(["setCookieDomain", "*.' . $site_hosts[0] . '"]);';
+            $options .= PHP_EOL . '  _paq.push(["setCookieDomain", "*.' . $site_hosts[0] . '"]);' . PHP_EOL;
         }
         if ($mergeAliasUrls) {
             $urls = '["*.'.implode('","*.',$site_hosts).'"]';
-            $aliasText = PHP_EOL . '  _paq.push(["setDomains", '.$urls.']);';
+            $options .= '  _paq.push(["setDomains", '.$urls.']);' . PHP_EOL;
         }
-        $jsCode = str_replace(PHP_EOL . '{$mergeSubdomains}', $subdomainText, $jsCode);
-        $jsCode = str_replace(PHP_EOL . '{$groupPageTitlesByDomain}', $prependText, $jsCode);
-        $jsCode = str_replace(PHP_EOL . '{$mergeAliasUrls}', $aliasText, $jsCode);
+		if ($visitorCustomVariables) {
+			$options .=  '// you can set up to 5 custom variables for each visitor' . PHP_EOL;
+			$index = 0;
+			foreach ($visitorCustomVariables as $visitorCustomVariable) {
+				$options .=  '  _paq.push(["setCustomVariable", '.$index++.', "'.$visitorCustomVariable[0].'", "'.$visitorCustomVariable[1].'", "visitor"]);' . PHP_EOL;
+			}
+		}
+		if ($pageCustomVariables) {
+			$options .=  '  // you can set up to 5 custom variables for each action (page view, download, click, site search)' . PHP_EOL;
+			$index = 0;
+			foreach ($pageCustomVariables as $pageCustomVariable) {
+				$options .=  '  _paq.push(["setCustomVariable", '.$index++.', "'.$pageCustomVariable[0].'", "'.$pageCustomVariable[1].'", "page"]);' . PHP_EOL;
+			}
+		}
+		if ($customCampaignNameQueryParam) {
+			$options .=  '  _paq.push(["setCampaignNameKey", "'.$customCampaignNameQueryParam.'"]);' . PHP_EOL;
+		}
+		if ($customCampaignKeywordParam) {
+			$options .=  '  _paq.push(["setCampaignKeywordKey", "'.$customCampaignKeywordParam.'"]);' . PHP_EOL;
+		}
+		if ($doNotTrack) {
+			$options .= '  _paq.push(["setDoNotTrack", true]);' . PHP_EOL;
+		}
+        $jsCode = str_replace('{$options}'.PHP_EOL, $options, $jsCode);
         return $jsCode;
     }
 

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -152,7 +152,7 @@ class Piwik
             $urls = '["*.';
             foreach ($site_urls as $site_url) {
                 // We need to parse_url so we can exclude paths
-                $referrerParsed = parse_url($alia['url']);
+                $referrerParsed = parse_url($site_url);
                 $urls .= '","*.'.$referrerParsed['host'];
             }
             $urls .= '"]';

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -141,19 +141,19 @@ class Piwik
         }
         if ($mergeSubdomains || $mergeAliasUrls) {
             // Both flags need url data
-			$site_urls = API::getInstance()->getSiteUrlsFromId( $idSite );
+            $site_urls = APISitesManager::getInstance()->getSiteUrlsFromId( $idSite );
         }
         if ($mergeSubdomains) {
-			// We need to parse_url so we can exclude paths
+            // We need to parse_url so we can exclude paths
             $referrerParsed = parse_url($site_urls[0]);
             $subdomainText = PHP_EOL . '  _paq.push(["setCookieDomain", "*.' . $referrerParsed['host'] . '"]);';
         }
         if ($mergeAliasUrls) {
             $urls = '["*.';
             foreach ($site_urls as $site_url) {
-				// We need to parse_url so we can exclude paths
+                // We need to parse_url so we can exclude paths
                 $referrerParsed = parse_url($alia['url']);
-				$urls .= '","*.'.$referrerParsed['host'];
+                $urls .= '","*.'.$referrerParsed['host'];
             }
             $urls .= '"]';
             $aliasText = PHP_EOL . '  _paq.push(["setDomains", '.$urls.']);';

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -126,53 +126,53 @@ class Piwik
      */
     static public function getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains = false, $prependDomain = false, $hideAlias = false)
     {
-		$jsCode = file_get_contents(PIWIK_INCLUDE_PATH . "/plugins/Zeitgeist/templates/javascriptCode.tpl");
+        $jsCode = file_get_contents(PIWIK_INCLUDE_PATH . "/plugins/Zeitgeist/templates/javascriptCode.tpl");
         $jsCode = htmlentities($jsCode);
         preg_match('~^(http|https)://(.*)$~D', $piwikUrl, $matches);
         $piwikUrl = @$matches[2];
         $jsCode = str_replace('{$idSite}', $idSite, $jsCode);
         $jsCode = str_replace('{$piwikUrl}', Common::sanitizeInputValue($piwikUrl), $jsCode);
-		$subdomainText = '';
-		$prependText = '';
-		$aliasText = '';
-		if ($prependDomain) {
-			$prependText = PHP_EOL . '  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);';
-		}
+        $subdomainText = '';
+        $prependText = '';
+        $aliasText = '';
+        if ($prependDomain) {
+            $prependText = PHP_EOL . '  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);';
+        }
         if ($mergeSubdomains || $hideAlias) {
-			// Both flags need the main_url
-			$site = Db::get()->fetchRow("SELECT main_url
-								FROM " . Common::prefixTable("site") . "
-								WHERE idsite = ?", Common::sanitizeInputValue($idSite));
-			$referrerParsed = parse_url($site['main_url']);
-			// If we don't have a valid main_url, the flags cannot be processed successfully
-			// We could throw an exception, but this code will instead degrade gracefully
-			if (empty($referrerParsed['host'])) {
-				$mergeSubdomains = false;
-				$subdomainText = '/* Site must have a valid URL to track visitors across subdomains */';
-				$hideAlias = false;
-				$aliasText = PHP_EOL . '/* Site must have a valid URL to hide clicks known to alias site */';
-			}
-		}
+            // Both flags need the main_url
+            $site = Db::get()->fetchRow("SELECT main_url
+                                FROM " . Common::prefixTable("site") . "
+                                WHERE idsite = ?", Common::sanitizeInputValue($idSite));
+            $referrerParsed = parse_url($site['main_url']);
+            // If we don't have a valid main_url, the flags cannot be processed successfully
+            // We could throw an exception, but this code will instead degrade gracefully
+            if (empty($referrerParsed['host'])) {
+                $mergeSubdomains = false;
+                $subdomainText = '/* Site must have a valid URL to track visitors across subdomains */';
+                $hideAlias = false;
+                $aliasText = PHP_EOL . '/* Site must have a valid URL to hide clicks known to alias site */';
+            }
+        }
         if ($mergeSubdomains) {
-			$subdomainText = PHP_EOL . '  _paq.push(["setCookieDomain", "*.' . $referrerParsed['host'] . '"]);';
-		}
-		if ($hideAlias) {
-			$urls = '["*.' . $referrerParsed['host']; // We know this value is good else $hideAlias would be false from above
-			$alias = Db::get()->fetchAll("SELECT url
-								FROM " . Common::prefixTable("site_url") . "
-								WHERE idsite = ?", Common::sanitizeInputValue($idSite));
-			foreach ($alias as $alia) {
-				$referrerParsed = parse_url($alia['url']);
-				if (!empty($referrerParsed['host'])) {
-					$urls .= '","*.'.$referrerParsed['host'];
-				}
-			}
-			$urls .= '"]';
-			$aliasText = PHP_EOL . '  _paq.push(["setDomains", '.$urls.']);';
-		}
-		$jsCode = str_replace(PHP_EOL . '{$mergeSubdomains}', $subdomainText, $jsCode);
-		$jsCode = str_replace(PHP_EOL . '{$prependDomain}', $prependText, $jsCode);
-		$jsCode = str_replace(PHP_EOL . '{$hideAlias}', $aliasText, $jsCode);
+            $subdomainText = PHP_EOL . '  _paq.push(["setCookieDomain", "*.' . $referrerParsed['host'] . '"]);';
+        }
+        if ($hideAlias) {
+            $urls = '["*.' . $referrerParsed['host']; // We know this value is good else $hideAlias would be false from above
+            $alias = Db::get()->fetchAll("SELECT url
+                                FROM " . Common::prefixTable("site_url") . "
+                                WHERE idsite = ?", Common::sanitizeInputValue($idSite));
+            foreach ($alias as $alia) {
+                $referrerParsed = parse_url($alia['url']);
+                if (!empty($referrerParsed['host'])) {
+                    $urls .= '","*.'.$referrerParsed['host'];
+                }
+            }
+            $urls .= '"]';
+            $aliasText = PHP_EOL . '  _paq.push(["setDomains", '.$urls.']);';
+        }
+        $jsCode = str_replace(PHP_EOL . '{$mergeSubdomains}', $subdomainText, $jsCode);
+        $jsCode = str_replace(PHP_EOL . '{$prependDomain}', $prependText, $jsCode);
+        $jsCode = str_replace(PHP_EOL . '{$hideAlias}', $aliasText, $jsCode);
         return $jsCode;
     }
 

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -127,14 +127,14 @@ class Piwik
      */
     static public function getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains = false, $groupPageTitlesByDomain = false, $mergeAliasUrls = false, $visitorCustomVariables = false, $pageCustomVariables = false, $customCampaignNameQueryParam = false, $customCampaignKeywordParam = false, $doNotTrack = false)
     {
-		// changes made to this code should be mirrored in plugins/CoreAdminHome/javascripts/jsTrackingGenerator.js var generateJsCode
+        // changes made to this code should be mirrored in plugins/CoreAdminHome/javascripts/jsTrackingGenerator.js var generateJsCode
         $jsCode = file_get_contents(PIWIK_INCLUDE_PATH . "/plugins/Zeitgeist/templates/javascriptCode.tpl");
         $jsCode = htmlentities($jsCode);
         preg_match('~^(http|https)://(.*)$~D', $piwikUrl, $matches);
         $piwikUrl = @$matches[2];
         $jsCode = str_replace('{$idSite}', $idSite, $jsCode);
         $jsCode = str_replace('{$piwikUrl}', Common::sanitizeInputValue($piwikUrl), $jsCode);
-		// Build optional parameters to be added to text
+        // Build optional parameters to be added to text
         $options = '';
         if ($groupPageTitlesByDomain) {
             $options .= PHP_EOL . '  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);' . PHP_EOL;
@@ -156,29 +156,29 @@ class Piwik
             $urls = '["*.'.implode('","*.',$site_hosts).'"]';
             $options .= '  _paq.push(["setDomains", '.$urls.']);' . PHP_EOL;
         }
-		if ($visitorCustomVariables) {
-			$options .=  '// you can set up to 5 custom variables for each visitor' . PHP_EOL;
-			$index = 0;
-			foreach ($visitorCustomVariables as $visitorCustomVariable) {
-				$options .=  '  _paq.push(["setCustomVariable", '.$index++.', "'.$visitorCustomVariable[0].'", "'.$visitorCustomVariable[1].'", "visitor"]);' . PHP_EOL;
-			}
-		}
-		if ($pageCustomVariables) {
-			$options .=  '  // you can set up to 5 custom variables for each action (page view, download, click, site search)' . PHP_EOL;
-			$index = 0;
-			foreach ($pageCustomVariables as $pageCustomVariable) {
-				$options .=  '  _paq.push(["setCustomVariable", '.$index++.', "'.$pageCustomVariable[0].'", "'.$pageCustomVariable[1].'", "page"]);' . PHP_EOL;
-			}
-		}
-		if ($customCampaignNameQueryParam) {
-			$options .=  '  _paq.push(["setCampaignNameKey", "'.$customCampaignNameQueryParam.'"]);' . PHP_EOL;
-		}
-		if ($customCampaignKeywordParam) {
-			$options .=  '  _paq.push(["setCampaignKeywordKey", "'.$customCampaignKeywordParam.'"]);' . PHP_EOL;
-		}
-		if ($doNotTrack) {
-			$options .= '  _paq.push(["setDoNotTrack", true]);' . PHP_EOL;
-		}
+        if ($visitorCustomVariables) {
+            $options .=  '// you can set up to 5 custom variables for each visitor' . PHP_EOL;
+            $index = 0;
+            foreach ($visitorCustomVariables as $visitorCustomVariable) {
+                $options .=  '  _paq.push(["setCustomVariable", '.$index++.', "'.$visitorCustomVariable[0].'", "'.$visitorCustomVariable[1].'", "visitor"]);' . PHP_EOL;
+            }
+        }
+        if ($pageCustomVariables) {
+            $options .=  '  // you can set up to 5 custom variables for each action (page view, download, click, site search)' . PHP_EOL;
+            $index = 0;
+            foreach ($pageCustomVariables as $pageCustomVariable) {
+                $options .=  '  _paq.push(["setCustomVariable", '.$index++.', "'.$pageCustomVariable[0].'", "'.$pageCustomVariable[1].'", "page"]);' . PHP_EOL;
+            }
+        }
+        if ($customCampaignNameQueryParam) {
+            $options .=  '  _paq.push(["setCampaignNameKey", "'.$customCampaignNameQueryParam.'"]);' . PHP_EOL;
+        }
+        if ($customCampaignKeywordParam) {
+            $options .=  '  _paq.push(["setCampaignKeywordKey", "'.$customCampaignKeywordParam.'"]);' . PHP_EOL;
+        }
+        if ($doNotTrack) {
+            $options .= '  _paq.push(["setDoNotTrack", true]);' . PHP_EOL;
+        }
         $jsCode = str_replace('{$options}'.PHP_EOL, $options, $jsCode);
         return $jsCode;
     }

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -17,6 +17,7 @@ use Piwik\Db;
 
 use Piwik\Plugin;
 use Piwik\Plugins\UsersManager\API;
+use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Session;
 use Piwik\Tracker;
 use Piwik\View;

--- a/plugins/CoreAdminHome/javascripts/jsTrackingGenerator.js
+++ b/plugins/CoreAdminHome/javascripts/jsTrackingGenerator.js
@@ -212,6 +212,7 @@
             var idSite = params.idSite;
 
             // generate JS
+			// changes made to this code should be mirrored in core/Piwik.php function getJavascriptCode()
             var result = '<!-- Piwik -->\n\
 <script type="text/javascript">\n\
   var _paq = _paq || [];\n';

--- a/plugins/CoreAdminHome/javascripts/jsTrackingGenerator.js
+++ b/plugins/CoreAdminHome/javascripts/jsTrackingGenerator.js
@@ -212,7 +212,7 @@
             var idSite = params.idSite;
 
             // generate JS
-			// changes made to this code should be mirrored in core/Piwik.php function getJavascriptCode()
+            // changes made to this code should be mirrored in core/Piwik.php function getJavascriptCode()
             var result = '<!-- Piwik -->\n\
 <script type="text/javascript">\n\
   var _paq = _paq || [];\n';

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -65,7 +65,7 @@ class API extends \Piwik\Plugin\API
      * @param string $piwikUrl
      * @return string The Javascript tag ready to be included on the HTML pages
      */
-    public function getJavascriptTag($idSite, $piwikUrl = '', $mergeSubdomains = false, $prependDomain = false, $hideAlias = false)
+    public function getJavascriptTag($idSite, $piwikUrl = '', $mergeSubdomains = false, $groupPageTitlesByDomain = false, $mergeAliasUrls = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
@@ -74,7 +74,7 @@ class API extends \Piwik\Plugin\API
         }
         $piwikUrl = Common::sanitizeInputValues($piwikUrl);
 
-        $htmlEncoded = Piwik::getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains, $prependDomain, $hideAlias);
+        $htmlEncoded = Piwik::getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains, $groupPageTitlesByDomain, $mergeAliasUrls);
         $htmlEncoded = str_replace(array('<br>', '<br />', '<br/>'), '', $htmlEncoded);
         return $htmlEncoded;
     }

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -65,7 +65,7 @@ class API extends \Piwik\Plugin\API
      * @param string $piwikUrl
      * @return string The Javascript tag ready to be included on the HTML pages
      */
-    public function getJavascriptTag($idSite, $piwikUrl = '', $mergeSubdomains = false, $groupPageTitlesByDomain = false, $mergeAliasUrls = false)
+    public function getJavascriptTag($idSite, $piwikUrl = '', $mergeSubdomains = false, $groupPageTitlesByDomain = false, $mergeAliasUrls = false, $visitorCustomVariables = false, $pageCustomVariables = false, $customCampaignNameQueryParam = false, $customCampaignKeywordParam = false, $doNotTrack = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
@@ -74,7 +74,7 @@ class API extends \Piwik\Plugin\API
         }
         $piwikUrl = Common::sanitizeInputValues($piwikUrl);
 
-        $htmlEncoded = Piwik::getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains, $groupPageTitlesByDomain, $mergeAliasUrls);
+        $htmlEncoded = Piwik::getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains, $groupPageTitlesByDomain, $mergeAliasUrls, $visitorCustomVariables, $pageCustomVariables, $customCampaignNameQueryParam, $customCampaignKeywordParam, $doNotTrack);
         $htmlEncoded = str_replace(array('<br>', '<br />', '<br/>'), '', $htmlEncoded);
         return $htmlEncoded;
     }

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -65,7 +65,7 @@ class API extends \Piwik\Plugin\API
      * @param string $piwikUrl
      * @return string The Javascript tag ready to be included on the HTML pages
      */
-    public function getJavascriptTag($idSite, $piwikUrl = '')
+    public function getJavascriptTag($idSite, $piwikUrl = '', $mergeSubdomains = false, $prependDomain = false, $hideAlias = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
@@ -74,7 +74,7 @@ class API extends \Piwik\Plugin\API
         }
         $piwikUrl = Common::sanitizeInputValues($piwikUrl);
 
-        $htmlEncoded = Piwik::getJavascriptCode($idSite, $piwikUrl);
+        $htmlEncoded = Piwik::getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains, $prependDomain, $hideAlias);
         $htmlEncoded = str_replace(array('<br>', '<br />', '<br/>'), '', $htmlEncoded);
         return $htmlEncoded;
     }

--- a/plugins/Zeitgeist/templates/javascriptCode.tpl
+++ b/plugins/Zeitgeist/templates/javascriptCode.tpl
@@ -1,9 +1,7 @@
 <!-- Piwik -->
 <script type="text/javascript"> 
   var _paq = _paq || [];
-{$groupPageTitlesByDomain}
-{$mergeSubdomains}
-{$mergeAliasUrls}
+{$options}
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {

--- a/plugins/Zeitgeist/templates/javascriptCode.tpl
+++ b/plugins/Zeitgeist/templates/javascriptCode.tpl
@@ -1,9 +1,9 @@
 <!-- Piwik -->
 <script type="text/javascript"> 
   var _paq = _paq || [];
-{$prependDomain}
+{$groupPageTitlesByDomain}
 {$mergeSubdomains}
-{$hideAlias}
+{$mergeAliasUrls}
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {

--- a/plugins/Zeitgeist/templates/javascriptCode.tpl
+++ b/plugins/Zeitgeist/templates/javascriptCode.tpl
@@ -1,6 +1,9 @@
 <!-- Piwik -->
 <script type="text/javascript"> 
   var _paq = _paq || [];
+{$prependDomain}
+{$mergeSubdomains}
+{$hideAlias}
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {


### PR DESCRIPTION
This pull request brings the getJavascriptTag API call up to parity with the Piwik Administrative interface (Tracking Code section) by adding three boolean parameters:
- mergeSubdomains:  Track visitors across all subdomains of [site name]
- prependDomain:  Prepend the site domain to the page title when tracking
- hideAlias:  In the "Outlinks" report, hide clicks to known alias URLs of [site name]

Please note that the new code makes database calls.  I'm not certain how you normally sanitize user input so I have applied `Common::sanitizeInputValue()` to the variables that could be used to inject SQL.  Please provide guidance if you prefer a different strategy.
