### PR TITLE
Mark unrecognized devices as desktop

### DIFF
--- a/plugins/DevicesDetection/UserAgentParserEnhanced/UserAgentParserEnhanced.php
+++ b/plugins/DevicesDetection/UserAgentParserEnhanced/UserAgentParserEnhanced.php
@@ -419,7 +419,7 @@ class UserAgentParserEnhanced
     protected $userAgent;
     protected $os = '';
     protected $browser = '';
-    protected $device = '';
+    protected $device = 0;
     protected $brand = '';
     protected $model = '';
     protected $debug = false;


### PR DESCRIPTION
Fixes error while tracking new visit using mysql 5.6 default config (STRICT_TRANS_TABLES) as it won't cast empty string to 0.

`SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'config_device_type'`
