### PR TITLE
Fixed tracking actions with empty page title

### DIFF
--- a/core/Tracker/TableLogAction.php
+++ b/core/Tracker/TableLogAction.php
@@ -157,7 +157,7 @@ class TableLogAction
         foreach ($actionsNameAndType as $fieldName => &$actionNameType) {
             @list($name, $type, $urlPrefix) = $actionNameType;
             if (empty($name)) {
-                $fieldNameToActionId[$fieldName] = false;
+                $fieldNameToActionId[$fieldName] = 0;
                 continue;
             }
 


### PR DESCRIPTION
Setting idaction_name in log_link_visit_action to false (this is by default) returns error with incorrect integer value for this column.
