### PR TITLE
Fixed issue where browser language was greater than 20 characters

### DIFF
--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -609,7 +609,7 @@ class Visit implements VisitInterface
         $os = UserAgentParser::getOperatingSystem($userAgent);
         $os = $os === false ? 'UNK' : $os['id'];
 
-        $browserLang = $this->request->getBrowserLanguage();
+        $browserLang = substr($this->request->getBrowserLanguage(), 20); // limit the length of this string to match db
         $configurationHash = $this->getConfigHash(
             $os,
             $browserName,


### PR DESCRIPTION
Truncate the browser language string to match database specs and avoid sql error:

Error query: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column &#039;location_browser_lang&#039; at row 1
