### PR TITLE
make the opt-out form work even if JavaScript is disabled

### DIFF
--- a/plugins/CoreAdminHome/templates/optOut.twig
+++ b/plugins/CoreAdminHome/templates/optOut.twig
@@ -26,6 +26,9 @@
             {{ 'CoreAdminHome_YouAreOptedOut'|translate }} {{ 'CoreAdminHome_ClickHereToOptIn'|translate }}
         {% endif %}
     </strong></label>
+    <noscript>
+        <button type="submit">{{ 'General_Save'|translate }}</button>
+    </noscript>
 </form>
 </body>
 </html>


### PR DESCRIPTION
This makes the opt-out form work even if JavaScript is disabled. I've attached two screenshots, showing the current state and the new "JS is disabled, so we need a proper submit button" state, both using the default size of 600x200 pixels for the iframe.

**previous state with and without JavaScript + new state with JavaScript:**
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;![piwik-opt-out-a](https://cloud.githubusercontent.com/assets/800119/3605094/abc25e00-0d27-11e4-9baf-013a24fadecc.png)

**new state without JavaScript:**
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;![piwik-opt-out-b](https://cloud.githubusercontent.com/assets/800119/3642655/1b7a35ba-10c5-11e4-87b5-f26eb0484a0a.png)

The result is not that beautiful, but should still fit into the iframe in every language.

It might be a good idea to make the button text translatable, as the browser's language is just used currently. Which translation key and English text should I use?
