### PR TITLE
Moved attachment generation to report renderer

### DIFF
--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -122,6 +122,16 @@ abstract class ReportRenderer
     abstract public function renderReport($processedReport);
 
     /**
+     * Get report attachments, ex. graph images
+     *
+     * @param $report
+     * @param $processedReports
+     * @param $prettyDate
+     * @return array
+     */
+    abstract public function getAttachments($report, $processedReports, $prettyDate);
+
+    /**
      * Append $extension to $filename
      *
      * @static

--- a/core/ReportRenderer/Csv.php
+++ b/core/ReportRenderer/Csv.php
@@ -148,4 +148,17 @@ class Csv extends ReportRenderer
     {
         return str_replace("_", ".", $uniqueId);
     }
+
+    /**
+     * Get report attachments, ex. graph images
+     *
+     * @param $report
+     * @param $processedReports
+     * @param $prettyDate
+     * @return array
+     */
+    public function getAttachments($report, $processedReports, $prettyDate)
+    {
+        return array();
+    }
 }

--- a/core/ReportRenderer/Html.php
+++ b/core/ReportRenderer/Html.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\ReportRenderer;
 
+use Piwik\Piwik;
 use Piwik\Plugins\API\API;
 use Piwik\ReportRenderer;
 use Piwik\SettingsPiwik;
@@ -160,5 +161,59 @@ class Html extends ReportRenderer
         }
 
         $this->rendering .= $reportView->render();
+    }
+
+    public function getAttachments($report, $processedReports, $prettyDate)
+    {
+        $additionalFiles = array();
+
+        foreach ($processedReports as $processedReport) {
+            if ($processedReport['displayGraph']) {
+
+                $additionalFiles[] = $this->getAttachment($report, $processedReport, $prettyDate);
+            }
+        }
+
+        return $additionalFiles;
+    }
+
+    protected function getAttachment($report, $processedReport, $prettyDate)
+    {
+        $additionalFile = array();
+
+        $segment = \Piwik\Plugins\ScheduledReports\API::getSegment($report['idsegment']);
+
+        $segmentName = $segment != null ? sprintf(' (%s)', $segment['name']) : '';
+
+        $processedReportMetadata = $processedReport['metadata'];
+
+        $additionalFile['filename'] =
+            sprintf(
+                '%s - %s - %s %d - %s %d%s.png',
+                $processedReportMetadata['name'],
+                $prettyDate,
+                Piwik::translate('General_Website'),
+                $report['idsite'],
+                Piwik::translate('General_Report'),
+                $report['idreport'],
+                $segmentName
+            );
+
+        $additionalFile['cid'] = $processedReportMetadata['uniqueId'];
+
+        $additionalFile['content'] =
+            ReportRenderer::getStaticGraph(
+                $processedReportMetadata,
+                Html::IMAGE_GRAPH_WIDTH,
+                Html::IMAGE_GRAPH_HEIGHT,
+                $processedReport['evolutionGraph'],
+                $segment
+            );
+
+        $additionalFile['mimeType'] = 'image/png';
+
+        $additionalFile['encoding'] = \Zend_Mime::ENCODING_BASE64;
+
+        return $additionalFile;
     }
 }

--- a/core/ReportRenderer/Pdf.php
+++ b/core/ReportRenderer/Pdf.php
@@ -523,4 +523,17 @@ class Pdf extends ReportRenderer
         $this->TCPDF->Write("1em", $message);
         $this->TCPDF->Ln();
     }
+
+    /**
+     * Get report attachments, ex. graph images
+     *
+     * @param $report
+     * @param $processedReports
+     * @param $prettyDate
+     * @return array
+     */
+    public function getAttachments($report, $processedReports, $prettyDate)
+    {
+        return array();
+    }
 }

--- a/plugins/MobileMessaging/ReportRenderer/ReportRendererException.php
+++ b/plugins/MobileMessaging/ReportRenderer/ReportRendererException.php
@@ -68,4 +68,17 @@ class ReportRendererException extends ReportRenderer
     {
         // nothing to do
     }
+
+    /**
+     * Get report attachments, ex. graph images
+     *
+     * @param $report
+     * @param $processedReports
+     * @param $prettyDate
+     * @return array
+     */
+    public function getAttachments($report, $processedReports, $prettyDate)
+    {
+        return array();
+    }
 }

--- a/plugins/MobileMessaging/ReportRenderer/Sms.php
+++ b/plugins/MobileMessaging/ReportRenderer/Sms.php
@@ -128,4 +128,17 @@ class Sms extends ReportRenderer
 
         $this->rendering .= $view->render();
     }
+
+    /**
+     * Get report attachments, ex. graph images
+     *
+     * @param $report
+     * @param $processedReports
+     * @param $prettyDate
+     * @return array
+     */
+    public function getAttachments($report, $processedReports, $prettyDate)
+    {
+        return array();
+    }
 }

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -885,60 +885,7 @@ class API extends \Piwik\Plugin\API
 
     private function getAttachments($reportRenderer, $report, $processedReports, $prettyDate)
     {
-        $additionalFiles = array();
-
-        if ($reportRenderer instanceof Html) {
-
-            foreach ($processedReports as $processedReport) {
-
-                if ($processedReport['displayGraph']) {
-
-                    $additionalFiles[] = $this->createAttachment($report, $processedReport, $prettyDate);
-                }
-            }
-        }
-
-        return $additionalFiles;
-    }
-
-    private function createAttachment($report, $processedReport, $prettyDate)
-    {
-        $additionalFile = array();
-
-        $segment = self::getSegment($report['idsegment']);
-
-        $segmentName = $segment != null ? sprintf(' (%s)', $segment['name']) : '';
-
-        $processedReportMetadata = $processedReport['metadata'];
-
-        $additionalFile['filename'] =
-            sprintf(
-                '%s - %s - %s %d - %s %d%s.png',
-                $processedReportMetadata['name'],
-                $prettyDate,
-                Piwik::translate('General_Website'),
-                $report['idsite'],
-                Piwik::translate('General_Report'),
-                $report['idreport'],
-                $segmentName
-            );
-
-        $additionalFile['cid'] = $processedReportMetadata['uniqueId'];
-
-        $additionalFile['content'] =
-            ReportRenderer::getStaticGraph(
-                $processedReportMetadata,
-                Html::IMAGE_GRAPH_WIDTH,
-                Html::IMAGE_GRAPH_HEIGHT,
-                $processedReport['evolutionGraph'],
-                $segment
-            );
-
-        $additionalFile['mimeType'] = 'image/png';
-
-        $additionalFile['encoding'] = Zend_Mime::ENCODING_BASE64;
-
-        return $additionalFile;
+        return $reportRenderer->getAttachments($report, $processedReports, $prettyDate);
     }
 
     private function checkUserHasViewPermission($login, $idSite)


### PR DESCRIPTION
The ReportRenderer can be overridden using ScheduledReports.getRendererInstance event. This allows to render non-standard html/pdf/csv reports. If such report contains several graphs then it is not possible to send it as e-mail as the attachments are generated in ScheduledReports/API. This seems to be inconsistent. If a ReportRenderer can decide about the content of a report it should also be able to decide about the attachments.

I 've added small changes to the code which allow to override the default attachment creation process.
