### PR TITLE
See the focus of menu items when tabbing through the page (accessibility)

### DIFF
--- a/plugins/Morpheus/stylesheets/general/_default.less
+++ b/plugins/Morpheus/stylesheets/general/_default.less
@@ -51,7 +51,7 @@ pre.code-pre {
 
 /* remember to define focus styles! */
 :focus {
-    outline: 0;
+    outline: auto;
 }
 
 /* remember to highlight inserts somehow! */


### PR DESCRIPTION
You can now see the focus of menu items when tabbing through the page. #6997 
