### PR TITLE
added hook allowing to replace idSite in Live plugin API

### DIFF
--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -586,7 +586,10 @@ class API extends \Piwik\Plugin\API
     private function loadLastVisitorDetailsFromDatabase($idSite, $period, $date, $segment = false, $numLastVisitorsToFetch = 100, $visitorId = false, $minTimestamp = false)
     {
         $where = $whereBind = array();
-        $where[] = "log_visit.idsite = ? ";
+        $where[] = "log_visit.idsite in (?) ";
+
+        Piwik::postEvent('Live.API.getIdSitesString', array(&$idSite));
+
         $whereBind[] = $idSite;
         $orderBy = "idsite, visit_last_action_time DESC";
         $orderByParent = "sub.visit_last_action_time DESC";


### PR DESCRIPTION
This pull request adds possibility to alter idSite parameter in Live plugin API so that other plugins can replace single idSite with imploded string of other idSites. It could be that it's not the only place that should be changed to fully introduce this functionality for Live plugin, so in that case just please let me know where else should this be added and I'll update pull request.
