### PR TITLE
Dependency injection in API classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
   * `isIpInRange()`
   * `getHostByAddr()`
 
+### Deprecations
+* `API` classes should no longer have a protected constructor. Classes with a protected constructor will generate a notice in the logs and should expose a public constructor instead.
+
+### New features
+* `API` classes can now use dependency injection in their constructor to inject other instances.
+
 ### New commands
 * There is now a command `core:purge-old-archive-data` that can be used to manually purge temporary, error-ed and invalidated archives from one or more archive tables.
 

--- a/core/Plugin/API.php
+++ b/core/Plugin/API.php
@@ -9,7 +9,8 @@
 
 namespace Piwik\Plugin;
 
-use Piwik\Singleton;
+use Piwik\Container\StaticContainer;
+use Psr\Log\LoggerInterface;
 
 /**
  * The base class of all API singletons.
@@ -39,7 +40,56 @@ use Piwik\Singleton;
  *
  * @api
  */
-abstract class API extends Singleton
+abstract class API
 {
-   
+    private static $instances;
+
+    /**
+     * Returns the singleton instance for the derived class. If the singleton instance
+     * has not been created, this method will create it.
+     *
+     * @return static
+     */
+    public static function getInstance() {
+        $class = get_called_class();
+
+        if (!isset(self::$instances[$class])) {
+            $container = StaticContainer::getContainer();
+
+            $refl = new \ReflectionClass($class);
+
+            if (!$refl->getConstructor() || $refl->getConstructor()->isPublic()) {
+                self::$instances[$class] = $container->get($class);
+            } else {
+                /** @var LoggerInterface $logger */
+                $logger = $container->get('Psr\Log\LoggerInterface');
+
+                // BC with API defining a protected constructor
+                $logger->notice('The API class {class} defines a protected constructor which is deprecated, make the constructor public instead', array('class' => $class));
+                self::$instances[$class] = new $class;
+            }
+        }
+
+        return self::$instances[$class];
+    }
+
+    /**
+     * Used in tests only
+     * @ignore
+     */
+    public static function unsetInstance()
+    {
+        $class = get_called_class();
+        unset(self::$instances[$class]);
+    }
+
+    /**
+     * Sets the singleton instance. For testing purposes.
+     * @ignore
+     */
+    public static function setSingletonInstance($instance)
+    {
+        $class = get_called_class();
+        self::$instances[$class] = $instance;
+    }
 }

--- a/core/Plugin/API.php
+++ b/core/Plugin/API.php
@@ -76,6 +76,7 @@ abstract class API
     /**
      * Used in tests only
      * @ignore
+     * @deprecated
      */
     public static function unsetInstance()
     {
@@ -86,6 +87,7 @@ abstract class API
     /**
      * Sets the singleton instance. For testing purposes.
      * @ignore
+     * @deprecated
      */
     public static function setSingletonInstance($instance)
     {

--- a/plugins/DBStats/API.php
+++ b/plugins/DBStats/API.php
@@ -13,12 +13,6 @@ use Piwik\DataTable;
 use Piwik\Piwik;
 
 /**
- *
- * @see plugins/DBStats/MySQLMetadataProvider.php
- */
-require_once PIWIK_INCLUDE_PATH . '/plugins/DBStats/MySQLMetadataProvider.php';
-
-/**
  * DBStats API is used to request the overall status of the Mysql tables in use by Piwik.
  * @hideExceptForSuperUser
  * @method static \Piwik\Plugins\DBStats\API getInstance()
@@ -30,12 +24,9 @@ class API extends \Piwik\Plugin\API
      */
     private $metadataProvider;
 
-    /**
-     * Constructor.
-     */
-    protected function __construct()
+    public function __construct(MySQLMetadataProvider $metadataProvider)
     {
-        $this->metadataProvider = new MySQLMetadataProvider();
+        $this->metadataProvider = $metadataProvider;
     }
 
     /**

--- a/plugins/Dashboard/API.php
+++ b/plugins/Dashboard/API.php
@@ -19,9 +19,9 @@ class API extends \Piwik\Plugin\API
 {
     private $dashboard = null;
 
-    protected function __construct()
+    public function __construct(Dashboard $dashboard)
     {
-        $this->dashboard = new Dashboard();
+        $this->dashboard = $dashboard;
     }
 
     /**

--- a/plugins/Insights/API.php
+++ b/plugins/Insights/API.php
@@ -39,11 +39,9 @@ class API extends \Piwik\Plugin\API
      */
     private $model;
 
-    protected function __construct()
+    public function __construct(Model $model)
     {
-        parent::__construct();
-
-        $this->model = new Model();
+        $this->model = $model;
     }
 
     private function getOverviewReports()

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -45,9 +45,9 @@ class API extends \Piwik\Plugin\API
 
     private static $instance = null;
 
-    protected function __construct()
+    public function __construct(Model $model)
     {
-        $this->model = new Model();
+        $this->model = $model;
     }
 
     /**
@@ -71,7 +71,7 @@ class API extends \Piwik\Plugin\API
             self::$instance = $instance;
             
         } catch (Exception $e) {
-            self::$instance = new self;
+            self::$instance = StaticContainer::get('Piwik\Plugins\UsersManager\API');
             StaticContainer::getContainer()->set('UsersManager_API', self::$instance);
         }
 


### PR DESCRIPTION
This introduces the ability to use dependency injection in API classes.

This also registers API classes in the container (so these classes can be injected), though they are still singletons. The problem is that the singleton pattern in Piwik also offers `unsetInstance()` and `setSingletonInstance()` and I think this would mess up with the container, but since those should only be used in tests (right?) we should be fine and be able to fix it easily.
