### PR TITLE
refs #6013 use console only if executed from cli

### DIFF
--- a/core/Console.php
+++ b/core/Console.php
@@ -108,6 +108,11 @@ class Console extends Application
         }
     }
 
+    public static function isSupported()
+    {
+        return Common::isPhpCliMode() && !Common::isPhpCgiType();
+    }
+
     protected function initPiwikHost(InputInterface $input)
     {
         $piwikHostname = $input->getParameterOption('--piwik-domain');

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -38,11 +38,14 @@ Using this 'archive.php' script is no longer recommended.
 Please use '/path/to/php $piwikHome/console core:archive " . implode('', array_slice($_SERVER['argv'], 1)) . "' instead.
 To get help use '/path/to/php $piwikHome/console core:archive --help'
 See also: http://piwik.org/docs/setup-auto-archiving/
+
+If you cannot use the console because it requires CLI
+try 'php archive.php -- url=http://your.piwik/path'
 -------------------------------------------------------
 \n\n";
 }
 
-if (isset($_SERVER['argv']) && Piwik\Common::isPhpCliMode()) {
+if (isset($_SERVER['argv']) && Piwik\Console::isSupported()) {
     $console = new Piwik\Console();
     $console->init();
 

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -42,7 +42,7 @@ See also: http://piwik.org/docs/setup-auto-archiving/
 \n\n";
 }
 
-if (isset($_SERVER['argv'])) {
+if (isset($_SERVER['argv']) && Piwik\Common::isPhpCliMode()) {
     $console = new Piwik\Console();
     $console->init();
 


### PR DESCRIPTION
refs #6013 #6012 The created issue makes absolutely sense I think as a command would be executed only in CLI mode anyway see https://github.com/piwik/piwik/blob/master/core/Plugin/ConsoleCommand.php#L30

What I am not sure is whether HHVM & co reports itself as CLI/CGI as well? But this is maybe worth a separate issue.

@mattab Please merge if you cannot think of any problems with that.
