### PR TITLE
Various performance improvements, especially for Range period and installations with many sites

### DIFF
--- a/core/API/DataTableManipulator.php
+++ b/core/API/DataTableManipulator.php
@@ -124,7 +124,7 @@ abstract class DataTableManipulator
             }
         }
 
-        $method = $this->getApiMethodForSubtable();
+        $method = $this->getApiMethodForSubtable($request);
         return $this->callApiAndReturnDataTable($this->apiModule, $method, $request);
     }
 
@@ -144,10 +144,16 @@ abstract class DataTableManipulator
      * @throws Exception
      * @return string
      */
-    private function getApiMethodForSubtable()
+    private function getApiMethodForSubtable($request)
     {
         if (!$this->apiMethodForSubtable) {
-            $meta = API::getInstance()->getMetadata('all', $this->apiModule, $this->apiMethod);
+            if (!empty($request['idSite'])) {
+                $idSite = $request['idSite'];
+            } else {
+                $idSite = 'all';
+            }
+
+            $meta = API::getInstance()->getMetadata($idSite, $this->apiModule, $this->apiMethod);
 
             if (empty($meta)) {
                 throw new Exception(sprintf(

--- a/core/Common.php
+++ b/core/Common.php
@@ -829,11 +829,20 @@ class Common
      */
     public static function getSearchEngineUrls()
     {
-        require_once PIWIK_INCLUDE_PATH . '/core/DataFiles/SearchEngines.php';
+        $cacheId = 'Common.getSearchEngineUrls';
+        $cache = Cache::getTransientCache();
+        $searchEngines = $cache->fetch($cacheId);
 
-        $searchEngines = $GLOBALS['Piwik_SearchEngines'];
+        if (empty($searchEngines)) {
 
-        Piwik::postEvent('Referrer.addSearchEngineUrls', array(&$searchEngines));
+            require_once PIWIK_INCLUDE_PATH . '/core/DataFiles/SearchEngines.php';
+
+            $searchEngines = $GLOBALS['Piwik_SearchEngines'];
+
+            Piwik::postEvent('Referrer.addSearchEngineUrls', array(&$searchEngines));
+
+            $cache->save($cacheId, $searchEngines);
+        }
 
         return $searchEngines;
     }
@@ -847,13 +856,21 @@ class Common
      */
     public static function getSearchEngineNames()
     {
-        $searchEngines = self::getSearchEngineUrls();
+        $cacheId = 'Common.getSearchEngineNames';
+        $cache = Cache::getTransientCache();
+        $nameToUrl = $cache->fetch($cacheId);
 
-        $nameToUrl = array();
-        foreach ($searchEngines as $url => $info) {
-            if (!isset($nameToUrl[$info[0]])) {
-                $nameToUrl[$info[0]] = $url;
+        if (empty($nameToUrl)) {
+
+            $searchEngines = self::getSearchEngineUrls();
+
+            $nameToUrl = array();
+            foreach ($searchEngines as $url => $info) {
+                if (!isset($nameToUrl[$info[0]])) {
+                    $nameToUrl[$info[0]] = $url;
+                }
             }
+            $cache->save($cacheId, $nameToUrl);
         }
 
         return $nameToUrl;
@@ -868,11 +885,20 @@ class Common
      */
     public static function getSocialUrls()
     {
-        require_once PIWIK_INCLUDE_PATH . '/core/DataFiles/Socials.php';
+        $cacheId = 'Common.getSocialUrls';
+        $cache = Cache::getTransientCache();
+        $socialUrls = $cache->fetch($cacheId);
 
-        $socialUrls = $GLOBALS['Piwik_socialUrl'];
+        if (empty($socialUrls)) {
 
-        Piwik::postEvent('Referrer.addSocialUrls', array(&$socialUrls));
+            require_once PIWIK_INCLUDE_PATH . '/core/DataFiles/Socials.php';
+
+            $socialUrls = $GLOBALS['Piwik_socialUrl'];
+
+            Piwik::postEvent('Referrer.addSocialUrls', array(&$socialUrls));
+
+            $cache->save($cacheId, $socialUrls);
+        }
 
         return $socialUrls;
     }

--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -9,6 +9,7 @@
 namespace Piwik\Period;
 
 use Exception;
+use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Date;
 use Piwik\Period;
@@ -33,6 +34,11 @@ class Range extends Period
     protected $today;
 
     /**
+     * @var null|Date
+     */
+    protected $defaultEndDate;
+
+    /**
      * Constructor.
      *
      * @param string $strPeriod The type of period each subperiod is. Either `'day'`, `'week'`,
@@ -54,6 +60,41 @@ class Range extends Period
         }
 
         $this->today = $today;
+    }
+
+    private function getCache()
+    {
+        return Cache::getTransientCache();
+    }
+
+    private function getCacheId()
+    {
+        $end = '';
+        if ($this->defaultEndDate) {
+            $end = $this->defaultEndDate->getTimestamp();
+        }
+
+        $today = $this->today->getTimestamp();
+
+        return 'range' . $this->strPeriod . $this->strDate . $this->timezone . $end . $today;
+    }
+
+    private function loadAllFromCache()
+    {
+        $range = $this->getCache()->fetch($this->getCacheId());
+
+        if (!empty($range)) {
+            foreach ($range as $key => $val) {
+                $this->$key = $val;
+            }
+        }
+    }
+
+    private function cacheAll()
+    {
+        $props = get_object_vars($this);
+
+        $this->getCache()->save($this->getCacheId(), $props);
     }
 
     /**
@@ -156,6 +197,12 @@ class Range extends Period
             return;
         }
 
+        $this->loadAllFromCache();
+
+        if ($this->subperiodsProcessed) {
+            return;
+        }
+
         parent::generate();
 
         if (preg_match('/(last|previous)([0-9]*)/', $this->strDate, $regs)) {
@@ -214,6 +261,7 @@ class Range extends Period
 
         if ($this->strPeriod != 'range') {
             $this->fillArraySubPeriods($startDate, $endDate, $this->strPeriod);
+            $this->cacheAll();
             return;
         }
 
@@ -221,6 +269,7 @@ class Range extends Period
         // When period=range, we want End Date to be the actual specified end date,
         // rather than the end of the month / week / whatever is used for processing this range
         $this->endDate = $endDate;
+        $this->cacheAll();
     }
 
     /**
@@ -461,5 +510,18 @@ class Range extends Period
                 && $endDate->isLater($this->today)));
 
         return $isEndOfWeekLaterThanEndDate;
+    }
+
+    /**
+     * Returns the date range string comprising two dates
+     *
+     * @return string eg, `'2012-01-01,2012-01-31'`.
+     */
+    public function getRangeString()
+    {
+        $dateStart = $this->getDateStart();
+        $dateEnd   = $this->getDateEnd();
+
+        return $dateStart->toString("Y-m-d") . "," . $dateEnd->toString("Y-m-d");
     }
 }

--- a/core/ViewDataTable/Manager.php
+++ b/core/ViewDataTable/Manager.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\ViewDataTable;
 
+use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Option;
 use Piwik\Piwik;
@@ -63,6 +64,14 @@ class Manager
      */
     public static function getAvailableViewDataTables()
     {
+        $cache = Cache::getTransientCache();
+        $cacheId = 'ViewDataTable.getAvailableViewDataTables';
+        $dataTables = $cache->fetch($cacheId);
+
+        if (!empty($dataTables)) {
+            return $dataTables;
+        }
+
         $klassToExtend = '\\Piwik\\Plugin\\ViewDataTable';
 
         /** @var string[] $visualizations */
@@ -106,6 +115,8 @@ class Manager
 
             $result[$vizId] = $viz;
         }
+
+        $cache->save($cacheId, $result);
 
         return $result;
     }


### PR DESCRIPTION
- In the DataTableManipulator we requested the metadata for `all` websites. If an installation has many websites we ended up building the report metadata for all sites. This takes a long time, especially since some reports get site information eg `getFor('sitesearch')`. If an installation has 100 Piwik websites it resulted in 100 queries to `piwik_site` which resulted in 100 posted events in `Piwik::setSite` etc. 
- Post much less events. Eg we posted two events for each row in a GetSearchEngines datatable (which is slow as it will always notify all plugins). Instead we do now cache SearchEngineUrls / Names and SocialUrls. This saves about 100-200ms on a simple `Referrers.getSearchEngine` request if not more.
- When requesting a date range eg `date=last30&period=range` about 40% of the request time was spent in generating the sub periods. In one simple request we did this eg. 20 times for the same date range which took about 700ms on my server. As we cache it now it will take only about 35ms making all calls to range dates faster. I just this is more or less "only" a performance boost for `flat=1` as it looks like it generates the subperiods for each subtable. Note: If there was any long/endless running job this cache could result in a memory issue.

On our demo test server this call does now take only about 0.75s instead of 1.7s:
`index.php?date=2015-01-04,2015-02-02&module=Referrers&action=getSearchEngines&widget=1&isFooterExpandedInDashboard=true&flat=1&idSite=1&period=range` 
