### PR TITLE
When loading URL and not logged in, this should load the login form

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -1003,7 +1003,9 @@ abstract class Controller
 
     protected function checkSitePermission()
     {
-        if (empty($this->site) || empty($this->idSite)) {
+        if (!empty($this->idSite) && empty($this->site)) {
+            throw new NoAccessException(Piwik::translate('General_ExceptionPrivilegeAccessWebsite', array("'view'", $this->idSite)));
+        } else if (empty($this->site) || empty($this->idSite)) {
             throw new Exception("The requested website idSite is not found in the request, or is invalid.
 				Please check that you are logged in Piwik and have permission to access the specified website.");
         }


### PR DESCRIPTION
refs #7193 

I don't think the issue is a regression. At least it doesn't look like it. This is one solution for that fix but not 100% correct. It would trigger the exception as well if an idSite is given for a site that does not exist! Will try to find a better solution.
