### PR TITLE
Optimized how archive data is fetched from database

### DIFF
--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -248,8 +248,8 @@ class ArchiveSelector
                                 WHERE idarchive IN (%s)
                                   AND " . $whereNameIs;
 
-        // get data from every table we're querying
-        $rows = array();
+        // make a list of all archive IDs we want to fetch (for each archive table)
+        $tables = array();
         foreach ($archiveIds as $period => $ids) {
 
             if (empty($ids)) {
@@ -265,6 +265,16 @@ class ArchiveSelector
                 $table = ArchiveTableCreator::getBlobTable($date);
             }
 
+            if (isset($tables[$table])) {
+                $tables[$table] = array_merge($tables[$table], $ids);
+            } else {
+                $tables[$table] = $ids;
+            }
+        }
+
+        // get data from every table we're querying
+        $rows = array();
+        foreach ($tables as $table => $ids) {
             $sql      = sprintf($getValuesSql, $table, implode(',', $ids));
             $dataRows = Db::fetchAll($sql, $bind);
 


### PR DESCRIPTION
References #6846

Now we try to make only 1 query per archive table (before there could be multiple queries per table).

In weekly archiving with very few data the number of SQL queries went from 2500 to 1000, saved 6% of execution time, 5% of memory usage. Real results could be much less significant (or more) I have no idea…

Also, please review the change because:

![image](https://cloud.githubusercontent.com/assets/720328/5750937/e4936cfa-9cc0-11e4-958b-9cdbaa8fbec9.png)

I juste tried to optimize that bit from what I could understand.

We could also consider issuing only 1 MySQL request by selecting from all tables at once using `UNION`, by I don't know if it could explode because of the amount of data…
