### PR TITLE
Use exceptions instead of calls to Piwik_ExitWithMessage

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -314,13 +314,13 @@ class Config extends Singleton
 
         // read defaults from global.ini.php
         if (!is_readable($this->pathGlobal) && $reportError) {
-            Piwik_ExitWithMessage(Piwik::translate('General_ExceptionConfigurationFileNotFound', array($this->pathGlobal)));
+            throw new Exception(Piwik::translate('General_ExceptionConfigurationFileNotFound', array($this->pathGlobal)));
         }
 
         $this->configGlobal = _parse_ini_file($this->pathGlobal, true);
 
         if (empty($this->configGlobal) && $reportError) {
-            Piwik_ExitWithMessage(Piwik::translate('General_ExceptionUnreadableFileDisabledMethod', array($this->pathGlobal, "parse_ini_file()")));
+            throw new Exception(Piwik::translate('General_ExceptionUnreadableFileDisabledMethod', array($this->pathGlobal, "parse_ini_file()")));
         }
 
         $this->configCommon = _parse_ini_file($this->pathCommon, true);
@@ -330,7 +330,7 @@ class Config extends Singleton
 
         $this->configLocal = _parse_ini_file($this->pathLocal, true);
         if (empty($this->configLocal) && $reportError) {
-            Piwik_ExitWithMessage(Piwik::translate('General_ExceptionUnreadableFileDisabledMethod', array($this->pathLocal, "parse_ini_file()")));
+            throw new Exception(Piwik::translate('General_ExceptionUnreadableFileDisabledMethod', array($this->pathLocal, "parse_ini_file()")));
         }
     }
 
@@ -725,5 +725,4 @@ class Config extends Singleton
         }
         return $merged;
     }
-
 }

--- a/core/Db.php
+++ b/core/Db.php
@@ -81,7 +81,7 @@ class Db
          */
         Piwik::postEvent('Db.getDatabaseConfig', array(&$dbConfig));
 
-        $dbConfig['profiler'] = $config->Debug['enable_sql_profiler'];
+        $dbConfig['profiler'] = @$config->Debug['enable_sql_profiler'];
 
         return $dbConfig;
     }

--- a/core/Exceptions/HtmlMessageException.php
+++ b/core/Exceptions/HtmlMessageException.php
@@ -11,12 +11,17 @@ namespace Piwik\Exceptions;
 use Exception;
 
 /**
- * TODO
+ * An exception whose message has HTML content. When these exceptions are caught
+ * the messgae will not be sanitized before being displayed to the user.
+ *
+ * @api
  */
 class HtmlMessageException extends Exception
 {
     /**
-     * TODO
+     * Returns the exception message.
+     *
+     * @return string
      */
     public function getHtmlMessage()
     {

--- a/core/Exceptions/HtmlMessageException.php
+++ b/core/Exceptions/HtmlMessageException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Exceptions;
+
+use Exception;
+
+/**
+ * TODO
+ */
+class HtmlMessageException extends Exception
+{
+    /**
+     * TODO
+     */
+    public function getHtmlMessage()
+    {
+        return $this->getMessage();
+    }
+}

--- a/core/Exceptions/HtmlMessageException.php
+++ b/core/Exceptions/HtmlMessageException.php
@@ -12,7 +12,7 @@ use Exception;
 
 /**
  * An exception whose message has HTML content. When these exceptions are caught
- * the messgae will not be sanitized before being displayed to the user.
+ * the message will not be sanitized before being displayed to the user.
  *
  * @api
  */

--- a/core/Filechecks.php
+++ b/core/Filechecks.php
@@ -8,6 +8,8 @@
  */
 namespace Piwik;
 
+use Piwik\Exceptions\HtmlMessageException;
+
 class Filechecks
 {
     /**
@@ -102,7 +104,7 @@ class Filechecks
             . "<p>After applying the modifications, you can <a href='index.php'>refresh the page</a>.</p>"
             . "<p>If you need more help, try <a href='?module=Proxy&action=redirect&url=http://piwik.org'>Piwik.org</a>.</p>";
 
-        Piwik_ExitWithMessage($directoryMessage, false, true);
+        throw new HtmlMessageException($directoryMessage);
     }
 
     /**

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -12,6 +12,7 @@ namespace Piwik;
 use Exception;
 use Piwik\API\Request;
 use Piwik\API\ResponseBuilder;
+use Piwik\Exceptions\HtmlMessageException;
 use Piwik\Http\Router;
 use Piwik\Plugin\Controller;
 use Piwik\Plugin\Report;
@@ -417,7 +418,7 @@ class FrontController extends Singleton
         try {
             $authAdapter = Registry::get('auth');
         } catch (Exception $e) {
-            throw new Exception("Authentication object cannot be found in the Registry. Maybe the Login plugin is not activated?
+            throw new HtmlMessageException("Authentication object cannot be found in the Registry. Maybe the Login plugin is not activated?
                             <br />You can activate the plugin by adding:<br />
                             <code>Plugins[] = Login</code><br />
                             under the <code>[Plugins]</code> section in your config/config.ini.php");

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -617,7 +617,20 @@ class FrontController extends Singleton
             $message = Common::sanitizeInputValue($ex->getMessage());
         }
 
-        return Piwik_GetErrorMessagePage($message, $debugTrace, true, true);
+        $result = Piwik_GetErrorMessagePage($message, $debugTrace, true, true);
+
+        /**
+         * Triggered before a Piwik error page is displayed to the user.
+         *
+         * This event can be used to modify the content of the error page that is displayed when
+         * an exception is caught.
+         *
+         * @param string &$result The HTML of the error page.
+         * @param Exception $ex The Exception displayed in the error page.
+         */
+        Piwik::postEvent('FrontController.modifyErrorPage', array(&$result, $ex));
+
+        return $result;
     }
 }
 

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -599,6 +599,26 @@ class FrontController extends Singleton
         Piwik::postEvent('Request.dispatch.end', array(&$result, $module, $action, $parameters));
         return $result;
     }
+
+    /**
+     * Returns HTML that displays an exception's error message (and possibly stack trace).
+     * The result of this method is echo'd by dispatch.php.
+     *
+     * @param Exception $ex The exception to use when generating the error page's HTML.
+     * @return string The HTML to echo.
+     */
+    public function getErrorResponse(Exception $ex)
+    {
+        $debugTrace = $ex->getTraceAsString();
+
+        if (method_exists($ex, 'getHtmlMessage')) {
+            $message = $ex->getHtmlMessage();
+        } else {
+            $message = Common::sanitizeInputValue($ex->getMessage());
+        }
+
+        return Piwik_GetErrorMessagePage($message, $debugTrace, true, true);
+    }
 }
 
 /**

--- a/core/Log.php
+++ b/core/Log.php
@@ -264,7 +264,10 @@ class Log extends Singleton
     private function setLogWritersFromConfig($logConfig)
     {
         // set the log writers
-        $logWriters = $logConfig[self::LOG_WRITERS_CONFIG_OPTION];
+        $logWriters = @$logConfig[self::LOG_WRITERS_CONFIG_OPTION];
+        if (empty($logWriters)) {
+            return;
+        }
 
         $logWriters = array_map('trim', $logWriters);
         foreach ($logWriters as $writerName) {
@@ -309,7 +312,11 @@ class Log extends Singleton
 
     private function setLogFilePathFromConfig($logConfig)
     {
-        $logPath = $logConfig[self::LOGGER_FILE_PATH_CONFIG_OPTION];
+        $logPath = @$logConfig[self::LOGGER_FILE_PATH_CONFIG_OPTION];
+        if (empty($logPath)) {
+            $logPath = $this->getDefaultFileLogPath();
+        }
+
         if (!SettingsServer::isWindows()
             && $logPath[0] != '/'
         ) {
@@ -320,6 +327,11 @@ class Log extends Singleton
             $logPath .= '/piwik.log';
         }
         $this->logToFilePath = $logPath;
+    }
+
+    private function getDefaultFileLogPath()
+    {
+        return 'tmp/logs/piwik.log';
     }
 
     private function getAvailableWriters()

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -17,6 +17,7 @@ use Piwik\Config as PiwikConfig;
 use Piwik\Config;
 use Piwik\DataTable\Filter\CalculateEvolutionFilter;
 use Piwik\Date;
+use Piwik\Exceptions\HtmlMessageException;
 use Piwik\FrontController;
 use Piwik\Menu\MenuTop;
 use Piwik\Menu\MenuUser;
@@ -581,61 +582,56 @@ abstract class Controller
     {
         $view->date = $this->strDate;
 
-        try {
-            $view->idSite = $this->idSite;
-            $this->checkSitePermission();
-            $this->setPeriodVariablesView($view);
+        $view->idSite = $this->idSite;
+        $this->checkSitePermission();
+        $this->setPeriodVariablesView($view);
 
-            $rawDate = Common::getRequestVar('date');
-            $periodStr = Common::getRequestVar('period');
-            if ($periodStr != 'range') {
-                $date = Date::factory($this->strDate);
-                $period = Period\Factory::build($periodStr, $date);
-            } else {
-                $period = new Range($periodStr, $rawDate, $this->site->getTimezone());
-            }
-            $view->rawDate = $rawDate;
-            $view->prettyDate = self::getCalendarPrettyDate($period);
+        $rawDate = Common::getRequestVar('date');
+        $periodStr = Common::getRequestVar('period');
+        if ($periodStr != 'range') {
+            $date = Date::factory($this->strDate);
+            $period = Period\Factory::build($periodStr, $date);
+        } else {
+            $period = new Range($periodStr, $rawDate, $this->site->getTimezone());
+        }
+        $view->rawDate = $rawDate;
+        $view->prettyDate = self::getCalendarPrettyDate($period);
 
-            $view->siteName = $this->site->getName();
-            $view->siteMainUrl = $this->site->getMainUrl();
+        $view->siteName = $this->site->getName();
+        $view->siteMainUrl = $this->site->getMainUrl();
 
-            $datetimeMinDate = $this->site->getCreationDate()->getDatetime();
-            $minDate = Date::factory($datetimeMinDate, $this->site->getTimezone());
-            $this->setMinDateView($minDate, $view);
+        $datetimeMinDate = $this->site->getCreationDate()->getDatetime();
+        $minDate = Date::factory($datetimeMinDate, $this->site->getTimezone());
+        $this->setMinDateView($minDate, $view);
 
-            $maxDate = Date::factory('now', $this->site->getTimezone());
-            $this->setMaxDateView($maxDate, $view);
+        $maxDate = Date::factory('now', $this->site->getTimezone());
+        $this->setMaxDateView($maxDate, $view);
 
-            // Setting current period start & end dates, for pre-setting the calendar when "Date Range" is selected
-            $dateStart = $period->getDateStart();
-            if ($dateStart->isEarlier($minDate)) {
-                $dateStart = $minDate;
-            }
-            $dateEnd = $period->getDateEnd();
-            if ($dateEnd->isLater($maxDate)) {
-                $dateEnd = $maxDate;
-            }
+        // Setting current period start & end dates, for pre-setting the calendar when "Date Range" is selected
+        $dateStart = $period->getDateStart();
+        if ($dateStart->isEarlier($minDate)) {
+            $dateStart = $minDate;
+        }
+        $dateEnd = $period->getDateEnd();
+        if ($dateEnd->isLater($maxDate)) {
+            $dateEnd = $maxDate;
+        }
 
-            $view->startDate = $dateStart;
-            $view->endDate = $dateEnd;
+        $view->startDate = $dateStart;
+        $view->endDate = $dateEnd;
 
-            $language = LanguagesManager::getLanguageForSession();
-            $view->language = !empty($language) ? $language : LanguagesManager::getLanguageCodeForCurrentUser();
+        $language = LanguagesManager::getLanguageForSession();
+        $view->language = !empty($language) ? $language : LanguagesManager::getLanguageCodeForCurrentUser();
 
-            $this->setBasicVariablesView($view);
+        $this->setBasicVariablesView($view);
 
-            $view->topMenu  = MenuTop::getInstance()->getMenu();
-            $view->userMenu = MenuUser::getInstance()->getMenu();
+        $view->topMenu  = MenuTop::getInstance()->getMenu();
+        $view->userMenu = MenuUser::getInstance()->getMenu();
 
-            $notifications = $view->notifications;
-            if (empty($notifications)) {
-                $view->notifications = NotificationManager::getAllNotificationsToDisplay();
-                NotificationManager::cancelAllNonPersistent();
-            }
-
-        } catch (Exception $e) {
-            Piwik_ExitWithMessage($e->getMessage(), $e->getTraceAsString());
+        $notifications = $view->notifications;
+        if (empty($notifications)) {
+            $view->notifications = NotificationManager::getAllNotificationsToDisplay();
+            NotificationManager::cancelAllNonPersistent();
         }
     }
 
@@ -841,15 +837,20 @@ abstract class Controller
         }
 
         if (Piwik::hasUserSuperUserAccess()) {
-            Piwik_ExitWithMessage("Error: no website was found in this Piwik installation.
-			<br />Check the table '" . Common::prefixTable('site') . "' in your database, it should contain your Piwik websites.", false, true);
+            $siteTableName = Common::prefixTable('site');
+            $message = "Error: no website was found in this Piwik installation.
+			<br />Check the table '$siteTableName' in your database, it should contain your Piwik websites.";
+
+            throw new HtmlMessageException($message);
         }
 
         if (!Piwik::isUserIsAnonymous()) {
+            $currentLogin = Piwik::getCurrentUserLogin();
             $emails = implode(',', Piwik::getAllSuperUserAccessEmailAddresses());
             $errorMessage = sprintf(Piwik::translate('CoreHome_NoPrivilegesAskPiwikAdmin'), $currentLogin, "<br/><a href='mailto:" . $emails . "?subject=Access to Piwik for user $currentLogin'>", "</a>");
             $errorMessage .= "<br /><br />&nbsp;&nbsp;&nbsp;<b><a href='index.php?module=" . Registry::get('auth')->getName() . "&amp;action=logout'>&rsaquo; " . Piwik::translate('General_Logout') . "</a></b><br />";
-            Piwik_ExitWithMessage($errorMessage, false, true);
+
+            throw new HtmlMessageException($errorMessage);
         }
 
         echo FrontController::getInstance()->dispatch(Piwik::getLoginPluginName(), false);

--- a/core/Session.php
+++ b/core/Session.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\Exceptions\HtmlMessageException;
 use Piwik\Session\SaveHandler\DbTable;
 use Zend_Session;
 
@@ -38,6 +39,7 @@ class Session extends Zend_Session
      *
      * @param array|bool $options An array of configuration options; the auto-start (bool) setting is ignored
      * @return void
+     * @throws Exception if starting a session fails
      */
     public static function start($options = false)
     {
@@ -130,7 +132,7 @@ class Session extends Zend_Session
                 $e->getMessage()
             );
 
-            Piwik_ExitWithMessage($message, $e->getTraceAsString());
+            throw new HtmlMessageException($message, $e->getCode(), $e);
         }
     }
 

--- a/core/dispatch.php
+++ b/core/dispatch.php
@@ -41,14 +41,10 @@ if (PIWIK_ENABLE_DISPATCH) {
             echo $response;
         }
     } catch (Exception $ex) {
-        $debugTrace = $ex->getTraceAsString();
+        $response = $controller->getErrorResponse($ex);
 
-        if (method_exists($ex, 'getHtmlMessage')) {
-            $message = $ex->getHtmlMessage();
-        } else {
-            $message = Piwik\Common::sanitizeInputValue($ex->getMessage());
-        }
+        echo $response;
 
-        Piwik_ExitWithMessage($message, $debugTrace, true, true);
+        exit(1);
     }
 }

--- a/core/dispatch.php
+++ b/core/dispatch.php
@@ -30,12 +30,25 @@ if (!defined('PIWIK_ENABLE_DISPATCH')) {
 
 if (PIWIK_ENABLE_DISPATCH) {
     $controller = FrontController::getInstance();
-    $controller->init();
-    $response = $controller->dispatch();
 
-    if (is_array($response)) {
-        var_export($response);
-    } elseif (!is_null($response)) {
-        echo $response;
+    try {
+        $controller->init();
+        $response = $controller->dispatch();
+
+        if (is_array($response)) {
+            var_export($response);
+        } elseif (!is_null($response)) {
+            echo $response;
+        }
+    } catch (Exception $ex) {
+        $debugTrace = $ex->getTraceAsString();
+
+        if (method_exists($ex, 'getHtmlMessage')) {
+            $message = $ex->getHtmlMessage();
+        } else {
+            $message = Piwik\Common::sanitizeInputValue($ex->getMessage());
+        }
+
+        Piwik_ExitWithMessage($message, $debugTrace, true, true);
     }
 }

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -82,6 +82,8 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
     /**
      * Displays info/warning/error message in a friendly UI and exits.
      *
+     * Note: this method should not be called by anyone other than FrontController.
+     *
      * @param string $message Main message, must be html encoded before calling
      * @param bool|string $optionalTrace Backtrace; will be displayed in lighter color
      * @param bool $optionalLinks If true, will show links to the Piwik website for help

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -64,7 +64,7 @@ if ($minimumPhpInvalid) {
 
 define('PAGE_TITLE_WHEN_ERROR', 'Piwik &rsaquo; Error');
 
-if (!function_exists('Piwik_ExitWithMessage')) {
+if (!function_exists('Piwik_GetErrorMessagePage')) {
     /**
      * Returns true if Piwik should print the backtrace with error messages.
      *
@@ -86,8 +86,9 @@ if (!function_exists('Piwik_ExitWithMessage')) {
      * @param bool|string $optionalTrace Backtrace; will be displayed in lighter color
      * @param bool $optionalLinks If true, will show links to the Piwik website for help
      * @param bool $optionalLinkBack If true, displays a link to go back
+     * @return string
      */
-    function Piwik_ExitWithMessage($message, $optionalTrace = false, $optionalLinks = false, $optionalLinkBack = false)
+    function Piwik_GetErrorMessagePage($message, $optionalTrace = false, $optionalLinks = false, $optionalLinkBack = false)
     {
         if (!headers_sent()) {
             header('Content-Type: text/html; charset=utf-8');
@@ -133,17 +134,19 @@ if (!function_exists('Piwik_ExitWithMessage')) {
         $message = str_replace("\t", "", $message);
         $message = strip_tags($message);
 
-        if ($isCli) {
-            echo $message;
-        } else {
-            echo $headerPage . $content . $footerPage;
+        if (!$isCli) {
+            $message = $headerPage . $content . $footerPage;
         }
-        echo "\n";
+
+        $message .= "\n";
+
         error_log(sprintf("Error in Piwik: %s", str_replace("\n", " ", $message)));
-        exit(1);
+
+        return $message;
     }
 }
 
 if (!empty($piwik_errorMessage)) {
-    Piwik_ExitWithMessage($piwik_errorMessage, false, true);
+    echo Piwik_GetErrorMessagePage($piwik_errorMessage, false, true);
+    exit(1);
 }

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\CorePluginsAdmin;
 use Exception;
 use Piwik\API\Request;
 use Piwik\Common;
+use Piwik\Exceptions\HtmlMessageException;
 use Piwik\Filechecks;
 use Piwik\Filesystem;
 use Piwik\Nonce;
@@ -361,8 +362,8 @@ class Controller extends Plugin\ControllerAdmin
             return $message;
         }
 
-        if (Common::isPhpCliMode()) {
-            Piwik_ExitWithMessage("Error:" . var_export($lastError, true));
+        if (Common::isPhpCliMode()) { // TODO: I can't find how this will ever get called / safeMode is never set for Console
+            throw new Exception("Error: " . var_export($lastError, true));
         }
 
         $view = new View('@CorePluginsAdmin/safemode');
@@ -445,7 +446,8 @@ class Controller extends Plugin\ControllerAdmin
                 $pluginName);
             $exitMessage = $messageIntro . "<br/><br/>" . $messagePermissions;
             $exitMessage .= "<br> Or manually delete this directory (using FTP or SSH access)";
-            Piwik_ExitWithMessage($exitMessage, $optionalTrace = false, $optionalLinks = false, $optionalLinkBack = true);
+
+            throw new HtmlMessageException($exitMessage);
         }
 
         $this->redirectAfterModification($redirectAfter);

--- a/plugins/Installation/Installation.php
+++ b/plugins/Installation/Installation.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\Installation;
 
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Exceptions\HtmlMessageException;
 use Piwik\FrontController;
 use Piwik\Piwik;
 use Piwik\Translate;
@@ -42,7 +43,7 @@ class Installation extends \Piwik\Plugin
         $view = new PiwikView("@Installation/cannotConnectToDb");
         $view->exceptionMessage = $exception->getMessage();
 
-        Piwik_ExitWithMessage($view->render());
+        throw new HtmlMessageException($view->render());
     }
 
     public function dispatchIfNotInstalledYet(&$module, &$action, &$parameters)


### PR DESCRIPTION
As title. Also includes refactoring Piwik_ExitWithMessage so no echo-ing or exit-ing is done by the function (function is renamed). Includes modification to Log.php so it will work even if config is empty. Finally, includes event that allows modification of error page contents.

Thoughts and reviews are welcome (cc @mattab @mnapoli @tsteur ).

Tests I did:
- check config.php exceptions result in correct error page
- Filechecks.php (check changed code results in same behavior)
- FrontController::init() (check changed code results in same behavior)
- Log succeeds when no config available.
- Controller.php (check changed code results in same behavior)
- minimum php version warning (check error message displayed the same)
- CorePluginsAdmin controller (check changed code results in same behavior)
- installation (check works)
