### PR TITLE
added missing variable to postEvent

### DIFF
--- a/plugins/CoreHome/templates/_topBar.twig
+++ b/plugins/CoreHome/templates/_topBar.twig
@@ -1,4 +1,4 @@
-{{ postEvent("Template.beforeTopBar", userAlias, userLogin, topMenu) }}
+{{ postEvent("Template.beforeTopBar", userAlias, userLogin, topMenu, userMenu) }}
 <div id="topBars">
     {% include "@CoreHome/_topBarTopMenu.twig" %}
 </div>


### PR DESCRIPTION
Since top menu construction change, some themes can't work anymore. This PR adds missing twig variable to postEvent
