### PR TITLE
Fix for #5300: prevent email reports from being sent twice

### DIFF
--- a/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
+++ b/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
@@ -33,7 +33,15 @@ class RunScheduledTasks extends ConsoleCommand
         $this->forceRunAllTasksIfRequested($input);
 
         FrontController::getInstance()->init();
-        API::getInstance()->runScheduledTasks();
+        $scheduledTasksResults = API::getInstance()->runScheduledTasks();
+
+        foreach ($scheduledTasksResults as $scheduledTasksResult) {
+            $output->writeln(sprintf(
+                '<comment>%s</comment> - %s',
+                $scheduledTasksResult['task'],
+                $scheduledTasksResult['output']
+            ));
+        }
 
         $this->writeSuccessMessage($output, array('Scheduled Tasks executed'));
     }

--- a/plugins/MobileMessaging/MobileMessaging.php
+++ b/plugins/MobileMessaging/MobileMessaging.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\MobileMessaging;
 
 use Piwik\Option;
+use Piwik\Period;
 use Piwik\Piwik;
 use Piwik\Plugins\API\API as APIPlugins;
 use Piwik\Plugins\MobileMessaging\API as APIMobileMessaging;
@@ -177,7 +178,7 @@ class MobileMessaging extends \Piwik\Plugin
     }
 
     public function sendReport($reportType, $report, $contents, $filename, $prettyDate, $reportSubject, $reportTitle,
-                               $additionalFiles)
+                               $additionalFiles, Period $period = null, $force)
     {
         if (self::manageEvent($reportType)) {
             $parameters = $report['parameters'];

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -466,7 +466,7 @@ class API extends \Piwik\Plugin\API
         }
     }
 
-    public function sendReport($idReport, $period = false, $date = false)
+    public function sendReport($idReport, $period = false, $date = false, $force = false)
     {
         Piwik::checkUserIsNotAnonymous();
 
@@ -527,6 +527,9 @@ class API extends \Piwik\Plugin\API
          * @param string $reportTitle The scheduled report's given title (given by a Piwik user).
          * @param array $additionalFiles The list of additional files that should be
          *                               sent with this report.
+         * @param \Piwik\Period $period The period for which the report has been generated.
+         * @param boolean $force A report can only be sent once per period. Setting this to true
+         *                       will force to send the report even if it has already been sent.
          */
         Piwik::postEvent(
             self::SEND_REPORT_EVENT,
@@ -538,7 +541,9 @@ class API extends \Piwik\Plugin\API
                 $prettyDate,
                 $reportSubject,
                 $reportTitle,
-                $additionalFiles
+                $additionalFiles,
+                \Piwik\Period\Factory::build($report['period'], $date),
+                $force
             )
         );
 

--- a/plugins/ScheduledReports/javascripts/pdf.js
+++ b/plugins/ScheduledReports/javascripts/pdf.js
@@ -142,6 +142,7 @@ function initManagePdf() {
         var idReport = $(this).attr('idreport');
         var parameters = getReportAjaxRequest(idReport, 'ScheduledReports.sendReport');
         parameters.idReport = idReport;
+        parameters.force = true;
 
         var ajaxHandler = new ajaxHelper();
         ajaxHandler.addParams(parameters, 'POST');

--- a/tests/PHPUnit/Integration/Plugins/MobileMessagingTest.php
+++ b/tests/PHPUnit/Integration/Plugins/MobileMessagingTest.php
@@ -251,7 +251,7 @@ class Plugins_MobileMessagingTest extends DatabaseTestCase
         \Piwik\Plugins\MobileMessaging\API::setSingletonInstance($stubbedAPIMobileMessaging);
 
         $mobileMessaging = new MobileMessaging();
-        $mobileMessaging->sendReport(MobileMessaging::MOBILE_TYPE, $report, $reportContent, null, null, $reportSubject, null, null);
+        $mobileMessaging->sendReport(MobileMessaging::MOBILE_TYPE, $report, $reportContent, null, null, $reportSubject, null, null, null, false);
 
         \Piwik\Plugins\MobileMessaging\API::unsetInstance();
     }


### PR DESCRIPTION
This is a hotfix for #5300 to prevent email reports from being sent more than once.

Now each time a report is sent, the last "period" it was sent for will be stored in the Option table. Before sending a report, we check if we have already sent a report for the same period.

If the report is sent manually through the web interface, a `force` parameter is set to `true`, which means that the whole "prevent from sending it twice" thing is ignored.
