### PR TITLE
Normalize less decimal fields in System tests

### DIFF
--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -251,8 +251,6 @@ class Response
         // http://bugs.php.net/bug.php?id=54508
         $response = str_replace('.000000</l', '</l', $response); //lat/long
         $response = str_replace('.00</revenue>', '</revenue>', $response);
-        $response = str_replace('.1</revenue>', '</revenue>', $response);
-        $response = str_replace('.11</revenue>', '</revenue>', $response);
 
         return $response;
     }

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_GoalOrder__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_GoalOrder__Goals.get_day.xml
@@ -3,7 +3,7 @@
 	<nb_conversions>2</nb_conversions>
 	<nb_visits_converted>1</nb_visits_converted>
 	<conversion_rate>33.33</conversion_rate>
-	<revenue>3111</revenue>
+	<revenue>3111.11</revenue>
 	<revenue_subtotal>2500</revenue_subtotal>
 	<revenue_tax>511</revenue_tax>
 	<revenue_shipping>100.11</revenue_shipping>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_GoalOrder__Goals.get_week.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_GoalOrder__Goals.get_week.xml
@@ -3,7 +3,7 @@
 	<nb_conversions>4</nb_conversions>
 	<nb_visits_converted>2</nb_visits_converted>
 	<conversion_rate>40</conversion_rate>
-	<revenue>13351</revenue>
+	<revenue>13351.11</revenue>
 	<revenue_subtotal>2700</revenue_subtotal>
 	<revenue_tax>531</revenue_tax>
 	<revenue_shipping>120.11</revenue_shipping>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_GoalOverall__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_GoalOverall__Goals.get_day.xml
@@ -3,5 +3,5 @@
 	<nb_conversions>3</nb_conversions>
 	<nb_visits_converted>2</nb_visits_converted>
 	<conversion_rate>66.67</conversion_rate>
-	<revenue>3121</revenue>
+	<revenue>3121.11</revenue>
 </result>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_GoalOverall__Goals.get_week.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_GoalOverall__Goals.get_week.xml
@@ -3,5 +3,5 @@
 	<nb_conversions>5</nb_conversions>
 	<nb_visits_converted>4</nb_visits_converted>
 	<conversion_rate>80</conversion_rate>
-	<revenue>13361</revenue>
+	<revenue>13361.11</revenue>
 </result>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_LiveEcommerceStatusOrdered__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_LiveEcommerceStatusOrdered__Live.getLastVisitsDetails_day.xml
@@ -224,7 +224,7 @@
 			</row>
 			<row>
 				<type>ecommerceAbandonedCart</type>
-				<revenue>2510</revenue>
+				<revenue>2510.11</revenue>
 				<items>4</items>
 				
 				<itemDetails>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_Metadata_Goals.Get_Order__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_Metadata_Goals.Get_Order__API.getProcessedReport_day.xml
@@ -45,7 +45,7 @@
 		<nb_conversions>2</nb_conversions>
 		<nb_visits_converted>1</nb_visits_converted>
 		<conversion_rate>33.33%</conversion_rate>
-		<revenue>$ 3111</revenue>
+		<revenue>$ 3111.11</revenue>
 		<revenue_subtotal>$ 2500</revenue_subtotal>
 		<revenue_tax>$ 511</revenue_tax>
 		<revenue_shipping>$ 100.11</revenue_shipping>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
@@ -77,7 +77,7 @@
 			<nb_visits>1</nb_visits>
 			<nb_actions>6</nb_actions>
 			<nb_users>0</nb_users>
-			<revenue>$ 3111</revenue>
+			<revenue>$ 3111.11</revenue>
 			<nb_actions_per_visit>6</nb_actions_per_visit>
 			<avg_time_on_site>01:06:01</avg_time_on_site>
 			<bounce_rate>0%</bounce_rate>
@@ -321,6 +321,6 @@
 		<nb_actions>13</nb_actions>
 		<nb_conversions>3</nb_conversions>
 		<bounce_count>0</bounce_count>
-		<revenue>3121</revenue>
+		<revenue>3121.11</revenue>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
@@ -51,7 +51,7 @@
 			<nb_uniq_visitors>1</nb_uniq_visitors>
 			<nb_visits>2</nb_visits>
 			<nb_actions>9</nb_actions>
-			<revenue>$ 3111</revenue>
+			<revenue>$ 3111.11</revenue>
 			<nb_actions_per_visit>4.5</nb_actions_per_visit>
 			<avg_time_on_site>00:39:01</avg_time_on_site>
 			<bounce_rate>0%</bounce_rate>
@@ -87,6 +87,6 @@
 		<nb_actions>13</nb_actions>
 		<nb_conversions>3</nb_conversions>
 		<bounce_count>0</bounce_count>
-		<revenue>3121</revenue>
+		<revenue>3121.11</revenue>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__CustomVariables.getCustomVariables_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__CustomVariables.getCustomVariables_day.xml
@@ -18,7 +18,7 @@
 			<row idgoal='ecommerceOrder'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111</revenue>
+				<revenue>3111.11</revenue>
 				<revenue_subtotal>2500</revenue_subtotal>
 				<revenue_tax>511</revenue_tax>
 				<revenue_shipping>100.11</revenue_shipping>
@@ -32,7 +32,7 @@
 			</row>
 		</goals>
 		<nb_conversions>3</nb_conversions>
-		<revenue>3121</revenue>
+		<revenue>3121.11</revenue>
 		<subtable>
 			<row>
 				<label>0</label>
@@ -52,7 +52,7 @@
 					<row idgoal='ecommerceOrder'>
 						<nb_conversions>2</nb_conversions>
 						<nb_visits_converted>1</nb_visits_converted>
-						<revenue>3111</revenue>
+						<revenue>3111.11</revenue>
 						<revenue_subtotal>2500</revenue_subtotal>
 						<revenue_tax>511</revenue_tax>
 						<revenue_shipping>100.11</revenue_shipping>
@@ -66,7 +66,7 @@
 					</row>
 				</goals>
 				<nb_conversions>3</nb_conversions>
-				<revenue>3121</revenue>
+				<revenue>3121.11</revenue>
 			</row>
 		</subtable>
 	</row>
@@ -88,7 +88,7 @@
 			<row idgoal='ecommerceOrder'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111</revenue>
+				<revenue>3111.11</revenue>
 				<revenue_subtotal>2500</revenue_subtotal>
 				<revenue_tax>511</revenue_tax>
 				<revenue_shipping>100.11</revenue_shipping>
@@ -102,7 +102,7 @@
 			</row>
 		</goals>
 		<nb_conversions>3</nb_conversions>
-		<revenue>3121</revenue>
+		<revenue>3121.11</revenue>
 		<subtable>
 			<row>
 				<label>NewLoggedOut</label>
@@ -122,7 +122,7 @@
 					<row idgoal='ecommerceOrder'>
 						<nb_conversions>2</nb_conversions>
 						<nb_visits_converted>1</nb_visits_converted>
-						<revenue>3111</revenue>
+						<revenue>3111.11</revenue>
 						<revenue_subtotal>2500</revenue_subtotal>
 						<revenue_tax>511</revenue_tax>
 						<revenue_shipping>100.11</revenue_shipping>
@@ -136,7 +136,7 @@
 					</row>
 				</goals>
 				<nb_conversions>3</nb_conversions>
-				<revenue>3121</revenue>
+				<revenue>3121.11</revenue>
 			</row>
 		</subtable>
 	</row>
@@ -250,7 +250,7 @@
 			<row idgoal='ecommerceOrder'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111</revenue>
+				<revenue>3111.11</revenue>
 				<revenue_subtotal>2500</revenue_subtotal>
 				<revenue_tax>511</revenue_tax>
 				<revenue_shipping>100.11</revenue_shipping>
@@ -259,7 +259,7 @@
 			</row>
 		</goals>
 		<nb_conversions>2</nb_conversions>
-		<revenue>3111</revenue>
+		<revenue>3111.11</revenue>
 		<subtable>
 			<row>
 				<label>Great name!</label>
@@ -279,7 +279,7 @@
 					<row idgoal='ecommerceOrder'>
 						<nb_conversions>2</nb_conversions>
 						<nb_visits_converted>1</nb_visits_converted>
-						<revenue>3111</revenue>
+						<revenue>3111.11</revenue>
 						<revenue_subtotal>2500</revenue_subtotal>
 						<revenue_tax>511</revenue_tax>
 						<revenue_shipping>100.11</revenue_shipping>
@@ -288,7 +288,7 @@
 					</row>
 				</goals>
 				<nb_conversions>2</nb_conversions>
-				<revenue>3111</revenue>
+				<revenue>3111.11</revenue>
 			</row>
 		</subtable>
 	</row>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Goals.get_day.xml
@@ -3,5 +3,5 @@
 	<nb_conversions>3</nb_conversions>
 	<nb_visits_converted>2</nb_visits_converted>
 	<conversion_rate>66.67</conversion_rate>
-	<revenue>3121</revenue>
+	<revenue>3121.11</revenue>
 </result>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Goals.get_week.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Goals.get_week.xml
@@ -3,5 +3,5 @@
 	<nb_conversions>5</nb_conversions>
 	<nb_visits_converted>4</nb_visits_converted>
 	<conversion_rate>80</conversion_rate>
-	<revenue>13361</revenue>
+	<revenue>13361.11</revenue>
 </result>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Live.getLastVisitsDetails_day.xml
@@ -89,7 +89,7 @@
 			</row>
 			<row>
 				<type>ecommerceAbandonedCart</type>
-				<revenue>2510</revenue>
+				<revenue>2510.11</revenue>
 				<items>4</items>
 				
 				<itemDetails>
@@ -283,7 +283,7 @@
 			<row>
 				<type>ecommerceOrder</type>
 				<orderId>937nsjusu 3894</orderId>
-				<revenue>1111</revenue>
+				<revenue>1111.11</revenue>
 				<revenueSubTotal>1000</revenueSubTotal>
 				<revenueTax>111</revenueTax>
 				<revenueShipping>0.11</revenueShipping>
@@ -419,7 +419,7 @@
 			</row>
 			<row>
 				<type>ecommerceAbandonedCart</type>
-				<revenue>2510</revenue>
+				<revenue>2510.11</revenue>
 				<items>4</items>
 				
 				<itemDetails>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getCity_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getCity_day.xml
@@ -19,7 +19,7 @@
 			<row idgoal='ecommerceOrder'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111</revenue>
+				<revenue>3111.11</revenue>
 				<revenue_subtotal>2500</revenue_subtotal>
 				<revenue_tax>511</revenue_tax>
 				<revenue_shipping>100.11</revenue_shipping>
@@ -33,7 +33,7 @@
 			</row>
 		</goals>
 		<nb_conversions>3</nb_conversions>
-		<revenue>3121</revenue>
+		<revenue>3121.11</revenue>
 		<city_name>Unknown</city_name>
 		<city>xx</city>
 		<region>xx</region>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getContinent_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getContinent_day.xml
@@ -19,7 +19,7 @@
 			<row idgoal='ecommerceOrder'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111</revenue>
+				<revenue>3111.11</revenue>
 				<revenue_subtotal>2500</revenue_subtotal>
 				<revenue_tax>511</revenue_tax>
 				<revenue_shipping>100.11</revenue_shipping>
@@ -33,7 +33,7 @@
 			</row>
 		</goals>
 		<nb_conversions>3</nb_conversions>
-		<revenue>3121</revenue>
+		<revenue>3121.11</revenue>
 		<code>Europe</code>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getCountry_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getCountry_day.xml
@@ -19,7 +19,7 @@
 			<row idgoal='ecommerceOrder'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111</revenue>
+				<revenue>3111.11</revenue>
 				<revenue_subtotal>2500</revenue_subtotal>
 				<revenue_tax>511</revenue_tax>
 				<revenue_shipping>100.11</revenue_shipping>
@@ -28,7 +28,7 @@
 			</row>
 		</goals>
 		<nb_conversions>2</nb_conversions>
-		<revenue>3111</revenue>
+		<revenue>3111.11</revenue>
 		<code>pl</code>
 		<logo>plugins/UserCountry/images/flags/pl.png</logo>
 		<logoWidth>16</logoWidth>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getRegion_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getRegion_day.xml
@@ -19,7 +19,7 @@
 			<row idgoal='ecommerceOrder'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111</revenue>
+				<revenue>3111.11</revenue>
 				<revenue_subtotal>2500</revenue_subtotal>
 				<revenue_tax>511</revenue_tax>
 				<revenue_shipping>100.11</revenue_shipping>
@@ -33,7 +33,7 @@
 			</row>
 		</goals>
 		<nb_conversions>3</nb_conversions>
-		<revenue>3121</revenue>
+		<revenue>3121.11</revenue>
 		<region>xx</region>
 		<country>xx</country>
 		<country_name>Unknown</country_name>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__VisitTime.getVisitInformationPerServerTime_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__VisitTime.getVisitInformationPerServerTime_day.xml
@@ -43,13 +43,13 @@
 			<row idgoal='ecommerceAbandonedCart'>
 				<nb_conversions>1</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>2510</revenue>
+				<revenue>2510.11</revenue>
 				<items>4</items>
 			</row>
 			<row idgoal='ecommerceOrder'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111</revenue>
+				<revenue>3111.11</revenue>
 				<revenue_subtotal>2500</revenue_subtotal>
 				<revenue_tax>511</revenue_tax>
 				<revenue_shipping>100.11</revenue_shipping>
@@ -58,7 +58,7 @@
 			</row>
 		</goals>
 		<nb_conversions>2</nb_conversions>
-		<revenue>3111</revenue>
+		<revenue>3111.11</revenue>
 	</row>
 	<row>
 		<label>3h</label>
@@ -117,7 +117,7 @@
 			<row idgoal='ecommerceAbandonedCart'>
 				<nb_conversions>1</nb_conversions>
 				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>2510</revenue>
+				<revenue>2510.11</revenue>
 				<items>4</items>
 			</row>
 		</goals>


### PR DESCRIPTION
Normalizing the `.1` and `.11` values were not needed see test result. The pass both on PDO and Mysqli. 

It is better to test for the full result including the `.11` and it is less confusing. For example I spent more than 1.5 hours this morning trying to figure out why a `*,11` was present when a German locale is used but an integer when an English locale is used.
