### PR TITLE
Fix some export links were not working, eg Insights

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1048,6 +1048,14 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             .attr('href', function () {
                 var format = $(this).attr('format');
                 var method = $(this).attr('methodToCall');
+                var params = $(this).attr('requestParams');
+
+                if (params) {
+                    params = JSON.parse(params)
+                } else {
+                    params = {};
+                }
+
                 var segment = self.param.segment;
                 var label = self.param.label;
                 var idGoal = self.param.idGoal;
@@ -1072,6 +1080,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                     && self.param.viewDataTable == "graphEvolution") {
                     period = 'day';
                 }
+
                 var str = 'index.php?module=API'
                     + '&method=' + method
                     + '&format=' + format
@@ -1080,6 +1089,12 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                     + '&date=' + param_date
                     + ( typeof self.param.filter_pattern != "undefined" ? '&filter_pattern=' + self.param.filter_pattern : '')
                     + ( typeof self.param.filter_pattern_recursive != "undefined" ? '&filter_pattern_recursive=' + self.param.filter_pattern_recursive : '');
+
+                if ($.isPlainObject(params)) {
+                    $.each(params, function (index, param) {
+                        str += '&' + index + '=' + encodeURIComponent(param);
+                    });
+                }
 
                 if (typeof self.param.flat != "undefined") {
                     str += '&flat=' + (self.param.flat == 0 ? '0' : '1');

--- a/plugins/CoreHome/templates/_dataTableFooter.twig
+++ b/plugins/CoreHome/templates/_dataTableFooter.twig
@@ -16,7 +16,7 @@
 
         {% if properties.show_search %}
             <span class="dataTableSearchPattern">
-		<label for="widgetSearch_{{ properties.report_id }}" style="display:none;"> {{ 'General_Search'|translate }} {{ visualization.config.translations.label|default('') }}</label>
+        <label for="widgetSearch_{{ properties.report_id }}" style="display:none;"> {{ 'General_Search'|translate }} {{ visualization.config.translations.label|default('') }}</label>
                 <input id="widgetSearch_{{ properties.report_id }}" type="text" class="searchInput" length="15" />
                 <input type="submit" value="{{ 'General_Search'|translate }}" />
             </span>
@@ -57,20 +57,21 @@
                             <img width="16" height="16" src="plugins/Morpheus/images/export.png" title="{{ 'General_ExportThisReport'|translate }}"/>
                         </a>
                     </span>
-				    <span class="exportToFormatItems" style="display:none;">
-					{{ 'General_Export'|translate }}:
-					<a target="_blank" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="CSV" filter_limit="{{ properties.export_limit }}">CSV</a> |
-					<a target="_blank" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="TSV" filter_limit="{{ properties.export_limit }}">TSV (Excel)</a> |
-					<a target="_blank" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="XML" filter_limit="{{ properties.export_limit }}">XML</a> |
-					<a target="_blank" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="JSON" filter_limit="{{ properties.export_limit }}">Json</a> |
-					<a target="_blank" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="PHP" filter_limit="{{ properties.export_limit }}">Php</a>
+                    <span class="exportToFormatItems" style="display:none;">
+                    {{ 'General_Export'|translate }}:
+                    {% set requestParams = properties.request_parameters_to_modify|json_encode %}
+                    <a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="CSV" filter_limit="{{ properties.export_limit }}">CSV</a> |
+                    <a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="TSV" filter_limit="{{ properties.export_limit }}">TSV (Excel)</a> |
+                    <a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="XML" filter_limit="{{ properties.export_limit }}">XML</a> |
+                    <a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="JSON" filter_limit="{{ properties.export_limit }}">Json</a> |
+                    <a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="PHP" filter_limit="{{ properties.export_limit }}">Php</a>
                         {% if properties.show_export_as_rss_feed %}
                             |
-                            <a target="_blank" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="RSS" filter_limit="{{ properties.export_limit }}" date="last10">
+                            <a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="RSS" filter_limit="{{ properties.export_limit }}" date="last10">
                                 <img border="0" src="plugins/Morpheus/images/feed.png"/>
                             </a>
                         {% endif %}
-				    </span>
+                    </span>
                     {% if properties.show_export_as_image_icon %}
                         <span id="dataTableFooterExportAsImageIcon">
                             <a class="tableIcon" href="#" onclick="$(this).closest('.dataTable').find('div.jqplot-target').trigger('piwikExportAsImage'); return false;">

--- a/plugins/Insights/Visualizations/Insight.php
+++ b/plugins/Insights/Visualizations/Insight.php
@@ -93,6 +93,7 @@ class Insight extends Visualization
         $this->config->show_pagination_control = false;
         $this->config->show_offset_information = false;
         $this->config->show_search = false;
+        $this->config->show_export_as_rss_feed = false;
 
         if (!self::canDisplayViewDataTable($this)) {
             $this->assignTemplateVar('cannotDisplayReport', true);


### PR DESCRIPTION
refs #6790 when exporting a report we need to apply the same request params that were used to render the datatable.

This will not only fix this bug but should also fix potential other bugs
where request params were not forwarded. For example an abandonedCarts
param in Ecommerce, or hideFutureHoursWhenToday in VisitTime.
