### PR TITLE
Allow wildcard domain for 3rd party cookies to be set explicitly in config.ini.php

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -337,6 +337,10 @@ enable_marketplace = 0
 ; this is useful when you want to do cross websites analysis
 use_third_party_id_cookie = 0
 
+; Allows to explicitly define a cookie domain for 3rd party cookies. Requires
+; the property 'use_third_party_id_cookie' to be set to 1
+cookie_domain = 
+
 ; There is a feature in the Tracking API that lets you create new visit at any given time, for example if you know that a different user/customer is using
 ; the app then you would want to tell Piwik to create a new visit (even though both users are using the same browser/computer).
 ; To prevent abuse and easy creation of fake visits, this feature requires admin token_auth by default

--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -143,8 +143,14 @@ class Cookie
             if (!strncasecmp($Domain, 'www.', 4)) {
                 $Domain = substr($Domain, 4);
             }
-            $Domain = '.' . $Domain;
 
+            if (strncasecmp($Domain, '*', 1) == 0) {
+                $Domain = substr($Domain, 1);
+            }
+            if (strncasecmp($Domain, '.', 1) != 0) {
+                $Domain = '.' . $Domain;
+            }
+            
             // Remove port information.
             $Port = strpos($Domain, ':');
             if ($Port !== false) $Domain = substr($Domain, 0, $Port);

--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -83,10 +83,11 @@ class Cookie
      * @param string $path The path on the server in which the cookie will be available on.
      * @param bool|string $keyStore Will be used to store several bits of data (eg. one array per website)
      */
-    public function __construct($cookieName, $expire = null, $path = null, $keyStore = false)
+    public function __construct($cookieName, $expire = null, $path = null, $domain = null, $keyStore = false)
     {
         $this->name = $cookieName;
         $this->path = $path;
+        $this->domain = $domain;
         $this->expire = $expire;
         if (is_null($expire)
             || !is_numeric($expire)

--- a/core/Tracker/IgnoreCookie.php
+++ b/core/Tracker/IgnoreCookie.php
@@ -30,8 +30,9 @@ class IgnoreCookie
     {
         $cookie_name = @Config::getInstance()->Tracker['cookie_name'];
         $cookie_path = @Config::getInstance()->Tracker['cookie_path'];
+        $cookie_domain = @Piwik_Config::getInstance()->Tracker['cookie_domain']; 
 
-        return new Cookie($cookie_name, null, $cookie_path);
+        return new Cookie($cookie_name, null, $cookie_path, $cookie_domain);
     }
 
     /**
@@ -43,8 +44,9 @@ class IgnoreCookie
     {
         $cookie_name = @Config::getInstance()->Tracker['ignore_visits_cookie_name'];
         $cookie_path = @Config::getInstance()->Tracker['cookie_path'];
+        $cookie_domain = @Piwik_Config::getInstance()->Tracker['cookie_domain']; 
 
-        return new Cookie($cookie_name, null, $cookie_path);
+        return new Cookie($cookie_name, null, $cookie_path, $cookie_domain);
     }
 
     /**

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -393,7 +393,8 @@ class Request
         $cookie = new Cookie(
             $this->getCookieName(),
             $this->getCookieExpire(),
-            $this->getCookiePath());
+            $this->getCookiePath(),
+            $this->getCookieDomain());
         Common::printDebug($cookie);
         return $cookie;
     }
@@ -408,6 +409,15 @@ class Request
         return $this->getCurrentTimestamp() + Config::getInstance()->Tracker['cookie_expire'];
     }
 
+     /**
+     * Returns cookie domain
+     * @return string
+     */
+    protected function getCookieDomain()
+    {
+        return Piwik_Config::getInstance()->Tracker['cookie_domain'];
+    }
+    
     protected function getCookiePath()
     {
         return Config::getInstance()->Tracker['cookie_path'];


### PR DESCRIPTION
Pull request for the enhancements discussed in this thread: http://forum.piwik.org/read.php?2,107159,page=1#msg-107379

Please note that in order that this feature can work propperly an entry in the config.ini.php must be set. The key for that entry is "cookie_domain". I was not sure whether there must be a default value set somewhere else for that config key. Means: I do not know whether there would be a runtime error in line 418 of Request.php in case that value is not set in config.ini.php.
