### PR TITLE
Added a new "Development" language that shows the raw translation IDs

### DIFF
--- a/config/environment/dev.php
+++ b/config/environment/dev.php
@@ -2,7 +2,9 @@
 
 return array(
 
-    // Disable translation cache
-    'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\JsonFileLoader'),
+    'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\LoaderCache')
+        ->constructor(DI\link('Piwik\Translation\Loader\DevelopmentLoader')),
+    'Piwik\Translation\Loader\DevelopmentLoader' => DI\object()
+        ->constructor(DI\link('Piwik\Translation\Loader\JsonFileLoader')),
 
 );

--- a/core/Translation/Loader/DevelopmentLoader.php
+++ b/core/Translation/Loader/DevelopmentLoader.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Translation\Loader;
+
+/**
+ * Loads a pseudo-language for developers where translation are equal to translation ids.
+ */
+class DevelopmentLoader implements LoaderInterface
+{
+    const LANGUAGE_ID = 'dev';
+
+    /**
+     * Decorated loader.
+     *
+     * @var LoaderInterface
+     */
+    private $loader;
+
+    /**
+     * @var string
+     */
+    private $fallbackLanguage = 'en';
+
+    /**
+     * @param LoaderInterface $loader Decorate another loader to add the pseudo-language.
+     */
+    public function __construct(LoaderInterface $loader)
+    {
+        $this->loader = $loader;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load($language, array $directories)
+    {
+        if ($language !== self::LANGUAGE_ID) {
+            return $this->loader->load($language, $directories);
+        }
+
+        return $this->getDevelopmentTranslations($directories);
+    }
+
+    private function getDevelopmentTranslations(array $directories)
+    {
+        $fallbackTranslations = $this->loader->load($this->fallbackLanguage, $directories);
+
+        $translations = array();
+
+        foreach ($fallbackTranslations as $section => $sectionFallbackTranslations) {
+            $translationIds = array_keys($sectionFallbackTranslations);
+            $sectionTranslations = $this->prefixTranslationsWithSection($section, $translationIds);
+
+            $translations[$section] = array_combine($translationIds, $sectionTranslations);
+        }
+
+        return $translations;
+    }
+
+    private function prefixTranslationsWithSection($section, $translationIds)
+    {
+        return array_map(function ($translation) use ($section) {
+            return $section . '_' . $translation;
+        }, $translationIds);
+    }
+}

--- a/lang/dev.json
+++ b/lang/dev.json
@@ -1,0 +1,6 @@
+{
+    "General": {
+        "OriginalLanguageName": "Development",
+        "EnglishLanguageName": "Development"
+    }
+}

--- a/plugins/LanguagesManager/API.php
+++ b/plugins/LanguagesManager/API.php
@@ -10,10 +10,12 @@
 namespace Piwik\Plugins\LanguagesManager;
 
 use Piwik\Db;
+use Piwik\Development;
 use Piwik\Filesystem;
 use Piwik\Piwik;
 use Piwik\Cache as PiwikCache;
 use Piwik\Plugin\Manager as PluginManager;
+use Piwik\Translation\Loader\DevelopmentLoader;
 
 /**
  * The LanguagesManager API lets you access existing Piwik translations, and change Users languages preferences.
@@ -65,6 +67,8 @@ class API extends \Piwik\Plugin\API
                 $languages[] = substr($language, $pathLength, -strlen('.json'));
             }
         }
+
+        $this->enableDevelopmentLanguageInDevEnvironment($languages);
 
         /**
          * Hook called after loading available language files.
@@ -294,5 +298,15 @@ class API extends \Piwik\Plugin\API
         }
 
         $this->availableLanguageNames = $languagesInfo;
+    }
+
+    private function enableDevelopmentLanguageInDevEnvironment(&$languages)
+    {
+        if (!Development::isEnabled()) {
+            $key = array_search(DevelopmentLoader::LANGUAGE_ID, $languages);
+            if ($key) {
+                unset($languages[$key]);
+            }
+        }
     }
 }

--- a/tests/PHPUnit/Unit/Translation/Loader/DevelopmentLoaderTest.php
+++ b/tests/PHPUnit/Unit/Translation/Loader/DevelopmentLoaderTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Translation\Loader;
+
+use Piwik\Translation\Loader\DevelopmentLoader;
+
+/**
+ * @group Translation
+ */
+class DevelopmentLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    private $translations = array(
+        'General' => array(
+            'translationId' => 'Hello',
+        ),
+    );
+
+    public function test_shouldReturnTranslationIds_ifDevelopmentLanguage()
+    {
+        $wrappedLoader = $this->getMockForAbstractClass('Piwik\Translation\Loader\LoaderInterface');
+        $loader = new DevelopmentLoader($wrappedLoader);
+
+        $wrappedLoader->expects($this->once())
+            ->method('load')
+            ->with('en', array('directory'))
+            ->willReturn($this->translations);
+
+        $translations = $loader->load(DevelopmentLoader::LANGUAGE_ID, array('directory'));
+
+        $expected = array(
+            'General' => array(
+                'translationId' => 'General_translationId',
+            ),
+        );
+
+        $this->assertEquals($expected, $translations);
+    }
+
+    public function test_shouldUseDecoratedLoader_ifNotDevelopmentLanguage()
+    {
+        $wrappedLoader = $this->getMockForAbstractClass('Piwik\Translation\Loader\LoaderInterface');
+        $loader = new DevelopmentLoader($wrappedLoader);
+
+        $wrappedLoader->expects($this->once())
+            ->method('load')
+            ->with('fr', array('directory'))
+            ->willReturn($this->translations);
+
+        $translations = $loader->load('fr', array('directory'));
+
+        $this->assertEquals($this->translations, $translations);
+    }
+}


### PR DESCRIPTION
Fixes #7094 

This language is shown when development mode is enabled.

![](https://cloud.githubusercontent.com/assets/273120/5930398/e87af22e-a6f3-11e4-9aa1-4dce806e4083.png)
