### PR TITLE
Added possibility to modify twig templates in own theme.

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -37,11 +37,25 @@ class Twig
     public function __construct()
     {
         $loader = $this->getDefaultThemeLoader();
+		$this->addPluginNamespaces($loader);
 
-        $this->addPluginNamespaces($loader);
-
-        // If theme != default we need to chain
-        $chainLoader = new Twig_Loader_Chain(array($loader));
+		//get current theme
+		$manager = Plugin\Manager::getInstance();
+		$theme = $manager->getThemeEnabled();
+		$loaders = array();
+		
+		//create loader for custom theme to overwrite twig templates
+		if($theme->getPluginName() != \Piwik\Plugin\Manager::DEFAULT_THEME){
+			$customLoader = $this->getCustomThemeLoader($theme);
+			if($customLoader){
+				//make it possible to overwrite plugin templates
+				$this->addCustomPluginNamespaces($customLoader,$theme->getPluginName());
+				$loaders[] = $customLoader;
+			}
+		}
+		$loaders[] = $loader;
+        
+        $chainLoader = new Twig_Loader_Chain($loaders);
 
         // Create new Twig Environment and set cache dir
         $templatesCompiledPath = PIWIK_USER_PATH . '/tmp/templates_c';
@@ -164,6 +178,22 @@ class Twig
         return $themeLoader;
     }
 
+	/**
+	 * create template loader for a custom theme
+	 * @param \Piwik\Plugin $theme
+	 * @return \Twig_Loader_Filesystem
+	 */
+	protected function getCustomThemeLoader(Plugin $theme){
+		if(!file_exists(sprintf("%s/plugins/%s/templates/", PIWIK_INCLUDE_PATH, $theme->getPluginName()))){
+			return false;
+		}
+		$themeLoader = new Twig_Loader_Filesystem(array(
+                                                       sprintf("%s/plugins/%s/templates/", PIWIK_INCLUDE_PATH, $theme->getPluginName())
+                                                  ));
+
+        return $themeLoader;
+	}
+
     public function getTwigEnvironment()
     {
         return $this->twig;
@@ -285,6 +315,22 @@ class Twig
             $path = sprintf("%s/plugins/%s/templates/", PIWIK_INCLUDE_PATH, $name);
             if (is_dir($path)) {
                 $loader->addPath(PIWIK_INCLUDE_PATH . '/plugins/' . $name . '/templates', $name);
+            }
+        }
+    }
+
+	/**
+	*
+	* Plugin-Templates can be overwritten by putting identically named templates in plugins/[theme]/templates/plugins/[plugin]/
+	*
+	*/
+	private function addCustomPluginNamespaces(Twig_Loader_Filesystem $loader, $pluginName)
+    {
+        $plugins = \Piwik\Plugin\Manager::getInstance()->getAllPluginsNames();
+        foreach ($plugins as $name) {
+            $path = sprintf("%s/plugins/%s/templates/plugins/%s/", PIWIK_INCLUDE_PATH, $pluginName, $name);
+            if (is_dir($path)) {
+                $loader->addPath(PIWIK_INCLUDE_PATH . '/plugins/' . $pluginName . '/templates/plugins/'. $name , $name);
             }
         }
     }


### PR DESCRIPTION
Theme templates can be overridden by placing twig-templates of the same name  in plugins/[theme]/templates.
Plugin-templates can be overridden by placing twig-templates of the same name in plugins/[theme]/templates/plugin/[plugin]/

It would be great if this could be included in upcoming piwik versions as it improves theming a lot
