### PR TITLE
Live.getCounters times out on very large instance

### DIFF
--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -66,7 +66,18 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
         $model = new Model();
-        return $model->queryCounters($idSite, $lastMinutes, $segment);
+
+        $visits = $model->getNumVisits($idSite, $lastMinutes, $segment);
+        $actions = $model->getNumActions($idSite, $lastMinutes, $segment);
+        $visitors = $model->getNumVisitors($idSite, $lastMinutes, $segment);
+        $conversions = $model->getNumVisitsConverted($idSite, $lastMinutes, $segment);
+
+        return array(array(
+            'visits' => $visits,
+            'actions' => $actions,
+            'visitors' => $visitors,
+            'visitsConverted' => $conversions,
+        ));
     }
 
     /**

--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -60,24 +60,33 @@ class API extends \Piwik\Plugin\API
      * @param int $idSite Id Site
      * @param int $lastMinutes Number of minutes to look back at
      * @param bool|string $segment
+     * @param array $hideColumns The columns to hide / not to request. Eg 'visits', 'actions', ...
      * @return array( visits => N, actions => M, visitsConverted => P )
      */
-    public function getCounters($idSite, $lastMinutes, $segment = false)
+    public function getCounters($idSite, $lastMinutes, $segment = false, $hideColumns = array())
     {
         Piwik::checkUserHasViewAccess($idSite);
         $model = new Model();
 
-        $visits = $model->getNumVisits($idSite, $lastMinutes, $segment);
-        $actions = $model->getNumActions($idSite, $lastMinutes, $segment);
-        $visitors = $model->getNumVisitors($idSite, $lastMinutes, $segment);
-        $conversions = $model->getNumVisitsConverted($idSite, $lastMinutes, $segment);
+        $counters = array();
 
-        return array(array(
-            'visits' => $visits,
-            'actions' => $actions,
-            'visitors' => $visitors,
-            'visitsConverted' => $conversions,
-        ));
+        if (!in_array('visits', $hideColumns)) {
+            $counters['visits'] = $model->getNumVisits($idSite, $lastMinutes, $segment);
+        }
+
+        if (!in_array('actions', $hideColumns)) {
+            $counters['actions'] = $model->getNumActions($idSite, $lastMinutes, $segment);
+        }
+
+        if (!in_array('visitors', $hideColumns)) {
+            $counters['visitors'] = $model->getNumVisitors($idSite, $lastMinutes, $segment);
+        }
+
+        if (!in_array('visitsConverted', $hideColumns)) {
+            $counters['visitsConverted'] = $model->getNumVisitsConverted($idSite, $lastMinutes, $segment);
+        }
+
+        return array($counters);
     }
 
     /**

--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -88,9 +88,9 @@ class Controller extends \Piwik\Plugin\Controller
     private function setCounters($view)
     {
         $segment = Request::getRawSegmentFromRequest();
-        $last30min = API::getInstance()->getCounters($this->idSite, $lastMinutes = 30, $segment, array('visitors', 'visitsConverted'));
+        $last30min = API::getInstance()->getCounters($this->idSite, $lastMinutes = 30, $segment, array('visits', 'actions'));
         $last30min = $last30min[0];
-        $today = API::getInstance()->getCounters($this->idSite, $lastMinutes = 24 * 60, $segment, array('visitors', 'visitsConverted'));
+        $today = API::getInstance()->getCounters($this->idSite, $lastMinutes = 24 * 60, $segment, array('visits', 'actions'));
         $today = $today[0];
         $view->visitorsCountHalfHour = $last30min['visits'];
         $view->visitorsCountToday = $today['visits'];

--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -88,9 +88,9 @@ class Controller extends \Piwik\Plugin\Controller
     private function setCounters($view)
     {
         $segment = Request::getRawSegmentFromRequest();
-        $last30min = API::getInstance()->getCounters($this->idSite, $lastMinutes = 30, $segment);
+        $last30min = API::getInstance()->getCounters($this->idSite, $lastMinutes = 30, $segment, array('visitors', 'visitsConverted'));
         $last30min = $last30min[0];
-        $today = API::getInstance()->getCounters($this->idSite, $lastMinutes = 24 * 60, $segment);
+        $today = API::getInstance()->getCounters($this->idSite, $lastMinutes = 24 * 60, $segment, array('visitors', 'visitsConverted'));
         $today = $today[0];
         $view->visitorsCountHalfHour = $last30min['visits'];
         $view->visitorsCountToday = $today['visits'];

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -248,7 +248,7 @@ class Model
             $idSite,
             $lastMinutes,
             $segment,
-            'COUNT(*)',
+            'COUNT(log_visit.visit_last_action_time)',
             'log_visit',
             'log_visit.visit_last_action_time >= ?'
         );

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -273,13 +273,6 @@ class Model
         );
     }
 
-    /**
-     * @param $idSite
-     * @param $lastMinutes
-     * @param $segment
-     * @return int
-     * @throws Exception
-     */
     private function getLastMinutesCounterForQuery($idSite, $lastMinutes, $segment, $select, $from, $where)
     {
         $lastMinutes = (int)$lastMinutes;

--- a/plugins/Live/Reports/GetSimpleLastVisitCount.php
+++ b/plugins/Live/Reports/GetSimpleLastVisitCount.php
@@ -30,7 +30,8 @@ class GetSimpleLastVisitCount extends Base
     {
         $lastMinutes = Config::getInstance()->General[Controller::SIMPLE_VISIT_COUNT_WIDGET_LAST_MINUTES_CONFIG_KEY];
 
-        $lastNData = Request::processRequest('Live.getCounters', array('lastMinutes' => $lastMinutes));
+        $params    = array('lastMinutes' => $lastMinutes, 'showColumns' => array('visits', 'visitors', 'actions'));
+        $lastNData = Request::processRequest('Live.getCounters', $params);
 
         $formatter = new Formatter();
 

--- a/plugins/Live/tests/System/APITest.php
+++ b/plugins/Live/tests/System/APITest.php
@@ -73,14 +73,33 @@ class APITest extends SystemTestCase
     public function test_GetCounters_ShouldHideAllColumnsIfRequested()
     {
         $exampleCounter = $this->buildCounter(0, 0, 0, 0);
-        $counters = $this->api->getCounters($this->idSite, 5, false, array_keys($exampleCounter[0]));
+        $counters = $this->api->getCounters($this->idSite, 5, false, array(), array_keys($exampleCounter[0]));
         $this->assertEquals(array(array()), $counters);
     }
 
     public function test_GetCounters_ShouldHideSomeColumnsIfRequested()
     {
-        $counters = $this->api->getCounters($this->idSite, 20, false, array('visitsConverted', 'visitors'));
+        $counters = $this->api->getCounters($this->idSite, 20, false, array(), array('visitsConverted', 'visitors'));
         $this->assertEquals(array(array('visits' => 24, 'actions' => 60)), $counters);
+    }
+
+    public function test_GetCounters_ShouldShowAllColumnsIfRequested()
+    {
+        $counter = $this->buildCounter(24, 60, 20, 40);
+        $counters = $this->api->getCounters($this->idSite, 20, false, array_keys($counter[0]));
+        $this->assertEquals($counter, $counters);
+    }
+
+    public function test_GetCounters_ShouldShowSomeColumnsIfRequested()
+    {
+        $counters = $this->api->getCounters($this->idSite, 20, false, array('visits', 'actions'));
+        $this->assertEquals(array(array('visits' => 24, 'actions' => 60)), $counters);
+    }
+
+    public function test_GetCounters_ShouldHideColumnIfGivenInShowAndHide()
+    {
+        $counters = $this->api->getCounters($this->idSite, 20, false, array('visits', 'actions'), array('actions'));
+        $this->assertEquals(array(array('visits' => 24)), $counters);
     }
 
     private function trackSomeVisits()

--- a/plugins/Live/tests/System/APITest.php
+++ b/plugins/Live/tests/System/APITest.php
@@ -70,6 +70,19 @@ class APITest extends SystemTestCase
         $this->assertEquals($this->buildCounter(0, 0, 0, 0), $counters);
     }
 
+    public function test_GetCounters_ShouldHideAllColumnsIfRequested()
+    {
+        $exampleCounter = $this->buildCounter(0, 0, 0, 0);
+        $counters = $this->api->getCounters($this->idSite, 5, false, array_keys($exampleCounter[0]));
+        $this->assertEquals(array(array()), $counters);
+    }
+
+    public function test_GetCounters_ShouldHideSomeColumnsIfRequested()
+    {
+        $counters = $this->api->getCounters($this->idSite, 20, false, array('visitsConverted', 'visitors'));
+        $this->assertEquals(array(array('visits' => 24, 'actions' => 60)), $counters);
+    }
+
     private function trackSomeVisits()
     {
         $nowTimestamp = time();


### PR DESCRIPTION
fixes #6758 

We do only display the number of visits and actions in the Real time widget so let's only request those. This should make it very fast as we can avoid the `visitors` counter which is slow. Eg the visitors counter takes a few seconds on many million rows whereas the `visits` counter standalone takes maybe `0.05` seconds if at all. If someone uses the API it will be still "slow" on a very large instance. 

Adding a separate query for `visits` and `visitors` shouldn't make a huge difference as the `visitors` one is so slow compared to the `visits` one.

In the actual "Live counter" widget we do only request the last 3 minutes were we shouldn't have any problem with the unique visitors counter as MYSQL will choose a different index automatically.

I added another tweak: If `visits` is `0` we can assume that all other counters are `0` as well so we do not execute any further query at all. We can assume this as we request the `last_action_time` so we should be sure there was no further action etc.
