### PR TITLE
Fix User ID Segmentation

### DIFF
--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -160,8 +160,7 @@ class API extends \Piwik\Plugin\API
             'name'           => 'General_UserId',
             'segment'        => 'userId',
             'acceptedValues' => 'any non empty unique string identifying the user (such as an email address or a username).',
-            'sqlSegment'     => 'log_visit.idvisitor',
-            'sqlFilterValue' => array('Piwik\Common', 'convertUserIdToVisitorIdBin'),
+            'sqlSegment'     => 'log_visit.user_id',
             'sqlFilter'      => array($this, 'checkSegmentMatchTypeIsValidForUser'),
             'permission'     => $isAuthenticatedWithViewAccess,
 


### PR DESCRIPTION
Tried to segment all visits to Users and Not users.
Segmentation with rules User Id, Not equal, Empty generates next SQL:
`( log_visit.idvisitor IS NOT NULL AND (log_visit.idvisitor <> '' OR log_visit.idvisitor = 0)`

But in case Anonymous visitor there is Visitor ID but no User ID.

So after fix SQL changing for this:
`( log_visit.user_id IS NOT NULL AND (log_visit.user_id <> '' OR log_visit.user_id = 0) )`
