### PR TITLE
Removed group check before running any PHP tests.

### DIFF
--- a/tests/travis/travis.sh
+++ b/tests/travis/travis.sh
@@ -8,20 +8,6 @@ source $SCRIPT_DIR/travis-helper.sh
 # go to tests directory
 cd ../PHPUnit
 
-if [ "$TEST_SUITE" != "UITests" ] && [ "$TEST_SUITE" != "AngularJSTests" ]
-then
-    if [ `phpunit --group __nogroup__ | grep "No tests executed" | wc -l` -ne 1 ]
-    then
-        echo "=====> There are some tests functions which do not have a @group set or have no tests. "
-        echo "       Please add the @group phpdoc comment to the following tests: <====="
-        phpunit --group __nogroup__ --testdox | grep "[x]"
-
-        echo "Initial output of \$phpunit --group __nogroup__ "
-        phpunit --group __nogroup__
-        exit 1
-    fi
-fi
-
 if [ -n "$TEST_SUITE" ]
 then
     echo "Executing tests in test suite $TEST_SUITE..."


### PR DESCRIPTION
This check does not really makes sense as a group was never needed
for a test to be executed on Travis. The testsuites that always have been
used on Travis automatically execute all tests within the PHPUnit/Unit
Integration and System folder. A group was never needed. Maybe some
developers used groups to execute tests but then always only a part of
the tests was executed as a test does not necessarily has the "correct"
group. Removing this check is also important for plugin developers who
write tests for their plugin as we cannot expect that they set a group
as it is usually not needed in any other project. If plugin developers
do not set a group and we run our automated tests no test
would be executed because of this unneeded check.
