### PR TITLE
Add undocumented (ie, unsupported) config option (DI config only) to disable forcing range archiving on browser request.

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -161,5 +161,4 @@ return array(
     'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\LoaderCache')
         ->constructor(DI\link('Piwik\Translation\Loader\JsonFileLoader')),
 
-    'archiving.range.force_on_browser_request' => true
 );

--- a/config/global.php
+++ b/config/global.php
@@ -161,4 +161,5 @@ return array(
     'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\LoaderCache')
         ->constructor(DI\link('Piwik\Translation\Loader\JsonFileLoader')),
 
+    'archiving.range.force_on_browser_request' => true
 );

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -229,8 +229,12 @@ class Rules
 
     public static function isArchivingDisabledFor(array $idSites, Segment $segment, $periodLabel)
     {
+        $generalConfig = Config::getInstance()->General;
+
         if ($periodLabel == 'range') {
-            if (StaticContainer::get('archiving.range.force_on_browser_request') !== false) {
+            if (empty($generalConfig['archiving_range_force_on_browser_request'])
+                || $generalConfig['archiving_range_force_on_browser_request'] !== false
+            ) {
                 return false;
             } else {
                 Log::verbose("Not forcing archiving for range period.");
@@ -246,7 +250,7 @@ class Rules
             // When there is a segment, we disable archiving when browser_archiving_disabled_enforce applies
             if (!$segment->isEmpty()
                 && $isArchivingDisabled
-                && Config::getInstance()->General['browser_archiving_disabled_enforce']
+                && $generalConfig['browser_archiving_disabled_enforce']
                 && !SettingsServer::isArchivePhpTriggered() // Only applies when we are not running core:archive command
             ) {
                 Log::debug("Archiving is disabled because of config setting browser_archiving_disabled_enforce=1");

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -232,12 +232,12 @@ class Rules
         $generalConfig = Config::getInstance()->General;
 
         if ($periodLabel == 'range') {
-            if (empty($generalConfig['archiving_range_force_on_browser_request'])
-                || $generalConfig['archiving_range_force_on_browser_request'] !== false
+            if (!isset($generalConfig['archiving_range_force_on_browser_request'])
+                || $generalConfig['archiving_range_force_on_browser_request'] != false
             ) {
                 return false;
             } else {
-                Log::verbose("Not forcing archiving for range period.");
+                Log::debug("Not forcing archiving for range period.");
             }
         }
 

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -56,6 +56,7 @@ abstract class IntegrationTestCase extends SystemTestCase
     {
         static::configureFixture(static::$fixture);
         parent::setUpBeforeClass();
+        static::beforeTableDataCached();
 
         self::$tableData = self::getDbTablesWithData();
     }
@@ -97,6 +98,11 @@ abstract class IntegrationTestCase extends SystemTestCase
         $fixture->loadTranslations    = false;
         $fixture->createSuperUser     = false;
         $fixture->configureComponents = false;
+    }
+
+    protected static function beforeTableDataCached()
+    {
+        // empty
     }
 }
 

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\Integration;
+
+use Piwik\Archive;
+use Piwik\ArchiveProcessor\Rules;
+use Piwik\Common;
+use Piwik\Config;
+use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\Date;
+use Piwik\Db;
+use Piwik\Piwik;
+use Piwik\Tests\Fixtures\OneVisitorTwoVisits;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Core
+ */
+class ArchiveTest extends IntegrationTestCase
+{
+    /**
+     * @var OneVisitorTwoVisits
+     */
+    public static $fixture;
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        unset($_GET['trigger']);
+    }
+
+    protected static function configureFixture($fixture)
+    {
+        $fixture->createSuperUser = true;
+    }
+
+    protected static function beforeTableDataCached()
+    {
+        $date = Date::factory('2010-03-01');
+
+        $archiveTableCreator = new ArchiveTableCreator();
+        $archiveTableCreator->getBlobTable($date);
+        $archiveTableCreator->getNumericTable($date);
+    }
+
+    public function getForceOptionsForForceArchivingOnBrowserRequest()
+    {
+        return array(
+            array(1),
+            array(null)
+        );
+    }
+
+    /**
+     * @dataProvider getForceOptionsForForceArchivingOnBrowserRequest
+     */
+    public function test_ArchivingIsLaunchedForRanges_WhenForceOnBrowserRequest_IsTruthy($optionValue)
+    {
+        $this->archiveDataForIndividualDays();
+
+        Config::getInstance()->General['archiving_range_force_on_browser_request'] = $optionValue;
+        Rules::setBrowserTriggerArchiving(false);
+
+        $data = $this->initiateArchivingForRange();
+
+        $this->assertNotEmpty($data);
+        $this->assertArchiveTablesAreNotEmpty('2010_03');
+    }
+
+    public function test_ArchivingIsNotLaunchedForRanges_WhenForceOnBrowserRequest_IsFalse()
+    {
+        $this->archiveDataForIndividualDays();
+
+        Config::getInstance()->General['archiving_range_force_on_browser_request'] = 0;
+        Rules::setBrowserTriggerArchiving(false);
+
+        $data = $this->initiateArchivingForRange();
+
+        $this->assertEmpty($data);
+        $this->assertArchiveTablesAreEmpty('2010_03');
+    }
+
+    public function test_ArchiveIsLaunched_WhenForceOnBrowserRequest_IsFalse_AndArchivePhpTriggered()
+    {
+        $this->archiveDataForIndividualDays();
+
+        Config::getInstance()->General['archiving_range_force_on_browser_request'] = 0;
+        $_GET['trigger'] = 'archivephp';
+        Rules::setBrowserTriggerArchiving(false);
+
+        $data = $this->initiateArchivingForRange();
+
+        $this->assertNotEmpty($data);
+        $this->assertArchiveTablesAreNotEmpty('2010_03');
+    }
+
+    private function assertArchiveTablesAreNotEmpty($tableMonth)
+    {
+        $this->assertNotEquals(0, $this->getRangeArchiveTableCount('archive_numeric', $tableMonth));
+    }
+
+    private function assertArchiveTablesAreEmpty($tableMonth)
+    {
+        $this->assertEquals(0, $this->getRangeArchiveTableCount('archive_numeric', $tableMonth));
+        $this->assertEquals(0, $this->getRangeArchiveTableCount('archive_blob', $tableMonth));
+    }
+
+    private function getRangeArchiveTableCount($tableType, $tableMonth)
+    {
+        $table = Common::prefixTable($tableType . '_' . $tableMonth);
+        return Db::fetchOne("SELECT COUNT(*) FROM $table WHERE period = " . Piwik::$idPeriods['range']);
+    }
+
+    private function initiateArchivingForRange()
+    {
+        $archive = Archive::build(self::$fixture->idSite, 'range', '2010-03-04,2010-03-07');
+        return $archive->getNumeric('nb_visits');
+    }
+
+    private function archiveDataForIndividualDays()
+    {
+        $archive = Archive::build(self::$fixture->idSite, 'day', '2010-03-04,2010-03-07');
+        return $archive->getNumeric('nb_visits');
+    }
+}
+
+ArchiveTest::$fixture = new OneVisitorTwoVisits();


### PR DESCRIPTION
As title. From pro request on slack.

If in the future we decide there's a better way to do this, we can remove the option w/o any issue. If we decide it's a good thing, we can add an INI config option.
