### PR TITLE
Update Piwik over HTTPS

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -465,7 +465,8 @@ enable_trusted_host_check = 1
 
 ; The release server is an essential part of the Piwik infrastructure/ecosystem
 ; to provide the latest software version.
-latest_version_url = http://builds.piwik.org/piwik.zip
+latest_version_url = https://builds.piwik.org/piwik.zip
+latest_beta_version_url = https://builds.piwik.org/piwik-%s.zip
 
 ; The API server is an essential part of the Piwik infrastructure/ecosystem to
 ; provide services to Piwik installations, e.g., getLatestVersion and

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -463,11 +463,6 @@ enable_trusted_host_check = 1
 ; independantly of the hostname Piwik is currently running under.
 ; instance_id = stats.example.com
 
-; The release server is an essential part of the Piwik infrastructure/ecosystem
-; to provide the latest software version.
-latest_version_url = https://builds.piwik.org/piwik.zip
-latest_beta_version_url = https://builds.piwik.org/piwik-%s.zip
-
 ; The API server is an essential part of the Piwik infrastructure/ecosystem to
 ; provide services to Piwik installations, e.g., getLatestVersion and
 ; subscribeNewsletter.

--- a/core/Http.php
+++ b/core/Http.php
@@ -179,7 +179,7 @@ class Http
                 throw new Exception('Malformed URL: ' . $aUrl);
             }
 
-            if ($url['scheme'] != 'http') {
+            if ($url['scheme'] != 'http' && $url['scheme'] != 'https') {
                 throw new Exception('Invalid protocol/scheme: ' . $url['scheme']);
             }
             $host = $url['host'];
@@ -405,7 +405,11 @@ class Http
                 }
                 fclose($handle);
             } else {
-                $response = file_get_contents($aUrl, 0, $ctx);
+                $response = @file_get_contents($aUrl, 0, $ctx);
+                if ($response === false) {
+                    $error = error_get_last();
+                    throw new \Exception($error['message']);
+                }
                 $fileLength = strlen($response);
             }
 

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -48,7 +48,8 @@ class Controller extends \Piwik\Plugin\Controller
     protected static function getLatestZipUrl($newVersion)
     {
         if (@Config::getInstance()->Debug['allow_upgrades_to_beta']) {
-            return 'http://builds.piwik.org/piwik-' . $newVersion . '.zip';
+            $url = Config::getInstance()->General['latest_beta_version_url'];
+            return sprintf($url, $newVersion);
         }
         return Config::getInstance()->General['latest_version_url'];
     }
@@ -426,4 +427,12 @@ class Controller extends \Piwik\Plugin\Controller
         return PluginManager::getInstance()->getIncompatiblePlugins($piwikVersion);
     }
 
+    public static function isUpdatingOverHttps()
+    {
+        if (strpos(self::getLatestZipUrl(''), 'https') === false) {
+            return false;
+        }
+
+        return Http::getTransportMethod() === 'curl';
+    }
 }

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -433,6 +433,6 @@ class Controller extends \Piwik\Plugin\Controller
             return false;
         }
 
-        return Http::getTransportMethod() === 'curl';
+        return Http::getTransportMethod() !== 'socket';
     }
 }

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -37,6 +37,8 @@ use Piwik\View;
 class Controller extends \Piwik\Plugin\Controller
 {
     const PATH_TO_EXTRACT_LATEST_VERSION = '/latest/';
+    const LATEST_VERSION_URL = '://builds.piwik.org/piwik.zip';
+    const LATEST_BETA_VERSION_URL = '://builds.piwik.org/piwik-%s.zip';
 
     private $coreError = false;
     private $warningMessages = array();
@@ -48,10 +50,18 @@ class Controller extends \Piwik\Plugin\Controller
     protected static function getLatestZipUrl($newVersion)
     {
         if (@Config::getInstance()->Debug['allow_upgrades_to_beta']) {
-            $url = Config::getInstance()->General['latest_beta_version_url'];
-            return sprintf($url, $newVersion);
+            $url = sprintf(self::LATEST_BETA_VERSION_URL, $newVersion);
+        } else {
+            $url = self::LATEST_VERSION_URL;
         }
-        return Config::getInstance()->General['latest_version_url'];
+
+        if (self::isUpdatingOverHttps()) {
+            $url = 'https' . $url;
+        } else {
+            $url = 'http' . $url;
+        }
+
+        return $url;
     }
 
     public function newVersionAvailable()
@@ -429,10 +439,9 @@ class Controller extends \Piwik\Plugin\Controller
 
     public static function isUpdatingOverHttps()
     {
-        if (strpos(self::getLatestZipUrl(''), 'https') === false) {
-            return false;
-        }
+        $openSslEnabled = extension_loaded('openssl');
+        $usingMethodSupportingHttps = (Http::getTransportMethod() !== 'socket');
 
-        return Http::getTransportMethod() !== 'socket';
+        return $openSslEnabled && $usingMethodSupportingHttps;
     }
 }

--- a/plugins/Installation/SystemCheck.php
+++ b/plugins/Installation/SystemCheck.php
@@ -19,6 +19,7 @@ use Piwik\Filechecks;
 use Piwik\Filesystem;
 use Piwik\Http;
 use Piwik\Piwik;
+use Piwik\Plugins\CoreUpdater;
 use Piwik\Plugins\UserCountry\LocationProvider;
 use Piwik\SettingsServer;
 use Piwik\Url;
@@ -102,6 +103,9 @@ class SystemCheck
         $infos['tracker_status'] = Common::getRequestVar('trackerStatus', 0, 'int');
 
         $infos['is_nfs'] = Filesystem::checkIfFileSystemIsNFS();
+
+        $infos['https_update'] = CoreUpdater\Controller::isUpdatingOverHttps();
+
         $infos = self::enrichSystemChecks($infos);
 
         return $infos;

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -115,6 +115,8 @@
         "SystemCheckCronArchiveProcess": "Archive Cron",
         "SystemCheckCronArchiveProcessCLI": "Managing processes via CLI",
         "SystemCheckPhpSetting": "To prevent some critical issue, you must set the following in your php.ini file: %s",
+        "SystemCheckUpdateHttps": "Update over HTTPS",
+        "SystemCheckUpdateHttpsNotSupported": "Piwik will update without using HTTPS which is insecure. Check that CURL is installed.",
         "NotSupported": "not supported",
         "Tables": "Creating the Tables",
         "TablesCreatedSuccess": "Tables created with success!",

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -116,7 +116,7 @@
         "SystemCheckCronArchiveProcessCLI": "Managing processes via CLI",
         "SystemCheckPhpSetting": "To prevent some critical issue, you must set the following in your php.ini file: %s",
         "SystemCheckUpdateHttps": "Update over HTTPS",
-        "SystemCheckUpdateHttpsNotSupported": "Piwik cannot use HTTPS to update, it will fall back to the insecure HTTP update. Check that CURL or allow_url_fopen is supported.",
+        "SystemCheckUpdateHttpsNotSupported": "Piwik cannot use HTTPS to update, it will fall back to the insecure HTTP update. Check that CURL or allow_url_fopen is supported and that the openssl PHP extension is installed.",
         "NotSupported": "not supported",
         "Tables": "Creating the Tables",
         "TablesCreatedSuccess": "Tables created with success!",

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -116,7 +116,7 @@
         "SystemCheckCronArchiveProcessCLI": "Managing processes via CLI",
         "SystemCheckPhpSetting": "To prevent some critical issue, you must set the following in your php.ini file: %s",
         "SystemCheckUpdateHttps": "Update over HTTPS",
-        "SystemCheckUpdateHttpsNotSupported": "Piwik cannot use HTTPS to update, it will fall back to the insecure HTTP update. Check that CURL or allow_url_fopen is supported and that the openssl PHP extension is installed.",
+        "SystemCheckUpdateHttpsNotSupported": "Piwik cannot use HTTPS to update, it will fall back to the insecure HTTP update. Check that CURL or allow_url_fopen is supported and that the openssl PHP extension is installed: http://piwik.org/faq/troubleshooting/faq_177/.",
         "NotSupported": "not supported",
         "Tables": "Creating the Tables",
         "TablesCreatedSuccess": "Tables created with success!",

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -116,7 +116,7 @@
         "SystemCheckCronArchiveProcessCLI": "Managing processes via CLI",
         "SystemCheckPhpSetting": "To prevent some critical issue, you must set the following in your php.ini file: %s",
         "SystemCheckUpdateHttps": "Update over HTTPS",
-        "SystemCheckUpdateHttpsNotSupported": "Piwik will update without using HTTPS which is insecure. Check that CURL is installed.",
+        "SystemCheckUpdateHttpsNotSupported": "Piwik cannot use HTTPS to update, it will fall back to the insecure HTTP update. Check that CURL or allow_url_fopen is supported.",
         "NotSupported": "not supported",
         "Tables": "Creating the Tables",
         "TablesCreatedSuccess": "Tables created with success!",

--- a/plugins/Installation/templates/_systemCheckSection.twig
+++ b/plugins/Installation/templates/_systemCheckSection.twig
@@ -356,6 +356,17 @@
         </tr>
     {% endif %}
 
+    <tr>
+        <td class="label">{{ 'Installation_SystemCheckUpdateHttps'|translate }}</td>
+        <td>
+            {% if infos.https_update %}
+                {{ ok }}
+            {% else %}
+                {{ warning }} {{ 'Installation_SystemCheckUpdateHttpsNotSupported'|translate }}
+            {% endif %}
+        </td>
+    </tr>
+
 </table>
 
 {% include "@Installation/_integrityDetails.twig" %}

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -115,4 +115,15 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_numeric($result['headers']['Content-Length']), "Content-Length header not numeric!");
         $this->assertTrue(in_array($result['headers']['Content-Type'], array('application/zip', 'application/x-zip-compressed')));
     }
+
+    public function testHttps()
+    {
+        $result = Http::sendHttpRequestBy(
+            'curl',
+            'https://builds.piwik.org/LATEST',
+            10
+        );
+
+        $this->assertStringMatchesFormat('%d.%d.%d', $result);
+    }
 }

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -116,9 +116,12 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(in_array($result['headers']['Content-Type'], array('application/zip', 'application/x-zip-compressed')));
     }
 
-    public function testHttpsWorksWithValidCertificate()
+    /**
+     * @dataProvider getMethodsToTest
+     */
+    public function testHttpsWorksWithValidCertificate($method)
     {
-        $result = Http::sendHttpRequestBy('curl', 'https://builds.piwik.org/LATEST', 10);
+        $result = Http::sendHttpRequestBy($method, 'https://builds.piwik.org/LATEST', 10);
 
         $this->assertStringMatchesFormat('%d.%d.%d', $result);
     }
@@ -127,8 +130,26 @@ class HttpTest extends \PHPUnit_Framework_TestCase
      * @expectedException \Exception
      * @expectedExceptionMessage curl_exec: SSL certificate problem: Invalid certificate chain.
      */
-    public function testHttpsFailsWithInvalidCertificate()
+    public function testCurlHttpsFailsWithInvalidCertificate()
     {
         Http::sendHttpRequestBy('curl', 'https://divezone.net', 10);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Peer certificate CN=`*.piwik.org' did not match expected
+     */
+    public function testFopenHttpsFailsWithInvalidCertificate()
+    {
+        Http::sendHttpRequestBy('fopen', 'https://divezone.net', 10);
+    }
+
+    /**
+     * We check that HTTPS is not supported with the "socket" method
+     */
+    public function testSocketHttpsWorksEvenWithInvalidCertificate()
+    {
+        $result = Http::sendHttpRequestBy('socket', 'https://divezone.net', 10);
+        $this->assertNotEmpty($result);
     }
 }

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -116,14 +116,19 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(in_array($result['headers']['Content-Type'], array('application/zip', 'application/x-zip-compressed')));
     }
 
-    public function testHttps()
+    public function testHttpsWorksWithValidCertificate()
     {
-        $result = Http::sendHttpRequestBy(
-            'curl',
-            'https://builds.piwik.org/LATEST',
-            10
-        );
+        $result = Http::sendHttpRequestBy('curl', 'https://builds.piwik.org/LATEST', 10);
 
         $this->assertStringMatchesFormat('%d.%d.%d', $result);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage curl_exec: SSL certificate problem: Invalid certificate chain.
+     */
+    public function testHttpsFailsWithInvalidCertificate()
+    {
+        Http::sendHttpRequestBy('curl', 'https://divezone.net', 10);
     }
 }

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -128,7 +128,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage curl_exec: SSL certificate problem: Invalid certificate chain.
+     * @expectedExceptionMessage curl_exec: SSL certificate
      */
     public function testCurlHttpsFailsWithInvalidCertificate()
     {

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -128,7 +128,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage curl_exec: SSL certificate
+     * @expectedExceptionMessage curl_exec: SSL
      */
     public function testCurlHttpsFailsWithInvalidCertificate()
     {

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -137,7 +137,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage Peer certificate CN=`*.piwik.org' did not match expected
+     * @expectedExceptionMessage failed to open stream: operation failed
      */
     public function testFopenHttpsFailsWithInvalidCertificate()
     {


### PR DESCRIPTION
Fix for #6441

Piwik will update over HTTPS if supported by the system, else use HTTP. If using HTTPS, it will **not** fallback to HTTP (it would make HTTPS useless). HTTP is **only** used if a secure method (openssl/curl/fopen) is not supported.

| Method | Certificate | Result | Secure? | System check |
| --- | --- | --- | --- | --- |
| curl | valid | Success | yes | ok |
| curl | invalid | Error | yes | ok |
| curl + no openssl | valid or invalid | Success, using HTTP | **no** | warning |
| fopen | valid | Success | yes | ok |
| fopen | invalid | Error | yes | ok |
| fopen + no openssl | valid or invalid | Success, using HTTP | **no** | warning |
| socket | valid | Success | **no** | warning |
| socket | valid | Success | **no** | warning |
| socket + no openssl | valid or invalid | Success | **no** | warning |

**BC break?** I have removed the [`latest_version_url`](https://github.com/piwik/piwik/blob/master/config/global.ini.php#L468) option in `global.ini.php` because the URL can now be with or without HTTPS, and it wasn't consistent because the update URL for beta versions wasn't in the config. I don't think it's a BC break because that wasn't documented anywhere, and I doubt anybody would have any use for that…

TODO:
- [x] handle the case where trying to use fopen/curl but openssl is not installed ([see this](http://stackoverflow.com/questions/1975461/file-get-contents-with-https))
- [x] update the system check: fopen is now a valid method to update via HTTPS + check openssl is installed if fopen is used
- [x] fix tests ([see this](http://stackoverflow.com/questions/28802933/how-to-get-file-get-contents-warning-instead-of-the-php-error))
