### PR TITLE
Fixed reversed report documentation

### DIFF
--- a/plugins/Actions/Reports/GetEntryPageTitles.php
+++ b/plugins/Actions/Reports/GetEntryPageTitles.php
@@ -24,7 +24,7 @@ class GetEntryPageTitles extends Base
 
         $this->dimension     = new EntryPageTitle();
         $this->name          = Piwik::translate('Actions_EntryPageTitles');
-        $this->documentation = Piwik::translate('Actions_ExitPageTitlesReportDocumentation', '<br />')
+        $this->documentation = Piwik::translate('Actions_EntryPageTitlesReportDocumentation', '<br />')
                              . ' ' . Piwik::translate('General_UsePlusMinusIconsDocumentation');
         $this->metrics = array('entry_nb_visits', 'entry_bounce_count');
         $this->processedMetrics = array(

--- a/plugins/Actions/Reports/GetExitPageTitles.php
+++ b/plugins/Actions/Reports/GetExitPageTitles.php
@@ -24,7 +24,7 @@ class GetExitPageTitles extends Base
 
         $this->dimension     = new ExitPageTitle();
         $this->name          = Piwik::translate('Actions_ExitPageTitles');
-        $this->documentation = Piwik::translate('Actions_EntryPageTitlesReportDocumentation', '<br />')
+        $this->documentation = Piwik::translate('Actions_ExitPageTitlesReportDocumentation', '<br />')
                              . ' ' . Piwik::translate('General_UsePlusMinusIconsDocumentation');
 
         $this->metrics = array('exit_nb_visits', 'nb_visits');


### PR DESCRIPTION
The documentation for Actions.getEntryPageTitles and Actions.getExitPageTitles in the Report Metadata API call were reversed. 
