### PR TITLE
refactor to prevent API error "This report has been reprocessed since your last click" 

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1118,6 +1118,8 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
                 $depth++;
                 $aSerializedDataTable = $aSerializedDataTable + $subTable->getSerialized($maximumRowsInSubDataTable, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation);
                 $depth--;
+            } else {
+                $row->removeSubtable();
             }
         }
         // we load the current Id of the DataTable

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1114,10 +1114,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         $aSerializedDataTable = array();
         foreach ($this->rows as $row) {
             $subTable = $row->getSubtable();
-            if (!$subTable) {
-                // Not sure if this code is needed
-                $row->removeSubtable();
-            } else {
+            if ($subTable) {
                 $depth++;
                 $aSerializedDataTable = $aSerializedDataTable + $subTable->getSerialized($maximumRowsInSubDataTable, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation);
                 $depth--;

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -356,10 +356,11 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
         if ($this->enableRecursiveSort === true) {
             foreach ($this->getRows() as $row) {
-                if (($idSubtable = $row->getIdSubDataTable()) !== null) {
-                    $table = Manager::getInstance()->getTable($idSubtable);
-                    $table->enableRecursiveSort();
-                    $table->sort($functionCallback, $columnSortedBy);
+
+                $subTable = $row->getSubtable();
+                if ($subTable) {
+                    $subTable->enableRecursiveSort();
+                    $subTable->sort($functionCallback, $columnSortedBy);
                 }
             }
         }
@@ -868,8 +869,8 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     {
         $totalCount = 0;
         foreach ($this->rows as $row) {
-            if (($idSubTable = $row->getIdSubDataTable()) !== null) {
-                $subTable = Manager::getInstance()->getTable($idSubTable);
+            $subTable = $row->getSubtable();
+            if ($subTable) {
                 $count = $subTable->getRowsCountRecursive();
                 $totalCount += $count;
             }
@@ -907,8 +908,9 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
             $row->renameColumn($oldName, $newName);
 
             if ($doRenameColumnsOfSubTables) {
-                if (($idSubDataTable = $row->getIdSubDataTable()) !== null) {
-                    Manager::getInstance()->getTable($idSubDataTable)->renameColumn($oldName, $newName);
+                $subTable = $row->getSubtable();
+                if ($subTable) {
+                    $subTable->renameColumn($oldName, $newName);
                 }
             }
         }
@@ -929,8 +931,9 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
             foreach ($names as $name) {
                 $row->deleteColumn($name);
             }
-            if (($idSubDataTable = $row->getIdSubDataTable()) !== null) {
-                Manager::getInstance()->getTable($idSubDataTable)->deleteColumns($names, $deleteRecursiveInSubtables);
+            $subTable = $row->getSubtable();
+            if ($subTable) {
+                $subTable->deleteColumns($names, $deleteRecursiveInSubtables);
             }
         }
         if (!is_null($this->summaryRow)) {
@@ -1110,17 +1113,11 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         // but returns all serialized tables and subtable in an array of 1 dimension
         $aSerializedDataTable = array();
         foreach ($this->rows as $row) {
-            if (($idSubTable = $row->getIdSubDataTable()) !== null) {
-                $subTable = null;
-                try {
-                    $subTable = Manager::getInstance()->getTable($idSubTable);
-                } catch(TableNotFoundException $e) {
-                    // This occurs is an unknown & random data issue. Catch Exception and remove subtable from the row.
-                    $row->removeSubtable();
-                    // Go to next row
-                    continue;
-                }
-
+            $subTable = $row->getSubtable();
+            if (!$subTable) {
+                // Not sure if this code is needed
+                $row->removeSubtable();
+            } else {
                 $depth++;
                 $aSerializedDataTable = $aSerializedDataTable + $subTable->getSerialized($maximumRowsInSubDataTable, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation);
                 $depth--;
@@ -1616,8 +1613,8 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
                 // we simply add it (cloning the subtable)
                 // if the row has the subtable already
                 // then we have to recursively sum the subtables
-                if (($idSubTable = $row->getIdSubDataTable()) !== null) {
-                    $subTable = Manager::getInstance()->getTable($idSubTable);
+                $subTable = $row->getSubtable();
+                if ($subTable) {
                     $subTable->metadata[self::COLUMN_AGGREGATION_OPS_METADATA_NAME]
                         = $this->getMetadata(self::COLUMN_AGGREGATION_OPS_METADATA_NAME);
                     $rowFound->sumSubtable($subTable);

--- a/core/DataTable/BaseFilter.php
+++ b/core/DataTable/BaseFilter.php
@@ -73,8 +73,8 @@ abstract class BaseFilter
         if (!$this->enableRecursive) {
             return;
         }
-        if ($row->isSubtableLoaded()) {
-            $subTable = Manager::getInstance()->getTable($row->getIdSubDataTable());
+        $subTable = $row->getSubtable();
+        if ($subTable) {
             $this->filter($subTable);
         }
     }

--- a/core/DataTable/Filter/PatternRecursive.php
+++ b/core/DataTable/Filter/PatternRecursive.php
@@ -62,18 +62,15 @@ class PatternRecursive extends BaseFilter
             // AND 2 - the label is not found in the children
             $patternNotFoundInChildren = false;
 
-            try {
-                $idSubTable = $row->getIdSubDataTable();
-                $subTable = Manager::getInstance()->getTable($idSubTable);
-
+            $subTable = $row->getSubtable();
+            if(!$subTable) {
+                $patternNotFoundInChildren = true;
+            } else {
                 // we delete the row if we couldn't find the pattern in any row in the
                 // children hierarchy
                 if ($this->filter($subTable) == 0) {
                     $patternNotFoundInChildren = true;
                 }
-            } catch (Exception $e) {
-                // there is no subtable loaded for example
-                $patternNotFoundInChildren = true;
             }
 
             if ($patternNotFoundInChildren

--- a/core/DataTable/Filter/ReplaceSummaryRowLabel.php
+++ b/core/DataTable/Filter/ReplaceSummaryRowLabel.php
@@ -65,8 +65,8 @@ class ReplaceSummaryRowLabel extends BaseFilter
 
         // recurse
         foreach ($rows as $row) {
-            if ($row->isSubtableLoaded()) {
-                $subTable = Manager::getInstance()->getTable($row->getIdSubDataTable());
+            $subTable = $row->getSubtable();
+            if ($subTable) {
                 $this->filter($subTable);
             }
         }

--- a/core/DataTable/Manager.php
+++ b/core/DataTable/Manager.php
@@ -61,7 +61,7 @@ class Manager extends Singleton
     public function getTable($idTable)
     {
         if (!isset($this->tables[$idTable])) {
-            throw new TableNotFoundException(sprintf("This report has been reprocessed since your last click. To see this error less often, please increase the timeout value in seconds in Settings > General Settings. (error: id %s not found).", $idTable));
+            throw new TableNotFoundException(sprintf("Error: table id %s not found in memory. (If this error is causing you problems in production, please report it in Piwik issue tracker.)", $idTable));
         }
 
         return $this->tables[$idTable];

--- a/core/DataTable/Renderer/Console.php
+++ b/core/DataTable/Renderer/Console.php
@@ -120,14 +120,10 @@ class Console extends Renderer
                 . $row->getIdSubDataTable() . "]<br />\n";
 
             if (!is_null($row->getIdSubDataTable())) {
-                if ($row->isSubtableLoaded()) {
+                $subTable = $row->getSubtable();
+                if ($subTable) {
                     $depth++;
-                    $output .= $this->renderTable(
-                        Manager::getInstance()->getTable(
-                            $row->getIdSubDataTable()
-                        ),
-                        $prefix . '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;'
-                    );
+                    $output .= $this->renderTable($subTable, $prefix . '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;');
                     $depth--;
                 } else {
                     $output .= "-- Sub DataTable not loaded<br />\n";

--- a/core/DataTable/Renderer/Php.php
+++ b/core/DataTable/Renderer/Php.php
@@ -206,10 +206,10 @@ class Php extends Renderer
                 $newRow['issummaryrow'] = true;
             }
 
+            $subTable = $row->getSubtable();
             if ($this->isRenderSubtables()
-                && $row->isSubtableLoaded()
+                && $subTable
             ) {
-                $subTable = $this->renderTable(Manager::getInstance()->getTable($row->getIdSubDataTable()));
                 $newRow['subtable'] = $subTable;
                 if ($this->hideIdSubDatatable === false
                     && isset($newRow['metadata']['idsubdatatable_in_db'])

--- a/core/DataTable/Renderer/Php.php
+++ b/core/DataTable/Renderer/Php.php
@@ -210,6 +210,7 @@ class Php extends Renderer
             if ($this->isRenderSubtables()
                 && $subTable
             ) {
+                $subTable = $this->renderTable($subTable);
                 $newRow['subtable'] = $subTable;
                 if ($this->hideIdSubDatatable === false
                     && isset($newRow['metadata']['idsubdatatable_in_db'])

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -317,7 +317,11 @@ class Row implements \ArrayAccess, \IteratorAggregate
     public function getSubtable()
     {
         if ($this->isSubtableLoaded()) {
-            return Manager::getInstance()->getTable($this->getIdSubDataTable());
+            try {
+                return Manager::getInstance()->getTable($this->getIdSubDataTable());
+            } catch(TableNotFoundException $e) {
+                // edge case
+            }
         }
         return false;
     }

--- a/core/DataTable/Row/DataTableSummaryRow.php
+++ b/core/DataTable/Row/DataTableSummaryRow.php
@@ -47,9 +47,8 @@ class DataTableSummaryRow extends Row
      */
     public function recalculate()
     {
-        $id = $this->getIdSubDataTable();
-        if ($id !== null) {
-            $subTable = Manager::getInstance()->getTable($id);
+        $subTable = $this->getSubtable();
+        if ($subTable) {
             $this->sumTable($subTable);
         }
     }

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -198,9 +198,9 @@ class ArchivingHelper
             if (($idSubtable = $row->getIdSubDataTable()) !== null
                 || $id === DataTable::ID_SUMMARY_ROW
             ) {
-                if ($idSubtable !== null) {
-                    $subtable = Manager::getInstance()->getTable($idSubtable);
-                    self::deleteInvalidSummedColumnsFromDataTable($subtable);
+                $subTable = $row->getSubtable();
+                if ($subTable) {
+                    self::deleteInvalidSummedColumnsFromDataTable($subTable);
                 }
 
                 if ($row instanceof DataTableSummaryRow) {

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -523,8 +523,8 @@ class API extends \Piwik\Plugin\API
             if ($visits) {
                 // load details (i.e. subtables)
                 $details = array();
-                if ($idSubTable = $row->getIdSubDataTable()) {
-                    $subTable = Manager::getInstance()->getTable($idSubTable);
+                $subTable = $row->getSubtable();
+                if ($subTable) {
                     foreach ($subTable->getRows() as $subRow) {
                         $details[] = array(
                             'label'     => $subRow->getColumn('label'),

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSummaryRowTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSummaryRowTest.php
@@ -11,6 +11,9 @@ namespace Piwik\Tests\Unit\DataTable\Filter;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Filter_AddSummaryRowTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/PHPUnit/Unit/DataTable/Filter/ExcludeLowPopulationTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/ExcludeLowPopulationTest.php
@@ -12,6 +12,9 @@ use Piwik\DataTable\Filter\ExcludeLowPopulation;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Filter_ExcludeLowPopulationTest extends \PHPUnit_Framework_TestCase
 {
     protected function getTestDataTable()

--- a/tests/PHPUnit/Unit/DataTable/Filter/LimitTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/LimitTest.php
@@ -12,6 +12,9 @@ use Piwik\DataTable\Filter\Limit;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -39,9 +42,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         return $table;
     }
 
-    /**
-     * @group Core
-     */
+
     public function testNormal()
     {
         $offset = 2;
@@ -55,9 +56,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $table->getMetadata(DataTable::TOTAL_ROWS_BEFORE_LIMIT_METADATA_NAME));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testLimitLessThanCountShouldReturnCountLimit()
     {
         $offset = 2;
@@ -71,9 +70,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $table->getMetadata(DataTable::TOTAL_ROWS_BEFORE_LIMIT_METADATA_NAME));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testLimitIsCountShouldNotDeleteAnything()
     {
         $offset = 0;
@@ -88,9 +85,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $table->getMetadata(DataTable::TOTAL_ROWS_BEFORE_LIMIT_METADATA_NAME));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testLimitGreaterThanCountShouldReturnCountUntilCount()
     {
         $offset = 5;
@@ -105,9 +100,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $table->getMetadata(DataTable::TOTAL_ROWS_BEFORE_LIMIT_METADATA_NAME));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testLimitIsNullShouldReturnCountIsOffset()
     {
         $offset = 1;
@@ -120,9 +113,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $table->getMetadata(DataTable::TOTAL_ROWS_BEFORE_LIMIT_METADATA_NAME));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testOffsetJustBeforeSummaryRowShouldJustReturnSummaryRow()
     {
         $offset = 9;
@@ -136,9 +127,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $table->getMetadata(DataTable::TOTAL_ROWS_BEFORE_LIMIT_METADATA_NAME));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testOffsetJustBeforeSummaryRowWithBigLimitShouldJustReturnSummaryRow()
     {
         $offset = 9;
@@ -152,9 +141,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $table->getMetadata(DataTable::TOTAL_ROWS_BEFORE_LIMIT_METADATA_NAME));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testOffsetBeforeSummaryRowShouldJustReturnRowAndSummaryRow()
     {
         $offset = 8;
@@ -168,9 +155,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $table->getMetadata(DataTable::TOTAL_ROWS_BEFORE_LIMIT_METADATA_NAME));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testOffsetGreaterThanCountShouldReturnEmptyTable()
     {
         $offset = 10;
@@ -182,9 +167,7 @@ class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(10, $table->getMetadata(DataTable::TOTAL_ROWS_BEFORE_LIMIT_METADATA_NAME));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testLimitIsZeroShouldReturnEmptyTable()
     {
         $offset = 0;

--- a/tests/PHPUnit/Unit/DataTable/Filter/PatternRecursiveTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PatternRecursiveTest.php
@@ -11,6 +11,9 @@ namespace Piwik\Tests\Unit\DataTable\Filter;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Filter_PatternRecursiveTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/PHPUnit/Unit/DataTable/Filter/PatternTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PatternTest.php
@@ -11,6 +11,9 @@ namespace Piwik\Tests\Unit\DataTable\Filter;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Filter_PatternTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/PHPUnit/Unit/DataTable/Filter/PivotByDimensionTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PivotByDimensionTest.php
@@ -17,7 +17,7 @@ use PHPUnit_Framework_TestCase;
 use Exception;
 
 /**
- * @group Core
+ * @group DataTableTest
  */
 class PivotByDimensionTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Unit/DataTable/Filter/RangeCheckTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/RangeCheckTest.php
@@ -12,11 +12,12 @@ use Piwik\DataTable\Filter\RangeCheck;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Filter_RangeCheckTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @group Core
-     */
+
     public function testRangeCheckNormalDataTable()
     {
         $table = new DataTable();
@@ -34,9 +35,7 @@ class DataTable_Filter_RangeCheckTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedOrder, $table->getColumn('count'));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRangeCheckNormalDataTableNonIntegerValues()
     {
         $table = new DataTable();

--- a/tests/PHPUnit/Unit/DataTable/Filter/SortTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/SortTest.php
@@ -13,13 +13,11 @@ use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
 /**
- * @group SortTest
+ * @group DataTableTest
  */
 class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @group Core
-     */
+
     public function testNormalSortDescending()
     {
         $table = new DataTable();
@@ -34,9 +32,7 @@ class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedOrder, $table->getColumn('label'));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testNormalSortAscending()
     {
         $table = new DataTable();
@@ -51,9 +47,7 @@ class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedOrder, $table->getColumn('label'));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testMissingColumnValuesShouldAppearLastAfterSortAsc()
     {
         $table = new DataTable();
@@ -71,9 +65,7 @@ class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedOrder, $table->getColumn('label'));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testMissingColumnValuesShouldAppearLastAfterSortDesc()
     {
         $table = new DataTable();

--- a/tests/PHPUnit/Unit/DataTable/Filter/TruncateTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/TruncateTest.php
@@ -12,11 +12,12 @@ use Piwik\DataTable\Filter\Truncate;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @group Core
-     */
+
     public function testUnrelatedDataTableNotFiltered()
     {
         // remark: this unit test would become invalid and would need to be rewritten if
@@ -38,9 +39,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
         $filter->filter($dataTableBeingFiltered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testForInfiniteRecursion()
     {
         $dataTableBeingFiltered = new DataTable();
@@ -62,9 +61,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
         $filter->filter($dataTableBeingFiltered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testOffsetIsCountSummaryRowShouldBeTheRow()
     {
         $table = $this->getDataTableCount5();
@@ -74,9 +71,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Row::isEqual($table->getLastRow(), $this->getRow4()));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testOffsetIsLessThanCountSummaryRowShouldBeTheSum()
     {
         $table = $this->getDataTableCount5();
@@ -89,9 +84,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array_keys($table->getLastRow()->getColumns()), array_keys($expectedRow->getColumns()));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testOffsetIsMoreThanCountShouldNotTruncate()
     {
         $table = $this->getDataTableCount5();
@@ -101,9 +94,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Row::isEqual($table->getLastRow(), $this->getRow4()));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testWhenThereIsAlreadyASummaryRowShouldReplaceTheSummaryRow()
     {
         $table = $this->getDataTableCount5();
@@ -116,9 +107,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Row::isEqual($table->getLastRow(), $expectedRow));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testSumTablesWithSummaryRowShouldSumTheSummaryRow()
     {
         // row0, row1, row2, rowSummary1
@@ -142,9 +131,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(DataTable::isEqual($expectedTable, $table1));
     }
 
-    /**
-     * @group Core
-     */
+
     public function testAddOneTableWithSummaryRow()
     {
         // row0, row1, row2, rowSummary1
@@ -169,9 +156,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
 
     }
 
-    /**
-     * @group Core
-     */
+
     public function testWhenRowsInRandomOrderButSortSpecifiedShouldComputeSummaryRowAfterSort()
     {
         $table = new DataTable;

--- a/tests/PHPUnit/Unit/DataTable/MapTest.php
+++ b/tests/PHPUnit/Unit/DataTable/MapTest.php
@@ -7,6 +7,9 @@ use Piwik\DataTable\Manager;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
+/**
+ * @group DataTableTest
+ */
 class Test_DataTable_Map extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
@@ -14,6 +14,9 @@ use Piwik\DataTable\Renderer\Csv;
 use Piwik\DataTable\Row;
 use Piwik\DataTable\Simple;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
@@ -93,9 +96,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         return $table;
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVTest1()
     {
         $dataTable = $this->_getDataTableTest();
@@ -111,9 +112,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVTest2()
     {
         $dataTable = $this->_getDataTableSimpleTest();
@@ -125,9 +124,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVTest3()
     {
         $dataTable = $this->_getDataTableSimpleOneRowTest();
@@ -139,9 +136,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVTest5()
     {
         $dataTable = $this->_getDataTableSimpleOneZeroRowTest();
@@ -153,9 +148,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVTest4()
     {
         $dataTable = $this->_getDataTableEmpty();
@@ -167,9 +160,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVTest6()
     {
         $dataTable = $this->_getDataTableSimpleOneFalseRowTest();
@@ -181,9 +172,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVRendererCorrectlyEscapesHeadersAndValues()
     {
         $dataTable = $this->_getDataTableSimpleWithCommasInCells();
@@ -301,9 +290,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         return $table;
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVMapTest1()
     {
         $dataTable = $this->_getDataTableMapTest();
@@ -320,9 +307,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVMapTest2()
     {
         $dataTable = $this->_getDataTableSimpleMapTest();
@@ -335,9 +320,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVMapTest3()
     {
         $dataTable = $this->_getDataTableSimpleOneRowMapTest();
@@ -349,9 +332,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVMapisMadeOfMapTest1()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_normal();
@@ -368,9 +349,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVMapIsMadeOfMapTest2()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_simple();
@@ -383,9 +362,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testCSVMapIsMadeOfMapTest3()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_simpleOneRow();
@@ -397,9 +374,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray1()
     {
         $data = array();
@@ -412,9 +387,7 @@ class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray2()
     {
         $data = array('a', 'b', 'c');
@@ -429,9 +402,7 @@ c';
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray3()
     {
         $data = array('a' => 'b', 'c' => 'd', 'e' => 'f', 5 => 'g');
@@ -445,9 +416,7 @@ b,d,f,g';
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray4()
     {
         $data = array('a' => 'b');

--- a/tests/PHPUnit/Unit/DataTable/Renderer/ConsoleTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/ConsoleTest.php
@@ -13,6 +13,9 @@ use Piwik\DataTable;
 use Piwik\DataTable\Renderer\Console;
 use Piwik\DataTable\Row;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Renderer_ConsoleTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
@@ -89,9 +92,7 @@ class DataTable_Renderer_ConsoleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray1()
     {
         $data = array();
@@ -104,9 +105,7 @@ class DataTable_Renderer_ConsoleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray2()
     {
         $data = array('a', 'b', 'c');
@@ -121,9 +120,7 @@ class DataTable_Renderer_ConsoleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray3()
     {
         $data = array('a' => 'b', 'c' => 'd', 'e' => 'f', 5 => 'g');
@@ -136,9 +133,7 @@ class DataTable_Renderer_ConsoleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray4()
     {
         $data = array('a' => 'b');

--- a/tests/PHPUnit/Unit/DataTable/Renderer/JSONTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/JSONTest.php
@@ -14,6 +14,9 @@ use Piwik\DataTable\Renderer\Json;
 use Piwik\DataTable\Row;
 use Piwik\DataTable\Simple;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
@@ -93,9 +96,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         return $table;
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONTest1()
     {
         $dataTable = $this->_getDataTableTest();
@@ -108,9 +109,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONTest2()
     {
         $dataTable = $this->_getDataTableSimpleTest();
@@ -121,9 +120,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONTest3()
     {
         $dataTable = $this->_getDataTableSimpleOneRowTest();
@@ -133,9 +130,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONTest4()
     {
         $dataTable = $this->_getDataTableEmpty();
@@ -145,9 +140,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONTest5()
     {
         $dataTable = $this->_getDataTableSimpleOneZeroRowTest();
@@ -157,9 +150,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONTest6()
     {
         $dataTable = $this->_getDataTableSimpleOneFalseRowTest();
@@ -274,9 +265,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         return $table;
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONArrayTest1()
     {
         $dataTable = $this->_getDataTableMapTest();
@@ -288,9 +277,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONMapTest2()
     {
         $dataTable = $this->_getDataTableSimpleMapTest();
@@ -303,9 +290,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONMapTest3()
     {
         $dataTable = $this->_getDataTableSimpleOneRowMapTest();
@@ -317,9 +302,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONMapIsMadeOfMapTest1()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_normal();
@@ -330,9 +313,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONMapIsMadeOfMapTest2()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_simple();
@@ -345,9 +326,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testJSONMapIsMadeOfMapTest3()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_simpleOneRow();
@@ -359,9 +338,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray1()
     {
         $data = array();
@@ -373,9 +350,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray2()
     {
         $data = array('a', 'b', 'c', array('a' => 'b'), array(1, 2));
@@ -387,9 +362,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray3()
     {
         $data = array('a' => 'b', 'c' => 'd', 'e' => 'f', 5 => 'g');
@@ -401,9 +374,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray4()
     {
         $data = array('a' => 'b', 'c' => array(1, 2, 3, 4), 'e' => array('f' => 'g', 'h' => 'i', 'j' => 'k'));
@@ -415,9 +386,7 @@ class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray5()
     {
         $data = array('a' => 'b');

--- a/tests/PHPUnit/Unit/DataTable/Renderer/PHPTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/PHPTest.php
@@ -14,6 +14,9 @@ use Piwik\DataTable\Renderer\Php;
 use Piwik\DataTable\Row;
 use Piwik\DataTable\Simple;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
@@ -93,9 +96,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         return $table;
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPTest1()
     {
         $dataTable = $this->_getDataTableTest();
@@ -157,9 +158,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPTest2()
     {
         $dataTable = $this->_getDataTableSimpleTest();
@@ -176,9 +175,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPTest3()
     {
         $dataTable = $this->_getDataTableSimpleOneRowTest();
@@ -188,9 +185,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPTest4()
     {
         $dataTable = $this->_getDataTableEmpty();
@@ -200,9 +195,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPTest5()
     {
         $dataTable = $this->_getDataTableSimpleOneZeroRowTest();
@@ -212,9 +205,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPTest6()
     {
         $dataTable = $this->_getDataTableSimpleOneFalseRowTest();
@@ -329,9 +320,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         return $table;
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPMapTest1()
     {
         $dataTable = $this->_getDataTableMapTest();
@@ -383,9 +372,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPMapTest2()
     {
         $dataTable = $this->_getDataTableSimpleMapTest();
@@ -410,9 +397,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPMapTest3()
     {
         $dataTable = $this->_getDataTableSimpleOneRowMapTest();
@@ -428,9 +413,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPMapIsMadeOfMapTest1()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_normal();
@@ -484,9 +467,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPMapIsMadeOfMapTest2()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_simple();
@@ -512,9 +493,7 @@ class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testPHPMapIsMadeOfMapTest3()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_simpleOneRow();

--- a/tests/PHPUnit/Unit/DataTable/Renderer/XMLTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/XMLTest.php
@@ -14,6 +14,9 @@ use Piwik\DataTable\Renderer\Xml;
 use Piwik\DataTable\Row;
 use Piwik\DataTable\Simple;
 
+/**
+ * @group DataTableTest
+ */
 class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
@@ -93,9 +96,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         return $table;
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLTest1()
     {
         $dataTable = $this->_getDataTableTest();
@@ -152,9 +153,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLTest2()
     {
         $dataTable = $this->_getDataTableSimpleTest();
@@ -172,9 +171,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLTest3()
     {
         $dataTable = $this->_getDataTableSimpleOneRowTest();
@@ -185,9 +182,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLTest4()
     {
         $dataTable = $this->_getDataTableEmpty();
@@ -198,9 +193,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLTest5()
     {
         $dataTable = $this->_getDataTableSimpleOneZeroRowTest();
@@ -211,9 +204,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLTest6()
     {
         $dataTable = $this->_getDataTableSimpleOneFalseRowTest();
@@ -224,9 +215,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLRendererSuccessfullyRendersWhenSimpleDataTableColumnsHaveInvalidXmlCharacters()
     {
         $dataTable = $this->_getDataTableSimpleWithInvalidChars();
@@ -241,9 +230,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLRendererSuccessfullyRendersWhenDataTableColumnsHaveInvalidXmlCharacters()
     {
         $dataTable = $this->_getDataTableWithInvalidChars();
@@ -365,9 +352,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         return $table;
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLMapTest1()
     {
         $dataTable = $this->_getDataTableMapTest();
@@ -412,9 +397,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLArrayIsMadeOfMapTest1()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_normal();
@@ -463,9 +446,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLMapTest2()
     {
         $dataTable = $this->_getDataTableSimpleMapTest();
@@ -487,9 +468,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLArrayIsMadeOfMapTest2()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_simple();
@@ -513,9 +492,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLMapTest3()
     {
         $dataTable = $this->_getDataTableSimpleOneRowMapTest();
@@ -532,9 +509,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testXMLArrayIsMadeOfMapTest3()
     {
         $dataTable = $this->_getDataTableMap_containsDataTableMap_simpleOneRow();
@@ -552,9 +527,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $rendered);
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray1()
     {
         $data = array();
@@ -567,9 +540,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray2()
     {
         $data = array("firstElement",
@@ -592,9 +563,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray3()
     {
         $data = array('a' => 'b', 'c' => 'd', 'e' => 'f', 5 => 'g');
@@ -614,9 +583,7 @@ class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $render->render());
     }
 
-    /**
-     * @group Core
-     */
+
     public function testRenderArray4()
     {
         $data = array('c' => array(1, 2, 3, 4), 'e' => array('f' => 'g', 'h' => 'i', 'j' => 'k'));

--- a/tests/PHPUnit/Unit/DataTable/RowTest.php
+++ b/tests/PHPUnit/Unit/DataTable/RowTest.php
@@ -12,7 +12,7 @@ use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
 /**
- * @group Core
+ * @group DataTableTest
  */
 class RowTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -14,6 +14,9 @@ use Piwik\DataTable\Row;
 use Piwik\DataTable;
 use Piwik\Timer;
 
+/**
+ * @group DataTableTest
+ */
 class DataTableTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
should fix #3414 by making Archiving code and other code use `getSubTable()` helper method which will not throw when the sub-table is somehow not found in memory
