### PR TITLE
fix various issues with user menu.

### DIFF
--- a/core/View.php
+++ b/core/View.php
@@ -221,6 +221,7 @@ class View implements ViewInterface
             $this->url = Common::sanitizeInputValue(Url::getCurrentUrl());
             $this->token_auth = Piwik::getCurrentUserTokenAuth();
             $this->userHasSomeAdminAccess = Piwik::isUserHasSomeAdminAccess();
+            $this->userIsAnonymous = Piwik::isUserIsAnonymous();
             $this->userIsSuperUser = Piwik::hasUserSuperUserAccess();
             $this->latest_version_available = UpdateCheck::isNewestVersionAvailable();
             $this->disableLink = Common::getRequestVar('disableLink', 0, 'int');

--- a/plugins/CoreAdminHome/Menu.php
+++ b/plugins/CoreAdminHome/Menu.php
@@ -57,14 +57,16 @@ class Menu extends \Piwik\Plugin\Menu
 
     public function configureUserMenu(MenuUser $menu)
     {
-        $menu->addManageItem('CoreAdminHome_TrackingCode',
-            $this->urlForAction('trackingCodeGenerator'),
-            $order = 10);
+        if (!Piwik::isUserIsAnonymous()) {
+            $menu->addManageItem('CoreAdminHome_TrackingCode',
+                $this->urlForAction('trackingCodeGenerator'),
+                $order = 10);
 
-        if (SettingsManager::hasUserPluginsSettingsForCurrentUser()) {
-            $menu->addPersonalItem('CoreAdminHome_PluginSettings',
-                $this->urlForAction('userPluginSettings'),
-                $order = 15);
+            if (SettingsManager::hasUserPluginsSettingsForCurrentUser()) {
+                $menu->addPersonalItem('CoreAdminHome_PluginSettings',
+                    $this->urlForAction('userPluginSettings'),
+                    $order = 15);
+            }
         }
     }
 

--- a/plugins/CoreHome/Menu.php
+++ b/plugins/CoreHome/Menu.php
@@ -12,6 +12,7 @@ use Piwik\Db;
 use Piwik\Menu\MenuTop;
 use Piwik\Menu\MenuUser;
 use Piwik\Piwik;
+use Piwik\Plugin;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 
 class Menu extends \Piwik\Plugin\Menu
@@ -25,7 +26,15 @@ class Menu extends \Piwik\Plugin\Menu
             $login = $user['alias'];
         }
 
-        $menu->addItem($login, null, array('module' => 'UsersManager', 'action' => 'userSettings'), 998);
+        if (Piwik::isUserIsAnonymous()) {
+            if (Plugin\Manager::getInstance()->isPluginActivated('Feedback')) {
+                $menu->addItem($login, null, array('module' => 'Feedback', 'action' => 'index'), 998);
+            } else {
+                $menu->addItem($login, null, array('module' => 'API', 'action' => 'listAllAPI'), 998);
+            }
+        } else {
+            $menu->addItem($login, null, array('module' => 'UsersManager', 'action' => 'userSettings'), 998);
+        }
 
         $module = $this->getLoginModule();
         if (Piwik::isUserIsAnonymous()) {

--- a/plugins/MobileMessaging/Menu.php
+++ b/plugins/MobileMessaging/Menu.php
@@ -23,6 +23,8 @@ class Menu extends \Piwik\Plugin\Menu
 
     public function configureUserMenu(MenuUser $menu)
     {
-        $menu->addPersonalItem('MobileMessaging_SettingsMenu', $this->urlForAction('userSettings'), $order = 12);
+        if (!Piwik::isUserIsAnonymous()) {
+            $menu->addPersonalItem('MobileMessaging_SettingsMenu', $this->urlForAction('userSettings'), $order = 12);
+        }
     }
 }

--- a/plugins/Morpheus/templates/user.twig
+++ b/plugins/Morpheus/templates/user.twig
@@ -5,8 +5,13 @@
 {% set bodyClass = postEvent('Template.bodyClass', 'admin') %}
 
 {% block body %}
-    {% set topMenuModule = 'UsersManager' %}
-    {% set topMenuAction = 'userSettings' %}
+    {% if userIsAnonymous %}
+        {% set topMenuModule = 'Feedback' %}
+        {% set topMenuAction = 'index' %}
+    {% else %}
+        {% set topMenuModule = 'UsersManager' %}
+        {% set topMenuAction = 'userSettings' %}
+    {% endif %}
     {{ parent() }}
 {% endblock %}
 


### PR DESCRIPTION
- When clicking on the anonymous user a login form was shown
- Some menu items were shown although the anonymous user has no access to it

We will now load the Help page when clicking on anonymous user name.
If the plugin Feedback is not activated we will open the API page since
this has to be activated. If Feedback plugin is disabled the anonymus user login
which will be a known issue but I think we can ignore this case.
