### PR TITLE
Make sure password reset process works in case there is no site in Piwik

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -276,13 +276,7 @@ class Controller extends \Piwik\Plugin\Controller
         }
 
         if (is_null($errorMessage)) { // if success, show login w/ success message
-            // have to do this as super user since redirectToIndex checks if there's a default website ID for
-            // the current user and if not, doesn't redirect to the requested action. TODO: this behavior is wrong. somehow.
-            $self = $this;
-            Access::doAsSuperUser(function () use ($self) {
-                $self->redirectToIndex(Piwik::getLoginPluginName(), 'resetPasswordSuccess');
-            });
-            return null;
+            return $this->resetPasswordSuccess();
         } else {
             // show login page w/ error. this will keep the token in the URL
             return $this->login($errorMessage);


### PR DESCRIPTION
refs #7073 
do not redirect in case of success, render passwordSuccess directly to prevent an error in case no website is defined when trying to get the defaultWebsiteId
