### PR TITLE
Add fix for when the 'shell_exec' function doesn't exists.

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -203,7 +203,7 @@ class Process
         $command = 'shell_exec';
         $disabled = explode(',', ini_get('disable_functions'));
         $disabled = array_map('trim', $disabled);
-        return in_array($command, $disabled);
+        return in_array($command, $disabled)  || !function_exists($command);
     }
 
     private static function returnsSuccessCode($command)


### PR DESCRIPTION
Hi Guys, 

My screen got blank in the second step of the setup wizard. I found that the source or the problem is the absence of the `shell_exec` function. I found that there is a function which checks if that specific function is disabled in the php.ini file. But it doesn't check if the function actually exists. So I add that check.

Regards,

Peter 
