### PR TITLE
Use proper base timestamp when setting cookie TTL

### DIFF
--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -498,7 +498,7 @@ class PiwikTracker
         }
         return $domain;
     }
-    
+
     /**
      * Get cookie name with prefix and domain hash
      */
@@ -968,10 +968,10 @@ class PiwikTracker
 
     /**
      * Loads values from the VisitorId Cookie
-     * 
+     *
      * @return bool True if cookie exists and is valid, False otherwise
      */
-    protected function loadVisitorIdCookie() 
+    protected function loadVisitorIdCookie()
     {
         $idCookie = $this->getCookieMatchingName('id');
         if ($idCookie === false) {
@@ -995,7 +995,7 @@ class PiwikTracker
     /**
      * Deletes all first party cookies from the client
      */
-    public function deleteCookies() 
+    public function deleteCookies()
     {
         $expire = $this->currentTs - 86400;
         $cookies = array('id', 'ses', 'cvar', 'ref');
@@ -1003,7 +1003,7 @@ class PiwikTracker
             $this->setCookie($cookie, '', $expire);
         }
     }
-    
+
     /**
      * Returns the currently assigned Attribution Information stored in a first party cookie.
      *
@@ -1280,7 +1280,7 @@ class PiwikTracker
             '&_idvc=' . $this->visitCount .
             (!empty($this->lastVisitTs) ? '&_viewts=' . $this->lastVisitTs : '' ) .
             (!empty($this->lastEcommerceOrderTs) ? '&_ects=' . $this->lastEcommerceOrderTs : '' ) .
-            
+
             // These parameters are set by the JS, but optional when using API
             (!empty($this->plugins) ? $this->plugins : '') .
             (($this->localHour !== false && $this->localMinute !== false && $this->localSecond !== false) ? '&h=' . $this->localHour . '&m=' . $this->localMinute . '&s=' . $this->localSecond : '') .
@@ -1489,7 +1489,7 @@ class PiwikTracker
      */
     protected function setCookie($cookieName, $cookieValue, $cookieTTL)
     {
-        $cookieExpire = $this->createTs + $cookieTTL;
+        $cookieExpire = $this->currentTs + $cookieTTL;
         if(!headers_sent()) {
             setcookie($this->getCookieName($cookieName), $cookieValue, $cookieExpire, $this->configCookiePath, $this->configCookieDomain);
         }


### PR DESCRIPTION
The PiwikTracker PHP class was using the createTs as a base
for applying the cookie TTL offset instead of using the currentTs.

This will result in cookie TTLs being in the past TTL seconds
after the initial visitorId cookie is created. For example, 30
minutes after the initial visitorId cookie is set, all "ses"
cookies will start getting set with expiration times in the past.
