### PR TITLE
Remove one index from log_visit that is actually not needed.

### DIFF
--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -153,8 +153,7 @@ class Mysql implements SchemaInterface
                               config_id BINARY(8) NOT NULL,
                               location_ip VARBINARY(16) NOT NULL,
                                 PRIMARY KEY(idvisit),
-                                INDEX index_idsite_config_datetime (idsite, config_id, visit_last_action_time),
-                                INDEX index_idsite_datetime (idsite, visit_last_action_time),
+                                INDEX index_idsite_config_datetime (idsite, visit_last_action_time, config_id),
                                 INDEX index_idsite_idvisitor (idsite, idvisitor)
                               ) ENGINE=$engine DEFAULT CHARSET=utf8
             ",

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -153,7 +153,7 @@ class Mysql implements SchemaInterface
                               config_id BINARY(8) NOT NULL,
                               location_ip VARBINARY(16) NOT NULL,
                                 PRIMARY KEY(idvisit),
-                                INDEX index_idsite_config_datetime (idsite, visit_last_action_time, config_id),
+                                INDEX index_idsite_configid_datetime (idsite, visit_last_action_time, config_id),
                                 INDEX index_idsite_idvisitor (idsite, idvisitor)
                               ) ENGINE=$engine DEFAULT CHARSET=utf8
             ",

--- a/core/Updates/2.12.0-b1.php
+++ b/core/Updates/2.12.0-b1.php
@@ -23,7 +23,7 @@ class Updates_2_12_0_b1 extends Updates
         return array(
             'DROP INDEX index_idsite_config_datetime ON `' . $logVisitTable . '`' => 1091,
             'DROP INDEX index_idsite_datetime ON `' . $logVisitTable . '`' => 1091,
-            'CREATE INDEX index_idsite_config_datetime ON `' . $logVisitTable . '`(idsite, visit_last_action_time, config_id)' => 1061,
+            'CREATE INDEX index_idsite_configid_datetime ON `' . $logVisitTable . '`(idsite, visit_last_action_time, config_id)' => 1061,
         );
     }
 

--- a/core/Updates/2.12.0-b1.php
+++ b/core/Updates/2.12.0-b1.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Common;
+use Piwik\Updater;
+use Piwik\Updates;
+
+class Updates_2_12_0_b1 extends Updates
+{
+
+    static function getSql()
+    {
+        $logVisitTable = Common::prefixTable('log_visit');
+
+        return array(
+            'DROP INDEX index_idsite_config_datetime ON `' . $logVisitTable . '`' => 1091,
+            'DROP INDEX index_idsite_datetime ON `' . $logVisitTable . '`' => 1091,
+            'CREATE INDEX index_idsite_config_datetime ON `' . $logVisitTable . '`(idsite, visit_last_action_time, config_id)' => 1061,
+        );
+    }
+
+    static function update()
+    {
+        Updater::updateDatabase(__FILE__, self::getSql());
+    }
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Piwik version.
      * @var string
      */
-    const VERSION = '2.11.1-b4';
+    const VERSION = '2.12.0-b1';
 
     public function isStableVersion($version)
     {


### PR DESCRIPTION
Noticed the index is quite big for `log_visit` table so had a look and noticed there is one index not needed when we move `config_id` to the end of the existing `index_idsite_datetime` index.

We had a quick look and it seems that we query `config_id` always in combination with `visit_last_action_time` so should be all good. Probably in the past this was not the case and therefore this index was needed.

refs #6953 this does not affect `log_link_visit_action` so should be ok? 
