### PR TITLE
Replace @ in front of header() with a test

### DIFF
--- a/core/API/ApiRenderer.php
+++ b/core/API/ApiRenderer.php
@@ -116,7 +116,9 @@ abstract class ApiRenderer
         }
 
         $availableRenderers = implode(', ', $availableRenderers);
-        @header('Content-Type: text/plain; charset=utf-8');
+        if(! headers_sent()) {
+            header('Content-Type: text/plain; charset=utf-8');
+        }
         throw new Exception(Piwik::translate('General_ExceptionInvalidRendererFormat', array($format, $availableRenderers)));
     }
 


### PR DESCRIPTION
The @ is bad practice I think, I do not know if Piwik care about it. But if the goal of this one was to hide the "headers already sent" error, I suggest to test it explicitly.
