### PR TITLE
Remove TestRunner plugin in latest.zip

### DIFF
--- a/misc/package/build.sh
+++ b/misc/package/build.sh
@@ -65,6 +65,9 @@ function organizePackage() {
     mkdir piwik/tests
     mv README.md piwik/tests/
 
+    sed -i '/Plugins\[\] = TestRunner/d' config/global.ini.php
+    rm -rf piwik/plugins/TestRunner
+
     cp piwik/misc/How\ to\ install\ Piwik.html .
     if [ -e piwik/misc/package ]; then
         cp piwik/misc/package/WebAppGallery/*.* .


### PR DESCRIPTION
Just a suggestion. Feel free to merge or not. It is a bit fragile this way but should work and if it doesn't work it wouldn't really hurt :) Maybe it would be an idea to move the build.sh script using Phing or something similar. This would make it much less fragile.

refs #6533  #6429 
