### PR TITLE
Load translations in core\Console.php so translations are accessible to console commands.

### DIFF
--- a/core/Console.php
+++ b/core/Console.php
@@ -163,6 +163,7 @@ class Console extends Application
     public static function initPlugins()
     {
         Plugin\Manager::getInstance()->loadActivatedPlugins();
+        Plugin\Manager::getInstance()->loadPluginTranslations();
     }
 
     private function getDefaultPiwikCommands()


### PR DESCRIPTION
Translations were not accessible to core commands before this change, which may have caused issues in commands like `core:update`.
