### PR TITLE
Add compatibility for running ./console with php-cgi by setting SERVER args from GET parameters.

### DIFF
--- a/core/Console.php
+++ b/core/Console.php
@@ -119,6 +119,10 @@ class Console extends Application
 
                 $_SERVER['argv'][] = $argument;
             }
+
+            if (!defined('STDIN')) {
+                define('STDIN', fopen('php://stdin','r'));
+            }
         }
     }
 

--- a/core/Console.php
+++ b/core/Console.php
@@ -33,7 +33,7 @@ class Console extends Application
 
     public function init()
     {
-        $this->checkCompatibility();
+        $this->setServerArgsIfPhpCgi();
     }
 
     public function doRun(InputInterface $input, OutputInterface $output)
@@ -107,13 +107,18 @@ class Console extends Application
         return $commands;
     }
 
-    private function checkCompatibility()
+    private function setServerArgsIfPhpCgi()
     {
         if (Common::isPhpCgiType()) {
-            echo 'Piwik Console is known to be not compatible with PHP-CGI (you are using '.php_sapi_name().'). ' .
-                 'Please execute console using PHP-CLI. For instance "/usr/bin/php-cli console ..."';
-            echo "\n";
-            exit(1);
+            $_SERVER['argv'] = array();
+            foreach ($_GET as $name => $value) {
+                $argument = $name;
+                if (!empty($value)) {
+                    $argument .= '=' . $value;
+                }
+
+                $_SERVER['argv'][] = $argument;
+            }
         }
     }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -844,6 +844,8 @@ class CronArchive
 
         $config->log = $log;
 
+        Log::unsetInstance();
+        
         // Make sure we log at least INFO (if logger is set to DEBUG then keep it)
         $logLevel = Log::getInstance()->getLogLevel();
         if ($logLevel < Log::INFO) {


### PR DESCRIPTION
As title. Tested `php-cgi ./console list`, `php-cgi ./console help tests:run`, `php-cgi ./console test:run Core_OptionsTest` and `php-cgi ./console core:archive --url=localhost`. No output received on last one, but logs show archiving succeeded.

What do you think @tsteur?

CC @mattab 
