### PR TITLE
include server time (as timestamp) in visitor actions (visitor live API)

### DIFF
--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -398,6 +398,7 @@ class Visitor implements VisitorInterface
             // Convert datetimes to the site timezone
             $dateTimeVisit = Date::factory($details['serverTimePretty'], $timezone);
             $details['serverTimePretty'] = $dateTimeVisit->getLocalized(Piwik::translate('CoreHome_ShortDateFormat') . ' %time%');
+            $details['timestamp'] = $dateTimeVisit->getTimestamp();
         }
         $visitorDetailsArray['goalConversions'] = count($goalDetails);
         return $visitorDetailsArray;


### PR DESCRIPTION
Events in the returned JSON/XML only have a field "serverTimePretty" but no locale-independent time field (e.g. Unix epoch, iso9660, ...). I don't see a reason why the API does not contain the date/time in such a format.

Please note I'm not a PHP developer and this was only tested lightly.
