### PR TITLE
Fixed a test to use the configured root URL

### DIFF
--- a/tests/PHPUnit/Core/HttpTest.php
+++ b/tests/PHPUnit/Core/HttpTest.php
@@ -6,6 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 use Piwik\Http;
+use Piwik\Tests\Fixture;
 
 /**
  * @group HttpTest
@@ -66,7 +67,7 @@ class HttpTest extends PHPUnit_Framework_TestCase
     {
         $result = Http::sendHttpRequestBy(
             $method,
-            'http://localhost/piwik.js',
+            Fixture::getRootUrl() . '/piwik.js',
             30,
             $userAgent = null,
             $destinationPath = null,


### PR DESCRIPTION
There was a hardcoded `http://localhost`, so if you use a different port that 80 then the test fails (I use `http://localhost:8080`).

Tell me if it isn't correct to use `Fixture::getRootUrl()` here.
