### PR TITLE
fixed composer.json to download the same set of vendors as with use of c...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": ">=5.3.2",
         "twig/twig": "1.*",
-        "leafo/lessphp": "~0.3",
+        "leafo/lessphp": "0.4",
         "symfony/console": ">=v2.3.5",
         "tedivm/jshrink": "v0.5.1",
         "mustangostang/spyc": "0.5.*",


### PR DESCRIPTION
...omposer.lock. that way Piwik can be also installed with Composer as dependency along with its dependencies.

Originally this issue came out when I tried to download Piwik along with it's plugins using different composer.json file. That way Composer would download dependencies described in composer.json. This caused installation and Piwik in general to break down due to vendor version mismatch. In 'standard' use case on the other hand it worked well, as strict version was stored inside of composer.lock file.

Tilde operator is not quite safe for precise version marking (ref. https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-operator- ) , so I would propose to always keep composer.json and composer.lock up-to-date using precise versioning in composer.json, so Piwik can be managed with Composer easily.

For now I have found that lessphp was causing problems after download, but it generally could be a good idea to switch to strict versioning for all vendors.
