### PR TITLE
Visitor interface implementation.

### DIFF
--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -740,8 +740,9 @@ class API extends \Piwik\Plugin\API
          * @param \Piwik\Plugins\Live\VisitorInterface &$visitor Initialized to null, but can be set to
          *                                              a new visitor object. If it isn't modified
          *                                              Piwik uses the default class.
+         * @param array $visitorRawData Raw data using in Visitor object constructor.
          */
-        Piwik::postEvent('Live.makeNewVisitorObject', array(&$visitor));
+        Piwik::postEvent('Live.makeNewVisitorObject', array(&$visitor, $visitorRawData));
 
         if (is_null($visitor)) {
             $visitor = new Visitor($visitorRawData);

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -39,7 +39,7 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/Provider/functions.php';
 
 /**
  */
-class Visitor
+class Visitor implements VisitorInterface
 {
     const DELIMITER_PLUGIN_NAME = ", ";
 

--- a/plugins/Live/VisitorFactory.php
+++ b/plugins/Live/VisitorFactory.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\Live;
+
+use Exception;
+use Piwik\Piwik;
+
+class VisitorFactory
+{
+    /**
+     * Returns Visitor object.
+     * This method can be overwritten to use a different Visitor object
+     *
+     * @param array $visitorRawData
+     * @throws \Exception
+     * @return \Piwik\Plugins\Live\VisitorInterface
+     * @ignore
+     */
+    public function create(array $visitorRawData = array())
+    {
+        $visitor = null;
+
+        /**
+         * Triggered while visit is filtering in live plugin. Subscribers to this
+         * event can force the use of a custom visitor object that extends from
+         * {@link Piwik\Plugins\Live\VisitorInterface}.
+         *
+         * @param \Piwik\Plugins\Live\VisitorInterface &$visitor Initialized to null, but can be set to
+         *                                              a new visitor object. If it isn't modified
+         *                                              Piwik uses the default class.
+         * @param array $visitorRawData Raw data using in Visitor object constructor.
+         */
+        Piwik::postEvent('Live.makeNewVisitorObject', array(&$visitor, $visitorRawData));
+
+        if (is_null($visitor)) {
+            $visitor = new Visitor($visitorRawData);
+        } elseif (!($visitor instanceof VisitorInterface)) {
+            throw new Exception("The Visitor object set in the plugin must implement VisitorInterface");
+        }
+
+        return $visitor;
+    }
+} 

--- a/plugins/Live/VisitorInterface.php
+++ b/plugins/Live/VisitorInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\Live;
+
+interface VisitorInterface
+{
+    /**
+     * @return array
+     */
+    public function getAllVisitorDetails();
+
+    /**
+     * @return string|bool
+     */
+    public function getVisitorId();
+} 


### PR DESCRIPTION
Hook which give possibility to manipulate Visitor object instance. I've used same convention which is implemented in Tracker class. (https://github.com/piwik/piwik/blob/master/core/Tracker.php#L631) This hook could be used to overwrite some fields in Live plugin API methods. Interface is simply as possible. Only two methods should be visible outside of Visitor class. (in my, and my phpstorm opinion)
