### PR TITLE
Adding segment name in report title

### DIFF
--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -452,6 +452,11 @@ class API extends \Piwik\Plugin\API
         list($reportSubject, $reportTitle) = self::getReportSubjectAndReportTitle(Site::getNameFor($idSite), $report['reports']);
         $filename = "$reportTitle - $prettyDate - $description";
 
+	// if reporting for a segment, use the segment's name in the title
+	if(is_array($segment) && strlen($segment['name'])) {
+		$reportTitle .= " - ".$segment['name'];
+	}
+	
         $reportRenderer->renderFrontPage($reportTitle, $prettyDate, $description, $reportMetadata, $segment);
         array_walk($processedReports, array($reportRenderer, 'renderReport'));
 


### PR DESCRIPTION
Adding segment name in report title (mail subject and filename) in order to allow recipients to differentiate reports when receiving reports on a per-segment basis:

"sitename - segmentname - date" instead of "sitename - date"
