### PR TITLE
fixed API response for php format with multidimensional arrays

### DIFF
--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -396,10 +396,7 @@ class ResponseBuilder
                                 break;
 
                             case 'php':
-                                if ($this->caseRendererPHPSerialize($defaultSerialize = 0)) {
-                                    return serialize($array);
-                                }
-                                return $array;
+                                return serialize($array);
 
                             case 'xml':
                                 @header("Content-Type: text/xml;charset=utf-8");


### PR DESCRIPTION
This should fix invalid response from API, where are multidimensional arrays in the result. ScheduledReports.getReports is the one i tested it with. The current response is `Array` and produces a warning:

```
Notice: Array to string conversion in core/dispatch.php on line 33
Backtrace -->

 #0 Piwik\Error::errorHandler(...) called at [core/dispatch.php:33]
 #1 require_once(...) called at [index.php:47]
```

I tested this only with this one api call, so not sure if this is even a proper fix.
