### PR TITLE
Find components only of activated dimensions

### DIFF
--- a/core/Plugin/Dimension/ActionDimension.php
+++ b/core/Plugin/Dimension/ActionDimension.php
@@ -216,7 +216,7 @@ abstract class ActionDimension extends Dimension
 
         if (!$cache->has()) {
 
-            $plugins   = PluginManager::getInstance()->getLoadedPlugins();
+            $plugins   = PluginManager::getInstance()->getPluginsLoadedAndActivated();
             $instances = array();
 
             foreach ($plugins as $plugin) {

--- a/core/Plugin/Dimension/ConversionDimension.php
+++ b/core/Plugin/Dimension/ConversionDimension.php
@@ -159,7 +159,7 @@ abstract class ConversionDimension extends Dimension
 
         if (!$cache->has()) {
 
-            $plugins   = PluginManager::getInstance()->getLoadedPlugins();
+            $plugins   = PluginManager::getInstance()->getPluginsLoadedAndActivated();
             $instances = array();
 
             foreach ($plugins as $plugin) {

--- a/core/Plugin/Dimension/VisitDimension.php
+++ b/core/Plugin/Dimension/VisitDimension.php
@@ -275,7 +275,7 @@ abstract class VisitDimension extends Dimension
 
         if (!$cache->has()) {
 
-            $plugins   = PluginManager::getInstance()->getLoadedPlugins();
+            $plugins   = PluginManager::getInstance()->getPluginsLoadedAndActivated();
             $instances = array();
 
             foreach ($plugins as $plugin) {

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -604,7 +604,8 @@ class Manager extends Singleton
     }
 
     /**
-     * Load the specified plugins.
+     * Load AND activates the specified plugins. It will also overwrite all previously loaded plugins, so it acts
+     * as a setter. 
      *
      * @param array $pluginsToLoad Array of plugins to load.
      */
@@ -822,7 +823,8 @@ class Manager extends Singleton
     }
 
     /**
-     * Loads the plugin filename and instantiates the plugin with the given name, eg. UserCountry
+     * Loads the plugin filename and instantiates the plugin with the given name, eg. UserCountry.
+     * Contrary to loadPlugins() it does not activate the plugin, it only loads it.
      *
      * @param string $pluginName
      * @throws \Exception

--- a/tests/PHPUnit/Core/Columns/DimensionTest.php
+++ b/tests/PHPUnit/Core/Columns/DimensionTest.php
@@ -9,7 +9,10 @@
 namespace Piwik\Plugins\Test;
 // there is a test that requires the class to be defined in a plugin
 
+use Piwik\Cache\PersistentCache;
+use Piwik\Cache\StaticCache;
 use Piwik\Columns\Dimension;
+use Piwik\Config;
 use Piwik\Plugin\Segment;
 use Piwik\Plugin\Manager;
 
@@ -56,12 +59,15 @@ class Core_DimensionTest extends \PHPUnit_Framework_TestCase
     {
         Manager::getInstance()->unloadPlugins();
         Manager::getInstance()->doNotLoadAlwaysActivatedPlugins();
+        Config::getInstance()->clear();
+        Config::getInstance()->init();
 
         $this->dimension = new DimensionTest();
     }
 
     public function tearDown()
     {
+        Config::unsetInstance();
         Manager::unsetInstance();
         parent::tearDown();
     }

--- a/tests/PHPUnit/Core/Columns/DimensionTest.php
+++ b/tests/PHPUnit/Core/Columns/DimensionTest.php
@@ -55,8 +55,15 @@ class Core_DimensionTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         Manager::getInstance()->unloadPlugins();
+        Manager::getInstance()->doNotLoadAlwaysActivatedPlugins();
 
         $this->dimension = new DimensionTest();
+    }
+
+    public function tearDown()
+    {
+        Manager::unsetInstance();
+        parent::tearDown();
     }
 
     public function test_hasImplementedEvent_shouldDetectWhetherAMethodWasOverwrittenInTheActualPluginClass()
@@ -87,10 +94,7 @@ class Core_DimensionTest extends \PHPUnit_Framework_TestCase
 
     public function test_getAllDimensions_shouldReturnActionVisitAndConversionDimensions()
     {
-        Manager::getInstance()->loadPlugin('Actions');
-        Manager::getInstance()->loadPlugin('Events');
-        Manager::getInstance()->loadPlugin('DevicesDetector');
-        Manager::getInstance()->loadPlugin('Goals');
+        Manager::getInstance()->loadPlugins(array('Actions', 'Events', 'DevicesDetector', 'Goals'));
 
         $dimensions = Dimension::getAllDimensions();
 

--- a/tests/PHPUnit/Core/Plugin/Dimension/ActionDimensionTest.php
+++ b/tests/PHPUnit/Core/Plugin/Dimension/ActionDimensionTest.php
@@ -55,8 +55,15 @@ class Plugin_ActionDimensionTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         Manager::getInstance()->unloadPlugins();
+        Manager::getInstance()->doNotLoadAlwaysActivatedPlugins();
 
         $this->dimension = new FakeActionDimension();
+    }
+
+    public function tearDown()
+    {
+        Manager::unsetInstance();
+        parent::tearDown();
     }
 
     public function test_install_shouldNotReturnAnything_IfColumnTypeNotSpecified()
@@ -125,6 +132,7 @@ class Plugin_ActionDimensionTest extends \PHPUnit_Framework_TestCase
 
     public function test_getDimensions_shouldOnlyLoadAllActionDimensionsFromACertainPlugin()
     {
+        Manager::getInstance()->loadPlugins(array('Actions'));
         $plugin = Manager::getInstance()->loadPlugin('Actions');
 
         $dimensions = ActionDimension::getDimensions($plugin);
@@ -139,8 +147,7 @@ class Plugin_ActionDimensionTest extends \PHPUnit_Framework_TestCase
 
     public function test_getAllDimensions_shouldLoadAllDimensionsButOnlyIfLoadedPlugins()
     {
-        Manager::getInstance()->loadPlugin('Actions');
-        Manager::getInstance()->loadPlugin('Events');
+        Manager::getInstance()->loadPlugins(array('Actions', 'Events'));
 
         $dimensions = ActionDimension::getAllDimensions();
 

--- a/tests/PHPUnit/Core/Plugin/Dimension/ConversionDimensionTest.php
+++ b/tests/PHPUnit/Core/Plugin/Dimension/ConversionDimensionTest.php
@@ -55,8 +55,15 @@ class Plugin_ConversionDimensionTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         Manager::getInstance()->unloadPlugins();
+        Manager::getInstance()->doNotLoadAlwaysActivatedPlugins();
 
         $this->dimension = new FakeConversionDimension();
+    }
+
+    public function tearDown()
+    {
+        Manager::unsetInstance();
+        parent::tearDown();
     }
 
     public function test_install_shouldNotReturnAnything_IfColumnTypeNotSpecified()
@@ -125,6 +132,7 @@ class Plugin_ConversionDimensionTest extends \PHPUnit_Framework_TestCase
 
     public function test_getDimensions_shouldOnlyLoadAllConversionDimensionsFromACertainPlugin()
     {
+        Manager::getInstance()->loadPlugins(array('ExampleTracker'));
         $plugin = Manager::getInstance()->loadPlugin('ExampleTracker');
 
         $dimensions = ConversionDimension::getDimensions($plugin);
@@ -139,8 +147,7 @@ class Plugin_ConversionDimensionTest extends \PHPUnit_Framework_TestCase
 
     public function test_getAllDimensions_shouldLoadAllDimensionsButOnlyIfLoadedPlugins()
     {
-        Manager::getInstance()->loadPlugin('ExampleTracker');
-        Manager::getInstance()->loadPlugin('Goals');
+        Manager::getInstance()->loadPlugins(array('Goals', 'ExampleTracker'));
 
         $dimensions = ConversionDimension::getAllDimensions();
 

--- a/tests/PHPUnit/Core/Plugin/Dimension/VisitDimensionTest.php
+++ b/tests/PHPUnit/Core/Plugin/Dimension/VisitDimensionTest.php
@@ -76,9 +76,16 @@ class Plugin_VisitDimensionTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         Manager::getInstance()->unloadPlugins();
+        Manager::getInstance()->doNotLoadAlwaysActivatedPlugins();
 
         $this->dimension = new FakeVisitDimension();
         $this->conversionDimension = new FakeConversionVisitDimension();
+    }
+
+    public function tearDown()
+    {
+        Manager::unsetInstance();
+        parent::tearDown();
     }
 
     public function test_install_shouldNotReturnAnything_IfColumnTypeNotSpecified()
@@ -224,6 +231,7 @@ class Plugin_VisitDimensionTest extends \PHPUnit_Framework_TestCase
 
     public function test_getDimensions_shouldOnlyLoadAllVisitDimensionsFromACertainPlugin()
     {
+        Manager::getInstance()->loadPlugins(array('Actions'));
         $plugin = Manager::getInstance()->loadPlugin('Actions');
 
         $dimensions = VisitDimension::getDimensions($plugin);
@@ -239,8 +247,7 @@ class Plugin_VisitDimensionTest extends \PHPUnit_Framework_TestCase
 
     public function test_getAllDimensions_shouldLoadAllDimensionsButOnlyIfLoadedPlugins()
     {
-        Manager::getInstance()->loadPlugin('Actions');
-        Manager::getInstance()->loadPlugin('DevicesDetection');
+        Manager::getInstance()->loadPlugins(array('Actions', 'DevicesDetection'));
 
         $dimensions = VisitDimension::getAllDimensions();
 


### PR DESCRIPTION
We should actually load only dimensions of activated plugins, not of loaded plugins. 
