### PR TITLE
The initSession method has not been changed

### DIFF
--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -389,7 +389,11 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         // logs the user in with the new password
         if ($newPassword !== false) {
-            \Piwik\Registry::get('auth')->initSession($userLogin, md5($newPassword), $rememberMe = false);
+            $sessionInitializer = new SessionInitializer();
+            $auth = \Piwik\Registry::get('auth');
+            $auth->setLogin($userLogin);
+            $auth->setPassword($password);
+            $sessionInitializer->initSession($auth, $rememberMe = false);
         }
     }
 }

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -15,6 +15,7 @@ use Piwik\MetricsFormatter;
 use Piwik\Piwik;
 use Piwik\Plugins\LanguagesManager\API as APILanguagesManager;
 use Piwik\Plugins\LanguagesManager\LanguagesManager;
+use Piwik\Plugins\Login\SessionInitializer;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 use Piwik\Site;


### PR DESCRIPTION
Reproduce the error: When changing the password of the user from "User settings", it throws an fatal error.

Why ? : The initSession method has not been changed in the processPasswordChange method of the UsersManager Controller class.
