### PR TITLE
Add command to benchmark either a PHPUnit test case w/ custom Piwik related code or Piwik URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ before_script:
   - ./tests/travis/prepare.sh
   - ./tests/travis/setup_webserver.sh
 
-  - export GENERATE_TRAVIS_YML_COMMAND="php ./console generate:travis-yml --core"
+  - export GENERATE_TRAVIS_YML_COMMAND="php ./console  --core"
   - ./tests/travis/autoupdate_travis_yml.sh
 
   - cd tests/PHPUnit

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -117,8 +117,13 @@ class CliMulti {
     {
         $bin = $this->findPhpBinary();
 
-        return sprintf('%s %s/console climulti:request --piwik-domain=%s %s > %s 2>&1 &',
-                       $bin, PIWIK_INCLUDE_PATH, escapeshellarg($hostname), escapeshellarg($query), $outputFile);
+        $domainArg = '';
+        if (!empty($hostname)) {
+            $domainArg = '--piwik-domain=' . escapeshellarg($hostname);
+        }
+
+        return sprintf('%s %s/console climulti:request %s %s > %s 2>&1 &',
+                       $bin, PIWIK_INCLUDE_PATH, $domainArg, escapeshellarg($query), $outputFile);
     }
 
     private function getResponse()

--- a/core/CliMulti/RequestCommand.php
+++ b/core/CliMulti/RequestCommand.php
@@ -70,7 +70,9 @@ class RequestCommand extends ConsoleCommand
         $_GET = array();
 
         $hostname = $input->getOption('piwik-domain');
-        Url::setHost($hostname);
+        if (!empty($hostname)) {
+            Url::setHost($hostname);
+        }
 
         $query = $input->getArgument('url-query');
         $query = UrlHelper::getArrayFromQueryString($query);

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -50,4 +50,38 @@ class ConsoleCommand extends SymfonyCommand
             }
         }
     }
+
+    protected function getConsoleCommandStringFromInput(InputInterface $input)
+    {
+        return $this->getConsoleCommandString($input->getArguments(), $input->getOptions());
+    }
+
+    protected function getConsoleCommandString($arguments, $options)
+    {
+        $command = "php ./console " . $this->getName();
+
+        foreach ($arguments as $argValue) {
+            $command .= " \"" . addslashes($argValue) . "\"";
+        }
+
+        foreach ($options as $name => $value) {
+            if ($value === false
+                || $value === null
+            ) {
+                continue;
+            }
+
+            if ($value === true) {
+                $command .= " --$name";
+            } else if (is_array($value)) {
+                foreach ($value as $arrayValue) {
+                    $command .= " --$name=\"" . addslashes($arrayValue) . "\"";
+                }
+            } else {
+                $command .= " --$name=\"" . addslashes($value) . "\"";
+            }
+        }
+
+        return $command;
+    }
 }

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -58,7 +58,7 @@ class ConsoleCommand extends SymfonyCommand
 
     protected function getConsoleCommandString($arguments, $options)
     {
-        $command = "php ./console " . $this->getName();
+        $command = "php ./console ";
 
         foreach ($arguments as $argValue) {
             $command .= " \"" . addslashes($argValue) . "\"";

--- a/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
+++ b/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
@@ -132,32 +132,11 @@ class GenerateTravisYmlFile extends ConsoleCommand
 
     private function getExecutedConsoleCommandForTravis(InputInterface $input)
     {
-        $command = "php ./console " . $this->getName();
-
-        $arguments = $input->getOptions();
-        unset($arguments['github-token']);
-        unset($arguments['artifacts-pass']);
-        unset($arguments['dump']);
-
-        foreach ($arguments as $name => $value) {
-            if ($value === false
-                || $value === null
-            ) {
-                continue;
-            }
-
-            if ($value === true) {
-                $command .= " --$name";
-            } else if (is_array($value)) {
-                foreach ($value as $arrayValue) {
-                    $command .= " --$name=\"" . addslashes($arrayValue) . "\"";
-                }
-            } else {
-                $command .= " --$name=\"" . addslashes($value) . "\"";
-            }
-        }
-
-        return $command;
+        $options = $input->getOptions();
+        unset($options['github-token']);
+        unset($options['artifacts-pass']);
+        unset($options['dump']);
+        return $this->getConsoleCommandString($args = array(), $options);
     }
 
 

--- a/plugins/TestRunner/Commands/TestsBenchmark.php
+++ b/plugins/TestRunner/Commands/TestsBenchmark.php
@@ -95,14 +95,16 @@ You can also run the tests on EC2 (if you have the proper credentials) and run t
         $arguments = $input->getArguments();
         $options = $input->getOptions();
 
+        unset($options['aws']);
+
         if (!empty($fixtureFile)) {
             $testRunner->uploadFile($fixtureFile, 'tmp/BenchmarkFixture.php');
-            $options['--fixture-file'] = 'tmp/BenchmarkFixture.php';
+            $options['fixture-file'] = 'tmp/BenchmarkFixture.php';
         }
 
         if (!empty($benchmarkFile)) {
             $testRunner->uploadFile($benchmarkFile, 'tmp/BenchmarkTestCase.php');
-            $options['--benchmark-file'] = 'tmp/BenchmarkTestCase.php';
+            $options['benchmark-file'] = 'tmp/BenchmarkTestCase.php';
         }
 
         $thisCommand = $this->getConsoleCommandString($arguments, $options);

--- a/plugins/TestRunner/Commands/TestsBenchmark.php
+++ b/plugins/TestRunner/Commands/TestsBenchmark.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\TestRunner\Commands;
+
+use Piwik\Profiler;
+use Piwik\CliMulti;
+use Piwik\Plugin\ConsoleCommand;
+use Piwik\SettingsPiwik;
+use Piwik\Plugins\TestRunner\Aws\Config;
+use Piwik\Plugins\TestRunner\Aws\Instance;
+use Piwik\Plugins\TestRunner\Aws\Ssh;
+use Piwik\Plugins\TestRunner\Runner\InstanceLauncher;
+use Piwik\Plugins\TestRunner\Runner\Remote;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\OutputInterface;
+use InvalidArgumentException;
+use Exception;
+
+/**
+ * Benchmarks Piwik code.
+ */
+class TestsBenchmark extends ConsoleCommand
+{
+    protected function configure()
+    {
+        $this->setName('tests:benchmark');
+        $this->setDescription('Run a Piwik benchmark locally or on AWS.');
+        $this->addOption('benchmark-file', null, InputOption::VALUE_REQUIRED, 'Run the test case found in this file. Specify a path to the file.');
+        $this->addOption('fixture', null, InputOption::VALUE_REQUIRED,
+            'The data to load into the DB before benchmarking. This argument is required and should be set to a fully qualified'
+          . ' class name.');
+        $this->addOption('fixture-file', null, InputOption::VALUE_REQUIRED, 'Path to the PHP file that contains the fixture definition to use.');
+        $this->addOption('url', null, InputOption::VALUE_REQUIRED,
+            'A Piwik request URL to benchmark. eg, "?module=API&action=VisitsSummary.get&idSite=1&date=today&period=day"');
+        $this->addOption('aws', null, InputOption::VALUE_NONE, 'If supplied, benchmark is run on AWS. (recommended for core devs)');
+        $this->addOption('xhprof', null, InputOption::VALUE_NONE, 'If supplied, execution is profiled w/ xhprof.');
+        $this->addOption('checkout', null, InputOption::VALUE_REQUIRED, 'Git hash, tag or branch to checkout. Defaults to current hash', $this->getCurrentGitHash());
+        $this->setHelp('This command will benchmark a URL or PHPUnit test case of your choosing. Before executing the benchmark, it will load a fixture of your choosing into the database. This lets you run benchmarks under any number of conditions.
+
+To benchmark a URL, run the command using the --url=\'?...\' option. To benchmark a PHPUnit test case, run the command with the --benchmark-file=path/to/file.php option.
+
+Specify a fixture to setup before running the benchmark with the --fixture=Piwik\\\\Tests\\\\Fixtures\\\\SomeFixtureClass option. You can benchmark with your own test data by creating a new fixture in a PHP class and using the --fixture-file=path/to/fixture.php option. Then specify the fixture class using the --fixture=... option.
+
+You can also run the tests on EC2 (if you have the proper credentials) and run the benchmark w/ xhprof using the appropriate options.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $benchmarkFile = $input->getOption('benchmark-file');
+        $fixture = $input->getOption('fixture');
+        $fixtureFile = $input->getOption('fixture-file');
+        $urlToTest = $input->getOption('url');
+        $useAws = $input->getOption('aws');
+        $useXhprof = $input->getOption('xhprof');
+        $gitHash = $input->getOption('checkout');
+
+        $this->checkThereIsSomethingToTest($benchmarkFile, $urlToTest);
+        $this->checkTheFixtureCanBeFound($fixture, $fixtureFile);
+
+        if ($useAws) {
+            $this->launchAndForwardCommandToAws($input, $output, $gitHash);
+        } else {
+            $this->loadFixture($output, $fixture);
+            $this->executeBenchmark($output, $urlToTest, $benchmarkFile, $useXhprof);
+        }
+    }
+
+    private function launchAndForwardCommandToAws(InputInterface $input, OutputInterface $output, $gitHash)
+    {
+        // TODO: code duplication w/ TestsRunOnAws.
+        $awsConfig = new Config();
+        $awsConfig->validate();
+
+        $runOnAwsCommand = new TestsRunOnAws();
+        $host = $runOnAwsCommand->launchInstance($output, $useOneInstancePerTestSuite = false, $awsConfig, $testSuite = null);
+
+        $ssh = Ssh::connectToAws($host, $awsConfig->getPemFile());
+        $ssh->setOutput($output);
+
+        $testRunner = new Remote($ssh);
+        $testRunner->updatePiwik($gitHash);
+        $testRunner->replaceConfigIni(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Aws/config.ini.php');
+
+        if (!empty($patchFile)) {
+            $testRunner->applyPatch($patchFile);
+        }
+
+        // TODO: need to send the benchmark file & fixture file if running on AWS
+
+        $thisCommand = $this->getConsoleCommandStringFromInput($input);
+        $ssh->exec($thisCommand);
+    }
+
+    private function loadFixture(OutputInterface $output, $fixtureClass)
+    {
+        $output->writeln("Setting up fixture <comment>$fixtureClass</comment>...");
+
+        $fixtureInput = new ArrayInput(array(
+            'fixture' => $fixtureClass
+        ));
+
+        $setupFixture = new TestsSetupFixture();
+        $setupFixture->run($fixtureInput, $output);
+    }
+
+    private function executeBenchmark(OutputInterface $output, $urlToTest, $benchmarkFile, $useXhprof)
+    {
+        if (!empty($benchmarkFile)) {
+            $this->benchmarkPhpTestCase($output, $benchmarkFile, $useXhprof);
+        } else {
+            $this->benchmarkPiwikUrl($output, $urlToTest, $useXhprof);
+        }
+    }
+
+    private function benchmarkPhpTestCase(OutputInterface $output, $urlToTest, $benchmarkFile, $useXhprof)
+    {
+        if ($useXhprof) {
+            Profiler::setupProfilerXHProf($isMainRun = true);
+            putenv('PIWIK_USE_XHPROF=1');
+
+            $output->writeln("Using xhprof.");
+        }
+
+        $output->writeln("Running the test cases in <comment>$benchmarkFile</comment>...");
+
+        $phpunitCommand = 'cd tests/PHPUnit && ../../vendor/phpunit/phpunit/phpunit "' . $benchmarkFile . '"';
+
+        $startTime = microtime(true);
+        passthru($phpunitCommand);
+        $elapsed = microtime(true) - $startTime;
+
+        $this->finishBenchmark($output, $elapsed);
+    }
+
+    private function benchmarkPiwikUrl(OutputInterface $output, $urlToTest, $useXhprof)
+    {
+        if ($useXhprof) {
+            $urlToTest .= '&xhprof=1';
+        }
+
+        $urlToTest .= '&testmode=1';
+
+        $output->writeln("Requesting <comment>$urlToTest</comment>...");
+
+        $cliMulti = new CliMulti();
+
+        $startTime = microtime(true);
+        $requestOutput = $cliMulti->request(array($urlToTest));
+        $elapsed = microtime(true) - $startTime;
+
+        $this->finishBenchmark($output, $elapsed);
+
+        $output->writeln("Url returned: <comment>" . reset($requestOutput) . "</comment>");
+    }
+
+    private function finishBenchmark(OutputInterface $output, $elapsed)
+    {
+        $output->writeln("");
+        $output->writeln("Finished in <comment>{$elapsed}s</comment>.");
+        $output->writeln("");
+    }
+
+    private function checkThereIsSomethingToTest($benchmarkFile, $urlToTest)
+    {
+        // TODO: split into multiple functions
+        if (empty($benchmarkFile)
+            && empty($urlToTest)
+        ) {
+            throw new Exception("Nothing to test: either the --benchmark-file or the --url must be specified.");
+        }
+
+        if (!empty($benchmarkFile)
+            && !empty($urlToTest)
+        ) {
+            throw new Exception("Both --benchmark-file and --url specified, not sure which to test. Please use only one.");
+        }
+
+        if (!empty($benchmarkFile)) {
+            if (!file_exists($benchmarkFile)) {
+                throw new Exception("Cannot find benchmark file '$benchmarkFile'.");
+            }
+        }
+    }
+
+    private function checkTheFixtureCanBeFound($fixture, $fixtureFile)
+    {
+        if (empty($fixture)) {
+            throw new Exception("The --fixture option is required. Set it to the fully qualified class name of the fixture to load.");
+        }
+
+        if (!empty($fixtureFile)) {
+            if (!file_exists($fixtureFile)) {
+                throw new Exception("Cannot find fixture file '$fixtureFile'.");
+            }
+
+            require_once $fixtureFile;
+        }
+
+        if (!class_exists($fixture)) {
+            throw new Exception("Fixture '$fixture' does not exist.");
+        }
+    }
+
+    // TODO: copied from other command, must refactor
+    private function getCurrentGitHash()
+    {
+        return trim(`git rev-parse HEAD`);
+    }
+}

--- a/plugins/TestRunner/Commands/TestsBenchmark.php
+++ b/plugins/TestRunner/Commands/TestsBenchmark.php
@@ -130,7 +130,7 @@ You can also run the tests on EC2 (if you have the proper credentials) and run t
         }
     }
 
-    private function benchmarkPhpTestCase(OutputInterface $output, $urlToTest, $benchmarkFile, $useXhprof)
+    private function benchmarkPhpTestCase(OutputInterface $output, $benchmarkFile, $useXhprof)
     {
         if ($useXhprof) {
             Profiler::setupProfilerXHProf($isMainRun = true);
@@ -141,13 +141,20 @@ You can also run the tests on EC2 (if you have the proper credentials) and run t
 
         $output->writeln("Running the test cases in <comment>$benchmarkFile</comment>...");
 
-        $phpunitCommand = 'cd tests/PHPUnit && ../../vendor/phpunit/phpunit/phpunit "' . $benchmarkFile . '"';
+        $phpunitCommand = 'cd tests/PHPUnit && ../../vendor/phpunit/phpunit/phpunit "' . '../../' . $benchmarkFile . '"';
 
         $startTime = microtime(true);
-        passthru($phpunitCommand);
+        exec($phpunitCommand, $commandOutput, $returnCode);
         $elapsed = microtime(true) - $startTime;
 
-        $this->finishBenchmark($output, $elapsed);
+        if ($returnCode != 0) {
+            $output->writeln("");
+            $output->writeln("<error>PHPUNIT FAILED, output:</error>");
+            $output->writeln("");
+            $output->writeln(implode("\n", $commandOutput));
+        } else {
+            $this->finishBenchmark($output, $elapsed);
+        }
     }
 
     private function benchmarkPiwikUrl(OutputInterface $output, $urlToTest, $useXhprof)

--- a/plugins/TestRunner/Commands/TestsRun.php
+++ b/plugins/TestRunner/Commands/TestsRun.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
 
 namespace Piwik\Plugins\TestRunner\Commands;

--- a/plugins/TestRunner/Commands/TestsRunOnAws.php
+++ b/plugins/TestRunner/Commands/TestsRunOnAws.php
@@ -109,7 +109,7 @@ This feature is still beta and there might be problems with pictures and/or bina
         $ssh->disconnect();
     }
 
-    private function launchInstance(OutputInterface $output, $useOneInstancePerTestSuite, Config $awsConfig, $testSuite)
+    public function launchInstance(OutputInterface $output, $useOneInstancePerTestSuite, Config $awsConfig, $testSuite)
     {
         $awsInstance = new Instance($awsConfig, $testSuite);
 

--- a/plugins/TestRunner/Commands/TestsRunOnAws.php
+++ b/plugins/TestRunner/Commands/TestsRunOnAws.php
@@ -16,6 +16,7 @@ use Piwik\Plugins\TestRunner\Aws\Instance;
 use Piwik\Plugins\TestRunner\Aws\Ssh;
 use Piwik\Plugins\TestRunner\Runner\InstanceLauncher;
 use Piwik\Plugins\TestRunner\Runner\Remote;
+use Piwik\Plugins\TestRunner\GitRepository;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -32,12 +33,14 @@ class TestsRunOnAws extends ConsoleCommand
 
     protected function configure()
     {
+        $thisRepo = new GitRepository(PIWIK_USER_PATH);
+
         $this->setName('tests:run-aws');
         $this->addArgument('testsuite', InputArgument::OPTIONAL, 'Allowed values: ' . implode(', ', $this->allowedTestSuites));
         $this->addOption('launch-only', null, InputOption::VALUE_NONE, 'Only launches an instance and outputs the connection parameters. Useful if you want to connect via SSH.');
         $this->addOption('update-only', null, InputOption::VALUE_NONE, 'Launches an instance, outputs the connection parameters and prepares the instance for a test run but does not actually run the tests. It will also checkout the specified version.');
         $this->addOption('one-instance-per-testsuite', null, InputOption::VALUE_NONE, 'Launches an instance, outputs the connection parameters and prepares the instance for a test run but does not actually run the tests. It will also checkout the specified version.');
-        $this->addOption('checkout', null, InputOption::VALUE_REQUIRED, 'Git hash, tag or branch to checkout. Defaults to current hash', $this->getCurrentGitHash());
+        $this->addOption('checkout', null, InputOption::VALUE_REQUIRED, 'Git hash, tag or branch to checkout. Defaults to current hash', $thisRepo->getHeadHash());
         $this->addOption('patch-file', null, InputOption::VALUE_REQUIRED, 'Apply the given patch file after performing a checkout');
         $this->setDescription('Run a specific testsuite on AWS');
         $this->setHelp('To use this command you have to configure the [tests]aws_* section in config/config.ini.php. See config/global.ini.php for all available options.
@@ -138,11 +141,6 @@ This feature is still beta and there might be problems with pictures and/or bina
         }
 
         return $testsuite;
-    }
-
-    private function getCurrentGitHash()
-    {
-        return trim(`git rev-parse HEAD`);
     }
 
     private function buildFinishedMessage($testSuite, $host)

--- a/plugins/TestRunner/GitRepository.php
+++ b/plugins/TestRunner/GitRepository.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Plugins\TestRunner;
+
+/**
+ * git repository introspection.
+ */
+class GitRepository
+{
+    /**
+     * The path to the git repository.
+     *
+     * @var string
+     */
+    private $repoPath;
+
+    /**
+     * Constructor.
+     *
+     * @param string $repoPath
+     */
+    public function __construct($repoPath)
+    {
+        $this->repoPath;
+    }
+
+    /**
+     * Gets the commit hash from a revision description (eg, `"HEAD^^"`).
+     *
+     * @param string $revisionDesc
+     * @return string
+     */
+    public function getRevisionHash($revisionDesc)
+    {
+        return trim(`cd "{$this->repoPath}" && git rev-parse HEAD`);
+    }
+
+    /**
+     * Returns the commit hash for HEAD.
+     *
+     * @return string
+     */
+    public function getHeadHash()
+    {
+        return $this->getRevisionHash("HEAD");
+    }
+}

--- a/plugins/TestRunner/Runner/Remote.php
+++ b/plugins/TestRunner/Runner/Remote.php
@@ -37,12 +37,7 @@ class Remote
 
     public function replaceConfigIni($file)
     {
-        $content = file_get_contents($file);
-
-        if (!empty($content)) {
-            $content = escapeshellarg($content);
-            $this->ssh->exec('echo ' . $content . ' > config/config.ini.php');
-        }
+        $this->uploadFile($file, 'config/config.ini.php');
     }
 
     public function applyPatch($fileToApply)
@@ -52,6 +47,16 @@ class Remote
         if (!empty($content)) {
             $content = escapeshellarg($content);
             $this->ssh->exec('echo ' . $content . ' | git apply - ');
+        }
+    }
+
+    public function uploadFile($srcPath, $destPath)
+    {
+        $content = file_get_contents($srcPath);
+
+        if (!empty($content)) {
+            $content = escapeshellarg($content);
+            $this->ssh->exec('echo ' . $content . ' > ' . $destPath);
         }
     }
 


### PR DESCRIPTION
As title, new command `tests:benchmark` will load a fixture into the DB (specified through command line arguments and can be your own custom file) and then benchmark either a phpunit test case or URL. The phpunit test case can be your own custom test case (so you can benchmark any bit of Piwik code). Benchmarking can be done on AWS as well as locally.

Includes some refactorings to CliMulti/RequestCommand/RunTestsOnAws/GenerateTravisYmlFile.

CC @mattab @mnapoli @tsteur Reviews welcome.
