### PR TITLE
Do not report notices to error log

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@ if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
 }
 
-error_reporting(E_ALL | E_NOTICE);
+error_reporting(E_ALL);
 @ini_set('display_errors', defined('PIWIK_DISPLAY_ERRORS') ? PIWIK_DISPLAY_ERRORS : @ini_get('display_errors'));
 @ini_set('xdebug.show_exception_trace', 0);
 @ini_set('magic_quotes_runtime', 0);

--- a/misc/others/cli-script-bootstrap.php
+++ b/misc/others/cli-script-bootstrap.php
@@ -9,7 +9,7 @@
 use Piwik\Config;
 use Piwik\FrontController;
 
-error_reporting(E_ALL | E_NOTICE);
+error_reporting(E_ALL);
 
 define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__) == '/' ? '' : dirname(__FILE__) . '/../..');
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {

--- a/piwik.php
+++ b/piwik.php
@@ -27,7 +27,7 @@ if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
 }
 
 $GLOBALS['PIWIK_TRACKER_MODE'] = true;
-error_reporting(E_ALL | E_NOTICE);
+error_reporting(E_ALL);
 @ini_set('xdebug.show_exception_trace', 0);
 @ini_set('magic_quotes_runtime', 0);
 

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -24,7 +24,7 @@ if (!defined('PIWIK_INCLUDE_SEARCH_PATH')) {
 @ini_set('include_path', PIWIK_INCLUDE_SEARCH_PATH);
 @set_include_path(PIWIK_INCLUDE_SEARCH_PATH);
 @ini_set('memory_limit', -1);
-error_reporting(E_ALL | E_NOTICE);
+error_reporting(E_ALL);
 @date_default_timezone_set('UTC');
 
 require_once file_exists(PIWIK_INCLUDE_PATH . '/vendor/autoload.php')

--- a/tests/resources/staticFileServer.php
+++ b/tests/resources/staticFileServer.php
@@ -18,7 +18,7 @@ if(file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php'))
 	require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
 }
 
-error_reporting(E_ALL|E_NOTICE);
+error_reporting(E_ALL);
 @ini_set('display_errors', defined('PIWIK_DISPLAY_ERRORS') ? PIWIK_DISPLAY_ERRORS : @ini_get('display_errors'));
 @ini_set('xdebug.show_exception_trace', 0);
 @ini_set('magic_quotes_runtime', 0);


### PR DESCRIPTION
Hi!
I'm using the latest Piwik 2.5.0 and I'm seeing lots of _notices_ in my php error log (they are generated by plugins).
I guess intended behavior was to ignore notices, but there are `E_ALL | E_NOTICE` everywhere.

``` php
var_dump([E_ALL, E_NOTICE, E_ALL | E_NOTICE, E_ALL & ~E_NOTICE]);
/*
array(4) {
  [0] =>
  int(32767)
  [1] =>
  int(8)
  [2] =>
  int(32767)
  [3] =>
  int(32759)
}
*/
```

:wink:
