### PR TITLE
Piwik.js JS tracker: allow developer to pass a 'callback' argument

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -3017,6 +3017,7 @@ if (typeof Piwik !== 'object') {
                  * @param string sourceUrl
                  * @param string linkType
                  * @param mixed customData
+                 * @param function callback
                  */
                 trackLink: function (sourceUrl, linkType, customData, callback) {
                     trackCallback(function () {

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -1352,7 +1352,7 @@ if (typeof Piwik !== 'object') {
 
                 image.onload = function () {
                     iterator = 0; // To avoid JSLint warning of empty block
-                    if (typeof callback === 'function') callback()
+                    if (typeof callback === 'function') { callback(); }
                 };
                 image.src = configTrackerUrl + (configTrackerUrl.indexOf('?') < 0 ? '?' : '&') + request;
             }
@@ -1378,7 +1378,7 @@ if (typeof Piwik !== 'object') {
                         if (this.readyState === 4 && !(this.status >= 200 && this.status < 300)) {
                             getImage(request, callback);
                         } else {
-                          if (typeof callback === 'function') callback()
+                            if (typeof callback === 'function') { callback(); }
                         }
                     };
 
@@ -3372,4 +3372,3 @@ if (typeof piwik_log !== 'function') {
 }
 
 /*! @license-end */
-

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -1347,11 +1347,12 @@ if (typeof Piwik !== 'object') {
              * Send image request to Piwik server using GET.
              * The infamous web bug (or beacon) is a transparent, single pixel (1x1) image
              */
-            function getImage(request) {
+            function getImage(request, callback) {
                 var image = new Image(1, 1);
 
                 image.onload = function () {
                     iterator = 0; // To avoid JSLint warning of empty block
+                    if (typeof callback === 'function') callback()
                 };
                 image.src = configTrackerUrl + (configTrackerUrl.indexOf('?') < 0 ? '?' : '&') + request;
             }
@@ -1359,7 +1360,7 @@ if (typeof Piwik !== 'object') {
             /*
              * POST request to Piwik server using XMLHttpRequest.
              */
-            function sendXmlHttpRequest(request) {
+            function sendXmlHttpRequest(request, callback) {
                 try {
                     // we use the progid Microsoft.XMLHTTP because
                     // IE5.5 included MSXML 2.5; the progid MSXML2.XMLHTTP
@@ -1375,7 +1376,9 @@ if (typeof Piwik !== 'object') {
                     // fallback on error
                     xhr.onreadystatechange = function () {
                         if (this.readyState === 4 && !(this.status >= 200 && this.status < 300)) {
-                            getImage(request);
+                            getImage(request, callback);
+                        } else {
+                          if (typeof callback === 'function') callback()
                         }
                     };
 
@@ -1384,21 +1387,21 @@ if (typeof Piwik !== 'object') {
                     xhr.send(request);
                 } catch (e) {
                     // fallback
-                    getImage(request);
+                    getImage(request, callback);
                 }
             }
 
             /*
              * Send request
              */
-            function sendRequest(request, delay) {
+            function sendRequest(request, delay, callback) {
                 var now = new Date();
 
                 if (!configDoNotTrack) {
                     if (configRequestMethod === 'POST') {
-                        sendXmlHttpRequest(request);
+                        sendXmlHttpRequest(request, callback);
                     } else {
-                        getImage(request);
+                        getImage(request, callback);
                     }
 
                     expireDateTime = now.getTime() + delay;
@@ -1695,6 +1698,7 @@ if (typeof Piwik !== 'object') {
                         visitCount++;
                         lastVisitTs = currentVisitTs;
                     }
+
 
                     // Detect the campaign information from the current URL
                     // Only if campaign wasn't previously set
@@ -2016,10 +2020,10 @@ if (typeof Piwik !== 'object') {
             /*
              * Log the link or click with the server
              */
-            function logLink(url, linkType, customData) {
+            function logLink(url, linkType, customData, callback) {
                 var request = getRequest(linkType + '=' + encodeWrapper(purify(url)), customData, 'link');
 
-                sendRequest(request, configTrackerPause);
+                sendRequest(request, (callback ? 0 : configTrackerPause), callback);
             }
 
             /*
@@ -3014,9 +3018,9 @@ if (typeof Piwik !== 'object') {
                  * @param string linkType
                  * @param mixed customData
                  */
-                trackLink: function (sourceUrl, linkType, customData) {
+                trackLink: function (sourceUrl, linkType, customData, callback) {
                     trackCallback(function () {
-                        logLink(sourceUrl, linkType, customData);
+                        logLink(sourceUrl, linkType, customData, callback);
                     });
                 },
 
@@ -3064,6 +3068,7 @@ if (typeof Piwik !== 'object') {
                         logSiteSearch(keyword, category, resultsCount);
                     });
                 },
+
 
                 /**
                  * Used to record that the current page view is an item (product) page view, or a Ecommerce Category page view.

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -947,7 +947,7 @@ if ($sqlite) {
     });
 
     test("tracking", function() {
-        expect(97);
+        expect(98);
 
         /*
          * Prevent Opera and HtmlUnit from performing the default action (i.e., load the href URL)
@@ -1023,7 +1023,11 @@ if ($sqlite) {
 
         tracker.trackPageView();
 
-        tracker.trackLink("http://example.ca", "link", { "token" : getToken() });
+        var trackLinkCallbackFired = false;
+        var trackLinkCallback = function () {
+            trackLinkCallbackFired = true;
+        };
+        tracker.trackLink("http://example.ca", "link", { "token" : getToken() }, trackLinkCallback);
 
         // async tracker proxy
         _paq.push(["trackLink", "http://example.fr/async.zip", "download",  { "token" : getToken() }]);
@@ -1232,6 +1236,9 @@ if ($sqlite) {
             xhr.send(null);
             results = xhr.responseText;
             equal( (/<span\>([0-9]+)\<\/span\>/.exec(results))[1], "30", "count tracking events" );
+
+            // firing callback
+            ok( trackLinkCallbackFired, "trackLink() callback fired" );
 
             // tracking requests
             ok( /PiwikTest/.test( results ), "trackPageView(), setDocumentTitle()" );


### PR DESCRIPTION
Implemented in the API #trackLink method, as it’s the one in which using callback makes most sense but it can be added to all of the other methods as well.

Somewhere in the code where link `click` is being caught:
`_paq.push(['trackLink', url, type, {}, function() { window.location = url }])`

In this way we don't block the UI in `#beforeUnloadHandler` function.
