### PR TITLE
Fix one unit test in PHP 5.6 allow charset complement in content-type

### DIFF
--- a/tests/PHPUnit/Core/ServeStaticFileTest.php
+++ b/tests/PHPUnit/Core/ServeStaticFileTest.php
@@ -154,7 +154,7 @@ class Test_Piwik_ServeStaticFile extends PHPUnit_Framework_TestCase
         $this->assertEquals(200, $responseInfo["http_code"]);
 
         // Tests content type
-        $this->assertEquals(TEST_FILE_CONTENT_TYPE, $responseInfo["content_type"]);
+        $this->assertContains(TEST_FILE_CONTENT_TYPE, $responseInfo["content_type"]);
 
         // Tests no compression has been applied
         $this->assertNull($this->getContentEncodingValue($fullResponse));


### PR DESCRIPTION
Received text/plain;charset=UTF-8 should match with an expected text/plain
