### PR TITLE
Theme customizing hooks

### DIFF
--- a/plugins/API/templates/listAllAPI.twig
+++ b/plugins/API/templates/listAllAPI.twig
@@ -4,7 +4,7 @@
 {% block content %}
 
 {% include "@CoreHome/_siteSelectHeader.twig" %}
-
+    {{ postEvent("Template.addBeforeMenuContent", "ApiDocs") }}
 <div class="page_api pageWrap">
 
     <div class="top_controls">

--- a/plugins/CoreAdminHome/templates/_menu.twig
+++ b/plugins/CoreAdminHome/templates/_menu.twig
@@ -1,4 +1,5 @@
 {% if adminMenu|length > 1 %}
+    {{ postEvent("Template.addBeforeMenuContent", "Settings") }}
     <div class="Menu Menu--admin">
         <ul class="Menu-tabList">
         {% for name,submenu in adminMenu %}

--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -1,3 +1,4 @@
+{{ postEvent("Template.addBeforeMenuContent", "") }}
 <div class="Menu--dashboard">
     <ul class="Menu-tabList">
         {% for level1,level2 in menu %}

--- a/plugins/CoreHome/templates/_topBar.twig
+++ b/plugins/CoreHome/templates/_topBar.twig
@@ -1,3 +1,4 @@
+{{ postEvent("Template.addExtraContentTopBar", userAlias, userLogin, topMenu) }}
 <div id="topBars">
     {% include "@CoreHome/_topBarHelloMenu.twig" %}
     {% include "@CoreHome/_topBarTopMenu.twig" %}

--- a/plugins/LanguagesManager/LanguagesManager.php
+++ b/plugins/LanguagesManager/LanguagesManager.php
@@ -89,7 +89,9 @@ class LanguagesManager extends \Piwik\Plugin
     private function getLanguagesSelector()
     {
         $view = new View("@LanguagesManager/getLanguagesSelector");
-        $view->languages = API::getInstance()->getAvailableLanguageNames();
+        $languages = API::getInstance()->getAvailableLanguageNames();
+        Piwik::postEvent('LanguageManager.alterAvailableLanguages', array(&$languages));
+        $view->languages = $languages;
         $view->currentLanguageCode = self::getLanguageCodeForCurrentUser();
         $view->currentLanguageName = self::getLanguageNameForCurrentUser();
         return $view->render();

--- a/plugins/Login/templates/login.twig
+++ b/plugins/Login/templates/login.twig
@@ -38,6 +38,7 @@
 	    {% if 'General_LayoutDirection'|translate =='rtl' %}
 		<link rel="stylesheet" type="text/css" href="plugins/Zeitgeist/stylesheets/rtl.css"/>
 	    {% endif %}
+    {{ postEvent("Template.loginScreenExtraAssets") }}
 	</head>
 	<body id="loginPage">
 

--- a/plugins/MultiSites/templates/getSitesInfo.twig
+++ b/plugins/MultiSites/templates/getSitesInfo.twig
@@ -1,6 +1,7 @@
 {% extends isWidgetized ? 'empty.twig' : 'dashboard.twig' %}
 
 {% block content %}
+{{ postEvent("Template.addBeforeMenuContent", "") }}
 {% if not isWidgetized %}
     <div class="top_controls">
         {% include "@CoreHome/_periodSelect.twig" %}

--- a/plugins/ScheduledReports/templates/index.twig
+++ b/plugins/ScheduledReports/templates/index.twig
@@ -3,7 +3,7 @@
 {% block content %}
 
 {% include "@CoreHome/_siteSelectHeader.twig" %}
-
+    {{ postEvent("Template.addBeforeMenuContent", "Reports") }}
 <div class="top_controls">
     {% include "@CoreHome/_periodSelect.twig" %}
 </div>

--- a/plugins/Widgetize/templates/index.twig
+++ b/plugins/Widgetize/templates/index.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-
+    {{ postEvent("Template.addBeforeMenuContent", "Widgets") }}
 <div class="pageWrap">
     <div class="top_controls">
         {% include "@CoreHome/_siteSelectHeader.twig" %}

--- a/plugins/Zeitgeist/templates/dashboard.twig
+++ b/plugins/Zeitgeist/templates/dashboard.twig
@@ -45,6 +45,6 @@
     </div>
 
     {% include "_piwikTag.twig" %}
-    
+    {{ postEvent("Template.footerAddExtra") }}
     </body>
 </html>


### PR DESCRIPTION
Added some hooks required for custom theming:
- Template.addBeforeMenuContent - was used for adding breadcrumbs. Parameter is used to pass what should be last element of breadcrumbs, according to active plugin.
- Template.addExtraContentTopBar - this allows to formulate own top menu, not necessarily split into two twig templates. All variables used in respective templates are passed into this hook, allowing to apply own logic.
- LanguageManager.alterAvailableLanguages - allows plugins to nicely limit available languages to only defined list.
- Template.loginScreenExtraAssets - allows to inject additional assets to modify login screen look
- Template.footerAddExtra - allows to inject some custom footer into Piwik
