### PR TITLE
Fixed #6398 - probably fixed/worked-around by sorting

### DIFF
--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1356,6 +1356,7 @@ class Recorder(object):
     """
 
     recorders = []
+    hits_by_client = []
 
     def __init__(self):
         self.queue = Queue.Queue(maxsize=2)
@@ -1370,6 +1371,7 @@ class Recorder(object):
         Launch a bunch of Recorder objects in a separate thread.
         """
         for i in xrange(recorder_count):
+            cls.hits_by_client.append([])
             recorder = Recorder()
             cls.recorders.append(recorder)
 
@@ -1387,18 +1389,24 @@ class Recorder(object):
         """
         # Organize hits so that one client IP will always use the same queue.
         # We have to do this so visits from the same IP will be added in the right order.
-        hits_by_client = [[] for r in cls.recorders]
-        for hit in sorted(all_hits, key=lambda hit: hit.ip):
-            hits_by_client[hit.get_visitor_id_hash() % len(cls.recorders)].append(hit)
+        for hit in all_hits:
+            id = hit.get_visitor_id_hash() % len(cls.recorders)
+            cls.hits_by_client[id].append(hit)
 
-        for i, recorder in enumerate(cls.recorders):
-            recorder.queue.put(hits_by_client[i])
+            if( len(cls.hits_by_client[id]) >= config.options.recorder_max_payload_size ):
+                cls.recorders[id].queue.put(sorted(cls.hits_by_client[id], key=lambda hit: (hit.ip,hit.date)))
+                cls.hits_by_client[id] = []
+
 
     @classmethod
     def wait_empty(cls):
         """
         Wait until all recorders have an empty queue.
         """
+        for i, recorder in enumerate(cls.recorders):
+           recorder.queue.put(sorted(cls.hits_by_client[i], key=lambda hit: (hit.ip,hit.date)))
+           cls.hits_by_client[i] = []
+
         for recorder in cls.recorders:
             recorder._wait_empty()
 
@@ -1590,7 +1598,7 @@ class Hit(object):
             self.full_path = self.full_path.lower()
 
     def get_visitor_id_hash(self):
-        visitor_id = self.ip
+        visitor_id = self.user_agent
 
         if config.options.replay_tracking:
             for param_name_to_use in ['uid', 'cid', '_id', 'cip']:
@@ -2031,7 +2039,7 @@ class Parser(object):
 
             hits.append(hit)
 
-            if len(hits) >= config.options.recorder_max_payload_size * len(Recorder.recorders):
+            if len(hits) >= config.options.recorder_max_payload_size:
                 Recorder.add_hits(hits)
                 hits = []
 

--- a/misc/log-analytics/import_logs.py
+++ b/misc/log-analytics/import_logs.py
@@ -1388,7 +1388,7 @@ class Recorder(object):
         # Organize hits so that one client IP will always use the same queue.
         # We have to do this so visits from the same IP will be added in the right order.
         hits_by_client = [[] for r in cls.recorders]
-        for hit in all_hits:
+        for hit in sorted(all_hits, key=lambda hit: hit.ip):
             hits_by_client[hit.get_visitor_id_hash() % len(cls.recorders)].append(hit)
 
         for i, recorder in enumerate(cls.recorders):


### PR DESCRIPTION
please review.
small-scale test has finished without error.

Deadlock occurs because 
Thread A holds lock on row 1,5,8,9 and wants 20.
Thread B holds lock on 2,3,15,20,25 and wants 9.

this happens because the Hit Objects in Recorders are not ordered. 
So Thread B can get a lock on row 20, and want to "warp back" to 9,
while Thread A holds row 9  and wants to advance to row 20.

Solution:
Ordering ensures Thread B waits for lock release on row 9, without having row 20 already locked.
