### PR TITLE
code cleanup

### DIFF
--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -79,9 +79,8 @@ class DocumentationGenerator
                     if ($exampleUrl !== false) {
                         $lastNUrls = '';
                         if (preg_match('/(&period)|(&date)/', $exampleUrl)) {
-                            $exampleUrlRss1 = $prefixUrls . $this->getExampleUrl($class, $methodName, array('date' => 'last10', 'period' => 'day') + $parametersToSet);
-                            $exampleUrlRss2 = $prefixUrls . $this->getExampleUrl($class, $methodName, array('date' => 'last5', 'period' => 'week',) + $parametersToSet);
-                            $lastNUrls = ",	RSS of the last <a target=_blank href='$exampleUrlRss1&format=rss$token_auth&translateColumnNames=1'>10 days</a>";
+                            $exampleUrlRss = $prefixUrls . $this->getExampleUrl($class, $methodName, array('date' => 'last10', 'period' => 'day') + $parametersToSet);
+                            $lastNUrls = ",	RSS of the last <a target=_blank href='$exampleUrlRss&format=rss$token_auth&translateColumnNames=1'>10 days</a>";
                         }
                         $exampleUrl = $prefixUrls . $exampleUrl;
                         $str .= " [ Example in

--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -500,7 +500,7 @@ class Proxy extends Singleton
     private function checkClassIsSingleton($className)
     {
         if (!method_exists($className, "getInstance")) {
-            throw new Exception("$className that provide an API must be Singleton and have a 'static public function getInstance()' method.");
+            throw new Exception("$className that provide an API must be Singleton and have a 'public static function getInstance()' method.");
         }
     }
 }

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -80,7 +80,7 @@ class Request
      *                              `'module=UserSettings&action=getWidescreen'`.
      * @return array
      */
-    static public function getRequestArrayFromString($request)
+    public static function getRequestArrayFromString($request)
     {
         $defaultRequest = $_GET + $_POST;
 
@@ -227,7 +227,7 @@ class Request
      * @param string $plugin The plugin name, eg, `'Referrers'`.
      * @return string The fully qualified API class name, eg, `'\Piwik\Plugins\Referrers\API'`.
      */
-    static public function getClassNameAPI($plugin)
+    public static function getClassNameAPI($plugin)
     {
         return sprintf('\Piwik\Plugins\%s\API', $plugin);
     }
@@ -241,7 +241,7 @@ class Request
      * @return void
      * @ignore
      */
-    static public function reloadAuthUsingTokenAuth($request = null)
+    public static function reloadAuthUsingTokenAuth($request = null)
     {
         // if a token_auth is specified in the API request, we load the right permissions
         $token_auth = Common::getRequestVar('token_auth', '', 'string', $request);
@@ -382,7 +382,7 @@ class Request
      * 
      * @return array|bool
      */
-    static public function getRawSegmentFromRequest()
+    public static function getRawSegmentFromRequest()
     {
         // we need the URL encoded segment parameter, we fetch it from _SERVER['QUERY_STRING'] instead of default URL decoded _GET
         $segmentRaw = false;

--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -400,7 +400,7 @@ class ResponseBuilder
         $first = reset($array);
         foreach ($array as $first) {
             if (is_array($first)) {
-                foreach ($first as $key => $value) {
+                foreach ($first as $value) {
                     // Yes, this is a multi dim array
                     if (is_array($value)) {
                         switch ($this->outputFormat) {

--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -459,7 +459,7 @@ class ResponseBuilder
      * @param array $request
      * @return array
      */
-    static public function getLabelFromRequest($request)
+    public static function getLabelFromRequest($request)
     {
         $label = Common::getRequestVar('label', array(), 'array', $request);
         if (empty($label)) {
@@ -473,7 +473,7 @@ class ResponseBuilder
         return $label;
     }
 
-    static public function unsanitizeLabelParameter($label)
+    public static function unsanitizeLabelParameter($label)
     {
         // this is needed because Proxy uses Common::getRequestVar which in turn
         // uses Common::sanitizeInputValue. This causes the > that separates recursive labels

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -129,12 +129,12 @@ class Rules
         return $doneFlags;
     }
 
-    static public function disablePurgeOutdatedArchives()
+    public static function disablePurgeOutdatedArchives()
     {
         self::$purgeOutdatedArchivesIsDisabled = true;
     }
 
-    static public function enablePurgeOutdatedArchives()
+    public static function enablePurgeOutdatedArchives()
     {
         self::$purgeOutdatedArchivesIsDisabled = false;
     }

--- a/core/Common.php
+++ b/core/Common.php
@@ -1070,7 +1070,7 @@ class Common
      * @param $var The object to destroy.
      * @api
      */
-    static public function destroy(&$var)
+    public static function destroy(&$var)
     {
         if (is_object($var) && method_exists($var, '__destruct')) {
             $var->__destruct();
@@ -1079,7 +1079,7 @@ class Common
         $var = null;
     }
 
-    static public function printDebug($info = '')
+    public static function printDebug($info = '')
     {
         if (isset($GLOBALS['PIWIK_TRACKER_DEBUG']) && $GLOBALS['PIWIK_TRACKER_DEBUG']) {
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -96,7 +96,7 @@ class CronArchive
      * @param string $period
      * @return string
      */
-    static public function lastRunKey($idSite, $period)
+    public static function lastRunKey($idSite, $period)
     {
         return "lastRunArchive" . $period . "_" . $idSite;
     }

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1169,7 +1169,7 @@ class CronArchive
     private function logFatalErrorUrlExpected()
     {
         $this->logFatalError("./console core:archive expects the argument 'url' to be set to your Piwik URL, for example: --url=http://example.org/piwik/ "
-            . "\n--help for more information", $backtrace = false);
+            . "\n--help for more information");
     }
 
     private function getVisitsLastPeriodFromApiResponse($stats)

--- a/core/DataAccess/ArchivePurger.php
+++ b/core/DataAccess/ArchivePurger.php
@@ -22,7 +22,7 @@ use Piwik\Piwik;
  */
 class ArchivePurger
 {
-    static public function purgeOutdatedArchives(Date $dateStart)
+    public static function purgeOutdatedArchives(Date $dateStart)
     {
         $purgeArchivesOlderThan = Rules::shouldPurgeOutdatedArchives($dateStart);
         if (!$purgeArchivesOlderThan) {

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -40,7 +40,7 @@ class ArchiveSelector
 
     const NB_VISITS_CONVERTED_RECORD_LOOKED_UP = "nb_visits_converted";
 
-    static public function getArchiveIdAndVisits(ArchiveProcessor\Parameters $params, $minDatetimeArchiveProcessedUTC)
+    public static function getArchiveIdAndVisits(ArchiveProcessor\Parameters $params, $minDatetimeArchiveProcessedUTC)
     {
         $dateStart = $params->getPeriod()->getDateStart();
         $bindSQL = array($params->getSite()->getId(),
@@ -148,7 +148,7 @@ class ArchiveSelector
      *               )
      * @throws
      */
-    static public function getArchiveIds($siteIds, $periods, $segment, $plugins, $isSkipAggregationOfSubTables = false)
+    public static function getArchiveIds($siteIds, $periods, $segment, $plugins, $isSkipAggregationOfSubTables = false)
     {
         if(empty($siteIds)) {
             throw new \Exception("Website IDs could not be read from the request, ie. idSite=");
@@ -224,7 +224,7 @@ class ArchiveSelector
      * @throws Exception
      * @return array
      */
-    static public function getArchiveData($archiveIds, $recordNames, $archiveDataType, $loadAllSubtables)
+    public static function getArchiveData($archiveIds, $recordNames, $archiveDataType, $loadAllSubtables)
     {
         // create the SQL to select archive data
         $inNames = Common::getSqlStringFieldsArray($recordNames);
@@ -280,7 +280,7 @@ class ArchiveSelector
      * @param bool $isSkipAggregationOfSubTables
      * @return string
      */
-    static private function getNameCondition(array $plugins, Segment $segment, $isSkipAggregationOfSubTables)
+    private static function getNameCondition(array $plugins, Segment $segment, $isSkipAggregationOfSubTables)
     {
         // the flags used to tell how the archiving process for a specific archive was completed,
         // if it was completed

--- a/core/DataAccess/ArchiveTableCreator.php
+++ b/core/DataAccess/ArchiveTableCreator.php
@@ -23,17 +23,17 @@ class ArchiveTableCreator
 
     static public $tablesAlreadyInstalled = null;
 
-    static public function getNumericTable(Date $date)
+    public static function getNumericTable(Date $date)
     {
         return self::getTable($date, self::NUMERIC_TABLE);
     }
 
-    static public function getBlobTable(Date $date)
+    public static function getBlobTable(Date $date)
     {
         return self::getTable($date, self::BLOB_TABLE);
     }
 
-    static protected function getTable(Date $date, $type)
+    protected static function getTable(Date $date, $type)
     {
         $tableNamePrefix = "archive_" . $type;
         $tableName = $tableNamePrefix . "_" . $date->toString('Y_m');
@@ -42,7 +42,7 @@ class ArchiveTableCreator
         return $tableName;
     }
 
-    static protected function createArchiveTablesIfAbsent($tableName, $tableNamePrefix)
+    protected static function createArchiveTablesIfAbsent($tableName, $tableNamePrefix)
     {
         if (is_null(self::$tablesAlreadyInstalled)) {
             self::refreshTableList();
@@ -67,12 +67,12 @@ class ArchiveTableCreator
         }
     }
 
-    static public function clear()
+    public static function clear()
     {
         self::$tablesAlreadyInstalled = null;
     }
 
-    static public function refreshTableList($forceReload = false)
+    public static function refreshTableList($forceReload = false)
     {
         self::$tablesAlreadyInstalled = DbHelper::getTablesInstalled($forceReload);
     }
@@ -82,7 +82,7 @@ class ArchiveTableCreator
      *
      * @return array
      */
-    static public function getTablesArchivesInstalled()
+    public static function getTablesArchivesInstalled()
     {
         if (is_null(self::$tablesAlreadyInstalled)) {
             self::refreshTableList();
@@ -99,14 +99,14 @@ class ArchiveTableCreator
         return $archiveTables;
     }
 
-    static public function getDateFromTableName($tableName)
+    public static function getDateFromTableName($tableName)
     {
         $tableName = Common::unprefixTable($tableName);
         $date = str_replace(array('archive_numeric_', 'archive_blob_'), '', $tableName);
         return $date;
     }
 
-    static public function getTypeFromTableName($tableName)
+    public static function getTypeFromTableName($tableName)
     {
         if (strpos($tableName, 'archive_numeric_') !== false) {
             return self::NUMERIC_TABLE;

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -116,7 +116,7 @@ class ArchiveWriter
         $this->logArchiveStatusAsFinal();
     }
 
-    static protected function compress($data)
+    protected static function compress($data)
     {
         if (Db::get()->hasBlobDataType()) {
             return gzcompress($data);

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -662,7 +662,7 @@ class LogAggregator
 
     protected function getActionsMetricFields()
     {
-        return $availableMetrics = array(
+        return array(
             Metrics::INDEX_NB_VISITS        => "count(distinct " . self::LOG_ACTIONS_TABLE . ".idvisit)",
             Metrics::INDEX_NB_UNIQ_VISITORS => "count(distinct " . self::LOG_ACTIONS_TABLE . ".idvisitor)",
             Metrics::INDEX_NB_ACTIONS       => "count(*)",

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -167,7 +167,7 @@ class LogAggregator
         );
     }
 
-    static public function getConversionsMetricFields()
+    public static function getConversionsMetricFields()
     {
         return array(
             Metrics::INDEX_GOAL_NB_CONVERSIONS             => "count(*)",
@@ -181,12 +181,12 @@ class LogAggregator
         );
     }
 
-    static private function getSqlConversionRevenueSum($field)
+    private static function getSqlConversionRevenueSum($field)
     {
         return self::getSqlRevenue('SUM(' . self::LOG_CONVERSION_TABLE . '.' . $field . ')');
     }
 
-    static public function getSqlRevenue($field)
+    public static function getSqlRevenue($field)
     {
         return "ROUND(" . $field . "," . GoalManager::REVENUE_PRECISION . ")";
     }
@@ -856,7 +856,7 @@ class LogAggregator
      *                                 value is used.
      * @return array
      */
-    static public function makeArrayOneColumn($row, $columnName, $lookForThisPrefix = false)
+    public static function makeArrayOneColumn($row, $columnName, $lookForThisPrefix = false)
     {
         $cleanRow = array();
         foreach ($row as $label => $count) {

--- a/core/DataArray.php
+++ b/core/DataArray.php
@@ -332,7 +332,7 @@ class DataArray
      */
     protected function enrichWithConversions(&$data)
     {
-        foreach ($data as $label => &$values) {
+        foreach ($data as &$values) {
             if (!isset($values[Metrics::INDEX_GOALS])) {
                 continue;
             }

--- a/core/DataArray.php
+++ b/core/DataArray.php
@@ -57,7 +57,7 @@ class DataArray
      *
      * @return array
      */
-    static public function makeEmptyRow()
+    public static function makeEmptyRow()
     {
         return array(Metrics::INDEX_NB_UNIQ_VISITORS    => 0,
                      Metrics::INDEX_NB_VISITS           => 0,
@@ -195,7 +195,7 @@ class DataArray
         $this->doSumVisitsMetrics($row, $this->data[$label], $onlyMetricsAvailableInActionsTable = true);
     }
 
-    static protected function makeEmptyActionRow()
+    protected static function makeEmptyActionRow()
     {
         return array(
             Metrics::INDEX_NB_UNIQ_VISITORS => 0,
@@ -212,7 +212,7 @@ class DataArray
         $this->doSumEventsMetrics($row, $this->data[$label], $onlyMetricsAvailableInActionsTable = true);
     }
 
-    static protected function makeEmptyEventRow()
+    protected static function makeEmptyEventRow()
     {
         return array(
             Metrics::INDEX_NB_UNIQ_VISITORS         => 0,
@@ -369,7 +369,7 @@ class DataArray
      * @param $row
      * @return bool
      */
-    static public function isRowActions($row)
+    public static function isRowActions($row)
     {
         return (count($row) == count(self::makeEmptyActionRow())) && isset($row[Metrics::INDEX_NB_ACTIONS]);
     }

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1026,7 +1026,6 @@ class DataTable implements DataTableInterface
     public static function isEqual(DataTable $table1, DataTable $table2)
     {
         $rows1 = $table1->getRows();
-        $rows2 = $table2->getRows();
 
         $table1->rebuildIndex();
         $table2->rebuildIndex();

--- a/core/DataTable/Filter/ColumnCallbackAddColumnQuotient.php
+++ b/core/DataTable/Filter/ColumnCallbackAddColumnQuotient.php
@@ -75,7 +75,7 @@ class ColumnCallbackAddColumnQuotient extends BaseFilter
      */
     public function filter($table)
     {
-        foreach ($table->getRows() as $key => $row) {
+        foreach ($table->getRows() as $row) {
             $value = $this->getDividend($row);
             if ($value === false && $this->shouldSkipRows) {
                 continue;

--- a/core/DataTable/Filter/ColumnCallbackReplace.php
+++ b/core/DataTable/Filter/ColumnCallbackReplace.php
@@ -72,7 +72,7 @@ class ColumnCallbackReplace extends BaseFilter
      */
     public function filter($table)
     {
-        foreach ($table->getRows() as $key => $row) {
+        foreach ($table->getRows() as $row) {
             $extraColumnParameters = array();
             foreach ($this->extraColumnParameters as $columnName) {
                 $extraColumnParameters[] = $row->getColumn($columnName);

--- a/core/DataTable/Filter/Pattern.php
+++ b/core/DataTable/Filter/Pattern.php
@@ -53,7 +53,7 @@ class Pattern extends BaseFilter
      * @return string
      * @ignore
      */
-    static public function getPatternQuoted($pattern)
+    public static function getPatternQuoted($pattern)
     {
         return '/' . str_replace('/', '\/', $pattern) . '/';
     }
@@ -67,7 +67,7 @@ class Pattern extends BaseFilter
      * @return int
      * @ignore
      */
-    static public function match($patternQuoted, $string, $invertedMatch = false)
+    public static function match($patternQuoted, $string, $invertedMatch = false)
     {
         return preg_match($patternQuoted . "i", $string) == 1 ^ $invertedMatch;
     }

--- a/core/DataTable/Filter/ReplaceColumnNames.php
+++ b/core/DataTable/Filter/ReplaceColumnNames.php
@@ -81,7 +81,7 @@ class ReplaceColumnNames extends BaseFilter
      */
     protected function filterTable($table)
     {
-        foreach ($table->getRows() as $key => $row) {
+        foreach ($table->getRows() as $row) {
             $oldColumns = $row->getColumns();
             $newColumns = $this->getRenamedColumns($oldColumns);
             $row->setColumns($newColumns);

--- a/core/DataTable/Map.php
+++ b/core/DataTable/Map.php
@@ -104,7 +104,7 @@ class Map implements DataTableInterface
      */
     public function filter($className, $parameters = array())
     {
-        foreach ($this->getDataTables() as $id => $table) {
+        foreach ($this->getDataTables() as $table) {
             $table->filter($className, $parameters);
         }
     }

--- a/core/DataTable/Renderer.php
+++ b/core/DataTable/Renderer.php
@@ -182,7 +182,7 @@ abstract class Renderer
      *
      * @return array
      */
-    static public function getRenderers()
+    public static function getRenderers()
     {
         return self::$availableRenderers;
     }
@@ -194,7 +194,7 @@ abstract class Renderer
      * @throws Exception If the renderer is unknown
      * @return \Piwik\DataTable\Renderer
      */
-    static public function factory($name)
+    public static function factory($name)
     {
         $className = ucfirst(strtolower($name));
         $className = 'Piwik\DataTable\Renderer\\' . $className;
@@ -214,7 +214,7 @@ abstract class Renderer
      * @param String $rawData data to be converted
      * @return String
      */
-    static protected function renderHtmlEntities($rawData)
+    protected static function renderHtmlEntities($rawData)
     {
         return self::formatValueXml($rawData);
     }

--- a/core/DataTable/Renderer/Rss.php
+++ b/core/DataTable/Renderer/Rss.php
@@ -184,7 +184,6 @@ class Rss extends Renderer
             }
         }
         $html .= "\n</tr>";
-        $colspan = count($allColumns);
 
         foreach ($tableStructure as $row) {
             $html .= "\n\n<tr>";

--- a/core/DataTable/Renderer/Xml.php
+++ b/core/DataTable/Renderer/Xml.php
@@ -373,7 +373,7 @@ class Xml extends Renderer
 
             // Handing case idgoal=7, creating a new array for that one
             $rowAttribute = '';
-            if (($equalFound = strstr($rowId, '=')) !== false) {
+            if (strstr($rowId, '=') !== false) {
                 $rowAttribute = explode('=', $rowId);
                 $rowAttribute = " " . $rowAttribute[0] . "='" . $rowAttribute[1] . "'";
             }

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -658,7 +658,7 @@ class Row
      * @return bool
      * @ignore
      */
-    static public function compareElements($elem1, $elem2)
+    public static function compareElements($elem1, $elem2)
     {
         if (is_array($elem1)) {
             if (is_array($elem2)) {
@@ -689,7 +689,7 @@ class Row
      * @param \Piwik\DataTable\Row $row2 second to compare
      * @return bool
      */
-    static public function isEqual(Row $row1, Row $row2)
+    public static function isEqual(Row $row1, Row $row2)
     {
         //same columns
         $cols1 = $row1->getColumns();

--- a/core/Db.php
+++ b/core/Db.php
@@ -124,7 +124,7 @@ class Db
      * @throws \Exception If there is an error in the SQL.
      * @return integer|\Zend_Db_Statement
      */
-    static public function exec($sql)
+    public static function exec($sql)
     {
         /** @var \Zend_Db_Adapter_Abstract $db */
         $db = self::get();
@@ -154,7 +154,7 @@ class Db
      * @throws \Exception If there is a problem with the SQL or bind parameters.
      * @return \Zend_Db_Statement
      */
-    static public function query($sql, $parameters = array())
+    public static function query($sql, $parameters = array())
     {
         try {
             return self::get()->query($sql, $parameters);
@@ -173,7 +173,7 @@ class Db
      * @return array The fetched rows, each element is an associative array mapping column names
      *               with column values.
      */
-    static public function fetchAll($sql, $parameters = array())
+    public static function fetchAll($sql, $parameters = array())
     {
         try {
             return self::get()->fetchAll($sql, $parameters);
@@ -192,7 +192,7 @@ class Db
      * @return array The fetched row, each element is an associative array mapping column names
      *               with column values.
      */
-    static public function fetchRow($sql, $parameters = array())
+    public static function fetchRow($sql, $parameters = array())
     {
         try {
             return self::get()->fetchRow($sql, $parameters);
@@ -211,7 +211,7 @@ class Db
      * @throws \Exception If there is a problem with the SQL or bind parameters.
      * @return string
      */
-    static public function fetchOne($sql, $parameters = array())
+    public static function fetchOne($sql, $parameters = array())
     {
         try {
             return self::get()->fetchOne($sql, $parameters);
@@ -234,7 +234,7 @@ class Db
      *                     'col1value2' => array('col2' => '...', 'col3' => ...))
      *               ```
      */
-    static public function fetchAssoc($sql, $parameters = array())
+    public static function fetchAssoc($sql, $parameters = array())
     {
         try {
             return self::get()->fetchAssoc($sql, $parameters);
@@ -264,7 +264,7 @@ class Db
      * @param array $parameters Parameters to bind for each query.
      * @return int The total number of rows deleted.
      */
-    static public function deleteAllRows($table, $where, $orderBy, $maxRowsPerQuery = 100000, $parameters = array())
+    public static function deleteAllRows($table, $where, $orderBy, $maxRowsPerQuery = 100000, $parameters = array())
     {
         $orderByClause = $orderBy ? "ORDER BY $orderBy" : "";
         $sql = "DELETE FROM $table
@@ -293,7 +293,7 @@ class Db
      *                             Table names must be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @return \Zend_Db_Statement
      */
-    static public function optimizeTables($tables)
+    public static function optimizeTables($tables)
     {
         $optimize = Config::getInstance()->General['enable_sql_optimize_queries'];
         if (empty($optimize)) {
@@ -332,7 +332,7 @@ class Db
      *                             Table names must be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @return \Zend_Db_Statement
      */
-    static public function dropTables($tables)
+    public static function dropTables($tables)
     {
         if (!is_array($tables)) {
             $tables = array($tables);
@@ -344,7 +344,7 @@ class Db
     /**
      * Drops all tables
      */
-    static public function dropAllTables()
+    public static function dropAllTables()
     {
         $tablesAlreadyInstalled = DbHelper::getTablesInstalled();
         self::dropTables($tablesAlreadyInstalled);
@@ -356,7 +356,7 @@ class Db
      * @param string|array $table The name of the table you want to get the columns definition for.
      * @return \Zend_Db_Statement
      */
-    static public function getColumnNamesFromTable($table)
+    public static function getColumnNamesFromTable($table)
     {
         $columns = self::fetchAll("SHOW COLUMNS FROM `" . $table . "`");
 
@@ -380,7 +380,7 @@ class Db
      *                                    be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @return \Zend_Db_Statement
      */
-    static public function lockTables($tablesToRead, $tablesToWrite = array())
+    public static function lockTables($tablesToRead, $tablesToWrite = array())
     {
         if (!is_array($tablesToRead)) {
             $tablesToRead = array($tablesToRead);
@@ -408,7 +408,7 @@ class Db
      * 
      * @return \Zend_Db_Statement
      */
-    static public function unlockAllTables()
+    public static function unlockAllTables()
     {
         return self::exec("UNLOCK TABLES");
     }
@@ -451,7 +451,7 @@ class Db
      *
      * @return string
      */
-    static public function segmentedFetchFirst($sql, $first, $last, $step, $params = array())
+    public static function segmentedFetchFirst($sql, $first, $last, $step, $params = array())
     {
         $result = false;
         if ($step > 0) {
@@ -487,7 +487,7 @@ class Db
      * @param array $params Parameters to bind in the query, `array(param1 => value1, param2 => value2)`
      * @return array An array of primitive values.
      */
-    static public function segmentedFetchOne($sql, $first, $last, $step, $params = array())
+    public static function segmentedFetchOne($sql, $first, $last, $step, $params = array())
     {
         $result = array();
         if ($step > 0) {
@@ -524,7 +524,7 @@ class Db
      * @return array An array of rows that includes the result set of every smaller
      *               query.
      */
-    static public function segmentedFetchAll($sql, $first, $last, $step, $params = array())
+    public static function segmentedFetchAll($sql, $first, $last, $step, $params = array())
     {
         $result = array();
         if ($step > 0) {
@@ -559,7 +559,7 @@ class Db
      * @param int $step The maximum number of rows to scan in one query.
      * @param array $params Parameters to bind in the query, `array(param1 => value1, param2 => value2)`
      */
-    static public function segmentedQuery($sql, $first, $last, $step, $params = array())
+    public static function segmentedQuery($sql, $first, $last, $step, $params = array())
     {
         if ($step > 0) {
             for ($i = $first; $i <= $last; $i += $step) {
@@ -580,7 +580,7 @@ class Db
      * @param string $tableName The name of the table to check for. Must be prefixed.
      * @return bool
      */
-    static public function tableExists($tableName)
+    public static function tableExists($tableName)
     {
         return self::query("SHOW TABLES LIKE ?", $tableName)->rowCount() > 0;
     }
@@ -593,7 +593,7 @@ class Db
      * @param int $maxRetries The max number of times to retry.
      * @return bool `true` if the lock was obtained, `false` if otherwise.
      */
-    static public function getDbLock($lockName, $maxRetries = 30)
+    public static function getDbLock($lockName, $maxRetries = 30)
     {
         /*
          * the server (e.g., shared hosting) may have a low wait timeout
@@ -620,7 +620,7 @@ class Db
      * @param string $lockName The lock name.
      * @return bool `true` if the lock was released, `false` if otherwise.
      */
-    static public function releaseDbLock($lockName)
+    public static function releaseDbLock($lockName)
     {
         $sql = 'SELECT RELEASE_LOCK(?)';
 

--- a/core/Db/BatchInsert.php
+++ b/core/Db/BatchInsert.php
@@ -214,7 +214,7 @@ class BatchInsert
      * @param array $rows Array of array corresponding to rows of values
      * @throws Exception  if unable to create or write to file
      */
-    static protected function createCSVFile($filePath, $fileSpec, $rows)
+    protected static function createCSVFile($filePath, $fileSpec, $rows)
     {
         // Set up CSV delimiters, quotes, etc
         $delim = $fileSpec['delim'];

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -26,7 +26,7 @@ class Mysql implements SchemaInterface
      * @param string $engineName
      * @return bool  True if available and enabled; false otherwise
      */
-    static private function hasStorageEngine($engineName)
+    private static function hasStorageEngine($engineName)
     {
         $db = Db::get();
         $allEngines = $db->fetchAssoc('SHOW ENGINES');
@@ -42,7 +42,7 @@ class Mysql implements SchemaInterface
      *
      * @return bool  True if schema is available; false otherwise
      */
-    static public function isAvailable()
+    public static function isAvailable()
     {
         return self::hasStorageEngine('InnoDB');
     }

--- a/core/Db/SchemaInterface.php
+++ b/core/Db/SchemaInterface.php
@@ -19,7 +19,7 @@ interface SchemaInterface
      *
      * @return bool  True if schema is available; false otherwise
      */
-    static public function isAvailable();
+    public static function isAvailable();
 
     /**
      * Get the SQL to create a specific Piwik table

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -234,12 +234,12 @@ class FrontController extends Singleton
         || SettingsServer::isArchivePhpTriggered();
     }
 
-    static public function setUpSafeMode()
+    public static function setUpSafeMode()
     {
         register_shutdown_function(array('\\Piwik\\FrontController','triggerSafeModeWhenError'));
     }
 
-    static public function triggerSafeModeWhenError()
+    public static function triggerSafeModeWhenError()
     {
         $lastError = error_get_last();
         if (!empty($lastError) && $lastError['type'] == E_ERROR) {
@@ -257,7 +257,7 @@ class FrontController extends Singleton
      *
      * @return Exception
      */
-    static public function createConfigObject()
+    public static function createConfigObject()
     {
         $exceptionToThrow = false;
         try {

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -390,7 +390,7 @@ class FrontController extends Singleton
 
             // ensure the current Piwik URL is known for later use
             if (method_exists('Piwik\SettingsPiwik', 'getPiwikUrl')) {
-                $host = SettingsPiwik::getPiwikUrl();
+                SettingsPiwik::getPiwikUrl();
             }
 
             /**
@@ -419,7 +419,7 @@ class FrontController extends Singleton
 
             // Force the auth to use the token_auth if specified, so that embed dashboard
             // and all other non widgetized controller methods works fine
-            if (($token_auth = Common::getRequestVar('token_auth', false, 'string')) !== false) {
+            if (Common::getRequestVar('token_auth', false, 'string') !== false) {
                 Request::reloadAuthUsingTokenAuth();
             }
             SettingsServer::raiseMemoryLimitIfNecessary();

--- a/core/IP.php
+++ b/core/IP.php
@@ -170,9 +170,8 @@ class IP
      */
     public static function isIPv4($ip)
     {
-        // in case mbstring overloads strlen and substr functions
+        // in case mbstring overloads strlen function
         $strlen = function_exists('mb_orig_strlen') ? 'mb_orig_strlen' : 'strlen';
-        $substr = function_exists('mb_orig_substr') ? 'mb_orig_substr' : 'substr';
 
         // IPv4
         if ($strlen($ip) == 4) {

--- a/core/Metrics.php
+++ b/core/Metrics.php
@@ -159,7 +159,7 @@ class Metrics
         Metrics::INDEX_NB_VISITS_CONVERTED,
     );
 
-    static public function getVisitsMetricNames()
+    public static function getVisitsMetricNames()
     {
         $names = array();
         foreach (self::$metricsAggregatedFromLogs as $metricId) {
@@ -168,7 +168,7 @@ class Metrics
         return $names;
     }
 
-    static public function getMappingFromIdToName()
+    public static function getMappingFromIdToName()
     {
         $idToName = array_flip(self::$mappingFromIdToName);
         return $idToName;
@@ -181,7 +181,7 @@ class Metrics
      *
      * @ignore
      */
-    static public function isLowerValueBetter($column)
+    public static function isLowerValueBetter($column)
     {
         $lowerIsBetterPatterns = array(
             'bounce', 'exit'
@@ -203,7 +203,7 @@ class Metrics
      * @return string
      * @ignore
      */
-    static public function getUnit($column, $idSite)
+    public static function getUnit($column, $idSite)
     {
         $nameToUnit = array(
             '_rate'   => '%',
@@ -220,7 +220,7 @@ class Metrics
         return '';
     }
 
-    static public function getDefaultMetricTranslations()
+    public static function getDefaultMetricTranslations()
     {
         $cache = new PluginAwareStaticCache('DefaultMetricTranslations');
 
@@ -278,7 +278,7 @@ class Metrics
         return $translations;
     }
 
-    static public function getDefaultMetrics()
+    public static function getDefaultMetrics()
     {
         $cache = new LanguageAwareStaticCache('DefaultMetrics');
 
@@ -298,7 +298,7 @@ class Metrics
         return $translations;
     }
 
-    static public function getDefaultProcessedMetrics()
+    public static function getDefaultProcessedMetrics()
     {
         $cache = new LanguageAwareStaticCache('DefaultProcessedMetrics');
 
@@ -320,7 +320,7 @@ class Metrics
         return $translations;
     }
 
-    static public function getReadableColumnName($columnIdRaw)
+    public static function getReadableColumnName($columnIdRaw)
     {
         $mappingIdToName = self::$mappingFromIdToName;
 
@@ -332,7 +332,7 @@ class Metrics
         return $columnIdRaw;
     }
 
-    static public function getMetricIdsToProcessReportTotal()
+    public static function getMetricIdsToProcessReportTotal()
     {
         return array(
             self::INDEX_NB_VISITS,
@@ -351,7 +351,7 @@ class Metrics
         );
     }
 
-    static public function getDefaultMetricsDocumentation()
+    public static function getDefaultMetricsDocumentation()
     {
         $cache = new PluginAwareStaticCache('DefaultMetricsDocumentation');
 

--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -33,7 +33,7 @@ class Nonce
      *                 the nonce will no longer be valid).
      * @return string
      */
-    static public function getNonce($id, $ttl = 600)
+    public static function getNonce($id, $ttl = 600)
     {
         // save session-dependent nonce
         $ns = new SessionNamespace($id);
@@ -67,7 +67,7 @@ class Nonce
      * @param string $cnonce Nonce sent from client.
      * @return bool `true` if valid; `false` otherwise.
      */
-    static public function verifyNonce($id, $cnonce)
+    public static function verifyNonce($id, $cnonce)
     {
         $ns = new SessionNamespace($id);
         $nonce = $ns->nonce;
@@ -100,7 +100,7 @@ class Nonce
      *
      * @param string $id The unique nonce ID.
      */
-    static public function discardNonce($id)
+    public static function discardNonce($id)
     {
         $ns = new SessionNamespace($id);
         $ns->unsetAll();
@@ -111,7 +111,7 @@ class Nonce
      * 
      * @return string|bool
      */
-    static public function getOrigin()
+    public static function getOrigin()
     {
         if (!empty($_SERVER['HTTP_ORIGIN'])) {
             return $_SERVER['HTTP_ORIGIN'];
@@ -124,7 +124,7 @@ class Nonce
      *
      * @return array
      */
-    static public function getAcceptableOrigins()
+    public static function getAcceptableOrigins()
     {
         $host = Url::getCurrentHost(null);
         $port = '';
@@ -160,7 +160,7 @@ class Nonce
      *                           **nonce** query parameter is used.
      * @throws Exception if the nonce is invalid. See {@link verifyNonce()}.
      */
-    static public function checkNonce($nonceName, $nonce = null)
+    public static function checkNonce($nonceName, $nonce = null)
     {
         if ($nonce === null) {
             $nonce = Common::getRequestVar('nonce', null, 'string');

--- a/core/Option.php
+++ b/core/Option.php
@@ -134,7 +134,7 @@ class Option
      *
      * @return \Piwik\Option
      */
-    static private function getInstance()
+    private static function getInstance()
     {
         if (self::$instance == null) {
             self::$instance = new self;

--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -27,7 +27,7 @@ class Factory
      * @throws Exception If `$strPeriod` is invalid.
      * @return \Piwik\Period
      */
-    static public function build($period, $date, $timezone = 'UTC')
+    public static function build($period, $date, $timezone = 'UTC')
     {
         self::checkPeriodIsEnabled($period);
 

--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -220,7 +220,7 @@ class Range extends Period
      * @param string $dateString
      * @return mixed  array(1 => dateStartString, 2 => dateEndString) or `false` if the input was not a date range.
      */
-    static public function parseDateRange($dateString)
+    public static function parseDateRange($dateString)
     {
         $matched = preg_match('/^([0-9]{4}-[0-9]{1,2}-[0-9]{1,2}),(([0-9]{4}-[0-9]{1,2}-[0-9]{1,2})|today|now|yesterday)$/D', trim($dateString), $regs);
         if (empty($matched)) {

--- a/core/Period/Week.php
+++ b/core/Period/Week.php
@@ -53,7 +53,7 @@ class Week extends Period
      *
      * @return mixed
      */
-    static protected function getTranslatedRange($format, $dateStart, $dateEnd)
+    protected static function getTranslatedRange($format, $dateStart, $dateEnd)
     {
         $string = str_replace('From%', '%', $format);
         $string = $dateStart->getLocalized($string);

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -63,7 +63,7 @@ class Piwik
      *
      * @param string $message
      */
-    static public function error($message = '')
+    public static function error($message = '')
     {
         trigger_error($message, E_USER_ERROR);
     }
@@ -74,7 +74,7 @@ class Piwik
      *
      * @param string $message
      */
-    static public function exitWithErrorMessage($message)
+    public static function exitWithErrorMessage($message)
     {
         if (!Common::isPhpCliMode()) {
             @header('Content-Type: text/html; charset=utf-8');
@@ -97,7 +97,7 @@ class Piwik
      * @param number $i2
      * @return number The result of the division or zero
      */
-    static public function secureDiv($i1, $i2)
+    public static function secureDiv($i1, $i2)
     {
         if (is_numeric($i1) && is_numeric($i2) && floatval($i2) != 0) {
             return $i1 / $i2;
@@ -113,7 +113,7 @@ class Piwik
      * @param int $precision
      * @return number
      */
-    static public function getPercentageSafe($dividend, $divisor, $precision = 0)
+    public static function getPercentageSafe($dividend, $divisor, $precision = 0)
     {
         if ($divisor == 0) {
             return 0;
@@ -128,7 +128,7 @@ class Piwik
      * @param string $piwikUrl http://path/to/piwik/directory/
      * @return string
      */
-    static public function getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains = false, $groupPageTitlesByDomain = false,
+    public static function getJavascriptCode($idSite, $piwikUrl, $mergeSubdomains = false, $groupPageTitlesByDomain = false,
                                              $mergeAliasUrls = false, $visitorCustomVariables = false, $pageCustomVariables = false,
                                              $customCampaignNameQueryParam = false, $customCampaignKeywordParam = false,
                                              $doNotTrack = false)
@@ -224,7 +224,7 @@ class Piwik
      *
      * @return string
      */
-    static public function getRandomTitle()
+    public static function getRandomTitle()
     {
         static $titles = array(
             'Web analytics',
@@ -254,7 +254,7 @@ class Piwik
      * @return string
      * @api
      */
-    static public function getCurrentUserEmail()
+    public static function getCurrentUserEmail()
     {
         $user = APIUsersManager::getInstance()->getUser(Piwik::getCurrentUserLogin());
         return $user['email'];
@@ -265,7 +265,7 @@ class Piwik
      *
      * @return array
      */
-    static public function getAllSuperUserAccessEmailAddresses()
+    public static function getAllSuperUserAccessEmailAddresses()
     {
         $emails = array();
 
@@ -288,7 +288,7 @@ class Piwik
      * @return string
      * @api
      */
-    static public function getCurrentUserLogin()
+    public static function getCurrentUserLogin()
     {
         return Access::getInstance()->getLogin();
     }
@@ -299,7 +299,7 @@ class Piwik
      * @return string
      * @api
      */
-    static public function getCurrentUserTokenAuth()
+    public static function getCurrentUserTokenAuth()
     {
         return Access::getInstance()->getTokenAuth();
     }
@@ -312,7 +312,7 @@ class Piwik
      * @return bool
      * @api
      */
-    static public function hasUserSuperUserAccessOrIsTheUser($theUser)
+    public static function hasUserSuperUserAccessOrIsTheUser($theUser)
     {
         try {
             self::checkUserHasSuperUserAccessOrIsTheUser($theUser);
@@ -329,7 +329,7 @@ class Piwik
      * @throws NoAccessException If the user is neither the Super User nor the user `$theUser`.
      * @api
      */
-    static public function checkUserHasSuperUserAccessOrIsTheUser($theUser)
+    public static function checkUserHasSuperUserAccessOrIsTheUser($theUser)
     {
         try {
             if (Piwik::getCurrentUserLogin() !== $theUser) {
@@ -348,7 +348,7 @@ class Piwik
      * @return bool
      * @api
      */
-    static public function hasTheUserSuperUserAccess($theUser)
+    public static function hasTheUserSuperUserAccess($theUser)
     {
         if (empty($theUser)) {
             return false;
@@ -380,7 +380,7 @@ class Piwik
      * @return bool
      * @api
      */
-    static public function hasUserSuperUserAccess()
+    public static function hasUserSuperUserAccess()
     {
         try {
             self::checkUserHasSuperUserAccess();
@@ -396,7 +396,7 @@ class Piwik
      * @return bool
      * @api
      */
-    static public function isUserIsAnonymous()
+    public static function isUserIsAnonymous()
     {
         return Piwik::getCurrentUserLogin() == 'anonymous';
     }
@@ -407,7 +407,7 @@ class Piwik
      * @throws NoAccessException if the current user is the anonymous user.
      * @api
      */
-    static public function checkUserIsNotAnonymous()
+    public static function checkUserIsNotAnonymous()
     {
         if (Access::getInstance()->hasSuperUserAccess()) {
             return;
@@ -423,7 +423,7 @@ class Piwik
      *
      * @param bool $bool true to set current user as Super User
      */
-    static public function setUserHasSuperUserAccess($bool = true)
+    public static function setUserHasSuperUserAccess($bool = true)
     {
         Access::getInstance()->setSuperUserAccess($bool);
     }
@@ -434,7 +434,7 @@ class Piwik
      * @throws Exception if the current user is not the superuser.
      * @api
      */
-    static public function checkUserHasSuperUserAccess()
+    public static function checkUserHasSuperUserAccess()
     {
         Access::getInstance()->checkUserHasSuperUserAccess();
     }
@@ -446,7 +446,7 @@ class Piwik
      * @return bool
      * @api
      */
-    static public function isUserHasAdminAccess($idSites)
+    public static function isUserHasAdminAccess($idSites)
     {
         try {
             self::checkUserHasAdminAccess($idSites);
@@ -463,7 +463,7 @@ class Piwik
      * @throws Exception If user doesn't have admin access.
      * @api
      */
-    static public function checkUserHasAdminAccess($idSites)
+    public static function checkUserHasAdminAccess($idSites)
     {
         Access::getInstance()->checkUserHasAdminAccess($idSites);
     }
@@ -474,7 +474,7 @@ class Piwik
      * @return bool
      * @api
      */
-    static public function isUserHasSomeAdminAccess()
+    public static function isUserHasSomeAdminAccess()
     {
         try {
             self::checkUserHasSomeAdminAccess();
@@ -490,7 +490,7 @@ class Piwik
      * @throws Exception if user doesn't have admin access to any site.
      * @api
      */
-    static public function checkUserHasSomeAdminAccess()
+    public static function checkUserHasSomeAdminAccess()
     {
         Access::getInstance()->checkUserHasSomeAdminAccess();
     }
@@ -502,7 +502,7 @@ class Piwik
      * @return bool
      * @api
      */
-    static public function isUserHasViewAccess($idSites)
+    public static function isUserHasViewAccess($idSites)
     {
         try {
             self::checkUserHasViewAccess($idSites);
@@ -519,7 +519,7 @@ class Piwik
      * @throws Exception if the current user does not have view access to every site in the list.
      * @api
      */
-    static public function checkUserHasViewAccess($idSites)
+    public static function checkUserHasViewAccess($idSites)
     {
         Access::getInstance()->checkUserHasViewAccess($idSites);
     }
@@ -530,7 +530,7 @@ class Piwik
      * @return bool
      * @api
      */
-    static public function isUserHasSomeViewAccess()
+    public static function isUserHasSomeViewAccess()
     {
         try {
             self::checkUserHasSomeViewAccess();
@@ -546,7 +546,7 @@ class Piwik
      * @throws Exception if user doesn't have view access to any site.
      * @api
      */
-    static public function checkUserHasSomeViewAccess()
+    public static function checkUserHasSomeViewAccess()
     {
         Access::getInstance()->checkUserHasSomeViewAccess();
     }
@@ -562,7 +562,7 @@ class Piwik
      *
      * @return string
      */
-    static public function getLoginPluginName()
+    public static function getLoginPluginName()
     {
         return Registry::get('auth')->getName();
     }
@@ -572,7 +572,7 @@ class Piwik
      *
      * @return Plugin
      */
-    static public function getCurrentPlugin()
+    public static function getCurrentPlugin()
     {
         return \Piwik\Plugin\Manager::getInstance()->getLoadedPlugin(Piwik::getModule());
     }
@@ -582,7 +582,7 @@ class Piwik
      *
      * @return string
      */
-    static public function getModule()
+    public static function getModule()
     {
         return Common::getRequestVar('module', '', 'string');
     }
@@ -592,7 +592,7 @@ class Piwik
      *
      * @return string
      */
-    static public function getAction()
+    public static function getAction()
     {
         return Common::getRequestVar('action', '', 'string');
     }
@@ -606,7 +606,7 @@ class Piwik
      * @param array|string $columns
      * @return array
      */
-    static public function getArrayFromApiParameter($columns)
+    public static function getArrayFromApiParameter($columns)
     {
         if (empty($columns)) {
             return array();
@@ -627,7 +627,7 @@ class Piwik
      * @param array $parameters The query parameter values to modify before redirecting.
      * @api
      */
-    static public function redirectToModule($newModule, $newAction = '', $parameters = array())
+    public static function redirectToModule($newModule, $newAction = '', $parameters = array())
     {
         $newUrl = 'index.php' . Url::getCurrentQueryStringWithParametersModified(
                 array('module' => $newModule, 'action' => $newAction)
@@ -647,7 +647,7 @@ class Piwik
      * @return bool
      * @api
      */
-    static public function isValidEmailString($emailAddress)
+    public static function isValidEmailString($emailAddress)
     {
         return (preg_match('/^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9_.-]+\.[a-zA-Z]{2,7}$/D', $emailAddress) > 0);
     }
@@ -661,7 +661,7 @@ class Piwik
      * @throws Exception
      * @return bool
      */
-    static public function checkValidLoginString($userLogin)
+    public static function checkValidLoginString($userLogin)
     {
         if (!SettingsPiwik::isUserCredentialsSanityCheckEnabled()
             && !empty($userLogin)
@@ -686,7 +686,7 @@ class Piwik
      * @param array $types List of class names that $o is expected to be one of.
      * @throws Exception if $o is not an instance of the types contained in $types.
      */
-    static public function checkObjectTypeIs($o, $types)
+    public static function checkObjectTypeIs($o, $types)
     {
         foreach ($types as $type) {
             if ($o instanceof $type) {
@@ -708,7 +708,7 @@ class Piwik
      * @param array $array
      * @return bool
      */
-    static public function isAssociativeArray($array)
+    public static function isAssociativeArray($array)
     {
         reset($array);
         if (!is_numeric(key($array))

--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -86,7 +86,7 @@ abstract class ControllerAdmin extends Controller
     /**
      * @ignore
      */
-    static public function displayWarningIfConfigFileNotWritable()
+    public static function displayWarningIfConfigFileNotWritable()
     {
         $isConfigFileWritable = PiwikConfig::getInstance()->isFileWritable();
 
@@ -157,7 +157,7 @@ abstract class ControllerAdmin extends Controller
      * @param View $view
      * @api
      */
-    static public function setBasicVariablesAdminView(View $view)
+    public static function setBasicVariablesAdminView(View $view)
     {
         self::notifyWhenTrackingStatisticsDisabled();
         self::notifyIfEAcceleratorIsUsed();
@@ -188,12 +188,12 @@ abstract class ControllerAdmin extends Controller
         }
     }
 
-    static public function isDataPurgeSettingsEnabled()
+    public static function isDataPurgeSettingsEnabled()
     {
         return (bool) Config::getInstance()->General['enable_delete_old_data_settings_admin'];
     }
 
-    static protected function getPiwikVersion()
+    protected static function getPiwikVersion()
     {
         return "Piwik " . Version::VERSION;
     }

--- a/core/Profiler.php
+++ b/core/Profiler.php
@@ -94,7 +94,7 @@ class Profiler
         return $a['sum_time_ms'] < $b['sum_time_ms'];
     }
 
-    static private function sortTimeDesc($a, $b)
+    private static function sortTimeDesc($a, $b)
     {
         return $a['sumTimeMs'] < $b['sumTimeMs'];
     }
@@ -166,7 +166,7 @@ class Profiler
      *
      * @param array $infoIndexedByQuery
      */
-    static private function getSqlProfilingQueryBreakdownOutput($infoIndexedByQuery)
+    private static function getSqlProfilingQueryBreakdownOutput($infoIndexedByQuery)
     {
         $output = '<hr /><strong>Breakdown by query</strong><br/>';
         foreach ($infoIndexedByQuery as $query => $queryInfo) {

--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -46,7 +46,7 @@ abstract class ReportRenderer
      * @param string $rendererType
      * @return \Piwik\ReportRenderer
      */
-    static public function factory($rendererType)
+    public static function factory($rendererType)
     {
         $name = ucfirst(strtolower($rendererType));
         $className = 'Piwik\ReportRenderer\\' . $name;

--- a/core/ScheduledTime.php
+++ b/core/ScheduledTime.php
@@ -54,7 +54,7 @@ abstract class ScheduledTime
      * @throws \Exception
      * @ignore
      */
-    static public function getScheduledTimeForPeriod($period)
+    public static function getScheduledTimeForPeriod($period)
     {
         switch ($period) {
             case self::PERIOD_MONTH:

--- a/core/SegmentExpression.php
+++ b/core/SegmentExpression.php
@@ -63,7 +63,7 @@ class SegmentExpression
     public function parseSubExpressions()
     {
         $parsedSubExpressions = array();
-        foreach ($this->tree as $id => $leaf) {
+        foreach ($this->tree as $leaf) {
             $operand = $leaf[self::INDEX_OPERAND];
 
             $operand = urldecode($operand);
@@ -339,7 +339,6 @@ class SegmentExpression
         if (count($this->tree) == 0) {
             throw new Exception("Invalid segment, please specify a valid segment.");
         }
-        $bind = array();
         $sql = '';
         $subExpression = false;
         foreach ($this->tree as $expression) {

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -299,7 +299,7 @@ class SettingsPiwik
      * @param $piwikServerUrl
      * @return bool
      */
-    static public function checkPiwikServerWorking($piwikServerUrl, $acceptInvalidSSLCertificates = false)
+    public static function checkPiwikServerWorking($piwikServerUrl, $acceptInvalidSSLCertificates = false)
     {
         // Now testing if the webserver is running
         try {

--- a/core/Site.php
+++ b/core/Site.php
@@ -355,7 +355,7 @@ class Site
      * @param bool|string $_restrictSitesToLogin Implementation detail. Used only when running as a scheduled task.
      * @return array An array of valid, unique integers.
      */
-    static public function getIdSitesFromIdSitesString($ids, $_restrictSitesToLogin = false)
+    public static function getIdSitesFromIdSitesString($ids, $_restrictSitesToLogin = false)
     {
         if ($ids === 'all') {
             return API::getInstance()->getSitesIdWithAtLeastViewAccess($_restrictSitesToLogin);
@@ -385,7 +385,7 @@ class Site
      * 
      * See also {@link setSites()} and {@link setSitesFromArray()}.
      */
-    static public function clearCache()
+    public static function clearCache()
     {
         self::$infoSites = array();
     }
@@ -398,7 +398,7 @@ class Site
      * @param bool|string $field The name of the field to get.
      * @return array|string
      */
-    static protected function getFor($idsite, $field = false)
+    protected static function getFor($idsite, $field = false)
     {
         $idsite = (int)$idsite;
 
@@ -417,7 +417,7 @@ class Site
      *
      * @ignore
      */
-    static public function getSites()
+    public static function getSites()
     {
         return self::$infoSites;
     }
@@ -425,7 +425,7 @@ class Site
     /**
      * @ignore
      */
-    static public function getSite($id)
+    public static function getSite($id)
     {
         return self::getFor($id);
     }
@@ -436,7 +436,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function getNameFor($idsite)
+    public static function getNameFor($idsite)
     {
         return self::getFor($idsite, 'name');
     }
@@ -447,7 +447,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function getGroupFor($idsite)
+    public static function getGroupFor($idsite)
     {
         return self::getFor($idsite, 'group');
     }
@@ -458,7 +458,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function getTimezoneFor($idsite)
+    public static function getTimezoneFor($idsite)
     {
         return self::getFor($idsite, 'timezone');
     }
@@ -469,7 +469,7 @@ class Site
      * @param $idsite
      * @return string
      */
-    static public function getTypeFor($idsite)
+    public static function getTypeFor($idsite)
     {
         return self::getFor($idsite, 'type');
     }
@@ -480,7 +480,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function getCreationDateFor($idsite)
+    public static function getCreationDateFor($idsite)
     {
         return self::getFor($idsite, 'ts_created');
     }
@@ -491,7 +491,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function getMainUrlFor($idsite)
+    public static function getMainUrlFor($idsite)
     {
         return self::getFor($idsite, 'main_url');
     }
@@ -502,7 +502,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function isEcommerceEnabledFor($idsite)
+    public static function isEcommerceEnabledFor($idsite)
     {
         return self::getFor($idsite, 'ecommerce') == 1;
     }
@@ -513,7 +513,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function isSiteSearchEnabledFor($idsite)
+    public static function isSiteSearchEnabledFor($idsite)
     {
         return self::getFor($idsite, 'sitesearch') == 1;
     }
@@ -524,7 +524,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function getCurrencyFor($idsite)
+    public static function getCurrencyFor($idsite)
     {
         return self::getFor($idsite, 'currency');
     }
@@ -535,7 +535,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function getExcludedIpsFor($idsite)
+    public static function getExcludedIpsFor($idsite)
     {
         return self::getFor($idsite, 'excluded_ips');
     }
@@ -546,7 +546,7 @@ class Site
      * @param int $idsite The site ID.
      * @return string
      */
-    static public function getExcludedQueryParametersFor($idsite)
+    public static function getExcludedQueryParametersFor($idsite)
     {
         return self::getFor($idsite, 'excluded_parameters');
     }

--- a/core/TaskScheduler.php
+++ b/core/TaskScheduler.php
@@ -77,7 +77,7 @@ class TaskScheduler extends Singleton
      *               )
      *               ```
      */
-    static public function runTasks()
+    public static function runTasks()
     {
         return self::getInstance()->doRunTasks();
     }
@@ -164,7 +164,7 @@ class TaskScheduler extends Singleton
      * @param ScheduledTask $task Describes the scheduled task being rescheduled.
      * @api
      */
-    static public function rescheduleTask(ScheduledTask $task)
+    public static function rescheduleTask(ScheduledTask $task)
     {
         self::getInstance()->timetable->rescheduleTask($task);
     }
@@ -174,7 +174,7 @@ class TaskScheduler extends Singleton
      * 
      * @return bool
      */
-    static public function isTaskBeingExecuted()
+    public static function isTaskBeingExecuted()
     {
         return self::getInstance()->isRunning;
     }
@@ -188,7 +188,7 @@ class TaskScheduler extends Singleton
      * @return mixed int|bool The time in miliseconds when the scheduled task will be executed
      *                        next or false if it is not scheduled to run.
      */
-    static public function getScheduledTimeForMethod($className, $methodName, $methodParameter = null)
+    public static function getScheduledTimeForMethod($className, $methodName, $methodParameter = null)
     {
         return self::getInstance()->timetable->getScheduledTimeForMethod($className, $methodName, $methodParameter);
     }
@@ -199,7 +199,7 @@ class TaskScheduler extends Singleton
      * @param ScheduledTask $task
      * @return string
      */
-    static private function executeTask($task)
+    private static function executeTask($task)
     {
         try {
             $timer = new Timer();

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -115,7 +115,7 @@ class Tracker
      * Do not load the specified plugins (used during testing, to disable Provider plugin)
      * @param array $plugins
      */
-    static public function setPluginsNotToLoad($plugins)
+    public static function setPluginsNotToLoad($plugins)
     {
         self::$pluginsNotToLoad = $plugins;
     }
@@ -125,7 +125,7 @@ class Tracker
      *
      * @return array
      */
-    static public function getPluginsNotToLoad()
+    public static function getPluginsNotToLoad()
     {
         return self::$pluginsNotToLoad;
     }
@@ -136,7 +136,7 @@ class Tracker
      * @param string $name Setting name
      * @param mixed $value Value
      */
-    static private function updateTrackerConfig($name, $value)
+    private static function updateTrackerConfig($name, $value)
     {
         $section = Config::getInstance()->Tracker;
         $section[$name] = $value;
@@ -402,7 +402,7 @@ class Tracker
      * Used to initialize core Piwik components on a piwik.php request
      * Eg. when cache is missed and we will be calling some APIs to generate cache
      */
-    static public function initCorePiwikInTrackerMode()
+    public static function initCorePiwikInTrackerMode()
     {
         if (SettingsServer::isTrackerApiRequest()
             && self::$initTrackerMode === false

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -411,8 +411,8 @@ class Tracker
             require_once PIWIK_INCLUDE_PATH . '/core/Loader.php';
             require_once PIWIK_INCLUDE_PATH . '/core/Option.php';
 
-            $access = Access::getInstance();
-            $config = Config::getInstance();
+            Access::getInstance();
+            Config::getInstance();
 
             try {
                 Db::get();

--- a/core/Tracker/Action.php
+++ b/core/Tracker/Action.php
@@ -48,7 +48,7 @@ abstract class Action
      * @param Request $request
      * @return Action
      */
-    static public function factory(Request $request)
+    public static function factory(Request $request)
     {
         /** @var Action[] $actions */
         $actions = self::getAllActions($request);
@@ -90,7 +90,7 @@ abstract class Action
         return false;
     }
 
-    static private function getAllActions(Request $request)
+    private static function getAllActions(Request $request)
     {
         $actions   = Manager::getInstance()->findMultipleComponents('Actions', '\\Piwik\\Tracker\\Action');
         $instances = array();

--- a/core/Tracker/Cache.php
+++ b/core/Tracker/Cache.php
@@ -28,7 +28,7 @@ class Cache
      */
     static public $trackerCache = null;
 
-    static protected function getInstance()
+    protected static function getInstance()
     {
         if (is_null(self::$trackerCache)) {
             $ttl = Config::getInstance()->Tracker['tracker_cache_file_ttl'];
@@ -101,7 +101,7 @@ class Cache
     /**
      * Clear general (global) cache
      */
-    static public function clearCacheGeneral()
+    public static function clearCacheGeneral()
     {
         self::getInstance()->delete('general');
     }
@@ -112,7 +112,7 @@ class Cache
      *
      * @return array
      */
-    static public function getCacheGeneral()
+    public static function getCacheGeneral()
     {
         $cache = self::getInstance();
         $cacheId = 'general';
@@ -159,7 +159,7 @@ class Cache
      * @param mixed $value
      * @return bool
      */
-    static public function setCacheGeneral($value)
+    public static function setCacheGeneral($value)
     {
         $cache = self::getInstance();
         $cacheId = 'general';
@@ -172,7 +172,7 @@ class Cache
      *
      * @param array|int $idSites Array of idSites to clear cache for
      */
-    static public function regenerateCacheWebsiteAttributes($idSites = array())
+    public static function regenerateCacheWebsiteAttributes($idSites = array())
     {
         if (!is_array($idSites)) {
             $idSites = array($idSites);
@@ -188,7 +188,7 @@ class Cache
      *
      * @param string $idSite (website ID of the site to clear cache for
      */
-    static public function deleteCacheWebsiteAttributes($idSite)
+    public static function deleteCacheWebsiteAttributes($idSite)
     {
         $idSite = (int)$idSite;
         self::getInstance()->delete($idSite);
@@ -197,7 +197,7 @@ class Cache
     /**
      * Deletes all Tracker cache files
      */
-    static public function deleteTrackerCache()
+    public static function deleteTrackerCache()
     {
         self::getInstance()->deleteAll();
     }

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -84,7 +84,7 @@ class GoalManager
         }
     }
 
-    static public function getGoalDefinitions($idSite)
+    public static function getGoalDefinitions($idSite)
     {
         $websiteAttributes = Cache::getCacheWebsiteAttributes($idSite);
         if (isset($websiteAttributes['goals'])) {
@@ -93,7 +93,7 @@ class GoalManager
         return array();
     }
 
-    static public function getGoalDefinition($idSite, $idGoal)
+    public static function getGoalDefinition($idSite, $idGoal)
     {
         $goals = self::getGoalDefinitions($idSite);
         foreach ($goals as $goal) {
@@ -104,7 +104,7 @@ class GoalManager
         throw new Exception('Goal not found');
     }
 
-    static public function getGoalIds($idSite)
+    public static function getGoalIds($idSite)
     {
         $goals = self::getGoalDefinitions($idSite);
         $goalIds = array();

--- a/core/Tracker/IgnoreCookie.php
+++ b/core/Tracker/IgnoreCookie.php
@@ -22,7 +22,7 @@ class IgnoreCookie
      *
      * @return Cookie
      */
-    static public function getTrackingCookie()
+    public static function getTrackingCookie()
     {
         $cookie_name = @Config::getInstance()->Tracker['cookie_name'];
         $cookie_path = @Config::getInstance()->Tracker['cookie_path'];
@@ -35,7 +35,7 @@ class IgnoreCookie
      *
      * @return Cookie
      */
-    static public function getIgnoreCookie()
+    public static function getIgnoreCookie()
     {
         $cookie_name = @Config::getInstance()->Tracker['ignore_visits_cookie_name'];
         $cookie_path = @Config::getInstance()->Tracker['cookie_path'];
@@ -46,7 +46,7 @@ class IgnoreCookie
     /**
      * Set ignore (visit) cookie or deletes it if already present
      */
-    static public function setIgnoreCookie()
+    public static function setIgnoreCookie()
     {
         $ignoreCookie = self::getIgnoreCookie();
         if ($ignoreCookie->isCookieFound()) {
@@ -65,7 +65,7 @@ class IgnoreCookie
      *
      * @return bool  True if ignore cookie found; false otherwise
      */
-    static public function isIgnoreCookieFound()
+    public static function isIgnoreCookieFound()
     {
         $cookie = self::getIgnoreCookie();
         return $cookie->isCookieFound() && $cookie->get('ignore') === '*';

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -363,7 +363,7 @@ class Visit implements VisitInterface
     /**
      * @return string returns random 16 chars hex string
      */
-    static public function generateUniqueVisitorId()
+    public static function generateUniqueVisitorId()
     {
         $uniqueId = substr(Common::generateUniqId(), 0, Tracker::LENGTH_HEX_ID_STRING);
         return $uniqueId;
@@ -406,7 +406,7 @@ class Visit implements VisitInterface
     }
 
     // is the referrer host any of the registered URLs for this website?
-    static public function isHostKnownAliasHost($urlHost, $idSite)
+    public static function isHostKnownAliasHost($urlHost, $idSite)
     {
         $websiteData = Cache::getCacheWebsiteAttributes($idSite);
         if (isset($websiteData['hosts'])) {

--- a/core/Unzip.php
+++ b/core/Unzip.php
@@ -27,7 +27,7 @@ class Unzip
      * @param string $filename Name of .zip archive
      * @return \Piwik\Unzip\UncompressInterface
      */
-    static public function factory($name, $filename)
+    public static function factory($name, $filename)
     {
         switch ($name) {
             case 'ZipArchive':

--- a/core/Url.php
+++ b/core/Url.php
@@ -60,7 +60,7 @@ class Url
      * @return string eg, `"http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"`
      * @api
      */
-    static public function getCurrentUrl()
+    public static function getCurrentUrl()
     {
         return self::getCurrentScheme() . '://'
         . self::getCurrentHost()
@@ -77,7 +77,7 @@ class Url
      *                `"http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"`.
      * @api
      */
-    static public function getCurrentUrlWithoutQueryString($checkTrustedHost = true)
+    public static function getCurrentUrlWithoutQueryString($checkTrustedHost = true)
     {
         return self::getCurrentScheme() . '://'
         . self::getCurrentHost($default = 'unknown', $checkTrustedHost)
@@ -92,7 +92,7 @@ class Url
      *                `"http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"`.
      * @api
      */
-    static public function getCurrentUrlWithoutFileName()
+    public static function getCurrentUrlWithoutFileName()
     {
         return self::getCurrentScheme() . '://'
         . self::getCurrentHost()
@@ -106,7 +106,7 @@ class Url
      *                `"http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"`
      * @api
      */
-    static public function getCurrentScriptPath()
+    public static function getCurrentScriptPath()
     {
         $queryString = self::getCurrentScriptName();
 
@@ -127,7 +127,7 @@ class Url
      *                `"http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"`
      * @api
      */
-    static public function getCurrentScriptName()
+    public static function getCurrentScriptName()
     {
         $url = '';
 
@@ -177,7 +177,7 @@ class Url
      * @return string `'https'` or `'http'`
      * @api
      */
-    static public function getCurrentScheme()
+    public static function getCurrentScheme()
     {
         try {
             $assume_secure_protocol = @Config::getInstance()->General['assume_secure_protocol'];
@@ -202,7 +202,7 @@ class Url
      *                          value from the request.
      * @return bool `true` if valid; `false` otherwise.
      */
-    static public function isValidHost($host = false)
+    public static function isValidHost($host = false)
     {
         // only do trusted host check if it's enabled
         if (isset(Config::getInstance()->General['enable_trusted_host_check'])
@@ -285,7 +285,7 @@ class Url
      *                             except in Controller.
      * @return string|bool eg, `"demo.piwik.org"` or false if no host found.
      */
-    static public function getHost($checkIfTrusted = true)
+    public static function getHost($checkIfTrusted = true)
     {
         // HTTP/1.1 request
         if (isset($_SERVER['HTTP_HOST'])
@@ -309,7 +309,7 @@ class Url
      * 
      * @param $host string
      */
-    static public function setHost($host)
+    public static function setHost($host)
     {
         $_SERVER['HTTP_HOST'] = $host;
     }
@@ -324,7 +324,7 @@ class Url
      *                `"http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"`
      * @api
      */
-    static public function getCurrentHost($default = 'unknown', $checkTrustedHost = true)
+    public static function getCurrentHost($default = 'unknown', $checkTrustedHost = true)
     {
         $hostHeaders = array();
 
@@ -350,7 +350,7 @@ class Url
      *                `"http://example.org/dir1/dir2/index.php?param1=value1&param2=value2"`
      * @api
      */
-    static public function getCurrentQueryString()
+    public static function getCurrentQueryString()
     {
         $url = '';
         if (isset($_SERVER['QUERY_STRING'])
@@ -374,7 +374,7 @@ class Url
      *                   )
      * @api
      */
-    static public function getArrayFromCurrentQueryString()
+    public static function getArrayFromCurrentQueryString()
     {
         $queryString = self::getCurrentQueryString();
         $urlValues = UrlHelper::getArrayFromQueryString($queryString);
@@ -413,7 +413,7 @@ class Url
      * @return string eg. `"param1=10&param2[]=1&param2[]=2"`
      * @api
      */
-    static public function getQueryStringFromParameters($parameters)
+    public static function getQueryStringFromParameters($parameters)
     {
         $query = '';
         foreach ($parameters as $name => $value) {
@@ -432,7 +432,7 @@ class Url
         return $query;
     }
 
-    static public function getQueryStringFromUrl($url)
+    public static function getQueryStringFromUrl($url)
     {
         return parse_url($url, PHP_URL_QUERY);
     }
@@ -443,7 +443,7 @@ class Url
      * 
      * @api
      */
-    static public function redirectToReferrer()
+    public static function redirectToReferrer()
     {
         $referrer = self::getReferrer();
         if ($referrer !== false) {
@@ -458,7 +458,7 @@ class Url
      * @param string $url
      * @api
      */
-    static public function redirectToUrl($url)
+    public static function redirectToUrl($url)
     {
         // Close the session manually.
         // We should not have to call this because it was registered via register_shutdown_function,
@@ -482,7 +482,7 @@ class Url
     /**
      * If the page is using HTTP, redirect to the same page over HTTPS
      */
-    static public function redirectToHttps()
+    public static function redirectToHttps()
     {
         if(ProxyHttp::isHttps()) {
             return;
@@ -498,7 +498,7 @@ class Url
      * @return string|false
      * @api
      */
-    static public function getReferrer()
+    public static function getReferrer()
     {
         if (!empty($_SERVER['HTTP_REFERER'])) {
             return $_SERVER['HTTP_REFERER'];
@@ -513,7 +513,7 @@ class Url
      * @return bool True if local; false otherwise.
      * @api
      */
-    static public function isLocalUrl($url)
+    public static function isLocalUrl($url)
     {
         if (empty($url)) {
             return true;

--- a/core/View.php
+++ b/core/View.php
@@ -348,7 +348,7 @@ class View implements ViewInterface
      * Clear compiled Twig templates
      * @ignore
      */
-    static public function clearCompiledTemplates()
+    public static function clearCompiledTemplates()
     {
         $twig = new Twig();
         $twig->getTwigEnvironment()->clearTemplateCache();
@@ -364,7 +364,7 @@ class View implements ViewInterface
      * @param string $reportHtml The report body HTML.
      * @return string|void The report contents if `$fetch` is true.
      */
-    static public function singleReport($title, $reportHtml)
+    public static function singleReport($title, $reportHtml)
     {
         $view = new View('@CoreHome/_singleReport');
         $view->title = $title;

--- a/core/View/UIControl.php
+++ b/core/View/UIControl.php
@@ -136,7 +136,6 @@ class UIControl extends \Piwik\View
         }
 
         $this->templateVars['clientSideParameters'] = array();
-        $clientSideParameters = $this->getClientSideParameters();
         foreach ($this->getClientSideParameters() as $name) {
             $this->templateVars['clientSideParameters'][$name] = $innerTemplateVars[$name];
         }

--- a/core/WidgetsList.php
+++ b/core/WidgetsList.php
@@ -61,7 +61,7 @@ class WidgetsList extends Singleton
      *               )
      *               ```
      */
-    static public function get()
+    public static function get()
     {
         $cache = self::getCacheForCompleteList();
         if (!self::$listCacheToBeInvalidated && $cache->has()) {
@@ -168,7 +168,7 @@ class WidgetsList extends Singleton
      * @param array $customParameters Extra query parameters that should be sent while getting
      *                                this report.
      */
-    static public function add($widgetCategory, $widgetName, $controllerName, $controllerAction, $customParameters = array())
+    public static function add($widgetCategory, $widgetName, $controllerName, $controllerAction, $customParameters = array())
     {
         $widgetName     = Piwik::translate($widgetName);
         $widgetUniqueId = 'widget' . $controllerName . $controllerAction;
@@ -204,7 +204,7 @@ class WidgetsList extends Singleton
      *                                 translation token. If not supplied, the entire category
      *                                 will be removed.
      */
-    static public function remove($widgetCategory, $widgetName = false)
+    public static function remove($widgetCategory, $widgetName = false)
     {
         if (!isset(self::$widgets[$widgetCategory])) {
             return;
@@ -231,7 +231,7 @@ class WidgetsList extends Singleton
      * @param string $controllerAction The controller action of the report.
      * @return bool
      */
-    static public function isDefined($controllerName, $controllerAction)
+    public static function isDefined($controllerName, $controllerAction)
     {
         $widgetsList = self::get();
         foreach ($widgetsList as $widgets) {


### PR DESCRIPTION
<del>The 1st commit can be considered to be a bugfix because the wrong variable was used there, at least with my understanding of the code.</del>


The <del>2nd</del> 1st commit removes unused variables while trying not to break stuff, as the code seems to be pretty fragile. There are still plenty of unused variables when calling methods in the manner of naming arguments like for `self::json_decode($value, $assoc = true)` where `$assoc` is in fact useless. I could remove them all as well.

The <del>3rd</del> 2nd commit fixes the order of keywords in method signatures:
`static (public|protected|private) function` &rarr; `(public|protected|private) static function`.

Let me know what you think.
