### PR TITLE
Monolog plugin

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -732,6 +732,7 @@ Plugins[] = ExampleAPI
 Plugins[] = ExampleRssWidget
 Plugins[] = Provider
 Plugins[] = Feedback
+Plugins[] = Monolog
 
 Plugins[] = Login
 Plugins[] = UsersManager

--- a/config/global.php
+++ b/config/global.php
@@ -1,8 +1,6 @@
 <?php
 
 use Interop\Container\ContainerInterface;
-use Monolog\Logger;
-use Piwik\Log;
 use Piwik\Cache\Eager;
 use Piwik\SettingsServer;
 
@@ -52,87 +50,7 @@ return array(
         return 'eagercache-' . str_replace(array('.', '-'), '', \Piwik\Version::VERSION) . '-';
     },
 
-    // Log
-    'Psr\Log\LoggerInterface' => DI\object('Monolog\Logger')
-        ->constructor('piwik', DI\link('log.handlers'), DI\link('log.processors')),
-    'log.handlers' => DI\factory(function (ContainerInterface $c) {
-        if ($c->has('ini.log.log_writers')) {
-            $writerNames = $c->get('ini.log.log_writers');
-        } else {
-            return array();
-        }
-        $classes = array(
-            'file'     => 'Piwik\Log\Handler\FileHandler',
-            'screen'   => 'Piwik\Log\Handler\WebNotificationHandler',
-            'database' => 'Piwik\Log\Handler\DatabaseHandler',
-        );
-        $writerNames = array_map('trim', $writerNames);
-        $writers = array();
-        foreach ($writerNames as $writerName) {
-            if (isset($classes[$writerName])) {
-                $writers[$writerName] = $c->get($classes[$writerName]);
-            }
-        }
-        return array_values($writers);
-    }),
-    'log.processors' => array(
-        DI\link('Piwik\Log\Processor\ClassNameProcessor'),
-        DI\link('Piwik\Log\Processor\RequestIdProcessor'),
-        DI\link('Piwik\Log\Processor\ExceptionToTextProcessor'),
-        DI\link('Piwik\Log\Processor\SprintfProcessor'),
-        DI\link('Monolog\Processor\PsrLogMessageProcessor'),
-    ),
-    'Piwik\Log\Handler\FileHandler' => DI\object()
-        ->constructor(DI\link('log.file.filename'), DI\link('log.level'))
-        ->method('setFormatter', DI\link('Piwik\Log\Formatter\LineMessageFormatter')),
-    'Piwik\Log\Handler\DatabaseHandler' => DI\object()
-        ->constructor(DI\link('log.level'))
-        ->method('setFormatter', DI\link('Piwik\Log\Formatter\LineMessageFormatter')),
-    'Piwik\Log\Handler\WebNotificationHandler' => DI\object()
-        ->constructor(DI\link('log.level'))
-        ->method('setFormatter', DI\link('Piwik\Log\Formatter\LineMessageFormatter')),
-    'log.level' => DI\factory(function (ContainerInterface $c) {
-        if ($c->has('ini.log.log_level')) {
-            $level = strtoupper($c->get('ini.log.log_level'));
-            if (!empty($level) && defined('Piwik\Log::'.strtoupper($level))) {
-                return Log::getMonologLevel(constant('Piwik\Log::'.strtoupper($level)));
-            }
-        }
-        return Logger::WARNING;
-    }),
-    'log.file.filename' => DI\factory(function (ContainerInterface $c) {
-        $logPath = $c->get('ini.log.logger_file_path');
-
-        // Absolute path
-        if (strpos($logPath, '/') === 0) {
-            return $logPath;
-        }
-
-        // Remove 'tmp/' at the beginning
-        if (strpos($logPath, 'tmp/') === 0) {
-            $logPath = substr($logPath, strlen('tmp'));
-        }
-
-        if (empty($logPath)) {
-            // Default log file
-            $logPath = '/logs/piwik.log';
-        }
-
-        $logPath = $c->get('path.tmp') . $logPath;
-        if (is_dir($logPath)) {
-            $logPath .= '/piwik.log';
-        }
-
-        return $logPath;
-    }),
-    'Piwik\Log\Formatter\LineMessageFormatter' => DI\object()
-        ->constructor(DI\link('log.format')),
-    'log.format' => DI\factory(function (ContainerInterface $c) {
-        if ($c->has('ini.log.string_message_format')) {
-            return $c->get('ini.log.string_message_format');
-        }
-        return '%level% %tag%[%datetime%] %message%';
-    }),
+    'Psr\Log\LoggerInterface' => DI\object('Psr\Log\NullLogger'),
 
     'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\LoaderCache')
         ->constructor(DI\link('Piwik\Translation\Loader\JsonFileLoader')),

--- a/core/Updates/2.11.0-b5.php
+++ b/core/Updates/2.11.0-b5.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Plugin\Manager;
+use Piwik\Updates;
+
+class Updates_2_11_0_b5 extends Updates
+{
+    static function update()
+    {
+        try {
+            Manager::getInstance()->activatePlugin('Monolog');
+        } catch (\Exception $e) {
+        }
+    }
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Piwik version.
      * @var string
      */
-    const VERSION = '2.11.0-b4';
+    const VERSION = '2.11.0-b5';
 
     public function isStableVersion($version)
     {

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -73,7 +73,7 @@ if (isset($_SERVER['argv']) && Piwik\Console::isSupported()) {
         /** @var \Monolog\Logger $logger */
         $logger = StaticContainer::get('Psr\Log\LoggerInterface');
         $handler = new StreamHandler('php://output', Logger::INFO);
-        $handler->setFormatter(StaticContainer::get('Piwik\Log\Formatter\LineMessageFormatter'));
+        $handler->setFormatter(StaticContainer::get('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter'));
         $logger->pushHandler($handler);
     }
 

--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Log\Formatter;
+namespace Piwik\Plugins\Monolog\Formatter;
 
 use Monolog\Formatter\FormatterInterface;
 

--- a/plugins/Monolog/Handler/DatabaseHandler.php
+++ b/plugins/Monolog/Handler/DatabaseHandler.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Log\Handler;
+namespace Piwik\Plugins\Monolog\Handler;
 
 use Monolog\Handler\AbstractProcessingHandler;
 use Piwik\Common;

--- a/plugins/Monolog/Handler/FileHandler.php
+++ b/plugins/Monolog/Handler/FileHandler.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Log\Handler;
+namespace Piwik\Plugins\Monolog\Handler;
 
 use Monolog\Handler\StreamHandler;
 use Piwik\Filechecks;

--- a/plugins/Monolog/Handler/WebNotificationHandler.php
+++ b/plugins/Monolog/Handler/WebNotificationHandler.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Log\Handler;
+namespace Piwik\Plugins\Monolog\Handler;
 
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;

--- a/plugins/Monolog/Monolog.php
+++ b/plugins/Monolog/Monolog.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Monolog;
+
+use Piwik\Plugin;
+
+class Monolog extends Plugin
+{
+}

--- a/plugins/Monolog/Processor/ClassNameProcessor.php
+++ b/plugins/Monolog/Processor/ClassNameProcessor.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Log\Processor;
+namespace Piwik\Plugins\Monolog\Processor;
 
 use Piwik\Plugin;
 
@@ -52,7 +52,7 @@ class ClassNameProcessor
     private function getClassNameThatIsLogging($backtrace)
     {
         foreach ($backtrace as $line) {
-            if (isset($line['class']) && !in_array($line['class'], $this->skippedClasses)) {
+            if (isset($line['class'])) {
                 return $line['class'];
             }
         }
@@ -63,9 +63,19 @@ class ClassNameProcessor
     private function getBacktrace()
     {
         if (version_compare(phpversion(), '5.3.6', '>=')) {
-            return debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS | DEBUG_BACKTRACE_PROVIDE_OBJECT);
+            $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS | DEBUG_BACKTRACE_PROVIDE_OBJECT);
+        } else {
+            $backtrace = debug_backtrace();
         }
 
-        return debug_backtrace();
+        $skippedClasses = $this->skippedClasses;
+        $backtrace = array_filter($backtrace, function ($item) use ($skippedClasses) {
+            if (isset($item['class'])) {
+                return !in_array($item['class'], $skippedClasses);
+            }
+            return true;
+        });
+
+        return $backtrace;
     }
 }

--- a/plugins/Monolog/Processor/ExceptionToTextProcessor.php
+++ b/plugins/Monolog/Processor/ExceptionToTextProcessor.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Log\Processor;
+namespace Piwik\Plugins\Monolog\Processor;
 
 use Piwik\ErrorHandler;
 use Piwik\Log;

--- a/plugins/Monolog/Processor/RequestIdProcessor.php
+++ b/plugins/Monolog/Processor/RequestIdProcessor.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Log\Processor;
+namespace Piwik\Plugins\Monolog\Processor;
 
 use Piwik\Common;
 

--- a/plugins/Monolog/Processor/SprintfProcessor.php
+++ b/plugins/Monolog/Processor/SprintfProcessor.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Log\Processor;
+namespace Piwik\Plugins\Monolog\Processor;
 
 /**
  * Processes a log message using `sprintf()`.

--- a/plugins/Monolog/Test/Integration/Fixture/LoggerWrapper.php
+++ b/plugins/Monolog/Test/Integration/Fixture/LoggerWrapper.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Integration\Log\Fixture;
+namespace Piwik\Plugins\Monolog\Test\Integration\Fixture;
 
 use Piwik\Log;
 

--- a/plugins/Monolog/Test/Integration/LogTest.php
+++ b/plugins/Monolog/Test/Integration/LogTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Integration\Log;
+namespace Piwik\Plugins\Monolog\Test\Integration;
 
 use Exception;
 use Piwik\Common;
@@ -15,8 +15,8 @@ use Piwik\Container\ContainerFactory;
 use Piwik\Container\StaticContainer;
 use Piwik\Db;
 use Piwik\Log;
+use Piwik\Plugins\Monolog\Test\Integration\Fixture\LoggerWrapper;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
-use Piwik\Tests\Integration\Log\Fixture\LoggerWrapper;
 
 /**
  * @group Core
@@ -28,10 +28,10 @@ class LogTest extends IntegrationTestCase
     const STRING_MESSAGE_FORMAT = '[%tag%] %message%';
     const STRING_MESSAGE_FORMAT_SPRINTF = "[%s] %s";
 
-    public static $expectedExceptionOutput = '[Piwik\Tests\Integration\Log\LogTest] LogTest.php(120): dummy error message
+    public static $expectedExceptionOutput = '[Monolog] LogTest.php(120): dummy error message
   dummy backtrace';
 
-    public static $expectedErrorOutput = '[Piwik\Tests\Integration\Log\LogTest] dummyerrorfile.php(145): Unknown error (102) - dummy error string
+    public static $expectedErrorOutput = '[Monolog] dummyerrorfile.php(145): Unknown error (102) - dummy error string
   dummy backtrace';
 
     public function setUp()
@@ -82,7 +82,7 @@ class LogTest extends IntegrationTestCase
 
         Log::warning(self::TESTMESSAGE);
 
-        $this->checkBackend($backend, self::TESTMESSAGE, $formatMessage = true, $tag = __CLASS__);
+        $this->checkBackend($backend, self::TESTMESSAGE, $formatMessage = true, $tag = 'Monolog');
     }
 
     /**
@@ -94,7 +94,7 @@ class LogTest extends IntegrationTestCase
 
         Log::warning(self::TESTMESSAGE, " subst ");
 
-        $this->checkBackend($backend, sprintf(self::TESTMESSAGE, " subst "), $formatMessage = true, $tag = __CLASS__);
+        $this->checkBackend($backend, sprintf(self::TESTMESSAGE, " subst "), $formatMessage = true, $tag = 'Monolog');
     }
 
     /**
@@ -107,7 +107,7 @@ class LogTest extends IntegrationTestCase
         $error = new \ErrorException("dummy error string", 0, 102, "dummyerrorfile.php", 145);
         Log::error($error);
 
-        $this->checkBackend($backend, self::$expectedErrorOutput, $formatMessage = false, $tag = __CLASS__);
+        $this->checkBackend($backend, self::$expectedErrorOutput, $formatMessage = false, $tag = 'Monolog');
     }
 
     /**
@@ -120,7 +120,7 @@ class LogTest extends IntegrationTestCase
         $exception = new Exception("dummy error message");
         Log::error($exception);
 
-        $this->checkBackend($backend, self::$expectedExceptionOutput, $formatMessage = false, $tag = __CLASS__);
+        $this->checkBackend($backend, self::$expectedExceptionOutput, $formatMessage = false, $tag = 'Monolog');
     }
 
     /**
@@ -132,9 +132,7 @@ class LogTest extends IntegrationTestCase
 
         LoggerWrapper::doLog(self::TESTMESSAGE);
 
-        $tag = 'Piwik\Tests\Integration\Log\Fixture\LoggerWrapper';
-
-        $this->checkBackend($backend, self::TESTMESSAGE, $formatMessage = true, $tag);
+        $this->checkBackend($backend, self::TESTMESSAGE, $formatMessage = true, 'Monolog');
     }
 
     /**
@@ -159,9 +157,7 @@ class LogTest extends IntegrationTestCase
 
         LoggerWrapper::doLog(" \n   ".self::TESTMESSAGE."\n\n\n   \n");
 
-        $tag = 'Piwik\Tests\Integration\Log\Fixture\LoggerWrapper';
-
-        $this->checkBackend($backend, self::TESTMESSAGE, $formatMessage = true, $tag);
+        $this->checkBackend($backend, self::TESTMESSAGE, $formatMessage = true, 'Monolog');
     }
 
     /**
@@ -176,7 +172,7 @@ class LogTest extends IntegrationTestCase
 
         Log::info(self::TESTMESSAGE);
 
-        $this->checkBackend('database', self::TESTMESSAGE, $formatMessage = true, $tag = __CLASS__);
+        $this->checkBackend('database', self::TESTMESSAGE, $formatMessage = true, $tag = 'Monolog');
     }
 
     private function checkBackend($backend, $expectedMessage, $formatMessage = false, $tag = false)

--- a/plugins/Monolog/Test/Unit/Formatter/LineMessageFormatterTest.php
+++ b/plugins/Monolog/Test/Unit/Formatter/LineMessageFormatterTest.php
@@ -6,15 +6,14 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Log\Formatter;
+namespace Piwik\Plugins\Monolog\Test\Unit\Formatter;
 
 use DateTime;
-use Piwik\Log\Formatter\LineMessageFormatter;
+use Piwik\Plugins\Monolog\Formatter\LineMessageFormatter;
 
 /**
- * @group Core
  * @group Log
- * @covers \Piwik\Log\Formatter\LineMessageFormatter
+ * @covers \Piwik\Plugins\Monolog\Formatter\LineMessageFormatter
  */
 class LineMessageFormatterTest extends \PHPUnit_Framework_TestCase
 {

--- a/plugins/Monolog/Test/Unit/Processor/ClassNameProcessorTest.php
+++ b/plugins/Monolog/Test/Unit/Processor/ClassNameProcessorTest.php
@@ -6,14 +6,13 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Log\Processor;
+namespace Piwik\Plugins\Monolog\Test\Unit\Processor;
 
-use Piwik\Log\Processor\ClassNameProcessor;
+use Piwik\Plugins\Monolog\Processor\ClassNameProcessor;
 
 /**
- * @group Core
  * @group Log
- * @covers \Piwik\Log\Processor\ClassNameProcessor
+ * @covers \Piwik\Plugins\Monolog\Processor\ClassNameProcessor
  */
 class ClassNameProcessorTest extends \PHPUnit_Framework_TestCase
 {
@@ -33,7 +32,7 @@ class ClassNameProcessorTest extends \PHPUnit_Framework_TestCase
         $expected = array(
             'extra' => array(
                 'foo' => 'bar',
-                'class' => __CLASS__,
+                'class' => 'Monolog',
             ),
         );
 

--- a/plugins/Monolog/Test/Unit/Processor/ExceptionToTextProcessorTest.php
+++ b/plugins/Monolog/Test/Unit/Processor/ExceptionToTextProcessorTest.php
@@ -6,15 +6,14 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Log\Processor;
+namespace Piwik\Plugins\Monolog\Test\Unit\Processor;
 
 use Piwik\Log;
-use Piwik\Log\Processor\ExceptionToTextProcessor;
+use Piwik\Plugins\Monolog\Processor\ExceptionToTextProcessor;
 
 /**
- * @group Core
  * @group Log
- * @covers \Piwik\Log\Processor\ExceptionToTextProcessor
+ * @covers \Piwik\Plugins\Monolog\Processor\ExceptionToTextProcessor
  */
 class ExceptionToTextProcessorTest extends \PHPUnit_Framework_TestCase
 {
@@ -48,7 +47,7 @@ class ExceptionToTextProcessorTest extends \PHPUnit_Framework_TestCase
         $result = $processor($record);
 
         $expected = array(
-            'message' => __FILE__ . "(41): Hello world\n[stack trace]",
+            'message' => __FILE__ . "(40): Hello world\n[stack trace]",
             'context' => array(
                 'exception' => $exception,
             ),

--- a/plugins/Monolog/Test/Unit/Processor/RequestIdProcessorTest.php
+++ b/plugins/Monolog/Test/Unit/Processor/RequestIdProcessorTest.php
@@ -6,15 +6,15 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Log\Processor;
+namespace Piwik\Plugins\Monolog\Test\Unit\Processor;
 
+use PHPUnit_Framework_TestCase;
 use Piwik\Common;
-use Piwik\Log\Processor\RequestIdProcessor;
+use Piwik\Plugins\Monolog\Processor\RequestIdProcessor;
 
 /**
- * @group Core
  * @group Log
- * @covers \Piwik\Log\Processor\RequestIdProcessor
+ * @covers \Piwik\Plugins\Monolog\Processor\RequestIdProcessor
  */
 class RequestIdProcessorTest extends \PHPUnit_Framework_TestCase
 {

--- a/plugins/Monolog/Test/Unit/Processor/SprintfProcessorTest.php
+++ b/plugins/Monolog/Test/Unit/Processor/SprintfProcessorTest.php
@@ -6,14 +6,13 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Log\Processor;
+namespace Piwik\Plugins\Monolog\Test\Unit\Processor;
 
-use Piwik\Log\Processor\SprintfProcessor;
+use Piwik\Plugins\Monolog\Processor\SprintfProcessor;
 
 /**
- * @group Core
  * @group Log
- * @covers \Piwik\Log\Processor\SprintfProcessor
+ * @covers \Piwik\Plugins\Monolog\Processor\SprintfProcessor
  */
 class SprintfProcessorTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
I have moved all the Monolog extensions and the container configuration of Monolog into a new Monolog plugin. I had to bump the version to have the plugin registered in the config (if there's a simpler solution let me know).

This is an example of a plugin containing a configuration file (see #7117).

The idea of this plugin is that Piwik Core (and other plugins) only depends on `Psr\Log\LoggerInterface` and can work without Monolog, so Monolog stuff shouldn't be in Piwik Core. It also simplifies a lot the global container config.

**This PR is based on #7117 which explains why the diff includes those changes**
