### PR TITLE
MySQL port should be always integer (HHVM compatibility)

### DIFF
--- a/core/Tracker/Db/Mysqli.php
+++ b/core/Tracker/Db/Mysqli.php
@@ -46,7 +46,7 @@ class Mysqli extends Db
             $this->socket = $dbInfo['port'];
         } else {
             $this->host = $dbInfo['host'];
-            $this->port = $dbInfo['port'];
+            $this->port = (int)$dbInfo['port'];
             $this->socket = null;
         }
         $this->dbname = $dbInfo['dbname'];


### PR DESCRIPTION
This is only the change (so far), that is needed for compatibility with HHVM. 

PR solves this error message from HHVM:

```
Fatal error: Argument 5 to mysqli_connect() must be of type ?int, string given in /var/www/piwik/core/Tracker/Db/Mysqli.php on line 75
```
