### PR TITLE
Optimize DatabaseTestCase so travis build will be faster

### DIFF
--- a/plugins/CustomVariables/tests/ModelTest.php
+++ b/plugins/CustomVariables/tests/ModelTest.php
@@ -7,16 +7,36 @@
  */
 
 namespace Piwik\Plugins\CustomVariables\tests;
+use Piwik\Common;
 use Piwik\Db;
+use Piwik\DbHelper;
 use Piwik\Plugins\CustomVariables\Model;
 
 /**
  * @group CustomVariables
  * @group ModelTest
  * @group Database
+ * @group CustomVariables_ModelTest
  */
 class ModelTest extends \DatabaseTestCase
 {
+    private static $cvarScopes = array('log_link_visit_action', 'log_visit', 'log_conversion');
+
+    public function setUp()
+    {
+        // do not call parent::setUp() since it expects database to be created,
+        // but DB for this test is removed in tearDown
+
+        self::$fixture->performSetUp();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        self::$fixture->performTearDown();
+    }
+
     /**
      * @expectedException \Exception
      */
@@ -35,7 +55,7 @@ class ModelTest extends \DatabaseTestCase
 
     public function testGetAllScopes()
     {
-        $this->assertEquals(array('log_link_visit_action', 'log_visit', 'log_conversion'), Model::getScopes());
+        $this->assertEquals(self::$cvarScopes, Model::getScopes());
     }
 
     public function test_Install_Uninstall()

--- a/plugins/Goals/tests/APITest.php
+++ b/plugins/Goals/tests/APITest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\Goals\tests;
 use Piwik\Access;
+use Piwik\Piwik;
 use Piwik\Plugins\Goals\API;
 use Piwik\Tests\Fixture;
 
@@ -30,6 +31,9 @@ class APITest extends \DatabaseTestCase
     {
         parent::setUp();
         $this->api = API::getInstance();
+
+        Fixture::createAccessInstance();
+        Piwik::setUserHasSuperUserAccess();
 
         Fixture::createWebsite('2014-01-01 00:00:00');
         Fixture::createWebsite('2014-01-01 00:00:00');

--- a/tests/PHPUnit/DatabaseTestCase.php
+++ b/tests/PHPUnit/DatabaseTestCase.php
@@ -28,10 +28,15 @@ class DatabaseTestCase extends IntegrationTestCase
 
     public static function setUpBeforeClass()
     {
-        static::configureFixture(self::$fixture);
+        static::configureFixture(static::$fixture);
         parent::setUpBeforeClass();
 
         self::$tableData = self::getDbTablesWithData();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::$tableData = array();
     }
 
     /**

--- a/tests/PHPUnit/DatabaseTestCase.php
+++ b/tests/PHPUnit/DatabaseTestCase.php
@@ -26,6 +26,28 @@ class DatabaseTestCase extends IntegrationTestCase
     public static $fixture;
     public static $tableData;
 
+    /**
+     * Implementation details:
+     *
+     * To increase speed of tests, database setup is done once in setUpBeforeClass.
+     * Afterwards, the content of the tables is stored in a static class variable,
+     * self::$tableData. Before each individual test, the database tables are
+     * truncated and the data in self::$tableData is restored.
+     *
+     * If your test modifies table columns, you will need to recreate the database
+     * completely. This can be accomplished by:
+     *
+     *     public function setUp()
+     *     {
+     *         self::$fixture->performSetUp();
+     *     }
+     *
+     *     public function tearDown()
+     *     {
+     *         parent::tearDown();
+     *         self::$fixture->performTearDown();
+     *     }
+     */
     public static function setUpBeforeClass()
     {
         static::configureFixture(static::$fixture);

--- a/tests/PHPUnit/DatabaseTestCase.php
+++ b/tests/PHPUnit/DatabaseTestCase.php
@@ -5,8 +5,10 @@
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
+use Piwik\Config;
 use Piwik\Db;
 use Piwik\Tests\Fixture;
+use Piwik\Tests\IntegrationTestCase;
 
 /**
  * Tests extending DatabaseTestCase are much slower to run: the setUp will
@@ -16,12 +18,21 @@ use Piwik\Tests\Fixture;
  * then test it.
  *
  */
-class DatabaseTestCase extends PHPUnit_Framework_TestCase
+class DatabaseTestCase extends IntegrationTestCase
 {
     /**
      * @var Fixture
      */
-    protected $fixture = null;
+    public static $fixture;
+    public static $tableData;
+
+    public static function setUpBeforeClass()
+    {
+        static::configureFixture(self::$fixture);
+        parent::setUpBeforeClass();
+
+        self::$tableData = self::getDbTablesWithData();
+    }
 
     /**
      * Setup the database and create the base tables for all tests
@@ -30,9 +41,11 @@ class DatabaseTestCase extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->fixture = new Fixture();
-        $this->configureFixture();
-        $this->fixture->performSetUp();
+        Config::getInstance()->setTestEnvironment();
+
+        if (!empty(self::$tableData)) {
+            self::restoreDbTables(self::$tableData);
+        }
     }
 
     /**
@@ -40,14 +53,17 @@ class DatabaseTestCase extends PHPUnit_Framework_TestCase
      */
     public function tearDown()
     {
+        self::$fixture->clearInMemoryCaches();
+
         parent::tearDown();
-        $this->fixture->performTearDown();
     }
 
-    protected function configureFixture()
+    protected static function configureFixture($fixture)
     {
-        $this->fixture->loadTranslations = false;
-        $this->fixture->createSuperUser = false;
-        $this->fixture->configureComponents = false;
+        $fixture->loadTranslations = false;
+        $fixture->createSuperUser = false;
+        $fixture->configureComponents = false;
     }
 }
+
+DatabaseTestCase::$fixture = new Fixture();

--- a/tests/PHPUnit/Fixture.php
+++ b/tests/PHPUnit/Fixture.php
@@ -275,6 +275,11 @@ class Fixture extends PHPUnit_Framework_Assert
             $this->dropDatabase();
         }
 
+        $this->clearInMemoryCaches();
+    }
+
+    public function clearInMemoryCaches()
+    {
         DataTableManager::getInstance()->deleteAll();
         Option::clearCache();
         Site::clearCache();
@@ -291,7 +296,7 @@ class Fixture extends PHPUnit_Framework_Assert
         Config::unsetInstance();
 
         \Piwik\Config::getInstance()->Plugins; // make sure Plugins exists in a config object for next tests that use Plugin\Manager
-                                               // since Plugin\Manager uses getFromGlobalConfig which doesn't init the config object
+        // since Plugin\Manager uses getFromGlobalConfig which doesn't init the config object
     }
 
     public static function loadAllPlugins($testEnvironment = null, $testCaseClass = false, $extraPluginsToLoad = array())

--- a/tests/PHPUnit/Integration/Core/AccessTest.php
+++ b/tests/PHPUnit/Integration/Core/AccessTest.php
@@ -11,7 +11,6 @@ use Piwik\AuthResult;
 /**
  * Class Core_AccessTest
  *
- * @group Core_AccessTest
  * @group Core
  */
 class Core_AccessTest extends DatabaseTestCase

--- a/tests/PHPUnit/Integration/Core/CronArchive/SharedSiteIdsTest.php
+++ b/tests/PHPUnit/Integration/Core/CronArchive/SharedSiteIdsTest.php
@@ -10,6 +10,7 @@ use Piwik\CronArchive\SharedSiteIds;
 
 /**
  * @group Core
+ * @group SharedSiteIdsTest
  */
 class SharedSiteIdsTest extends DatabaseTestCase
 {
@@ -21,7 +22,6 @@ class SharedSiteIdsTest extends DatabaseTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->fixture->performSetUp(true);
 
         $this->sharedSiteIds = new SharedSiteIds(array(1,2,5,9));
     }

--- a/tests/PHPUnit/Integration/Core/LogTest.php
+++ b/tests/PHPUnit/Integration/Core/LogTest.php
@@ -31,9 +31,9 @@ class Core_LogTest extends DatabaseTestCase
         'screen' => 'dummy error message<br />
  <br />
  --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php',
-        'file' => '[Core_LogTest] LogTest.php(161): dummy error message
+        'file' => '[Core_LogTest] LogTest.php(165): dummy error message
   dummy backtrace',
-        'database' => '[Core_LogTest] LogTest.php(161): dummy error message
+        'database' => '[Core_LogTest] LogTest.php(165): dummy error message
 dummy backtrace'
     );
 
@@ -55,6 +55,8 @@ dummy backtrace'
 
     public static function setUpBeforeClass()
     {
+        parent::setUpBeforeClass();
+
         Error::setErrorHandler();
         ExceptionHandler::setUp();
     }
@@ -63,6 +65,8 @@ dummy backtrace'
     {
         restore_error_handler();
         restore_exception_handler();
+
+        parent::tearDownAfterClass();
     }
 
     public function setUp()

--- a/tests/PHPUnit/Integration/Core/OptionTest.php
+++ b/tests/PHPUnit/Integration/Core/OptionTest.php
@@ -13,6 +13,7 @@ use Piwik\Option;
  * Class Core_OptionTest
  *
  * @group Core
+ * @group Core_OptionTest
  */
 class Core_OptionTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Integration/Core/SegmentTest.php
+++ b/tests/PHPUnit/Integration/Core/SegmentTest.php
@@ -8,8 +8,10 @@
 use Piwik\Access;
 use Piwik\Common;
 use Piwik\Segment;
-use Piwik\Tests\Fixture;
 
+/**
+ * @group SegmentTest
+ */
 class SegmentTest extends DatabaseTestCase
 {
     public function setUp()
@@ -20,14 +22,11 @@ class SegmentTest extends DatabaseTestCase
         $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
         Access::setSingletonInstance($pseudoMockAccess);
-
-        Fixture::loadAllPlugins();
     }
 
     public function tearDown()
     {
         parent::tearDown();
-        Fixture::unloadAllPlugins();
     }
 
     protected function _filterWhitsSpaces($valueToFilter)

--- a/tests/PHPUnit/Integration/Core/TrackerTest.php
+++ b/tests/PHPUnit/Integration/Core/TrackerTest.php
@@ -19,9 +19,9 @@ class Core_TrackerTest extends DatabaseTestCase
         Fixture::createWebsite('2014-02-04');
     }
 
-    protected function configureFixture()
+    protected static function configureFixture($fixture)
     {
-        $this->fixture->createSuperUser = true;
+        $fixture->createSuperUser = true;
     }
 
     /**

--- a/tests/PHPUnit/IntegrationTestCase.php
+++ b/tests/PHPUnit/IntegrationTestCase.php
@@ -518,8 +518,10 @@ abstract class IntegrationTestCase extends PHPUnit_Framework_TestCase
      */
     protected static function restoreDbTables($tables)
     {
+        $tablesPrefix = Config::getInstance()->database_tests['tables_prefix'];
+
         $existingTables = array();
-        foreach (Db::fetchAll("SHOW TABLES LIKE '%'") as $row) {
+        foreach (Db::fetchAll("SHOW TABLES LIKE '$tablesPrefix%'") as $row) {
             $existingTables[] = reset($row);
         }
 

--- a/tests/PHPUnit/IntegrationTestCase.php
+++ b/tests/PHPUnit/IntegrationTestCase.php
@@ -518,11 +518,17 @@ abstract class IntegrationTestCase extends PHPUnit_Framework_TestCase
      */
     protected static function restoreDbTables($tables)
     {
+        $existingTables = array();
+        foreach (Db::fetchAll("SHOW TABLES LIKE '%'") as $row) {
+            $existingTables[] = reset($row);
+        }
+
         // truncate existing tables
-        DbHelper::truncateAllTables();
+        foreach ($existingTables as $existingTable) {
+            Db::exec("TRUNCATE `$existingTable`"); // NOTE: DbHelper::truncateAllTables() will not truncate non-core tables
+        }
 
         // insert data
-        $existingTables = DbHelper::getTablesInstalled();
         foreach ($tables as $table => $rows) {
             // create table if it's an archive table
             if (strpos($table, 'archive_') !== false && !in_array($table, $existingTables)) {

--- a/tests/PHPUnit/IntegrationTestCase.php
+++ b/tests/PHPUnit/IntegrationTestCase.php
@@ -518,19 +518,10 @@ abstract class IntegrationTestCase extends PHPUnit_Framework_TestCase
      */
     protected static function restoreDbTables($tables)
     {
-        $tablesPrefix = Config::getInstance()->database_tests['tables_prefix'];
-
-        $existingTables = array();
-        foreach (Db::fetchAll("SHOW TABLES LIKE '$tablesPrefix%'") as $row) {
-            $existingTables[] = reset($row);
-        }
-
-        // truncate existing tables
-        foreach ($existingTables as $existingTable) {
-            Db::exec("TRUNCATE `$existingTable`"); // NOTE: DbHelper::truncateAllTables() will not truncate non-core tables
-        }
+        DbHelper::truncateAllTables();
 
         // insert data
+        $existingTables = DbHelper::getTablesInstalled();
         foreach ($tables as $table => $rows) {
             // create table if it's an archive table
             if (strpos($table, 'archive_') !== false && !in_array($table, $existingTables)) {

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -34,8 +34,9 @@ require_once file_exists(PIWIK_INCLUDE_PATH . '/vendor/autoload.php')
 require_once PIWIK_INCLUDE_PATH . '/libs/upgradephp/upgrade.php';
 require_once PIWIK_INCLUDE_PATH . '/core/testMinimumPhpVersion.php';
 require_once PIWIK_INCLUDE_PATH . '/core/FrontController.php';
-require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/DatabaseTestCase.php';
+require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/Fixture.php';
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/IntegrationTestCase.php';
+require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/DatabaseTestCase.php';
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/ConsoleCommandTestCase.php';
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/FakeAccess.php';
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/MockPiwikOption.php';
@@ -49,8 +50,6 @@ if (getenv('PIWIK_USE_XHPROF') == 1) {
 }
 
 // require test fixtures
-require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/Fixture.php';
-
 $fixturesToLoad = array(
     '/tests/PHPUnit/Fixtures/*.php',
     '/tests/PHPUnit/UI/Fixtures/*.php',


### PR DESCRIPTION
I modified DatabaseTestCase to setup the database once per test case (in setUpBeforeClass) as is done with IntegrationTestCase. This decreases the build time for Integration tests for about 25 mins to 15mins.

@mattab Please review.
