### PR TITLE
fix download extensions pattern

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2082,7 +2082,7 @@ if (typeof Piwik !== 'object') {
                     linkPattern = getClassesRegExp(configLinkClasses, 'link'),
 
                     // does file extension indicate that it is a download?
-                    downloadExtensionsPattern = new RegExp('\\.(' + configDownloadExtensions + ')([?&#]|$)', 'i');
+                    downloadExtensionsPattern = new RegExp('^[^\\?]+\\.(' + configDownloadExtensions + ')([?&#]|$)', 'i');
 
                 // optimization of the if..elseif..else construct below
                 return linkPattern.test(className) ? 'link' : (downloadPattern.test(className) || downloadExtensionsPattern.test(href) ? 'download' : (isInLink ? 0 : 'link'));


### PR DESCRIPTION
when the param in link contains download extensions, it will match the old downlod extensions pattern.
eg.

``` js
var downloadExtensionsPattern = new RegExp('\.(' + 'jpg' + ')([?&#]|$)', 'i');
// the result will be true
downloadExtensionsPattern.test('http://hello.world.com?url=image.jpg');

// if we fix the download extensions pattern as follows
var downloadExtensionsPattern = new RegExp('^[^\\?]+\.(' + 'jpg' + ')([?&#]|$)', 'i');
// then it will be false
downloadExtensionsPattern.test('http://hello.world.com?url=image.jpg');
```

Although I think the better solution is to support customizing the downloadExtensionsPattern.
