### PR TITLE
Add using Piwik\Common

### DIFF
--- a/core/Tracker/ActionClickUrl.php
+++ b/core/Tracker/ActionClickUrl.php
@@ -11,6 +11,7 @@
 
 namespace Piwik\Tracker;
 
+use Piwik\Common;
 use Piwik\Tracker;
 
 /**


### PR DESCRIPTION
Following error:
PHP Fatal error:  Class 'Piwik\Tracker\Common' not found in /var/www/piwik/core/Tracker/ActionClickUrl.php on line 43
