### PR TITLE
refs #5936 remove gone files during update

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -219,13 +219,21 @@ class Filesystem
             $remove = $target . $file;
 
             if (is_dir($remove)) {
-                rmdir($remove);
+                @rmdir($remove);
             } else {
                 self::deleteFileIfExists($remove);
             }
         }
     }
 
+    /**
+     * Sort all given paths/filenames by its path length. Long path names will be listed first. This method can be
+     * useful if you have for instance a bunch of files/directories to delete. By sorting them by lengh you can make
+     * sure to delete all files within the folders before deleting the actual folder.
+     *
+     * @param string[] $files
+     * @return string[]
+     */
     public static function sortFilesDescByPathLength($files)
     {
         usort($files, function ($a, $b) {
@@ -247,7 +255,7 @@ class Filesystem
      * @param $source
      * @param $target
      *
-     * @return array
+     * @return string[]
      */
     public static function directoryDiff($source, $target)
     {

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -9,7 +9,6 @@
 namespace Piwik;
 
 use Exception;
-use Piwik\Plugins\Installation\ServerFilesGenerator;
 use Piwik\Tracker\Cache;
 
 /**

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -204,6 +204,42 @@ class Filesystem
         return;
     }
 
+    public static function unlinkTargetFilesNotPresentInSource($source, $target)
+    {
+        $sourceFiles = self::globr($source, '*');
+        $targetFiles = self::globr($target, '*');
+
+        $sourceFiles = array_map(function ($file) use ($source) {
+            return str_replace($source, '', $file);
+        }, $sourceFiles);
+
+        $targetFiles = array_map(function ($file) use ($target) {
+            return str_replace($target, '', $file);
+        }, $targetFiles);
+
+        $diff = array_diff($targetFiles, $sourceFiles);
+
+        usort($diff, function ($a,$b) {
+            // sort by filename length so we kinda make sure to remove files before its directories
+            if ($a == $b) {
+                return 0;
+            }
+
+            return (strlen($a) > strlen($b) ? -1 : 1);
+        });
+
+        foreach ($diff as $file) {
+            $remove = $target . $file;
+
+            if (is_dir($remove)) {
+                rmdir($remove);
+            } else {
+                unlink($remove);
+            }
+        }
+    }
+
+
     /**
      * Copies a file from `$source` to `$dest`.
      *

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -243,26 +243,6 @@ class Controller extends \Piwik\Plugin\Controller
         }
     }
 
-    private function getPluginsFromDirectoy($directoryToLook)
-    {
-        $directories = _glob($directoryToLook . '/plugins/' . '*', GLOB_ONLYDIR);
-
-        $directories = array_map(function ($directory) use ($directoryToLook) {
-            return str_replace($directoryToLook, '', $directory);
-        }, $directories);
-
-        return $directories;
-    }
-
-    private function removeGoneFiles($source, $target)
-    {
-        Filesystem::unlinkTargetFilesNotPresentInSource($source . '/core', $target . '/core');
-
-        foreach ($this->getPluginsFromDirectoy($source) as $pluginDir) {
-            Filesystem::unlinkTargetFilesNotPresentInSource($source . $pluginDir, $target . $pluginDir);
-        }
-    }
-
     private function oneClick_Copy()
     {
         /*
@@ -272,12 +252,14 @@ class Controller extends \Piwik\Plugin\Controller
             @chmod($this->pathRootExtractedPiwik . '/misc/cron/archive.sh', 0755);
         }
 
+        $model = new Model();
+
         /*
          * Copy all files to PIWIK_INCLUDE_PATH.
          * These files are accessed through the dispatcher.
          */
         Filesystem::copyRecursive($this->pathRootExtractedPiwik, PIWIK_INCLUDE_PATH);
-        $this->removeGoneFiles($this->pathRootExtractedPiwik, PIWIK_INCLUDE_PATH);
+        $model->removeGoneFiles($this->pathRootExtractedPiwik, PIWIK_INCLUDE_PATH);
 
         /*
          * These files are visible in the web root and are generally
@@ -301,7 +283,7 @@ class Controller extends \Piwik\Plugin\Controller
              * Copy the non-PHP files (e.g., images, css, javascript)
              */
             Filesystem::copyRecursive($this->pathRootExtractedPiwik, PIWIK_DOCUMENT_ROOT, true);
-            $this->removeGoneFiles($this->pathRootExtractedPiwik, PIWIK_DOCUMENT_ROOT);
+            $model->removeGoneFiles($this->pathRootExtractedPiwik, PIWIK_DOCUMENT_ROOT);
         }
 
         /*

--- a/plugins/CoreUpdater/Model.php
+++ b/plugins/CoreUpdater/Model.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\CoreUpdater;
+
+use Piwik\Filesystem;
+
+class Model
+{
+    public function getPluginsFromDirectoy($directoryToLook)
+    {
+        $directories = _glob($directoryToLook . '/plugins/' . '*', GLOB_ONLYDIR);
+
+        $directories = array_map(function ($directory) use ($directoryToLook) {
+            return str_replace($directoryToLook, '', $directory);
+        }, $directories);
+
+        return $directories;
+    }
+
+    public function removeGoneFiles($source, $target)
+    {
+        Filesystem::unlinkTargetFilesNotPresentInSource($source . '/core', $target . '/core');
+
+        foreach ($this->getPluginsFromDirectoy($source) as $pluginDir) {
+            Filesystem::unlinkTargetFilesNotPresentInSource($source . $pluginDir, $target . $pluginDir);
+        }
+    }
+}

--- a/plugins/CoreUpdater/tests/ModelTest.php
+++ b/plugins/CoreUpdater/tests/ModelTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreUpdater\tests;
+use Piwik\Plugins\CoreUpdater\Model;
+
+/**
+ * @group CoreUpdater
+ * @group ModelTest
+ * @group Unit
+ * @group Plugins
+ */
+class ModelTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Model
+     */
+    private $model;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->model = new Model();
+    }
+
+    public function test_getPluginsFromDirectoy_shouldReturnEmptyArray_IfNoPluginsExist()
+    {
+        $plugins = $this->model->getPluginsFromDirectoy(PIWIK_INCLUDE_PATH . '/config');
+
+        $this->assertEquals(array(), $plugins);
+    }
+
+    public function test_getPluginsFromDirectoy_shouldReturnAllDirectoriesWithinPlugins()
+    {
+        $plugins = $this->model->getPluginsFromDirectoy(PIWIK_INCLUDE_PATH);
+
+        $this->assertGreaterThan(40, count($plugins));
+        $this->assertContains('/plugins/API', $plugins);
+        $this->assertContains('/plugins/Actions', $plugins);
+        $this->assertContains('/plugins/Annotations', $plugins);
+
+        $this->assertNotContains('/plugins/.', $plugins);
+        $this->assertNotContains('/plugins/..', $plugins);
+        $this->assertNotContains('/plugins', $plugins);
+        $this->assertNotContains('/plugins/', $plugins);
+
+        foreach ($plugins as $plugin) {
+            $this->assertTrue(is_dir(PIWIK_INCLUDE_PATH . $plugin));
+            $this->assertStringStartsWith('/plugins/', $plugin);
+            $this->assertTrue(12 <= strlen($plugin)); // make sure it does not return something like '/plugins'.
+        }
+    }
+
+}

--- a/tests/PHPUnit/Core/FilesystemTest.php
+++ b/tests/PHPUnit/Core/FilesystemTest.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+use Piwik\Filesystem;
+
+/**
+ * @group Core
+ */
+class FilesystemTest extends PHPUnit_Framework_TestCase
+{
+    private $testPath;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->testPath = PIWIK_INCLUDE_PATH . '/tmp/filesystemtest';
+        Filesystem::mkdir($this->testPath);
+    }
+
+    public function tearDown()
+    {
+        Filesystem::unlinkRecursive($this->testPath, true);
+
+        parent::tearDown();
+    }
+
+    public function test_sortFilesDescByPathLength_shouldNotFail_IfEmptyArrayGiven()
+    {
+        $result = Filesystem::sortFilesDescByPathLength(array());
+        $this->assertEquals(array(), $result);
+    }
+
+    public function test_sortFilesDescByPathLength_shouldNotChangeOrder_IfAllHaveSameLength()
+    {
+        $input  = array('xyz/1.gif', 'x/xyz.gif', 'xxyyzzgg');
+        $result = Filesystem::sortFilesDescByPathLength($input);
+        $this->assertEquals($input, $result);
+    }
+
+    public function test_sortFilesDescByPathLength_shouldOrderDesc_IfDifferentLengthsGiven()
+    {
+        $input  = array('xyz/1.gif', '1.gif', 'x', 'x/xyz.gif', 'xyz', 'xxyyzzgg', 'xyz/long.gif');
+        $result = Filesystem::sortFilesDescByPathLength($input);
+
+        $expected = array(
+            'xyz/long.gif',
+            'x/xyz.gif',
+            'xyz/1.gif',
+            'xxyyzzgg',
+            '1.gif',
+            'xyz',
+            'x',
+        );
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_directoryDiff_shouldNotReturnDifference_IfBothDirectoriesAreSame()
+    {
+        $dir    = PIWIK_INCLUDE_PATH . '/core';
+        $result = Filesystem::directoryDiff($dir, $dir);
+
+        $this->assertEquals(array(), $result);
+    }
+
+    public function test_directoryDiff_shouldNotReturnAnything_IfTargetEmpty()
+    {
+        $result = Filesystem::directoryDiff($this->createSourceFiles(), $this->createEmptyTarget());
+
+        $this->assertEquals(array(), $result);
+    }
+
+    public function test_directoryDiff_shouldReturnAllTargetFiles_IfSourceIsEmpty()
+    {
+        $result = Filesystem::directoryDiff($this->createEmptySource(), $this->createTargetFiles());
+
+        $this->assertEquals(array(
+            '/DataTable',
+            '/DataTable/BaseFilter.php',
+            '/DataTable/Bridges.php',
+            '/DataTable/DataTableInterface.php',
+            '/DataTable/Filter',
+            '/DataTable/Manager.php',
+            '/DataTable/Map.php',
+            '/DataTable/Renderer',
+            '/DataTable/Renderer.php',
+            '/DataTable/Row',
+            '/DataTable/Row.php',
+            '/DataTable/Simple.php',
+            '/DataTable/Renderer/Console.php',
+            '/DataTable/Renderer/Csv.php',
+            '/DataTable/Renderer/Html.php',
+            '/DataTable/Renderer/Json.php',
+            '/DataTable/Renderer/Php.php',
+            '/DataTable/Renderer/Rss.php',
+            '/DataTable/Renderer/Tsv.php',
+            '/DataTable/Renderer/Xml',
+            '/DataTable/Renderer/Xml.php',
+            '/DataTable/Renderer/Xml/Other.php',
+            '/DataTable/Row/DataTableSummaryRow.php'
+        ), $result);
+    }
+
+    public function test_directoryDiff_shouldReturnFilesPresentInTargetButNotSource_IfSourceAndTargetGiven()
+    {
+        $result = Filesystem::directoryDiff($this->createSourceFiles(), $this->createTargetFiles());
+
+        $this->assertEquals(array(
+            '/DataTable/Filter',
+            '/DataTable/Row',
+            '/DataTable/Renderer/Json.php',
+            '/DataTable/Renderer/Php.php',
+            '/DataTable/Renderer/Rss.php',
+            '/DataTable/Renderer/Xml',
+            '/DataTable/Renderer/Xml/Other.php',
+            '/DataTable/Row/DataTableSummaryRow.php',
+        ), $result);
+    }
+
+    public function test_unlinkTargetFilesNotPresentInSource_shouldUnlinkFilesPresentInTargetButNotSource_IfSourceAndTargetGiven()
+    {
+        $source = $this->createSourceFiles();
+        $target = $this->createTargetFiles();
+
+        // make sure there is a difference between those folders
+        $result = Filesystem::directoryDiff($source, $target);
+        $this->assertCount(8, $result);
+
+        Filesystem::unlinkTargetFilesNotPresentInSource($source, $target);
+
+        // make sure there is no longer a difference
+        $result = Filesystem::directoryDiff($source, $target);
+        $this->assertEquals(array(), $result);
+
+        $result = Filesystem::directoryDiff($target, $source);
+        $this->assertEquals(array(
+             '/DataTable/NotInTarget.php',
+             '/DataTable/Renderer/NotInTarget.php'
+        ), $result);
+    }
+
+    public function test_unlinkTargetFilesNotPresentInSource_shouldNotFail_IfBothEmpty()
+    {
+        $source = $this->createEmptySource();
+        $target = $this->createEmptyTarget();
+
+        Filesystem::unlinkTargetFilesNotPresentInSource($source, $target);
+    }
+
+    public function test_unlinkTargetFilesNotPresentInSource_shouldUnlinkAllTargetFiles_IfSourceIsEmpty()
+    {
+        $source = $this->createEmptySource();
+        $target = $this->createTargetFiles();
+
+        // make sure there is a difference between those folders
+        $result = Filesystem::directoryDiff($source, $target);
+        $this->assertNotEmpty($result);
+
+        Filesystem::unlinkTargetFilesNotPresentInSource($source, $target);
+
+        // make sure there is no longer a difference
+        $result = Filesystem::directoryDiff($source, $target);
+        $this->assertEquals(array(), $result);
+
+        $result = Filesystem::directoryDiff($target, $source);
+        $this->assertEquals(array(), $result);
+    }
+
+    private function createSourceFiles()
+    {
+        $source = $this->createEmptySource();
+        Filesystem::mkdir($source . '/DataTable');
+        Filesystem::mkdir($source . '/DataTable/Renderer');
+
+        file_put_contents($source . '/DataTable/Renderer/Console.php', '');
+        file_put_contents($source . '/DataTable/Renderer/Csv.php', '');
+        file_put_contents($source . '/DataTable/Renderer/Html.php', '');
+        file_put_contents($source . '/DataTable/Renderer/Tsv.php', '');
+        file_put_contents($source . '/DataTable/Renderer/Xml.php', '');
+        file_put_contents($source . '/DataTable/Renderer/NotInTarget.php', '');
+
+        file_put_contents($source . '/DataTable/BaseFilter.php', '');
+        file_put_contents($source . '/DataTable/Bridges.php', '');
+        file_put_contents($source . '/DataTable/DataTableInterface.php', '');
+        file_put_contents($source . '/DataTable/NotInTarget.php', '');
+        file_put_contents($source . '/DataTable/Manager.php', '');
+        file_put_contents($source . '/DataTable/Map.php', '');
+        file_put_contents($source . '/DataTable/Renderer.php', '');
+        file_put_contents($source . '/DataTable/Row.php', '');
+        file_put_contents($source . '/DataTable/Simple.php', '');
+
+        return $source;
+    }
+
+    private function createTargetFiles()
+    {
+        $target = $this->createEmptyTarget();
+        Filesystem::mkdir($target . '/DataTable');
+        Filesystem::mkdir($target . '/DataTable/Filter');
+        Filesystem::mkdir($target . '/DataTable/Renderer');
+        Filesystem::mkdir($target . '/DataTable/Renderer/Xml');
+        Filesystem::mkdir($target . '/DataTable/Row');
+
+        file_put_contents($target . '/DataTable/Renderer/Console.php', '');
+        file_put_contents($target . '/DataTable/Renderer/Csv.php', '');
+        file_put_contents($target . '/DataTable/Renderer/Html.php', '');
+        file_put_contents($target . '/DataTable/Renderer/Json.php', '');
+        file_put_contents($target . '/DataTable/Renderer/Php.php', '');
+        file_put_contents($target . '/DataTable/Renderer/Rss.php', '');
+        file_put_contents($target . '/DataTable/Renderer/Tsv.php', '');
+        file_put_contents($target . '/DataTable/Renderer/Xml.php', '');
+        file_put_contents($target . '/DataTable/Renderer/Xml/Other.php', '');
+
+        file_put_contents($target . '/DataTable/Row/DataTableSummaryRow.php', '');
+
+        file_put_contents($target . '/DataTable/BaseFilter.php', '');
+        file_put_contents($target . '/DataTable/Bridges.php', '');
+        file_put_contents($target . '/DataTable/DataTableInterface.php', '');
+        file_put_contents($target . '/DataTable/Manager.php', '');
+        file_put_contents($target . '/DataTable/Map.php', '');
+        file_put_contents($target . '/DataTable/Renderer.php', '');
+        file_put_contents($target . '/DataTable/Row.php', '');
+        file_put_contents($target . '/DataTable/Simple.php', '');
+
+        return $target;
+    }
+
+    private function createEmptySource()
+    {
+        Filesystem::mkdir($this->testPath . '/source');
+
+        return $this->testPath . '/source';
+    }
+
+    private function createEmptyTarget()
+    {
+        Filesystem::mkdir($this->testPath . '/target');
+
+        return $this->testPath . '/target';
+    }
+
+}


### PR DESCRIPTION
As mentioned in the ticket when updating Piwik it will compare all directories within the plugins folder and the core directory of the latest.zip with the current installation and remove all files that are in the users current installation but not in the latest.zip.

To test it one has to update Piwik to make sure the CoreUpdater uses this new codebase and then update again to a later version. So it won't work directly with the next update. Maybe we can release to new betas and update after each?
