### PR TITLE
Improve detection of proc filesystem that works despite potential open_b...

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -203,6 +203,7 @@ class Process
      */
     private static function isProcFSMounted()
     {
-        return is_resource(@fopen('/proc', 'r'));
+      $type = shell_exec('stat -f -c "%T" /proc 2>/dev/null');
+      return strpos($type,'proc')==0;
     }
 }


### PR DESCRIPTION
Testing if /proc is a resource with @fopen fails on systems with open_basedir set. Addind /proc to the open_basedir is undesired and not always an option, resulting in a system that uses the HTTP API (with increased risk of timeouts) instead of the async CLI method. 

Additionally, by using stat we not only test the existance of /proc, but also confirm it's actually a 'proc' filesystem - just in case.
