### PR TITLE
Added a setSiteAliasUrls method to the SitesManager API

### DIFF
--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -713,6 +713,28 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
+     * Set the list of alias Urls for the given idSite
+     *
+     * Completely overwrites the current list of URLs with the provided list.
+     * The 'main_url' of the website won't be affected by this method.
+     *
+     * @return int the number of inserted URLs
+     */
+    public function setSiteAliasUrls($idSite, $urls)
+    {
+        Piwik::checkUserHasAdminAccess($idSite);
+
+        $urls = $this->cleanParameterUrls($urls);
+        $this->checkUrls($urls);
+
+	$this->deleteSiteAliasUrls($idSite);
+        $this->insertSiteUrls($idSite, $urls);
+        $this->postUpdateWebsite($idSite);
+
+        return count($urls);
+    }
+
+    /**
      * Get the start and end IP addresses for an IP address range
      *
      * @param string $ipRange IP address range in presentation format


### PR DESCRIPTION
This method works in a similar way to the addSiteAliasUrls method, but it completely overwrites the URL list rather than merely adding to it.

My use case: my site has an admin system where aliases can be added and removed by the users, and we need to update Piwik's alias list automatically. It's far easier to simply send over an API request containing the full list every time than to use the "add" method. The other option would be to use updateSite, but that means getting all the other data required by updateSite to send back.
