### PR TITLE
Make sure it actually clears the cached files, not only the internal template cache

### DIFF
--- a/core/View.php
+++ b/core/View.php
@@ -364,9 +364,11 @@ class View implements ViewInterface
      * @ignore
      */
     public static function clearCompiledTemplates()
-    {
+    {        
         $twig = new Twig();
-        $twig->getTwigEnvironment()->clearTemplateCache();
+        $environment = $twig->getTwigEnvironment();
+        $environment->clearTemplateCache();
+        $environment->clearCacheFiles();
     }
 
     /**


### PR DESCRIPTION
This fixes some problems that users reported when manually updating. They followed the manual step by step guide yet still some old twig templates were loaded. Noticed we never deleted/cleared the cached twig files which we do now.
