### PR TITLE
Let plugins further extend tracking code via Event 'Piwik.getJavascriptCode'

### DIFF
--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -142,6 +142,7 @@ class Piwik
 
         // Build optional parameters to be added to text
         $options = '';
+        $optionsBeforeTrackerUrl = '';
         if ($groupPageTitlesByDomain) {
             $options .= '  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);' . PHP_EOL;
         }
@@ -187,7 +188,9 @@ class Piwik
         $codeImpl = array(
             'idSite' => $idSite,
             'piwikUrl' => Common::sanitizeInputValue($piwikUrl),
-            'options' => $options
+            'options' => $options,
+            'optionsBeforeTrackerUrl' => $optionsBeforeTrackerUrl,
+            'protocol' => '//'
         );
         $parameters = compact('mergeSubdomains', 'groupPageTitlesByDomain', 'mergeAliasUrls', 'visitorCustomVariables',
                               'pageCustomVariables', 'customCampaignNameQueryParam', 'customCampaignKeywordParam',
@@ -205,6 +208,10 @@ class Piwik
          *                         - **piwikUrl**: The tracker URL to use.
          *                         - **options**: A string of JavaScript code that customises
          *                                        the JavaScript tracker.
+         *                         - **optionsBeforeTrackerUrl**: A string of Javascript code that customises
+         *                                        the JavaScript tracker inside of anonymous function before
+         *                                        adding setTrackerUrl into paq.
+         *                         - **protocol**: Piwik url protocol.
          *
          *                         The **httpsPiwikUrl** element can be set if the HTTPS
          *                         domain is different from the normal domain.
@@ -212,7 +219,7 @@ class Piwik
          */
         self::postEvent('Piwik.getJavascriptCode', array(&$codeImpl, $parameters));
 
-        $setTrackerUrl = 'var u="//{$piwikUrl}/";';
+        $setTrackerUrl = 'var u="' . $codeImpl['protocol'] . '{$piwikUrl}/";';
 
         if (!empty($codeImpl['httpsPiwikUrl'])) {
             $setTrackerUrl = 'var u=((document.location.protocol === "https:") ? "https://{$httpsPiwikUrl}/" : "http://{$piwikUrl}/");';

--- a/plugins/Morpheus/templates/javascriptCode.tpl
+++ b/plugins/Morpheus/templates/javascriptCode.tpl
@@ -5,11 +5,11 @@
   _paq.push(['enableLinkTracking']);
   (function() {
     {$setTrackerUrl}
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    {$optionsBeforeTrackerUrl}_paq.push(['setTrackerUrl', u+'piwik.php']);
     _paq.push(['setSiteId', {$idSite}]);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-<noscript><p><img src="//{$piwikUrl}/piwik.php?idsite={$idSite}" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="{$protocol}{$piwikUrl}/piwik.php?idsite={$idSite}" style="border:0;" alt="" /></p></noscript>
 <!-- End Piwik Code -->

--- a/tests/PHPUnit/Integration/Core/PiwikTest.php
+++ b/tests/PHPUnit/Integration/Core/PiwikTest.php
@@ -67,6 +67,99 @@ class Core_PiwikTest extends DatabaseTestCase
     }
 
     /**
+     * Tests the generated JS code with protocol overwrite
+     * @group Core
+     */
+    public function testJavascriptTrackingCode_withAllOptionsAndProtocolOverwrite()
+    {
+        Piwik::addAction('Piwik.getJavascriptCode', function (&$codeImpl) {
+            $codeImpl['protocol'] = 'https://';
+        });
+
+        $jsTag = Piwik::getJavascriptCode($idSite = 1, $piwikUrl = 'http://localhost/piwik',
+            $mergeSubdomains = true, $groupPageTitlesByDomain = true, $mergeAliasUrls = true,
+            $visitorCustomVariables = array( array("name", "value"), array("name 2", "value 2") ),
+            $pageCustomVariables = array( array("page cvar", "page cvar value") ),
+            $customCampaignNameQueryParam = "campaignKey", $customCampaignKeywordParam = "keywordKey",
+            $doNotTrack = true);
+
+        $expected = "&lt;!-- Piwik --&gt;
+&lt;script type=&quot;text/javascript&quot;&gt;
+  var _paq = _paq || [];
+  _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
+  // you can set up to 5 custom variables for each visitor
+  _paq.push([\"setCustomVariable\", 1, \"name\", \"value\", \"visit\"]);
+  _paq.push([\"setCustomVariable\", 2, \"name 2\", \"value 2\", \"visit\"]);
+  // you can set up to 5 custom variables for each action (page view, download, click, site search)
+  _paq.push([\"setCustomVariable\", 1, \"page cvar\", \"page cvar value\", \"page\"]);
+  _paq.push([\"setCampaignNameKey\", \"campaignKey\"]);
+  _paq.push([\"setCampaignKeywordKey\", \"keywordKey\"]);
+  _paq.push([\"setDoNotTrack\", true]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u=&quot;https://localhost/piwik/&quot;;
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', 1]);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+&lt;/script&gt;
+&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;https://localhost/piwik/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
+&lt;!-- End Piwik Code --&gt;
+";
+
+        $this->assertEquals($expected, $jsTag);
+    }
+
+    /**
+     * Tests the generated JS code with options before tracker url
+     * @group Core
+     */
+    public function testJavascriptTrackingCode_withAllOptionsAndOptionsBeforeTrackerUrl()
+    {
+        Piwik::addAction('Piwik.getJavascriptCode', function (&$codeImpl) {
+            $codeImpl['optionsBeforeTrackerUrl'] .= "_paq.push(['setAPIUrl', 'http://localhost/statistics']);\n    ";
+        });
+
+        $jsTag = Piwik::getJavascriptCode($idSite = 1, $piwikUrl = 'http://localhost/piwik',
+            $mergeSubdomains = true, $groupPageTitlesByDomain = true, $mergeAliasUrls = true,
+            $visitorCustomVariables = array( array("name", "value"), array("name 2", "value 2") ),
+            $pageCustomVariables = array( array("page cvar", "page cvar value") ),
+            $customCampaignNameQueryParam = "campaignKey", $customCampaignKeywordParam = "keywordKey",
+            $doNotTrack = true);
+
+        $expected = "&lt;!-- Piwik --&gt;
+&lt;script type=&quot;text/javascript&quot;&gt;
+  var _paq = _paq || [];
+  _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
+  // you can set up to 5 custom variables for each visitor
+  _paq.push([\"setCustomVariable\", 1, \"name\", \"value\", \"visit\"]);
+  _paq.push([\"setCustomVariable\", 2, \"name 2\", \"value 2\", \"visit\"]);
+  // you can set up to 5 custom variables for each action (page view, download, click, site search)
+  _paq.push([\"setCustomVariable\", 1, \"page cvar\", \"page cvar value\", \"page\"]);
+  _paq.push([\"setCampaignNameKey\", \"campaignKey\"]);
+  _paq.push([\"setCampaignKeywordKey\", \"keywordKey\"]);
+  _paq.push([\"setDoNotTrack\", true]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u=&quot;//localhost/piwik/&quot;;
+    _paq.push(['setAPIUrl', 'http://localhost/statistics']);
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', 1]);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+&lt;/script&gt;
+&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//localhost/piwik/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
+&lt;!-- End Piwik Code --&gt;
+";
+
+        $this->assertEquals($expected, $jsTag);
+    }
+
+    /**
      * Dataprovider for testIsNumericValid
      */
     public function getValidNumeric()


### PR DESCRIPTION
This PR add to new feature to tracking code:

possibility to overwrite tracking code protocol.
options which could be included before `setTrackerUrl`.

ref: https://github.com/piwik/piwik/pull/6274
