### PR TITLE
Site Searches metric should include duplicate site searches requests

### DIFF
--- a/core/Tracker/Settings.php
+++ b/core/Tracker/Settings.php
@@ -80,7 +80,9 @@ class Settings
     }
 
     /**
-     * Returns a 64-bit hash of all the configuration settings
+     * Returns a 64-bit hash that attemps to identify a user.
+     * Maintaining some privacy by default, eg. prevents the merging of several Piwik serve together for matching across instances..
+     *
      * @param $os
      * @param $browserName
      * @param $browserVersion

--- a/plugins/Actions/Archiver.php
+++ b/plugins/Actions/Archiver.php
@@ -466,7 +466,7 @@ class Archiver extends \Piwik\Plugin\Archiver
         $this->deleteUnusedColumnsFromKeywordsDataTable($dataTable);
         $this->insertTable($dataTable, self::SITE_SEARCH_RECORD_NAME);
 
-        $this->getProcessor()->insertNumericRecord(self::METRIC_SEARCHES_RECORD_NAME, array_sum($dataTable->getColumn(PiwikMetrics::INDEX_NB_VISITS)));
+        $this->getProcessor()->insertNumericRecord(self::METRIC_SEARCHES_RECORD_NAME, array_sum($dataTable->getColumn(PiwikMetrics::INDEX_PAGE_NB_HITS)));
         $this->getProcessor()->insertNumericRecord(self::METRIC_KEYWORDS_RECORD_NAME, $dataTable->getRowsCount());
     }
 

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.get_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.get_firstSite_lastN__API.getProcessedReport_day.xml
@@ -51,7 +51,7 @@
 			<nb_uniq_downloads>0</nb_uniq_downloads>
 			<nb_outlinks>0</nb_outlinks>
 			<nb_uniq_outlinks>0</nb_uniq_outlinks>
-			<nb_searches>5</nb_searches>
+			<nb_searches>9</nb_searches>
 			<nb_keywords>3</nb_keywords>
 		</result>
 		<result prettyDate="Monday 4 January 2010">
@@ -61,7 +61,7 @@
 			<nb_uniq_downloads>0</nb_uniq_downloads>
 			<nb_outlinks>0</nb_outlinks>
 			<nb_uniq_outlinks>0</nb_uniq_outlinks>
-			<nb_searches>3</nb_searches>
+			<nb_searches>4</nb_searches>
 			<nb_keywords>3</nb_keywords>
 		</result>
 		<result prettyDate="Tuesday 5 January 2010" />

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.get_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.get_firstSite_lastN__API.getProcessedReport_month.xml
@@ -51,7 +51,7 @@
 			<nb_uniq_downloads>0</nb_uniq_downloads>
 			<nb_outlinks>0</nb_outlinks>
 			<nb_uniq_outlinks>0</nb_uniq_outlinks>
-			<nb_searches>8</nb_searches>
+			<nb_searches>13</nb_searches>
 			<nb_keywords>5</nb_keywords>
 		</result>
 		<result prettyDate="2010, February" />

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.get_day.xml
@@ -8,7 +8,7 @@
 			<nb_uniq_downloads>0</nb_uniq_downloads>
 			<nb_outlinks>0</nb_outlinks>
 			<nb_uniq_outlinks>0</nb_uniq_outlinks>
-			<nb_searches>5</nb_searches>
+			<nb_searches>9</nb_searches>
 			<nb_keywords>3</nb_keywords>
 		</result>
 		<result date="2010-01-04">
@@ -18,7 +18,7 @@
 			<nb_uniq_downloads>0</nb_uniq_downloads>
 			<nb_outlinks>0</nb_outlinks>
 			<nb_uniq_outlinks>0</nb_uniq_outlinks>
-			<nb_searches>3</nb_searches>
+			<nb_searches>4</nb_searches>
 			<nb_keywords>3</nb_keywords>
 		</result>
 		<result date="2010-01-05" />

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.get_month.xml
@@ -8,7 +8,7 @@
 			<nb_uniq_downloads>0</nb_uniq_downloads>
 			<nb_outlinks>0</nb_outlinks>
 			<nb_uniq_outlinks>0</nb_uniq_outlinks>
-			<nb_searches>8</nb_searches>
+			<nb_searches>13</nb_searches>
 			<nb_keywords>5</nb_keywords>
 		</result>
 		<result date="2010-02" />

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.get_day.xml
@@ -6,6 +6,6 @@
 	<nb_uniq_downloads>0</nb_uniq_downloads>
 	<nb_outlinks>0</nb_outlinks>
 	<nb_uniq_outlinks>0</nb_uniq_outlinks>
-	<nb_searches>5</nb_searches>
+	<nb_searches>9</nb_searches>
 	<nb_keywords>3</nb_keywords>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.get_month.xml
@@ -6,6 +6,6 @@
 	<nb_uniq_downloads>0</nb_uniq_downloads>
 	<nb_outlinks>0</nb_outlinks>
 	<nb_uniq_outlinks>0</nb_uniq_outlinks>
-	<nb_searches>8</nb_searches>
+	<nb_searches>13</nb_searches>
 	<nb_keywords>5</nb_keywords>
 </result>


### PR DESCRIPTION
Currently, duplicate site searches by a same user are de-duped.
This causes confusion because users expect the sum Site Searches + Pageviews + Downloads + Outlinks etc. should equal the number of total actions.
fixes #7136
