### PR TITLE
Removed action attribute from login form

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -93,6 +93,7 @@ class Controller extends \Piwik\Plugin\Controller
     function login($messageNoAccess = null, $infoMessage = false)
     {
         $form = new FormLogin();
+        $form->removeAttribute('action'); // remove action attribute, otherwise hash part will be lost
         if ($form->validate()) {
             $nonce = $form->getSubmitValue('form_nonce');
             if (Nonce::verifyNonce('Login.login', $nonce)) {


### PR DESCRIPTION
See #7432 

Removed the action attribute from the login form. Without the attribute the browser will automatically use the current url. That also includes the hash, which we do not have available on server side.

It's quite a simple change. But I'm not sure if it opens up the form to any security attack.
