### PR TITLE
Remove morpheus priority, which broke custom themes.

### DIFF
--- a/core/AssetManager/UIAssetFetcher/StylesheetUIAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher/StylesheetUIAssetFetcher.php
@@ -19,10 +19,7 @@ class StylesheetUIAssetFetcher extends UIAssetFetcher
             'libs/',
             'plugins/CoreHome/stylesheets/color_manager.css', // must be before other Piwik stylesheets
             'plugins/Morpheus/stylesheets/base.less',
-            'plugins\/((?!Morpheus).)*\/',
             'plugins/Dashboard/stylesheets/dashboard.less',
-            'plugins/Morpheus/stylesheets/theme.less',
-            'plugins/Morpheus/stylesheets/',
             'tests/',
         );
     }


### PR DESCRIPTION
This priority order cause that all morpheus stylesheets are loaded at very end of generated css file and custom theme rules are overwritten by morpheus. I tried morpheus without this rules and looks ok, but I'm quite not sure what's purpose of these priorities.
