### PR TITLE
Increase allowed password length from 26 to 80

### DIFF
--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -21,7 +21,7 @@ use Piwik\SettingsPiwik;
 class UsersManager extends \Piwik\Plugin
 {
     const PASSWORD_MIN_LENGTH = 6;
-    const PASSWORD_MAX_LENGTH = 26;
+    const PASSWORD_MAX_LENGTH = 80;
 
     /**
      * @see Piwik\Plugin::getListHooksRegistered

--- a/plugins/UsersManager/tests/Integration/UsersManagerTest.php
+++ b/plugins/UsersManager/tests/Integration/UsersManagerTest.php
@@ -156,7 +156,7 @@ class UsersManagerTest extends IntegrationTestCase
     {
         return array(
             array("geggeqgeqag", "pas", "email@email.com", "alias"), // too short -> exception
-            array("ghqgeggg", "gegageqqqqqqqgeqgqeg84897897897897g122", "email@email.com", "alias"), // too long -> exception
+            array("ghqgeggg", "gegageqqqqqqqgeqgqeg84897897897897g122gerrgageqqqqqqqgeqgqeg84897897897897g12234k3", "email@email.com", "alias"), // too long -> exception
             array("geggeqgeqag", "", "email@email.com", "alias"), // empty -> exception
         );
     }


### PR DESCRIPTION
see #4558 

Tests pass. Translation already uses the variable "maxPwLength" in error message. I searched for some guides and FAQs but haven't found anything where the password length is mentioned (which makes sense as it is a detail).

Looking forward to being able to use long passwords!
