### PR TITLE
URLs without scheme eg. //example.com/home should be valid URLs in Piwik

### DIFF
--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -101,8 +101,8 @@ class UrlHelper
      */
     public static function isLookLikeUrl($url)
     {
-        return preg_match('~^(ftp|news|http|https)?://(.*)$~D', $url, $matches) !== 0
-        && strlen($matches[2]) > 0;
+        return preg_match('~^((ftp|news|http|https)?:)?//(.*)$~D', $url, $matches) !== 0
+        && strlen($matches[3]) > 0;
     }
 
     /**

--- a/tests/PHPUnit/Unit/UrlHelperTest.php
+++ b/tests/PHPUnit/Unit/UrlHelperTest.php
@@ -21,6 +21,7 @@ class Core_UrlHelperTest extends \PHPUnit_Framework_TestCase
         return array(
             // valid urls
             array('http://piwik.org', true),
+            array('//piwik.org', true), // valid network-path reference RFC3986
             array('http://www.piwik.org', true),
             array('https://piwik.org', true),
             array('https://piwik.org/dir/dir2/?oeajkgea7aega=&ge=a', true),
@@ -197,6 +198,7 @@ class Core_UrlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('localhost', UrlHelper::getHostFromUrl('http://localhost'));
         $this->assertEquals('localhost', UrlHelper::getHostFromUrl('http://localhost/path'));
         $this->assertEquals('localhost', UrlHelper::getHostFromUrl('localhost/path'));
+        $this->assertEquals('localhost', UrlHelper::getHostFromUrl('//localhost/path'));
         $this->assertEquals('sub.localhost', UrlHelper::getHostFromUrl('sub.localhost/path'));
         $this->assertEquals('sub.localhost', UrlHelper::getHostFromUrl('http://sub.localhost/path/?query=test'));
     }


### PR DESCRIPTION
Make URL recognition more conformant with RFC3986 and RFC1738 network-path references (URI beginning with a doubleslash).

When used with WP-Piwik in a Wordpress installation that uses such network-path references like '//domain' as base URI, Piwik does't recognize such a URI as valid, consequently putting a "http://" in front of it, resulting in a 'http:////domain' pattern which confuses the WP-Piwik plugin, resulting in multiple rewrites and creations of new sites.
