### PR TITLE
Improve the "Device model" report by prefixing the model with the brand name

### DIFF
--- a/plugins/DevicesDetection/Archiver.php
+++ b/plugins/DevicesDetection/Archiver.php
@@ -25,7 +25,7 @@ class Archiver extends \Piwik\Plugin\Archiver
 
     const DEVICE_TYPE_FIELD = "config_device_type";
     const DEVICE_BRAND_FIELD = "config_device_brand";
-    const DEVICE_MODEL_FIELD = "config_device_model";
+    const DEVICE_MODEL_FIELD = "CONCAT(log_visit.config_device_brand, ';', log_visit.config_device_model)";
     const OS_FIELD = "config_os";
     const OS_VERSION_FIELD = "CONCAT(log_visit.config_os, ';', COALESCE(log_visit.config_os_version, ''))";
     const BROWSER_FIELD = "config_browser_name";

--- a/plugins/DevicesDetection/Columns/DeviceModel.php
+++ b/plugins/DevicesDetection/Columns/DeviceModel.php
@@ -34,9 +34,6 @@ class DeviceModel extends Base
         $userAgent = $request->getUserAgent();
         $parser    = $this->getUAParser($userAgent);
 
-        $brand = $parser->getBrandName();
-        $brand = $brand ? $brand . ' - ' : '';
-
-        return $brand . $parser->getModel();
+        return $parser->getModel();
     }
 }

--- a/plugins/DevicesDetection/Columns/DeviceModel.php
+++ b/plugins/DevicesDetection/Columns/DeviceModel.php
@@ -34,6 +34,9 @@ class DeviceModel extends Base
         $userAgent = $request->getUserAgent();
         $parser    = $this->getUAParser($userAgent);
 
-        return $parser->getModel();
+        $brand = $parser->getBrandName();
+        $brand = $brand ? $brand . ' - ' : '';
+
+        return $brand . $parser->getModel();
     }
 }

--- a/plugins/DevicesDetection/functions.php
+++ b/plugins/DevicesDetection/functions.php
@@ -179,10 +179,19 @@ function getDeviceTypeLogo($label)
 
 function getModelName($label)
 {
-    if (!$label) {
-        return Piwik::translate('General_Unknown');
+    if (strpos($label, ';') !== false) {
+        list($brand, $model) = explode(';', $label, 2);
+    } else {
+        $brand = null;
+        $model = $label;
     }
-    return $label;
+    if (!$model) {
+        $model = Piwik::translate('General_Unknown');
+    }
+    if (!$brand) {
+        return $model;
+    }
+    return getDeviceBrandLabel($brand) . ' - ' . $model;
 }
 
 function getOSFamilyFullName($label)

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getModel_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getModel_month.xml
@@ -12,7 +12,7 @@
 		<sum_daily_nb_users>1</sum_daily_nb_users>
 	</row>
 	<row>
-		<label>Vision</label>
+		<label>HTC - Vision</label>
 		<nb_visits>2</nb_visits>
 		<nb_actions>2</nb_actions>
 		<max_actions>1</max_actions>
@@ -23,7 +23,7 @@
 		<sum_daily_nb_users>0</sum_daily_nb_users>
 	</row>
 	<row>
-		<label>GALAXY S5</label>
+		<label>Samsung - GALAXY S5</label>
 		<nb_visits>1</nb_visits>
 		<nb_actions>3</nb_actions>
 		<max_actions>3</max_actions>


### PR DESCRIPTION
References #6933 

E.g. _'iPad'_ would become _'Apple - iPad'_ in the **Device model** report.

This was the occasion for me to dive a bit into the reports (still very confused) so this is just a try. I'm not sure it's a really good implementation because it would break the continuity with previous reports.

Feedback appreciated, maybe there's a way to concatenate the brand and model name when generating the report (so that we keep continuity with previous reports). I couldn't succeed in doing that because I couldn't find any link between brands and models… E.g. how do I retrieve "Apple" when I have "iPad"…
