### PR TITLE
Fixed bug #6068. escape &quot; with \

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -337,7 +337,8 @@ class GoalManager
      */
     private function getEcommerceItemsFromRequest()
     {
-        $items = Common::unsanitizeInputValue($this->request->getParam('ec_items'));
+        $items = preg_replace('/(?<!\\\)&quot;/i','\&quot;',$this->request->getParam('ec_items'));
+        $items = Common::unsanitizeInputValue($items);
         if (empty($items)) {
             Common::printDebug("There are no Ecommerce items in the request");
             // we still record an Ecommerce order without any item in it


### PR DESCRIPTION
Possible solution for the bug #6068 
json_decode require that quotes will be escaped(\") however after conversion of &quot; to " it will be unescaped.
As result ..."old &quot;Käse&quot;"... will be converted to ..."old "Käse""... but it should be ..."old \"Käse\""
