### PR TITLE
Refactored Twig templates using a single base layout

### DIFF
--- a/plugins/Login/templates/login.twig
+++ b/plugins/Login/templates/login.twig
@@ -1,18 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-	<meta http-equiv="x-ua-compatible" content="IE=EDGE,chrome=1" >
-    <title>{% if isCustomLogo == false %}Piwik &rsaquo; {% endif %}{{ 'Login_LogIn'|translate }}</title>
+{% extends 'layout.twig' %}
 
-    {% include "@CoreHome/_favicon.twig" %}
-    {% autoescape false %}
-    {{ includeAssets({"type": "css"}) }}
-    {% endautoescape %}
-    <meta name="description" content="{{ 'General_OpenSourceWebAnalytics'|translate }}"/>
-    <meta name="apple-itunes-app" content="app-id=737216887" />
-    <meta name="google-play-app" content="app-id=org.piwik.mobile2">
-    {% include "_jsCssIncludes.twig" %}
+{% block head %}
+    {{ parent() }}
     <script type="text/javascript" src="libs/bower_components/jquery-placeholder/jquery.placeholder.js"></script>
     <!--[if lt IE 9]>
     <script src="libs/bower_components/html5shiv/dist/html5shiv.min.js"></script>
@@ -26,12 +15,16 @@
             $('input').placeholder();
             $.smartbanner({title: "Piwik Mobile 2", author: "Piwik team", hideOnInstall: false, layer: true, icon: "plugins/CoreHome/images/googleplay.png"});
         });
-	</script>
-	</head>
-	<!--[if lt IE 9 ]>
-	<body id="loginPage" class="old-ie"> <![endif]-->
-    <!--[if (gte IE 9)|!(IE)]><!-->
-    <body id="loginPage"><!--<![endif]-->
+    </script>
+{% endblock %}
+
+{% block pageTitle %}{% if isCustomLogo == false %}Piwik &rsaquo; {% endif %}{{ 'Login_LogIn'|translate }}{% endblock %}
+{% block pageDescription %}{{ 'General_OpenSourceWebAnalytics'|translate }}{% endblock %}
+
+{% set bodyId = 'loginPage' %}
+
+{% block body %}
+
     {{ postEvent("Template.beforeTopBar", "login") }}
     {{ postEvent("Template.beforeContent", "login") }}
 
@@ -151,5 +144,5 @@
             </div>
         {% endif %}
     </section>
-</body>
-</html>
+
+{% endblock %}

--- a/plugins/Morpheus/templates/admin.twig
+++ b/plugins/Morpheus/templates/admin.twig
@@ -1,29 +1,10 @@
-<!DOCTYPE html>
-<html id="ng-app" ng-app="piwikApp">
-    <head>
-{% block head %}
-            <meta charset="utf-8">
-			<meta http-equiv="x-ua-compatible" content="IE=EDGE,chrome=1" >
-            <title>{% if not isCustomLogo %}Piwik &rsaquo; {% endif %}{{ 'CoreAdminHome_Administration'|translate }}</title>
-            <meta name="generator" content="Piwik - free/libre analytics platform"/>
-            <link rel="shortcut icon" href="{{ customFavicon|default('plugins/CoreHome/images/favicon.ico') }}"/>
+{% extends 'layout.twig' %}
 
-{% include "@CoreHome/_favicon.twig" %}
-{% include "_jsGlobalVariables.twig" %}
-{% include "_piwikTag.twig" %}
-{% include "_jsCssIncludes.twig" %}
+{% block pageTitle %}{% if not isCustomLogo %}Piwik &rsaquo;{% endif %} {{ 'CoreAdminHome_Administration'|translate }}{% endblock %}
 
-            <!--[if IE]>
-            <link rel="stylesheet" type="text/css" href="plugins/Morpheus/stylesheets/ieonly.css"/>
-            <![endif]-->
-        {% endblock %}
-    </head>
-    <!--[if lt IE 9 ]>
-    <body ng-app="app" class="old-ie {{ postEvent('Template.bodyClass', 'admin') }}">
-    <![endif]-->
-    <!--[if (gte IE 9)|!(IE)]><!-->
-    <body ng-app="app" class="{{ postEvent('Template.bodyClass', 'admin') }}"><!--<![endif]-->
+{% set bodyClass = postEvent('Template.bodyClass', 'admin') %}
 
+{% block body %}
     {% if isSuperUser %}
         {% set topMenuModule = 'CoreAdminHome' %}
         {% set topMenuAction = 'generalSettings' %}
@@ -31,40 +12,37 @@
         {% set topMenuModule = 'SitesManager' %}
         {% set topMenuAction = 'index' %}
     {% endif %}
+    {{ parent() }}
+{% endblock %}
 
-    {% include "_iframeBuster.twig" %}
-    {% include "@CoreHome/_javaScriptDisabled.twig" %}
+{% block root %}
+    {% include "@CoreHome/_topScreen.twig" %}
 
-        <div id="root">
-            {% include "@CoreHome/_topScreen.twig" %}
+    {% import 'ajaxMacros.twig' as ajax %}
+    {{ ajax.requestErrorDiv(emailSuperUser|default('')) }}
+    {{ postEvent("Template.beforeContent", "admin", currentModule) }}
 
-            {% import 'ajaxMacros.twig' as ajax %}
-            {{ ajax.requestErrorDiv(emailSuperUser|default('')) }}
-            {{ postEvent("Template.beforeContent", "admin", currentModule) }}
+    <div id="container">
 
-            <div id="container">
+        {% if showMenu is not defined or showMenu %}
+            {% include "@CoreAdminHome/_menu.twig" %}
+        {% endif %}
 
-                {% if showMenu is not defined or showMenu %}
-                    {% include "@CoreAdminHome/_menu.twig" %}
-                {% endif %}
+        <div id="content" class="admin">
 
-                <div id="content" class="admin">
+            {% include "@CoreHome/_headerMessage.twig" %}
+            {% include "@CoreHome/_notifications.twig" %}
 
-                    {% include "@CoreHome/_headerMessage.twig" %}
-                    {% include "@CoreHome/_notifications.twig" %}
-
-                    <div class="ui-confirm" id="alert">
-                        <h2></h2>
-                        <input role="no" type="button" value="{{ 'General_Ok'|translate }}"/>
-                    </div>
-
-                    {% include "@CoreHome/_warningInvalidHost.twig" %}
-
-                    {% block content %}
-                    {% endblock %}
-
-                </div>
+            <div class="ui-confirm" id="alert">
+                <h2></h2>
+                <input role="no" type="button" value="{{ 'General_Ok'|translate }}"/>
             </div>
+
+            {% include "@CoreHome/_warningInvalidHost.twig" %}
+
+            {% block content %}
+            {% endblock %}
+
         </div>
-    </body>
-</html>
+    </div>
+{% endblock %}

--- a/plugins/Morpheus/templates/dashboard.twig
+++ b/plugins/Morpheus/templates/dashboard.twig
@@ -1,50 +1,38 @@
-<!DOCTYPE html>
-<html id="ng-app" lang="{{ language }}" ng-app="piwikApp">
-    <head>
-        {% block head %}
-            <meta charset="utf-8">
-            <title>{{ siteName|raw }} - {% if isCustomLogo == false %}Piwik &rsaquo; {% endif %} {{ 'CoreHome_WebAnalyticsReports'|translate }}</title>
-            <meta http-equiv="X-UA-Compatible" content="IE=EDGE,chrome=1"/>
-            <meta name="viewport" content="initial-scale=1.0" />
-            <meta name="generator" content="Piwik - free/libre analytics platform"/>
-            <meta name="description" content="Web Analytics report for '{{ siteName|escape("html_attr") }}' - Piwik"/>
-            <meta name="apple-itunes-app" content="app-id=737216887" />
-{% include "@CoreHome/_favicon.twig" %}
-{% include "_jsGlobalVariables.twig" %}
-{% include "_piwikTag.twig" %}
-            <!--[if lt IE 9]>
-            <script language="javascript" type="text/javascript" src="libs/jqplot/excanvas.min.js"></script>
-            <![endif]-->
-{% include "_jsCssIncludes.twig" %}
-            <!--[if IE]>
-            <link rel="stylesheet" type="text/css" href="plugins/Morpheus/stylesheets/ieonly.css"/>
-            <![endif]-->
-        {% endblock %}
-    </head>
-    <!--[if lt IE 9 ]>
-    <body ng-app="app" class="old-ie {{ postEvent('Template.bodyClass', 'dashboard') }}"> <![endif]-->
-    <!--[if (gte IE 9)|!(IE)]><!-->
-    <body ng-app="app" class="{{ postEvent('Template.bodyClass', 'dashboard') }}"><!--<![endif]-->
-    {% include "_iframeBuster.twig" %}
-    {% include "@CoreHome/_javaScriptDisabled.twig" %}
+{% extends 'layout.twig' %}
 
-    <div id="root">
-        {% include "@CoreHome/_warningInvalidHost.twig" %}
-        {% include "@CoreHome/_topScreen.twig" %}
+{% block head %}
+    {{ parent() }}
 
-        {% block notification %}
-            {% include "@CoreHome/_notifications.twig" %}
-        {% endblock %}
+    <!--[if lt IE 9]>
+    <script language="javascript" type="text/javascript" src="libs/jqplot/excanvas.min.js"></script>
+    <![endif]-->
+{% endblock %}
 
-        <div class="ui-confirm" id="alert">
-            <h2></h2>
-            <input role="yes" type="button" value="{{ 'General_Ok'|translate }}"/>
-        </div>
+{% block pageTitle %}{{ siteName|raw }} - {% if not isCustomLogo %}Piwik &rsaquo;{% endif %} {{ 'CoreHome_WebAnalyticsReports'|translate }}{% endblock %}
+{% block pageDescription %}Web Analytics report for {{ siteName|escape("html_attr") }} - Piwik{% endblock %}
+
+{% set bodyClass = postEvent('Template.bodyClass', 'dashboard') %}
+
+{% block body %}
+    {{ parent() }}
+    {{ postEvent("Template.footer") }}
+{% endblock %}
+
+{% block root %}
+    {% include "@CoreHome/_warningInvalidHost.twig" %}
+    {% include "@CoreHome/_topScreen.twig" %}
+
+    {% block notification %}
+        {% include "@CoreHome/_notifications.twig" %}
+    {% endblock %}
+
+    <div class="ui-confirm" id="alert">
+        <h2></h2>
+        <input role="yes" type="button" value="{{ 'General_Ok'|translate }}"/>
+    </div>
 
     {{ postEvent("Template.beforeContent", "dashboard", currentModule) }}
-        {% block content %}
-        {% endblock %}
-    </div>
-    {{ postEvent("Template.footer") }}
-    </body>
-</html>
+
+    {% block content %}
+    {% endblock %}
+{% endblock %}

--- a/plugins/Morpheus/templates/layout.twig
+++ b/plugins/Morpheus/templates/layout.twig
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html id="ng-app" {% if language is defined %}lang="{{ language }}"{% endif %} ng-app="piwikApp">
+    <head>
+        {% block head %}
+            <meta charset="utf-8">
+            <title>{% block pageTitle %}Piwik{% endblock %}</title>
+            <meta http-equiv="X-UA-Compatible" content="IE=EDGE,chrome=1"/>
+            <meta name="viewport" content="initial-scale=1.0"/>
+            <meta name="generator" content="Piwik - free/libre analytics platform"/>
+            <meta name="description" content="{% block pageDescription %}{% endblock %}"/>
+            <meta name="apple-itunes-app" content="app-id=737216887" />
+            <meta name="google-play-app" content="app-id=org.piwik.mobile2">
+            <link rel="shortcut icon" href="{{ customFavicon|default('plugins/CoreHome/images/favicon.ico') }}"/>
+
+            {% include "@CoreHome/_favicon.twig" %}
+            {% include "_jsGlobalVariables.twig" %}
+            {% include "_piwikTag.twig" %}
+            {% include "_jsCssIncludes.twig" %}
+
+            <!--[if IE]>
+            <link rel="stylesheet" type="text/css" href="plugins/Morpheus/stylesheets/ieonly.css"/>
+            <![endif]-->
+        {% endblock %}
+    </head>
+    <!--[if lt IE 9 ]>
+    <body id="{{ bodyId|default('') }}" ng-app="app" class="old-ie {{ bodyClass|default('') }}">
+    <![endif]-->
+    <!--[if (gte IE 9)|!(IE)]><!-->
+    <body id="{{ bodyId|default('') }}" ng-app="app" class="{{ bodyClass|default('') }}">
+    <!--<![endif]-->
+
+    {% block body %}
+
+        {% include "_iframeBuster.twig" %}
+        {% include "@CoreHome/_javaScriptDisabled.twig" %}
+
+        <div id="root">
+            {% block root %}
+            {% endblock %}
+        </div>
+
+    {% endblock %}
+
+    </body>
+</html>

--- a/plugins/Morpheus/templates/user.twig
+++ b/plugins/Morpheus/templates/user.twig
@@ -1,62 +1,40 @@
-<!DOCTYPE html>
-<html id="ng-app" ng-app="piwikApp">
-    <head>
-{% block head %}
-            <meta charset="utf-8">
-			<meta http-equiv="x-ua-compatible" content="IE=EDGE,chrome=1" >
-            <title>{% if not isCustomLogo %}Piwik &rsaquo; {% endif %}{{ 'CoreAdminHome_Administration'|translate }}</title>
-            <meta name="generator" content="Piwik - free/libre analytics platform"/>
-            <link rel="shortcut icon" href="{{ customFavicon|default('plugins/CoreHome/images/favicon.ico') }}"/>
+{% extends 'layout.twig' %}
 
-{% include "@CoreHome/_favicon.twig" %}
-{% include "_jsGlobalVariables.twig" %}
-{% include "_piwikTag.twig" %}
-{% include "_jsCssIncludes.twig" %}
+{% block pageTitle %}{% if not isCustomLogo %}Piwik &rsaquo; {% endif %}{{ 'CoreAdminHome_Administration'|translate }}{% endblock %}
 
-            <!--[if IE]>
-            <link rel="stylesheet" type="text/css" href="plugins/Morpheus/stylesheets/ieonly.css"/>
-            <![endif]-->
-        {% endblock %}
-    </head>
-    <!--[if lt IE 9 ]>
-    <body ng-app="app" class="old-ie {{ postEvent('Template.bodyClass', 'admin') }}">
-    <![endif]-->
-    <!--[if (gte IE 9)|!(IE)]><!-->
-    <body ng-app="app" class="{{ postEvent('Template.bodyClass', 'admin') }}"><!--<![endif]-->
+{% set bodyClass = postEvent('Template.bodyClass', 'admin') %}
 
+{% block body %}
     {% set topMenuModule = 'UsersManager' %}
     {% set topMenuAction = 'userSettings' %}
+    {{ parent() }}
+{% endblock %}
 
-    {% include "_iframeBuster.twig" %}
-    {% include "@CoreHome/_javaScriptDisabled.twig" %}
+{% block root %}
+    {% include "@CoreHome/_topScreen.twig" %}
 
-        <div id="root">
-            {% include "@CoreHome/_topScreen.twig" %}
+    {% import 'ajaxMacros.twig' as ajax %}
+    {{ ajax.requestErrorDiv(emailSuperUser|default('')) }}
+    {{ postEvent("Template.beforeContent", "user", currentModule) }}
 
-            {% import 'ajaxMacros.twig' as ajax %}
-            {{ ajax.requestErrorDiv(emailSuperUser|default('')) }}
-            {{ postEvent("Template.beforeContent", "user", currentModule) }}
+    <div id="container">
 
-            <div id="container">
+        {% if showMenu is not defined or showMenu %}
+            {% include "@CoreHome/_userMenu.twig" %}
+        {% endif %}
 
-                {% if showMenu is not defined or showMenu %}
-                    {% include "@CoreHome/_userMenu.twig" %}
-                {% endif %}
+        <div id="content" class="admin user">
 
-                <div id="content" class="admin user">
+            {% include "@CoreHome/_notifications.twig" %}
 
-                    {% include "@CoreHome/_notifications.twig" %}
-
-                    <div class="ui-confirm" id="alert">
-                        <h2></h2>
-                        <input role="no" type="button" value="{{ 'General_Ok'|translate }}"/>
-                    </div>
-
-                    {% block content %}
-                    {% endblock %}
-
-                </div>
+            <div class="ui-confirm" id="alert">
+                <h2></h2>
+                <input role="no" type="button" value="{{ 'General_Ok'|translate }}"/>
             </div>
+
+            {% block content %}
+            {% endblock %}
+
         </div>
-    </body>
-</html>
+    </div>
+{% endblock %}


### PR DESCRIPTION
There were several base layout files:
- dashboard
- admin
- user settings
- login

Those had a lot of similarities of course, and few discrepancies which could create bugs like #7036 or inconsistent stuff (e.g. missing favicon, missing description tag, CSS included twice in login, angularjs not initialized, …).

I added a new `layout.twig` file that defines the base HTML layout for pages. Other layouts extend it by redefining Twig blocks.

Also fixes #7036
