### PR TITLE
Test fixtures can set up DI config

### DIFF
--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -28,11 +28,17 @@ class ContainerFactory
     private $environment;
 
     /**
+     * @var array
+     */
+    private $definitions;
+
+    /**
      * @param string|null $environment Optional environment config to load.
      */
-    public function __construct($environment = null)
+    public function __construct($environment = null, array $definitions = array())
     {
         $this->environment = $environment;
+        $this->definitions = $definitions;
     }
 
     /**
@@ -68,6 +74,10 @@ class ContainerFactory
 
         // Environment config
         $this->addEnvironmentConfig($builder);
+
+        if (!empty($this->definitions)) {
+            $builder->addDefinitions($this->definitions);
+        }
 
         return $builder->build();
     }

--- a/core/Container/StaticContainer.php
+++ b/core/Container/StaticContainer.php
@@ -32,6 +32,13 @@ class StaticContainer
     private static $environment;
 
     /**
+     * Definitions to register in the container.
+     *
+     * @var array
+     */
+    private static $definitions = array();
+
+    /**
      * @return Container
      */
     public static function getContainer()
@@ -63,7 +70,7 @@ class StaticContainer
      */
     private static function createContainer()
     {
-        $containerFactory = new ContainerFactory(self::$environment);
+        $containerFactory = new ContainerFactory(self::$environment, self::$definitions);
         return $containerFactory->create();
     }
 
@@ -75,6 +82,11 @@ class StaticContainer
     public static function setEnvironment($environment)
     {
         self::$environment = $environment;
+    }
+
+    public static function addDefinitions(array $definitions)
+    {
+        self::$definitions = $definitions;
     }
 
     /**

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -882,4 +882,14 @@ class Fixture extends \PHPUnit_Framework_Assert
 
         return $result;
     }
+
+    /**
+     * Use this method to return custom container configuration that you want to apply for the tests.
+     *
+     * @return array
+     */
+    public function provideContainerConfig()
+    {
+        return array();
+    }
 }

--- a/tests/PHPUnit/TestingEnvironment.php
+++ b/tests/PHPUnit/TestingEnvironment.php
@@ -2,10 +2,12 @@
 
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Option;
 use Piwik\Plugin\Manager as PluginManager;
 use Piwik\DbHelper;
+use Piwik\Tests\Framework\Fixture;
 
 require_once PIWIK_INCLUDE_PATH . "/core/Config.php";
 
@@ -147,6 +149,19 @@ class Piwik_TestingEnvironment
         Config::setSingletonInstance(new Config(
             $testingEnvironment->configFileGlobal, $testingEnvironment->configFileLocal, $testingEnvironment->configFileCommon
         ));
+
+        // Apply DI config from the fixture
+        if ($testingEnvironment->fixtureClass) {
+            $fixtureClass = $testingEnvironment->fixtureClass;
+            if (class_exists($fixtureClass)) {
+                /** @var Fixture $fixture */
+                $fixture = new $fixtureClass;
+                $diConfig = $fixture->provideContainerConfig();
+                if (!empty($diConfig)) {
+                    StaticContainer::addDefinitions($diConfig);
+                }
+            }
+        }
 
         \Piwik\Cache\Backend\File::$invalidateOpCacheBeforeRead = true;
 

--- a/tests/lib/screenshot-testing/support/test-environment.js
+++ b/tests/lib/screenshot-testing/support/test-environment.js
@@ -153,6 +153,9 @@ TestingEnvironment.prototype.setupFixture = function (fixtureClass, done) {
         self.reload();
         self.addPluginOnCmdLineToTestEnv();
 
+        self.fixtureClass = fixtureClass;
+        self.save();
+
         console.log();
 
         if (code) {


### PR DESCRIPTION
In order to add tests for #7429 I added a way to provide DI configuration in test fixtures. This DI config is then applied to Piwik while running during the UI tests (like the "test environment" variables that allow to edit the INI config). That's really cool because then we can override any config/service to mock it.

Here is an example where I replace a service with a mock:

``` php
class FailUpdateHttpsFixture extends Fixture
{
    public function provideContainerConfig()
    {
        return array(
            'Piwik\Plugins\CoreUpdater\Updater' => \DI\object('Piwik\Plugins\CoreUpdater\Test\Mock\UpdaterMock'),
        );
    }
}
```

To provide DI config, a fixture has to implement `provideContainerConfig()` and return an array of config.
#7429 is based on this PR so it should be merged for 2.12 (and before #7429).
