### PR TITLE
Some performance improvements for the all websites dashboard

### DIFF
--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -674,8 +674,9 @@ class ProcessedReport
                     // if we handle MultiSites.getAll we do not always have the same idSite but different ones for
                     // each site, see https://github.com/piwik/piwik/issues/5006
                     $idSiteForRow = $idSite;
-                    if ($row->getMetadata('idsite') && is_numeric($row->getMetadata('idsite'))) {
-                        $idSiteForRow = (int) $row->getMetadata('idsite');
+                    $idSiteMetadata = $row->getMetadata('idsite');
+                    if ($idSiteMetadata && is_numeric($idSiteMetadata)) {
+                        $idSiteForRow = (int) $idSiteMetadata;
                     }
 
                     $prettyValue = self::getPrettyValue($formatter, $idSiteForRow, $columnName, $columnValue, $htmlAllowed = false);

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -138,6 +138,8 @@ class API extends \Piwik\Plugin\API
                     // added because caller could overwrite these
                       'serialize' => 0,
                       'format'    => 'original'));
+
+            Site::setSitesFromArray($sitesToProblablyAdd);
         }
 
         return $sitesToProblablyAdd;
@@ -185,7 +187,6 @@ class API extends \Piwik\Plugin\API
     {
         $idSites = array();
         if (!empty($sitesToProblablyAdd)) {
-            Site::setSitesFromArray($sitesToProblablyAdd);
             foreach ($sitesToProblablyAdd as $site) {
                 $idSites[] = $site['idsite'];
             }

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -232,7 +232,11 @@ class API extends \Piwik\Plugin\API
         // get the data
         // $dataTable instanceOf Set
         $dataTable = $archive->getDataTableFromNumeric($fieldsToGet);
-        $dataTable = $this->mergeDataTableMapAndPopulateLabel($idSites, $multipleWebsitesRequested, $dataTable);
+
+        if ($multipleWebsitesRequested && count($idSites) === 1 && Range::isMultiplePeriod($date, $period)) {
+        } else {
+            $dataTable = $this->mergeDataTableMapAndPopulateLabel($idSites, $multipleWebsitesRequested, $dataTable);
+        }
 
         if ($dataTable instanceof DataTable\Map) {
             foreach ($dataTable->getDataTables() as $table) {
@@ -262,7 +266,11 @@ class API extends \Piwik\Plugin\API
 
             $pastData = $pastArchive->getDataTableFromNumeric($fieldsToGet);
 
-            $pastData = $this->mergeDataTableMapAndPopulateLabel($idSites, $multipleWebsitesRequested, $pastData);
+            if ($multipleWebsitesRequested && count($idSites) === 1 && Range::isMultiplePeriod($date, $period)) {
+
+            } else {
+                $pastData = $this->mergeDataTableMapAndPopulateLabel($idSites, $multipleWebsitesRequested, $pastData);
+            }
 
             // use past data to calculate evolution percentages
             $this->calculateEvolutionPercentages($dataTable, $pastData, $apiMetrics);

--- a/tests/PHPUnit/System/BackwardsCompatibility1XTest.php
+++ b/tests/PHPUnit/System/BackwardsCompatibility1XTest.php
@@ -104,7 +104,10 @@ class BackwardsCompatibility1XTest extends SystemTestCase
 
              // the Action.getPageTitles test fails for unknown reason, so skipping it
              // eg. https://travis-ci.org/piwik/piwik/jobs/24449365
-            'Action.getPageTitles'
+            'Action.getPageTitles',
+
+             // the label column is not the first column here
+            'MultiSites.getAll'
         );
 
         return array(
@@ -127,7 +130,12 @@ class BackwardsCompatibility1XTest extends SystemTestCase
                                               'periods' => array('range'), 'disableArchiving' => true)),
 
             array('VisitFrequency.get', array('idSite' => $idSite, 'date' => '2012-03-03,2012-12-12', 'periods' => array('month'),
-                                              'testSuffix' => '_multipleOldNew', 'disableArchiving' => true))
+                                              'testSuffix' => '_multipleOldNew', 'disableArchiving' => true)),
+            array('MultiSites.getAll', array('idSite' => $idSite, 'date' => $dateTime,
+                                             'disableArchiving' => true,
+                                             'otherRequestParameters' => array(
+                                                 'hideColumns' => 'nb_users',
+                                             ))),
         );
     }
 }

--- a/tests/PHPUnit/System/expected/test_BackwardsCompatibility1XTest__MultiSites.getAll_day.xml
+++ b/tests/PHPUnit/System/expected/test_BackwardsCompatibility1XTest__MultiSites.getAll_day.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<nb_visits>2</nb_visits>
+		<nb_actions>8</nb_actions>
+		<nb_pageviews>4</nb_pageviews>
+		<revenue>43</revenue>
+		<label>new name</label>
+		<visits_evolution>100%</visits_evolution>
+		<actions_evolution>100%</actions_evolution>
+		<pageviews_evolution>100%</pageviews_evolution>
+		<revenue_evolution>100%</revenue_evolution>
+		<group />
+		<main_url>http://site.com</main_url>
+		<idsite>1</idsite>
+	</row>
+</result>


### PR DESCRIPTION
refs #6809 

I tested it with 4k websites. The change makes it only a couple of seconds faster
and requesting 4k websites would still take 4-8 seconds even if only 10 sites of
them are actually requested. For example before we did request each site 3 times
(12k times in total and triggered 12k events etc) which should be no longer the case.
The last `clearSiteCache` was there to free some memory but I think it shouldn't
be problematic to remove it. Also I removed one 'sort' as a lot of time is wasted
there. It should be in theory sorted afterwards anyway again. Need to see test
results whether this change is good or not.

This doesn't fix the issue #6809, it is only one part of it.

There might be a failing test but this one is also failing on master.
