### PR TITLE
initial work for alternative mysql engine support (InnoDB, TokuDB, XtraD...

### DIFF
--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -44,6 +44,8 @@ class FormDatabaseSetup extends QuickForm2
             $adapters[$adapter] = $adapter;
         }
 
+	$types = array('InnoDB' => 'InnoDB');
+
         $this->addElement('text', 'host')
             ->setLabel(Piwik::translate('Installation_DatabaseSetupServer'))
             ->addRule('required', Piwik::translate('General_Required', Piwik::translate('Installation_DatabaseSetupServer')));
@@ -72,6 +74,11 @@ class FormDatabaseSetup extends QuickForm2
             ->setLabel(Piwik::translate('Installation_DatabaseSetupAdapter'))
             ->loadOptions($adapters)
             ->addRule('required', Piwik::translate('General_Required', Piwik::translate('Installation_DatabaseSetupAdapter')));
+
+        $this->addElement('select', 'type')
+            ->setLabel(Piwik::translate('Installation_DatabaseSetupDatabaseEngine'))
+            ->loadOptions($types)
+            ->addRule('required', Piwik::translate('General_Required', Piwik::translate('Installation_DatabaseSetupDatabaseEngine')));
 
         $this->addElement('submit', 'submit', array('value' => Piwik::translate('General_Next') . ' »', 'class' => 'submit'));
 
@@ -108,7 +115,7 @@ class FormDatabaseSetup extends QuickForm2
             'adapter'       => $adapter,
             'port'          => $port,
             'schema'        => Config::getInstance()->database['schema'],
-            'type'          => Config::getInstance()->database['type']
+            'type'          => $this->getSubmitValue('type')
         );
 
         if (($portIndex = strpos($dbInfos['host'], '/')) !== false) {

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -15,6 +15,7 @@
         "DatabaseSetupLogin": "Login",
         "DatabaseSetupServer": "Database Server",
         "DatabaseSetupTablePrefix": "Table Prefix",
+        "DatabaseSetupDatabaseEngine": "Database Engine",
         "Email": "email",
         "Extension": "extension",
         "Filesystem": "Filesystem",

--- a/plugins/Installation/lang/hu.json
+++ b/plugins/Installation/lang/hu.json
@@ -13,6 +13,7 @@
         "DatabaseSetupLogin": "felhasználó",
         "DatabaseSetupServer": "Adatbázisszerver",
         "DatabaseSetupTablePrefix": "táblanév előtagja",
+        "DatabaseSetupDatabaseEngine": "Adatbázis táblatípusa",
         "Email": "e-mail",
         "Extension": "kiterjesztés",
         "GoBackAndDefinePrefix": "Lépj vissza, és add meg a Piwik táblák nevének előtagját!",


### PR DESCRIPTION
Database setup: add option to choose Database engine type. Only InnoDB right now, although I have tested the latest stable piwik with TokuDB and it had no problems at all.
