### PR TITLE
Fix installation when privacy form submitted

### DIFF
--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -396,8 +396,6 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     {
         $this->checkPiwikIsNotInstalled();
 
-        $this->markInstallationAsCompleted();
-
         $view = new View(
             '@Installation/finished',
             $this->getInstallationSteps(),
@@ -423,6 +421,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                  * @param \Piwik\Plugins\Installation\FormDefaultSettings $form
                  */
                 Piwik::postEvent('Installation.defaultSettingsForm.submit', array($form));
+
+                $this->markInstallationAsCompleted();
 
                 Url::redirectToUrl('index.php');
             } catch (Exception $e) {


### PR DESCRIPTION
Tried the installation today and the last step failed when submitting the form (nothing major as Piwik is accessible at that point, but the privacy options are not saved :/). This should fix it (tested).

I think it's worth including it in the future patch release.
