### PR TITLE
DI config: renamed the `old_config` prefix to `ini`

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -14,8 +14,8 @@ return array(
         $root = $c->get('path.root');
 
         // TODO remove that special case and instead have plugins override 'path.tmp' to add the instance id
-        if ($c->has('old_config.General.instance_id')) {
-            $instanceId = $c->get('old_config.General.instance_id');
+        if ($c->has('ini.General.instance_id')) {
+            $instanceId = $c->get('ini.General.instance_id');
             $instanceId = $instanceId ? '/' . $instanceId : '';
         } else {
             $instanceId = '';
@@ -36,7 +36,7 @@ return array(
         } elseif (\Piwik\Development::isEnabled()) {
             $backend = 'null';
         } else {
-            $backend = $c->get('old_config.Cache.backend');
+            $backend = $c->get('ini.Cache.backend');
         }
 
         return $backend;
@@ -80,8 +80,8 @@ return array(
     'Psr\Log\LoggerInterface' => DI\object('Monolog\Logger')
         ->constructor('piwik', DI\link('log.handlers'), DI\link('log.processors')),
     'log.handlers' => DI\factory(function (ContainerInterface $c) {
-        if ($c->has('old_config.log.log_writers')) {
-            $writerNames = $c->get('old_config.log.log_writers');
+        if ($c->has('ini.log.log_writers')) {
+            $writerNames = $c->get('ini.log.log_writers');
         } else {
             return array();
         }
@@ -116,8 +116,8 @@ return array(
         ->constructor(DI\link('log.level'))
         ->method('setFormatter', DI\link('Piwik\Log\Formatter\LineMessageFormatter')),
     'log.level' => DI\factory(function (ContainerInterface $c) {
-        if ($c->has('old_config.log.log_level')) {
-            $level = strtoupper($c->get('old_config.log.log_level'));
+        if ($c->has('ini.log.log_level')) {
+            $level = strtoupper($c->get('ini.log.log_level'));
             if (!empty($level) && defined('Piwik\Log::'.strtoupper($level))) {
                 return Log::getMonologLevel(constant('Piwik\Log::'.strtoupper($level)));
             }
@@ -125,7 +125,7 @@ return array(
         return Logger::WARNING;
     }),
     'log.file.filename' => DI\factory(function (ContainerInterface $c) {
-        $logPath = $c->get('old_config.log.logger_file_path');
+        $logPath = $c->get('ini.log.logger_file_path');
 
         // Absolute path
         if (strpos($logPath, '/') === 0) {
@@ -152,8 +152,8 @@ return array(
     'Piwik\Log\Formatter\LineMessageFormatter' => DI\object()
         ->constructor(DI\link('log.format')),
     'log.format' => DI\factory(function (ContainerInterface $c) {
-        if ($c->has('old_config.log.string_message_format')) {
-            return $c->get('old_config.log.string_message_format');
+        if ($c->has('ini.log.string_message_format')) {
+            return $c->get('ini.log.string_message_format');
         }
         return '%level% %tag%[%datetime%] %message%';
     }),

--- a/core/Container/IniConfigDefinitionSource.php
+++ b/core/Container/IniConfigDefinitionSource.php
@@ -32,7 +32,7 @@ class IniConfigDefinitionSource extends ChainableDefinitionSource
      * @param Config $config
      * @param string $prefix Prefix for the container entries.
      */
-    public function __construct(Config $config, $prefix = 'old_config.')
+    public function __construct(Config $config, $prefix = 'ini.')
     {
         $this->config = $config;
         $this->prefix = $prefix;

--- a/tests/PHPUnit/Unit/Container/IniConfigDefinitionSourceTest.php
+++ b/tests/PHPUnit/Unit/Container/IniConfigDefinitionSourceTest.php
@@ -44,10 +44,10 @@ class IniConfigDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         $definitionSource = new IniConfigDefinitionSource(Config::getInstance());
 
         /** @var ValueDefinition $definition */
-        $definition = $definitionSource->getDefinition('old_config.foo');
+        $definition = $definitionSource->getDefinition('ini.foo');
 
         $this->assertTrue($definition instanceof ValueDefinition);
-        $this->assertEquals('old_config.foo', $definition->getName());
+        $this->assertEquals('ini.foo', $definition->getName());
         $this->assertSame(array(), $definition->getValue());
     }
 
@@ -58,7 +58,7 @@ class IniConfigDefinitionSourceTest extends \PHPUnit_Framework_TestCase
     {
         $definitionSource = new IniConfigDefinitionSource(Config::getInstance());
 
-        $this->assertNull($definitionSource->getDefinition('old_config.foo.bar'));
+        $this->assertNull($definitionSource->getDefinition('ini.foo.bar'));
     }
 
     /**
@@ -68,7 +68,7 @@ class IniConfigDefinitionSourceTest extends \PHPUnit_Framework_TestCase
     {
         $definitionSource = new IniConfigDefinitionSource(Config::getInstance());
 
-        $this->assertNull($definitionSource->getDefinition('old_config.General.foo'));
+        $this->assertNull($definitionSource->getDefinition('ini.General.foo'));
     }
 
     /**
@@ -85,10 +85,10 @@ class IniConfigDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         $definitionSource = new IniConfigDefinitionSource($config);
 
         /** @var ValueDefinition $definition */
-        $definition = $definitionSource->getDefinition('old_config.General');
+        $definition = $definitionSource->getDefinition('ini.General');
 
         $this->assertTrue($definition instanceof ValueDefinition);
-        $this->assertEquals('old_config.General', $definition->getName());
+        $this->assertEquals('ini.General', $definition->getName());
         $this->assertInternalType('array', $definition->getValue());
         $this->assertEquals(array('foo' => 'bar'), $definition->getValue());
     }
@@ -107,10 +107,10 @@ class IniConfigDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         $definitionSource = new IniConfigDefinitionSource($config);
 
         /** @var ValueDefinition $definition */
-        $definition = $definitionSource->getDefinition('old_config.General.foo');
+        $definition = $definitionSource->getDefinition('ini.General.foo');
 
         $this->assertTrue($definition instanceof ValueDefinition);
-        $this->assertEquals('old_config.General.foo', $definition->getName());
+        $this->assertEquals('ini.General.foo', $definition->getName());
         $this->assertEquals('bar', $definition->getValue());
     }
 


### PR DESCRIPTION
Initially we considered dropping the `ini` config (which lead to the `old_config` name), but the current stance is we keep `config.ini.php` because it's a user friendly config.

I switched to `ini` because it's shorter and maybe more explicit. And it doesn't imply anymore that INI config is deprecated.

Reminder: this feature allows to get `Config` entries from the container (e.g. `$container->get('ini.log.string_message_format')`). The `Config` reads from INI files.
