### PR TITLE
Add a class uiTest to the html element in all uiTests.

### DIFF
--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -172,7 +172,16 @@ PageRenderer.prototype._load = function (url, callback) {
     }
 
     this._recreateWebPage(); // calling open a second time never calls the callback
-    this.webpage.open(url, callback);
+    this.webpage.open(url, function (status) {
+        this.evaluate(function () {
+            var $ = window.jQuery;
+            $('html').addClass('uiTest');
+        });
+
+        if (callback) {
+            callback(status);
+        }
+    });
 };
 
 PageRenderer.prototype._evaluate = function (impl, callback) {


### PR DESCRIPTION
This will allow developers to hide elements in the UI tests if needed as not everyone can change `override.css` etc. For example it allows to hide sparklines or a date that changes all the time and would otherwise always fail the test.

A couple of UI tests fail because of this but this seems to actually fix some random bugs we had before see http://builds-artifacts.piwik.org/ui-tests.master/7139.1/screenshot-diffs/diffviewer.html
