### PR TITLE
Faster Sort filter (requires PHP 5.4)

### DIFF
--- a/core/API/DataTableGenericFilter.php
+++ b/core/API/DataTableGenericFilter.php
@@ -88,6 +88,9 @@ class DataTableGenericFilter
                   array(
                       'filter_sort_column' => array('string'),
                       'filter_sort_order'  => array('string', 'desc'),
+                      $naturalSort = true,
+                      $recursiveSort = false,
+                      $doSortBySecondaryColumn = true
                   )),
             array('Truncate',
                   array(
@@ -133,22 +136,26 @@ class DataTableGenericFilter
             }
 
             foreach ($filterParams as $name => $info) {
-                // parameter type to cast to
-                $type = $info[0];
+                if (!is_array($info)) {
+                    $filterParameters[] = $info; // hard coded value that cannot be changed via API
+                } else {
+                    // parameter type to cast to
+                    $type = $info[0];
 
-                // default value if specified, when the parameter doesn't have a value
-                $defaultValue = null;
-                if (isset($info[1])) {
-                    $defaultValue = $info[1];
-                }
+                    // default value if specified, when the parameter doesn't have a value
+                    $defaultValue = null;
+                    if (isset($info[1])) {
+                        $defaultValue = $info[1];
+                    }
 
-                try {
-                    $value = Common::getRequestVar($name, $defaultValue, $type, $this->request);
-                    settype($value, $type);
-                    $filterParameters[] = $value;
-                } catch (Exception $e) {
-                    $exceptionRaised = true;
-                    break;
+                    try {
+                        $value = Common::getRequestVar($name, $defaultValue, $type, $this->request);
+                        settype($value, $type);
+                        $filterParameters[] = $value;
+                    } catch (Exception $e) {
+                        $exceptionRaised = true;
+                        break;
+                    }
                 }
             }
 

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -814,6 +814,14 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     }
 
     /**
+     * @ignore
+     */
+    public function getRowsCountWithoutSummaryRow()
+    {
+        return count($this->rows);
+    }
+
+    /**
      * Returns an array containing all column values for the requested column.
      *
      * @param string $name The column name.

--- a/core/DataTable/Filter/Sort.php
+++ b/core/DataTable/Filter/Sort.php
@@ -13,6 +13,7 @@ use Piwik\DataTable\Row;
 use Piwik\DataTable\Simple;
 use Piwik\DataTable;
 use Piwik\Metrics;
+use Piwik\Metrics\Sorter;
 
 /**
  * Sorts a {@link DataTable} based on the value of a specific column.
@@ -21,11 +22,11 @@ use Piwik\Metrics;
  *
  * @api
  */
-class
-Sort extends BaseFilter
+class Sort extends BaseFilter
 {
     protected $columnToSort;
     protected $order;
+    protected $naturalSort;
 
     /**
      * Constructor.
@@ -45,151 +46,8 @@ Sort extends BaseFilter
         }
 
         $this->columnToSort = $columnToSort;
-        $this->naturalSort  = $naturalSort;
-        $this->setOrder($order);
-    }
-
-    /**
-     * Updates the order
-     *
-     * @param string $order asc|desc
-     */
-    public function setOrder($order)
-    {
-        if ($order == 'asc') {
-            $this->order = 'asc';
-            $this->sign  = 1;
-        } else {
-            $this->order = 'desc';
-            $this->sign  = -1;
-        }
-    }
-
-    /**
-     * Sorting method used for sorting numbers
-     *
-     * @param Row $a
-     * @param Row $b
-     * @return int
-     */
-    public function numberSort($rowA, $rowB)
-    {
-        if (isset($rowA[0]) && isset($rowB[0])) {
-            if ($rowA[0] != $rowB[0] || !isset($rowA[1])) {
-                return $this->sign * ($rowA[0] < $rowB[0] ? -1 : 1);
-            } else {
-                return -1 * $this->sign * strnatcasecmp($rowA[1], $rowB[1]);
-            }
-        } elseif (!isset($rowB[0])) {
-            return -1;
-        } elseif (!isset($rowA[0])) {
-            return 1;
-        }
-
-        return 0;
-    }
-
-    /**
-     * Sorting method used for sorting values natural
-     *
-     * @param mixed $a
-     * @param mixed $b
-     * @return int
-     */
-    function naturalSort($rowA, $rowB)
-    {
-        $valA = $rowA[0];
-        $valB = $rowB[0];
-
-        return !isset($valA)
-        && !isset($valB)
-            ? 0
-            : (!isset($valA)
-                ? 1
-                : (!isset($valB)
-                    ? -1
-                    : $this->sign * strnatcasecmp(
-                        $valA,
-                        $valB
-                    )
-                )
-            );
-    }
-
-    /**
-     * Sorting method used for sorting values
-     *
-     * @param mixed $a
-     * @param mixed $b
-     * @return int
-     */
-    function sortString($rowA, $rowB)
-    {
-        $valA = $rowA[0];
-        $valB = $rowB[0];
-
-        return !isset($valA)
-        && !isset($valB)
-            ? 0
-            : (!isset($valA)
-                ? 1
-                : (!isset($valB)
-                    ? -1
-                    : $this->sign *
-                    strcasecmp($valA,
-                        $valB
-                    )
-                )
-            );
-    }
-
-    protected function getColumnValue(Row $row)
-    {
-        $value = $row->getColumn($this->columnToSort);
-
-        if ($value === false
-            || is_array($value)
-        ) {
-            return null;
-        }
-        return $value;
-    }
-
-    /**
-     * Sets the column to be used for sorting
-     *
-     * @param Row $row
-     * @return int
-     */
-    protected function selectColumnToSort($row)
-    {
-        $value = $row->getColumn($this->columnToSort);
-        if ($value !== false) {
-            return $this->columnToSort;
-        }
-
-        $columnIdToName = Metrics::getMappingFromNameToId();
-        // sorting by "nb_visits" but the index is Metrics::INDEX_NB_VISITS in the table
-        if (isset($columnIdToName[$this->columnToSort])) {
-            $column = $columnIdToName[$this->columnToSort];
-            $value = $row->getColumn($column);
-
-            if ($value !== false) {
-                return $column;
-            }
-        }
-
-        // eg. was previously sorted by revenue_per_visit, but this table
-        // doesn't have this column; defaults with nb_visits
-        $column = Metrics::INDEX_NB_VISITS;
-        $value = $row->getColumn($column);
-        if ($value !== false) {
-            return $column;
-        }
-
-        // even though this column is not set properly in the table,
-        // we select it for the sort, so that the table's internal state is set properly
-        return $this->columnToSort;
+        $this->naturalSort = $naturalSort;
+        $this->order = strtolower($order);
     }
 
     /**
@@ -208,74 +66,44 @@ Sort extends BaseFilter
             return;
         }
 
-        $rows = $table->getRows();
-        if (count($rows) == 0) {
+        if (!$table->getRowsCountWithoutSummaryRow()) {
             return;
         }
 
-        $row = current($rows);
+        $row = $table->getFirstRow();
+
         if ($row === false) {
             return;
         }
 
-        $this->columnToSort = $this->selectColumnToSort($row);
+        $config = new Sorter\Config();
+        $sorter = new Sorter($config);
 
-        $value = $row->getColumn($this->columnToSort);
-        if (is_numeric($value)) {
-            $methodToUse = "numberSort";
-        } else {
-            if ($this->naturalSort) {
-                $methodToUse = "naturalSort";
-            } else {
-                $methodToUse = "sortString";
-            }
-        }
+        $config->naturalSort = $this->naturalSort;
+        $config->primaryColumnToSort   = $sorter->getPrimaryColumnToSort($table, $this->columnToSort);
+        $config->primarySortOrder      = $sorter->getPrimarySortOrder($this->order);
+        $config->primarySortFlags      = $sorter->getBestSortFlags($table, $config->primaryColumnToSort);
+        $config->secondaryColumnToSort = $sorter->getSecondaryColumnToSort($row, $config->primaryColumnToSort);
+        $config->secondarySortOrder    = $sorter->getSecondarySortOrder($this->order, $config->secondaryColumnToSort);
+        $config->secondarySortFlags    = $sorter->getBestSortFlags($table, $config->secondaryColumnToSort);
 
-        $this->sort($table, $methodToUse);
+        $this->sort($sorter, $table);
     }
 
-    /**
-     * Sorts the DataTable rows using the supplied callback function.
-     *
-     * @param string $functionCallback A comparison callback compatible with {@link usort}.
-     * @param string $columnSortedBy The column name `$functionCallback` sorts by. This is stored
-     *                               so we can determine how the DataTable was sorted in the future.
-     */
-    private function sort(DataTable $table, $functionCallback)
+    private function sort(Sorter $sorter, DataTable $table)
     {
-        $table->setTableSortedBy($this->columnToSort);
-
-        $rows = $table->getRowsWithoutSummaryRow();
-
-        // get column value and label only once for performance tweak
-        $values = array();
-        foreach ($rows as $key => $row) {
-            $values[$key] = array($this->getColumnValue($row), $row->getColumn('label'));
-        }
-
-        uasort($values, array($this, $functionCallback));
-
-        $sortedRows = array();
-        foreach ($values as $key => $value) {
-            $sortedRows[$key] = $rows[$key];
-        }
-
-        $table->setRows(array_values($sortedRows));
-
-        unset($rows);
-        unset($sortedRows);
+        $sorter->sort($table);
 
         if ($table->isSortRecursiveEnabled()) {
             foreach ($table->getRows() as $row) {
-
                 $subTable = $row->getSubtable();
+
                 if ($subTable) {
                     $subTable->enableRecursiveSort();
-                    $this->sort($subTable, $functionCallback);
+                    $this->sort($sorter, $subTable);
                 }
             }
         }
-
     }
 
 }

--- a/core/Metrics/Sorter.php
+++ b/core/Metrics/Sorter.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Metrics;
+
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Metrics;
+use Piwik\Plugin\Metric;
+use Piwik\Plugin\Report;
+
+class Sorter
+{
+    /**
+     * @var Sorter\Config
+     */
+    private $config;
+
+    public function __construct(Sorter\Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Sorts the DataTable rows using the supplied callback function.
+     *
+     * @param DataTable $table The table to sort.
+     */
+    public function sort(DataTable $table)
+    {
+        // all that code is in here and not in separate methods for best performance. It does make a difference once
+        // php has to copy many (eg 50k) rows otherwise.
+
+        $table->setTableSortedBy($this->config->primaryColumnToSort);
+
+        $rows = $table->getRowsWithoutSummaryRow();
+
+        // we need to sort rows that have a value separately from rows that do not have a value since we always want
+        // to append rows that do not have a value at the end.
+        $rowsWithValues    = array();
+        $rowsWithoutValues = array();
+
+        $valuesToSort = array();
+        foreach ($rows as $key => $row) {
+            $value = $this->getColumnValue($row);
+            if (isset($value)) {
+                $valuesToSort[] = $value;
+                $rowsWithValues[] = $row;
+            } else {
+                $rowsWithoutValues[] = $row;
+            }
+        }
+
+        unset($rows);
+
+        if ($this->config->primarySortFlags === SORT_NUMERIC && $this->config->secondaryColumnToSort) {
+            // secondary sort should not be needed for all other sort flags (eg string/natural sort) as label is unique and would make it slower
+
+            $secondaryValues = array();
+            foreach ($rowsWithValues as $key => $row) {
+                $secondaryValues[$key] = $row->getColumn($this->config->secondaryColumnToSort);
+            }
+
+            array_multisort($valuesToSort, $this->config->primarySortOrder, $this->config->primarySortFlags, $secondaryValues, $this->config->secondarySortOrder, $this->config->secondarySortFlags, $rowsWithValues);
+
+            if (!empty($rowsWithoutValues)) {
+                $secondaryValues = array();
+                foreach ($rowsWithoutValues as $key => $row) {
+                    $secondaryValues[$key] = $row->getColumn($this->config->secondaryColumnToSort);
+                }
+
+                array_multisort($secondaryValues, $this->config->secondarySortOrder, $this->config->secondarySortFlags, $rowsWithoutValues);
+            }
+
+            unset($secondaryValues);
+
+        } else {
+            array_multisort($valuesToSort, $this->config->primarySortOrder, $this->config->primarySortFlags, $rowsWithValues);
+        }
+
+        foreach ($rowsWithoutValues as $row) {
+            $rowsWithValues[] = $row;
+        }
+
+        $table->setRows(array_values($rowsWithValues));
+    }
+
+    private function getColumnValue(Row $row)
+    {
+        $value = $row->getColumn($this->config->primaryColumnToSort);
+
+        if ($value === false || is_array($value)) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $order   'asc' or 'desc'
+     * @return int
+     */
+    public function getPrimarySortOrder($order)
+    {
+        if ($order === 'asc') {
+            return SORT_ASC;
+        }
+
+        return SORT_DESC;
+    }
+
+    /**
+     * @param string $order   'asc' or 'desc'
+     * @param string|int $secondarySortColumn  column name or column id
+     * @return int
+     */
+    public function getSecondarySortOrder($order, $secondarySortColumn)
+    {
+        if ($secondarySortColumn === 'label') {
+
+            $secondaryOrder = SORT_ASC;
+            if ($order === 'asc') {
+                $secondaryOrder = SORT_DESC;
+            }
+
+            return $secondaryOrder;
+        }
+
+        return $this->getPrimarySortOrder($order);
+    }
+
+    /**
+     * Detect the column to be used for sorting
+     *
+     * @param DataTable $table
+     * @param string|int $columnToSort  column name or column id
+     * @return int
+     */
+    public function getPrimaryColumnToSort(DataTable $table, $columnToSort)
+    {
+        // we fallback to nb_visits in case columnToSort does not exist
+        $columnsToCheck = array($columnToSort, 'nb_visits');
+
+        $row = $table->getFirstRow();
+
+        foreach ($columnsToCheck as $column) {
+            $column = Metric::getActualMetricColumn($table, $column);
+
+            if ($row->hasColumn($column)) {
+                // since getActualMetricColumn() returns a default value, we need to make sure it actually has that column
+                return $column;
+            }
+        }
+
+        return $columnToSort;
+    }
+
+    /**
+     * Detect the secondary sort column to be used for sorting
+     *
+     * @param Row $row
+     * @param int|string $primaryColumnToSort
+     * @return int
+     */
+    public function getSecondaryColumnToSort(Row $row, $primaryColumnToSort)
+    {
+        $defaultSecondaryColumn = array(Metrics::INDEX_NB_VISITS, 'nb_visits');
+
+        if (in_array($primaryColumnToSort, $defaultSecondaryColumn)) {
+            // if sorted by visits, then sort by label as a secondary column
+            $column = 'label';
+            $value  = $row->hasColumn($column);
+            if ($value !== false) {
+                return $column;
+            }
+
+            return null;
+        }
+
+        if ($primaryColumnToSort !== 'label') {
+            // we do not add this by default to make sure we do not sort by label as a first and secondary column
+            $defaultSecondaryColumn[] = 'label';
+        }
+
+        foreach ($defaultSecondaryColumn as $column) {
+            $value = $row->hasColumn($column);
+            if ($value !== false) {
+                return $column;
+            }
+        }
+    }
+
+    /**
+     * @param DataTable $table
+     * @param string|int $columnToSort  A column name or column id. Make sure that column actually exists in the row.
+     *                                  You might want to get a valid column via {@link getPrimaryColumnToSort()} or
+     *                                  {@link getSecondaryColumnToSort()}
+     * @return int
+     */
+    public function getBestSortFlags(DataTable $table, $columnToSort)
+    {
+        if ($columnToSort === 'label') {
+            return SORT_NATURAL | SORT_FLAG_CASE;
+        }
+
+        foreach ($table->getRows() as $row) {
+            $value = $row->getColumn($columnToSort);
+
+            if ($value !== false && $value !== null && !is_array($value)) {
+
+                if (is_numeric($value)) {
+                    $sortFlags = SORT_NUMERIC;
+                } else {
+                    if ($this->config->naturalSort) {
+                        $sortFlags = SORT_NATURAL | SORT_FLAG_CASE;
+                    } else {
+                        $sortFlags = SORT_STRING | SORT_FLAG_CASE;
+                    }
+                }
+
+                return $sortFlags;
+            }
+        }
+
+        return SORT_NATURAL | SORT_FLAG_CASE;
+    }
+
+
+}

--- a/core/Metrics/Sorter/Config.php
+++ b/core/Metrics/Sorter/Config.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Metrics\Sorter;
+
+class Config
+{
+    public $naturalSort = false;
+
+    public $primaryColumnToSort;
+    public $primarySortFlags;
+    public $primarySortOrder;
+
+    public $secondaryColumnToSort;
+    public $secondarySortOrder;
+    public $secondarySortFlags;
+
+}

--- a/core/Metrics/Sorter/Config.php
+++ b/core/Metrics/Sorter/Config.php
@@ -19,4 +19,6 @@ class Config
     public $secondarySortOrder;
     public $secondarySortFlags;
 
+    public $isSecondaryColumnSortEnabled = true;
+
 }

--- a/core/Plugin/Metric.php
+++ b/core/Plugin/Metric.php
@@ -179,16 +179,19 @@ abstract class Metric
      */
     public static function getActualMetricColumn(DataTable $table, $columnName, $mappingNameToId = null)
     {
-        if (empty($mappingIdToName)) {
-            $mappingNameToId = Metrics::getMappingFromNameToId();
+        $firstRow = $table->getFirstRow();
+
+        if (!empty($firstRow) && $firstRow->hasColumn($columnName) === false) {
+
+            if (empty($mappingIdToName)) {
+                $mappingNameToId = Metrics::getMappingFromNameToId();
+            }
+
+            if (array_key_exists($columnName, $mappingNameToId)) {
+                $columnName = $mappingNameToId[$columnName];
+            }
         }
 
-        $firstRow = $table->getFirstRow();
-        if (!empty($firstRow)
-            && $firstRow->getColumn($columnName) === false
-        ) {
-            $columnName = $mappingNameToId[$columnName];
-        }
         return $columnName;
     }
 }

--- a/tests/PHPUnit/Unit/DataTable/Filter/SortTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/SortTest.php
@@ -14,8 +14,10 @@ use Piwik\DataTable\Row;
 
 /**
  * @group DataTableTest
+ * @group Core
+ * @group sort
  */
-class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
+class SortTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testNormalSortDescending()
@@ -47,7 +49,6 @@ class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedOrder, $table->getColumn('label'));
     }
 
-
     public function testMissingColumnValuesShouldAppearLastAfterSortAsc()
     {
         $table = new DataTable();
@@ -61,10 +62,9 @@ class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
                                       )));
         $filter = new Sort($table, 'count', 'asc');
         $filter->filter($table);
-        $expectedOrder = array('nintendo', 'ask', 'amazing', 'nocolumnbis', 'nocolumn', 'summary');
+        $expectedOrder = array('nintendo', 'ask', 'nocolumnbis', 'nocolumn', 'amazing', 'summary');
         $this->assertEquals($expectedOrder, $table->getColumn('label'));
     }
-
 
     public function testMissingColumnValuesShouldAppearLastAfterSortDesc()
     {
@@ -83,8 +83,6 @@ class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test to sort by label
-     *
-     * @group Core
      */
     public function testFilterSortString()
     {
@@ -125,42 +123,78 @@ class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test to sort by visit
-     *
-     * @group Core
      */
     public function testFilterSortNumeric()
     {
-        $idcol = Row::COLUMNS;
-        $table = new DataTable();
+        $table = $this->createDataTable(array(
+            array('label' => 'google', 'nb_visits' => 897), //0
+            array('label' => 'ask', 'nb_visits' => -152), //1
+            array('label' => 'piwik', 'nb_visits' => 1.5), //2
+            array('label' => 'yahoo', 'nb_visits' => 154), //3
+            array('label' => 'amazon', 'nb_visits' => 30), //4
+            array('label' => '238949', 'nb_visits' => 0), //5
+            array('label' => 'Q*(%&*', 'nb_visits' => 1) //6
+        ));
+
         $rows = array(
-            array($idcol => array('label' => 'google', 'nb_visits' => 897)), //0
-            array($idcol => array('label' => 'ask', 'nb_visits' => -152)), //1
-            array($idcol => array('label' => 'piwik', 'nb_visits' => 1.5)), //2
-            array($idcol => array('label' => 'yahoo', 'nb_visits' => 154)), //3
-            array($idcol => array('label' => 'amazon', 'nb_visits' => 30)), //4
-            array($idcol => array('label' => '238949', 'nb_visits' => 0)), //5
-            array($idcol => array('label' => 'Q*(%&*', 'nb_visits' => 1)) //6
+            array('label' => 'ask', 'nb_visits' => -152), //1
+            array('label' => '238949', 'nb_visits' => 0), //5
+            array('label' => 'Q*(%&*', 'nb_visits' => 1), //6
+            array('label' => 'piwik', 'nb_visits' => 1.5), //2
+            array('label' => 'amazon', 'nb_visits' => 30), //4
+            array('label' => 'yahoo', 'nb_visits' => 154), //3
+            array('label' => 'google', 'nb_visits' => 897) //0
         );
-        $table->addRowsFromArray($rows);
-        $expectedtable = new DataTable();
-        $rows = array(
-            array($idcol => array('label' => 'ask', 'nb_visits' => -152)), //1
-            array($idcol => array('label' => '238949', 'nb_visits' => 0)), //5
-            array($idcol => array('label' => 'Q*(%&*', 'nb_visits' => 1)), //6
-            array($idcol => array('label' => 'piwik', 'nb_visits' => 1.5)), //2
-            array($idcol => array('label' => 'amazon', 'nb_visits' => 30)), //4
-            array($idcol => array('label' => 'yahoo', 'nb_visits' => 154)), //3
-            array($idcol => array('label' => 'google', 'nb_visits' => 897)) //0
-        );
-        $expectedtable->addRowsFromArray($rows);
-        $expectedtableReverse = new DataTable();
-        $expectedtableReverse->addRowsFromArray(array_reverse($rows));
+
+        $expectedtable = $this->createDataTable($rows);
+        $expectedtableReverse = $this->createDataTable(array_reverse($rows));
 
         $filter = new Sort($table, 'nb_visits', 'asc');
         $filter->filter($table);
         $this->assertTrue(DataTable::isEqual($table, $expectedtable));
 
         $filter = new Sort($table, 'nb_visits', 'desc');
+        $filter->filter($table);
+        $this->assertTrue(DataTable::isEqual($table, $expectedtableReverse));
+    }
+
+    /**
+     * Test to sort by visit
+     */
+    public function testFilterSortNumeric_withSecondaryColumnSortLabel()
+    {
+        $rows = array(
+            array('label' => 'google', 'nb_visits' => array()),
+            array('label' => 'ask', 'nb_visits' => false),
+            array('label' => 'piwik', 'nb_visits' => 143),
+            array('label' => 'yahoo', 'nb_visits' => 154),
+            array('label' => 'zzzzz', 'nb_visits' => false),
+            array('label' => 'amazon', 'nb_visits' => 154),
+            array('label' => '238949', 'nb_visits' => 154),
+            array('label' => 'Q*(%&*', 'nb_visits' => 1)
+        );
+        $table = $this->createDataTable($rows);
+
+        $rows = array(
+            array('label' => '238949', 'nb_visits' => 154),
+            array('label' => 'amazon', 'nb_visits' => 154),
+            array('label' => 'yahoo', 'nb_visits' => 154),
+            array('label' => 'piwik', 'nb_visits' => 143),
+            array('label' => 'Q*(%&*', 'nb_visits' => 1),
+            array('label' => 'ask', 'nb_visits' => false),
+            array('label' => 'google', 'nb_visits' => array()),
+            array('label' => 'zzzzz', 'nb_visits' => false)
+        );
+
+        $expectedtable        = $this->createDataTable($rows);
+        $expectedtableReverse = $this->createDataTable(array_reverse($rows));
+
+        $filter = new Sort($table, 'nb_visits', 'desc');
+        $filter->filter($table);
+
+        $this->assertTrue(DataTable::isEqual($table, $expectedtable));
+
+        $filter = new Sort($table, 'nb_visits', 'asc');
         $filter->filter($table);
         $this->assertTrue(DataTable::isEqual($table, $expectedtableReverse));
     }
@@ -179,5 +213,57 @@ class DataTable_Filter_SortTest extends \PHPUnit_Framework_TestCase
         $filter = new Sort($table, 'count_array', 'desc');
         $filter->filter($table);
         $this->assertTrue(DataTable::isEqual($tableOriginal, $table));
+    }
+
+
+    /**
+     * Test to sort by label
+     */
+    public function testFilter_shouldPickStringSearchEvenIfFirstLabelIsNumeric()
+    {
+        $table = $this->createDataTable(array(
+            array('label' => '238975247578949'),
+            array('label' => 'google'),
+            array('label' => '013494'),
+            array('label' => '9'),
+            array('label' => '999yahoo'),
+            array('label' => '494'),
+            array('label' => 'Q*(%&*("$&%*(&"$*")"))')
+        ));
+
+        $rows = array(
+            array('label' => '9'),
+            array('label' => '494'),
+            array('label' => '999yahoo'),
+            array('label' => '013494'),
+            array('label' => '238975247578949'),
+            array('label' => 'google'),
+            array('label' => 'Q*(%&*("$&%*(&"$*")"))')
+        );
+
+        $expectedtable = $this->createDataTable($rows);
+        $expectedtableReverse = $this->createDataTable(array_reverse($rows));
+
+        $filter = new Sort($table, 'label', 'asc', $natural = true);
+        $filter->filter($table);
+        $this->assertTrue(DataTable::isEqual($expectedtable, $table));
+
+        $filter = new Sort($table, 'label', 'desc');
+        $filter->filter($table);
+        $this->assertTrue(DataTable::isEqual($table, $expectedtableReverse));
+    }
+
+    private function createDataTable($rows)
+    {
+        $table = new DataTable();
+        foreach ($rows as $columns) {
+            $table->addRow($this->createRow($columns));
+        }
+        return $table;
+    }
+
+    private function createRow($columns)
+    {
+        return new Row(array(Row::COLUMNS => $columns));
     }
 }

--- a/tests/PHPUnit/Unit/DataTable/Filter/SortTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/SortTest.php
@@ -189,12 +189,12 @@ class SortTest extends \PHPUnit_Framework_TestCase
         $expectedtable        = $this->createDataTable($rows);
         $expectedtableReverse = $this->createDataTable(array_reverse($rows));
 
-        $filter = new Sort($table, 'nb_visits', 'desc');
+        $filter = new Sort($table, 'nb_visits', 'desc', $natural = true, $reverse = false, $secondaryColumn = true);
         $filter->filter($table);
 
         $this->assertTrue(DataTable::isEqual($table, $expectedtable));
 
-        $filter = new Sort($table, 'nb_visits', 'asc');
+        $filter = new Sort($table, 'nb_visits', 'asc', $natural = true, $reverse = false, $secondaryColumn = true);
         $filter->filter($table);
         $this->assertTrue(DataTable::isEqual($table, $expectedtableReverse));
     }

--- a/tests/PHPUnit/Unit/Metrics/SorterTest.php
+++ b/tests/PHPUnit/Unit/Metrics/SorterTest.php
@@ -1,0 +1,416 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\Unit\Metrics;
+
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\Metrics;
+use Piwik\Metrics\Sorter;
+use Piwik\Metrics\Sorter\Config;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
+
+/**
+ * @group Core
+ * @group sort
+ */
+class SorterTest extends UnitTestCase
+{
+    /**
+     * @var Sorter
+     */
+    private $sorter;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->config = new Config();
+        $this->config->primaryColumnToSort = 'nb_visits';
+        $this->config->primarySortOrder = SORT_DESC;
+        $this->config->primarySortFlags = SORT_NUMERIC;
+        $this->sorter = new Sorter($this->config);
+    }
+
+    public function test_getPrimarySortOrder_shouldReturnDescByDefault()
+    {
+        $this->assertSame(SORT_DESC, $this->sorter->getPrimarySortOrder(null));
+        $this->assertSame(SORT_DESC, $this->sorter->getPrimarySortOrder('whatever'));
+        $this->assertSame(SORT_DESC, $this->sorter->getPrimarySortOrder('desc'));
+    }
+
+    public function test_getPrimarySortOrder_shouldReturnAscIfRequestedLowerCase()
+    {
+        $this->assertSame(SORT_ASC, $this->sorter->getPrimarySortOrder('asc'));
+        $this->assertSame(SORT_DESC, $this->sorter->getPrimarySortOrder('AsC')); // we require 'asc' to be lowercase
+    }
+
+    public function test_getSecondarySortOrder_shouldReturnInvertedOrder_IfColumnIsLabel()
+    {
+        $this->assertSame(SORT_DESC, $this->sorter->getSecondarySortOrder('asc', 'label'));
+        $this->assertSame(SORT_ASC, $this->sorter->getSecondarySortOrder('whatever', 'label'));
+        $this->assertSame(SORT_ASC, $this->sorter->getSecondarySortOrder('desc', 'label'));
+        $this->assertSame(SORT_ASC, $this->sorter->getSecondarySortOrder('AsC', 'label'));
+    }
+    public function test_getPrimarySortOrder_shouldReturnDescByDefault_IfNotLabelColumnIsRequested()
+    {
+        $this->assertSame(SORT_DESC, $this->sorter->getSecondarySortOrder(null, 'nb_visits'));
+        $this->assertSame(SORT_DESC, $this->sorter->getSecondarySortOrder('whatever', 'nb_visits'));
+        $this->assertSame(SORT_DESC, $this->sorter->getSecondarySortOrder('desc', 'nb_visits'));
+    }
+
+    public function test_getSecondarySortOrder_shouldReturnAscIfRequestedLowerCase_IfNotLabelColumnIsRequested()
+    {
+        $this->assertSame(SORT_ASC, $this->sorter->getSecondarySortOrder('asc', 'nb_visits'));
+        $this->assertSame(SORT_DESC, $this->sorter->getSecondarySortOrder('AsC', 'nb_visits')); // we require 'asc' to be lowercase
+    }
+
+    /**
+     * @dataProvider getPrimaryColumnsToSort
+     */
+    public function test_getPrimaryColumnToSort_shouldPickCorrectPrimaryColumnAndMapMetricNameToIdIfNeededAndReverse($expectedUsedColumn, $columnToSortBy)
+    {
+        $table = $this->createDataTable(array(
+            array('label' => 'nintendo', 'nb_visits' => false, 'nb_hits' => 0, Metrics::INDEX_NB_VISITS_CONVERTED => false, Metrics::INDEX_BOUNCE_COUNT => 5)
+        ));
+
+        $this->assertSame($expectedUsedColumn, $this->sorter->getPrimaryColumnToSort($table, $columnToSortBy));
+    }
+
+    public function getPrimaryColumnsToSort()
+    {
+        return array(
+            array('nb_visits', 'nb_visits'), // it is present in the row and should be used even though the value is false
+            array('nb_hits', 'nb_hits'),      // it is present in the row and should be used even though the value is zero
+            array(Metrics::INDEX_NB_VISITS_CONVERTED, 'nb_visits_converted'), // the column name is not present but it should find the column id even though the value is false
+            array(Metrics::INDEX_NB_VISITS_CONVERTED, Metrics::INDEX_NB_VISITS_CONVERTED),  // if a column is present as id it should still be able to find it
+            array(Metrics::INDEX_BOUNCE_COUNT, 'bounce_count'),  // should resolve column name to id, column has a value
+            array(Metrics::INDEX_BOUNCE_COUNT, Metrics::INDEX_BOUNCE_COUNT), // should find a column with a value
+        );
+    }
+
+    public function test_getPrimaryColumnToSort_shouldFallbackToNbVisitsIfPossible()
+    {
+        $table = $this->createDataTable(array(
+            array('label' => 'nintendo', 'nb_visits' => false)
+        ));
+
+        $this->assertSame('nb_visits', $this->sorter->getPrimaryColumnToSort($table, 'any_random_column_that_doesnt_exist'));
+    }
+
+    public function test_getPrimaryColumnToSort_shouldFallbackToThePassedColumnNameIfColumnCannotBeFoundAndNbVisitsDoesNotExist()
+    {
+        $table = $this->createDataTable(array(array('label' => 'nintendo')));
+
+        $this->assertSame('any_random_column_that_doesnt_exist', $this->sorter->getPrimaryColumnToSort($table, 'any_random_column_that_doesnt_exist'));
+    }
+
+    public function test_getSecondaryColumnToSort_shouldNotFindASecondaryColumnToSort_IfSortedByLabelButNoVisitsColumnPresent()
+    {
+        $row = $this->createRow(array('label' => 'nintendo'));
+
+        $this->assertNull($this->sorter->getSecondaryColumnToSort($row, 'label'));
+    }
+
+    public function test_getSecondaryColumnToSort_shouldPreferVisitsColumn_IfColumnIsPresent_EvenIfValueIsFalse()
+    {
+        $row = $this->createRow(array('label' => 'nintendo', 'nb_visits' => false, 'nb_hits' => 10));
+
+        $this->assertSame('nb_visits', $this->sorter->getSecondaryColumnToSort($row, 'nb_hits'));
+        $this->assertSame('nb_visits', $this->sorter->getSecondaryColumnToSort($row, 'label'));
+    }
+
+    public function test_getSecondaryColumnToSort_shouldPreferVisitsColumn_IfColumnIsPresent_EvenIfVisitsColumnIsId()
+    {
+        $row = $this->createRow(array('label' => 'nintendo', Metrics::INDEX_NB_VISITS => false, 'nb_hits' => 10));
+
+        $this->assertSame(Metrics::INDEX_NB_VISITS, $this->sorter->getSecondaryColumnToSort($row, 'nb_hits'));
+        $this->assertSame(Metrics::INDEX_NB_VISITS, $this->sorter->getSecondaryColumnToSort($row, 'label'));
+    }
+
+    public function test_getSecondaryColumnToSort_shouldUseLabelColumn_IfColumnIsPresentButNotNbVisitsColumn()
+    {
+        $row = $this->createRow(array('label' => 'nintendo', 'nb_hits' => 10));
+
+        $this->assertSame('label', $this->sorter->getSecondaryColumnToSort($row, 'nb_hits'));
+    }
+
+    public function test_getSecondaryColumnToSort_shouldUseLabelColumn_IfPrimaryColumnIsNbVisitsColumn()
+    {
+        $row = $this->createRow(array('label' => 'nintendo', 'nb_visits' => 10));
+
+        $this->assertSame('label', $this->sorter->getSecondaryColumnToSort($row, 'nb_visits'));
+        $this->assertSame('label', $this->sorter->getSecondaryColumnToSort($row, Metrics::INDEX_NB_VISITS));
+    }
+
+    public function test_getSecondaryColumnToSort_shouldNotBeAbleToFallback_IfVisitsColumnIsUsedButThereIsNoLabelColumn()
+    {
+        $row = $this->createRow(array('nb_visits' => 10, 'nb_hits' => 10));
+
+        $this->assertNull($this->sorter->getSecondaryColumnToSort($row, 'nb_visits'));
+    }
+
+    public function test_getSecondaryColumnToSort_shouldUseVisitsAsSecondaryColumn_IfLabelIsUsedAsPrimaryColumn()
+    {
+        $row = $this->createRow(array('label' => 'nintendo', 'nb_visits' => false));
+
+        $this->assertSame('nb_visits', $this->sorter->getSecondaryColumnToSort($row, 'label'));
+    }
+
+    /**
+     * @dataProvider getLabelsForNaturalSortTest
+     */
+    public function test_getBestSortFlags_shouldAlwaysPickNaturalSortCaseInsensitive($label)
+    {
+        $this->config->naturalSort = false; // even if natural sort is not preferred it should be still used
+
+        $table = $this->createDataTable(array(array('label' => $label)));
+
+        $this->assertSame(SORT_NATURAL | SORT_FLAG_CASE, $this->sorter->getBestSortFlags($table, 'label'));
+    }
+
+    public function getLabelsForNaturalSortTest()
+    {
+        return array(array('nintendo'), array('2015'), array('240.4'), array(2015), array('/test'));
+    }
+
+    /**
+     * @dataProvider getColumnsForBestSortFlagsTest
+     */
+    public function test_getBestSortFlags($expectedSortFlags, $columnToReadFrom, $naturalSort = false)
+    {
+        $this->config->naturalSort = $naturalSort;
+
+        $table = $this->createDataTable(array(
+            array('label' => 'nintendo1', 'nb_visits' => false, 'nb_hits' => 0, Metrics::INDEX_NB_VISITS_CONVERTED => false, Metrics::INDEX_BOUNCE_COUNT => 5),
+            array('label' => 'nintendo2', 'nb_visits' => 100, 'nb_pageviews' => 100, Metrics::INDEX_NB_VISITS_CONVERTED => null, 'sum_visit_length' => '5.5s'),
+            array('label' => 'nintendo2', Metrics::INDEX_NB_VISITS_CONVERTED => array(), 'min_time_generation' => '5.5')
+        ));
+
+        $this->assertSame($expectedSortFlags, $this->sorter->getBestSortFlags($table, $columnToReadFrom));
+    }
+
+    /**
+     * @dataProvider getColumnsForBestSortFlagsTest
+     */
+    public function test_sort_shouldNotFailIfNoRowsAreSet()
+    {
+        $table = $this->createDataTable(array());
+
+        $this->sorter->sort($table);
+
+        $this->assertSame(0, $table->getRowsCount());
+    }
+
+    /**
+     * @dataProvider getColumnsForBestSortFlagsTest
+     */
+    public function test_sort_shouldSetTheSortedColumnNameOnTheTable()
+    {
+        $table = $this->createDataTable(array(array('nb_test' => 5)));
+        $this->config->primaryColumnToSort = 'nb_test';
+
+        $this->sorter->sort($table);
+
+        $this->assertSame('nb_test', $table->getSortedByColumnName());
+    }
+
+    /**
+     * @dataProvider getColumnsForBestSortFlagsTest
+     */
+    public function test_sort_shouldKeepTheAmountOfColumns()
+    {
+        $table = $this->createDataTableFromValues(array(5, null));
+        $table->addSummaryRow($this->createRow(array('nb_test' => 10)));
+
+        $this->sorter->sort($table);
+
+        $this->assertSame(3, $table->getRowsCount());
+        $this->assertSame(2, $table->getRowsCountWithoutSummaryRow());
+    }
+
+    /**
+     * @dataProvider getColumnsForBestSortFlagsTest
+     */
+    public function test_sort_shouldNotSortOrChangeTheSummaryRow()
+    {
+        $table = $this->createDataTableFromValues(array(5, null));
+        $table->addSummaryRow($this->createRow(array('nb_test' => 10)));
+
+        $this->sorter->sort($table);
+
+        $summaryRow = $table->getRowFromId(DataTable::ID_SUMMARY_ROW);
+
+        $this->assertSame(10, $summaryRow->getColumn('nb_test'));
+    }
+
+    public function test_sort_shouldSortNumeric_AndShouldAddEmptyValuesAlwaysAtTheEnd()
+    {
+        $table = $this->createDataTableFromValues(array(5, null, 61, array(), 10, false, 20, 15));
+
+        $this->config->primarySortFlags = SORT_NUMERIC;
+        $this->config->primarySortOrder = SORT_ASC;
+        $this->sorter->sort($table);
+
+        $expected = array(5, 10, 15, 20, 61, false, array(), false);
+        $this->assertExpectedRowsOrder($expected, $table);
+
+        $this->config->primarySortOrder = SORT_DESC;
+        $this->sorter->sort($table);
+
+        $expected = array(61, 20, 15, 10, 5, false, array(), false);
+        $this->assertExpectedRowsOrder($expected, $table);
+    }
+
+    public function test_sort_sortNatural_ShoudAddEmptyValuesAlwaysAtTheEnd()
+    {
+        $table = $this->createDataTableFromValues(array('nintendo', null, 'abc', array(), 'DeF', 'def', false, '1210', 'piwik'));
+
+        $this->config->primarySortFlags = SORT_NATURAL;
+        $this->config->primarySortOrder = SORT_ASC;
+        $this->sorter->sort($table);
+
+        $expected = array('1210', 'DeF', 'abc', 'def', 'nintendo', 'piwik', false, array(), false);
+        $this->assertExpectedRowsOrder($expected, $table);
+
+        $this->config->primarySortOrder = SORT_DESC;
+        $this->sorter->sort($table);
+
+        $expected = array('piwik', 'nintendo', 'def', 'abc', 'DeF', '1210', false, array(), false);
+        $this->assertExpectedRowsOrder($expected, $table);
+    }
+
+    public function test_sort_ShoudIgnoreASecondColumnSort_IfNotSortedNumeric()
+    {
+        $table = $this->createDataTableFromValues(array('abc', 'abc', 'abc', 'abc', 'abc'));
+
+        $this->config->primarySortFlags = SORT_NATURAL;
+        $this->config->secondaryColumnToSort = 'label';
+        $this->config->secondarySortOrder = SORT_ASC;
+        $this->sorter->sort($table);
+
+        // we make sure the labels order did not change neither when ASC nor DESC
+        $expected = array('My Label 0', 'My Label 1', 'My Label 2', 'My Label 3', 'My Label 4');
+        $this->assertExpectedRowsOrder($expected, $table, 'label');
+
+        $this->config->secondarySortOrder = SORT_DESC;
+        $this->sorter->sort($table);
+
+        $this->assertExpectedRowsOrder($expected, $table, 'label');
+    }
+
+    public function test_sort_ShoudIgnoreASecondColumnSort_IfSortIsNumericButNoSecondaryColumnIsSet()
+    {
+        $table = $this->createDataTableFromValues(array('abc', 'abc', 'abc', 'abc', 'abc'));
+
+        $this->config->primarySortFlags = SORT_NUMERIC;
+        $this->sorter->sort($table);
+
+        // we make sure the labels order did not change neither when ASC nor DESC
+        $expected = array('My Label 0', 'My Label 1', 'My Label 2', 'My Label 3', 'My Label 4');
+        $this->assertExpectedRowsOrder($expected, $table, 'label');
+
+        $this->config->secondarySortOrder = SORT_DESC;
+        $this->sorter->sort($table);
+
+        $this->assertExpectedRowsOrder($expected, $table, 'label');
+    }
+
+    public function test_sort_ShoudSortBySecondColumn_IfSortedNumeric()
+    {
+        $table = $this->createDataTableFromValues(array('abc', 'abc', 'abc', 'abc', 'abc'));
+
+        $this->config->primarySortFlags = SORT_NUMERIC;
+        $this->config->secondaryColumnToSort = 'label';
+        $this->config->secondarySortOrder = SORT_ASC;
+        $this->config->secondarySortFlags = SORT_NATURAL;
+
+        $this->sorter->sort($table);
+
+        // we make sure the labels order did not change neither when ASC nor DESC
+        $expected = array('My Label 0', 'My Label 1', 'My Label 2', 'My Label 3', 'My Label 4');
+        $this->assertExpectedRowsOrder($expected, $table, 'label');
+
+        $this->config->secondarySortOrder = SORT_DESC;
+        $this->sorter->sort($table);
+
+        $expected = array_reverse($expected);
+        $this->assertExpectedRowsOrder($expected, $table, 'label');
+    }
+
+    public function test_sort_ShoudSortEmptyValues_BySecondColumn_IfSortedNumeric()
+    {
+        $table = $this->createDataTableFromValues(array(null, null, null, null, null));
+
+        $this->config->primarySortFlags = SORT_NUMERIC;
+        $this->config->secondaryColumnToSort = 'label';
+        $this->config->secondarySortOrder = SORT_ASC;
+        $this->config->secondarySortFlags = SORT_NATURAL;
+
+        $this->sorter->sort($table);
+
+        // we make sure the labels order did not change neither when ASC nor DESC
+        $expected = array('My Label 0', 'My Label 1', 'My Label 2', 'My Label 3', 'My Label 4');
+        $this->assertExpectedRowsOrder($expected, $table, 'label');
+
+        $this->config->secondarySortOrder = SORT_DESC;
+        $this->sorter->sort($table);
+
+        $expected = array_reverse($expected);
+        $this->assertExpectedRowsOrder($expected, $table, 'label');
+    }
+
+    private function assertExpectedRowsOrder($expectedValuesOrder, $table, $column = 'nb_visits')
+    {
+        foreach ($table->getRows() as $index => $row) {
+            $this->assertSame($expectedValuesOrder[$index], $row->getColumn($column));
+        }
+    }
+
+    public function getColumnsForBestSortFlagsTest()
+    {
+        $defaultSortOrder = SORT_NATURAL | SORT_FLAG_CASE;
+        return array(
+            array(SORT_NUMERIC, 'nb_visits'), // should find a numeric value in the first row
+            array(SORT_NUMERIC, 'nb_pageviews'), // should find a numeric value in the second row
+            array($defaultSortOrder, Metrics::INDEX_NB_VISITS_CONVERTED), // should not find any value in any row and use default value
+            array(SORT_STRING | SORT_FLAG_CASE, 'sum_visit_length'), // it is not numeric so should use string as natural is disabled
+            array(SORT_NATURAL | SORT_FLAG_CASE, 'sum_visit_length', true), // it is not numeric but natural is preferred so should use natural sort
+            array(SORT_NUMERIC, 'min_time_generation') // value is a string but numeric so should use numeric
+        );
+    }
+
+    private function createDataTableFromValues($values)
+    {
+        $rows = array();
+        foreach ($values as $index => $value) {
+            $rows[] = array('nb_visits' => $value, 'label' => 'My Label ' . $index);
+        }
+
+        return $this->createDataTable($rows);
+    }
+
+    private function createDataTable($rows)
+    {
+        $table = new DataTable();
+        foreach ($rows as $columns) {
+            $table->addRow($this->createRow($columns));
+        }
+        return $table;
+    }
+
+    private function createRow($columns)
+    {
+        return new Row(array(Row::COLUMNS => $columns));
+    }
+
+}


### PR DESCRIPTION
Made sort much faster by using builtin php methods. Currently, we sort via `usort` in PHP. This is quite slow especially when we sort many rows, eg 25k rows or more. The time needed to sort depends a lot on the data, the column to sort, etc. that's why it is hard to say how much performance improvement we will gain. On 25k rows it can drop from eg before about 900ms to 500ms.

As I side effect I fixed many bugs that were in the previous sort filter implementation, the code is much better tested and it does now use a secondary column on nb_visits or label if possible. refs #7401 

Some of the fixed bugs include:
- We would pick wrong sorting algorithm if label is numeric. This is eg often the case when having labels like '2015' etc.
- We would pick wrong column to sort if first row of the table has a value `false` for the selected column.
- ...

We need to wait till we drop support for PHP 5.3 since the sort flags `SORT_NATURAL` and `SORT_FLAG_CASE` were added in PHP 5.4 which this pull request requires.

refs #4768
