### PR TITLE
fix annotations which were broken in case there was no space after anota...

### DIFF
--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -480,7 +480,7 @@ class Proxy extends Singleton
         $hideLine = trim($hideLine);
         $hideLine .= ' ';
 
-        $token = strtok($hideLine, " ");
+	$token = trim(strtok($hideLine, " "), "\n");
 
         $hide = false;
 


### PR DESCRIPTION
...tion and new line character.
In previous form proper hooks just weren't called and methods weren't hided.
