### PR TITLE
Change the layout of the engagement page

### DIFF
--- a/plugins/VisitFrequency/templates/_sparklines.twig
+++ b/plugins/VisitFrequency/templates/_sparklines.twig
@@ -1,3 +1,4 @@
+<div id="leftcolumn">
 <div class="sparkline">
     {{ sparkline(urlSparklineNbVisitsReturning) }}
     {{ 'VisitFrequency_ReturnVisits'|translate("<strong>"~nbVisitsReturning~"</strong>")|raw }}
@@ -10,6 +11,7 @@
     {{ sparkline(urlSparklineActionsPerVisitReturning) }}
     {{ 'VisitFrequency_ReturnAvgActions'|translate("<strong>"~nbActionsPerVisitReturning~"</strong>")|raw }}
 </div>
+    </div><div id="rightcolumn">
 <div class="sparkline">
     {{ sparkline(urlSparklineAvgVisitDurationReturning) }}
     {% set avgVisitDurationReturning=avgVisitDurationReturning|sumtime %}
@@ -20,3 +22,5 @@
     {{ 'VisitFrequency_ReturnBounceRate'|translate("<strong>"~bounceRateReturning~"</strong>")|raw }}
 </div>
 {% include "_sparklineFooter.twig" %}
+</div>
+<div style="clear:both"></div>

--- a/plugins/VisitorInterest/VisitorInterest.php
+++ b/plugins/VisitorInterest/VisitorInterest.php
@@ -30,22 +30,12 @@ class VisitorInterest extends \Piwik\Plugin
 
     function postLoad()
     {
-        Piwik::addAction('Template.headerVisitsFrequency', array('Piwik\Plugins\VisitorInterest\VisitorInterest', 'headerVisitsFrequency'));
         Piwik::addAction('Template.footerVisitsFrequency', array('Piwik\Plugins\VisitorInterest\VisitorInterest', 'footerVisitsFrequency'));
-    }
-
-    public static function headerVisitsFrequency(&$out)
-    {
-        $out = '<div id="leftcolumn">';
     }
 
     public static function footerVisitsFrequency(&$out)
     {
-        $out = '</div>
-			<div id="rightcolumn">
-			';
         $out .= FrontController::getInstance()->fetchDispatch('VisitorInterest', 'index');
-        $out .= '</div>';
     }
 
     public function extendVisitorDetails(&$visitor, $details)

--- a/plugins/VisitorInterest/templates/index.twig
+++ b/plugins/VisitorInterest/templates/index.twig
@@ -1,11 +1,19 @@
-<h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsPerDuration'|translate }}</h2>
-{{ dataTableNumberOfVisitsPerVisitDuration|raw }}
-
-<h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsPerNbOfPages'|translate }}</h2>
-{{ dataTableNumberOfVisitsPerPage|raw }}
-
-<h2 piwik-enriched-headline>{{ 'VisitorInterest_visitsByVisitCount'|translate }}</h2>
-{{ dataTableNumberOfVisitsByVisitNum|raw }}
-
-<h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsByDaysSinceLast'|translate }}</h2>
-{{ dataTableNumberOfVisitsByDaysSinceLast|raw }}
+<br />
+<div id="leftcolumn">
+    <h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsPerDuration'|translate }}</h2>
+    {{ dataTableNumberOfVisitsPerVisitDuration|raw }}
+</div>
+<div id="rightcolumn">
+    <h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsPerNbOfPages'|translate }}</h2>
+    {{ dataTableNumberOfVisitsPerPage|raw }}
+</div>
+<div style="clear:both"></div>
+<div id="leftcolumn">
+    <h2 piwik-enriched-headline>{{ 'VisitorInterest_visitsByVisitCount'|translate }}</h2>
+    {{ dataTableNumberOfVisitsByVisitNum|raw }}
+</div>
+<div id="rightcolumn">
+    <h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsByDaysSinceLast'|translate }}</h2>
+    {{ dataTableNumberOfVisitsByDaysSinceLast|raw }}
+</div>
+<div style="clear:both"></div>


### PR DESCRIPTION
Reports are shown next to each other instead of randomly, see attachment
![uiintegrationtest_visitors_engagement](https://cloud.githubusercontent.com/assets/273120/5674156/d25aeb9a-980a-11e4-9eb3-70190d9c9faa.png)
