### PR TITLE
Enabled some ArchiveCronTests

### DIFF
--- a/tests/PHPUnit/System/ArchiveCronTest.php
+++ b/tests/PHPUnit/System/ArchiveCronTest.php
@@ -25,6 +25,9 @@ use Exception;
  */
 class ArchiveCronTest extends SystemTestCase
 {
+    /**
+     * @var ManySitesImportedLogs
+     */
     public static $fixture = null; // initialized below class definition
 
     public function getApiForTesting()
@@ -35,21 +38,21 @@ class ArchiveCronTest extends SystemTestCase
         // Disabling these tests as they randomly fail... This could actually be a bug.
         // FIXME - I have failed finding the cause for these test to randomly fail
         // eg.
-//        foreach (self::$fixture->getDefaultSegments() as $segmentName => $info) {
-//            $results[] = array('VisitsSummary.get', array('idSite'     => 'all',
-//                                                          'date'       => '2012-08-09',
-//                                                          'periods'    => array('day', 'week', 'month', 'year'),
-//                                                          'segment'    => $info['definition'],
-//                                                          'testSuffix' => '_' . $segmentName));
-//
-//
-//        }
+        foreach (self::$fixture->getDefaultSegments() as $segmentName => $info) {
+            $results[] = array('VisitsSummary.get', array('idSite'     => 'all',
+                                                          'date'       => '2012-08-09',
+                                                          'periods'    => array('day', 'week', 'month', 'year'),
+                                                          'segment'    => $info['definition'],
+                                                          'testSuffix' => '_' . $segmentName));
+
+
+        }
 
         // API Call Without segments
         // TODO uncomment week and year period
         $results[] = array('VisitsSummary.get', array('idSite'  => 'all',
                                                       'date'    => '2012-08-09',
-                                                      'periods' => array('day', 'month', /* 'year',  'week' */)));
+                                                      'periods' => array('day', 'month', 'year',  'week')));
 
         $results[] = array('VisitsSummary.get', array('idSite'     => 'all',
                                                       'date'       => '2012-08-09',

--- a/tests/PHPUnit/System/expected/test_ArchiveCronTest_noOptions__VisitsSummary.get_week.xml
+++ b/tests/PHPUnit/System/expected/test_ArchiveCronTest_noOptions__VisitsSummary.get_week.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <results>
-	<result idSite="1" />
+	<result idSite="1">
+		<nb_uniq_visitors>25</nb_uniq_visitors>
+		<nb_users>0</nb_users>
+		<nb_visits>25</nb_visits>
+		<nb_actions>28</nb_actions>
+		<nb_visits_converted>23</nb_visits_converted>
+		<bounce_count>23</bounce_count>
+		<sum_visit_length>305</sum_visit_length>
+		<max_actions>3</max_actions>
+		<bounce_rate>92%</bounce_rate>
+		<nb_actions_per_visit>1.1</nb_actions_per_visit>
+		<avg_time_on_site>12</avg_time_on_site>
+	</result>
 	<result idSite="2" />
 </results>


### PR DESCRIPTION
refs #6753 

They are green in that branch. I reckon we will only find out whether they still fail randomly by merging them into master? If they still fail we can simply disable them again
