### PR TITLE
Fix for #6215 Added a "learn more" link on "Others" row in reports

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -208,6 +208,7 @@
         "LastDays": "Last %s days (including today)",
         "LastDaysShort": "Last %s days",
         "LayoutDirection": "ltr",
+        "LearnMore": "%1$slearn more%2$s",
         "Live": "Live",
         "Loading": "Loading...",
         "LoadingData": "Loading data...",

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -249,5 +249,6 @@ class CoreHome extends \Piwik\Plugin
         $translationKeys[] = 'General_YourChangesHaveBeenSaved';
         $translationKeys[] = 'CoreHome_UndoPivotBySubtable';
         $translationKeys[] = 'CoreHome_PivotBySubtable';
+        $translationKeys[] = 'General_LearnMore';
     }
 }

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -312,6 +312,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         self.handleColumnHighlighting(domElem);
         self.handleExpandFooter(domElem);
         self.setFixWidthToMakeEllipsisWork(domElem);
+        self.handleSummaryRow(domElem);
     },
 
     setFixWidthToMakeEllipsisWork: function (domElem) {
@@ -1697,6 +1698,22 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             }
 
             self.reloadAjaxDataTable(true);
+        });
+    },
+
+    handleSummaryRow: function (domElem) {
+        var details = _pk_translate('General_LearnMore', [' (<a href="http://piwik.org/faq/how-to/faq_54/" target="_blank">', '</a>)']);
+
+        domElem.find('tr.summaryRow').each(function () {
+            var labelSpan = $(this).find('.label .value');
+            var defaultLabel = labelSpan.text();
+
+            $(this).hover(function() {
+                    labelSpan.html(defaultLabel + details);
+                },
+                function() {
+                    labelSpan.text(defaultLabel);
+                });
         });
     },
 

--- a/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_htmlTable.twig
@@ -18,7 +18,8 @@
         {% else %}
             {%- for rowId, row in dataTable.getRows() -%}
                 {%- set rowHasSubtable = not subtablesAreDisabled and row.getIdSubDataTable() and properties.subtable_controller_action is not null -%}
-                {%- set shouldHighlightRow = rowId == constant('Piwik\\DataTable::ID_SUMMARY_ROW') and properties.highlight_summary_row -%}
+                {%- set isSummaryRow = rowId == constant('Piwik\\DataTable::ID_SUMMARY_ROW') -%}
+                {%- set shouldHighlightRow = isSummaryRow and properties.highlight_summary_row -%}
 
                 {# display this row if it doesn't have a subtable or if we don't replace the row with the subtable #}
                 {%- set showRow = subtablesAreDisabled
@@ -28,7 +29,7 @@
 
                 {% if showRow %}
                 <tr {% if rowHasSubtable %}id="{{ row.getIdSubDataTable() }}"{% endif %}
-                    class="{{ row.getMetadata('css_class') }} {% if rowHasSubtable %}subDataTable{% endif %}{% if shouldHighlightRow %} highlight{% endif %}"
+                    class="{{ row.getMetadata('css_class') }} {% if rowHasSubtable %}subDataTable{% endif %}{% if shouldHighlightRow %} highlight{% endif %}{% if isSummaryRow %} summaryRow{% endif %}"
                     {% if rowHasSubtable %}title="{{ 'CoreHome_ClickRowToExpandOrContract'|translate }}"{% endif %}>
                     {% for column in properties.columns_to_display %}
                         <td>


### PR DESCRIPTION
This is a fix for #6215 

When not hovering the row (no change):

![normal](https://cloud.githubusercontent.com/assets/720328/4554027/9ea96ac8-4ea5-11e4-984f-874a1b672697.png)

When hovering the row (new link):

![hover](https://cloud.githubusercontent.com/assets/720328/4554030/a9f56422-4ea5-11e4-9c02-8c8b9039e02f.png)

_(don't mind the translation)_

To achieve this I added a new method `handleSummaryRow()` in `dataTable.js` I hope it makes sense. If not, let me know.
