### PR TITLE
Dependency injection in commands

### DIFF
--- a/core/Console/Command.php
+++ b/core/Console/Command.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Console;
+
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+/**
+ * Alternate command class that allows lazy-loading by having the configuration in a static method.
+ */
+abstract class Command extends SymfonyCommand
+{
+    public static function configuration(CommandConfiguration $configuration)
+    {
+    }
+
+    protected function configure()
+    {
+        $configuration = new CommandConfiguration();
+
+        static::configuration($configuration);
+
+        $configuration->apply($this);
+    }
+}

--- a/core/Console/CommandConfiguration.php
+++ b/core/Console/CommandConfiguration.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Console;
+
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Configuration of a command.
+ */
+class CommandConfiguration
+{
+    private $name;
+    private $processTitle;
+    private $aliases = array();
+    private $help;
+    private $description;
+    private $arguments = array();
+    private $options = array();
+
+    /**
+     * Apply the configuration to a Symfony command.
+     *
+     * @param SymfonyCommand $command
+     */
+    public function apply(SymfonyCommand $command)
+    {
+        if ($this->name !== null) {
+            $command->setName($this->name);
+        }
+        if ($this->processTitle !== null) {
+            $command->setProcessTitle($this->processTitle);
+        }
+        if (! empty($this->aliases)) {
+            $command->setAliases($this->aliases);
+        }
+        if ($this->help !== null) {
+            $command->setHelp($this->help);
+        }
+        if ($this->description !== null) {
+            $command->setDescription($this->description);
+        }
+
+        $definition = $command->getDefinition();
+        $definition->addArguments($this->arguments);
+        $definition->addOptions($this->options);
+    }
+
+    /**
+     * Adds an argument.
+     *
+     * @param string $name        The argument name
+     * @param int    $mode        The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
+     * @param string $description A description text
+     * @param mixed  $default     The default value (for InputArgument::OPTIONAL mode only)
+     *
+     * @return CommandConfiguration The current instance
+     */
+    public function addArgument($name, $mode = null, $description = '', $default = null)
+    {
+        $this->arguments[] = new InputArgument($name, $mode, $description, $default);
+
+        return $this;
+    }
+
+    /**
+     * Adds an option.
+     *
+     * @param string $name        The option name
+     * @param string $shortcut    The shortcut (can be null)
+     * @param int    $mode        The option mode: One of the InputOption::VALUE_* constants
+     * @param string $description A description text
+     * @param mixed  $default     The default value (must be null for InputOption::VALUE_REQUIRED or InputOption::VALUE_NONE)
+     *
+     * @return CommandConfiguration The current instance
+     */
+    public function addOption($name, $shortcut = null, $mode = null, $description = '', $default = null)
+    {
+        $this->options[] = new InputOption($name, $shortcut, $mode, $description, $default);
+
+        return $this;
+    }
+
+    /**
+     * Sets the name of the command.
+     *
+     * This method can set both the namespace and the name if
+     * you separate them by a colon (:)
+     *
+     *     $command->setName('foo:bar');
+     *
+     * @param string $name The command name
+     *
+     * @return CommandConfiguration The current instance
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Sets the process title of the command.
+     *
+     * This feature should be used only when creating a long process command,
+     * like a daemon.
+     *
+     * PHP 5.5+ or the proctitle PECL library is required
+     *
+     * @param string $title The process title
+     *
+     * @return CommandConfiguration The current instance
+     */
+    public function setProcessTitle($title)
+    {
+        $this->processTitle = $title;
+
+        return $this;
+    }
+
+    /**
+     * Sets the description for the command.
+     *
+     * @param string $description The description for the command
+     *
+     * @return CommandConfiguration The current instance
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    /**
+     * Sets the help for the command.
+     *
+     * @param string $help The help for the command
+     *
+     * @return CommandConfiguration The current instance
+     */
+    public function setHelp($help)
+    {
+        $this->help = $help;
+
+        return $this;
+    }
+
+    /**
+     * Sets the aliases for the command.
+     *
+     * @param string[] $aliases An array of aliases for the command
+     *
+     * @return CommandConfiguration The current instance
+     *
+     * @throws \InvalidArgumentException When an alias is invalid
+     */
+    public function setAliases($aliases)
+    {
+        if (!is_array($aliases) && !$aliases instanceof \Traversable) {
+            throw new \InvalidArgumentException('$aliases must be an array or an instance of \Traversable');
+        }
+
+        $this->aliases = $aliases;
+
+        return $this;
+    }
+}

--- a/core/Console/CommandProxy.php
+++ b/core/Console/CommandProxy.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Console;
+
+use Interop\Container\ContainerInterface;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Proxies console command to allow lazy-loading.
+ */
+class CommandProxy extends SymfonyCommand
+{
+    /**
+     * Actual command class name.
+     *
+     * @var string
+     */
+    private $commandClass;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function __construct($commandClass, ContainerInterface $container)
+    {
+        if (! class_exists($commandClass)) {
+            throw new \InvalidArgumentException(sprintf('The class %s does not exist', $commandClass));
+        }
+
+        if (! is_subclass_of($commandClass, 'Piwik\Console\Command')) {
+            throw new \InvalidArgumentException(sprintf('The class %s does not extend Piwik\Console\Command', $commandClass));
+        }
+
+        $this->commandClass = $commandClass;
+        $this->container = $container;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $configuration = new CommandConfiguration();
+
+        // Calls Piwik\Console\Command::configuration($configuration)
+        call_user_func(array($this->commandClass, 'configuration'), $configuration);
+
+        $configuration->apply($this);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $command = $this->container->get($this->commandClass);
+
+        $command->execute($input, $output);
+    }
+}

--- a/core/Plugin/ConsoleCommand.php
+++ b/core/Plugin/ConsoleCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @api
  */
-class ConsoleCommand extends SymfonyCommand
+abstract class ConsoleCommand extends SymfonyCommand
 {
     public function writeSuccessMessage(OutputInterface $output, $messages)
     {


### PR DESCRIPTION
We want to be able to use dependency injection in commands just like we can in controllers. I'll copy-paste the explanation of the problem which makes it problematic today:

> The problem lies with how Symfony's Console work: we need to register command **objects**, so that means **instantiating** every single command just to init the console (see symfony/symfony#12063).
> 
> So if we start doing dependency injection in commands, that means every dependency will be created and injected, with dependencies of dependencies, etc... So 1 or 2 command isn't a big deal but we risk running into a case where a huge load of objects (maybe most of the application) are created by the container just to end up using a few of them…

TL/DR: problem == configuration of commands

With this PR we have an alternative way to configure commands.

The Symfony/current Piwik way:

``` php
class GreetCommand extends \Piwik\Plugin\ConsoleCommand
{
    protected function configure() {
        $this->setName('demo:greet');
    }
    protected function execute(InputInterface $input, OutputInterface $output) {
        // ...
    }
}
```

The alternate way:

``` php
class GreetCommand extends \Piwik\Console\Command
{
    public static function configuration(CommandConfiguration $configuration) {
        $configuration->setName('demo:greet');
    }
    protected function execute(InputInterface $input, OutputInterface $output) {
        // ...
    }
}
```

That way, getting the configuration of a command will not trigger its creation. That allows to do lazy-loading, and thus to use dependency injection without problems.

I have not modified `\Piwik\Plugin\ConsoleCommand` to keep BC. That means we can now extend either `\Piwik\Plugin\ConsoleCommand` or `\Piwik\Console\Command` depending on whether we want to use DI or not.

This PR is not finished, I just want your feedback first. What I want to do is polish this and put it in a new **Piwik/Console** component. I'm convinced it would be super useful to make it open source for the rest of the world, I know I would use it everywhere I have the same problem in many projects.

**So would you be OK with the idea and me creating a new _Piwik/Console_ component that would make the Symfony/Console more flexible?**

(The implementation might change a bit. In https://github.com/symfony/symfony/issues/12063 it is mentioned that only the name and the command alias are needed to build the command list, so maybe I could figure out a simpler solution considering that. I just wanted to try and get a POC working first.)
