### PR TITLE
Corrects a issue where the Login is lost (Zend-Server 6.3/PHP 5.5)

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -35,6 +35,8 @@ use Piwik\Url;
 use Piwik\View;
 use Piwik\View\ViewInterface;
 use Piwik\ViewDataTable\Factory as ViewDataTableFactory;
+/* PHP-5.5 */
+use Piwik\Session;
 
 /**
  * Base class of all plugin Controllers.
@@ -730,6 +732,9 @@ abstract class Controller
                 . "&period=" . $defaultPeriod
                 . "&date=" . $defaultDate
                 . $parametersString;
+
+            /* PHP-5.5: Close Session */
+            Session::writeClose();
             header($url);
             exit;
         }

--- a/core/Session.php
+++ b/core/Session.php
@@ -112,7 +112,8 @@ class Session extends Zend_Session
         }
 
         try {
-            Zend_Session::start();
+        	/* PHP-5.5: Call parent function */
+            parent::start();
             register_shutdown_function(array('Zend_Session', 'writeClose'), true);
         } catch (Exception $e) {
             Log::warning('Unable to start session: ' . $e->getMessage());
@@ -146,4 +147,31 @@ class Session extends Zend_Session
         $path = PIWIK_USER_PATH . '/tmp/sessions';
         return SettingsPiwik::rewriteTmpPathWithHostname($path);
     }
+    
+    /*
+     * Regenerate the Session PHP 5.5 compatible
+     * by PILLWAX Industrial Solutions Consulting
+     */
+    public static function regenerateId()
+    {
+    	/* PHP 5.5: */
+    	if (!self::$_unitTestEnabled && headers_sent($filename, $linenum)) {
+    		throw new Zend_Session_Exception("You must call " . __CLASS__ . '::' . __FUNCTION__ .
+    				"() before any output has been sent to the browser; output started in {$filename}/{$linenum}");
+    	}
+    	
+    	if ( !self::$sessionStarted ) {
+    		self::start();
+    	} else {
+    		if (!self::$_unitTestEnabled) {
+    			/* PHP-5.5: Regenerate Session-ID WITH keeping session data */
+    			session_regenerate_id(true);
+    			$sid = session_id();
+    			session_write_close();
+    			session_id($sid);
+    			session_start();
+    		}
+    	}
+    }    
+    
 }

--- a/core/Url.php
+++ b/core/Url.php
@@ -465,6 +465,8 @@ class Url
         if (UrlHelper::isLookLikeUrl($url)
             || strpos($url, 'index.php') === 0
         ) {
+        	/* PHP-5.5: Close Session */
+        	Session::writeClose();
             @header("Location: $url");
         } else {
             echo "Invalid URL to redirect to.";

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -78,6 +78,9 @@ class Auth implements \Piwik\Auth
     {
         $tokenAuth = API::getInstance()->getTokenAuth($login, $md5Password);
 
+        /* PHP-5.5: Regenerate Session before Cookie is created to keep session */
+        @Session::regenerateId();
+        
         $this->setLogin($login);
         $this->setTokenAuth($tokenAuth);
         $authResult = $this->authenticate();
@@ -97,7 +100,8 @@ class Auth implements \Piwik\Auth
         $cookie->setHttpOnly(true);
         $cookie->save();
 
-        @Session::regenerateId();
+        /* PHP-5-5: Do not regenerate Session here, cookie looses session */
+        /* @Session::regenerateId(); */
 
         // remove password reset entry if it exists
         Login::removePasswordResetInfo($login);


### PR DESCRIPTION
Corrects a issue where the Login is lost on Zend-Server 6.3 and PHP 5.5 and PIWIK returing to Login-Screen without message after successful login.

This is in response to Ticket #4806:
http://dev.piwik.org/trac/ticket/4806

Does regenerate the Session-ID as originally intended, however keeps the
session with the browsers resulting in a stable login on the above PHP
environment.
