### PR TITLE
Add name parameter to MenuTop.

### DIFF
--- a/core/Menu/MenuTop.php
+++ b/core/Menu/MenuTop.php
@@ -77,6 +77,7 @@ class MenuTop extends MenuAbstract
     {
         if ($displayedForCurrentUser) {
             if (!isset($this->menu[$menuName])) {
+                $this->menu[$menuName]['_name'] = $menuName;
                 $this->menu[$menuName]['_html'] = $data;
                 $this->menu[$menuName]['_order'] = $order;
                 $this->menu[$menuName]['_hasSubmenu'] = false;


### PR DESCRIPTION
It prevents menu sorting method before throws 'Warning'.
