### PR TITLE
Edge case: when sequence is not found, create it.

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -203,7 +203,15 @@ class Model
     public function allocateNewArchiveId($numericTable)
     {
         $sequence  = new Sequence($numericTable);
-        $idarchive = $sequence->getNextId();
+
+        try {
+            $idarchive = $sequence->getNextId();
+        } catch(Exception $e) {
+            // edge case: sequence was not found, create it now
+            $sequence->create();
+
+            $idarchive = $sequence->getNextId();
+        }
 
         return $idarchive;
     }


### PR DESCRIPTION
 This should not be necessary but we got several user reports that this was happening.

fixes #6929
