### PR TITLE
Fix tracking actions with empty page titles using MySQL 5.6+.

### DIFF
--- a/core/Tracker/Action.php
+++ b/core/Tracker/Action.php
@@ -267,7 +267,7 @@ abstract class Action
         }
 
         foreach($this->actionIdsCached as $field => $idAction) {
-            $visitAction[$field] = $idAction;
+            $visitAction[$field] = ($idAction === false) ? 0 : $idAction;
         }
 
         $customValue = $this->getCustomFloatValue();


### PR DESCRIPTION
Fixes error while tracking actions with empty page title using mysql 5.6 default config (STRICT_TRANS_TABLES) as it won't cast false to 0.
