### PR TITLE
generate:travis-yml command sometimes fails to detect tests in plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "twig/twig": "~1.0",
         "leafo/lessphp": "~0.4.0",
         "symfony/console": "~2.3",
+        "symfony/finder": "~2.3",
         "tedivm/jshrink": "~0.5.1",
         "mustangostang/spyc": "~0.5.0",
         "piwik/device-detector": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2b25fd70ade7d65dd13a492195c96dc1",
+    "hash": "30d30e806fbc919cf0bbdcc9714267a3",
     "packages": [
         {
             "name": "leafo/lessphp",
@@ -178,17 +178,17 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.5.5",
+            "version": "v2.5.6",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "ca053eaa031c93afb68a71e4eb1f4168dfd4a661"
+                "reference": "6f177fca24200a5b97aef5ce7a5c98124a0f0db0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/ca053eaa031c93afb68a71e4eb1f4168dfd4a661",
-                "reference": "ca053eaa031c93afb68a71e4eb1f4168dfd4a661",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/6f177fca24200a5b97aef5ce7a5c98124a0f0db0",
+                "reference": "6f177fca24200a5b97aef5ce7a5c98124a0f0db0",
                 "shasum": ""
             },
             "require": {
@@ -229,7 +229,54 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
-            "time": "2014-09-25 09:53:56"
+            "time": "2014-10-05 13:57:04"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v2.5.6",
+            "target-dir": "Symfony/Component/Finder",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Finder.git",
+                "reference": "cf66df4e783e6aade319b273c9bcf9e42aa9b10f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/cf66df4e783e6aade319b273c9bcf9e42aa9b10f",
+                "reference": "cf66df4e783e6aade319b273c9bcf9e42aa9b10f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Finder\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-10-01 05:50:18"
         },
         {
             "name": "tedivm/jshrink",
@@ -1104,9 +1151,7 @@
             "time": "2014-09-22 09:14:18"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "facebook/xhprof": 20
@@ -1115,7 +1160,5 @@
     "platform": {
         "php": ">=5.3.3"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/tests/PHPUnit/IntegrationTestCase.php
+++ b/tests/PHPUnit/IntegrationTestCase.php
@@ -7,11 +7,10 @@
  */
 
 /**
- * @deprecated since 2.8.0 extend \Piwik\Tests\Framework\TestCase\SystemTestCase instead
+ * @deprecated since 2.8.0 extend \Piwik\Tests\Framework\TestCase\IntegrationTestCase instead
  */
 class IntegrationTestCase extends \Piwik\Tests\Framework\TestCase\SystemTestCase
 {
-
     public static function setUpBeforeClass()
     {
         \Piwik\Log::debug('\IntegrationTestCase is deprecated since 2.8.0 extend \Piwik\Tests\Framework\TestCase\SystemTestCase instead');


### PR DESCRIPTION
The `generate:travis-yml` was looking for test files in plugins, but it was looking in `tests/*Test.php` or `tests/*/*Test.php`. And of course, for plugins that had plugins in a 3 level deep subdirectory (i.e. `tests/*/*/*Test.php`) the command was failing because no tests were found. This is the case for example for the ActivityLog plugin.

I could have fixed it by adding another test to the list (because `glob()` doesn't match recursively):

``` php
$testFiles = array_merge(glob($folderPath . "/*/*Test.php"), glob($folderPath . "/*Test.php"), glob($folderPath . "/*/*/*Test.php"));
return !empty($testFiles);
```

But this is not really ideal, so instead of writing useless complex code I went with using [Symfony's Finder component](http://symfony.com/doc/current/components/finder.html):

``` php
$finder = new Finder();
$finder->files()
    ->in($folderPath)
    ->name('*Test.php');
return count($finder) > 0;
```

So that's the reason I'm opening a pull request: **do you think that's fine to introduce a new dependency to that component?** I've been using the Finder for a while in other projects and it's really useful, I'm guessing it could be reused in many places in Piwik.
