### PR TITLE
Fixed jsdoc for trackSiteSearch parameters

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -3031,8 +3031,9 @@ if (typeof Piwik !== 'object') {
                 /**
                  * Log special pageview: Internal search
                  *
-                 * @param string customTitle
-                 * @param mixed customData
+                 * @param string keyword
+                 * @param string category
+                 * @param int resultsCount
                  */
                 trackSiteSearch: function (keyword, category, resultsCount) {
                     trackCallback(function () {


### PR DESCRIPTION
JSDOC for trackSiteSearch method parameters was wrong - number of parameters, their names and types did not match.
This patch fixes the issue.
