### PR TITLE
Fixes #6765 Moved the 'Settings' menu in the top menu

### DIFF
--- a/plugins/UsersManager/Menu.php
+++ b/plugins/UsersManager/Menu.php
@@ -9,7 +9,7 @@
 namespace Piwik\Plugins\UsersManager;
 
 use Piwik\Menu\MenuAdmin;
-use Piwik\Menu\MenuUser;
+use Piwik\Menu\MenuTop;
 use Piwik\Piwik;
 
 class Menu extends \Piwik\Plugin\Menu
@@ -22,10 +22,10 @@ class Menu extends \Piwik\Plugin\Menu
         }
     }
 
-    public function configureUserMenu(MenuUser $menu)
+    public function configureTopMenu(MenuTop $menu)
     {
         if (!Piwik::isUserIsAnonymous()) {
-            $menu->addItem('', 'General_Settings', $this->urlForAction('userSettings'), 0);
+            $menu->addItem('General_Settings', null, $this->urlForAction('userSettings'), 30);
         }
     }
 }


### PR DESCRIPTION
The settings menu is now visible on every page and doesn't require to click on the user name.

As I said on #6765, the first times I used Piwik I was very confused because I couldn't find this link.

![capture d ecran 2014-12-23 a 10 28 47](https://cloud.githubusercontent.com/assets/720328/5531259/85a4adc4-8a8e-11e4-9eae-f543541d68bc.png)
