### PR TITLE
Prevent stderr from commandExists()

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -192,7 +192,7 @@ class Process
 
     private static function commandExists($command)
     {
-        $result = shell_exec('which ' . escapeshellarg($command));
+        $result = shell_exec('which ' . escapeshellarg($command) . ' 2> /dev/null');
 
         return !empty($result);
     }


### PR DESCRIPTION
If the program 'ps' is not available like in shared hosts prevent stderr messages from shell_exec(which ps) which gets repeated quite often.
