### PR TITLE
FrontController refactoring

### DIFF
--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Http;
+
+use DI\FactoryInterface;
+use Exception;
+use Piwik\Plugin\Controller;
+use Piwik\Plugin\Report;
+use Piwik\Plugin\Widgets;
+use Piwik\Session;
+
+/**
+ * Resolves the controller that will handle the request.
+ *
+ * A controller is a PHP callable.
+ */
+class ControllerResolver
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $abstractFactory;
+
+    public function __construct(FactoryInterface $abstractFactory)
+    {
+        $this->abstractFactory = $abstractFactory;
+    }
+
+    /**
+     * @param string $module
+     * @param string|null $action
+     * @param array $parameters
+     * @throws Exception Controller not found.
+     * @return callable The controller is a PHP callable.
+     */
+    public function getController($module, $action, array &$parameters)
+    {
+        // Controller action
+        $controllerClass = $this->getControllerClass($module);
+        if (class_exists($controllerClass)) {
+            $controller = $this->createPluginController($controllerClass, $action);
+            if ($controller) {
+                return $controller;
+            }
+        }
+
+        // Widget action
+        $widget = Widgets::factory($module, $action);
+        if ($widget) {
+            return $this->createWidgetController($module, $action, $parameters);
+        }
+
+        // Report action
+        $report = Report::factory($module, $action);
+        if ($report) {
+            return $this->createReportController($module, $action, $parameters);
+        }
+
+        // Report menu action
+        if ($this->isReportMenuAction($action)) {
+            $controller = $this->createReportMenuController($module, $action, $parameters);
+            if ($controller) {
+                return $controller;
+            }
+        }
+
+        throw new Exception(sprintf("Action '%s' not found in the module '%s'", $action, $module));
+    }
+
+    private function getControllerClass($module)
+    {
+        return "Piwik\\Plugins\\$module\\Controller";
+    }
+
+    private function createPluginController($controllerClass, $action)
+    {
+        /** @var $controller Controller */
+        $controller = $this->abstractFactory->make($controllerClass);
+
+        $action = $action ?: $controller->getDefaultAction();
+
+        if (!is_callable(array($controller, $action))) {
+            return null;
+        }
+
+        return array($controller, $action);
+    }
+
+    private function createWidgetController($module, $action, array &$parameters)
+    {
+        $parameters['widgetModule'] = $module;
+        $parameters['widgetMethod'] = $action;
+
+        return array($this->abstractFactory->make('Piwik\Plugins\CoreHome\Controller'), 'renderWidget');
+    }
+
+    private function createReportController($module, $action, array &$parameters)
+    {
+        $parameters['reportModule'] = $module;
+        $parameters['reportAction'] = $action;
+
+        return array($this->abstractFactory->make('Piwik\Plugins\CoreHome\Controller'), 'renderReportWidget');
+    }
+
+    private function createReportMenuController($module, $action, array &$parameters)
+    {
+        $action = lcfirst(substr($action, 4)); // menuGetPageUrls => getPageUrls
+        $report = Report::factory($module, $action);
+
+        if ($report) {
+            $parameters['reportModule'] = $module;
+            $parameters['reportAction'] = $action;
+
+            return array($this->abstractFactory->make('Piwik\Plugins\CoreHome\Controller'), 'renderReportMenu');
+        }
+
+        return null;
+    }
+
+    private function isReportMenuAction($action)
+    {
+        $startsWithMenu = (Report::PREFIX_ACTION_IN_MENU === substr($action, 0, strlen(Report::PREFIX_ACTION_IN_MENU)));
+
+        return !empty($action) && $startsWithMenu;
+    }
+}

--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -51,9 +51,10 @@ class ControllerResolver
         }
 
         // Widget action
+        /** @var Widgets|null $widget */
         $widget = Widgets::factory($module, $action);
         if ($widget) {
-            return $this->createWidgetController($module, $action, $parameters);
+            return $this->createWidgetController($widget, $action, $parameters);
         }
 
         // Report action
@@ -92,10 +93,10 @@ class ControllerResolver
         return array($controller, $action);
     }
 
-    private function createWidgetController($module, $action, array &$parameters)
+    private function createWidgetController(Widgets $widget, $action, array &$parameters)
     {
-        $parameters['widgetModule'] = $module;
-        $parameters['widgetMethod'] = $action;
+        $parameters['widget'] = $widget;
+        $parameters['method'] = $action;
 
         return array($this->abstractFactory->make('Piwik\Plugins\CoreHome\Controller'), 'renderWidget');
     }

--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -60,7 +60,7 @@ class ControllerResolver
         // Report action
         $report = Report::factory($module, $action);
         if ($report) {
-            return $this->createReportController($module, $action, $parameters);
+            return $this->createReportController($report, $parameters);
         }
 
         // Report menu action
@@ -101,10 +101,9 @@ class ControllerResolver
         return array($this->abstractFactory->make('Piwik\Plugins\CoreHome\Controller'), 'renderWidget');
     }
 
-    private function createReportController($module, $action, array &$parameters)
+    private function createReportController(Report $report, array &$parameters)
     {
-        $parameters['reportModule'] = $module;
-        $parameters['reportAction'] = $action;
+        $parameters['report'] = $report;
 
         return array($this->abstractFactory->make('Piwik\Plugins\CoreHome\Controller'), 'renderReportWidget');
     }

--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -113,14 +113,13 @@ class ControllerResolver
         $action = lcfirst(substr($action, 4)); // menuGetPageUrls => getPageUrls
         $report = Report::factory($module, $action);
 
-        if ($report) {
-            $parameters['reportModule'] = $module;
-            $parameters['reportAction'] = $action;
-
-            return array($this->abstractFactory->make('Piwik\Plugins\CoreHome\Controller'), 'renderReportMenu');
+        if (!$report) {
+            return null;
         }
 
-        return null;
+        $parameters['report'] = $report;
+
+        return array($this->abstractFactory->make('Piwik\Plugins\CoreHome\Controller'), 'renderReportMenu');
     }
 
     private function isReportMenuAction($action)

--- a/core/Plugin/Widgets.php
+++ b/core/Plugin/Widgets.php
@@ -125,6 +125,7 @@ class Widgets
 
     /**
      * @ignore
+     * @return Widgets|null
      */
     public static function factory($module, $action)
     {

--- a/plugins/CoreHome/Controller.php
+++ b/plugins/CoreHome/Controller.php
@@ -69,21 +69,15 @@ class Controller extends \Piwik\Plugin\Controller
         }
 
         $menuTitle = $this->translator->translate($menuTitle);
-        $content   = $this->renderReportWidget($reportModule, $reportAction);
+        $content   = $this->renderReportWidget($report);
 
         return View::singleReport($menuTitle, $content);
     }
 
-    public function renderReportWidget($reportModule = null, $reportAction = null)
+    public function renderReportWidget(Report $report)
     {
         Piwik::checkUserHasSomeViewAccess();
         $this->checkSitePermission();
-
-        $report = Report::factory($reportModule, $reportAction);
-
-        if (empty($report)) {
-            throw new Exception($this->translator->translate('General_ExceptionReportNotFound'));
-        }
 
         $report->checkIsEnabled();
 

--- a/plugins/CoreHome/Controller.php
+++ b/plugins/CoreHome/Controller.php
@@ -90,17 +90,11 @@ class Controller extends \Piwik\Plugin\Controller
         return $report->render();
     }
 
-    public function renderWidget($widgetModule = null, $widgetAction = null)
+    public function renderWidget(PluginWidgets $widget, $method)
     {
         Piwik::checkUserHasSomeViewAccess();
 
-        $widget = PluginWidgets::factory($widgetModule, $widgetAction);
-
-        if (!empty($widget)) {
-            return $widget->$widgetAction();
-        }
-
-        throw new Exception($this->translator->translate('General_ExceptionWidgetNotFound'));
+        return $widget->$method();
     }
 
     function redirectToCoreHomeIndex()

--- a/plugins/CoreHome/Controller.php
+++ b/plugins/CoreHome/Controller.php
@@ -49,16 +49,10 @@ class Controller extends \Piwik\Plugin\Controller
         return 'redirectToCoreHomeIndex';
     }
 
-    public function renderReportMenu($reportModule = null, $reportAction = null)
+    public function renderReportMenu(Report $report)
     {
         Piwik::checkUserHasSomeViewAccess();
         $this->checkSitePermission();
-
-        $report = Report::factory($reportModule, $reportAction);
-
-        if (empty($report)) {
-            throw new Exception($this->translator->translate('General_ExceptionReportNotFound'));
-        }
 
         $report->checkIsEnabled();
 


### PR DESCRIPTION
This is a small refactoring: I have extracted code from the FrontController in order to simplify it.

I have followed Symfony's architecture by putting the code responsible to create the controllers in a ControllerResolver class. A controller is now a simple `callable` in the front controller.

Also that's minor but the report/widget classes where created 2-3 times, now there are created only once. I think in the future the `Widget::factory()`/`Report::factory()` static methods could be moved to the `ControllerResolver` so that widget and report classes are created by the container: that would allow to use dependency injection in them.

(if you want to see the diff, I think seeing each commit diff separately is easier)
