### PR TITLE
Display a warning in admin to super users in case PHP 5.3 is used

### DIFF
--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -65,7 +65,7 @@ abstract class ControllerAdmin extends Controller
         $notification = new Notification($invalidPluginsWarning);
         $notification->raw = true;
         $notification->context = Notification::CONTEXT_WARNING;
-        $notification->title = Piwik::translate('General_Warning') . ':';
+        $notification->title = Piwik::translate('General_Warning');
         Notification\Manager::notify('ControllerAdmin_InvalidPluginsWarning', $notification);
     }
 
@@ -178,6 +178,16 @@ abstract class ControllerAdmin extends Controller
 
         self::checkPhpVersion($view);
 
+        if (Piwik::hasUserSuperUserAccess() && self::isPhpVersion53()) {
+            $notification = new Notification(Piwik::translate('General_WarningPhpVersionXIsTooOld', '5.3'));
+            $notification->title    = Piwik::translate('General_Warning');
+            $notification->priority = Notification::PRIORITY_LOW;
+            $notification->context  = Notification::CONTEXT_WARNING;
+            $notification->type     = Notification::TYPE_TRANSIENT;
+            $notification->flags    = Notification::FLAG_NO_CLEAR;
+            NotificationManager::notify('PHP53VersionCheck', $notification);
+        }
+
         $adminMenu = MenuAdmin::getInstance()->getMenu();
         $view->adminMenu = $adminMenu;
 
@@ -207,4 +217,10 @@ abstract class ControllerAdmin extends Controller
         $view->phpVersion = PHP_VERSION;
         $view->phpIsNewEnough = version_compare($view->phpVersion, '5.3.0', '>=');
     }
+
+    private static function isPhpVersion53()
+    {
+        return strpos(PHP_VERSION, '5.3') === 0;
+    }
+
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -428,6 +428,7 @@
         "VisitType": "Visitor type",
         "VisitTypeExample": "For example, to select all visitors who have returned to the website, including those who have bought something in their previous visits, the API request would contain %s",
         "Warning": "Warning",
+        "WarningPhpVersionXIsTooOld": "The PHP version %s you are using has reached its End of Life (EOL). You are strongly urged to upgrade to a current version, as using this version may expose you to security vulnerabilities and bugs that have been fixed in more recent versions of PHP.",
         "WarningFileIntegrityNoManifest": "File integrity check could not be performed due to missing manifest.inc.php.",
         "WarningFileIntegrityNoManifestDeployingFromGit": "If you are deploying Piwik from Git, this message is normal.",
         "WarningFileIntegrityNoMd5file": "File integrity check could not be completed due to missing md5_file() function.",


### PR DESCRIPTION
#6056

It would be nice to provide a link how users can upgrade their PHP version as there are many different ways. If someone knows a page listing many different ways please let me know or add the link to the notification.

Once pull request is merged we need to add the translation key in oTrance.
