### PR TITLE
Adding the new variables to "UsersManager.addUser.end" and "UsersManager.updateUser.end" triggers

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -344,7 +344,7 @@ class API extends \Piwik\Plugin\API
          * 
          * @param string $userLogin The new user's login handle.
          */
-        Piwik::postEvent('UsersManager.addUser.end', array($userLogin));
+        Piwik::postEvent('UsersManager.addUser.end', array($userLogin, $email, $password));
     }
 
     /**
@@ -449,7 +449,7 @@ class API extends \Piwik\Plugin\API
          * @param string $userLogin The user's login handle.
          * @param boolean $passwordHasBeenUpdated Flag containing information about password change.
          */
-        Piwik::postEvent('UsersManager.updateUser.end', array($userLogin, $passwordHasBeenUpdated));
+        Piwik::postEvent('UsersManager.updateUser.end', array($userLogin, $passwordHasBeenUpdated, $email, $password));
     }
 
     /**

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -344,7 +344,7 @@ class API extends \Piwik\Plugin\API
          * 
          * @param string $userLogin The new user's login handle.
          */
-        Piwik::postEvent('UsersManager.addUser.end', array($userLogin, $email, $password));
+        Piwik::postEvent('UsersManager.addUser.end', array($userLogin, $email, $password, $alias));
     }
 
     /**
@@ -449,7 +449,7 @@ class API extends \Piwik\Plugin\API
          * @param string $userLogin The user's login handle.
          * @param boolean $passwordHasBeenUpdated Flag containing information about password change.
          */
-        Piwik::postEvent('UsersManager.updateUser.end', array($userLogin, $passwordHasBeenUpdated, $email, $password));
+        Piwik::postEvent('UsersManager.updateUser.end', array($userLogin, $passwordHasBeenUpdated, $email, $password, $alias));
     }
 
     /**


### PR DESCRIPTION
You've indicated "UsersManager.addUser" and "UsersManager.updateUser" triggers in your API Reference page(http://developer.piwik.org/api-reference/reporting-api#UsersManager)

But there are no triggers called "UsersManager.addUser" and "UsersManager.updateUser" in PIWIK. It contains only "UsersManager.addUser.end" and "UsersManager.updateUser.end" and these triggers are passed one variable that is $userLogin. But If we add/update any user and there are triggers about these processes, we also need an email, a password etc in order to do something these data, right ?

So, I've added these variables to "UsersManager.addUser.end" and "UsersManager.updateUser.end" triggers. Because I thought everyone need these variables when doing something during add/update the users.
