### PR TITLE
fix list of plugins is not sorted correct

### DIFF
--- a/core/DataTable/Filter/RangeCheck.php
+++ b/core/DataTable/Filter/RangeCheck.php
@@ -32,7 +32,7 @@ class RangeCheck extends BaseFilter
 
         $this->columnToFilter = $columnToFilter;
 
-        if ($minimumValue < $maximumValue) {
+        if ((float) $minimumValue < (float) $maximumValue) {
             self::$minimumValue = $minimumValue;
             self::$maximumValue = $maximumValue;
         }
@@ -48,9 +48,9 @@ class RangeCheck extends BaseFilter
         foreach ($table->getRows() as $row) {
             $value = $row->getColumn($this->columnToFilter);
             if ($value !== false) {
-                if ($value < self::$minimumValue) {
+                if ($value < (float) self::$minimumValue) {
                     $row->setColumn($this->columnToFilter, self::$minimumValue);
-                } elseif ($value > self::$maximumValue) {
+                } elseif ($value > (float) self::$maximumValue) {
                     $row->setColumn($this->columnToFilter, self::$maximumValue);
                 }
             }

--- a/plugins/UserSettings/API.php
+++ b/plugins/UserSettings/API.php
@@ -230,7 +230,7 @@ class API extends \Piwik\Plugin\API
             // The filter must be applied now so that the new column can
             // be sorted by the generic filters (applied right after this loop exits)
             $table->filter('ColumnCallbackAddColumnPercentage', array('nb_visits_percentage', Metrics::INDEX_NB_VISITS, $visitsSum, 1));
-            $table->filter('RangeCheck', array('nb_visits_percentage'));
+            $table->filter('RangeCheck', array('nb_visits_percentage', '0.00%', '100.00%'));
         }
 
         $dataTable->queueFilter('ColumnCallbackAddMetadata', array('label', 'logo', __NAMESPACE__ . '\getPluginsLogo'));


### PR DESCRIPTION
refs #6334 It was wrong if first value is < 0% or > 100% as it was overwritten with `$maximalValue` (which is a float) of the `RangeCheck` which leads to a numberSort but most values are actually strings and not floats. 
