### PR TITLE
Add segment name in mail subjet and filename

### DIFF
--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -450,6 +450,9 @@ class API extends \Piwik\Plugin\API
         $description = str_replace(array("\r", "\n"), ' ', $report['description']);
 
         list($reportSubject, $reportTitle) = self::getReportSubjectAndReportTitle(Site::getNameFor($idSite), $report['reports']);
+        
+        if(is_array($segment) && strlen($segment['name'])) $reportTitle .= " - ".$segment['name'];
+        
         $filename = "$reportTitle - $prettyDate - $description";
 
         $reportRenderer->renderFrontPage($reportTitle, $prettyDate, $description, $reportMetadata, $segment);


### PR DESCRIPTION
Adding segment name in report title (mail subject and filename) in order to allow recipients to differentiate reports when receiving reports on a per-segment basis: 

"sitename - segmentname - date" instead of "sitename - date"
