### PR TITLE
Dependency injection in widgets, menus, settings and tasks

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik;
 
+use Piwik\Container\StaticContainer;
 use Piwik\Plugin\Dependency;
 use Piwik\Plugin\MetadataLoader;
 
@@ -359,7 +360,7 @@ class Plugin
             $this->cache->save($cacheId, $classname);
         }
 
-        return new $classname;
+        return StaticContainer::get($classname);
     }
 
     public function findMultipleComponents($directoryWithinPlugin, $expectedSubclass)

--- a/core/Plugin/Menu.php
+++ b/core/Plugin/Menu.php
@@ -78,11 +78,12 @@ class Menu
      */
     protected function urlForAction($controllerAction, $additionalParams = array())
     {
-        $this->checkisValidCallable($this->getModule(), $controllerAction);
+        $module = $this->getModule();
+        $this->checkisValidCallable($module, $controllerAction);
 
         $params = (array) $additionalParams;
         $params['action'] = $controllerAction;
-        $params['module'] = $this->getModule();
+        $params['module'] = $module;
 
         return $params;
     }

--- a/core/Plugin/Menu.php
+++ b/core/Plugin/Menu.php
@@ -30,16 +30,6 @@ use Piwik\Plugins\UsersManager\UserPreferences;
  */
 class Menu
 {
-    protected $module = '';
-
-    /**
-     * @ignore
-     */
-    public function __construct()
-    {
-        $this->module = $this->getModule();
-    }
-
     private function getModule()
     {
         $className = get_class($this);
@@ -69,7 +59,7 @@ class Menu
     {
         $params = (array) $additionalParams;
         $params['action'] = '';
-        $params['module'] = $this->module;
+        $params['module'] = $this->getModule();
 
         return $params;
     }
@@ -88,11 +78,11 @@ class Menu
      */
     protected function urlForAction($controllerAction, $additionalParams = array())
     {
-        $this->checkisValidCallable($this->module, $controllerAction);
+        $this->checkisValidCallable($this->getModule(), $controllerAction);
 
         $params = (array) $additionalParams;
         $params['action'] = $controllerAction;
-        $params['module'] = $this->module;
+        $params['module'] = $this->getModule();
 
         return $params;
     }

--- a/core/Plugin/Widgets.php
+++ b/core/Plugin/Widgets.php
@@ -25,16 +25,6 @@ class Widgets
     protected $category = '';
     protected $widgets  = array();
 
-    private $module = '';
-
-    /**
-     * @ignore
-     */
-    public function __construct()
-    {
-        $this->module = $this->getModule();
-    }
-
     /**
      * @ignore
      */
@@ -77,7 +67,7 @@ class Widgets
                                  'name'     => $name,
                                  'params'   => $parameters,
                                  'method'   => $method,
-                                 'module'   => $this->module);
+                                 'module'   => $this->getModule());
     }
 
     /**
@@ -182,7 +172,7 @@ class Widgets
             return;
         }
 
-        $controllerClass = '\\Piwik\\Plugins\\' . $this->module . '\\Controller';
+        $controllerClass = 'Piwik\\Plugins\\' . $this->getModule() . '\\Controller';
 
         if (!Development::methodExists($this, $method) &&
             !Development::methodExists($controllerClass, $method)) {

--- a/plugins/CoreHome/Widgets.php
+++ b/plugins/CoreHome/Widgets.php
@@ -10,11 +10,24 @@ namespace Piwik\Plugins\CoreHome;
 
 use Piwik\Common;
 use Piwik\Piwik;
+use Piwik\Translation\Translator;
 use Piwik\View;
 
 class Widgets extends \Piwik\Plugin\Widgets
 {
     protected $category = 'Example Widgets';
+
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    public function __construct(Translator $translator)
+    {
+        $this->translator = $translator;
+
+        parent::__construct();
+    }
 
     protected function init()
     {
@@ -31,7 +44,7 @@ class Widgets extends \Piwik\Plugin\Widgets
 
         if (Common::getRequestVar('widget', false)
             && Piwik::hasUserSuperUserAccess()) {
-            $view->footerMessage = Piwik::translate('CoreHome_OnlyForSuperUserAccess');
+            $view->footerMessage = $this->translator->translate('CoreHome_OnlyForSuperUserAccess');
         }
 
         return $view->render();
@@ -43,8 +56,8 @@ class Widgets extends \Piwik\Plugin\Widgets
     public function getPromoVideo()
     {
         $view = new View('@CoreHome/getPromoVideo');
-        $view->shareText     = Piwik::translate('CoreHome_SharePiwikShort');
-        $view->shareTextLong = Piwik::translate('CoreHome_SharePiwikLong');
+        $view->shareText     = $this->translator->translate('CoreHome_SharePiwikShort');
+        $view->shareTextLong = $this->translator->translate('CoreHome_SharePiwikLong');
         $view->promoVideoUrl = 'https://www.youtube.com/watch?v=OslfF_EH81g';
 
         return $view->render();

--- a/plugins/CoreHome/Widgets.php
+++ b/plugins/CoreHome/Widgets.php
@@ -25,8 +25,6 @@ class Widgets extends \Piwik\Plugin\Widgets
     public function __construct(Translator $translator)
     {
         $this->translator = $translator;
-
-        parent::__construct();
     }
 
     protected function init()


### PR DESCRIPTION
Allows to use dependency injection in widgets, menus, settings and tasks.

This PR contains an example in the `Piwik\Plugins\CoreHome\Widgets` class.
