### PR TITLE
Ensure Database is set in Tracker

### DIFF
--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -562,6 +562,9 @@ class Tracker
      */
     public static function getDatabase()
     {
+        if (empty(self::$db)) {
+            self::connectDatabaseIfNotConnected();
+        }
         return self::$db;
     }
 


### PR DESCRIPTION
Perform an added check to ensure the database is connected prior to returning it. 
Corrects an error encountered in bulk tracking with PIWIK_TRACKER_MODE set.
