### PR TITLE
Allow opt-out to be shown within an iframe on other domains

### DIFF
--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -259,11 +259,21 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             ? $language
             : LanguagesManager::getLanguageCodeForCurrentUser();
 
-        return $this->renderTemplate('optOut', array(
-            'trackVisits' => $trackVisits,
-            'nonce'       => Nonce::getNonce('Piwik_OptOut', 3600),
-            'language'    => $lang
-        ));
+        //return $this->renderTemplate('optOut', array(
+        //    'trackVisits' => $trackVisits,
+        //    'nonce'       => Nonce::getNonce('Piwik_OptOut', 3600),
+        //    'language'    => $lang
+        //));
+
+        $view = new View('@CoreAdminHome/optOut');
+
+        $view->setXFrameOptions('allow');
+
+        $view->assign('trackVisits', $trackVisits);
+        $view->assign('nonce', Nonce::getNonce('Piwik_OptOut', 3600));
+        $view->assign('language', $lang);
+
+        return $view->render();
     }
 
     public function uploadCustomLogo()


### PR DESCRIPTION
In Piwik 2.6.1 the opt-out iframes are not shown anymore, because the X-Frame-Options setting blocks them at least when they are included within another domain.
This PR fixes this problem.
