### PR TITLE
Update piwik.js

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2183,7 +2183,7 @@ if (typeof Piwik !== 'object') {
                 configLinkClasses = [],
 
                 // Maximum delay to wait for web bug image to be fetched (in milliseconds)
-                configTrackerPause = 5000,
+                configTrackerPause = 500,
 
                 // Minimum visit time after initial page view (in milliseconds)
                 configMinimumVisitTime,

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2422,7 +2422,6 @@ if (typeof Piwik !== 'object') {
 
         		if (navigator && navigator.sendBeacon && navigator.sendBeacon(configTrackerUrl, request)) {
         			if (typeof callback === 'function') { callback(); }
-        			setExpireDateTime(0);
         			return true;
         		} else return false;
             }
@@ -2436,7 +2435,6 @@ if (typeof Piwik !== 'object') {
 
                 image.onerror = image.onload = function () {
                     if (typeof callback === 'function') { callback(); }
-                    setExpireDateTime(0);
                 };
                 image.src = configTrackerUrl + (configTrackerUrl.indexOf('?') < 0 ? '?' : '&') + request;
             }
@@ -2467,7 +2465,6 @@ if (typeof Piwik !== 'object') {
                             if (!sendBeacon(request, callback)) getImage(request, callback);
                         } else {
                             if (typeof callback === 'function') { callback(); }
-                            setExpireDateTime(0);
                         }
                     };
 


### PR DESCRIPTION
Tried implementing sendBeacon on the client side, but it seems the server side requires a different content-type? Remove "return false" from 2421 for testing.

In my experience the 500ms wait is arbitrary guesswork and is not enough for slow connections from distant places. I increased this in my own implementation to 5000ms and only use it as a fallback timeout so that the navigation do not get stuck forever.

Also the image.onready now requires image.onerror as well since piwik does not return a valid image anymore (return code 204)

refs #6641
