### PR TITLE
Browser language is used even when English is configured.

### DIFF
--- a/plugins/LanguagesManager/LanguagesManager.php
+++ b/plugins/LanguagesManager/LanguagesManager.php
@@ -35,6 +35,7 @@ class LanguagesManager extends \Piwik\Plugin
             'AssetManager.getStylesheetFiles'            => 'getStylesheetFiles',
             'AssetManager.getJavaScriptFiles'            => 'getJsFiles',
             'Request.dispatchCoreAndPluginUpdatesScreen' => 'initLanguage',
+            'Platform.initialized'                       => 'initLanguage',
             'UsersManager.deleteUser'                    => 'deleteUserLanguage',
             'Template.topBar'                            => 'addLanguagesManagerToOtherTopBar',
             'Template.jsGlobalVariables'                 => 'jsGlobalVariables'

--- a/plugins/UserCountryMap/UserCountryMap.php
+++ b/plugins/UserCountryMap/UserCountryMap.php
@@ -35,11 +35,6 @@ class UserCountryMap extends \Piwik\Plugin
 
     public function postLoad()
     {
-        if (PluginManager::getInstance()->isPluginActivated('UserCountry')) {
-            WidgetsList::add('General_Visitors', Piwik::translate('UserCountryMap_VisitorMap'), 'UserCountryMap', 'visitorMap');
-            WidgetsList::add('Live!', Piwik::translate('UserCountryMap_RealTimeMap'), 'UserCountryMap', 'realtimeMap');
-        }
-
         Piwik::addAction('Template.leftColumnUserCountry', array('Piwik\Plugins\UserCountryMap\UserCountryMap', 'insertMapInLocationReport'));
     }
 
@@ -54,9 +49,21 @@ class UserCountryMap extends \Piwik\Plugin
         $hooks = array(
             'AssetManager.getJavaScriptFiles' => 'getJsFiles',
             'AssetManager.getStylesheetFiles' => 'getStylesheetFiles',
-            'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys'
+            'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
+            'Platform.initialized' => array(
+                'after'    => true,
+                'function' => 'registerWidgets'
+            )
         );
         return $hooks;
+    }
+
+    public function registerWidgets()
+    {
+        if (PluginManager::getInstance()->isPluginActivated('UserCountry')) {
+            WidgetsList::add('General_Visitors', Piwik::translate('UserCountryMap_VisitorMap'), 'UserCountryMap', 'visitorMap');
+            WidgetsList::add('Live!', Piwik::translate('UserCountryMap_RealTimeMap'), 'UserCountryMap', 'realtimeMap');
+        }
     }
 
     public function getJsFiles(&$jsFiles)


### PR DESCRIPTION
fixes #7187  Problem was it did load the language while the user was not authenticated
yet. We need to detect the language again after the user was authenticated.
