### PR TITLE
provide a more useful error message on exception

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -234,7 +234,7 @@ class CliMulti {
         } catch (\Exception $e) {
             $message = "Got invalid response from API request: $url. ";
 
-            if (empty($response)) {
+            if (isset($response) && empty($response)) {
                 $message .= "The response was empty. This usually means a server error. This solution to this error is generally to increase the value of 'memory_limit' in your php.ini file. Please check your Web server Error Log file for more details.";
             } else {
                 $message .= "Response was '" . $e->getMessage() . "'";


### PR DESCRIPTION
This gives me a more useful error log entry

`<pre>ERROR Piwik\Tracker[2014-07-05 12:03:10] [33868] Got invalid response from API request: https://127.0.0.1/piwik/index.php?module=API&amp;method=API.getDefaultMetricTranslations&amp;format=original&amp;serialize=1&amp;trigger=archivephp. Response was &#039;Got invalid response from API request: https://127.0.0.1/piwik/index.php?module=API&amp;method=API.getDefaultMetricTranslations&amp;format=original&amp;serialize=1&amp;trigger=archivephp. Response was &#039;curl_exec: SSL certificate problem, verify that the CA cert is OK. Details: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed. Hostname requested was: 127.0.0.1&#039;&#039;</pre>`

instead of

`<pre>ERROR Piwik\Tracker[2014-07-05 12:02:06] [03840] Got invalid response from API request: https://127.0.0.1/piwik/index.php?module=API&amp;method=API.getDefaultMetricTranslations&amp;format=original&amp;serialize=1&amp;trigger=archivephp. Response was &#039;Got invalid response from API request: https://127.0.0.1/piwik/index.php?module=API&amp;method=API.getDefaultMetricTranslations&amp;format=original&amp;serialize=1&amp;trigger=archivephp. The response was empty. This usually means a server error. This solution to this error is generally to increase the value of &#039;memory_limit&#039; in your php.ini file. Please check your Web server Error Log file for more details.&#039;</pre>`

because in case of an exception in `Http::sendHttpRequestBy`, `$response` is undefined and always empty.

Maybe the entire branch for that dummy message could be removed. Let me know what you think or if I missed something here.
