### PR TITLE
add XSD to PHPUnit configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
         "piwik/device-detector": "2.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "~4.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "016b7b6646d1d3ec6d8b574b5a6c5561",
+    "hash": "a369c506837f7af17cd3258c889e3b57",
     "packages": [
         {
             "name": "leafo/lessphp",

--- a/tests/PHPUnit/phpunit.xml.dist
+++ b/tests/PHPUnit/phpunit.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="true"
          backupStaticAttributes="false"
          bootstrap="bootstrap.php"
          colors="false"
@@ -14,7 +16,6 @@
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         syntaxCheck="false"
          strict="false"
          verbose="true">
 


### PR DESCRIPTION
(The syntax check functionality has been removed in PHPUnit 3.6 already.)
