### PR TITLE
Set reply_to equal to report creator.

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -280,6 +280,9 @@ noreply_email_address = "noreply@{DOMAIN}"
 ; when testing, use your own email address or "nobody"
 feedback_email_address = "feedback@piwik.org"
 
+; using to set reply_to in reports e-mail to login of report creator
+set_reply_to_as_sender = 0
+
 ; during archiving, Piwik will limit the number of results recorded, for performance reasons
 ; maximum number of rows for any of the Referrers tables (keywords, search engines, campaigns, etc.)
 datatable_archiving_maximum_rows_referrers = 1000

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -281,7 +281,7 @@ noreply_email_address = "noreply@{DOMAIN}"
 feedback_email_address = "feedback@piwik.org"
 
 ; using to set reply_to in reports e-mail to login of report creator
-set_reply_to_as_sender = 0
+scheduled_reports_replyto_is_user_email_and_alias = 0
 
 ; during archiving, Piwik will limit the number of results recorded, for performance reasons
 ; maximum number of rows for any of the Referrers tables (keywords, search engines, campaigns, etc.)

--- a/plugins/ScheduledReports/ScheduledReports.php
+++ b/plugins/ScheduledReports/ScheduledReports.php
@@ -16,10 +16,12 @@ use Piwik\Mail;
 use Piwik\Piwik;
 use Piwik\Plugins\MobileMessaging\MobileMessaging;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
+use Piwik\Plugins\UsersManager\Model as UserModel;
 use Piwik\ReportRenderer;
 use Piwik\ScheduledTime;
 use Piwik\View;
 use Zend_Mime;
+use Piwik\Config;
 
 /**
  *
@@ -266,6 +268,8 @@ class ScheduledReports extends \Piwik\Plugin
             $mail->setDefaultFromPiwik();
             $mail->setSubject($subject);
             $attachmentName = $subject;
+
+            $this->setReplyToAsSender($mail, $report);
 
             $displaySegmentInfo = false;
             $segmentInfo = null;
@@ -601,5 +605,18 @@ class ScheduledReports extends \Piwik\Plugin
             ScheduledTime::PERIOD_YEAR  => Piwik::translate('General_YearlyReport'),
             ScheduledTime::PERIOD_RANGE => Piwik::translate('General_RangeReports'),
         );
+    }
+
+    protected function setReplyToAsSender(Mail $mail, array $report)
+    {
+        if (isset(Config::getInstance()->General['set_reply_to_as_sender'])
+            && Config::getInstance()->General['set_reply_to_as_sender'] == '1') {
+            if (isset($report['login'])) {
+                $userModel = new UserModel();
+                $user = $userModel->getUser($report['login']);
+
+                $mail->setReplyTo($user['email'], $user['alias']);
+            }
+        }
     }
 }

--- a/plugins/ScheduledReports/ScheduledReports.php
+++ b/plugins/ScheduledReports/ScheduledReports.php
@@ -609,8 +609,7 @@ class ScheduledReports extends \Piwik\Plugin
 
     protected function setReplyToAsSender(Mail $mail, array $report)
     {
-        if (isset(Config::getInstance()->General['set_reply_to_as_sender'])
-            && Config::getInstance()->General['set_reply_to_as_sender'] == '1') {
+        if (Config::getInstance()->General['scheduled_reports_replyto_is_user_email_and_alias']) {
             if (isset($report['login'])) {
                 $userModel = new UserModel();
                 $user = $userModel->getUser($report['login']);


### PR DESCRIPTION
Enable option to set reply_to in schedule reports for report creator e-mail and alias. 
