### PR TITLE
Device detector2 cache

### DIFF
--- a/core/Tracker/Settings.php
+++ b/core/Tracker/Settings.php
@@ -11,7 +11,6 @@ namespace Piwik\Tracker;
 use Piwik\DeviceDetectorCache;
 use Piwik\Tracker;
 use DeviceDetector\DeviceDetector;
-use DeviceDetector\Cache\CacheStatic;
 
 class Settings
 {
@@ -38,16 +37,17 @@ class Settings
         $resolution = $this->request->getParam('res');
         $userAgent = $this->request->getUserAgent();
 
-        static $deviceDetectorsCache;
-        $deviceDetectorsCache = new CacheStatic();
-        $deviceDetector = $deviceDetectorsCache->get($userAgent);
-        if (! $deviceDetector) {
+        static $deviceDetectorsCache = array();
+        if (array_key_exists($userAgent, $deviceDetectorsCache)) {
+            $deviceDetector = $deviceDetectorsCache[$userAgent];
+        }
+        else {
             $deviceDetector = new DeviceDetector($userAgent);
             $deviceDetector->discardBotInformation();
             $deviceDetector->setCache(new DeviceDetectorCache('tracker', 86400));
             $deviceDetector->parse();
 
-            $deviceDetectorsCache->set($userAgent, $deviceDetector);
+            $deviceDetectorsCache[$userAgent] = $deviceDetector;
         }
 
         $aBrowserInfo = $deviceDetector->getClient();

--- a/core/Tracker/Settings.php
+++ b/core/Tracker/Settings.php
@@ -11,6 +11,7 @@ namespace Piwik\Tracker;
 use Piwik\DeviceDetectorCache;
 use Piwik\Tracker;
 use DeviceDetector\DeviceDetector;
+use DeviceDetector\Cache\CacheStatic;
 
 class Settings
 {
@@ -37,10 +38,17 @@ class Settings
         $resolution = $this->request->getParam('res');
         $userAgent = $this->request->getUserAgent();
 
-        $deviceDetector = new DeviceDetector($userAgent);
-        $deviceDetector->discardBotInformation();
-        $deviceDetector->setCache(new DeviceDetectorCache('tracker', 86400));
-        $deviceDetector->parse();
+        static $deviceDetectorsCache;
+        $deviceDetectorsCache = new CacheStatic();
+        $deviceDetector = $deviceDetectorsCache->get($userAgent);
+        if (! $deviceDetector) {
+            $deviceDetector = new DeviceDetector($userAgent);
+            $deviceDetector->discardBotInformation();
+            $deviceDetector->setCache(new DeviceDetectorCache('tracker', 86400));
+            $deviceDetector->parse();
+
+            $deviceDetectorsCache->set($userAgent, $deviceDetector);
+        }
 
         $aBrowserInfo = $deviceDetector->getClient();
         if ($aBrowserInfo['type'] != 'browser') {


### PR DESCRIPTION
This patch provides an optimization that caches the parsed DeviceDetector.

Using The DeviceDetector2 branch, before the patch, a test case with 100000 line extracted from a real website, the result was :

Total time: 308 seconds
Requests imported per second: 323.87 requests per second

After the patch :

Total time: 144 seconds
Requests imported per second: 690.84 requests per second

The optimization really depends on the number of different user agents and the bulk size but in the worst case, we can expect nearly the same performance as without the patch.

Note : initially, I expected to provide the patch for the master branch but I prefered to provide one for the DeviceDetector2 branch, using CacheStatic instead of a static array.
