### PR TITLE
Remove CacheFile cache from APC on write

### DIFF
--- a/core/CacheFile.php
+++ b/core/CacheFile.php
@@ -213,10 +213,13 @@ class CacheFile
 
     public function opCacheInvalidate($filepath)
     {
-        if (function_exists('opcache_invalidate')
-            && is_file($filepath)
-        ) {
-            @opcache_invalidate($filepath, $force = true);
+        if (is_file($filepath)) {
+            if (function_exists('opcache_invalidate')) {
+                @opcache_invalidate($filepath, $force = true);
+            }
+            if (function_exists('apc_delete_file')) {
+                apc_delete_file($filepath);
+            }
         }
     }
 }


### PR DESCRIPTION
If APC is enabled on the piwik server, cache files written by the CacheFile
class are stored in the opcode cache. This causes disk io problems when doing
things like loading weblogs into piwik with the import_logs.py script,
especially when running in --disable-bulk-tracking mode. In this scenario,
apache write IO quickly reaches 100% and slows the import to a crawl.
