### PR TITLE
Fixes #6101 Unknown providers are now shown as "Unknown" instead of "IP"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -355,6 +355,7 @@
         "Seconds": "%ss",
         "SeeAll": "see all",
         "SeeTheOfficialDocumentationForMoreInformation": "See the %sofficial documentation%s for more information.",
+        "SeeThisFaq": "See %1$sthis faq%2$s.",
         "Segment": "Segment",
         "SelectYesIfYouWantToSendEmailsViaServer": "Select \"Yes\" if you want or have to send e-mail via a named server instead of the local mail function",
         "Settings": "Settings",

--- a/plugins/Provider/API.php
+++ b/plugins/Provider/API.php
@@ -34,7 +34,7 @@ class API extends \Piwik\Plugin\API
         $dataTable->queueFilter('ColumnCallbackReplace', array('label', __NAMESPACE__ . '\getPrettyProviderName'));
         $dataTable->queueFilter('ReplaceColumnNames');
         $dataTable->queueFilter('ReplaceSummaryRowLabel');
+        $dataTable->queueFilter('GroupBy', array('label'));
         return $dataTable;
     }
 }
-

--- a/plugins/Provider/Reports/GetProvider.php
+++ b/plugins/Provider/Reports/GetProvider.php
@@ -8,11 +8,13 @@
  */
 namespace Piwik\Plugins\Provider\Reports;
 
+use Piwik\Common;
 use Piwik\Piwik;
+use Piwik\Plugin\Report;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\Provider\Columns\Provider;
 
-class GetProvider extends \Piwik\Plugin\Report
+class GetProvider extends Report
 {
     protected function init()
     {
@@ -28,6 +30,14 @@ class GetProvider extends \Piwik\Plugin\Report
     {
         $view->requestConfig->filter_limit = 5;
         $view->config->addTranslation('label', $this->dimension->getName());
-    }
 
+        $message = Piwik::translate("General_Note") . ': ' . Piwik::translate('Provider_ProviderReportFooter', '');
+        if (! Common::getRequestVar('disableLink', 0, 'int')) {
+            $message .= ' ' . Piwik::translate(
+                    'General_SeeThisFaq',
+                    array('<a href="http://piwik.org/faq/general/faq_52/" target="_blank">', '</a>')
+                );
+        }
+        $view->config->show_footer_message = $message;
+    }
 }

--- a/plugins/Provider/functions.php
+++ b/plugins/Provider/functions.php
@@ -20,11 +20,8 @@ use Piwik\Piwik;
  */
 function getHostnameName($in)
 {
-    if (empty($in)) {
+    if (empty($in) || strtolower($in) === 'ip') {
         return Piwik::translate('General_Unknown');
-    }
-    if (strtolower($in) === 'ip') {
-        return "IP";
     }
     if (($positionDot = strpos($in, '.')) !== false) {
         return ucfirst(substr($in, 0, $positionDot));
@@ -40,14 +37,8 @@ function getHostnameName($in)
  */
 function getHostnameUrl($in)
 {
-    if ($in == DataTable::LABEL_SUMMARY_ROW) {
+    if ($in == DataTable::LABEL_SUMMARY_ROW || empty($in) || strtolower($in) === 'ip') {
         return false;
-    }
-    if (empty($in)
-        || strtolower($in) === 'ip'
-    ) {
-        // link to "what does 'IP' mean?"
-        return "http://piwik.org/faq/general/#faq_52";
     }
 
     // if the name looks like it can be used in a URL, use it in one, otherwise link to startpage

--- a/plugins/Provider/lang/en.json
+++ b/plugins/Provider/lang/en.json
@@ -4,6 +4,7 @@
         "PluginDescription": "Reports the Provider of the visitors.",
         "ProviderReportDocumentation": "This report shows which Internet Service Providers your visitors used to access the website. You can click on a provider name for more details. %s If Piwik can't determine a visitor's provider, it is listed as IP.",
         "SubmenuLocationsProvider": "Locations & Provider",
-        "WidgetProviders": "Providers"
+        "WidgetProviders": "Providers",
+        "ProviderReportFooter": "Unknown provider means the IP address could not be looked up."
     }
 }


### PR DESCRIPTION
This implements the change described in #6101.
- [x] change from IP to `Unknown` (i.e. "IP" is now merged with real "Unknown" IPs)
- [x] in the report footer, we could write `Unknown provider means the IP could not be looked up. See <a href='http://piwik.org/faq/general/faq_52/'>this faq</a>.`
- [x] update [the faq](http://piwik.org/faq/general/faq_52/)
- [x] when `disableLink` is used, we could hide the link to piwik.org

I do not have the access to edit the FAQ.
