### PR TITLE
aclocal and autoconf calls are necessary to build the xhprof php extension

### DIFF
--- a/misc/composer/build-xhprof.sh
+++ b/misc/composer/build-xhprof.sh
@@ -27,6 +27,16 @@ if ! phpize &> ../../../../tmp/xhprof-logs/phpize.log; then
     exit 1
 fi
 
+if ! aclocal &> ../../../../tmp/xhprof-logs/aclocal.log; then
+    echo "Fatal error: aclocal failed! View tmp/xhprof-logs/aclocal.log for more info."
+    exit 1
+fi
+
+if ! autoconf &> ../../../../tmp/xhprof-logs/autoconf.log; then
+    echo "Fatal error: autoconf failed! View tmp/xhprof-logs/autoconf.log for more info."
+    exit 1
+fi
+
 if ! ./configure &> ../../../../tmp/xhprof-logs/configure.log; then
     echo "Fatal error: configure script failed! View tmp/xhprof-logs/configure.log for more info."
     exit 2


### PR DESCRIPTION
`aclocal` and `autoconf` calls are necessary to build the xhprof php extension in Gentoo.
This is the same situation as with other extensions like `mongo`.
See: http://php.net/manual/en/mongo.installation.php#mongo.installation.gentoo

Not sure, if it affects the build process in other distros.
