### PR TITLE
Refactoring translation handling into a Translation component

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,7 +21,7 @@
 [submodule "plugins/CustomAlerts"]
     path = plugins/CustomAlerts
     url = https://github.com/piwik/plugin-CustomAlerts.git
-    branch = master
+    branch = translation
 [submodule "plugins/TasksTimetable"]
     path = plugins/TasksTimetable
     url = https://github.com/piwik/plugin-TasksTimetable.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
 ### Breaking Changes
 * The event `User.getLanguage` has been removed.
 
+### Deprecations
+* The `Piwik\Translate` class has been deprecated in favor of `Piwik\Translation\Translator`.
+
 ## Piwik 2.10.0
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is a changelog for Piwik platform developers. All changes for our HTTP API's, Plugins, Themes, etc will be listed here. 
 
+## Piwik 2.11.0
+
+### Breaking Changes
+* The event `User.getLanguage` has been removed.
+
 ## Piwik 2.10.0
 
 ### Breaking Changes

--- a/config/environment/dev.php
+++ b/config/environment/dev.php
@@ -1,0 +1,8 @@
+<?php
+
+return array(
+
+    // Disable translation cache
+    'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\JsonFileLoader'),
+
+);

--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -5,4 +5,10 @@ return array(
     // Disable logging
     'Psr\Log\LoggerInterface' => DI\object('Psr\Log\NullLogger'),
 
+    // Disable translation cache
+    'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\JsonFileLoader'),
+    // Disable loading core translations
+    'Piwik\Translation\Translator' => DI\object()
+        ->constructorParameter('directories', array()),
+
 );

--- a/config/global.php
+++ b/config/global.php
@@ -158,4 +158,7 @@ return array(
         return '%level% %tag%[%datetime%] %message%';
     }),
 
+    'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\LoaderCache')
+        ->constructor(DI\link('Piwik\Translation\Loader\JsonFileLoader')),
+
 );

--- a/console
+++ b/console
@@ -14,8 +14,6 @@ if (!defined('PIWIK_INCLUDE_PATH')) {
 
 require_once PIWIK_INCLUDE_PATH . '/core/bootstrap.php';
 
-Piwik\Translate::loadEnglishTranslation();
-
 if (!Piwik\Common::isPhpCliMode()) {
     exit;
 }

--- a/core/Console.php
+++ b/core/Console.php
@@ -47,8 +47,6 @@ class Console extends Application
             // Piwik not installed yet, no config file?
         }
 
-        Translate::reloadLanguage('en');
-
         $commands = $this->getAvailableCommands();
 
         foreach ($commands as $command) {

--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -12,6 +12,7 @@ use DI\Container;
 use DI\ContainerBuilder;
 use Doctrine\Common\Cache\ArrayCache;
 use Piwik\Config;
+use Piwik\Development;
 
 /**
  * Creates a configured DI container.
@@ -54,6 +55,11 @@ class ContainerFactory
 
         // Global config
         $builder->addDefinitions(PIWIK_USER_PATH . '/config/global.php');
+
+        // Development config
+        if (Development::isEnabled()) {
+            $builder->addDefinitions(PIWIK_USER_PATH . '/config/environment/dev.php');
+        }
 
         // User config
         if (file_exists(PIWIK_USER_PATH . '/config/config.php')) {

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -19,6 +19,7 @@ use Piwik\Plugin\Controller;
 use Piwik\Plugin\Report;
 use Piwik\Plugin\Widgets;
 use Piwik\Session;
+use Piwik\Translation\Translator;
 
 /**
  * This singleton dispatches requests to the appropriate plugin Controller.
@@ -331,7 +332,9 @@ class FrontController extends Singleton
         $this->handleProfiler();
         $this->handleSSLRedirection();
 
-        Plugin\Manager::getInstance()->loadPluginTranslations('en');
+        /** @var Translator $translator */
+        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+        $translator->loadPluginsTranslations('en');
         Plugin\Manager::getInstance()->loadActivatedPlugins();
 
         if ($exceptionToThrow) {

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -19,7 +19,6 @@ use Piwik\Plugin\Controller;
 use Piwik\Plugin\Report;
 use Piwik\Plugin\Widgets;
 use Piwik\Session;
-use Piwik\Translation\Translator;
 
 /**
  * This singleton dispatches requests to the appropriate plugin Controller.

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -442,7 +442,6 @@ class FrontController extends Singleton
         }
         SettingsServer::raiseMemoryLimitIfNecessary();
 
-        Translate::reloadLanguage();
         \Piwik\Plugin\Manager::getInstance()->postLoadPlugins();
 
         /**

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -324,17 +324,13 @@ class FrontController extends Singleton
             $tmpPath . '/templates_c/',
         );
 
-        Translate::loadEnglishTranslation();
-
         Filechecks::dieIfDirectoriesNotWritable($directoriesToCheck);
 
         $this->handleMaintenanceMode();
         $this->handleProfiler();
         $this->handleSSLRedirection();
 
-        /** @var Translator $translator */
-        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
-        $translator->loadPluginsTranslations('en');
+        Plugin\Manager::getInstance()->loadPluginTranslations();
         Plugin\Manager::getInstance()->loadActivatedPlugins();
 
         if ($exceptionToThrow) {

--- a/core/Intl/Locale.php
+++ b/core/Intl/Locale.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Piwik\Intl;
+
+class Locale
+{
+    public static function setLocale($locale)
+    {
+        $localeVariant = str_replace('UTF-8', 'UTF8', $locale);
+
+        setlocale(LC_ALL, $locale, $localeVariant);
+        setlocale(LC_CTYPE, '');
+    }
+
+    public static function setDefaultLocale()
+    {
+        self::setLocale('en_US.UTF-8');
+    }
+}

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -735,15 +735,16 @@ class Piwik
      * @param string $translationId Translation ID, eg, `'General_Date'`.
      * @param array|string|int $args `sprintf` arguments to be applied to the internationalized
      *                               string.
+     * @param string|null $language Optionally force the language.
      * @return string The translated string or `$translationId`.
      * @api
      */
-    public static function translate($translationId, $args = array())
+    public static function translate($translationId, $args = array(), $language = null)
     {
         /** @var Translator $translator */
         $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
 
-        return $translator->translate($translationId, $args);
+        return $translator->translate($translationId, $args, $language);
     }
 
     /**

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\Container\StaticContainer;
 use Piwik\Db\Adapter;
 use Piwik\Db\Schema;
 use Piwik\Db;
@@ -16,6 +17,7 @@ use Piwik\Plugin;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 use Piwik\Session;
 use Piwik\Tracker;
+use Piwik\Translation\Translator;
 use Piwik\View;
 
 /**
@@ -738,20 +740,10 @@ class Piwik
      */
     public static function translate($translationId, $args = array())
     {
-        if (!is_array($args)) {
-            $args = array($args);
-        }
+        /** @var Translator $translator */
+        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
 
-        if (strpos($translationId, "_") !== false) {
-            list($plugin, $key) = explode("_", $translationId, 2);
-            if (isset($GLOBALS['Piwik_translations'][$plugin]) && isset($GLOBALS['Piwik_translations'][$plugin][$key])) {
-                $translationId = $GLOBALS['Piwik_translations'][$plugin][$key];
-            }
-        }
-        if (count($args) == 0) {
-            return $translationId;
-        }
-        return vsprintf($translationId, $args);
+        return $translator->translate($translationId, $args);
     }
 
     /**

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -11,11 +11,10 @@ namespace Piwik\Plugin;
 
 use Piwik\Cache;
 use Piwik\Columns\Dimension;
-use Piwik\Common;
 use Piwik\Config as PiwikConfig;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\Db;
-use Piwik\Development;
 use Piwik\EventDispatcher;
 use Piwik\Filesystem;
 use Piwik\Log;
@@ -26,8 +25,8 @@ use Piwik\Singleton;
 use Piwik\Theme;
 use Piwik\Tracker;
 use Piwik\Translate;
+use Piwik\Translation\Translator;
 use Piwik\Updater;
-use Piwik\SettingsServer;
 use Piwik\Plugin\Dimension\ActionDimension;
 use Piwik\Plugin\Dimension\ConversionDimension;
 use Piwik\Plugin\Dimension\VisitDimension;
@@ -572,6 +571,9 @@ class Manager extends Singleton
     {
         $language = Translate::getLanguageToLoad();
 
+        /** @var Translator $translator */
+        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+
         $plugins = array();
 
         $listPlugins = array_merge(
@@ -594,7 +596,7 @@ class Manager extends Singleton
                     'uninstallable'   => true,
                 );
             } else {
-                $this->loadTranslation($pluginName, $language);
+                $translator->loadPluginTranslations($pluginName, $language);
                 $this->loadPlugin($pluginName);
                 $info = array(
                     'activated'       => $this->isPluginActivated($pluginName),
@@ -605,7 +607,7 @@ class Manager extends Singleton
 
             $plugins[$pluginName] = $info;
         }
-        $this->loadPluginTranslations();
+        $translator->loadPluginsTranslations();
 
         $loadedPlugins = $this->getLoadedPlugins();
         foreach ($loadedPlugins as $oPlugin) {
@@ -684,57 +686,6 @@ class Manager extends Singleton
     public function doNotLoadAlwaysActivatedPlugins()
     {
         $this->doLoadAlwaysActivatedPlugins = false;
-    }
-
-    /**
-     * Load translations for loaded plugins
-     *
-     * @param bool|string $language Optional language code
-     */
-    public function loadPluginTranslations($language = false)
-    {
-        if (empty($language)) {
-            $language = Translate::getLanguageToLoad();
-        }
-
-        $cacheKey = 'PluginTranslations';
-
-        if (!empty($language)) {
-            $cacheKey .= '-' . trim($language);
-        }
-
-        if (!empty($this->loadedPlugins)) {
-            // makes sure to create a translation in case loaded plugins change (ie Tests vs Tracker vs UI etc)
-            $cacheKey .= '-' . md5(implode('', $this->getLoadedPluginsName()));
-        }
-
-        $cache = Cache::getLazyCache();
-        $translations = $cache->fetch($cacheKey);
-
-        if (!empty($translations) &&
-            is_array($translations) &&
-            !Development::isEnabled()) { // TODO remove this one here once we have environments in DI
-
-            Translate::mergeTranslationArray($translations);
-            return;
-        }
-
-        $translations = array();
-        $pluginNames  = self::getAllPluginsNames();
-
-        foreach ($pluginNames as $pluginName) {
-            if ($this->isPluginLoaded($pluginName) ||
-                $this->isPluginBundledWithCore($pluginName)) {
-
-                $this->loadTranslation($pluginName, $language);
-
-                if (isset($GLOBALS['Piwik_translations'][$pluginName])) {
-                    $translations[$pluginName] = $GLOBALS['Piwik_translations'][$pluginName];
-                }
-            }
-        }
-
-        $cache->save($cacheKey, $translations, 43200); // ttl=12hours
     }
 
     /**
@@ -1028,60 +979,6 @@ class Manager extends Singleton
     }
 
     /**
-     * Load translation
-     *
-     * @param Plugin $plugin
-     * @param string $langCode
-     * @throws \Exception
-     * @return bool whether the translation was found and loaded
-     */
-    private function loadTranslation($plugin, $langCode)
-    {
-        // we are in Tracker mode if Loader is not (yet) loaded
-        if (SettingsServer::isTrackerApiRequest()) {
-            return false;
-        }
-
-        if (is_string($plugin)) {
-            $pluginName = $plugin;
-        } else {
-            $pluginName = $plugin->getPluginName();
-        }
-
-        $path = self::getPluginsDirectory() . $pluginName . '/lang/%s.json';
-
-        $defaultLangPath = sprintf($path, $langCode);
-        $defaultEnglishLangPath = sprintf($path, 'en');
-
-        $translationsLoaded = false;
-
-        // merge in english translations as default first
-        if (file_exists($defaultEnglishLangPath)) {
-            $translations = $this->getTranslationsFromFile($defaultEnglishLangPath);
-            $translationsLoaded = true;
-            if (isset($translations[$pluginName])) {
-                // only merge translations of plugin - prevents overwritten strings
-                Translate::mergeTranslationArray(array($pluginName => $translations[$pluginName]));
-            }
-        }
-
-        // merge in specific language translations (to overwrite english defaults)
-        if (!empty($langCode) &&
-            $defaultEnglishLangPath != $defaultLangPath &&
-            file_exists($defaultLangPath)) {
-
-            $translations = $this->getTranslationsFromFile($defaultLangPath);
-            $translationsLoaded = true;
-            if (isset($translations[$pluginName])) {
-                // only merge translations of plugin - prevents overwritten strings
-                Translate::mergeTranslationArray(array($pluginName => $translations[$pluginName]));
-            }
-        }
-
-        return $translationsLoaded;
-    }
-
-    /**
      * Return names of all installed plugins.
      *
      * @return array
@@ -1206,27 +1103,6 @@ class Manager extends Singleton
             unset($pluginsEnabled[$key]);
         }
         $this->updatePluginsConfig($pluginsEnabled);
-    }
-
-    /**
-     * @param  string $pathToTranslationFile
-     * @throws \Exception
-     * @return mixed
-     */
-    private function getTranslationsFromFile($pathToTranslationFile)
-    {
-        $data         = file_get_contents($pathToTranslationFile);
-        $translations = json_decode($data, true);
-
-        if (is_null($translations) && Common::hasJsonErrorOccurred()) {
-            $jsonError = Common::getLastJsonError();
-
-            $message = sprintf('Not able to load translation file %s: %s', $pathToTranslationFile, $jsonError);
-
-            throw new \Exception($message);
-        }
-
-        return $translations;
     }
 
     /**

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -569,8 +569,6 @@ class Manager extends Singleton
      */
     public function loadAllPluginsAndGetTheirInfo()
     {
-        $language = Translate::getLanguageToLoad();
-
         /** @var Translator $translator */
         $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
 
@@ -596,7 +594,7 @@ class Manager extends Singleton
                     'uninstallable'   => true,
                 );
             } else {
-                $translator->loadPluginTranslations($pluginName, $language);
+                $translator->addDirectory(self::getPluginsDirectory() . $pluginName . '/lang');
                 $this->loadPlugin($pluginName);
                 $info = array(
                     'activated'       => $this->isPluginActivated($pluginName),
@@ -607,7 +605,6 @@ class Manager extends Singleton
 
             $plugins[$pluginName] = $info;
         }
-        $translator->loadPluginsTranslations();
 
         $loadedPlugins = $this->getLoadedPlugins();
         foreach ($loadedPlugins as $oPlugin) {
@@ -1297,6 +1294,15 @@ class Manager extends Singleton
         $sorted = array_merge($defaultPluginsLoadedFirst, $otherPluginsToLoadAfterDefaultPlugins);
 
         return $sorted;
+    }
+
+    public function loadPluginTranslations()
+    {
+        /** @var Translator $translator */
+        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+        foreach ($this->getAllPluginsNames() as $pluginName) {
+            $translator->addDirectory(self::getPluginsDirectory() . $pluginName . '/lang');
+        }
     }
 }
 

--- a/core/Tracker/ScheduledTasksRunner.php
+++ b/core/Tracker/ScheduledTasksRunner.php
@@ -78,10 +78,6 @@ class ScheduledTasksRunner
             // Scheduled tasks assume Super User is running
             Piwik::setUserHasSuperUserAccess();
 
-            // While each plugins should ensure that necessary languages are loaded,
-            // we ensure English translations at least are loaded
-            Translate::loadEnglishTranslation();
-
             ob_start();
             CronArchive::$url = SettingsPiwik::getPiwikUrl();
             $cronArchive = new CronArchive();

--- a/core/Translate.php
+++ b/core/Translate.php
@@ -9,14 +9,15 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\Container\StaticContainer;
+use Piwik\Translation\Translator;
 
 /**
+ * @deprecated Use Piwik\Translation\Translator instead.
+ * @see \Piwik\Translation\Translator
  */
 class Translate
 {
-    private static $languageToLoad = null;
-    private static $loadedLanguage = false;
-
     /**
      * Clean a string that may contain HTML special chars, single/double quotes, HTML entities, leading/trailing whitespace
      *
@@ -25,28 +26,22 @@ class Translate
      */
     public static function clean($s)
     {
-        return html_entity_decode(trim($s), ENT_QUOTES, 'UTF-8');
+        return self::getTranslator()->clean($s);
     }
 
     public static function loadEnglishTranslation()
     {
-        self::loadCoreTranslationFile('en');
+        self::getTranslator()->loadEnglishTranslation();
     }
 
     public static function unloadEnglishTranslation()
     {
-        $GLOBALS['Piwik_translations'] = array();
+        self::getTranslator()->unloadEnglishTranslation();
     }
 
     public static function reloadLanguage($language = false)
     {
-        if (empty($language)) {
-            $language = self::getLanguageToLoad();
-        }
-        self::unloadEnglishTranslation();
-        self::loadEnglishTranslation();
-        self::loadCoreTranslation($language);
-        \Piwik\Plugin\Manager::getInstance()->loadPluginTranslations($language);
+        self::getTranslator()->reloadLanguage($language);
     }
 
     /**
@@ -57,41 +52,12 @@ class Translate
      */
     public static function loadCoreTranslation($language = false)
     {
-        if (empty($language)) {
-            $language = self::getLanguageToLoad();
-        }
-        if (self::$loadedLanguage == $language) {
-            return;
-        }
-        self::loadCoreTranslationFile($language);
-    }
-
-    private static function loadCoreTranslationFile($language)
-    {
-        if (empty($language)) {
-            return;
-        }
-        $path = PIWIK_INCLUDE_PATH . '/lang/' . $language . '.json';
-        if (!Filesystem::isValidFilename($language) || !is_readable($path)) {
-            throw new Exception(Piwik::translate('General_ExceptionLanguageFileNotFound', array($language)));
-        }
-        $data = file_get_contents($path);
-        $translations = json_decode($data, true);
-        self::mergeTranslationArray($translations);
-        self::setLocale();
-        self::$loadedLanguage = $language;
+        self::getTranslator()->loadCoreTranslation($language);
     }
 
     public static function mergeTranslationArray($translation)
     {
-        if (!isset($GLOBALS['Piwik_translations'])) {
-            $GLOBALS['Piwik_translations'] = array();
-        }
-        if (empty($translation)) {
-            return;
-        }
-        // we could check that no string overlap here
-        $GLOBALS['Piwik_translations'] = array_replace_recursive($GLOBALS['Piwik_translations'], $translation);
+        self::getTranslator()->mergeTranslationArray($translation);
     }
 
     /**
@@ -100,46 +66,13 @@ class Translate
      */
     public static function getLanguageToLoad()
     {
-        if (is_null(self::$languageToLoad)) {
-            $lang = Common::getRequestVar('language', '', 'string');
-
-            /**
-             * Triggered when the current user's language is requested.
-             *
-             * By default the current language is determined by the **language** query
-             * parameter. Plugins can override this logic by subscribing to this event.
-             *
-             * **Example**
-             *
-             *     public function getLanguage(&$lang)
-             *     {
-             *         $client = new My3rdPartyAPIClient();
-             *         $thirdPartyLang = $client->getLanguageForUser(Piwik::getCurrentUserLogin());
-             *
-             *         if (!empty($thirdPartyLang)) {
-             *             $lang = $thirdPartyLang;
-             *         }
-             *     }
-             *
-             * @param string &$lang The language that should be used for the current user. Will be
-             *                      initialized to the value of the **language** query parameter.
-             */
-            Piwik::postEvent('User.getLanguage', array(&$lang));
-
-            self::$languageToLoad = $lang;
-        }
-
-        return self::$languageToLoad;
+        return self::getTranslator()->getLanguageToLoad();
     }
 
     /** Reset the cached language to load. Used in tests. */
     public static function reset()
     {
-        self::$languageToLoad = null;
-    }
-
-    private static function isALanguageLoaded() {
-        return !empty($GLOBALS['Piwik_translations']);
+        self::getTranslator()->reset();
     }
 
     /**
@@ -148,16 +81,12 @@ class Translate
      */
     public static function getLanguageLoaded()
     {
-        if (!self::isALanguageLoaded()) {
-            return null;
-        }
-
-        return self::$loadedLanguage;
+        return self::getTranslator()->getLanguageLoaded();
     }
 
     public static function getLanguageDefault()
     {
-        return Config::getInstance()->General['default_language'];
+        return self::getTranslator()->getLanguageDefault();
     }
 
     /**
@@ -165,77 +94,19 @@ class Translate
      */
     public static function getJavascriptTranslations()
     {
-        $translations = & $GLOBALS['Piwik_translations'];
-
-        $clientSideTranslations = array();
-        foreach (self::getClientSideTranslationKeys() as $key) {
-            list($plugin, $stringName) = explode("_", $key, 2);
-            $clientSideTranslations[$key] = $translations[$plugin][$stringName];
-        }
-
-        $js = 'var translations = ' . json_encode($clientSideTranslations) . ';';
-        $js .= "\n" . 'if (typeof(piwik_translations) == \'undefined\') { var piwik_translations = new Object; }' .
-            'for(var i in translations) { piwik_translations[i] = translations[i];} ';
-        return $js;
-    }
-
-    /**
-     * Returns the list of client side translations by key. These translations will be outputted
-     * to the translation JavaScript.
-     */
-    private static function getClientSideTranslationKeys()
-    {
-        $result = array();
-
-        /**
-         * Triggered before generating the JavaScript code that allows i18n strings to be used
-         * in the browser.
-         *
-         * Plugins should subscribe to this event to specify which translations
-         * should be available to JavaScript.
-         *
-         * Event handlers should add whole translation keys, ie, keys that include the plugin name.
-         *
-         * **Example**
-         *
-         *     public function getClientSideTranslationKeys(&$result)
-         *     {
-         *         $result[] = "MyPlugin_MyTranslation";
-         *     }
-         *
-         * @param array &$result The whole list of client side translation keys.
-         */
-        Piwik::postEvent('Translate.getClientSideTranslationKeys', array(&$result));
-
-        $result = array_unique($result);
-
-        return $result;
-    }
-
-    /**
-     * Set locale
-     *
-     * @see http://php.net/setlocale
-     */
-    private static function setLocale()
-    {
-        $locale = $GLOBALS['Piwik_translations']['General']['Locale'];
-        $locale_variant = str_replace('UTF-8', 'UTF8', $locale);
-        setlocale(LC_ALL, $locale, $locale_variant);
-        setlocale(LC_CTYPE, '');
+        return self::getTranslator()->getJavascriptTranslations();
     }
 
     public static function findTranslationKeyForTranslation($translation)
     {
-        if (empty($GLOBALS['Piwik_translations'])) {
-            return;
-        }
+        return self::getTranslator()->findTranslationKeyForTranslation($translation);
+    }
 
-        foreach ($GLOBALS['Piwik_translations'] as $key => $translations) {
-            $possibleKey = array_search($translation, $translations);
-            if (!empty($possibleKey)) {
-                return $key . '_' . $possibleKey;
-            }
-        }
+    /**
+     * @return Translator
+     */
+    private static function getTranslator()
+    {
+        return StaticContainer::getContainer()->get('Piwik\Translation\Translator');
     }
 }

--- a/core/Translate.php
+++ b/core/Translate.php
@@ -31,10 +31,12 @@ class Translate
 
     public static function loadEnglishTranslation()
     {
+        self::loadCoreTranslation();
     }
 
     public static function unloadEnglishTranslation()
     {
+        self::getTranslator()->reset();
     }
 
     public static function reloadLanguage($language = false)
@@ -49,6 +51,7 @@ class Translate
      */
     public static function loadCoreTranslation($language = false)
     {
+        self::getTranslator()->addDirectory(PIWIK_INCLUDE_PATH . '/lang');
     }
 
     public static function mergeTranslationArray($translation)
@@ -67,7 +70,7 @@ class Translate
     /** Reset the cached language to load. Used in tests. */
     public static function reset()
     {
-        self::getTranslator()->setCurrentLanguage(null);
+        self::getTranslator()->reset();
     }
 
     /**

--- a/core/Translate.php
+++ b/core/Translate.php
@@ -10,6 +10,7 @@ namespace Piwik;
 
 use Exception;
 use Piwik\Container\StaticContainer;
+use Piwik\Plugin\Manager;
 use Piwik\Translation\Translator;
 
 /**
@@ -29,16 +30,25 @@ class Translate
         return html_entity_decode(trim($s), ENT_QUOTES, 'UTF-8');
     }
 
+    /**
+     * @deprecated
+     */
     public static function loadEnglishTranslation()
     {
-        self::loadCoreTranslation();
+        self::loadAllTranslations();
     }
 
+    /**
+     * @deprecated
+     */
     public static function unloadEnglishTranslation()
     {
-        self::getTranslator()->reset();
+        self::reset();
     }
 
+    /**
+     * @deprecated
+     */
     public static function reloadLanguage($language = false)
     {
     }
@@ -54,6 +64,9 @@ class Translate
         self::getTranslator()->addDirectory(PIWIK_INCLUDE_PATH . '/lang');
     }
 
+    /**
+     * @deprecated
+     */
     public static function mergeTranslationArray($translation)
     {
     }
@@ -106,5 +119,11 @@ class Translate
     private static function getTranslator()
     {
         return StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+    }
+
+    public static function loadAllTranslations()
+    {
+        self::loadCoreTranslation();
+        Manager::getInstance()->loadPluginTranslations();
     }
 }

--- a/core/Translate.php
+++ b/core/Translate.php
@@ -26,22 +26,19 @@ class Translate
      */
     public static function clean($s)
     {
-        return self::getTranslator()->clean($s);
+        return html_entity_decode(trim($s), ENT_QUOTES, 'UTF-8');
     }
 
     public static function loadEnglishTranslation()
     {
-        self::getTranslator()->loadEnglishTranslation();
     }
 
     public static function unloadEnglishTranslation()
     {
-        self::getTranslator()->unloadEnglishTranslation();
     }
 
     public static function reloadLanguage($language = false)
     {
-        self::getTranslator()->reloadLanguage($language);
     }
 
     /**
@@ -52,12 +49,10 @@ class Translate
      */
     public static function loadCoreTranslation($language = false)
     {
-        self::getTranslator()->loadCoreTranslation($language);
     }
 
     public static function mergeTranslationArray($translation)
     {
-        self::getTranslator()->mergeTranslationArray($translation);
     }
 
     /**
@@ -66,13 +61,13 @@ class Translate
      */
     public static function getLanguageToLoad()
     {
-        return self::getTranslator()->getLanguageToLoad();
+        return self::getTranslator()->getCurrentLanguage();
     }
 
     /** Reset the cached language to load. Used in tests. */
     public static function reset()
     {
-        self::getTranslator()->reset();
+        self::getTranslator()->setCurrentLanguage(null);
     }
 
     /**
@@ -81,12 +76,12 @@ class Translate
      */
     public static function getLanguageLoaded()
     {
-        return self::getTranslator()->getLanguageLoaded();
+        return self::getTranslator()->getCurrentLanguage();
     }
 
     public static function getLanguageDefault()
     {
-        return self::getTranslator()->getLanguageDefault();
+        return self::getTranslator()->getDefaultLanguage();
     }
 
     /**

--- a/core/Translation/Loader/JsonFileLoader.php
+++ b/core/Translation/Loader/JsonFileLoader.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Translation\Loader;
+
+use Exception;
+use Piwik\Common;
+
+/**
+ * Loads translations from JSON files.
+ */
+class JsonFileLoader implements LoaderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load($language, array $directories)
+    {
+        if (empty($language)) {
+            return array();
+        }
+
+        $translations = array();
+
+        foreach ($directories as $directory) {
+            $filename = $directory . '/' . $language . '.json';
+
+            if (! file_exists($filename)) {
+                continue;
+            }
+
+            $translations = array_replace_recursive(
+                $translations,
+                $this->loadFile($filename)
+            );
+        }
+
+        return $translations;
+    }
+
+    private function loadFile($filename)
+    {
+        $data = file_get_contents($filename);
+        $translations = json_decode($data, true);
+
+        if (is_null($translations) && Common::hasJsonErrorOccurred()) {
+            throw new \Exception(sprintf(
+                'Not able to load translation file %s: %s',
+                $filename,
+                Common::getLastJsonError()
+            ));
+        }
+
+        if (!is_array($translations)) {
+            return array();
+        }
+
+        return $translations;
+    }
+}

--- a/core/Translation/Loader/LoaderCache.php
+++ b/core/Translation/Loader/LoaderCache.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Translation\Loader;
+
+use Piwik\Cache;
+
+/**
+ * Caches the translations loaded by another loader.
+ */
+class LoaderCache implements LoaderInterface
+{
+    /**
+     * @var LoaderInterface
+     */
+    private $loader;
+
+    /**
+     * @var Cache\Lazy
+     */
+    private $cache;
+
+    public function __construct(LoaderInterface $loader, Cache\Lazy $cache = null)
+    {
+        $this->loader = $loader;
+        // TODO DI
+        $this->cache = $cache ?: Cache::getLazyCache();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load($language, array $directories)
+    {
+        if (empty($language)) {
+            return array();
+        }
+
+        $cacheKey = $this->getCacheKey($language, $directories);
+
+        $translations = $this->cache->fetch($cacheKey);
+
+        if (empty($translations) || !is_array($translations)) {
+            $translations = $this->loader->load($language, $directories);
+
+            $this->cache->save($cacheKey, $translations, 43200); // ttl=12hours
+        }
+
+        return $translations;
+    }
+
+    private function getCacheKey($language, array $directories)
+    {
+        $cacheKey = 'Translations-' . $language . '-';
+
+        // in case loaded plugins change (ie Tests vs Tracker vs UI etc)
+        $cacheKey .= sha1(implode('', $directories));
+
+        return $cacheKey;
+    }
+}

--- a/core/Translation/Loader/LoaderInterface.php
+++ b/core/Translation/Loader/LoaderInterface.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Translation\Loader;
+
+/**
+ * Loads translations.
+ */
+interface LoaderInterface
+{
+    /**
+     * @param string $language
+     * @param mixed[] $directories Directories containing translation files.
+     * @throws \Exception The translation file was not found
+     * @return string[] Translations.
+     */
+    public function load($language, array $directories);
+}

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -68,16 +68,19 @@ class Translator
      * @param string $translationId Translation ID, eg, `General_Date`.
      * @param array|string|int $args `sprintf` arguments to be applied to the internationalized
      *                               string.
+     * @param string|null $language Optionally force the language.
      * @return string The translated string or `$translationId`.
      * @api
      */
-    public function translate($translationId, $args = array())
+    public function translate($translationId, $args = array(), $language = null)
     {
         $args = is_array($args) ? $args : array($args);
 
         if (strpos($translationId, "_") !== false) {
             list($plugin, $key) = explode("_", $translationId, 2);
-            $translationId = $this->getTranslation($translationId, $this->currentLanguage, $plugin, $key);
+            $language = is_string($language) ? $language : $this->currentLanguage;
+
+            $translationId = $this->getTranslation($translationId, $language, $plugin, $key);
         }
 
         if (count($args) == 0) {

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -308,7 +308,7 @@ class Translator
     public function loadPluginsTranslations($language = false)
     {
         if (empty($language)) {
-            $language = self::getLanguageToLoad();
+            $language = $this->getLanguageToLoad();
         }
 
         $pluginManager = Manager::getInstance();
@@ -331,7 +331,7 @@ class Translator
             is_array($translations) &&
             !Development::isEnabled()) { // TODO remove this one here once we have environments in DI
 
-            self::mergeTranslationArray($translations);
+            $this->mergeTranslationArray($translations);
             return;
         }
 

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -178,6 +178,16 @@ class Translator
     }
 
     /**
+     * Should be used by tests only, and this method should eventually be removed.
+     */
+    public function reset()
+    {
+        $this->currentLanguage = $this->getDefaultLanguage();
+        $this->directories = array();
+        $this->translations = array();
+    }
+
+    /**
      * @param string $translation
      * @return null|string
      */

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -102,6 +102,10 @@ class Translator
      */
     public function setCurrentLanguage($language)
     {
+        if (!$language) {
+            $language = $this->getDefaultLanguage();
+        }
+
         $this->currentLanguage = $language;
     }
 

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -344,8 +344,8 @@ class Translator
 
                 $this->loadPluginTranslations($pluginName, $language);
 
-                if (isset($GLOBALS['Piwik_translations'][$pluginName])) {
-                    $translations[$pluginName] = $GLOBALS['Piwik_translations'][$pluginName];
+                if (isset($this->translations[$pluginName])) {
+                    $translations[$pluginName] = $this->translations[$pluginName];
                 }
             }
         }
@@ -425,5 +425,15 @@ class Translator
         }
 
         return $translations;
+    }
+
+    /**
+     * Returns all the translation messages loaded.
+     *
+     * @return array
+     */
+    public function getAllTranslations()
+    {
+        return $this->translations;
     }
 }

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -355,27 +355,23 @@ class Translator
     /**
      * Load translation
      *
-     * @param Plugin $plugin
-     * @param string $langCode
+     * @param Plugin|string $plugin
+     * @param string $language
      * @throws \Exception
      * @return bool whether the translation was found and loaded
      */
-    public function loadPluginTranslations($plugin, $langCode)
+    public function loadPluginTranslations($plugin, $language)
     {
         // we are in Tracker mode if Loader is not (yet) loaded
         if (SettingsServer::isTrackerApiRequest()) {
             return false;
         }
 
-        if (is_string($plugin)) {
-            $pluginName = $plugin;
-        } else {
-            $pluginName = $plugin->getPluginName();
-        }
+        $pluginName = ($plugin instanceof Plugin) ? $plugin->getPluginName() : $plugin;
 
         $path = Manager::getPluginsDirectory() . $pluginName . '/lang/%s.json';
 
-        $defaultLangPath = sprintf($path, $langCode);
+        $defaultLangPath = sprintf($path, $language);
         $defaultEnglishLangPath = sprintf($path, 'en');
 
         $translationsLoaded = false;
@@ -391,7 +387,7 @@ class Translator
         }
 
         // merge in specific language translations (to overwrite english defaults)
-        if (!empty($langCode) &&
+        if (!empty($language) &&
             $defaultEnglishLangPath != $defaultLangPath &&
             file_exists($defaultLangPath)) {
 

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Translation;
+
+use Exception;
+use Piwik\Common;
+use Piwik\Config;
+use Piwik\Filesystem;
+use Piwik\Piwik;
+use Piwik\Plugin\Manager;
+
+/**
+ * Translates messages.
+ *
+ * @api
+ */
+class Translator
+{
+    /**
+     * Contains the translated messages.
+     *
+     * @var array
+     */
+    private $translations = array();
+
+    /**
+     * @var string|null
+     */
+    private $languageToLoad;
+
+    /**
+     * @var bool
+     */
+    private $loadedLanguage = false;
+
+    /**
+     * Returns an internationalized string using a translation ID. If a translation
+     * cannot be found for the ID, the ID is returned.
+     *
+     * @param string $translationId Translation ID, eg, `'General_Date'`.
+     * @param array|string|int $args `sprintf` arguments to be applied to the internationalized
+     *                               string.
+     * @return string The translated string or `$translationId`.
+     * @api
+     */
+    public function translate($translationId, $args = array())
+    {
+        if (!is_array($args)) {
+            $args = array($args);
+        }
+
+        if (strpos($translationId, "_") !== false) {
+            list($plugin, $key) = explode("_", $translationId, 2);
+            if (isset($this->translations[$plugin]) && isset($this->translations[$plugin][$key])) {
+                $translationId = $this->translations[$plugin][$key];
+            }
+        }
+        if (count($args) == 0) {
+            return $translationId;
+        }
+        return vsprintf($translationId, $args);
+    }
+
+    /**
+     * Clean a string that may contain HTML special chars, single/double quotes, HTML entities, leading/trailing whitespace
+     *
+     * @param string $s
+     * @return string
+     */
+    public function clean($s)
+    {
+        return html_entity_decode(trim($s), ENT_QUOTES, 'UTF-8');
+    }
+
+    public function loadEnglishTranslation()
+    {
+        $this->loadCoreTranslationFile('en');
+    }
+
+    public function unloadEnglishTranslation()
+    {
+        $this->translations = array();
+    }
+
+    public function reloadLanguage($language = false)
+    {
+        if (empty($language)) {
+            $language = $this->getLanguageToLoad();
+        }
+        $this->unloadEnglishTranslation();
+        $this->loadEnglishTranslation();
+        $this->loadCoreTranslation($language);
+        Manager::getInstance()->loadPluginTranslations($language);
+    }
+
+    /**
+     * Reads the specified code translation file in memory.
+     *
+     * @param bool|string $language 2 letter language code. If not specified, will detect current user translation, or load default translation.
+     * @return void
+     */
+    public function loadCoreTranslation($language = false)
+    {
+        if (empty($language)) {
+            $language = $this->getLanguageToLoad();
+        }
+        if ($this->loadedLanguage == $language) {
+            return;
+        }
+        $this->loadCoreTranslationFile($language);
+    }
+
+    private function loadCoreTranslationFile($language)
+    {
+        if (empty($language)) {
+            return;
+        }
+
+        $path = PIWIK_INCLUDE_PATH . '/lang/' . $language . '.json';
+        if (!Filesystem::isValidFilename($language) || !is_readable($path)) {
+            throw new Exception(Piwik::translate('General_ExceptionLanguageFileNotFound', array($language)));
+        }
+        $data = file_get_contents($path);
+        $translations = json_decode($data, true);
+        $this->mergeTranslationArray($translations);
+        $this->setLocale();
+        $this->loadedLanguage = $language;
+    }
+
+    public function mergeTranslationArray($translation)
+    {
+        if (empty($translation)) {
+            return;
+        }
+        // we could check that no string overlap here
+        $this->translations = array_replace_recursive($this->translations, $translation);
+    }
+
+    /**
+     * @return string the language filename prefix, eg 'en' for english
+     * @throws exception if the language set is not a valid filename
+     */
+    public function getLanguageToLoad()
+    {
+        if (is_null($this->languageToLoad)) {
+            $lang = Common::getRequestVar('language', '', 'string');
+
+            /**
+             * Triggered when the current user's language is requested.
+             *
+             * By default the current language is determined by the **language** query
+             * parameter. Plugins can override this logic by subscribing to this event.
+             *
+             * **Example**
+             *
+             *     public function getLanguage(&$lang)
+             *     {
+             *         $client = new My3rdPartyAPIClient();
+             *         $thirdPartyLang = $client->getLanguageForUser(Piwik::getCurrentUserLogin());
+             *
+             *         if (!empty($thirdPartyLang)) {
+             *             $lang = $thirdPartyLang;
+             *         }
+             *     }
+             *
+             * @param string &$lang The language that should be used for the current user. Will be
+             *                      initialized to the value of the **language** query parameter.
+             */
+            Piwik::postEvent('User.getLanguage', array(&$lang));
+
+            $this->languageToLoad = $lang;
+        }
+
+        return $this->languageToLoad;
+    }
+
+    /**
+     * Reset the cached language to load. Used in tests.
+     */
+    public function reset()
+    {
+        $this->languageToLoad = null;
+    }
+
+    private function isALanguageLoaded()
+    {
+        return !empty($this->translations);
+    }
+
+    /**
+     * Either the name of the currently loaded language such as 'en' or 'de' or null if no language is loaded at all.
+     * @return bool|string
+     */
+    public function getLanguageLoaded()
+    {
+        if (!$this->isALanguageLoaded()) {
+            return null;
+        }
+
+        return $this->loadedLanguage;
+    }
+
+    public function getLanguageDefault()
+    {
+        return Config::getInstance()->General['default_language'];
+    }
+
+    /**
+     * Generate javascript translations array
+     */
+    public function getJavascriptTranslations()
+    {
+        $translations = & $this->translations;
+
+        $clientSideTranslations = array();
+        foreach ($this->getClientSideTranslationKeys() as $key) {
+            list($plugin, $stringName) = explode("_", $key, 2);
+            $clientSideTranslations[$key] = $translations[$plugin][$stringName];
+        }
+
+        $js = 'var translations = ' . json_encode($clientSideTranslations) . ';';
+        $js .= "\n" . 'if (typeof(piwik_translations) == \'undefined\') { var piwik_translations = new Object; }' .
+            'for(var i in translations) { piwik_translations[i] = translations[i];} ';
+        return $js;
+    }
+
+    /**
+     * Returns the list of client side translations by key. These translations will be outputted
+     * to the translation JavaScript.
+     */
+    private function getClientSideTranslationKeys()
+    {
+        $result = array();
+
+        /**
+         * Triggered before generating the JavaScript code that allows i18n strings to be used
+         * in the browser.
+         *
+         * Plugins should subscribe to this event to specify which translations
+         * should be available to JavaScript.
+         *
+         * Event handlers should add whole translation keys, ie, keys that include the plugin name.
+         *
+         * **Example**
+         *
+         *     public function getClientSideTranslationKeys(&$result)
+         *     {
+         *         $result[] = "MyPlugin_MyTranslation";
+         *     }
+         *
+         * @param array &$result The whole list of client side translation keys.
+         */
+        Piwik::postEvent('Translate.getClientSideTranslationKeys', array(&$result));
+
+        $result = array_unique($result);
+
+        return $result;
+    }
+
+    /**
+     * Set locale
+     *
+     * @see http://php.net/setlocale
+     */
+    private function setLocale()
+    {
+        $locale = $this->translations['General']['Locale'];
+        $locale_variant = str_replace('UTF-8', 'UTF8', $locale);
+        setlocale(LC_ALL, $locale, $locale_variant);
+        setlocale(LC_CTYPE, '');
+    }
+
+    /**
+     * @param string $translation
+     * @return null|string
+     */
+    public function findTranslationKeyForTranslation($translation)
+    {
+        if (empty($this->translations)) {
+            return null;
+        }
+
+        foreach ($this->translations as $key => $translations) {
+            $possibleKey = array_search($translation, $translations);
+            if (!empty($possibleKey)) {
+                return $key . '_' . $possibleKey;
+            }
+        }
+
+        return null;
+    }
+}

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -12,6 +12,7 @@ use Piwik\API\Proxy;
 use Piwik\API\Request;
 use Piwik\Columns\Dimension;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\DataTable;
 use Piwik\DataTable\Filter\ColumnDelete;
 use Piwik\DataTable\Row;
@@ -25,6 +26,7 @@ use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\CoreAdminHome\CustomLogo;
 use Piwik\Segment\SegmentExpression;
 use Piwik\Translate;
+use Piwik\Translation\Translator;
 use Piwik\Version;
 
 require_once PIWIK_INCLUDE_PATH . '/core/Config.php';
@@ -321,7 +323,10 @@ class API extends \Piwik\Plugin\API
     public function getMetadata($idSite, $apiModule, $apiAction, $apiParameters = array(), $language = false,
                                 $period = false, $date = false, $hideMetricsDoc = false, $showSubtableReports = false)
     {
-        Translate::reloadLanguage($language);
+        /** @var Translator $translator */
+        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+        $translator->setCurrentLanguage($language);
+
         $reporter = new ProcessedReport();
         $metadata = $reporter->getMetadata($idSite, $apiModule, $apiAction, $apiParameters, $language, $period, $date, $hideMetricsDoc, $showSubtableReports);
         return $metadata;

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -323,9 +323,11 @@ class API extends \Piwik\Plugin\API
     public function getMetadata($idSite, $apiModule, $apiAction, $apiParameters = array(), $language = false,
                                 $period = false, $date = false, $hideMetricsDoc = false, $showSubtableReports = false)
     {
-        /** @var Translator $translator */
-        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
-        $translator->setCurrentLanguage($language);
+        if ($language) {
+            /** @var Translator $translator */
+            $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+            $translator->setCurrentLanguage($language);
+        }
 
         $reporter = new ProcessedReport();
         $metadata = $reporter->getMetadata($idSite, $apiModule, $apiAction, $apiParameters, $language, $period, $date, $hideMetricsDoc, $showSubtableReports);

--- a/plugins/Actions/tests/Unit/ArchiverTest.php
+++ b/plugins/Actions/tests/Unit/ArchiverTest.php
@@ -23,12 +23,12 @@ class ArchiverTests extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        Translate::reloadLanguage('en');
+        Translate::loadAllTranslations();
     }
 
     public function tearDown()
     {
-        Translate::unloadEnglishTranslation();
+        Translate::reset();
     }
 
     public function getActionNameTestData()

--- a/plugins/Contents/tests/System/ContentsTest.php
+++ b/plugins/Contents/tests/System/ContentsTest.php
@@ -47,12 +47,13 @@ class ContentsTest extends SystemTestCase
     protected function setup()
     {
         parent::setup();
-        Translate::reloadLanguage('en');
+        Translate::loadAllTranslations();
     }
 
     protected function tearDown()
     {
         parent::tearDown();
+        Translate::reset();
     }
 
     public function getApiForTesting()

--- a/plugins/Feedback/API.php
+++ b/plugins/Feedback/API.php
@@ -80,22 +80,12 @@ class API extends \Piwik\Plugin\API
 
     private function getEnglishTranslationForFeatureName($featureName)
     {
-        $loadedLanguage = Translate::getLanguageLoaded();
-
-        if ($loadedLanguage == 'en') {
+        if (Translate::getLanguageLoaded() == 'en') {
             return $featureName;
         }
 
         $translationKeyForFeature = Translate::findTranslationKeyForTranslation($featureName);
 
-        if (!empty($translationKeyForFeature)) {
-            Translate::reloadLanguage('en');
-
-            $featureName = Piwik::translate($translationKeyForFeature);
-            Translate::reloadLanguage($loadedLanguage);
-            return $featureName;
-        }
-
-        return $featureName;
+        return Piwik::translate($translationKeyForFeature, array(), 'en');
     }
 }

--- a/plugins/Insights/tests/Integration/ApiTest.php
+++ b/plugins/Insights/tests/Integration/ApiTest.php
@@ -41,8 +41,15 @@ class ApiTest extends SystemTestCase
 
         PiwikCache::flushAll();
 
-        Translate::reloadLanguage('en');
+        Translate::loadAllTranslations();
         $this->api = API::getInstance();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Translate::reset();
     }
 
     /**

--- a/plugins/Installation/Installation.php
+++ b/plugins/Installation/Installation.php
@@ -91,8 +91,6 @@ class Installation extends \Piwik\Plugin
             $message = '';
         }
 
-        Translate::reloadLanguage();
-
         $action = Common::getRequestVar('action', 'welcome', 'string');
 
         if ($this->isAllowedAction($action)) {

--- a/plugins/LanguagesManager/Commands/CompareKeys.php
+++ b/plugins/LanguagesManager/Commands/CompareKeys.php
@@ -52,7 +52,7 @@ class CompareKeys extends TranslationBase
 
         /** @var Translator $translator */
         $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
-        $translator->reloadLanguage('en');
+        $translator->setCurrentLanguage('en');
         $availableTranslations = $translator->getAllTranslations();
 
         $categories = array_unique(array_merge(array_keys($englishFromOTrance), array_keys($availableTranslations)));

--- a/plugins/LanguagesManager/Commands/CompareKeys.php
+++ b/plugins/LanguagesManager/Commands/CompareKeys.php
@@ -9,7 +9,8 @@
 
 namespace Piwik\Plugins\LanguagesManager\Commands;
 
-use Piwik\Translate;
+use Piwik\Container\StaticContainer;
+use Piwik\Translation\Translator;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -49,8 +50,10 @@ class CompareKeys extends TranslationBase
 
         $englishFromOTrance = json_decode(file_get_contents($englishFromOTrance), true);
 
-        Translate::reloadLanguage('en');
-        $availableTranslations = $GLOBALS['Piwik_translations'];
+        /** @var Translator $translator */
+        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+        $translator->reloadLanguage('en');
+        $availableTranslations = $translator->getAllTranslations();
 
         $categories = array_unique(array_merge(array_keys($englishFromOTrance), array_keys($availableTranslations)));
         sort($categories);

--- a/plugins/LanguagesManager/Commands/FetchFromOTrance.php
+++ b/plugins/LanguagesManager/Commands/FetchFromOTrance.php
@@ -11,6 +11,8 @@ namespace Piwik\Plugins\LanguagesManager\Commands;
 
 use Piwik\Container\StaticContainer;
 use Piwik\Unzip;
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -36,6 +38,7 @@ class FetchFromOTrance extends TranslationBase
     {
         $output->writeln("Starting to fetch latest language pack");
 
+        /** @var DialogHelper $dialog */
         $dialog = $this->getHelperSet()->get('dialog');
 
         $cookieFile = self::getDownloadPath() . DIRECTORY_SEPARATOR . 'cookie.txt';
@@ -139,6 +142,7 @@ class FetchFromOTrance extends TranslationBase
 
         $output->writeln("Converting downloaded php files to json");
 
+        /** @var ProgressHelper $progress */
         $progress = $this->getHelperSet()->get('progress');
 
         $progress->start($output, count($filesToConvert));

--- a/plugins/LanguagesManager/Commands/SetTranslations.php
+++ b/plugins/LanguagesManager/Commands/SetTranslations.php
@@ -10,20 +10,19 @@
 namespace Piwik\Plugins\LanguagesManager\Commands;
 
 use Piwik\Plugins\LanguagesManager\API;
-use Piwik\Translate\Filter\ByBaseTranslations;
-use Piwik\Translate\Filter\ByParameterCount;
-use Piwik\Translate\Filter\EmptyTranslations;
-use Piwik\Translate\Filter\EncodedEntities;
-use Piwik\Translate\Filter\UnnecassaryWhitespaces;
-use Piwik\Translate\Validate\CoreTranslations;
-use Piwik\Translate\Validate\NoScripts;
-use Piwik\Translate\Writer;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\ByBaseTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\ByParameterCount;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\EmptyTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\EncodedEntities;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\UnnecassaryWhitespaces;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\CoreTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\NoScripts;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Writer;
+use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- */
 class SetTranslations extends TranslationBase
 {
     protected function configure()
@@ -37,6 +36,7 @@ class SetTranslations extends TranslationBase
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        /** @var DialogHelper $dialog */
         $dialog = $this->getHelperSet()->get('dialog');
 
         $languageCode = $input->getOption('code');

--- a/plugins/LanguagesManager/Commands/Update.php
+++ b/plugins/LanguagesManager/Commands/Update.php
@@ -10,6 +10,8 @@
 namespace Piwik\Plugins\LanguagesManager\Commands;
 
 use Piwik\Plugins\LanguagesManager\API;
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -31,6 +33,7 @@ class Update extends TranslationBase
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        /** @var DialogHelper $dialog */
         $dialog = $this->getHelperSet()->get('dialog');
 
         $command = $this->getApplication()->find('translations:fetch');
@@ -60,6 +63,7 @@ class Update extends TranslationBase
             $output->writeln("(!) Non interactive mode: New languages will be skipped");
         }
 
+        /** @var ProgressHelper $progress */
         $progress = $this->getHelperSet()->get('progress');
 
         $progress->start($output, count($files));

--- a/plugins/LanguagesManager/LanguagesManager.php
+++ b/plugins/LanguagesManager/LanguagesManager.php
@@ -15,6 +15,7 @@ use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Cookie;
 use Piwik\Db;
+use Piwik\Intl\Locale;
 use Piwik\Piwik;
 use Piwik\Translate;
 use Piwik\Translation\Translator;
@@ -108,9 +109,7 @@ class LanguagesManager extends \Piwik\Plugin
         }
 
         $locale = $translator->translate('General_Locale');
-        $localeVariant = str_replace('UTF-8', 'UTF8', $locale);
-        setlocale(LC_ALL, $locale, $localeVariant);
-        setlocale(LC_CTYPE, '');
+        Locale::setLocale($locale);
     }
 
     public function deleteUserLanguage($userLogin)

--- a/plugins/LanguagesManager/Test/Integration/LanguagesManagerTest.php
+++ b/plugins/LanguagesManager/Test/Integration/LanguagesManagerTest.php
@@ -6,21 +6,24 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\LanguagesManager\tests;
+namespace Piwik\Plugins\LanguagesManager\Test\Integration;
 
 use Piwik\Common;
 use Piwik\Plugins\LanguagesManager\API;
-use Piwik\Translate\Filter\ByParameterCount;
-use Piwik\Translate\Filter\EmptyTranslations;
-use Piwik\Translate\Filter\EncodedEntities;
-use Piwik\Translate\Filter\UnnecassaryWhitespaces;
-use Piwik\Translate\Validate\CoreTranslations;
-use Piwik\Translate\Validate\NoScripts;
-use Piwik\Translate\Writer;
 use \Exception;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\ByParameterCount;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\EmptyTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\EncodedEntities;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\UnnecassaryWhitespaces;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\CoreTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\NoScripts;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Writer;
 
 require_once PIWIK_INCLUDE_PATH . '/plugins/LanguagesManager/API.php';
 
+/**
+ * @group LanguagesManager
+ */
 class LanguagesManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/ByBaseTranslationsTest.php
+++ b/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/ByBaseTranslationsTest.php
@@ -6,12 +6,12 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\Test\Unit\TranslationWriter\Filter;
 
-use Piwik\Translate\Filter\ByBaseTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\ByBaseTranslations;
 
 /**
- * @group Translation
+ * @group LanguagesManager
  */
 class ByBaseTranslationsTest extends \PHPUnit_Framework_TestCase
 {

--- a/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/ByParameterCountTest.php
+++ b/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/ByParameterCountTest.php
@@ -6,20 +6,21 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\Test\Unit\TranslationWriter\Filter;
 
-use Piwik\Translate\Filter\EncodedEntities;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\ByParameterCount;
 
 /**
- * @group Translation
+ * @group LanguagesManager
  */
-class EncodedEntitiesTest extends \PHPUnit_Framework_TestCase
+class ByParameterCountTest extends \PHPUnit_Framework_TestCase
 {
     public function getFilterTestData()
     {
         return array(
             // empty stays empty - nothing to filter
             array(
+                array(),
                 array(),
                 array(),
                 array()
@@ -29,12 +30,11 @@ class EncodedEntitiesTest extends \PHPUnit_Framework_TestCase
                 array(
                     'test' => array()
                 ),
-                array(
-                    'test' => array()
-                ),
+                array(),
+                array(),
                 array(),
             ),
-            // no entites - nothing to filter
+            // value with %s will be removed, as it isn't there in base
             array(
                 array(
                     'test' => array(
@@ -44,57 +44,64 @@ class EncodedEntitiesTest extends \PHPUnit_Framework_TestCase
                 ),
                 array(
                     'test' => array(
-                        'key' => 'val%sue',
-                        'test' => 'test'
+                        'key' => 'value',
                     )
                 ),
                 array(),
-            ),
-            // entities needs to be decodded
-            array(
                 array(
                     'test' => array(
-                        'test' => 'te&amp;st'
-                    )
-                ),
-                array(
-                    'test' => array(
-                        'test' => 'te&st'
-                    )
-                ),
-                array(
-                    'test' => array(
-                        'test' => 'te&amp;st'
+                        'key' => 'val%sue',
                     )
                 ),
             ),
+            // no change if placeholder count is the same
+            array(
+                array(
+                    'test' => array(
+                        'test' => 'te%sst'
+                    )
+                ),
+                array(
+                    'test' => array(
+                        'test' => 'test%s'
+                    )
+                ),
+                array(
+                    'test' => array(
+                        'test' => 'te%sst'
+                    )
+                ),
+                array()
+            ),
+            // missing placeholder will be removed
             array(
                 array(
                     'empty' => array(
-                        'test' => 't&uuml;sest'
+                        'test' => 't%1$sest'
                     ),
                     'test' => array(
                         'test' => '%1$stest',
-                        'empty' => '&tilde;',
+                        'empty' => '     ',
                     )
                 ),
                 array(
                     'empty' => array(
-                        'test' => 'tüsest'
+                        'test' => 'test%1$s'
                     ),
                     'test' => array(
-                        'test' => '%1$stest',
-                        'empty' => '˜',
+                        'test' => '%1$stest%2$s',
                     )
                 ),
                 array(
                     'empty' => array(
-                        'test' => 't&uuml;sest'
+                        'test' => 't%1$sest'
                     ),
-                    'test' => array(
-                        'empty' => '&tilde;',
-                    )
                 ),
+                array(
+                    'test' => array(
+                        'test' => '%1$stest',
+                    )
+                )
             ),
         );
     }
@@ -103,11 +110,12 @@ class EncodedEntitiesTest extends \PHPUnit_Framework_TestCase
      * @dataProvider getFilterTestData
      * @group Core
      */
-    public function testFilter($translations, $expected, $filteredData)
+    public function testFilter($translations, $baseTranslations, $expected, $filteredData)
     {
-        $filter = new EncodedEntities();
+        $filter = new ByParameterCount($baseTranslations);
         $result = $filter->filter($translations);
-        $this->assertEquals($expected, $result);
+        $message = sprintf("got %s but expected %s", var_export($result, true), var_export($expected, true));
+        $this->assertEquals($expected, $result, $message);
         $this->assertEquals($filteredData, $filter->getFilteredData());
     }
 }

--- a/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/EmptyTranslationsTest.php
+++ b/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/EmptyTranslationsTest.php
@@ -6,12 +6,12 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\Test\Unit\TranslationWriter\Filter;
 
-use Piwik\Translate\Filter\EmptyTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\EmptyTranslations;
 
 /**
- * @group Translation
+ * @group LanguagesManager
  */
 class EmptyTranslationsTest extends \PHPUnit_Framework_TestCase
 {

--- a/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/EncodedEntitiesTest.php
+++ b/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/EncodedEntitiesTest.php
@@ -6,21 +6,20 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\Test\Unit\TranslationWriter\Filter;
 
-use Piwik\Translate\Filter\ByParameterCount;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\EncodedEntities;
 
 /**
- * @group Translation
+ * @group LanguagesManager
  */
-class ByParameterCountTest extends \PHPUnit_Framework_TestCase
+class EncodedEntitiesTest extends \PHPUnit_Framework_TestCase
 {
     public function getFilterTestData()
     {
         return array(
             // empty stays empty - nothing to filter
             array(
-                array(),
                 array(),
                 array(),
                 array()
@@ -30,11 +29,12 @@ class ByParameterCountTest extends \PHPUnit_Framework_TestCase
                 array(
                     'test' => array()
                 ),
-                array(),
-                array(),
+                array(
+                    'test' => array()
+                ),
                 array(),
             ),
-            // value with %s will be removed, as it isn't there in base
+            // no entites - nothing to filter
             array(
                 array(
                     'test' => array(
@@ -44,64 +44,57 @@ class ByParameterCountTest extends \PHPUnit_Framework_TestCase
                 ),
                 array(
                     'test' => array(
-                        'key' => 'value',
+                        'key' => 'val%sue',
+                        'test' => 'test'
                     )
                 ),
                 array(),
-                array(
-                    'test' => array(
-                        'key' => 'val%sue',
-                    )
-                ),
             ),
-            // no change if placeholder count is the same
+            // entities needs to be decodded
             array(
                 array(
                     'test' => array(
-                        'test' => 'te%sst'
+                        'test' => 'te&amp;st'
                     )
                 ),
                 array(
                     'test' => array(
-                        'test' => 'test%s'
+                        'test' => 'te&st'
                     )
                 ),
                 array(
                     'test' => array(
-                        'test' => 'te%sst'
+                        'test' => 'te&amp;st'
                     )
                 ),
-                array()
             ),
-            // missing placeholder will be removed
             array(
                 array(
                     'empty' => array(
-                        'test' => 't%1$sest'
+                        'test' => 't&uuml;sest'
                     ),
                     'test' => array(
                         'test' => '%1$stest',
-                        'empty' => '     ',
+                        'empty' => '&tilde;',
                     )
                 ),
                 array(
                     'empty' => array(
-                        'test' => 'test%1$s'
+                        'test' => 'tüsest'
                     ),
                     'test' => array(
-                        'test' => '%1$stest%2$s',
+                        'test' => '%1$stest',
+                        'empty' => '˜',
                     )
                 ),
                 array(
                     'empty' => array(
-                        'test' => 't%1$sest'
+                        'test' => 't&uuml;sest'
                     ),
-                ),
-                array(
                     'test' => array(
-                        'test' => '%1$stest',
+                        'empty' => '&tilde;',
                     )
-                )
+                ),
             ),
         );
     }
@@ -110,12 +103,11 @@ class ByParameterCountTest extends \PHPUnit_Framework_TestCase
      * @dataProvider getFilterTestData
      * @group Core
      */
-    public function testFilter($translations, $baseTranslations, $expected, $filteredData)
+    public function testFilter($translations, $expected, $filteredData)
     {
-        $filter = new ByParameterCount($baseTranslations);
+        $filter = new EncodedEntities();
         $result = $filter->filter($translations);
-        $message = sprintf("got %s but expected %s", var_export($result, true), var_export($expected, true));
-        $this->assertEquals($expected, $result, $message);
+        $this->assertEquals($expected, $result);
         $this->assertEquals($filteredData, $filter->getFilteredData());
     }
 }

--- a/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/UnnecassaryWhitespacesTest.php
+++ b/plugins/LanguagesManager/Test/Unit/TranslationWriter/Filter/UnnecassaryWhitespacesTest.php
@@ -6,12 +6,12 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\Test\Unit\TranslationWriter\Filter;
 
-use Piwik\Translate\Filter\UnnecassaryWhitespaces;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\UnnecassaryWhitespaces;
 
 /**
- * @group Translation
+ * @group LanguagesManager
  */
 class UnnecassaryWhitepsacesTest extends \PHPUnit_Framework_TestCase
 {

--- a/plugins/LanguagesManager/Test/Unit/TranslationWriter/Validate/CoreTranslationsTest.php
+++ b/plugins/LanguagesManager/Test/Unit/TranslationWriter/Validate/CoreTranslationsTest.php
@@ -6,12 +6,12 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Translate\Validate;
+namespace Piwik\Plugins\LanguagesManager\Test\Unit\TranslationWriter\Validate;
 
-use Piwik\Translate\Validate\CoreTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\CoreTranslations;
 
 /**
- * @group Translation
+ * @group LanguagesManager
  */
 class CoreTranslationsTest extends \PHPUnit_Framework_TestCase
 {

--- a/plugins/LanguagesManager/Test/Unit/TranslationWriter/Validate/NoScriptsTest.php
+++ b/plugins/LanguagesManager/Test/Unit/TranslationWriter/Validate/NoScriptsTest.php
@@ -6,12 +6,12 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Translate\Validate;
+namespace Piwik\Plugins\LanguagesManager\Test\Unit\TranslationWriter\Validate;
 
-use Piwik\Translate\Validate\NoScripts;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\NoScripts;
 
 /**
- * @group Translation
+ * @group LanguagesManager
  */
 class NoScriptsTest extends \PHPUnit_Framework_TestCase
 {

--- a/plugins/LanguagesManager/Test/Unit/TranslationWriter/WriterTest.php
+++ b/plugins/LanguagesManager/Test/Unit/TranslationWriter/WriterTest.php
@@ -6,18 +6,18 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Translate;
+namespace Piwik\Plugins\LanguagesManager\Test\Unit\TranslationWriter;
 
 use Piwik\Container\StaticContainer;
-use Piwik\Translate\Filter\ByBaseTranslations;
-use Piwik\Translate\Filter\ByParameterCount;
-use Piwik\Translate\Filter\UnnecassaryWhitespaces;
-use Piwik\Translate\Validate\CoreTranslations;
-use Piwik\Translate\Validate\NoScripts;
-use Piwik\Translate\Writer;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\ByBaseTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\ByParameterCount;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\UnnecassaryWhitespaces;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\CoreTranslations;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\NoScripts;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Writer;
 
 /**
- * @group Translation
+ * @group LanguagesManager
  */
 class WriterTest extends \PHPUnit_Framework_TestCase
 {

--- a/plugins/LanguagesManager/TranslationWriter/Filter/ByBaseTranslations.php
+++ b/plugins/LanguagesManager/TranslationWriter/Filter/ByBaseTranslations.php
@@ -7,10 +7,8 @@
  *
  */
 
-namespace Piwik\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter\Filter;
 
-/**
- */
 class ByBaseTranslations extends FilterAbstract
 {
     protected $baseTranslations = array();

--- a/plugins/LanguagesManager/TranslationWriter/Filter/ByParameterCount.php
+++ b/plugins/LanguagesManager/TranslationWriter/Filter/ByParameterCount.php
@@ -7,10 +7,8 @@
  *
  */
 
-namespace Piwik\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter\Filter;
 
-/**
- */
 class ByParameterCount extends FilterAbstract
 {
     protected $baseTranslations = array();

--- a/plugins/LanguagesManager/TranslationWriter/Filter/EmptyTranslations.php
+++ b/plugins/LanguagesManager/TranslationWriter/Filter/EmptyTranslations.php
@@ -7,10 +7,8 @@
  *
  */
 
-namespace Piwik\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter\Filter;
 
-/**
- */
 class EmptyTranslations extends FilterAbstract
 {
     /**

--- a/plugins/LanguagesManager/TranslationWriter/Filter/EncodedEntities.php
+++ b/plugins/LanguagesManager/TranslationWriter/Filter/EncodedEntities.php
@@ -7,12 +7,10 @@
  *
  */
 
-namespace Piwik\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter\Filter;
 
 use Piwik\Translate;
 
-/**
- */
 class EncodedEntities extends FilterAbstract
 {
     /**

--- a/plugins/LanguagesManager/TranslationWriter/Filter/FilterAbstract.php
+++ b/plugins/LanguagesManager/TranslationWriter/Filter/FilterAbstract.php
@@ -7,10 +7,8 @@
  *
  */
 
-namespace Piwik\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter\Filter;
 
-/**
- */
 abstract class FilterAbstract
 {
     protected $filteredData = array();

--- a/plugins/LanguagesManager/TranslationWriter/Filter/UnnecassaryWhitespaces.php
+++ b/plugins/LanguagesManager/TranslationWriter/Filter/UnnecassaryWhitespaces.php
@@ -7,10 +7,8 @@
  *
  */
 
-namespace Piwik\Translate\Filter;
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter\Filter;
 
-/**
- */
 class UnnecassaryWhitespaces extends FilterAbstract
 {
     protected $baseTranslations = array();

--- a/plugins/LanguagesManager/TranslationWriter/Validate/CoreTranslations.php
+++ b/plugins/LanguagesManager/TranslationWriter/Validate/CoreTranslations.php
@@ -7,12 +7,10 @@
  *
  */
 
-namespace Piwik\Translate\Validate;
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter\Validate;
 
 use Piwik\Common;
 
-/**
- */
 class CoreTranslations extends ValidateAbstract
 {
     /**

--- a/plugins/LanguagesManager/TranslationWriter/Validate/NoScripts.php
+++ b/plugins/LanguagesManager/TranslationWriter/Validate/NoScripts.php
@@ -7,10 +7,8 @@
  *
  */
 
-namespace Piwik\Translate\Validate;
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter\Validate;
 
-/**
- */
 class NoScripts extends ValidateAbstract
 {
     /**

--- a/plugins/LanguagesManager/TranslationWriter/Validate/ValidateAbstract.php
+++ b/plugins/LanguagesManager/TranslationWriter/Validate/ValidateAbstract.php
@@ -7,10 +7,8 @@
  *
  */
 
-namespace Piwik\Translate\Validate;
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter\Validate;
 
-/**
- */
 abstract class ValidateAbstract
 {
     protected $message = null;

--- a/plugins/LanguagesManager/TranslationWriter/Writer.php
+++ b/plugins/LanguagesManager/TranslationWriter/Writer.php
@@ -4,21 +4,19 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
- *
  */
-namespace Piwik\Translate;
+
+namespace Piwik\Plugins\LanguagesManager\TranslationWriter;
 
 use Exception;
 use Piwik\Container\StaticContainer;
 use Piwik\Filesystem;
 use Piwik\Piwik;
-use Piwik\Translate\Filter\FilterAbstract;
-use Piwik\Translate\Validate\ValidateAbstract;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\FilterAbstract;
+use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\ValidateAbstract;
 
 /**
- * Writes clean translations to file
- *
+ * Writes translations to file.
  */
 class Writer
 {
@@ -30,7 +28,7 @@ class Writer
     protected $language = '';
 
     /**
-     * Name of a plugin (if set in contructor)
+     * Name of a plugin (if set in constructor)
      *
      * @var string|null
      */

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\ScheduledReports;
 use Exception;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\Log;
@@ -23,6 +24,7 @@ use Piwik\ReportRenderer;
 use Piwik\Site;
 use Piwik\Tracker;
 use Piwik\Translate;
+use Piwik\Translation\Translator;
 
 /**
  * The ScheduledReports API lets you manage Scheduled Email reports, as well as generate, download or email any existing report.
@@ -270,7 +272,9 @@ class API extends \Piwik\Plugin\API
             $language = Translate::getLanguageDefault();
         }
 
-        Translate::reloadLanguage($language);
+        /** @var Translator $translator */
+        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+        $translator->setCurrentLanguage($language);
 
         $reports = $this->getReports($idSite = false, $_period = false, $idReport);
         $report = reset($reports);

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -217,7 +217,7 @@ class Fixture extends \PHPUnit_Framework_Assert
 
         // Make sure translations are loaded to check messages in English
         if ($this->loadTranslations) {
-            Translate::reloadLanguage('en');
+            Translate::loadAllTranslations();
             APILanguageManager::getInstance()->setLanguageForUser('superUserLogin', 'en');
         }
 
@@ -314,7 +314,7 @@ class Fixture extends \PHPUnit_Framework_Assert
         EventDispatcher::getInstance()->clearAllObservers();
 
         $_GET = $_REQUEST = array();
-        Translate::unloadEnglishTranslation();
+        Translate::reset();
 
         Config::unsetInstance();
 

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -12,7 +12,7 @@ use Exception;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Common;
 use Piwik\Config;
-use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\Container\StaticContainer;
 use Piwik\Db;
 use Piwik\DbHelper;
 use Piwik\ReportRenderer;
@@ -24,6 +24,7 @@ use Piwik\Translate;
 use Piwik\Log;
 use PHPUnit_Framework_TestCase;
 use Piwik\Tests\Framework\Fixture;
+use Piwik\Translation\Translator;
 
 require_once PIWIK_INCLUDE_PATH . '/libs/PiwikTracker/PiwikTracker.php';
 
@@ -492,8 +493,9 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
     {
         if ($this->lastLanguage != $langId) {
             $_GET['language'] = $langId;
-            Translate::reset();
-            Translate::reloadLanguage($langId);
+            /** @var Translator $translator */
+            $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+            $translator->setCurrentLanguage($langId);
         }
 
         $this->lastLanguage = $langId;

--- a/tests/PHPUnit/Integration/CacheIdTest.php
+++ b/tests/PHPUnit/Integration/CacheIdTest.php
@@ -20,12 +20,12 @@ class CacheIdTest extends IntegrationTestCase
 {
     public function setUp()
     {
-        Translate::loadEnglishTranslation();
+        Translate::loadAllTranslations();
     }
 
     public function tearDown()
     {
-        Translate::unloadEnglishTranslation();
+        Translate::reset();
     }
 
     public function test_languageAware_shouldAppendTheLoadedLanguage()

--- a/tests/PHPUnit/Integration/ReportTest.php
+++ b/tests/PHPUnit/Integration/ReportTest.php
@@ -116,7 +116,6 @@ class ReportTest extends IntegrationTestCase
     {
         WidgetsList::getInstance()->_reset();
         MenuReporting::getInstance()->unsetInstance();
-        Translate::unloadEnglishTranslation();
         unset($_GET['idSite']);
         parent::tearDown();
     }
@@ -157,14 +156,16 @@ class ReportTest extends IntegrationTestCase
 
     public function test_getWidgetTitle_shouldReturnTranslatedTitleIfSet()
     {
-        $this->loadEnglishTranslation();
+        Translate::loadAllTranslations();
         $this->assertEquals('Page Titles Following a Site Search', $this->advancedReport->getWidgetTitle());
+        Translate::reset();
     }
 
     public function test_getCategory_shouldReturnTranslatedCategory()
     {
-        $this->loadEnglishTranslation();
+        Translate::loadAllTranslations();
         $this->assertEquals('Goals', $this->advancedReport->getCategory());
+        Translate::reset();
     }
 
     public function test_configureWidget_shouldNotAddAWidgetIfNoWidgetTitleIsSet()
@@ -538,10 +539,5 @@ class ReportTest extends IntegrationTestCase
     private function unloadAllPlugins()
     {
         PluginManager::getInstance()->unloadPlugins();
-    }
-
-    private function loadEnglishTranslation()
-    {
-        Translate::reloadLanguage('en');
     }
 }

--- a/tests/PHPUnit/Integration/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ActionTest.php
@@ -40,7 +40,14 @@ class ActionTest extends IntegrationTestCase
 
         PluginManager::getInstance()->loadPlugins(array('SitesManager'));
 
-        Translate::loadEnglishTranslation();
+        Translate::loadAllTranslations();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Translate::reset();
     }
 
     protected function setUpRootAccess()

--- a/tests/PHPUnit/Integration/WidgetsListTest.php
+++ b/tests/PHPUnit/Integration/WidgetsListTest.php
@@ -164,7 +164,7 @@ class WidgetsListTest extends IntegrationTestCase
         FakeAccess::$superUser = true;
         Access::setSingletonInstance($pseudoMockAccess);
 
-        Translate::loadEnglishTranslation();
+        Translate::loadAllTranslations();
 
         Fixture::createWebsite('2009-01-04 00:11:42', true);
 
@@ -175,5 +175,7 @@ class WidgetsListTest extends IntegrationTestCase
 
         $this->assertTrue(WidgetsList::isDefined('Actions', 'getPageUrls'));
         $this->assertFalse(WidgetsList::isDefined('Actions', 'inValiD'));
+
+        Translate::reset();
     }
 }

--- a/tests/PHPUnit/Unit/Metrics/Formatter/HtmlTest.php
+++ b/tests/PHPUnit/Unit/Metrics/Formatter/HtmlTest.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik\Tests\Unit\Metrics\Formatter;
 
+use Piwik\Intl\Locale;
 use Piwik\Metrics\Formatter\Html;
 use Piwik\Translate;
 use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
@@ -34,8 +35,6 @@ class HtmlTest extends \PHPUnit_Framework_TestCase
 
         $this->formatter = new Html();
 
-        setlocale(LC_ALL, null);
-
         Translate::loadEnglishTranslation();
         $this->setSiteManagerApiMock();
     }
@@ -44,8 +43,6 @@ class HtmlTest extends \PHPUnit_Framework_TestCase
     {
         Translate::unloadEnglishTranslation();
         $this->unsetSiteManagerApiMock();
-
-        setlocale(LC_ALL, null);
     }
 
     public function test_getPrettyTimeFromSeconds_DefaultsToShowingSentences_AndUsesNonBreakingSpaces()

--- a/tests/PHPUnit/Unit/Metrics/Formatter/HtmlTest.php
+++ b/tests/PHPUnit/Unit/Metrics/Formatter/HtmlTest.php
@@ -35,13 +35,13 @@ class HtmlTest extends \PHPUnit_Framework_TestCase
 
         $this->formatter = new Html();
 
-        Translate::loadEnglishTranslation();
+        Translate::loadAllTranslations();
         $this->setSiteManagerApiMock();
     }
 
     public function tearDown()
     {
-        Translate::unloadEnglishTranslation();
+        Translate::reset();
         $this->unsetSiteManagerApiMock();
     }
 

--- a/tests/PHPUnit/Unit/Metrics/FormatterTest.php
+++ b/tests/PHPUnit/Unit/Metrics/FormatterTest.php
@@ -51,13 +51,13 @@ class FormatterTest extends \PHPUnit_Framework_TestCase
 
         $this->formatter = new Formatter();
 
-        Translate::loadEnglishTranslation();
+        Translate::loadAllTranslations();
         $this->setSiteManagerApiMock();
     }
 
     public function tearDown()
     {
-        Translate::unloadEnglishTranslation();
+        Translate::reset();
         $this->unsetSiteManagerApiMock();
     }
 

--- a/tests/PHPUnit/Unit/Metrics/FormatterTest.php
+++ b/tests/PHPUnit/Unit/Metrics/FormatterTest.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik\Tests\Unit\Metrics;
 
+use Piwik\Intl\Locale;
 use Piwik\Metrics\Formatter;
 use Piwik\Translate;
 use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
@@ -50,8 +51,6 @@ class FormatterTest extends \PHPUnit_Framework_TestCase
 
         $this->formatter = new Formatter();
 
-        setlocale(LC_ALL, null);
-
         Translate::loadEnglishTranslation();
         $this->setSiteManagerApiMock();
     }
@@ -60,8 +59,6 @@ class FormatterTest extends \PHPUnit_Framework_TestCase
     {
         Translate::unloadEnglishTranslation();
         $this->unsetSiteManagerApiMock();
-
-        setlocale(LC_ALL, null);
     }
 
     /**
@@ -83,6 +80,7 @@ class FormatterTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertEquals($expected, $this->formatter->getPrettyNumber($number, 2));
+        Locale::setDefaultLocale();
     }
 
     /**

--- a/tests/PHPUnit/Unit/Period/BasePeriodTest.php
+++ b/tests/PHPUnit/Unit/Period/BasePeriodTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Period;
+
+use Piwik\Container\StaticContainer;
+use Piwik\Translate;
+use Piwik\Translation\Translator;
+
+abstract class BasePeriodTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        Translate::loadCoreTranslation();
+        /** @var Translator $translator */
+        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
+        $translator->addDirectory(PIWIK_INCLUDE_PATH . '/plugins/CoreHome/lang');
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Translate::reset();
+    }
+}

--- a/tests/PHPUnit/Unit/Period/BasePeriodTest.php
+++ b/tests/PHPUnit/Unit/Period/BasePeriodTest.php
@@ -8,9 +8,7 @@
 
 namespace Piwik\Tests\Unit\Period;
 
-use Piwik\Container\StaticContainer;
 use Piwik\Translate;
-use Piwik\Translation\Translator;
 
 abstract class BasePeriodTest extends \PHPUnit_Framework_TestCase
 {
@@ -18,10 +16,7 @@ abstract class BasePeriodTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        Translate::loadCoreTranslation();
-        /** @var Translator $translator */
-        $translator = StaticContainer::getContainer()->get('Piwik\Translation\Translator');
-        $translator->addDirectory(PIWIK_INCLUDE_PATH . '/plugins/CoreHome/lang');
+        Translate::loadAllTranslations();
     }
 
     public function tearDown()

--- a/tests/PHPUnit/Unit/Period/DayTest.php
+++ b/tests/PHPUnit/Unit/Period/DayTest.php
@@ -10,9 +10,8 @@ namespace Piwik\Tests\Unit\Period;
 
 use Piwik\Date;
 use Piwik\Period\Day;
-use Piwik\Translate;
 
-class Period_DayTest extends \PHPUnit_Framework_TestCase
+class DayTest extends BasePeriodTest
 {
     /**
      * @group Core
@@ -215,8 +214,6 @@ class Period_DayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedShortString()
     {
-        $this->loadEnglishTranslation();
-
         $month = new Day(Date::factory('2024-10-09'));
         $shouldBe = 'Wed 9 Oct';
         $this->assertEquals($shouldBe, $month->getLocalizedShortString());
@@ -227,8 +224,6 @@ class Period_DayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedLongString()
     {
-        $this->loadEnglishTranslation();
-
         $month = new Day(Date::factory('2024-10-09'));
         $shouldBe = 'Wednesday 9 October 2024';
         $this->assertEquals($shouldBe, $month->getLocalizedLongString());
@@ -239,15 +234,8 @@ class Period_DayTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetPrettyString()
     {
-        $this->loadEnglishTranslation();
-
         $month = new Day(Date::factory('2024-10-09'));
         $shouldBe = '2024-10-09';
         $this->assertEquals($shouldBe, $month->getPrettyString());
-    }
-
-    private function loadEnglishTranslation()
-    {
-        Translate::reloadLanguage('en');
     }
 }

--- a/tests/PHPUnit/Unit/Period/MonthTest.php
+++ b/tests/PHPUnit/Unit/Period/MonthTest.php
@@ -10,9 +10,8 @@ namespace Piwik\Tests\Unit\Period;
 
 use Piwik\Date;
 use Piwik\Period\Month;
-use Piwik\Translate;
 
-class Period_MonthTest extends \PHPUnit_Framework_TestCase
+class MonthTest extends BasePeriodTest
 {
     /**
      * testing december
@@ -271,8 +270,6 @@ class Period_MonthTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedShortString()
     {
-        $this->loadEnglishTranslation();
-
         $month = new Month(Date::factory('2024-10-09'));
         $shouldBe = 'Oct 2024';
         $this->assertEquals($shouldBe, $month->getLocalizedShortString());
@@ -283,8 +280,6 @@ class Period_MonthTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedLongString()
     {
-        $this->loadEnglishTranslation();
-
         $month = new Month(Date::factory('2024-10-09'));
         $shouldBe = '2024, October';
         $this->assertEquals($shouldBe, $month->getLocalizedLongString());
@@ -295,15 +290,9 @@ class Period_MonthTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetPrettyString()
     {
-        $this->loadEnglishTranslation();
-
         $month = new Month(Date::factory('2024-10-09'));
         $shouldBe = '2024-10';
         $this->assertEquals($shouldBe, $month->getPrettyString());
     }
 
-    private function loadEnglishTranslation()
-    {
-        Translate::reloadLanguage('en');
-    }
 }

--- a/tests/PHPUnit/Unit/Period/RangeTest.php
+++ b/tests/PHPUnit/Unit/Period/RangeTest.php
@@ -14,9 +14,8 @@ use Piwik\Period\Month;
 use Piwik\Period\Range;
 use Piwik\Period\Week;
 use Piwik\Period\Year;
-use Piwik\Translate;
 
-class Period_RangeTest extends \PHPUnit_Framework_TestCase
+class RangeTest extends BasePeriodTest
 {
     // test range 1
     /**
@@ -1272,7 +1271,6 @@ class Period_RangeTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedShortString()
     {
-        $this->loadEnglishTranslation();
         $month = new Range('range', '2000-12-09,2001-02-01');
         $shouldBe = '9 Dec 00 - 1 Feb 01';
         $this->assertEquals($shouldBe, $month->getLocalizedShortString());
@@ -1283,7 +1281,6 @@ class Period_RangeTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedLongString()
     {
-        $this->loadEnglishTranslation();
         $month = new Range('range', '2023-05-09,2023-05-21');
         $shouldBe = '8 May 23 - 21 May 23';
         $this->assertEquals($shouldBe, $month->getLocalizedLongString());
@@ -1294,7 +1291,6 @@ class Period_RangeTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetPrettyString()
     {
-        $this->loadEnglishTranslation();
         $month = new Range('range', '2007-02-09,2007-03-15');
         $shouldBe = 'From 2007-02-09 to 2007-03-15';
         $this->assertEquals($shouldBe, $month->getPrettyString());
@@ -1321,10 +1317,5 @@ class Period_RangeTest extends \PHPUnit_Framework_TestCase
     {
         $range = new Range($period, 'last' . $lastN);
         $this->assertEquals($expectedLastN, $range->getNumberOfSubperiods());
-    }
-
-    private function loadEnglishTranslation()
-    {
-        Translate::reloadLanguage('en');
     }
 }

--- a/tests/PHPUnit/Unit/Period/WeekTest.php
+++ b/tests/PHPUnit/Unit/Period/WeekTest.php
@@ -10,9 +10,8 @@ namespace Piwik\Tests\Unit\Period;
 
 use Piwik\Date;
 use Piwik\Period\Week;
-use Piwik\Translate;
 
-class Period_WeekTest extends \PHPUnit_Framework_TestCase
+class WeekTest extends BasePeriodTest
 {
     /**
      * test week between 2 years
@@ -123,7 +122,6 @@ class Period_WeekTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedShortString()
     {
-        $this->loadEnglishTranslation();
         $week = new Week(Date::factory('2024-10-09'));
         $shouldBe = '7 Oct - 13 Oct 24';
         $this->assertEquals($shouldBe, $week->getLocalizedShortString());
@@ -134,7 +132,6 @@ class Period_WeekTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedLongString()
     {
-        $this->loadEnglishTranslation();
         $week = new Week(Date::factory('2024-10-09'));
         $shouldBe = 'Week 7 October - 13 October 2024';
         $this->assertEquals($shouldBe, $week->getLocalizedLongString());
@@ -145,14 +142,8 @@ class Period_WeekTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetPrettyString()
     {
-        $this->loadEnglishTranslation();
         $week = new Week(Date::factory('2024-10-09'));
         $shouldBe = 'From 2024-10-07 to 2024-10-13';
         $this->assertEquals($shouldBe, $week->getPrettyString());
-    }
-
-    private function loadEnglishTranslation()
-    {
-        Translate::reloadLanguage('en');
     }
 }

--- a/tests/PHPUnit/Unit/Period/YearTest.php
+++ b/tests/PHPUnit/Unit/Period/YearTest.php
@@ -10,9 +10,8 @@ namespace Piwik\Tests\Unit\Period;
 
 use Piwik\Date;
 use Piwik\Period\Year;
-use Piwik\Translate;
 
-class Period_YearTest extends \PHPUnit_Framework_TestCase
+class YearTest extends BasePeriodTest
 {
     /**
      * test normal case
@@ -70,7 +69,6 @@ class Period_YearTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedShortString()
     {
-        Translate::loadEnglishTranslation();
         $year = new Year(Date::factory('2024-10-09'));
         $shouldBe = '2024';
         $this->assertEquals($shouldBe, $year->getLocalizedShortString());
@@ -81,7 +79,6 @@ class Period_YearTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetLocalizedLongString()
     {
-        Translate::loadEnglishTranslation();
         $year = new Year(Date::factory('2024-10-09'));
         $shouldBe = '2024';
         $this->assertEquals($shouldBe, $year->getLocalizedLongString());
@@ -92,7 +89,6 @@ class Period_YearTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetPrettyString()
     {
-        Translate::loadEnglishTranslation();
         $year = new Year(Date::factory('2024-10-09'));
         $shouldBe = '2024';
         $this->assertEquals($shouldBe, $year->getPrettyString());

--- a/tests/PHPUnit/Unit/Translate/Filter/ByBaseTranslationsTest.php
+++ b/tests/PHPUnit/Unit/Translate/Filter/ByBaseTranslationsTest.php
@@ -10,6 +10,9 @@ namespace Piwik\Tests\Unit\Translate\Filter;
 
 use Piwik\Translate\Filter\ByBaseTranslations;
 
+/**
+ * @group Translation
+ */
 class ByBaseTranslationsTest extends \PHPUnit_Framework_TestCase
 {
     public function getFilterTestData()

--- a/tests/PHPUnit/Unit/Translate/Filter/ByParameterCountTest.php
+++ b/tests/PHPUnit/Unit/Translate/Filter/ByParameterCountTest.php
@@ -11,7 +11,7 @@ namespace Piwik\Tests\Unit\Translate\Filter;
 use Piwik\Translate\Filter\ByParameterCount;
 
 /**
- * @group ByParameterCountTest
+ * @group Translation
  */
 class ByParameterCountTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/PHPUnit/Unit/Translate/Filter/EmptyTranslationsTest.php
+++ b/tests/PHPUnit/Unit/Translate/Filter/EmptyTranslationsTest.php
@@ -10,6 +10,9 @@ namespace Piwik\Tests\Unit\Translate\Filter;
 
 use Piwik\Translate\Filter\EmptyTranslations;
 
+/**
+ * @group Translation
+ */
 class EmptyTranslationsTest extends \PHPUnit_Framework_TestCase
 {
     public function getFilterTestData()

--- a/tests/PHPUnit/Unit/Translate/Filter/EncodedEntitiesTest.php
+++ b/tests/PHPUnit/Unit/Translate/Filter/EncodedEntitiesTest.php
@@ -10,6 +10,9 @@ namespace Piwik\Tests\Unit\Translate\Filter;
 
 use Piwik\Translate\Filter\EncodedEntities;
 
+/**
+ * @group Translation
+ */
 class EncodedEntitiesTest extends \PHPUnit_Framework_TestCase
 {
     public function getFilterTestData()

--- a/tests/PHPUnit/Unit/Translate/Filter/UnnecassaryWhitespacesTest.php
+++ b/tests/PHPUnit/Unit/Translate/Filter/UnnecassaryWhitespacesTest.php
@@ -10,6 +10,9 @@ namespace Piwik\Tests\Unit\Translate\Filter;
 
 use Piwik\Translate\Filter\UnnecassaryWhitespaces;
 
+/**
+ * @group Translation
+ */
 class UnnecassaryWhitepsacesTest extends \PHPUnit_Framework_TestCase
 {
     public function getFilterTestData()

--- a/tests/PHPUnit/Unit/Translate/Validate/CoreTranslationsTest.php
+++ b/tests/PHPUnit/Unit/Translate/Validate/CoreTranslationsTest.php
@@ -10,6 +10,9 @@ namespace Piwik\Tests\Unit\Translate\Validate;
 
 use Piwik\Translate\Validate\CoreTranslations;
 
+/**
+ * @group Translation
+ */
 class CoreTranslationsTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/tests/PHPUnit/Unit/Translate/Validate/NoScriptsTest.php
+++ b/tests/PHPUnit/Unit/Translate/Validate/NoScriptsTest.php
@@ -10,6 +10,9 @@ namespace Piwik\Tests\Unit\Translate\Validate;
 
 use Piwik\Translate\Validate\NoScripts;
 
+/**
+ * @group Translation
+ */
 class NoScriptsTest extends \PHPUnit_Framework_TestCase
 {
     public function getFilterTestDataValid()

--- a/tests/PHPUnit/Unit/Translate/WriterTest.php
+++ b/tests/PHPUnit/Unit/Translate/WriterTest.php
@@ -16,6 +16,9 @@ use Piwik\Translate\Validate\CoreTranslations;
 use Piwik\Translate\Validate\NoScripts;
 use Piwik\Translate\Writer;
 
+/**
+ * @group Translation
+ */
 class WriterTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/tests/PHPUnit/Unit/TranslateTest.php
+++ b/tests/PHPUnit/Unit/TranslateTest.php
@@ -10,6 +10,9 @@ namespace Piwik\Tests\Unit;
 
 use Piwik\Translate;
 
+/**
+ * @group Translation
+ */
 class TranslateTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/tests/PHPUnit/Unit/Translation/Loader/JsonFileLoaderTest.php
+++ b/tests/PHPUnit/Unit/Translation/Loader/JsonFileLoaderTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Translation\Loader;
+
+use Piwik\Translation\Loader\JsonFileLoader;
+
+/**
+ * @group Translation
+ */
+class JsonFileLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_shouldLoadJsonFile()
+    {
+        $loader = new JsonFileLoader();
+        $translations = $loader->load('en', array(__DIR__ . '/fixtures/dir1'));
+
+        $expected = array(
+            'General' => array(
+                'test1' => 'Hello',
+                'test2' => 'Hello',
+            ),
+        );
+
+        $this->assertEquals($expected, $translations);
+    }
+
+    public function test_shouldIgnoreMissingFiles()
+    {
+        $loader = new JsonFileLoader();
+        $translations = $loader->load('foo', array(__DIR__ . '/fixtures/dir1'));
+
+        $this->assertEquals(array(), $translations);
+    }
+
+    public function test_shouldMergeTranslations_ifLoadingMultipleFiles()
+    {
+        $loader = new JsonFileLoader();
+        $translations = $loader->load('en', array(__DIR__ . '/fixtures/dir1', __DIR__ . '/fixtures/dir2'));
+
+        $expected = array(
+            'General' => array(
+                'test1' => 'Hello',
+                'test2' => 'Hello 2', // the second file should overwrite the first one
+                'test3' => 'Hello 3',
+            ),
+        );
+
+        $this->assertEquals($expected, $translations);
+    }
+}

--- a/tests/PHPUnit/Unit/Translation/Loader/LoaderCacheTest.php
+++ b/tests/PHPUnit/Unit/Translation/Loader/LoaderCacheTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Translation\Loader;
+
+use Piwik\Cache\Backend\ArrayCache;
+use Piwik\Cache\Lazy;
+use Piwik\Translation\Loader\LoaderCache;
+
+/**
+ * @group Translation
+ */
+class LoaderCacheTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_shouldNotLoad_ifInCache()
+    {
+        $cache = $this->getMock('Piwik\Cache\Lazy', array(), array(), '', false);
+        $cache->expects($this->any())
+            ->method('fetch')
+            ->willReturn(array('translations!'));
+        $wrappedLoader = $this->getMockForAbstractClass('Piwik\Translation\Loader\LoaderInterface');
+        $wrappedLoader->expects($this->never())
+            ->method('load');
+
+        $loader = new LoaderCache($wrappedLoader, $cache);
+        $translations = $loader->load('en', array('foo'));
+
+        $this->assertEquals(array('translations!'), $translations);
+    }
+
+    public function test_shouldLoad_ifNotInCache()
+    {
+        $cache = $this->getMock('Piwik\Cache\Lazy', array(), array(), '', false);
+        $cache->expects($this->any())
+            ->method('fetch')
+            ->willReturn(null);
+        $wrappedLoader = $this->getMockForAbstractClass('Piwik\Translation\Loader\LoaderInterface');
+        $wrappedLoader->expects($this->once())
+            ->method('load')
+            ->with('en', array('foo'))
+            ->willReturn(array('translations!'));
+
+        $loader = new LoaderCache($wrappedLoader, $cache);
+        $translations = $loader->load('en', array('foo'));
+
+        $this->assertEquals(array('translations!'), $translations);
+    }
+
+    public function test_shouldReLoad_ifDifferentDirectories()
+    {
+        $cache = new Lazy(new ArrayCache());
+
+        $wrappedLoader = $this->getMockForAbstractClass('Piwik\Translation\Loader\LoaderInterface');
+        $wrappedLoader->expects($this->exactly(2))
+            ->method('load')
+            ->willReturn(array('translations!'));
+
+        $loader = new LoaderCache($wrappedLoader, $cache);
+
+        // Should call the wrapped loader only once
+        $loader->load('en', array('foo'));
+        $loader->load('en', array('foo'));
+
+        // Should call the wrapped loader a second time
+        $loader->load('en', array('foo', 'bar'));
+    }
+}

--- a/tests/PHPUnit/Unit/Translation/Loader/fixtures/dir1/en.json
+++ b/tests/PHPUnit/Unit/Translation/Loader/fixtures/dir1/en.json
@@ -1,0 +1,6 @@
+{
+  "General": {
+    "test1": "Hello",
+    "test2": "Hello"
+  }
+}

--- a/tests/PHPUnit/Unit/Translation/Loader/fixtures/dir1/fr.json
+++ b/tests/PHPUnit/Unit/Translation/Loader/fixtures/dir1/fr.json
@@ -1,0 +1,5 @@
+{
+  "General": {
+    "test1": "Bonjour"
+  }
+}

--- a/tests/PHPUnit/Unit/Translation/Loader/fixtures/dir2/en.json
+++ b/tests/PHPUnit/Unit/Translation/Loader/fixtures/dir2/en.json
@@ -1,0 +1,6 @@
+{
+  "General": {
+    "test2": "Hello 2",
+    "test3": "Hello 3"
+  }
+}

--- a/tests/PHPUnit/Unit/Translation/TranslatorTest.php
+++ b/tests/PHPUnit/Unit/Translation/TranslatorTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Translation\Loader;
+
+use Piwik\Translation\Loader\JsonFileLoader;
+use Piwik\Translation\Translator;
+
+/**
+ * @group Translation
+ */
+class TranslatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_translate_shouldReturnTranslationId_ifNoTranslationFound()
+    {
+        $loader = $this->createLoader();
+        $translator = new Translator($loader, array());
+
+        $this->assertEquals('General_foo', $translator->translate('General_foo'));
+    }
+
+    public function test_translate_shouldReturnTranslation()
+    {
+        $loader = $this->createLoader(array(
+            'General' => array(
+                'foo' => 'Hello world',
+            ),
+        ));
+        $translator = new Translator($loader, array());
+
+        $this->assertEquals('Hello world', $translator->translate('General_foo'));
+    }
+
+    public function test_translate_shouldReplacePlaceholders()
+    {
+        $loader = $this->createLoader(array(
+            'General' => array(
+                'foo' => 'Hello %s',
+            ),
+        ));
+        $translator = new Translator($loader, array());
+
+        $this->assertEquals('Hello John', $translator->translate('General_foo', 'John'));
+    }
+
+    public function test_translate_withADifferentLanguage()
+    {
+        $translator = new Translator(new JsonFileLoader(), array(__DIR__ . '/Loader/fixtures/dir1'));
+
+        $this->assertEquals('Hello', $translator->translate('General_test1'));
+
+        $translator->setCurrentLanguage('fr');
+        $this->assertEquals('fr', $translator->getCurrentLanguage());
+        $this->assertEquals('Bonjour', $translator->translate('General_test1'));
+    }
+
+    public function test_translate_shouldFallback_ifTranslationNotFound()
+    {
+        $translator = new Translator(new JsonFileLoader(), array(__DIR__ . '/Loader/fixtures/dir1'));
+        $translator->setCurrentLanguage('fr');
+        $this->assertEquals('Hello', $translator->translate('General_test2'));
+    }
+
+    public function test_addDirectory_shouldImportNewTranslations()
+    {
+        $translator = new Translator(new JsonFileLoader(), array(__DIR__ . '/Loader/fixtures/dir1'));
+        // translation not found
+        $this->assertEquals('General_test3', $translator->translate('General_test3'));
+
+        $translator->addDirectory(__DIR__ . '/Loader/fixtures/dir2');
+        // translation is now found
+        $this->assertEquals('Hello 3', $translator->translate('General_test3'));
+    }
+
+    public function test_addDirectory_shouldImportOverExistingTranslations()
+    {
+        $translator = new Translator(new JsonFileLoader(), array(__DIR__ . '/Loader/fixtures/dir1'));
+        $this->assertEquals('Hello', $translator->translate('General_test2'));
+
+        $translator->addDirectory(__DIR__ . '/Loader/fixtures/dir2');
+        $this->assertEquals('Hello 2', $translator->translate('General_test2'));
+    }
+
+    private function createLoader(array $translations = array())
+    {
+        $loader = $this->getMockForAbstractClass('Piwik\Translation\Loader\LoaderInterface');
+        $loader->expects($this->any())
+            ->method('load')
+            ->willReturn($translations);
+
+        return $loader;
+    }
+}

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -3,6 +3,7 @@
 use Piwik\Container\StaticContainer;
 use Piwik\Http;
 use Piwik\Tests\Framework\Fixture;
+use Piwik\Intl\Locale;
 
 define('PIWIK_TEST_MODE', true);
 define('PIWIK_PRINT_ERROR_BACKTRACE', false);
@@ -57,6 +58,8 @@ foreach($fixturesToLoad as $fixturePath) {
         require_once $file;
     }
 }
+
+Locale::setDefaultLocale();
 
 function prepareServerVariables()
 {


### PR DESCRIPTION
Translations were stored in a `$GLOBALS` array and handled by a static class `Piwik\Translate`. Furthermore, handling of translations were spread all over the place, caching logic was mixed with translation logic, …

This refactoring contains:
- created a **Translation** component following the naming of Symfony's Translation component ("Translator" class, "Loaders", …)
- all logic related to loading/handling translations is now encapsulated in that component
- classes of that component are using dependency injection
- `Piwik\Translate` is kept for BC and forwards call to the new `Translator` class
- that new component is decoupled from the rest of Piwik (except for a few exceptions to improve later): it doesn't know about the HTTP request, about Plugins, about Piwik directories, etc...
- translations are **lazily loaded**, i.e. you ask for a french translation then french translations will be loaded automatically
- that means that Piwik/plugins don't have to tell the translator to load anything: the plugin manager just configures the directories where to find translations (which are the installed plugins…)
- there is a `LoaderInterface` with the following implementations:
  - `JsonFileLoader`
  - `LoaderCache`: caches another loader by wrapping it (which would be the `JsonFileLoader`)
- that way of caching things brings the following benefits:
  - caching can be configured in DI, and disabled with the container using the new `dev` environment (which addresses [this TODO](https://github.com/piwik/piwik/blob/master/core/Plugin/Manager.php#L716))
  - core translations are cached as well as the plugin ones, which fixes #6060
- as said above, there's a new `dev` environment (= new DI config file) where translation cache is disabled: this environment can be used for other things as well
- there is now a fallback mechanism (previously all translations were merged together in one array): if a french/… translation is not found, then the english one is returned
- that fallback mechanism would allow to do #4983 (regional overrides) by having multiple fallbacks, for example: `fr_CA` (canadian french) would fallback to `fr` which would fallback to `en` (not implemented)
- moved `Piwik\Translate\Writer` and its subclasses to the LanguagesManager plugin because these classes were only used in that plugin

And I was able to unit tests the new classes, which is just an awesome feeling :)

There's still a lot of room for improvement, I'll keep working on that PR. Feedback welcome!
