### PR TITLE
Relax tmp/* permission to 0770 (solves #7354).

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -82,7 +82,6 @@ class Filesystem
     public static function mkdir($path)
     {
         if (!is_dir($path)) {
-            // the mode in mkdir is modified by the current umask
             @mkdir($path, self::getChmodForPath($path), $recursive = true);
         }
 
@@ -443,7 +442,7 @@ class Filesystem
         $pathIsTmp = StaticContainer::get('path.tmp');
         if (strpos($path, $pathIsTmp) === 0) {
             // tmp/* folder
-            return 0750;
+            return 0770;
         }
         // plugins/* and all others
         return 0755;


### PR DESCRIPTION
I am running piwik embedded into different virtual host, running as different users which are all members of a piwik group. This results in permission problems writing to tmp/\* files.

Commit 6c6e5e9d11cc29c17341bd2e181a73c29dae5e6d / #5034 overwrites the umask settings and restricts the group write permission.

Might no big problem to allow group members to write on directories which they can already read.
