### PR TITLE
Speed up unit tests

### DIFF
--- a/tests/PHPUnit/Unit/AssetManagerTest.php
+++ b/tests/PHPUnit/Unit/AssetManagerTest.php
@@ -251,7 +251,7 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
     {
         $this->clearDateCache();
 
-        sleep(1.5);
+        sleep(1);
 
         $modificationDate = $this->mergedAsset->getModificationDate();
 

--- a/tests/PHPUnit/Unit/AssetManagerTest.php
+++ b/tests/PHPUnit/Unit/AssetManagerTest.php
@@ -239,23 +239,9 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    private function clearDateCache()
+    private function getAssetContent()
     {
-        clearstatcache();
-    }
-
-    /**
-     * @return int
-     */
-    private function waitAndGetModificationDate()
-    {
-        $this->clearDateCache();
-
-        sleep(1);
-
-        $modificationDate = $this->mergedAsset->getModificationDate();
-
-        return $modificationDate;
+        return $this->mergedAsset->getContent();
     }
 
     /**
@@ -393,23 +379,19 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param int $previousDate
+     * @param string $previousContent
      */
-    private function validateDateDidNotChange($previousDate)
+    private function assertAssetContentIsSameAs($previousContent)
     {
-        $this->clearDateCache();
-
-        $this->assertEquals($previousDate, $this->mergedAsset->getModificationDate());
+        $this->assertEquals($previousContent, $this->getAssetContent());
     }
 
     /**
-     * @param int $previousDate
+     * @param string $previousContent
      */
-    private function validateDateIsMoreRecent($previousDate)
+    private function assertAssetContentChanged($previousContent)
     {
-        $this->clearDateCache();
-
-        $this->assertTrue($previousDate < $this->mergedAsset->getModificationDate());
+        $this->assertNotEquals($previousContent, $this->getAssetContent());
     }
 
     /**
@@ -496,11 +478,11 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
 
         $this->triggerGetMergedCoreJavaScript();
 
-        $modDateBeforeSecondRequest = $this->waitAndGetModificationDate();
+        $content = $this->getAssetContent();
 
         $this->triggerGetMergedCoreJavaScript();
 
-        $this->validateDateDidNotChange($modDateBeforeSecondRequest);
+        $this->assertAssetContentIsSameAs($content);
     }
 
     /**
@@ -514,13 +496,13 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
 
         $this->triggerGetMergedCoreJavaScript();
 
-        $modDateBeforeSecondRequest = $this->waitAndGetModificationDate();
+        $content = $this->getAssetContent();
 
         $this->setJSCacheBuster(self::SECOND_CACHE_BUSTER_JS);
 
         $this->triggerGetMergedCoreJavaScript();
 
-        $this->validateDateIsMoreRecent($modDateBeforeSecondRequest);
+        $this->assertAssetContentChanged($content);
 
         $this->validateMergedCoreJs();
     }
@@ -549,13 +531,13 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
 
         $this->triggerGetMergedStylesheet();
 
-        $modDateBeforeSecondRequest = $this->waitAndGetModificationDate();
+        $content = $this->getAssetContent();
 
         $this->setStylesheetCacheBuster(self::SECOND_CACHE_BUSTER_SS);
 
         $this->triggerGetMergedStylesheet();
 
-        $this->validateDateIsMoreRecent($modDateBeforeSecondRequest);
+        $this->assertAssetContentChanged($content);
 
         $this->validateMergedStylesheet();
     }
@@ -572,13 +554,13 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
 
         $this->triggerGetMergedStylesheet();
 
-        $modDateBeforeSecondRequest = $this->waitAndGetModificationDate();
+        $content = $this->getAssetContent();
 
         $this->setStylesheetCacheBuster(self::SECOND_CACHE_BUSTER_SS);
 
         $this->triggerGetMergedStylesheet();
 
-        $this->validateDateIsMoreRecent($modDateBeforeSecondRequest);
+        $this->assertAssetContentChanged($content);
 
         $this->validateMergedStylesheet();
     }
@@ -594,11 +576,11 @@ class AssetManagerTest extends PHPUnit_Framework_TestCase
 
         $this->triggerGetMergedStylesheet();
 
-        $modDateBeforeSecondRequest = $this->waitAndGetModificationDate();
+        $content = $this->getAssetContent();
 
         $this->triggerGetMergedStylesheet();
 
-        $this->validateDateDidNotChange($modDateBeforeSecondRequest);
+        $this->assertAssetContentIsSameAs($content);
     }
 
     /**

--- a/tests/PHPUnit/Unit/CliMulti/ProcessTest.php
+++ b/tests/PHPUnit/Unit/CliMulti/ProcessTest.php
@@ -102,11 +102,13 @@ class ProcessTest extends PHPUnit_Framework_TestCase
 
     public function test_getSecondsSinceCreation()
     {
-        sleep(2);
+        // This is not proper, but it avoids using sleep and stopping the tests for several seconds
+        $r = new ReflectionProperty($this->process, 'timeCreation');
+        $r->setAccessible(true);
+        $r->setValue($this->process, time() - 2);
+
         $seconds = $this->process->getSecondsSinceCreation();
 
-        $this->assertGreaterThanOrEqual(2, $seconds);
-        $this->assertLessThanOrEqual(3, $seconds);
+        $this->assertEquals(2, $seconds);
     }
-
 }

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -5,6 +5,8 @@ use Piwik\Filesystem;
 /**
  * Piwik - free/libre analytics platform
  *
+ * @backupGlobals enabled
+ *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */

--- a/tests/PHPUnit/Unit/DataTable/Filter/PivotByDimensionTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PivotByDimensionTest.php
@@ -181,6 +181,9 @@ class PivotByDimensionTest extends PHPUnit_Framework_TestCase
         $this->assertTableRowsEquals($expectedRows, $table);
     }
 
+    /**
+     * @backupGlobals enabled
+     */
     public function test_filter_UsesCorrectSegment_WhenPivotingSegmentedReport()
     {
         $this->loadPlugins('Referrers', 'UserCountry', 'CustomVariables');

--- a/tests/PHPUnit/Unit/IPTest.php
+++ b/tests/PHPUnit/Unit/IPTest.php
@@ -7,6 +7,8 @@ use Piwik\SettingsServer;
 /**
  * Piwik - free/libre analytics platform
  *
+ * @backupGlobals enabled
+ *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */

--- a/tests/PHPUnit/Unit/NonceTest.php
+++ b/tests/PHPUnit/Unit/NonceTest.php
@@ -5,6 +5,8 @@ use Piwik\Nonce;
 /**
  * Piwik - free/libre analytics platform
  *
+ * @backupGlobals enabled
+ *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -5,6 +5,8 @@ use Piwik\Url;
 /**
  * Piwik - free/libre analytics platform
  *
+ * @backupGlobals enabled
+ *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */


### PR DESCRIPTION
On my machine the unit tests went from 20 seconds to 5 seconds! (with several plugins installed)

I've done some profiling to see where we have some room for improvements:
- I've removed usages of `sleep()` in the tests and replaced with something else
- we can run the unit tests with the `--no-globals-backup`: globals backup by PHPUnit was the most expensive operation in all the test run
- we can run without xdebug using `php -n`

About `--no-globals-backup`: unit tests should obviously not mess with global variables, so there shouldn't be any problem in theory. However there are some tests that do change the global variables, so for each of these tests I've used the `@backupGlobals enabled` annotation.

E.g. you can use this command line:

```
$ php -n ../../vendor/bin/phpunit --testsuite UnitTests --no-globals-backup
```

Or you can also setup PhpStorm by setting `--testsuite UnitTests --no-globals-backup` in the "Test Runner options" and `-n` in "Interpreter options".
