### PR TITLE
Move JSON format bug fixes to new JSON2 format so existing clients will not fail.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ We removed our own autoloader that was used to load Piwik files in favor of the 
 ### New commmands
 * `core:run-scheduled-tasks` Let's you run all scheduled tasks due to run at this time. Useful for instance when testing tasks.
 
-### Breaking Changes
-* A bug in JSON formatting was fixed so API methods that return simple associative arrays like `array('name' => 'value', 'name2' => 'value2')` will now appear correctly as `{"name":"value","name2":"value2"}` in JSON API output instead of `[{"name":"value","name2":"value2"}]`. API methods like **SitesManager.getSiteFromId** & **UsersManager.getUser** are affected
+### Deprecations
+* The `'json'` API format is considered deprecated. We ask all new code to use the `'json2'` format. Eventually when Piwik 3.0 is released the `'json'` format will be replaced with `'json2'`. Differences in the json2 format include:
+  * A bug in JSON formatting was fixed so API methods that return simple associative arrays like `array('name' => 'value', 'name2' => 'value2')` will now appear correctly as `{"name":"value","name2":"value2"}` in JSON API output instead of `[{"name":"value","name2":"value2"}]`. API methods like **SitesManager.getSiteFromId** & **UsersManager.getUser** are affected.
 
 ## Piwik 2.5.0
 

--- a/core/API/ApiRenderer.php
+++ b/core/API/ApiRenderer.php
@@ -80,6 +80,10 @@ abstract class ApiRenderer
     protected function buildDataTableRenderer($dataTable)
     {
         $format   = self::getFormatFromClass(get_class($this));
+        if ($format == 'json2') {
+            $format = 'json';
+        }
+
         $renderer = Renderer::factory($format);
         $renderer->setTable($dataTable);
         $renderer->setRenderSubTables(Common::getRequestVar('expanded', false, 'int', $this->request));

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -880,7 +880,7 @@ class Piwik(object):
         """
         args = {
             'module' : 'API',
-            'format' : 'json',
+            'format' : 'json2',
             'method' : method,
         }
         # token_auth, by default, is taken from config.

--- a/plugins/API/Renderer/Json.php
+++ b/plugins/API/Renderer/Json.php
@@ -15,9 +15,16 @@ use Piwik\DataTable;
 use Piwik\Piwik;
 use Piwik\ProxyHttp;
 
+/**
+ * API output renderer for JSON.
+ *
+ * **NOTE: This is the old JSON format. It includes bugs that are fixed in the JSON2 API output
+ * format. Please use that format instead of this.**
+ *
+ * @deprecated
+ */
 class Json extends ApiRenderer
 {
-
     public function renderSuccess($message)
     {
         $result = json_encode(array('result' => 'success', 'message' => $message));
@@ -49,16 +56,7 @@ class Json extends ApiRenderer
             return $this->applyJsonpIfNeeded($result);
         }
 
-        $result = $this->renderDataTable($array);
-
-        // if $array is a simple associative array, remove the JSON root array that is added by renderDataTable
-        if (!empty($array)
-            && Piwik::isAssociativeArray($array)
-        ) {
-            $result = substr($result, 1, strlen($result) - 2);
-        }
-
-        return $result;
+        return $this->renderDataTable($array);
     }
 
     public function sendHeader()

--- a/plugins/API/Renderer/Json2.php
+++ b/plugins/API/Renderer/Json2.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\API\Renderer;
+
+use Piwik\Piwik;
+
+/**
+ * Correct API output renderer for JSON. Includes bug fixes for bugs in the old JSON API
+ * format.
+ */
+class Json2 extends Json
+{
+    public function renderArray($array)
+    {
+        $result = parent::renderArray($array);
+
+        // if $array is a simple associative array, remove the JSON root array that is added by renderDataTable
+        if (!empty($array)
+            && Piwik::isAssociativeArray($array)
+            && !Piwik::isMultiDimensionalArray($array)
+        ) {
+            $result = substr($result, 1, strlen($result) - 2);
+        }
+
+        return $result;
+    }
+}

--- a/plugins/API/tests/JsonRendererTest.php
+++ b/plugins/API/tests/JsonRendererTest.php
@@ -10,10 +10,12 @@ namespace Piwik\Plugins\API\tests;
 
 use Piwik\DataTable;
 use Piwik\Plugins\API\Renderer\Json;
+use Piwik\Plugins\API\Renderer\Json2;
 
 /**
  * @group Plugin
  * @group API
+ * @group API_JsonRendererTest
  */
 class JsonRendererTest extends \PHPUnit_Framework_TestCase
 {
@@ -353,9 +355,27 @@ class JsonRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertNoJsonError($actual);
     }
 
+    /**
+     * backwards compatibility test
+     */
+    public function test_oldJson_renderArray_ShouldConvertSingleDimensionalAssociativeArray()
+    {
+        $input = array(
+            "firstElement" => "isFirst",
+            "secondElement" => "isSecond"
+        );
+
+        $expected = '[{"firstElement":"isFirst","secondElement":"isSecond"}]';
+
+        $oldJsonBuilder = new Json($input);
+        $actual = $oldJsonBuilder->renderArray($input);
+        $this->assertEquals($expected, $actual);
+        $this->assertNoJsonError($actual);
+    }
+
     private function makeBuilder($request)
     {
-        return new Json($request);
+        return new Json2($request);
     }
 
     private function assertNoJsonError($response)

--- a/plugins/CoreHome/angularjs/common/services/piwik-api.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik-api.js
@@ -185,7 +185,7 @@ angular.module('piwikApp.service').factory('piwikApi', function ($http, $q, $roo
     piwikApi.fetch = function (getParams) {
 
         getParams.module = getParams.module || 'API';
-        getParams.format = 'JSON';
+        getParams.format = 'JSON2';
 
         addParams(getParams, 'GET');
 

--- a/plugins/CoreHome/angularjs/common/services/piwik-api_spec.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik-api_spec.js
@@ -29,7 +29,7 @@ describe('piwikApiClient', function () {
         piwikApi.fetch({
             method: "SomePlugin.action"
         }).then(function (response) {
-            expect(response).to.equal("Request url: index.php?date=&format=JSON&idSite=1&method=SomePlugin.action&module=API&period=day");
+            expect(response).to.equal("Request url: index.php?date=&format=JSON2&idSite=1&method=SomePlugin.action&module=API&period=day");
 
             done();
         }).catch(function (ex) {
@@ -86,7 +86,7 @@ describe('piwikApiClient', function () {
         piwikApi.fetch({
             method: "SomePlugin.action"
         }).then(function (response) {
-            expect(response).to.equal("Request url: index.php?date=&format=JSON&idSite=1&method=SomePlugin.action&module=API&period=day");
+            expect(response).to.equal("Request url: index.php?date=&format=JSON2&idSite=1&method=SomePlugin.action&module=API&period=day");
 
             request1Done = true;
 
@@ -98,7 +98,7 @@ describe('piwikApiClient', function () {
         piwikApi.fetch({
             method: "SomeOtherPlugin.action"
         }).then(function (response) {
-            expect(response).to.equal("Request url: index.php?date=&format=JSON&idSite=1&method=SomeOtherPlugin.action&module=API&period=day");
+            expect(response).to.equal("Request url: index.php?date=&format=JSON2&idSite=1&method=SomeOtherPlugin.action&module=API&period=day");
 
             request2Done = true;
 
@@ -133,7 +133,7 @@ describe('piwikApiClient', function () {
         piwikApi.fetch({
             method: "SomeOtherPlugin.action"
         }).then(function (response) {
-            expect(response).to.equal("Request url: index.php?date=&format=JSON&idSite=1&method=SomeOtherPlugin.action&module=API&period=day");
+            expect(response).to.equal("Request url: index.php?date=&format=JSON2&idSite=1&method=SomeOtherPlugin.action&module=API&period=day");
 
             request2Done = true;
 

--- a/tests/PHPUnit/Core/API/ApiRendererTest.php
+++ b/tests/PHPUnit/Core/API/ApiRendererTest.php
@@ -7,6 +7,7 @@
  */
 
 use Piwik\API\ApiRenderer;
+use Piwik\API\ApiRenderer\Json;
 
 /**
  * @group Core


### PR DESCRIPTION
Adds deprecation note for JSON format and uses JSON2 in future proof code (angularjs/log importer).

Other JavaScript will automatically use this format when switched to angularjs.
