### PR TITLE
Suppress cron errors while performing file cleanup

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -204,10 +204,12 @@ class CliMulti {
         }
 
         foreach ($files as $file) {
-            $timeLastModified = @filemtime($file);
+            if (file_exists($file)) {
+                $timeLastModified = filemtime($file);
 
-            if ($timeLastModified !== FALSE && $timeOneWeekAgo > $timeLastModified) {
-                unlink($file);
+                if ($timeLastModified !== FALSE && $timeOneWeekAgo > $timeLastModified) {
+                    unlink($file);
+                }
             }
         }
     }

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -204,9 +204,9 @@ class CliMulti {
         }
 
         foreach ($files as $file) {
-            $timeLastModified = filemtime($file);
+            $timeLastModified = @filemtime($file);
 
-            if ($timeOneWeekAgo > $timeLastModified) {
+            if ($timeLastModified !== FALSE && $timeOneWeekAgo > $timeLastModified) {
                 unlink($file);
             }
         }


### PR DESCRIPTION
When performing simultaneous cron core:archive runs for large instances, there is a race condition during the file cleanup phase when one process sees the files of another process just before the other process deletes those files, causing the filemtime() call to fail since the file no longer exists.  Also, since the return value from filemtime() is not checked for failure (=== FALSE), it tries to unlink() the file on failure, which also fails.  At the least, this is causing unnecessary emailings from the cron process.  The failure of filemtime() is harmless, though unlinking on that failure _may_ not be.  The filemtime() failure can be safely ignored since this function's only purpose is to clean up old files, and the failure just means the file no longer exists.
