### PR TITLE
Fixes the UI tests (admin_privacy_settings)

### DIFF
--- a/plugins/PrivacyManager/javascripts/privacySettings.js
+++ b/plugins/PrivacyManager/javascripts/privacySettings.js
@@ -93,7 +93,10 @@ $(document).ready(function () {
         toggleBlock("deleteLogSettings", $("input[name=deleteEnable]:checked").val());
         toggleBlock("anonymizeIPenabled", $("input[name=anonymizeIPEnable]:checked").val());
         toggleBlock("deleteReportsSettings", $("input[name=deleteReportsEnable]:checked").val());
-        toggleBlock("deleteOldReportsMoreInfo", $("input[name=deleteReportsEnable]:checked").val());
+        // This one is in an AngularJS directive, so is generated later
+        setTimeout(function () {
+            toggleBlock("deleteOldReportsMoreInfo", $("input[name=deleteReportsEnable]:checked").val());
+        }, 500);
         toggleOtherDeleteSections();
     });
 


### PR DESCRIPTION
There was a notification that wasn't hidden on page load (as it should have been). This is because the JS code that hides it is in jQuery, and is run on the page load. But the message to hide is inside an Angular directive which is being "rendered" on page load.

So I suspect that when jQuery tries to hide the span, it doesn't exist in the DOM as the Angular directive hasn't generated it yet. Later, when we click on the checkbox, jQuery can find the span and hide it correctly.

This fix is not really pretty but messing with AngularJS from jQuery is not really simple :/

Link to the failing test: http://builds-artifacts.piwik.org/ui-tests.master/4951.1/screenshot-diffs/singlediff.html?processed=../processed-ui-screenshots/UIIntegrationTest_admin_privacy_settings.png&expected=UIIntegrationTest_admin_privacy_settings.png&github=UIIntegrationTest_admin_privacy_settings.png
