### PR TITLE
Optimizations for import_logs.py

### DIFF
--- a/misc/log-analytics/README.md
+++ b/misc/log-analytics/README.md
@@ -4,6 +4,7 @@
 
 * Python 2.6 or 2.7. Python 3.x is not supported.
 * Update to Piwik 1.11
+* OrderedDict is optional (see https://pypi.python.org/pypi/ordereddict for more details). .
 
 ## How to use this script?
 

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1627,6 +1627,7 @@ class Parser(object):
                 is_robot=False,
                 is_error=False,
                 is_redirect=False,
+                date=None,
                 args={},
             )
 

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -524,7 +524,7 @@ class Configuration(object):
             level=logging.DEBUG if self.options.debug >= 1 else logging.INFO,
         )
 
-        self.options.excluded_useragents = {s.lower() for s in self.options.excluded_useragents}
+        self.options.excluded_useragents = set([s.lower() for s in self.options.excluded_useragents])
 
         if self.options.exclude_path_from:
             paths = [path.strip() for path in open(self.options.exclude_path_from).readlines()]

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1676,7 +1676,11 @@ class Parser(object):
             # We parse it after calling check_methods as it's quite CPU hungry, and
             # we want to avoid that cost for excluded hits.
             # To mitigate CPU usage, parsed dates are cached.
-            date_key = format.get('date') + '|' + format.get('timezone')
+            try:
+                timezone_key = format.get('timezone')
+            except BaseFormatException:
+                timezone_key = ''
+            date_key = format.get('date') + '|' + timezone_key
             hit.date = cache_dates.get(date_key)
             if not hit.date:
                 date_string = format.get('date')

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1687,7 +1687,7 @@ class Parser(object):
                     timezone_key = format.get('timezone')
                 except BaseFormatException:
                     timezone_key = ''
-                date_key = format.get('date') + '|' + timezone_key
+                date_key = (format.get('date'), timezone_key)
                 hit.date = cache_dates.get(date_key)
             if not hit.date:
                 date_string = format.get('date')

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1318,12 +1318,11 @@ class Recorder(object):
         """
         Inserts several hits into Piwik.
         """
-        data = {
-            'token_auth': config.options.piwik_token_auth,
-            'requests': [self._get_hit_args(hit) for hit in hits]
-        }
-
         if not config.options.dry_run:
+            data = {
+                'token_auth': config.options.piwik_token_auth,
+                'requests': [self._get_hit_args(hit) for hit in hits]
+            }
             piwik.call(
                 '/piwik.php', args={},
                 expected_content=None,

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -53,7 +53,7 @@ except ImportError:
     try:
         from ordereddict import OrderedDict
     except ImportError:
-        print >> sys.stderr, 'ordereddict (https://pypi.python.org/pypi/ordereddict) is required to enable dates caching.'
+        pass
 
 
 ##

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1414,8 +1414,7 @@ class Parser(object):
         return result
 
     def check_static(self, hit):
-        extension = hit.path.rsplit('.')[-1].lower()
-        if extension in STATIC_EXTENSIONS:
+        if hit.extension in STATIC_EXTENSIONS:
             if config.options.enable_static:
                 hit.is_download = True
                 return True
@@ -1425,8 +1424,7 @@ class Parser(object):
         return True
 
     def check_download(self, hit):
-        extension = hit.path.rsplit('.')[-1].lower()
-        if extension in DOWNLOAD_EXTENSIONS:
+        if hit.extension in DOWNLOAD_EXTENSIONS:
             stats.count_lines_downloads.increment()
             hit.is_download = True
         return True
@@ -1629,6 +1627,8 @@ class Parser(object):
                 hit.path = hit.full_path
             except BaseFormatException:
                 hit.path, _, hit.query_string = hit.full_path.partition(config.options.query_string_delimiter)
+
+            hit.extension = hit.path.rsplit('.')[-1].lower()
 
             try:
                 hit.referrer = format.get('referrer')

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1719,13 +1719,11 @@ class Parser(object):
                     invalid_line(line, 'invalid encoding')
                     continue
 
-            # Check if the hit must be excluded.
-            if all((method(hit) for method in self.check_methods)):
-                hits.append(hit)
+            hits.append(hit)
 
-                if len(hits) >= config.options.recorder_max_payload_size * len(Recorder.recorders):
-                    Recorder.add_hits(hits)
-                    hits = []
+            if len(hits) >= config.options.recorder_max_payload_size * len(Recorder.recorders):
+                Recorder.add_hits(hits)
+                hits = []
 
         # add last chunk of hits
         if len(hits) > 0:

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -57,18 +57,18 @@ except ImportError:
 ## Constants.
 ##
 
-STATIC_EXTENSIONS = (
+STATIC_EXTENSIONS = set((
     'gif jpg jpeg png bmp ico svg ttf eot woff class swf css js xml robots.txt'
-).split()
+).split())
 
 
-DOWNLOAD_EXTENSIONS = (
+DOWNLOAD_EXTENSIONS = set((
     '7z aac arc arj asf asx avi bin csv deb dmg doc exe flv gz gzip hqx '
     'jar mpg mp2 mp3 mp4 mpeg mov movie msi msp odb odf odg odp '
     'ods odt ogg ogv pdf phps ppt qt qtm ra ram rar rpm sea sit tar tbz '
     'bz2 tbz tgz torrent txt wav wma wmv wpd xls xml xsd z zip '
     'azw3 epub mobi'
-).split()
+).split())
 
 
 # A good source is: http://phpbb-bots.blogspot.com/
@@ -524,18 +524,20 @@ class Configuration(object):
             level=logging.DEBUG if self.options.debug >= 1 else logging.INFO,
         )
 
-        self.options.excluded_useragents = [s.lower() for s in self.options.excluded_useragents]
+        self.options.excluded_useragents = {s.lower() for s in self.options.excluded_useragents}
 
         if self.options.exclude_path_from:
             paths = [path.strip() for path in open(self.options.exclude_path_from).readlines()]
             self.options.excluded_paths.extend(path for path in paths if len(path) > 0)
         if self.options.excluded_paths:
+            self.options.excluded_paths = set(self.options.excluded_paths)
             logging.debug('Excluded paths: %s', ' '.join(self.options.excluded_paths))
 
         if self.options.include_path_from:
             paths = [path.strip() for path in open(self.options.include_path_from).readlines()]
             self.options.included_paths.extend(path for path in paths if len(path) > 0)
         if self.options.included_paths:
+            self.options.included_paths = set(self.options.included_paths)
             logging.debug('Included paths: %s', ' '.join(self.options.included_paths))
 
         if self.options.hostnames:


### PR DESCRIPTION
This set of patches addresses some optimizations in the log-analytics script.
Tests were made on an extract of 1 million lines from logs in ncsa format (dry-run).

Before the optimizations :
Total time: 219 seconds
Requests imported per second: 4554.54 requests per second

After :
Total time: 72 seconds
Requests imported per second: 13717.18 requests per second
