### PR TITLE
Do not rename columns twice when aggregating dataTable records

### DIFF
--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -344,7 +344,10 @@ class ArchiveProcessor
         // By default we shall aggregate all sub-tables.
         $dataTable = $this->getArchive()->getDataTableExpanded($name, $idSubTable = null, $depth = null, $addMetadataSubtableId = false);
 
+        $columnsRenamed = false;
+
         if ($dataTable instanceof Map) {
+            $columnsRenamed = true;
             // see https://github.com/piwik/piwik/issues/4377
             $self = $this;
             $dataTable->filter(function ($table) use ($self, $columnsToRenameAfterAggregation) {
@@ -353,7 +356,11 @@ class ArchiveProcessor
         }
 
         $dataTable = $this->getAggregatedDataTableMap($dataTable, $columnsAggregationOperation);
-        $this->renameColumnsAfterAggregation($dataTable, $columnsToRenameAfterAggregation);
+
+        if (!$columnsRenamed) {
+            $this->renameColumnsAfterAggregation($dataTable, $columnsToRenameAfterAggregation);
+        }
+        
         return $dataTable;
     }
 


### PR DESCRIPTION
refs #4768 

We can assume that columns are already renamed if we have already renamed all columns of all dataTables in a map.

This saves 50-200ms when aggregating records (eg when range date is requested) per record. Depending on the dataTables can save even way more time or a bit less.

I just did some profiling on the demo database where the performance benefit is > 1 second (out of 26 seconds total time)
