### PR TITLE
Plugins can provide their own config files

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -24,7 +24,6 @@ use Piwik\Plugin;
 use Piwik\Singleton;
 use Piwik\Theme;
 use Piwik\Tracker;
-use Piwik\Translate;
 use Piwik\Translation\Translator;
 use Piwik\Updater;
 use Piwik\Plugin\Dimension\ActionDimension;
@@ -98,7 +97,7 @@ class Manager extends Singleton
      */
     public function loadActivatedPlugins()
     {
-        $pluginsToLoad = Config::getInstance()->Plugins['Plugins'];
+        $pluginsToLoad = $this->getActivatedPluginsFromConfig();
         $this->loadPlugins($pluginsToLoad);
     }
 
@@ -776,6 +775,15 @@ class Manager extends Singleton
     public function getActivatedPlugins()
     {
         return $this->pluginsToLoad;
+    }
+
+    public function getActivatedPluginsFromConfig()
+    {
+        $plugins = Config::getInstance()->Plugins['Plugins'];
+
+        $plugins = $this->sortPluginsSameOrderAsGlobalConfig($plugins);
+
+        return $plugins;
     }
 
     /**


### PR DESCRIPTION
See #6609 and #7115

Plugins can provide DI config by putting it in `plugin.php`.

The file name is completely arbitrary and can be changed… I first went with `config.php` but some plugins already have a `Config` class.
