### PR TITLE
Adding a function to piwik.js to hook an external js file that can be fired when piwik.js is not

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -1933,6 +1933,14 @@ if (typeof Piwik !== 'object') {
             }
 
             /*
+             * Log other signals (e.g. events)
+             */
+            function logGeneral(customData) {
+                var request = getRequest(customData, 'general');
+                sendRequest(request, configTrackerPause);
+            }
+
+            /*
              * Browser prefix
              */
             function prefixPropertyName(prefix, propertyName) {
@@ -2943,6 +2951,10 @@ if (typeof Piwik !== 'object') {
                  */
                 trackEcommerceCartUpdate: function (grandTotal) {
                     logEcommerceCartUpdate(grandTotal);
+                },
+
+                generalTracker: function(customData) {
+                    logGeneral(customData);
                 }
 
             };

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2953,6 +2953,12 @@ if (typeof Piwik !== 'object') {
                     logEcommerceCartUpdate(grandTotal);
                 },
 
+                /**
+                 * Tracks everything that is not directly tracked by Piwik. E.g. piwik.js is not fired when a scroll happens, calling this function allows us to us the
+                 * getRequest method without rewriting it in an external js file.
+                 *
+                 * @param string customData data that will be added to the final request
+                 */
                 generalTracker: function(customData) {
                     logGeneral(customData);
                 }


### PR DESCRIPTION
Adding a new function to piwik.js in order to be able to hook an external js file that could be fired when piwik.js is not fired. 
E.g. to track scrolls, piwik.js is not fired. In order not to rewrite the entire getRequest method from piwik.js, add the possibility to hook an external js file which takes care of this new tracking and can then use the core to send the request.
