### PR TITLE
Faster bootstrap for PHPUnit tests

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -99,7 +99,7 @@ class Http
      *
      * @param string $method
      * @param string $aUrl
-     * @param int $timeout
+     * @param int $timeout in seconds
      * @param string $userAgent
      * @param string $destinationPath
      * @param resource $file

--- a/plugins/TestRunner/Controller.php
+++ b/plugins/TestRunner/Controller.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TestRunner;
+
+class Controller extends \Piwik\Plugin\Controller
+{
+    public function check()
+    {
+        return 'OK';
+    }
+}

--- a/plugins/TestRunner/plugin.json
+++ b/plugins/TestRunner/plugin.json
@@ -1,19 +1,22 @@
 {
-  "name": "TestRunner",
-  "version": "0.1.0",
-  "description": "Let's you run Piwik tests. Only needed in development.",
-  "theme": false,
-  "require": {
-     "piwik": ">=2.8.1-rc1"
-  },
-  "authors": [
-      {
-          "name": "Piwik",
-          "email": "hello@piwik.org",
-          "homepage": "http://piwik.org"
-      }
-  ],
-  "license": "GPL v3+",
-  "keywords": ["test", "runner"],
-  "homepage": "http://piwik.org"
+    "name": "TestRunner",
+    "version": "0.1.0",
+    "description": "Let's you run Piwik tests. Only needed in development.",
+    "theme": false,
+    "require": {
+        "piwik": ">=2.10.0-rc1"
+    },
+    "authors": [
+        {
+            "name": "Piwik",
+            "email": "hello@piwik.org",
+            "homepage": "http:\/\/piwik.org"
+        }
+    ],
+    "license": "GPL v3+",
+    "keywords": [
+        "test",
+        "runner"
+    ],
+    "homepage": "http:\/\/piwik.org"
 }

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -110,11 +110,14 @@ Try again.";
     $url = Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php?module=TestRunner&action=check';
     $response = Http::sendHttpRequestBy('curl', $url, 2);
 
-    if ($response !== 'OK') {
-        throw new Exception(sprintf(
-            "Piwik should be running at %s but this URL returned an unexpected response: '%s'",
-            Fixture::getRootUrl(),
-            $response
-        ));
+    // The SQL error is for Travis...
+    if ($response === 'OK' || strpos($response, 'Base table or view not found: 1146 Table &#039;piwik_tests.option&#039; doesn&#039;t exist') !== false) {
+        return;
     }
+
+    throw new Exception(sprintf(
+        "Piwik should be running at %s but this URL returned an unexpected response: '%s'",
+        Fixture::getRootUrl(),
+        $response
+    ));
 }

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -107,7 +107,7 @@ Try again.";
         exit(1);
     }
 
-    $url = Fixture::getRootUrl() . 'index.php?module=TestRunner&action=check';
+    $url = Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php?module=TestRunner&action=check';
     $response = Http::sendHttpRequestBy('curl', $url, 2);
 
     if ($response !== 'OK') {

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -111,7 +111,7 @@ Try again.";
     $response = Http::sendHttpRequestBy('curl', $url, 2);
 
     // The SQL error is for Travis...
-    if ($response === 'OK' || strpos($response, 'Base table or view not found: 1146 Table &#039;piwik_tests.option&#039; doesn&#039;t exist') !== false) {
+    if ($response === 'OK' || strpos($response, 'Table &#039;piwik_tests.option&#039; doesn&#039;t exist') !== false) {
         return;
     }
 

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 use Piwik\Container\StaticContainer;
+use Piwik\Http;
+use Piwik\Tests\Framework\Fixture;
 
 define('PIWIK_TEST_MODE', true);
 define('PIWIK_PRINT_ERROR_BACKTRACE', false);
@@ -104,7 +106,15 @@ remote_addr = \"127.0.0.1\"
 Try again.";
         exit(1);
     }
-    $baseUrl = \Piwik\Tests\Framework\Fixture::getRootUrl();
 
-    \Piwik\SettingsPiwik::checkPiwikServerWorking($baseUrl, $acceptInvalidSSLCertificates = true);
+    $url = Fixture::getRootUrl() . 'index.php?module=TestRunner&action=check';
+    $response = Http::sendHttpRequestBy('curl', $url, 2);
+
+    if ($response !== 'OK') {
+        throw new Exception(sprintf(
+            "Piwik should be running at %s but this URL returned an unexpected response: '%s'",
+            Fixture::getRootUrl(),
+            $response
+        ));
+    }
 }


### PR DESCRIPTION
When running PHPUnit tests other than unit tests, the bootstrap checks that Piwik server is running correctly.

Instead of hitting the home page (`/` 302 that redirect to `/index.php? CoreHome…`) which takes a couple seconds for the HTTP response, this uses a simpler and faster controller action.

The **TestsRunner** plugin is disabled in production right? So that new controller shouldn't be a problem.
