### PR TITLE
modified test case to allow overriding requests Collection and it's logic

### DIFF
--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -432,7 +432,7 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
             $this->changeLanguage($testConfig->language);
         }
 
-        $testRequests = new Collection($api, $testConfig, $api);
+        $testRequests = $this->getTestRequestsCollection($api, $testConfig, $api);
 
         foreach ($testRequests->getRequestUrls() as $apiId => $requestUrl) {
             $this->_testApiUrl($testName . $testConfig->testSuffix, $apiId, $requestUrl, $testConfig->compareAgainst, $testConfig->xmlFieldsToRemove, $params);
@@ -458,6 +458,11 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         }
 
         return count($this->comparisonFailures) == 0;
+    }
+
+    protected function getTestRequestsCollection($api, $testConfig, $api)
+    {
+       return new Collection($api, $testConfig, $api);
     }
 
     private function printComparisonFailures()

--- a/tests/PHPUnit/Framework/TestRequest/Collection.php
+++ b/tests/PHPUnit/Framework/TestRequest/Collection.php
@@ -288,7 +288,7 @@ class Collection
         return $result;
     }
 
-    private function shouldSkipApiMethod($moduleName, $methodName) {
+    protected function shouldSkipApiMethod($moduleName, $methodName) {
         $apiId = $moduleName . '.' . $methodName;
 
         // If Api to test were set, we only test these


### PR DESCRIPTION
In some cases it's impossible to test custom plugins API using current Collection class (API url's are being rejected). Purpose of this PR is to allow overriding this logic and use plugin's own test case for testing.
