### PR TITLE
Treat response with any 2xx status code as successful POST track request

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -1372,7 +1372,7 @@ if (typeof Piwik !== 'object') {
 
                     // fallback on error
                     xhr.onreadystatechange = function () {
-                        if (this.readyState === 4 && this.status !== 200) {
+                        if (this.readyState === 4 && !(this.status >= 200 && this.status < 300)) {
                             getImage(request);
                         }
                     };


### PR DESCRIPTION
So far piwik.js treated only 200/OK responses for POST track requests, as success.
This patch loosens POST track request success interpretation to responses with any 2xx status code.
