### PR TITLE
Simplified the cache configuration

### DIFF
--- a/config/environment/dev.php
+++ b/config/environment/dev.php
@@ -2,6 +2,8 @@
 
 return array(
 
+    'Piwik\Cache\Backend' => DI\object('Piwik\Cache\Backend\ArrayCache'),
+
     'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\LoaderCache')
         ->constructor(DI\link('Piwik\Translation\Loader\DevelopmentLoader')),
     'Piwik\Translation\Loader\DevelopmentLoader' => DI\object()

--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -5,8 +5,11 @@ return array(
     // Disable logging
     'Psr\Log\LoggerInterface' => DI\object('Psr\Log\NullLogger'),
 
-    // Disable translation cache
-    'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\JsonFileLoader'),
+    'Piwik\Cache\Backend' => function () {
+        return \Piwik\Cache::buildBackend('file');
+    },
+    'cache.eager.cache_id' => 'eagercache-test-',
+
     // Disable loading core translations
     'Piwik\Translation\Translator' => DI\object()
         ->constructorParameter('directories', array()),

--- a/config/global.php
+++ b/config/global.php
@@ -24,34 +24,11 @@ return array(
         return $root . '/tmp' . $instanceId;
     },
 
-    'path.cache' => function (ContainerInterface $c) {
-        $root = $c->get('path.tmp');
+    'path.cache' => DI\string('{path.tmp}/cache/tracker/'),
 
-        return $root . '/cache/tracker/';
-    },
-
-    'cache.backend' => function (ContainerInterface $c) {
-        if (defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE) { // todo replace this with isTest() instead of isCli()
-            $backend = 'file';
-        } elseif (\Piwik\Development::isEnabled()) {
-            $backend = 'array';
-        } else {
-            $backend = $c->get('ini.Cache.backend');
-        }
-
-        return $backend;
-    },
-    'Piwik\Cache\Lazy' => DI\object(),
-    'Piwik\Cache\Transient' => DI\object(),
     'Piwik\Cache\Eager' => function (ContainerInterface $c) {
-
         $backend = $c->get('Piwik\Cache\Backend');
-
-        if (defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE) {
-            $cacheId = 'eagercache-test-';
-        } else {
-            $cacheId = 'eagercache-' . str_replace(array('.', '-'), '', \Piwik\Version::VERSION) . '-';
-        }
+        $cacheId = $c->get('cache.eager.cache_id');
 
         if (SettingsServer::isTrackerApiRequest()) {
             $eventToPersist = 'Tracker.end';
@@ -69,11 +46,10 @@ return array(
         return $cache;
     },
     'Piwik\Cache\Backend' => function (ContainerInterface $c) {
-
-        $type    = $c->get('cache.backend');
-        $backend = \Piwik\Cache::buildBackend($type);
-
-        return $backend;
+        return \Piwik\Cache::buildBackend($c->get('ini.Cache.backend'));
+    },
+    'cache.eager.cache_id' => function () {
+        return 'eagercache-' . str_replace(array('.', '-'), '', \Piwik\Version::VERSION) . '-';
     },
 
     // Log

--- a/core/Translation/Loader/LoaderCache.php
+++ b/core/Translation/Loader/LoaderCache.php
@@ -25,11 +25,10 @@ class LoaderCache implements LoaderInterface
      */
     private $cache;
 
-    public function __construct(LoaderInterface $loader, Cache\Lazy $cache = null)
+    public function __construct(LoaderInterface $loader, Cache\Lazy $cache)
     {
         $this->loader = $loader;
-        // TODO DI
-        $this->cache = $cache ?: Cache::getLazyCache();
+        $this->cache = $cache;
     }
 
     /**


### PR DESCRIPTION
A few simplifications for the cache config.

By the way why use the file cache in tests? I'm afraid of all the possible side-effects.

I also simplified the Translator cache config by simply getting the configured cache (hopefully the file cache in tests will not create problems)

ping @tsteur 
