### PR TITLE
Entry pages footer links lead to "Action not found"

### DIFF
--- a/plugins/Actions/Reports/GetEntryPageUrls.php
+++ b/plugins/Actions/Reports/GetEntryPageUrls.php
@@ -44,14 +44,6 @@ class GetEntryPageUrls extends Base
 
     public function configureView(ViewDataTable $view)
     {
-        // link to the page, not just the report, but only if not a widget
-        $widget = Common::getRequestVar('widget', false);
-
-        $view->config->self_url = Request::getCurrentUrlWithoutGenericFilters(array(
-            'module' => 'Actions',
-            'action' => $widget === false ? 'indexEntryPageUrls' : 'getEntryPageUrls'
-        ));
-
         $view->config->addTranslations(array('label' => $this->dimension->getName()));
 
         $view->config->title = $this->name;


### PR DESCRIPTION
To reproduce this bug:
1. Goto Action > Entry pages
2. Click on at `Entry page titles` the bottom of the page (related reports)
3. Click on `Entry pages` again at the bottom of the report (NOT in the menu!)

Attaching screen from demo.piwik.org:
![demo-piwik-org-bug](https://cloud.githubusercontent.com/assets/576937/4755362/eebf8986-5ac4-11e4-80dc-f19e36942748.png)

My changes fix these error. I'm not sure what's the purpose of these lines. Maybe @tsteur will know that. Looks like you're author of this lines.
