### PR TITLE
Fix HHVM support for CLI

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -106,7 +106,7 @@ class CliMulti {
     {
         $bin = $this->findPhpBinary();
 
-        return sprintf('%s -q %s/console climulti:request --piwik-domain=%s %s > %s 2>&1 &',
+        return sprintf('%s %s/console climulti:request --piwik-domain=%s %s > %s 2>&1 &',
                        $bin, PIWIK_INCLUDE_PATH, escapeshellarg($hostname), escapeshellarg($query), $outputFile);
     }
 

--- a/core/CliMulti/CliPhp.php
+++ b/core/CliMulti/CliPhp.php
@@ -19,7 +19,7 @@ class CliPhp
         if (defined('PHP_BINARY')) {
 
             if($this->isValidPhpType(PHP_BINARY)) {
-                return PHP_BINARY;
+                return PHP_BINARY . ' -q';
             }
 
             if($this->isHhvmBinary(PHP_BINARY)) {

--- a/core/CliMulti/CliPhp.php
+++ b/core/CliMulti/CliPhp.php
@@ -54,6 +54,9 @@ class CliPhp
         if (!$this->isValidPhpVersion($bin)) {
             return false;
         }
+        
+        $bin .= ' -q';
+        
         return $bin;
     }
 


### PR DESCRIPTION
HHVM 3.0.1 doesn't like the -q flag used in the PHP command-line. Moving
the flag into findPhpBinary() in CliPhp adds compatibility with HHVM.
Previously mentioned in piwik/piwik/#5263
