### PR TITLE
automatically configure database_tests config for developers when running tests.

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -29,7 +29,7 @@ schema = Mysql
 
 [database_tests]
 host = localhost
-username = root
+username = "@USERNAME@"
 password =
 dbname = piwik_tests
 tables_prefix = piwiktests_

--- a/core/Updates/2.11.1-b3.php
+++ b/core/Updates/2.11.1-b3.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Config;
+use Piwik\Development;
+use Piwik\Updates;
+
+class Updates_2_11_1_b3 extends Updates
+{
+    /**
+     * Here you can define any action that should be performed during the update. For instance executing SQL statements,
+     * renaming config entries, updating files, etc.
+     */
+    static function update()
+    {
+        if (!Development::isEnabled()) {
+            return;
+        }
+
+        $config  = Config::getInstance();
+        $dbTests = $config->database_tests;
+
+        if ($dbTests['username'] === '@USERNAME@') {
+            $dbTests['username'] = 'root';
+        }
+
+        $config->database_tests = $dbTests;
+
+        $config->forceSave();
+    }
+}

--- a/core/Updates/2.11.1-b4.php
+++ b/core/Updates/2.11.1-b4.php
@@ -13,7 +13,7 @@ use Piwik\Config;
 use Piwik\Development;
 use Piwik\Updates;
 
-class Updates_2_11_1_b3 extends Updates
+class Updates_2_11_1_b4 extends Updates
 {
     /**
      * Here you can define any action that should be performed during the update. For instance executing SQL statements,

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Piwik version.
      * @var string
      */
-    const VERSION = '2.11.1-b3';
+    const VERSION = '2.11.1-b4';
 
     public function isStableVersion($version)
     {


### PR DESCRIPTION
fixes #6635  

I also replaced the check that does a request against Piwik to check
whether it is installed with `SettingsPiwik::isInstalled()` as discussed
recently
