### PR TITLE
Ignore any opcache_invalidate errors

### DIFF
--- a/core/CacheFile.php
+++ b/core/CacheFile.php
@@ -216,7 +216,7 @@ class CacheFile
         if (function_exists('opcache_invalidate')
             && is_file($filepath)
         ) {
-            opcache_invalidate($filepath, $force = true);
+            @opcache_invalidate($filepath, $force = true);
         }
     }
 }


### PR DESCRIPTION
Some webhosters with opcache enabled might disable functions like this for security reasons. This should prevent foreign applications from deleting cached things.

Without ignoring this error piwik is unusable and will always shows the error message:

```
There is an error. Please report the message (...)
Warning: Zend OPcache API is restricted by "restrict_api" configuration directive in /piwik/core/CacheFile.php on line 219
```

This call should treat the same way as opcache_reset() in core/Filesystem.php added with faffbd68b41a00a0e220138285094f517c07778d

Other functions which might be disabled:
- opcache_reset
- opcache_get_configuration
- opcache_get_status
- opcache_compile_file
