### PR TITLE
Deprecate Piwik::setUserHasSuperUserAccess() and switch to using Access::doAsSuperUser()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
   * Clarifying semantics of each method and what they must support and can support.
   * **Read the documentation for the [Auth interface](http://developer.piwik.org/api-reference/Piwik/Auth) to learn more.**
 
+### Deprecations
+* The Piwik::setUserHasSuperUserAccess method is deprecated, instead use Access::doAsSuperUser. This method will ensure that super user access is properly rescinded after the callback finishes.
+
 ### New commands
 * `generate:angular-directive` Let's you easily generate a template for a new angular directive for any plugin.
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -219,10 +219,13 @@ class CronArchive
      */
     public function main()
     {
-        $this->init();
-        $this->run();
-        $this->runScheduledTasks();
-        $this->end();
+        $self = $this;
+        Access::doAsSuperUser(function () use ($self) {
+            $self->init();
+            $self->run();
+            $self->runScheduledTasks();
+            $self->end();
+        });
     }
 
     public function init()
@@ -232,7 +235,6 @@ class CronArchive
         $this->initTokenAuth();
         $this->initCheckCli();
         $this->initStateFromParameters();
-        Piwik::setUserHasSuperUserAccess(true);
 
         $this->logInitInfo();
         $this->checkPiwikUrlIsValid();

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -427,7 +427,10 @@ class Piwik
      * Helper method user to set the current as superuser.
      * This should be used with great care as this gives the user all permissions.
      *
+     * This method is deprecated, use {@link Access::doAsSuperUser()} instead.
+     *
      * @param bool $bool true to set current user as Super User
+     * @deprecated
      */
     public static function setUserHasSuperUserAccess($bool = true)
     {

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -329,7 +329,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             $ecommerce = (int)$form->getSubmitValue('ecommerce');
 
             try {
-                $result = APISitesManager::getInstance()->addSite($name, $url, $ecommerce);
+                $result = Access::doAsSuperUser(function () use ($name, $url, $ecommerce) {
+                    return APISitesManager::getInstance()->addSite($name, $url, $ecommerce);
+                });
+
                 $params = array(
                     'site_idSite' => $result,
                     'site_name' => urlencode($name)

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -306,9 +306,11 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     {
         $this->checkPiwikIsNotInstalled();
 
-        $this->initObjectsToCallAPI();
+        $siteIdsCount = Access::doAsSuperUser(function () {
+            return count(APISitesManager::getInstance()->getAllSitesId());
+        });
 
-        if (count(APISitesManager::getInstance()->getAllSitesId()) > 0) {
+        if ($siteIdsCount > 0) {
             // if there is a already a website, skip this step and trackingCode step
             $this->redirectToNextStep('trackingCode');
         }

--- a/plugins/Installation/FormFirstWebsiteSetup.php
+++ b/plugins/Installation/FormFirstWebsiteSetup.php
@@ -13,6 +13,7 @@ use HTML_QuickForm2_DataSource_Array;
 use HTML_QuickForm2_Factory;
 use HTML_QuickForm2_Rule;
 use Piwik\Log;
+use Piwik\Access;
 use Piwik\Piwik;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\QuickForm2;
@@ -80,7 +81,9 @@ class Rule_isValidTimezone extends HTML_QuickForm2_Rule
         try {
             $timezone = $this->owner->getValue();
             if (!empty($timezone)) {
-                API::getInstance()->setDefaultTimezone($timezone);
+                Access::doAsSuperUser(function () use ($timezone) {
+                    API::getInstance()->setDefaultTimezone($timezone);
+                });
             }
         } catch (\Exception $e) {
             Log::warning($e->getMessage());

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\Login;
 
 use Exception;
+use Piwik\Access;
 use Piwik\Auth as AuthInterface;
 use Piwik\Common;
 use Piwik\Config;
@@ -278,7 +279,7 @@ class Controller extends \Piwik\Plugin\Controller
             // have to do this as super user since redirectToIndex checks if there's a default website ID for
             // the current user and if not, doesn't redirect to the requested action. TODO: this behavior is wrong. somehow.
             $self = $this;
-            Piwik::doAsSuperUser(function () use ($self) {
+            Access::doAsSuperUser(function () use ($self) {
                 $self->redirectToIndex(Piwik::getLoginPluginName(), 'resetPasswordSuccess');
             });
             return null;

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -210,7 +210,7 @@ class PasswordResetter
 
         // reset password of user
         $usersManager = $this->usersManagerApi;
-        UsersManagerAPI::doAsSuperUser(function () use ($usersManager, $user, $resetPassword) {
+        Access::doAsSuperUser(function () use ($usersManager, $user, $resetPassword) {
             $usersManager->updateUser(
                 $user['login'], $resetPassword, $email = false, $alias = false, $isPasswordHashed = true);
         });
@@ -360,7 +360,7 @@ class PasswordResetter
     protected function getUserInformation($loginOrMail)
     {
         $usersManager = $this->usersManagerApi;
-        return UsersManagerAPI::doAsSuperUser(function () use ($loginOrMail, $usersManager) {
+        return Access::doAsSuperUser(function () use ($loginOrMail, $usersManager) {
             $user = null;
             if ($usersManager->userExists($loginOrMail)) {
                 $user = $usersManager->getUser($loginOrMail);

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -8,6 +8,7 @@
 namespace Piwik\Plugins\Login;
 
 use Exception;
+use Piwik\Access;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\IP;
@@ -209,7 +210,7 @@ class PasswordResetter
 
         // reset password of user
         $usersManager = $this->usersManagerApi;
-        Piwik::doAsSuperUser(function () use ($usersManager, $user, $resetPassword) {
+        UsersManagerAPI::doAsSuperUser(function () use ($usersManager, $user, $resetPassword) {
             $usersManager->updateUser(
                 $user['login'], $resetPassword, $email = false, $alias = false, $isPasswordHashed = true);
         });
@@ -359,7 +360,7 @@ class PasswordResetter
     protected function getUserInformation($loginOrMail)
     {
         $usersManager = $this->usersManagerApi;
-        return Piwik::doAsSuperUser(function () use ($loginOrMail, $usersManager) {
+        return UsersManagerAPI::doAsSuperUser(function () use ($loginOrMail, $usersManager) {
             $user = null;
             if ($usersManager->userExists($loginOrMail)) {
                 $user = $usersManager->getUser($loginOrMail);

--- a/tests/PHPUnit/Fixture.php
+++ b/tests/PHPUnit/Fixture.php
@@ -185,7 +185,7 @@ class Fixture extends PHPUnit_Framework_Assert
         static::createAccessInstance();
 
         // We need to be SU to create websites for tests
-        Piwik::setUserHasSuperUserAccess();
+        Access::getInstance()->setSuperUserAccess();
 
         Cache::deleteTrackerCache();
 

--- a/tests/PHPUnit/Fixtures/SqlDump.php
+++ b/tests/PHPUnit/Fixtures/SqlDump.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik\Tests\Fixtures;
 
+use Piwik\Access;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Config;
 use Piwik\Db;
@@ -79,7 +80,7 @@ class SqlDump extends Fixture
         Rules::setBrowserTriggerArchiving(true);
 
         // reload access
-        Piwik::setUserHasSuperUserAccess();
+        Access::getInstance()->reloadAccess();
 
         $this->getTestEnvironment()->configOverride = array(
             'database' => array(

--- a/tests/PHPUnit/Integration/Core/AccessTest.php
+++ b/tests/PHPUnit/Integration/Core/AccessTest.php
@@ -13,6 +13,7 @@ use Piwik\AuthResult;
  *
  * @group Core_AccessTest
  * @group Core
+ * @group Only
  */
 class Core_AccessTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Integration/Core/AccessTest.php
+++ b/tests/PHPUnit/Integration/Core/AccessTest.php
@@ -13,7 +13,6 @@ use Piwik\AuthResult;
  *
  * @group Core_AccessTest
  * @group Core
- * @group Only
  */
 class Core_AccessTest extends DatabaseTestCase
 {

--- a/tests/PHPUnit/Integration/Core/AccessTest.php
+++ b/tests/PHPUnit/Integration/Core/AccessTest.php
@@ -309,4 +309,58 @@ class Core_AccessTest extends DatabaseTestCase
         $this->assertTrue($access->reloadAccess($mock));
         $this->assertFalse($access->hasSuperUserAccess());
     }
+
+    public function test_doAsSuperUser_ChangesSuperUserAccessCorrectly()
+    {
+        Access::getInstance()->setSuperUserAccess(false);
+
+        $this->assertFalse(Access::getInstance()->hasSuperUserAccess());
+
+        Access::doAsSuperUser(function () {
+            Core_AccessTest::assertTrue(Access::getInstance()->hasSuperUserAccess());
+        });
+
+        $this->assertFalse(Access::getInstance()->hasSuperUserAccess());
+    }
+
+    public function test_doAsSuperUser_RemovesSuperUserAccess_IfExceptionThrown()
+    {
+        Access::getInstance()->setSuperUserAccess(false);
+
+        $this->assertFalse(Access::getInstance()->hasSuperUserAccess());
+
+        try {
+            Access::doAsSuperUser(function () {
+                throw new Exception();
+            });
+
+            $this->fail("Exception was not propagated by doAsSuperUser.");
+        } catch (Exception $ex)
+        {
+            // pass
+        }
+
+        $this->assertFalse(Access::getInstance()->hasSuperUserAccess());
+    }
+
+    public function test_doAsSuperUser_ReturnsCallbackResult()
+    {
+        $result = Access::doAsSuperUser(function () {
+            return 24;
+        });
+        $this->assertEquals(24, $result);
+    }
+
+    public function test_reloadAccess_DoesNotRemoveSuperUserAccess_IfUsedInDoAsSuperUser()
+    {
+        Access::getInstance()->setSuperUserAccess(false);
+
+        Access::doAsSuperUser(function () {
+            $access = Access::getInstance();
+
+            Core_AccessTest::assertTrue($access->hasSuperUserAccess());
+            $access->reloadAccess();
+            Core_AccessTest::assertTrue($access->hasSuperUserAccess());
+        });
+    }
 }

--- a/tests/PHPUnit/Integration/Core/TrackerTest.php
+++ b/tests/PHPUnit/Integration/Core/TrackerTest.php
@@ -16,7 +16,6 @@ class Core_TrackerTest extends DatabaseTestCase
     public function setUp()
     {
         parent::setUp();
-        \Piwik\Piwik::setUserHasSuperUserAccess(true);
         Fixture::createWebsite('2014-02-04');
     }
 


### PR DESCRIPTION
As title.

doAsSuperUser() will rescind super user access if an exception is thrown by the callback passed to it and after the callback finishes, which means super user access will not accidentally be used.

@mattab Please review & merge if the build passes.
