### PR TITLE
Throw HTTP 400 error when idsite is invalid

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -1150,6 +1150,47 @@ class Common
     }
 
     /**
+     * Sends the given response code if supported.
+     *
+     * @param int $code  Eg 204
+     *
+     * @throws Exception
+     */
+    public static function sendResponseCode($code)
+    {
+        $messages = array(
+            200 => 'Ok',
+            204 => 'No Response',
+            301 => 'Moved Permanently',
+            302 => 'Found',
+            304 => 'Not Modified',
+            400 => 'Bad Request',
+            401 => 'Unauthorized',
+            403 => 'Forbidden',
+            404 => 'Not Found',
+            500 => 'Internal Server Error'
+        );
+
+        if (!array_key_exists($code, $messages)) {
+            throw new Exception('Response code not supported: ' . $code);
+        }
+
+        if (strpos(PHP_SAPI, '-fcgi') === false) {
+            $key = $_SERVER['SERVER_PROTOCOL'];
+        } else {
+            // FastCGI
+            $key = 'Status:';
+        }
+
+        if (strlen($key) > 11 || 0 !== strpos(strtolower($key), 'http')) {
+            $key = 'HTTP/1.1';
+        }
+
+        $message = $messages[$code];
+        Common::sendHeader($key . ' ' . $code . ' ' . $message);
+    }
+
+    /**
      * Returns the ID of the current LocationProvider (see UserCountry plugin code) from
      * the Tracker cache.
      */

--- a/core/Common.php
+++ b/core/Common.php
@@ -1177,13 +1177,14 @@ class Common
 
         if (strpos(PHP_SAPI, '-fcgi') === false) {
             $key = $_SERVER['SERVER_PROTOCOL'];
+
+            if (strlen($key) > 15 || empty($key)) {
+                $key = 'HTTP/1.1';
+            }
+
         } else {
             // FastCGI
             $key = 'Status:';
-        }
-
-        if (strlen($key) > 11 || 0 !== strpos(strtolower($key), 'http')) {
-            $key = 'HTTP/1.1';
         }
 
         $message = $messages[$code];

--- a/core/Exception/InvalidRequestParameterException.php
+++ b/core/Exception/InvalidRequestParameterException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Exception;
+
+class InvalidRequestParameterException extends Exception
+{
+}

--- a/core/Exception/UnexpectedWebsiteFoundException.php
+++ b/core/Exception/UnexpectedWebsiteFoundException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Exception;
+
+class UnexpectedWebsiteFoundException extends Exception
+{
+}

--- a/core/ProxyHttp.php
+++ b/core/ProxyHttp.php
@@ -66,7 +66,7 @@ class ProxyHttp
     {
         // if the file cannot be found return HTTP status code '404'
         if (!file_exists($file)) {
-            self::setHttpStatus('404 Not Found');
+            Common::sendResponseCode(404);
             return;
         }
 
@@ -87,7 +87,7 @@ class ProxyHttp
 
         // Return 304 if the file has not modified since
         if ($modifiedSince === $lastModified) {
-            self::setHttpStatus('304 Not Modified');
+            Common::sendResponseCode(304);
             return;
         }
 
@@ -158,7 +158,7 @@ class ProxyHttp
         }
 
         if (!_readfile($file, $byteStart, $byteEnd)) {
-            self::setHttpStatus('505 Internal server error');
+            Common::sendResponseCode(500);
         }
     }
 
@@ -217,24 +217,6 @@ class ProxyHttp
                 Common::sendHeader('Cache-Control: must-revalidate');
             }
         }
-    }
-
-    /**
-     * Set response header, e.g., HTTP/1.0 200 Ok
-     *
-     * @param string $status Status
-     * @return bool
-     */
-    protected static function setHttpStatus($status)
-    {
-        if (strpos(PHP_SAPI, '-fcgi') === false) {
-            $key = $_SERVER['SERVER_PROTOCOL'];
-        } else {
-            // FastCGI
-            $key = 'Status:';
-        }
-
-        Common::sendHeader($key . ' ' . $status);
     }
 
     /**

--- a/core/Site.php
+++ b/core/Site.php
@@ -10,6 +10,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Plugins\SitesManager\API;
 
 /**
@@ -95,7 +96,7 @@ class Site
     protected static function setSite($idSite, $infoSite)
     {
         if (empty($idSite) || empty($infoSite)) {
-            throw new Exception("An unexpected website was found, check idSite in the request.");
+            throw new UnexpectedWebsiteFoundException("An unexpected website was found, check idSite in the request.");
         }
 
         /**

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -669,7 +669,8 @@ class Tracker
         $request = $_GET + $_POST;
 
         if (array_key_exists('send_image', $request) && $request['send_image'] === '0') {
-            Common::sendHeader("HTTP/1.1 204 No Response");
+            Common::sendResponseCode(204);
+
             return;
         }
 

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -943,44 +943,4 @@ class Tracker
         return array_unique($siteIds);
     }
 
-    /**
-     * @param $e
-     * @param $authenticated
-     */
-    private function outputException($e, $authenticated)
-    {
-        if ($this->usingBulkTracking) {
-            // when doing bulk tracking we return JSON so the caller will know how many succeeded
-            $result = array(
-                'status' => 'error',
-                'tracked' => $this->countOfLoggedRequests
-            );
-            // send error when in debug mode or when authenticated (which happens when doing log importing,
-            if ((isset($GLOBALS['PIWIK_TRACKER_DEBUG']) && $GLOBALS['PIWIK_TRACKER_DEBUG'])
-                || $authenticated
-            ) {
-                $result['message'] = $this->getMessageFromException($e);
-            }
-            Common::sendHeader('Content-Type: application/json');
-            echo Common::json_encode($result);
-            return;
-        }
-
-        if (isset($GLOBALS['PIWIK_TRACKER_DEBUG']) && $GLOBALS['PIWIK_TRACKER_DEBUG']) {
-            Common::sendHeader('Content-Type: text/html; charset=utf-8');
-            $trailer = '<span style="color: #888888">Backtrace:<br /><pre>' . $e->getTraceAsString() . '</pre></span>';
-            $headerPage = file_get_contents(PIWIK_INCLUDE_PATH . '/plugins/Morpheus/templates/simpleLayoutHeader.tpl');
-            $footerPage = file_get_contents(PIWIK_INCLUDE_PATH . '/plugins/Morpheus/templates/simpleLayoutFooter.tpl');
-            $headerPage = str_replace('{$HTML_TITLE}', 'Piwik &rsaquo; Error', $headerPage);
-
-            echo $headerPage . '<p>' . $this->getMessageFromException($e) . '</p>' . $trailer . $footerPage;
-        } // If not debug, but running authenticated (eg. during log import) then we display raw errors
-        elseif ($authenticated) {
-            Common::sendHeader('Content-Type: text/html; charset=utf-8');
-            echo $this->getMessageFromException($e);
-        } else {
-            $this->outputTransparentGif();
-        }
-    }
-
 }

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Plugins\PrivacyManager\Config as PrivacyManagerConfig;
 use Piwik\Plugins\SitesManager\SiteUrls;
@@ -846,6 +847,9 @@ class Tracker
                 Common::printDebug("The request is invalid: empty request, or maybe tracking is disabled in the config.ini.php via record_statistics=0");
             }
         } catch (UnexpectedWebsiteFoundException $e) {
+            Common::printDebug("Exception: " . $e->getMessage());
+            $this->exitWithException($e, $isAuthenticated, 400);
+        } catch (InvalidRequestParameterException $e) {
             Common::printDebug("Exception: " . $e->getMessage());
             $this->exitWithException($e, $isAuthenticated, 400);
         } catch (DbException $e) {

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -12,6 +12,8 @@ use Exception;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Cookie;
+use Piwik\Exception\InvalidRequestParameterException;
+use Piwik\Exception\InvalidVisitorIdException;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\IP;
 use Piwik\Network\IPUtils;
@@ -304,7 +306,7 @@ class Request
         );
 
         if (!isset($supportedParams[$name])) {
-            throw new Exception("Requested parameter $name is not a known Tracking API Parameter.");
+            throw new InvalidRequestParameterException("Requested parameter $name is not a known Tracking API Parameter.");
         }
 
         $paramDefaultValue = $supportedParams[$name][0];
@@ -524,7 +526,7 @@ class Request
             $idVisitor = $this->getForcedVisitorId();
             if (!empty($idVisitor)) {
                 if (strlen($idVisitor) != Tracker::LENGTH_HEX_ID_STRING) {
-                    throw new Exception("Visitor ID (cid) $idVisitor must be " . Tracker::LENGTH_HEX_ID_STRING . " characters long");
+                    throw new InvalidRequestParameterException("Visitor ID (cid) $idVisitor must be " . Tracker::LENGTH_HEX_ID_STRING . " characters long");
                 }
                 Common::printDebug("Request will be recorded for this idvisitor = " . $idVisitor);
                 $found = true;

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -12,6 +12,7 @@ use Exception;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Cookie;
+use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\IP;
 use Piwik\Network\IPUtils;
 use Piwik\Piwik;
@@ -390,7 +391,7 @@ class Request
         Piwik::postEvent('Tracker.Request.getIdSite', array(&$idSite, $this->params));
 
         if ($idSite <= 0) {
-            throw new Exception('Invalid idSite: \'' . $idSite . '\'');
+            throw new UnexpectedWebsiteFoundException('Invalid idSite: \'' . $idSite . '\'');
         }
 
         return $idSite;

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -306,7 +306,7 @@ class Request
         );
 
         if (!isset($supportedParams[$name])) {
-            throw new InvalidRequestParameterException("Requested parameter $name is not a known Tracking API Parameter.");
+            throw new Exception("Requested parameter $name is not a known Tracking API Parameter.");
         }
 
         $paramDefaultValue = $supportedParams[$name][0];

--- a/misc/others/geoipUpdateRows.php
+++ b/misc/others/geoipUpdateRows.php
@@ -87,7 +87,7 @@ if (!Common::isPhpCliMode()) {
 function geoipUpdateError($message)
 {
     Log::error($message);
-    Common::sendHeader('HTTP/1.1 500 Internal Server Error', $replace = true, $responseCode = 500);
+    Common::sendResponseCode(500);
     exit;
 }
 

--- a/tests/PHPUnit/Framework/Constraint/ResponseCode.php
+++ b/tests/PHPUnit/Framework/Constraint/ResponseCode.php
@@ -9,6 +9,7 @@ namespace Piwik\Tests\Framework\Constraint;
 
 class ResponseCode extends \PHPUnit_Framework_Constraint
 {
+    private $actualCode;
 
     /**
      * @param integer $value Expected response code
@@ -41,7 +42,9 @@ class ResponseCode extends \PHPUnit_Framework_Constraint
         $responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
 
-        return $this->value === (int) $responseCode;
+        $this->actualCode = (int) $responseCode;
+
+        return $this->value === $this->actualCode;
     }
 
     /**
@@ -51,6 +54,6 @@ class ResponseCode extends \PHPUnit_Framework_Constraint
      */
     public function toString()
     {
-        return 'does not return response code ' . $this->exporter->export($this->value);
+        return 'does not return response code ' . $this->exporter->export($this->value) . ' it is ' . $this->actualCode;
     }
 }?>

--- a/tests/PHPUnit/Integration/ServeStaticFileTest.php
+++ b/tests/PHPUnit/Integration/ServeStaticFileTest.php
@@ -130,7 +130,7 @@ class Test_Piwik_ServeStaticFile extends PHPUnit_Framework_TestCase
         // Restoring file mode
         chmod(TEST_FILE_LOCATION, 0644);
 
-        $this->assertEquals($responseInfo["http_code"], 505);
+        $this->assertEquals($responseInfo["http_code"], 500);
     }
 
     /**

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -77,4 +77,12 @@ class TrackerTest extends SystemTestCase
         $this->assertResponseCode(400, $url);
     }
 
+    public function test_response_ShouldSend400ResponseCode_IfSiteIdIsZero()
+    {
+        $url = $this->tracker->getUrlTrackPageView('Test');
+        $url .= '&idsite=0';
+
+        $this->assertResponseCode(400, $url);
+    }
+
 }

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -69,4 +69,12 @@ class TrackerTest extends SystemTestCase
         $this->assertResponseCode(204, $url);
     }
 
+    public function test_response_ShouldSend400ResponseCode_IfSiteIdIsInvalid()
+    {
+        $url = $this->tracker->getUrlTrackPageView('Test');
+        $url .= '&idsite=100';
+
+        $this->assertResponseCode(400, $url);
+    }
+
 }

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -85,4 +85,13 @@ class TrackerTest extends SystemTestCase
         $this->assertResponseCode(400, $url);
     }
 
+    public function test_response_ShouldSend400ResponseCode_IfInvalidRequestParameterIsGiven()
+    {
+        $url = $this->tracker->getUrlTrackPageView('Test');
+        $url .= '&cid=' . str_pad('1', 16, '1');
+
+        $this->assertResponseCode(200, $url);
+        $this->assertResponseCode(400, $url . '1'); // has to be 16 char, but is 17 now
+    }
+
 }


### PR DESCRIPTION
#6661 When `idsite` is set to 0 or incorrectly, Piwik Tracker requests will send a HTTP 500 error. This causes monitoring system to be triggered when in fact this is not a server error 500 but rather it is a error `400 Bad Request`. Also if forced idVisitor is wrong. Not sure if there are many other use cases we'll have to add them on demand
