### PR TITLE
Anonymize IP exceptions

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -412,6 +412,10 @@ page_maximum_length = 1024;
 ; For IPv6 addresses 0..4 means that 0, 64, 80, 104 or all bits are masked.
 ip_address_mask_length = 1
 
+; Use anonymized IP to enrich visits in plugins.
+; Setting this to 0 allows, for example to get a more precise gelocation or ISP detection.
+use_anonymized_ip_for_visit_enrichment = 1
+
 ; Tracker cache files are the simple caching layer for Tracking.
 ; TTL: Time to live for cache files, in seconds. Default to 5 minutes.
 tracker_cache_file_ttl = 300

--- a/lang/en.json
+++ b/lang/en.json
@@ -698,7 +698,9 @@
         "GetPurgeEstimate": "Get purge estimate",
         "CannotLockSoDeleteLogActions": "The log_action table will not be purged: please grant the LOCK TABLES privilege to the '%s' MYSQL user.",
         "DBPurged": "DB purged.",
-        "GeolocationAnonymizeIpNote": "Note: Geolocation will have approximately the same results with 1 byte anonymized. With 2 bytes or more, Geolocation will be inaccurate."
+        "GeolocationAnonymizeIpNote": "Note: Geolocation will have approximately the same results with 1 byte anonymized. With 2 bytes or more, Geolocation will be inaccurate.",
+        "UseAnonymizedIpForVisitEnrichment": "Use anonymized IP adresses for visit enrichment.",
+        "UseAnonymizedIpForVisitEnrichmentNote": "If you have enabled the Anonymize IP feature, by default, Geo Location via geoip and Provider reverse name lookups will use the anonymized IP address. You can set this setting to let plugins use the full IP address when enriching visitor information.<br />Note: the IP will always be stored anonymized in the database."
     },
     "CorePluginsAdmin": {
         "PluginDescription": "Plugins Administration Interface.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1253,6 +1253,8 @@
         "Teaser": "Sur cette page, vous pouvez personnaliser Piwik pour que sa gestion de la vie privée respecte la législation en vigueur, en : %s rendant anonyme l'adresse IP du visiteur%s, %s supprime automatiquement les anciens logs de visiteurs de la base de données%s, et %s fournit un mécanisme d'exclusion pour votre site web%s.",
         "TeaserHeadline": "Paramètres de vie privée",
         "UseAnonymizeIp": "Rendre anonymes les adresses IP des visiteurs",
+        "UseAnonymizedIpForVisitEnrichment": "Utiliser les adresses IP anonymisées pour enrichir les visites",
+        "UseAnonymizedIpForVisitEnrichmentNote": "Si vous avez activé l'anonymisation des adresses IP, la géolocalisation (via geoip) et la recherche du FAI utiliseront, par défaut, l'adresse IP anonymisée. Vous pouvez modifier ce paramètre pour permettre l'autorisation de l'adresse IP complète pour l'enrichissement des informations sur le visiteur.<br />Note: quelle que soit la valeur de ce paramètre, l'adresse IP sera stockée sous forme anonymisée dans la base de données.",
         "UseDeleteLog": "Supprimer régulièrement les anciens logs de la base de données.",
         "UseDeleteReports": "Supprimer régulièrement les anciens rapports de la base de données"
     },

--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -42,6 +42,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                     $this->handlePluginState(Common::getRequestVar("anonymizeIPEnable", 0));
                     $trackerConfig = Config::getInstance()->Tracker;
                     $trackerConfig['ip_address_mask_length'] = Common::getRequestVar("maskLength", 1);
+                    $trackerConfig['use_anonymized_ip_for_visit_enrichment'] = Common::getRequestVar("useAnonymizedIpForVisitEnrichment", 1);
                     Config::getInstance()->Tracker = $trackerConfig;
                     Config::getInstance()->forceSave();
                     break;
@@ -227,10 +228,12 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         \Piwik\Plugin\Manager::getInstance()->loadPlugin(self::ANONYMIZE_IP_PLUGIN_NAME);
 
+        $trackerConfig = Config::getInstance()->Tracker;
         $anonymizeIP["name"] = self::ANONYMIZE_IP_PLUGIN_NAME;
         $anonymizeIP["enabled"] = \Piwik\Plugin\Manager::getInstance()->isPluginActivated(self::ANONYMIZE_IP_PLUGIN_NAME);
-        $anonymizeIP["maskLength"] = Config::getInstance()->Tracker['ip_address_mask_length'];
+        $anonymizeIP["maskLength"] = $trackerConfig['ip_address_mask_length'];
         $anonymizeIP["info"] = \Piwik\Plugin\Manager::getInstance()->getLoadedPlugin(self::ANONYMIZE_IP_PLUGIN_NAME)->getInformation();
+        $anonymizeIP["useAnonymizedIpForVisitEnrichment"] = $trackerConfig['use_anonymized_ip_for_visit_enrichment'];
 
         return $anonymizeIP;
     }

--- a/plugins/PrivacyManager/templates/privacySettings.twig
+++ b/plugins/PrivacyManager/templates/privacySettings.twig
@@ -48,6 +48,22 @@
                         {{ piwik.inlineHelp('PrivacyManager_GeolocationAnonymizeIpNote'|translate) }}
                     </td>
                 </tr>
+                <tr>
+                    <td width="250">
+                        {{ 'PrivacyManager_UseAnonymizedIpForVisitEnrichment'|translate }}
+                    </td>
+                    <td width='500'>
+                        <label>
+                            <input type="radio" name="useAnonymizedIpForVisitEnrichment" value="1" {% if anonymizeIP.useAnonymizedIpForVisitEnrichment == '1' %}checked {% endif %}/> {{ 'General_Yes'|translate }}
+                        </label>
+                        <label>
+                            <input type="radio" name="useAnonymizedIpForVisitEnrichment" value="0" style="margin-left:20px;" {% if anonymizeIP.useAnonymizedIpForVisitEnrichment == '0' %} checked {% endif %}/>  {{ 'General_No'|translate }}
+                        </label>
+                    </td>
+                    <td width="200">
+                        {{ piwik.inlineHelp('PrivacyManager_UseAnonymizedIpForVisitEnrichmentNote'|translate) }}
+                    </td>
+                </tr>
             </table>
         </div>
         <input type="submit" value="{{ 'General_Save'|translate }}" id="privacySettingsSubmit" class="submit"/>

--- a/plugins/Provider/Provider.php
+++ b/plugins/Provider/Provider.php
@@ -13,6 +13,7 @@ namespace Piwik\Plugins\Provider;
 use Exception;
 use Piwik\ArchiveProcessor;
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\Db;
 
 use Piwik\FrontController;
@@ -119,7 +120,7 @@ class Provider extends \Piwik\Plugin
             return;
         }
 
-        $ip = IP::N2P($visitorInfo['location_ip']);
+        $ip = IP::N2P(Config::getInstance()->Tracker['use_anonymized_ip_for_visit_enrichment'] == 1 ? $visitorInfo['location_ip'] : $request->getIp());
 
         // In case the IP was anonymized, we should not continue since the DNS reverse lookup will fail and this will slow down tracking
         if (substr($ip, -2, 2) == '.0') {

--- a/plugins/UserCountry/UserCountry.php
+++ b/plugins/UserCountry/UserCountry.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\UserCountry;
 
 use Piwik\ArchiveProcessor;
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\IP;
 use Piwik\Menu\MenuAdmin;
 use Piwik\Menu\MenuMain;
@@ -87,7 +88,7 @@ class UserCountry extends \Piwik\Plugin
 
         $userInfo = array(
             'lang' => $visitorInfo['location_browser_lang'],
-            'ip'   => IP::N2P($visitorInfo['location_ip'])
+            'ip' => IP::N2P(Config::getInstance()->Tracker['use_anonymized_ip_for_visit_enrichment'] == 1 ? $visitorInfo['location_ip'] : $request->getIp())
         );
 
         $location = array();


### PR DESCRIPTION
I added two options to the Privacy settings page:
- Allow using non-anonymized IP address to determine the visitor's location
- Allow using non-anonymized IP address to determine the visitor's ISP

When these are activated, the visitor's original IP address is used to determine location and/or ISP, in order to get a more accurate value.

The IP address saved in the `log_visit` table will honor the `ip_address_mask_length` setting.
