### PR TITLE
included default value for concurent threads number

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1320,6 +1320,10 @@ class CronArchive
      */
     private function getConcurrentRequestsPerWebsite()
     {
-        return $this->getParameterFromCli('--concurrent-requests-per-website', true);
+        $cliParam = $this->getParameterFromCli('--concurrent-requests-per-website', true);
+        if ($cliParam !== false) {
+            return $cliParam;
+        }
+        return self::MAX_CONCURRENT_API_REQUESTS;
     }
 }


### PR DESCRIPTION
For now, running archiving without --concurrent-requests-per-website on site with huge ammount of segments will cause big number of threads to be spawned. This patch falls back to default value in code in case there is no specific value passed to command.
