### PR TITLE
Add public accessor Tracker.getRequest() for plugin needs

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2402,6 +2402,16 @@ if (typeof Piwik !== 'object') {
                 },
 
                 /**
+                 * Returns the URL to call piwik.php,
+                 * with the standard parameters (plugins, resolution, url, referrer, etc.).
+                 *
+                 * @return string Raw URL
+                 */
+                getRequest: function(request, customData, pluginMethod, currentEcommerceOrderTs){
+                    return getRequest(request, customData, pluginMethod, currentEcommerceOrderTs);
+                },
+
+                /**
                  * Specify the Piwik server URL
                  *
                  * @param string trackerUrl


### PR DESCRIPTION
Hi there!

I'm working on a plugin for piwik, and I need the function getRequest from the Tracker to be accessible publicly before pushing the plugin on the marketplace.

If you need more information about this plugin, feel free to send me a private message :)

Cheers,
Vincent.
