### PR TITLE
Multiple commands classes components detector

### DIFF
--- a/core/Console.php
+++ b/core/Console.php
@@ -78,9 +78,28 @@ class Console extends Application
     private function getAvailableCommands()
     {
         $commands = $this->getDefaultPiwikCommands();
-        $detected = PluginManager::getInstance()->findMultipleComponents('Commands', 'Piwik\\Plugin\\ConsoleCommand');
+        $commandsClasses = array('Piwik\\Plugin\\ConsoleCommand');
 
-        $commands = array_merge($commands, $detected);
+        /**
+         * Triggered to gather all class names for components finder.
+         *
+         * **Example**
+         *
+         *     public function detectCommands(&$commandsClasses)
+         *     {
+         *         $commandsClasses[] = 'CustomCommand';
+         *     }
+         *
+         * @param array &$commandsClasses An array containing a list of command class names.
+         */
+        Piwik::postEvent('Console.detectCommands', array(&$commandsClasses));
+
+        foreach ($commandsClasses as $className) {
+            $commands = array_merge(
+                $commands,
+                PluginManager::getInstance()->findMultipleComponents('Commands', $className)
+            );
+        }
 
         /**
          * Triggered to filter / restrict console commands. Plugins that want to restrict commands
@@ -170,11 +189,6 @@ class Console extends Application
         $commands = array(
             'Piwik\CliMulti\RequestCommand'
         );
-
-        if (class_exists('Piwik\Plugins\EnterpriseAdmin\EnterpriseAdmin')) {
-            $extra = new \Piwik\Plugins\EnterpriseAdmin\EnterpriseAdmin();
-            $extra->addConsoleCommands($commands);
-        }
 
         return $commands;
     }


### PR DESCRIPTION
Hello team,

I remove hardcoded class name and replace them with hook. I suppose that is more universal and easier to maintain than path to EnterpriseAdmin plugin class. 
