### PR TITLE
Add reply-to in password recovery e-mails.

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -258,6 +258,12 @@ login_password_recovery_email_address = "password-recovery@{DOMAIN}"
 ; name that appears as a Sender in the password recovery email
 login_password_recovery_email_name = Piwik
 
+; email address that appears as a Repy-to in the password recovery email
+; if specified, {DOMAIN} will be replaced by the current Piwik domain
+login_password_recovery_replyto_email_address = "no-reply@{DOMAIN}"
+; name that appears as a Reply-to in the password recovery email
+login_password_recovery_replyto_email_name = "No-reply"
+
 ; By default when user logs out he is redirected to Piwik "homepage" usually the Login form.
 ; Uncomment the next line to set a URL to redirect the user to after he logs out of Piwik.
 ; login_logout_url = http://...

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -284,6 +284,11 @@ class Controller extends \Piwik\Plugin\Controller
         $fromEmailName = Config::getInstance()->General['login_password_recovery_email_name'];
         $fromEmailAddress = Config::getInstance()->General['login_password_recovery_email_address'];
         $mail->setFrom($fromEmailAddress, $fromEmailName);
+
+        $replytoEmailName = Config::getInstance()->General['login_password_recovery_replyto_email_name'];
+        $replytoEmailAddress = Config::getInstance()->General['login_password_recovery_replyto_email_address'];
+        $mail->setReplyTo($replytoEmailAddress, $replytoEmailName);
+
         @$mail->send();
     }
 


### PR DESCRIPTION
Reply-to field for recovery password e-mails working in the same way like sender header. 
