### PR TITLE
Added IPv6 support for GeoIP location, while still retaining IPv4 functi...

### DIFF
--- a/plugins/UserCountry/LocationProvider/GeoIp/ServerBased.php
+++ b/plugins/UserCountry/LocationProvider/GeoIp/ServerBased.php
@@ -95,6 +95,8 @@ class ServerBased extends GeoIp
         foreach (self::$geoIpServerVars as $resultKey => $geoipVarName) {
             if (!empty($_SERVER[$geoipVarName])) {
                 $result[$resultKey] = $_SERVER[$geoipVarName];
+            }elseif (!empty($_SERVER[$geoipVarName.'_V6'])) {
+                $result[$resultKey] = $_SERVER[$geoipVarName.'_V6'];
             }
         }
         foreach (self::$geoIpUtfServerVars as $resultKey => $geoipVarName) {
@@ -150,7 +152,8 @@ class ServerBased extends GeoIp
         }
 
         $available = !empty($_SERVER[self::TEST_SERVER_VAR])
-            || !empty($_SERVER[self::TEST_SERVER_VAR_ALT]);
+            || !empty($_SERVER[self::TEST_SERVER_VAR_ALT])
+            || !empty($_SERVER[self::TEST_SERVER_VAR_ALT.'+_V6']);
 
         if ($available) {
             return true;
@@ -180,6 +183,7 @@ class ServerBased extends GeoIp
     {
         if (empty($_SERVER[self::TEST_SERVER_VAR])
             && empty($_SERVER[self::TEST_SERVER_VAR_ALT])
+            && empty($_SERVER[self::TEST_SERVER_VAR_ALT.'_V6'])
         ) {
             return Piwik::translate("UserCountry_CannotFindGeoIPServerVar", self::TEST_SERVER_VAR . ' $_SERVER');
         }


### PR DESCRIPTION
IPv4 tracking depends on: 
- GEOIP_ADDR 
- GEOIP_CONTINENT_CODE 
- GEOIP_COUNTRY_CODE 
- GEOIP_COUNTRY_NAME 

And IPv6 depends on: 
GEOIP_ADDR 
GEOIP_CONTINENT_CODE_V6 
GEOIP_COUNTRY_CODE_V6 
GEOIP_COUNTRY_NAME_V6 

For the isAvailable() and isWorking() functions, added checks to see if the GEOIP_COUNTRY_CODE_V6 variable has been populated.

For getLocation, if each IPv4 variable is empty, check if the IPv6 equivalent is empty. If not, use the IPv6 equivalent instead.
