### PR TITLE
Explicitly enable access to web cron script

### DIFF
--- a/misc/cron/.htaccess
+++ b/misc/cron/.htaccess
@@ -1,5 +1,5 @@
-# Allow direct web access to selected files
-<FilesMatch "^(archive\.php|updatetoken\.php)$">
+# Allow direct web access to Web cron
+<Files "archive.php">
 	Order Allow,Deny
 	Allow from all
-</FilesMatch>
+</Files>

--- a/misc/cron/.htaccess
+++ b/misc/cron/.htaccess
@@ -1,0 +1,5 @@
+# Allow direct web access to selected files
+<FilesMatch "^(archive\.php|updatetoken\.php)$">
+	Order Allow,Deny
+	Allow from all
+</Files>

--- a/misc/cron/.htaccess
+++ b/misc/cron/.htaccess
@@ -2,4 +2,4 @@
 <FilesMatch "^(archive\.php|updatetoken\.php)$">
 	Order Allow,Deny
 	Allow from all
-</Files>
+</FilesMatch>


### PR DESCRIPTION
When somehow parent folder receives `.htaccess` file with `Deny from all` rules.
See issue [http://forum.piwik.org/read.php?2,109382]
