### PR TITLE
Refactoring in ScheduledReports to remove useless indentation

### DIFF
--- a/plugins/ScheduledReports/ScheduledReports.php
+++ b/plugins/ScheduledReports/ScheduledReports.php
@@ -122,37 +122,39 @@ class ScheduledReports extends \Piwik\Plugin
 
     public function validateReportParameters(&$parameters, $reportType)
     {
-        if (self::manageEvent($reportType)) {
-            $reportFormat = $parameters[self::DISPLAY_FORMAT_PARAMETER];
-            $availableDisplayFormats = array_keys(self::getDisplayFormats());
-            if (!in_array($reportFormat, $availableDisplayFormats)) {
-                throw new Exception(
-                    Piwik::translate(
-                    // General_ExceptionInvalidAggregateReportsFormat should be named General_ExceptionInvalidDisplayFormat
-                        'General_ExceptionInvalidAggregateReportsFormat',
-                        array($reportFormat, implode(', ', $availableDisplayFormats))
-                    )
-                );
-            }
+        if (! self::manageEvent($reportType)) {
+            return;
+        }
 
-            // emailMe is an optional parameter
-            if (!isset($parameters[self::EMAIL_ME_PARAMETER])) {
-                $parameters[self::EMAIL_ME_PARAMETER] = self::EMAIL_ME_PARAMETER_DEFAULT_VALUE;
-            } else {
-                $parameters[self::EMAIL_ME_PARAMETER] = self::valueIsTrue($parameters[self::EMAIL_ME_PARAMETER]);
-            }
+        $reportFormat = $parameters[self::DISPLAY_FORMAT_PARAMETER];
+        $availableDisplayFormats = array_keys(self::getDisplayFormats());
+        if (!in_array($reportFormat, $availableDisplayFormats)) {
+            throw new Exception(
+                Piwik::translate(
+                // General_ExceptionInvalidAggregateReportsFormat should be named General_ExceptionInvalidDisplayFormat
+                    'General_ExceptionInvalidAggregateReportsFormat',
+                    array($reportFormat, implode(', ', $availableDisplayFormats))
+                )
+            );
+        }
 
-            // evolutionGraph is an optional parameter
-            if (!isset($parameters[self::EVOLUTION_GRAPH_PARAMETER])) {
-                $parameters[self::EVOLUTION_GRAPH_PARAMETER] = self::EVOLUTION_GRAPH_PARAMETER_DEFAULT_VALUE;
-            } else {
-                $parameters[self::EVOLUTION_GRAPH_PARAMETER] = self::valueIsTrue($parameters[self::EVOLUTION_GRAPH_PARAMETER]);
-            }
+        // emailMe is an optional parameter
+        if (!isset($parameters[self::EMAIL_ME_PARAMETER])) {
+            $parameters[self::EMAIL_ME_PARAMETER] = self::EMAIL_ME_PARAMETER_DEFAULT_VALUE;
+        } else {
+            $parameters[self::EMAIL_ME_PARAMETER] = self::valueIsTrue($parameters[self::EMAIL_ME_PARAMETER]);
+        }
 
-            // additionalEmails is an optional parameter
-            if (isset($parameters[self::ADDITIONAL_EMAILS_PARAMETER])) {
-                $parameters[self::ADDITIONAL_EMAILS_PARAMETER] = self::checkAdditionalEmails($parameters[self::ADDITIONAL_EMAILS_PARAMETER]);
-            }
+        // evolutionGraph is an optional parameter
+        if (!isset($parameters[self::EVOLUTION_GRAPH_PARAMETER])) {
+            $parameters[self::EVOLUTION_GRAPH_PARAMETER] = self::EVOLUTION_GRAPH_PARAMETER_DEFAULT_VALUE;
+        } else {
+            $parameters[self::EVOLUTION_GRAPH_PARAMETER] = self::valueIsTrue($parameters[self::EVOLUTION_GRAPH_PARAMETER]);
+        }
+
+        // additionalEmails is an optional parameter
+        if (isset($parameters[self::ADDITIONAL_EMAILS_PARAMETER])) {
+            $parameters[self::ADDITIONAL_EMAILS_PARAMETER] = self::checkAdditionalEmails($parameters[self::ADDITIONAL_EMAILS_PARAMETER]);
         }
     }
 
@@ -164,22 +166,26 @@ class ScheduledReports extends \Piwik\Plugin
 
     public function getReportMetadata(&$reportMetadata, $reportType, $idSite)
     {
-        if (self::manageEvent($reportType)) {
-            $availableReportMetadata = \Piwik\Plugins\API\API::getInstance()->getReportMetadata($idSite);
+        if (! self::manageEvent($reportType)) {
+            return;
+        }
 
-            $filteredReportMetadata = array();
-            foreach ($availableReportMetadata as $reportMetadata) {
-                // removing reports from the API category and MultiSites.getOne
-                if (
-                    $reportMetadata['category'] == 'API' ||
-                    $reportMetadata['category'] == Piwik::translate('General_MultiSitesSummary') && $reportMetadata['name'] == Piwik::translate('General_SingleWebsitesDashboard')
-                ) continue;
+        $availableReportMetadata = \Piwik\Plugins\API\API::getInstance()->getReportMetadata($idSite);
 
-                $filteredReportMetadata[] = $reportMetadata;
+        $filteredReportMetadata = array();
+        foreach ($availableReportMetadata as $reportMetadata) {
+            // removing reports from the API category and MultiSites.getOne
+            if (
+                $reportMetadata['category'] == 'API' ||
+                $reportMetadata['category'] == Piwik::translate('General_MultiSitesSummary') && $reportMetadata['name'] == Piwik::translate('General_SingleWebsitesDashboard')
+            ) {
+                continue;
             }
 
-            $reportMetadata = $filteredReportMetadata;
+            $filteredReportMetadata[] = $reportMetadata;
         }
+
+        $reportMetadata = $filteredReportMetadata;
     }
 
     public function getReportTypes(&$reportTypes)
@@ -203,53 +209,57 @@ class ScheduledReports extends \Piwik\Plugin
 
     public function processReports(&$processedReports, $reportType, $outputType, $report)
     {
-        if (self::manageEvent($reportType)) {
-            $displayFormat = $report['parameters'][self::DISPLAY_FORMAT_PARAMETER];
-            $evolutionGraph = $report['parameters'][self::EVOLUTION_GRAPH_PARAMETER];
+        if (! self::manageEvent($reportType)) {
+            return;
+        }
 
-            foreach ($processedReports as &$processedReport) {
-                $metadata = $processedReport['metadata'];
+        $displayFormat = $report['parameters'][self::DISPLAY_FORMAT_PARAMETER];
+        $evolutionGraph = $report['parameters'][self::EVOLUTION_GRAPH_PARAMETER];
 
-                $isAggregateReport = !empty($metadata['dimension']);
+        foreach ($processedReports as &$processedReport) {
+            $metadata = $processedReport['metadata'];
 
-                $processedReport['displayTable'] = $displayFormat != self::DISPLAY_FORMAT_GRAPHS_ONLY;
+            $isAggregateReport = !empty($metadata['dimension']);
 
-                $processedReport['displayGraph'] =
-                    ($isAggregateReport ?
-                        $displayFormat == self::DISPLAY_FORMAT_GRAPHS_ONLY || $displayFormat == self::DISPLAY_FORMAT_TABLES_AND_GRAPHS
-                        :
-                        $displayFormat != self::DISPLAY_FORMAT_TABLES_ONLY)
-                    && \Piwik\SettingsServer::isGdExtensionEnabled()
-                    && \Piwik\Plugin\Manager::getInstance()->isPluginActivated('ImageGraph')
-                    && !empty($metadata['imageGraphUrl']);
+            $processedReport['displayTable'] = $displayFormat != self::DISPLAY_FORMAT_GRAPHS_ONLY;
 
-                $processedReport['evolutionGraph'] = $evolutionGraph;
+            $processedReport['displayGraph'] =
+                ($isAggregateReport ?
+                    $displayFormat == self::DISPLAY_FORMAT_GRAPHS_ONLY || $displayFormat == self::DISPLAY_FORMAT_TABLES_AND_GRAPHS
+                    :
+                    $displayFormat != self::DISPLAY_FORMAT_TABLES_ONLY)
+                && \Piwik\SettingsServer::isGdExtensionEnabled()
+                && \Piwik\Plugin\Manager::getInstance()->isPluginActivated('ImageGraph')
+                && !empty($metadata['imageGraphUrl']);
 
-                // remove evolution metrics from MultiSites.getAll
-                if ($metadata['module'] == 'MultiSites') {
-                    $columns = $processedReport['columns'];
+            $processedReport['evolutionGraph'] = $evolutionGraph;
 
-                    foreach (\Piwik\Plugins\MultiSites\API::getApiMetrics($enhanced = true) as $metricSettings) {
-                        unset($columns[$metricSettings[\Piwik\Plugins\MultiSites\API::METRIC_EVOLUTION_COL_NAME_KEY]]);
-                    }
+            // remove evolution metrics from MultiSites.getAll
+            if ($metadata['module'] == 'MultiSites') {
+                $columns = $processedReport['columns'];
 
-                    $processedReport['metadata'] = $metadata;
-                    $processedReport['columns'] = $columns;
+                foreach (\Piwik\Plugins\MultiSites\API::getApiMetrics($enhanced = true) as $metricSettings) {
+                    unset($columns[$metricSettings[\Piwik\Plugins\MultiSites\API::METRIC_EVOLUTION_COL_NAME_KEY]]);
                 }
+
+                $processedReport['metadata'] = $metadata;
+                $processedReport['columns'] = $columns;
             }
         }
     }
 
     public function getRendererInstance(&$reportRenderer, $reportType, $outputType, $report)
     {
-        if (self::manageEvent($reportType)) {
-            $reportFormat = $report['format'];
+        if (! self::manageEvent($reportType)) {
+            return;
+        }
 
-            $reportRenderer = ReportRenderer::factory($reportFormat);
+        $reportFormat = $report['format'];
 
-            if ($reportFormat == ReportRenderer::HTML_FORMAT) {
-                $reportRenderer->setRenderImageInline($outputType != API::OUTPUT_SAVE_ON_DISK);
-            }
+        $reportRenderer = ReportRenderer::factory($reportFormat);
+
+        if ($reportFormat == ReportRenderer::HTML_FORMAT) {
+            $reportRenderer->setRenderImageInline($outputType != API::OUTPUT_SAVE_ON_DISK);
         }
     }
 
@@ -263,144 +273,146 @@ class ScheduledReports extends \Piwik\Plugin
     public function sendReport($reportType, $report, $contents, $filename, $prettyDate, $reportSubject, $reportTitle,
                                $additionalFiles, Period $period = null, $force)
     {
-        if (self::manageEvent($reportType)) {
-            // Safeguard against sending the same report twice to the same email (unless $force is true)
-            if (!$force && $this->reportAlreadySent($report, $period)) {
-                Log::warning(
-                    'Preventing the same scheduled report from being sent again (report #%s for period "%s")',
-                    $report['idreport'],
-                    $prettyDate
-                );
-                return;
-            }
-            
-            $periods = self::getPeriodToFrequencyAsAdjective();
-            $message = Piwik::translate('ScheduledReports_EmailHello');
-            $subject = Piwik::translate('General_Report') . ' ' . $reportTitle . " - " . $prettyDate;
+        if (! self::manageEvent($reportType)) {
+            return;
+        }
 
-            $mail = new Mail();
-            $mail->setDefaultFromPiwik();
-            $mail->setSubject($subject);
-            $attachmentName = $subject;
+        // Safeguard against sending the same report twice to the same email (unless $force is true)
+        if (!$force && $this->reportAlreadySent($report, $period)) {
+            Log::warning(
+                'Preventing the same scheduled report from being sent again (report #%s for period "%s")',
+                $report['idreport'],
+                $prettyDate
+            );
+            return;
+        }
 
-            $this->setReplyToAsSender($mail, $report);
+        $periods = self::getPeriodToFrequencyAsAdjective();
+        $message = Piwik::translate('ScheduledReports_EmailHello');
+        $subject = Piwik::translate('General_Report') . ' ' . $reportTitle . " - " . $prettyDate;
 
-            $displaySegmentInfo = false;
-            $segmentInfo = null;
-            $segment = API::getSegment($report['idsegment']);
-            if ($segment != null) {
-                $displaySegmentInfo = true;
-                $segmentInfo = Piwik::translate('ScheduledReports_SegmentAppliedToReports', $segment['name']);
-            }
+        $mail = new Mail();
+        $mail->setDefaultFromPiwik();
+        $mail->setSubject($subject);
+        $attachmentName = $subject;
 
-            switch ($report['format']) {
-                case 'html':
+        $this->setReplyToAsSender($mail, $report);
 
-                    // Needed when using images as attachment with cid
-                    $mail->setType(Zend_Mime::MULTIPART_RELATED);
-                    $message .= "<br/>" . Piwik::translate('ScheduledReports_PleaseFindBelow', array($periods[$report['period']], $reportTitle));
+        $displaySegmentInfo = false;
+        $segmentInfo = null;
+        $segment = API::getSegment($report['idsegment']);
+        if ($segment != null) {
+            $displaySegmentInfo = true;
+            $segmentInfo = Piwik::translate('ScheduledReports_SegmentAppliedToReports', $segment['name']);
+        }
 
-                    if ($displaySegmentInfo) {
-                        $message .= " " . $segmentInfo;
-                    }
+        switch ($report['format']) {
+            case 'html':
 
-                    $mail->setBodyHtml($message . "<br/><br/>" . $contents);
-                    break;
+                // Needed when using images as attachment with cid
+                $mail->setType(Zend_Mime::MULTIPART_RELATED);
+                $message .= "<br/>" . Piwik::translate('ScheduledReports_PleaseFindBelow', array($periods[$report['period']], $reportTitle));
 
-                case 'csv':
-                    $message .= "\n" . Piwik::translate('ScheduledReports_PleaseFindAttachedFile', array($periods[$report['period']], $reportTitle));
+                if ($displaySegmentInfo) {
+                    $message .= " " . $segmentInfo;
+                }
 
-                    if ($displaySegmentInfo) {
-                        $message .= " " . $segmentInfo;
-                    }
+                $mail->setBodyHtml($message . "<br/><br/>" . $contents);
+                break;
 
-                    $mail->setBodyText($message);
-                    $mail->createAttachment(
-                        $contents,
-                        'application/csv',
-                        Zend_Mime::DISPOSITION_INLINE,
-                        Zend_Mime::ENCODING_BASE64,
-                        $attachmentName . '.csv'
-                    );
-                    break;
+            case 'csv':
+                $message .= "\n" . Piwik::translate('ScheduledReports_PleaseFindAttachedFile', array($periods[$report['period']], $reportTitle));
 
-                default:
-                case 'pdf':
-                    $message .= "\n" . Piwik::translate('ScheduledReports_PleaseFindAttachedFile', array($periods[$report['period']], $reportTitle));
+                if ($displaySegmentInfo) {
+                    $message .= " " . $segmentInfo;
+                }
 
-                    if ($displaySegmentInfo) {
-                        $message .= " " . $segmentInfo;
-                    }
-
-                    $mail->setBodyText($message);
-                    $mail->createAttachment(
-                        $contents,
-                        'application/pdf',
-                        Zend_Mime::DISPOSITION_INLINE,
-                        Zend_Mime::ENCODING_BASE64,
-                        $attachmentName . '.pdf'
-                    );
-                    break;
-            }
-
-            foreach ($additionalFiles as $additionalFile) {
-                $fileContent = $additionalFile['content'];
-                $at = $mail->createAttachment(
-                    $fileContent,
-                    $additionalFile['mimeType'],
+                $mail->setBodyText($message);
+                $mail->createAttachment(
+                    $contents,
+                    'application/csv',
                     Zend_Mime::DISPOSITION_INLINE,
-                    $additionalFile['encoding'],
-                    $additionalFile['filename']
+                    Zend_Mime::ENCODING_BASE64,
+                    $attachmentName . '.csv'
                 );
-                $at->id = $additionalFile['cid'];
+                break;
 
-                unset($fileContent);
-            }
+            default:
+            case 'pdf':
+                $message .= "\n" . Piwik::translate('ScheduledReports_PleaseFindAttachedFile', array($periods[$report['period']], $reportTitle));
 
-            // Get user emails and languages
-            $reportParameters = $report['parameters'];
-            $emails = array();
-
-            if (isset($reportParameters[self::ADDITIONAL_EMAILS_PARAMETER])) {
-                $emails = $reportParameters[self::ADDITIONAL_EMAILS_PARAMETER];
-            }
-
-            if ($reportParameters[self::EMAIL_ME_PARAMETER] == 1) {
-                if (Piwik::getCurrentUserLogin() == $report['login']) {
-                    $emails[] = Piwik::getCurrentUserEmail();
-                } else {
-                    try {
-                        $user = APIUsersManager::getInstance()->getUser($report['login']);
-                    } catch (Exception $e) {
-                        return;
-                    }
-                    $emails[] = $user['email'];
+                if ($displaySegmentInfo) {
+                    $message .= " " . $segmentInfo;
                 }
-            }
 
-            if (! $force) {
-                $this->markReportAsSent($report, $period);
-            }
+                $mail->setBodyText($message);
+                $mail->createAttachment(
+                    $contents,
+                    'application/pdf',
+                    Zend_Mime::DISPOSITION_INLINE,
+                    Zend_Mime::ENCODING_BASE64,
+                    $attachmentName . '.pdf'
+                );
+                break;
+        }
 
-            foreach ($emails as $email) {
-                if (empty($email)) {
-                    continue;
-                }
-                $mail->addTo($email);
+        foreach ($additionalFiles as $additionalFile) {
+            $fileContent = $additionalFile['content'];
+            $at = $mail->createAttachment(
+                $fileContent,
+                $additionalFile['mimeType'],
+                Zend_Mime::DISPOSITION_INLINE,
+                $additionalFile['encoding'],
+                $additionalFile['filename']
+            );
+            $at->id = $additionalFile['cid'];
 
+            unset($fileContent);
+        }
+
+        // Get user emails and languages
+        $reportParameters = $report['parameters'];
+        $emails = array();
+
+        if (isset($reportParameters[self::ADDITIONAL_EMAILS_PARAMETER])) {
+            $emails = $reportParameters[self::ADDITIONAL_EMAILS_PARAMETER];
+        }
+
+        if ($reportParameters[self::EMAIL_ME_PARAMETER] == 1) {
+            if (Piwik::getCurrentUserLogin() == $report['login']) {
+                $emails[] = Piwik::getCurrentUserEmail();
+            } else {
                 try {
-                    $mail->send();
+                    $user = APIUsersManager::getInstance()->getUser($report['login']);
                 } catch (Exception $e) {
-
-                    // If running from piwik.php with debug, we ignore the 'email not sent' error
-                    if (!isset($GLOBALS['PIWIK_TRACKER_DEBUG']) || !$GLOBALS['PIWIK_TRACKER_DEBUG']) {
-                        throw new Exception("An error occured while sending '$filename' " .
-                            " to " . implode(', ', $mail->getRecipients()) .
-                            ". Error was '" . $e->getMessage() . "'");
-                    }
+                    return;
                 }
-                $mail->clearRecipients();
+                $emails[] = $user['email'];
             }
+        }
+
+        if (! $force) {
+            $this->markReportAsSent($report, $period);
+        }
+
+        foreach ($emails as $email) {
+            if (empty($email)) {
+                continue;
+            }
+            $mail->addTo($email);
+
+            try {
+                $mail->send();
+            } catch (Exception $e) {
+
+                // If running from piwik.php with debug, we ignore the 'email not sent' error
+                if (!isset($GLOBALS['PIWIK_TRACKER_DEBUG']) || !$GLOBALS['PIWIK_TRACKER_DEBUG']) {
+                    throw new Exception("An error occured while sending '$filename' " .
+                        " to " . implode(', ', $mail->getRecipients()) .
+                        ". Error was '" . $e->getMessage() . "'");
+                }
+            }
+            $mail->clearRecipients();
         }
     }
 
@@ -448,20 +460,22 @@ class ScheduledReports extends \Piwik\Plugin
 
     public function getReportRecipients(&$recipients, $reportType, $report)
     {
-        if (self::manageEvent($reportType)) {
-            $parameters = $report['parameters'];
-            $eMailMe = $parameters[self::EMAIL_ME_PARAMETER];
-
-            if ($eMailMe) {
-                $recipients[] = Piwik::getCurrentUserEmail();
-            }
-
-            if (isset($parameters[self::ADDITIONAL_EMAILS_PARAMETER])) {
-                $additionalEMails = $parameters[self::ADDITIONAL_EMAILS_PARAMETER];
-                $recipients = array_merge($recipients, $additionalEMails);
-            }
-            $recipients = array_filter($recipients);
+        if (! self::manageEvent($reportType)) {
+            return;
         }
+
+        $parameters = $report['parameters'];
+        $eMailMe = $parameters[self::EMAIL_ME_PARAMETER];
+
+        if ($eMailMe) {
+            $recipients[] = Piwik::getCurrentUserEmail();
+        }
+
+        if (isset($parameters[self::ADDITIONAL_EMAILS_PARAMETER])) {
+            $additionalEMails = $parameters[self::ADDITIONAL_EMAILS_PARAMETER];
+            $recipients = array_merge($recipients, $additionalEMails);
+        }
+        $recipients = array_filter($recipients);
     }
 
     public static function template_reportParametersScheduledReports(&$out)
@@ -511,7 +525,6 @@ class ScheduledReports extends \Piwik\Plugin
         }
 
         $this->throwExceptionReportsAreUsingSegment($reportsNeedSegment);
-
     }
 
     public function segmentDeactivation($idSegment)


### PR DESCRIPTION
I have refactored the code a bit to make it (hopefully) more readable.

The diff is going crazy, but basically I have just replaced this:

``` php
if (self::manageEvent($reportType)) {
    // big block of code
}
```

By this:

``` php
if (! self::manageEvent($reportType)) {
    return;
}

// big block of code
```

It's not much but it removes one level of indentation in almost the whole class (almost all the methods were like that), which is kind of nice.

(by the way this is one of the "object calisthenics" rules)
