### PR TITLE
Tracker should not error out when config/config.ini.php is not created yet (eg. during installation)

### DIFF
--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -62,7 +62,12 @@ class Tracker
     public static function loadTrackerEnvironment()
     {
         SettingsServer::setIsTrackerApiRequest();
-        $GLOBALS['PIWIK_TRACKER_DEBUG'] = (bool) TrackerConfig::getConfigValue('debug');
+        try {
+            $debug = (bool)TrackerConfig::getConfigValue('debug');
+        } catch(Exception $e) {
+            $debug = false;
+        }
+        $GLOBALS['PIWIK_TRACKER_DEBUG'] = $debug;
         PluginManager::getInstance()->loadTrackerPlugins();
     }
 

--- a/piwik.php
+++ b/piwik.php
@@ -70,11 +70,7 @@ require_once PIWIK_INCLUDE_PATH . '/core/Cookie.php';
 session_cache_limiter('nocache');
 @date_default_timezone_set('UTC');
 
-try {
-    Tracker::loadTrackerEnvironment();
-} catch (Exception $e) {
-    // eg. Piwik is not installed yet
-}
+Tracker::loadTrackerEnvironment();
 
 $tracker    = new Tracker();
 $requestSet = new RequestSet();

--- a/piwik.php
+++ b/piwik.php
@@ -67,10 +67,14 @@ require_once PIWIK_INCLUDE_PATH . '/core/Tracker/Cache.php';
 require_once PIWIK_INCLUDE_PATH . '/core/Tracker/Request.php';
 require_once PIWIK_INCLUDE_PATH . '/core/Cookie.php';
 
-Tracker::loadTrackerEnvironment();
-
 session_cache_limiter('nocache');
 @date_default_timezone_set('UTC');
+
+try {
+    Tracker::loadTrackerEnvironment();
+} catch (Exception $e) {
+    // eg. Piwik is not installed yet
+}
 
 $tracker    = new Tracker();
 $requestSet = new RequestSet();


### PR DESCRIPTION
Fixes #6841
