### PR TITLE
Fixes #4616: Show only the first characters of tokens in the admin

### DIFF
--- a/plugins/UsersManager/javascripts/usersManager.js
+++ b/plugins/UsersManager/javascripts/usersManager.js
@@ -303,4 +303,12 @@ $(document).ready(function () {
             piwik.broadcast.propagateNewPage('segment=&idSite=' + site.id, false);
         }
     });
+
+    // Show the token_auth
+    $('.token_auth').click(function () {
+        var token = $(this).data('token');
+        if ($(this).text() != token) {
+            $(this).text(token);
+        }
+    });
 });

--- a/plugins/UsersManager/templates/index.twig
+++ b/plugins/UsersManager/templates/index.twig
@@ -135,7 +135,7 @@
                         <td id="password" class="editable">-</td>
                         <td id="email" class="editable">{{ user.email }}</td>
                         <td id="alias" class="editable">{{ user.alias|raw }}</td>
-                        <td id="token_auth">{{ user.token_auth }}</td>
+                        <td id="token_auth" class="token_auth" data-token="{{ user.token_auth }}">{{ user.token_auth|slice(0, 8) }}…</td>
                         {% if user.last_seen is defined %}
                         <td id="last_seen">{% if user.last_seen is empty %}-{% else %}{{ 'General_TimeAgo'|translate(user.last_seen)|raw }}{% endif %}</td>
                         {% endif %}


### PR DESCRIPTION
Tokens are shown in full only when we click on it.

Once token are expanded, clicking again will not collapse them again because that prevents from selecting them and copying them in the clipboard.
