### PR TITLE
Wrong dates returned when part of the date parameter is "today"

### DIFF
--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -353,6 +353,9 @@ class Range extends Period
      */
     protected function fillArraySubPeriods($startDate, $endDate, $period)
     {
+        $startDate = $startDate->setTime('00:00:00');
+        $endDate   = $endDate->setTime('00:00:00');
+
         $arrayPeriods = array();
         $endSubperiod = Period\Factory::build($period, $endDate);
         $arrayPeriods[] = $endSubperiod;

--- a/tests/PHPUnit/Unit/Period/RangeTest.php
+++ b/tests/PHPUnit/Unit/Period/RangeTest.php
@@ -143,6 +143,18 @@ class RangeTest extends BasePeriodTest
     }
 
     // test range date1,date2
+    // see https://github.com/piwik/piwik/issues/6194
+    public function testRangeComma3_EndDateIncludesToday()
+    {
+        $range = new Range('day', '2008-01-01,today');
+
+        $subPeriods = $range->getSubperiods();
+        $this->assertEquals('2008-01-01', $subPeriods[0]->toString());
+        $this->assertEquals('2008-01-02', $subPeriods[1]->toString());
+        $this->assertEquals('2008-01-03', $subPeriods[2]->toString());
+    }
+
+    // test range date1,date2
     public function testRangeWeekcomma1()
     {
         $range = new Range('week', '2007-12-22,2008-01-03');


### PR DESCRIPTION
refs #6194 

Problem is the following: An endDate that is `today` is converted to `now` which includes a time. This is done here: https://github.com/piwik/piwik/blob/2.11.0-b3/core/Period/Range.php#L200-L201 and was introduced by this commit: https://github.com/piwik/piwik/commit/3ff768b1d11947c378a3f4d7a41f9241b72cee7d . Unfortunately the commit message is not very helpful to me.

When comparing the dates to fill the subPeriods, `now` (which equals to eg 2008-01-01 23:23:23) will be later than `2008-01-01` (which would be 2008-01-01 00:00:00) and therefore adds an additional day see https://github.com/piwik/piwik/blob/2.11.0-b3/core/Period/Range.php#L359

This should be fixed now. Another fix would be to remove this `if` and always use `today` https://github.com/piwik/piwik/blob/2.11.0-b3/core/Period/Range.php#L200-L201 instead of `now` as `today` does not include a time. I didn't go for this fix as I am not sure why this `if` clause is there. There must be a reason otherwise one would not have added this special case. If one thinks it is actually not needed we can change the pull request to fix it like this.
