### PR TITLE
Fixing PEAR.php path so that the GeoIP untar can function properly witho...

### DIFF
--- a/libs/Archive_Tar/Tar.php
+++ b/libs/Archive_Tar/Tar.php
@@ -39,7 +39,7 @@
  * @link      http://pear.php.net/package/Archive_Tar
  */
 
-require_once './libs/PEAR.php';
+require_once __DIR__ . "../PEAR.php";
 
 define('ARCHIVE_TAR_ATT_SEPARATOR', 90001);
 define('ARCHIVE_TAR_END_BLOCK', pack("a512", ''));

--- a/libs/Archive_Tar/Tar.php
+++ b/libs/Archive_Tar/Tar.php
@@ -39,7 +39,7 @@
  * @link      http://pear.php.net/package/Archive_Tar
  */
 
-require_once 'PEAR.php';
+require_once './libs/PEAR.php';
 
 define('ARCHIVE_TAR_ATT_SEPARATOR', 90001);
 define('ARCHIVE_TAR_END_BLOCK', pack("a512", ''));


### PR DESCRIPTION
...ut needing php-pear to be installed - bug #4533
