### PR TITLE
[piwik-js] Added support for registering plugins in Tracker public API

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -408,7 +408,7 @@ if (typeof JSON2 !== 'object') {
     exec,
     res, width, height, devicePixelRatio,
     pdf, qt, realp, wma, dir, fla, java, gears, ag,
-    hook, getHook, getVisitorId, getVisitorInfo, setSiteId, setTrackerUrl, appendToTrackingUrl, getRequest,
+    hook, getHook, getVisitorId, getVisitorInfo, setSiteId, setTrackerUrl, appendToTrackingUrl, getRequest, addPlugin,
     getAttributionInfo, getAttributionCampaignName, getAttributionCampaignKeyword,
     getAttributionReferrerTimestamp, getAttributionReferrerUrl,
     setCustomData, getCustomData,
@@ -2487,6 +2487,16 @@ if (typeof Piwik !== 'object') {
                  */
                 getRequest: function (request) {
                     return getRequest(request);
+                },
+
+                /**
+                 * Add plugin
+                 *
+                 * @param string pluginName
+                 * @param Object pluginObj
+                 */
+                addPlugin: function (pluginName, pluginObj) {
+                    plugins[pluginName] = pluginObj;
                 },
 
                 /**

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -322,7 +322,7 @@ function PiwikTest() {
     });
 
     test("API methods", function() {
-        expect(56);
+        expect(57);
 
         equal( typeof Piwik.addPlugin, 'function', 'addPlugin' );
         equal( typeof Piwik.getTracker, 'function', 'getTracker' );
@@ -345,6 +345,7 @@ function PiwikTest() {
         equal( typeof tracker.getAttributionCampaignKeyword, 'function', 'getAttributionCampaignKeyword' );
         equal( typeof tracker.setTrackerUrl, 'function', 'setTrackerUrl' );
         equal( typeof tracker.getRequest, 'function', 'getRequest' );
+        equal( typeof tracker.addPlugin, 'function', 'addPlugin' );
         equal( typeof tracker.setSiteId, 'function', 'setSiteId' );
         equal( typeof tracker.setCustomData, 'function', 'setCustomData' );
         equal( typeof tracker.getCustomData, 'function', 'getCustomData' );
@@ -767,6 +768,50 @@ function PiwikTest() {
         equal( json.idsite, '42' );
         equal( json.rec, 1);
         ok( json.r.length > 0 );
+    });
+
+    // support for addPlugin( pluginName, pluginObj )
+    test("Tracker addPlugin() and getRequest()", function() {
+        expect(9);
+
+        var tracker = Piwik.getTracker();
+
+        var interactionTypePlugin = (function() {
+          function _getInteractionTypeQueryParam(method) { return "&_interactionType='" + method + "'"; }
+          function ecommerce() { return _getInteractionTypeQueryParam("ecommerce"); }
+          function event() { return _getInteractionTypeQueryParam("event"); }
+          function goal() { return _getInteractionTypeQueryParam("goal"); }
+          function link() { return _getInteractionTypeQueryParam("link"); }
+          function load() { return _getInteractionTypeQueryParam("load"); }
+          function log() { return _getInteractionTypeQueryParam("log"); }
+          function ping() { return _getInteractionTypeQueryParam("ping"); }
+          function sitesearch() { return _getInteractionTypeQueryParam("sitesearch"); }
+          function unload() { return _getInteractionTypeQueryParam("unload"); }
+
+          return {
+            ecommerce: ecommerce,
+            event : event,
+            goal : goal,
+            link : link,
+            load : load,
+            log : log,
+            ping: ping,
+            sitesearch : sitesearch,
+            unload : unload
+          };
+        })();
+
+        tracker.addPlugin("interactionTypePlugin", interactionTypePlugin);
+
+        ok( tracker.getRequest("", "", "ecommerce").indexOf("&_interactionType='ecommerce'") > -1);
+        ok( tracker.getRequest("", "", "event").indexOf("&_interactionType='event'") > -1);
+        ok( tracker.getRequest("", "", "goal").indexOf("&_interactionType='goal'") > -1);
+        ok( tracker.getRequest("", "", "link").indexOf("&_interactionType='link'") > -1);
+        ok( tracker.getRequest("", "", "load").indexOf("&_interactionType='load'") > -1);
+        ok( tracker.getRequest("", "", "log").indexOf("&_interactionType='log'") > -1);
+        ok( tracker.getRequest("", "", "ping").indexOf("&_interactionType='ping'") > -1);
+        ok( tracker.getRequest("", "", "sitesearch").indexOf("&_interactionType='sitesearch'") > -1);
+        ok( tracker.getRequest("", "", "unload").indexOf("&_interactionType='unload'") > -1);
     });
 
     test("prefixPropertyName()", function() {

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -772,21 +772,22 @@ function PiwikTest() {
 
     // support for addPlugin( pluginName, pluginObj )
     test("Tracker addPlugin() and getRequest()", function() {
-        expect(9);
+        expect(12);
 
         var tracker = Piwik.getTracker();
 
-        var interactionTypePlugin = (function() {
-          function _getInteractionTypeQueryParam(method) { return "&_interactionType='" + method + "'"; }
-          function ecommerce() { return _getInteractionTypeQueryParam("ecommerce"); }
-          function event() { return _getInteractionTypeQueryParam("event"); }
-          function goal() { return _getInteractionTypeQueryParam("goal"); }
-          function link() { return _getInteractionTypeQueryParam("link"); }
-          function load() { return _getInteractionTypeQueryParam("load"); }
-          function log() { return _getInteractionTypeQueryParam("log"); }
-          function ping() { return _getInteractionTypeQueryParam("ping"); }
-          function sitesearch() { return _getInteractionTypeQueryParam("sitesearch"); }
-          function unload() { return _getInteractionTypeQueryParam("unload"); }
+        var litp = (function() {
+          var lastInteractionType = "";
+          function ecommerce() { lastInteractionType = "ecommerce"; }
+          function event() { lastInteractionType = "event"; }
+          function goal() { lastInteractionType = "goal"; }
+          function link() { lastInteractionType = "link"; }
+          function load() { lastInteractionType = "load"; }
+          function log() { lastInteractionType = "log"; }
+          function ping() { lastInteractionType = "ping"; }
+          function sitesearch() { lastInteractionType = "sitesearch"; }
+          function unload() { lastInteractionType = "unload"; }
+          function getLastInteractionType() { return lastInteractionType; }
 
           return {
             ecommerce: ecommerce,
@@ -797,21 +798,36 @@ function PiwikTest() {
             log : log,
             ping: ping,
             sitesearch : sitesearch,
-            unload : unload
+            unload : unload,
+            getLastInteractionType: getLastInteractionType
           };
         })();
 
-        tracker.addPlugin("interactionTypePlugin", interactionTypePlugin);
+        tracker.addPlugin("interactionTypePlugin", litp);
 
-        ok( tracker.getRequest("", "", "ecommerce").indexOf("&_interactionType='ecommerce'") > -1);
-        ok( tracker.getRequest("", "", "event").indexOf("&_interactionType='event'") > -1);
-        ok( tracker.getRequest("", "", "goal").indexOf("&_interactionType='goal'") > -1);
-        ok( tracker.getRequest("", "", "link").indexOf("&_interactionType='link'") > -1);
-        ok( tracker.getRequest("", "", "load").indexOf("&_interactionType='load'") > -1);
-        ok( tracker.getRequest("", "", "log").indexOf("&_interactionType='log'") > -1);
-        ok( tracker.getRequest("", "", "ping").indexOf("&_interactionType='ping'") > -1);
-        ok( tracker.getRequest("", "", "sitesearch").indexOf("&_interactionType='sitesearch'") > -1);
-        ok( tracker.getRequest("", "", "unload").indexOf("&_interactionType='unload'") > -1);
+        ok(litp.getLastInteractionType() !== 'ecommerce');
+        tracker.trackEcommerceOrder("ORDER ID YES", 666.66);
+        ok(litp.getLastInteractionType() === 'ecommerce');
+
+        ok(litp.getLastInteractionType() !== 'event');
+        tracker.trackEvent("Event Category", "Event Action");
+        ok(litp.getLastInteractionType() === 'event');
+
+        ok(litp.getLastInteractionType() !== 'goal');
+        tracker.trackGoal(42);
+        ok(litp.getLastInteractionType() === 'goal');
+
+        ok(litp.getLastInteractionType() !== 'link');
+        tracker.trackLink("http://example.ca", "link");
+        ok(litp.getLastInteractionType() === 'link');
+
+        ok(litp.getLastInteractionType() !== 'log');
+        tracker.trackPageView();
+        ok(litp.getLastInteractionType() === 'log');
+
+        ok(litp.getLastInteractionType() !== 'sitesearch');
+        tracker.trackSiteSearch("search Keyword");
+        ok(litp.getLastInteractionType() === 'sitesearch');
     });
 
     test("prefixPropertyName()", function() {


### PR DESCRIPTION
So far adding plugins was only accessible through Piwik public API, Piwik.addPlugin.
Problem with this was that it was not possible to register plugins before any event has been handled, since Piwik singleton initialization (and any plugin registration) happens after _paq is processed and this is too late - any registered plugin will not be included in processing events fired by evaluation of _paq array items.

This patch enables registering Tracker plugins on Tracker itself, so addPlugin can be part of _paq instructions.
It is not enforced when addPlugin instructions will be processed (e.g. addPlugin is not part of alwaysFirst), for flexibility - e.g. one can have trackPageView evaluated without plugin, then addPlugin for all the next steps, or one can have addPlugin pushed first to _paq, and then trackPageView, if plugin should be applied for trackPageView as well.
