### PR TITLE
Removed $GLOBALS['PIWIK_TRACKER_DEBUG_FORCE_SCHEDULED_TASKS']

### DIFF
--- a/core/ScheduledTaskTimetable.php
+++ b/core/ScheduledTaskTimetable.php
@@ -72,9 +72,7 @@ class ScheduledTaskTimetable
      */
     public function shouldExecuteTask($taskName)
     {
-        $forceTaskExecution =
-            (isset($GLOBALS['PIWIK_TRACKER_DEBUG_FORCE_SCHEDULED_TASKS']) && $GLOBALS['PIWIK_TRACKER_DEBUG_FORCE_SCHEDULED_TASKS'])
-            || DEBUG_FORCE_SCHEDULED_TASKS;
+        $forceTaskExecution = (defined('DEBUG_FORCE_SCHEDULED_TASKS') && DEBUG_FORCE_SCHEDULED_TASKS);
 
         return $forceTaskExecution || ($this->taskHasBeenScheduledOnce($taskName) && time() >= $this->timetable[$taskName]);
     }

--- a/core/TaskScheduler.php
+++ b/core/TaskScheduler.php
@@ -13,7 +13,7 @@ use Exception;
 use Piwik\Plugin\Manager as PluginManager;
 
 // When set to true, all scheduled tasks will be triggered in all requests (careful!)
-define('DEBUG_FORCE_SCHEDULED_TASKS', false);
+//define('DEBUG_FORCE_SCHEDULED_TASKS', true);
 
 /**
  * Manages scheduled task execution.

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -338,7 +338,7 @@ class Tracker
 
         $nextRunTime = $cache['lastTrackerCronRun'] + $minimumInterval;
 
-        if ((isset($GLOBALS['PIWIK_TRACKER_DEBUG_FORCE_SCHEDULED_TASKS']) && $GLOBALS['PIWIK_TRACKER_DEBUG_FORCE_SCHEDULED_TASKS'])
+        if ((defined('DEBUG_FORCE_SCHEDULED_TASKS') && DEBUG_FORCE_SCHEDULED_TASKS)
             || $cache['lastTrackerCronRun'] === false
             || $nextRunTime < $now
         ) {

--- a/piwik.php
+++ b/piwik.php
@@ -15,7 +15,6 @@ use Piwik\Tracker;
 // Note: if you wish to debug the Tracking API please see this documentation:
 // http://developer.piwik.org/api-reference/tracking-api#debugging-the-tracker
 
-$GLOBALS['PIWIK_TRACKER_DEBUG_FORCE_SCHEDULED_TASKS'] = false;
 define('PIWIK_ENABLE_TRACKING', true);
 
 if (!defined('PIWIK_DOCUMENT_ROOT')) {

--- a/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
+++ b/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
@@ -51,7 +51,7 @@ class RunScheduledTasks extends ConsoleCommand
         $force = $input->getOption('force');
 
         if ($force) {
-            $GLOBALS['PIWIK_TRACKER_DEBUG_FORCE_SCHEDULED_TASKS'] = true;
+            define('DEBUG_FORCE_SCHEDULED_TASKS', true);
         }
     }
 }

--- a/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
+++ b/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
@@ -50,7 +50,7 @@ class RunScheduledTasks extends ConsoleCommand
     {
         $force = $input->getOption('force');
 
-        if ($force) {
+        if ($force && !defined('DEBUG_FORCE_SCHEDULED_TASKS')) {
             define('DEBUG_FORCE_SCHEDULED_TASKS', true);
         }
     }

--- a/tests/LocalTracker.php
+++ b/tests/LocalTracker.php
@@ -5,7 +5,6 @@ use Piwik\Tracker;
 use Piwik\Tracker\Cache;
 
 $GLOBALS['PIWIK_TRACKER_DEBUG'] = false;
-$GLOBALS['PIWIK_TRACKER_DEBUG_FORCE_SCHEDULED_TASKS'] = false;
 if (!defined('PIWIK_ENABLE_TRACKING')) {
     define('PIWIK_ENABLE_TRACKING', true);
 }

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -87,7 +87,7 @@ class Test_Piwik_ReleaseCheckListTest extends PHPUnit_Framework_TestCase
         $this->_checkEqual(array('log' => 'logger_api_call'), null);
 
         require_once PIWIK_INCLUDE_PATH . "/core/TaskScheduler.php";
-        $this->assertFalse(DEBUG_FORCE_SCHEDULED_TASKS);
+        $this->assertFalse(defined('DEBUG_FORCE_SCHEDULED_TASKS'));
 
         // Check the index.php has "backtrace disabled"
         $content = file_get_contents(PIWIK_INCLUDE_PATH . "/index.php");


### PR DESCRIPTION
Pull request for #6085

Removed `$GLOBALS['PIWIK_TRACKER_DEBUG_FORCE_SCHEDULED_TASKS']` and replaced it fully with `DEBUG_FORCE_SCHEDULED_TASKS`.

Explanation is in #6085
