### PR TITLE
API: skip truncation filter if truncate value is negative

### DIFF
--- a/core/DataTable/Filter/Truncate.php
+++ b/core/DataTable/Filter/Truncate.php
@@ -69,6 +69,10 @@ class Truncate extends BaseFilter
      */
     public function filter($table)
     {
+        if ($this->truncateAfter < 0) {
+            return;
+        }
+
         $this->addSummaryRow($table);
         $table->queueFilter('ReplaceSummaryRowLabel', array($this->labelSummaryRow));
 


### PR DESCRIPTION
In my opinion Truncate filter shouldn't truncate and add summary row if truncate parameter is negative. I'm not sure how it connects with other Piwik reports, but when I was checking this then everything seems to behave normally. 
