### PR TITLE
Proxy piwik.php script does not send http headers

### DIFF
--- a/misc/proxy-hide-piwik-url/piwik.php
+++ b/misc/proxy-hide-piwik-url/piwik.php
@@ -26,7 +26,7 @@ $timeout = 5;
 
 function sendHeader($header, $replace = true)
 {
-    headers_sent() || header($head, $replace);
+    headers_sent() || header($header, $replace);
 }
 
 function arrayValue($array, $key, $value = null)


### PR DESCRIPTION
There seems to be a typo, the function parameter is $header and the used variable is the undefined $head
