### PR TITLE
Added events for Piwik update, enable/disable plugin and Plugin Settings update

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -20,6 +20,7 @@ use Piwik\EventDispatcher;
 use Piwik\Filesystem;
 use Piwik\Log;
 use Piwik\Option;
+use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Singleton;
 use Piwik\Theme;
@@ -289,6 +290,13 @@ class Manager extends Singleton
         $this->removePluginFromConfig($pluginName);
 
         $this->clearCache($pluginName);
+
+        /**
+         * Event triggered after a plugin has been deactivated.
+         *
+         * @param string $pluginName The plugin that has been deactivated.
+         */
+        Piwik::postEvent('PluginManager.pluginDeactivated', array($pluginName));
     }
 
     /**
@@ -442,6 +450,13 @@ class Manager extends Singleton
         PiwikConfig::getInstance()->forceSave();
 
         $this->clearCache($pluginName);
+
+        /**
+         * Event triggered after a plugin has been activated.
+         *
+         * @param string $pluginName The plugin that has been activated.
+         */
+        Piwik::postEvent('PluginManager.pluginActivated', array($pluginName));
     }
 
     protected function isPluginInFilesystem($pluginName)

--- a/core/Plugin/Settings.php
+++ b/core/Plugin/Settings.php
@@ -167,6 +167,22 @@ abstract class Settings implements StorageInterface
     public function save()
     {
         Option::set($this->getOptionKey(), serialize($this->settingsValues));
+
+        $pluginName = $this->getPluginName();
+
+        /**
+         * Triggered after a plugin settings have been updated.
+         *
+         * **Example**
+         *
+         *     Piwik::addAction('Settings.MyPlugin.settingsUpdated', function (Settings $settings) {
+         *         $value = $settings->someSetting->getValue();
+         *         // Do something with the new setting value
+         *     });
+         *
+         * @param Settings $settings The plugin settings object.
+         */
+        Piwik::postEvent(sprintf('Settings.%s.settingsUpdated', $pluginName), array($this));
     }
 
     /**

--- a/plugins/CoreUpdater/CoreUpdater.php
+++ b/plugins/CoreUpdater/CoreUpdater.php
@@ -85,6 +85,11 @@ class CoreUpdater extends \Piwik\Plugin
             'deactivatedPlugins' => $deactivatedPlugins
         );
 
+        /**
+         * Triggered after Piwik has been updated.
+         */
+        Piwik::postEvent('CoreUpdater.update.end');
+
         return $result;
     }
 


### PR DESCRIPTION
This is needed for #6372

New events:
- `CoreUpdater.update.end`
  
  Triggered after Piwik has been updated.
- `PluginManager.pluginActivated` - Parameters: `$pluginName`
  
  Event triggered after a plugin has been activated.
- `PluginManager.pluginDeactivated` - Parameters: `$pluginName`
  
  Event triggered after a plugin has been deactivated.
- `Settings.$settingsName.settingsUpdated`
  
  Triggered after a plugin settings have been updated. - Parameters: `Settings $settings`
  
  Example:
  
  ``` php
  Piwik::addAction('Settings.MyPlugin.settingsUpdated', function (Settings $settings) {
      $value = $settings->someSetting->getValue();
      // Do something with the new setting value
  });
  ```
