### PR TITLE
CliMulti: If process or output size is unexpected large, declare it as finished

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -151,6 +151,14 @@ class CliMulti {
                 return false;
             }
 
+            $pid = $process->getPid();
+            foreach ($this->outputs as $output) {
+                if ($output->getOutputId() === $pid && $output->isAbnormal()) {
+                    $process->finishProcess();
+                    return true;
+                }
+            }
+
             if ($process->hasFinished()) {
                 // prevent from checking this process over and over again
                 unset($this->processes[$index]);

--- a/core/CliMulti/Output.php
+++ b/core/CliMulti/Output.php
@@ -13,6 +13,7 @@ use Piwik\Filesystem;
 class Output {
 
     private $tmpFile  = '';
+    private $outputId = null;
 
     public function __construct($outputId)
     {
@@ -23,7 +24,13 @@ class Output {
         $dir = CliMulti::getTmpPath();
         Filesystem::mkdir($dir);
 
-        $this->tmpFile = $dir . '/' . $outputId . '.output';
+        $this->tmpFile  = $dir . '/' . $outputId . '.output';
+        $this->outputId = $outputId;
+    }
+
+    public function getOutputId()
+    {
+        return $this->outputId;
     }
 
     public function write($content)
@@ -34,6 +41,13 @@ class Output {
     public function getPathToFile()
     {
         return $this->tmpFile;
+    }
+
+    public function isAbnormal()
+    {
+        $size = Filesystem::getFileSize($this->tmpFile, 'MB');
+
+        return $size !== null && $size >= 100;
     }
 
     public function exists()

--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -24,6 +24,7 @@ class Process
     private $pidFile = '';
     private $timeCreation = null;
     private $isSupported = null;
+    private $pid = null;
 
     public function __construct($pid)
     {
@@ -37,8 +38,14 @@ class Process
         $this->isSupported  = self::isSupported();
         $this->pidFile      = $pidDir . '/' . $pid . '.pid';
         $this->timeCreation = time();
+        $this->pid = $pid;
 
         $this->markAsNotStarted();
+    }
+
+    public function getPid()
+    {
+        return $this->pid;
     }
 
     private function markAsNotStarted()
@@ -97,6 +104,11 @@ class Process
             return false;
         }
 
+        if (!$this->pidFileSizeIsNormal()) {
+            $this->finishProcess();
+            return false;
+        }
+
         if ($this->isProcessStillRunning($content)) {
             return true;
         }
@@ -106,6 +118,13 @@ class Process
         }
 
         return false;
+    }
+
+    private function pidFileSizeIsNormal()
+    {
+        $size = Filesystem::getFileSize($this->pidFile);
+
+        return $size !== null && $size < 500;
     }
 
     public function finishProcess()

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -374,6 +374,40 @@ class Filesystem
     }
 
     /**
+     * Get the size of a file in the specified unit.
+     *
+     * @param string $pathToFile
+     * @param string $unit eg 'B' for Byte, 'KB', 'MB', 'GB', 'TB'.
+     *
+     * @return float|null Returns null if file does not exist or the size of the file in the specified unit
+     *
+     * @throws Exception In case the unit is invalid
+     */
+    public static function getFileSize($pathToFile, $unit = 'B')
+    {
+        $unit  = strtoupper($unit);
+        $units = array('TB' => pow(1024, 4),
+                       'GB' => pow(1024, 3),
+                       'MB' => pow(1024, 2),
+                       'KB' => 1024,
+                       'B' => 1);
+
+        if (!array_key_exists($unit, $units)) {
+            throw new Exception('Invalid unit given');
+        }
+
+        if (!file_exists($pathToFile)) {
+            return;
+        }
+
+        $filesize  = filesize($pathToFile);
+        $factor    = $units[$unit];
+        $converted = $filesize / $factor;
+
+        return $converted;
+    }
+
+    /**
      * @param $path
      * @return int
      */

--- a/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
+++ b/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
@@ -8,12 +8,14 @@
 
 namespace Piwik\Plugins\ExamplePlugin\tests\Unit;
 
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
+
 /**
  * @group ExamplePlugin
  * @group SimpleTest
  * @group Plugins
  */
-class SimpleTest extends \PHPUnit_Framework_TestCase
+class SimpleTest extends UnitTestCase
 {
 
     /**

--- a/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
+++ b/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
@@ -17,6 +17,17 @@ use Piwik\Tests\Framework\TestCase\UnitTestCase;
  */
 class SimpleTest extends UnitTestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+        // set up here if needed
+    }
+    
+    public function tearDown()
+    {
+        // tear down here if needed
+        parent::tearDown();
+    }
 
     /**
      * All your actual test methods should start with the name "test"

--- a/tests/PHPUnit/Framework/Mock/File.php
+++ b/tests/PHPUnit/Framework/Mock/File.php
@@ -1,0 +1,62 @@
+<?php
+/**
+* Piwik - free/libre analytics platform
+*
+* @link http://piwik.org
+* @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+*/
+namespace Piwik;
+
+use Piwik\Tests\Framework\Mock\File;
+
+function filesize($filename)
+{
+    if (File::getFileSize() !== null) {
+        return File::getFileSize();
+    }
+
+    return \filesize($filename);
+}
+
+function file_exists($filename)
+{
+    if (File::getFileExists() !== null) {
+        return File::getFileExists();
+    }
+
+    return \file_exists($filename);
+}
+
+namespace Piwik\Tests\Framework\Mock;
+
+class File
+{
+    static $filesize = null;
+    static $fileExists = null;
+
+    public static function getFileSize()
+    {
+        return self::$filesize;
+    }
+
+    public static function setFileSize($filesize)
+    {
+        self::$filesize = $filesize;
+    }
+
+    public static function reset()
+    {
+        self::$filesize = null;
+        self::$fileExists = null;
+    }
+
+    public static function getFileExists()
+    {
+        return self::$fileExists;
+    }
+
+    public static function setFileExists($exists)
+    {
+        self::$fileExists = $exists;
+    }
+}

--- a/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Framework\TestCase;
+use Piwik\Tests\Framework\Mock\File;
+
+
+/**
+ * Base class for Unit tests.
+ *
+ * @since 2.10.0
+ */
+abstract class UnitTestCase extends \PHPUnit_Framework_TestCase
+{
+    public function setup()
+    {
+        parent::setUp();
+        File::reset();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        File::reset();
+    }
+}

--- a/tests/PHPUnit/Integration/FilesystemTest.php
+++ b/tests/PHPUnit/Integration/FilesystemTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration;
+
+use Piwik\Filesystem;
+
+/**
+ * @group Core
+ */
+class FilesystemTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_getFileSize_ShouldRecognizeLowerUnits()
+    {
+        $size = Filesystem::getFileSize(__FILE__, 'b');
+
+        $this->assertGreaterThan(400, $size);
+        $this->assertLessThan(400000, $size);
+    }
+
+    public function test_getFileSize_ShouldReturnNull_IfFileDoesNotExists()
+    {
+        $size = Filesystem::getFileSize(PIWIK_INCLUDE_PATH . '/tests/NotExisting.File');
+
+        $this->assertNull($size);
+    }
+
+}

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -16,6 +16,7 @@ use Piwik\Tests\Framework\Fixture;
  *
  * @group Core
  * @group Core_CliMultiTest
+ * @group CliMulti
  */
 class Core_CliMultiTest extends SystemTestCase
 {

--- a/tests/PHPUnit/Unit/CliMulti/OutputTest.php
+++ b/tests/PHPUnit/Unit/CliMulti/OutputTest.php
@@ -26,6 +26,7 @@ class OutputTest extends UnitTestCase
 
     public function setUp()
     {
+        parent::setup();
         Url::setHost(false);
         $this->output = new Output('myid');
     }
@@ -33,6 +34,7 @@ class OutputTest extends UnitTestCase
     public function tearDown()
     {
         $this->output->destroy();
+        parent::tearDown();
     }
 
     /**

--- a/tests/PHPUnit/Unit/CliMulti/OutputTest.php
+++ b/tests/PHPUnit/Unit/CliMulti/OutputTest.php
@@ -9,12 +9,15 @@
 namespace Piwik\Tests\Unit\CliMulti;
 
 use Piwik\CliMulti\Output;
+use Piwik\Tests\Framework\Mock\File;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
 use Piwik\Url;
 
 /**
  * @group Core
+ * @group CliMulti
  */
-class OutputTest extends \PHPUnit_Framework_TestCase
+class OutputTest extends UnitTestCase
 {
     /**
      * @var Output
@@ -41,6 +44,11 @@ class OutputTest extends \PHPUnit_Framework_TestCase
         new Output('../../');
     }
 
+    public function test_getOutputId()
+    {
+        $this->assertSame('myid', $this->output->getOutputId());
+    }
+
     public function test_exists_ShouldReturnsFalse_IfNothingWrittenYet()
     {
         $this->assertFalse($this->output->exists());
@@ -52,6 +60,27 @@ class OutputTest extends \PHPUnit_Framework_TestCase
 
         $this->assertStringEndsWith($expectedEnd, $this->output->getPathToFile());
         $this->assertGreaterThan(strlen($expectedEnd), strlen($this->output->getPathToFile()));
+    }
+
+    public function test_isAbormal_ShouldReturnFalse_IfFileDoesNotExist()
+    {
+        $this->assertFalse($this->output->isAbnormal());
+    }
+
+    public function test_isAbormal_ShouldReturnTrue_IfFilesizeIsNotTooBig()
+    {
+        File::setFileSize(1024 * 1024 * 99);
+        File::setFileExists(true);
+
+        $this->assertFalse($this->output->isAbnormal());
+    }
+
+    public function test_isAbormal_ShouldReturnTrue_IfFilesizeIsTooBig()
+    {
+        File::setFileSize(1024 * 1024 * 101);
+        File::setFileExists(true);
+
+        $this->assertTrue($this->output->isAbnormal());
     }
 
     public function test_exists_ShouldReturnTrue_IfSomethingIsWritten()

--- a/tests/PHPUnit/Unit/CliMulti/ProcessTest.php
+++ b/tests/PHPUnit/Unit/CliMulti/ProcessTest.php
@@ -9,12 +9,15 @@
 namespace Piwik\Tests\Unit\CliMulti;
 
 use Piwik\CliMulti\Process;
+use Piwik\Tests\Framework\Mock\File;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
 use ReflectionProperty;
 
 /**
  * @group Core
+ * @group CliMulti
  */
-class ProcessTest extends \PHPUnit_Framework_TestCase
+class ProcessTest extends UnitTestCase
 {
     /**
      * @var Process
@@ -23,6 +26,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        parent::setup();
         $this->process = new Process('testPid');
     }
 
@@ -38,6 +42,11 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
     public function test_construct_shouldFailInCasePidIsInvalid()
     {
         new Process('../../htaccess');
+    }
+
+    public function test_getPid()
+    {
+        $this->assertSame('testPid', $this->process->getPid());
     }
 
     public function test_construct_shouldBeNotStarted_IfPidJustCreated()
@@ -82,6 +91,22 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($this->process->isRunning());
         $this->assertTrue($this->process->hasStarted());
+        $this->assertTrue($this->process->hasFinished());
+    }
+
+    public function test_isRunning_ShouldMarkProcessAsFinished_IfPidFileIsTooBig()
+    {
+        if (! Process::isSupported()) {
+            $this->markTestSkipped('Not supported');
+        }
+
+        $this->process->startProcess();
+        $this->assertTrue($this->process->isRunning());
+        $this->assertFalse($this->process->hasFinished());
+
+        File::setFileSize(505);
+
+        $this->assertFalse($this->process->isRunning());
         $this->assertTrue($this->process->hasFinished());
     }
 


### PR DESCRIPTION
#6617 Declares a process as finished as soon as a PID file is > 500bytes

(contains only PID) and output file is > 100MB (which should usually
not be larger than 100KB or 1MB) to prevent files growing up to many
GBs. I added unit and integration tests for the file size detection. It is
now possible to mock the methods file_exists and filesize although very
simple so far. Later we can allow to define callbacks to define different
return values for different files or we can use something like vfsStream
