### PR TITLE
Fix Sort filters are sometimes applied multiple times

### DIFF
--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -207,7 +207,7 @@ class DataTablePostProcessor
         if (0 == Common::getRequestVar('disable_generic_filters', '0', 'string', $this->request)) {
             $this->applyProcessedMetricsGenericFilters($dataTable);
 
-            $genericFilter = new DataTableGenericFilter($this->request);
+            $genericFilter = new DataTableGenericFilter($this->request, $this->report);
 
             $self = $this;
             $report = $this->report;

--- a/core/DataTable/Filter/Sort.php
+++ b/core/DataTable/Filter/Sort.php
@@ -163,8 +163,8 @@ Sort extends BaseFilter
      */
     protected function selectColumnToSort($row)
     {
-        $value = $row->getColumn($this->columnToSort);
-        if ($value !== false) {
+        $value = $row->hasColumn($this->columnToSort);
+        if ($value) {
             return $this->columnToSort;
         }
 
@@ -172,9 +172,9 @@ Sort extends BaseFilter
         // sorting by "nb_visits" but the index is Metrics::INDEX_NB_VISITS in the table
         if (isset($columnIdToName[$this->columnToSort])) {
             $column = $columnIdToName[$this->columnToSort];
-            $value = $row->getColumn($column);
+            $value = $row->hasColumn($column);
 
-            if ($value !== false) {
+            if ($value) {
                 return $column;
             }
         }
@@ -182,8 +182,8 @@ Sort extends BaseFilter
         // eg. was previously sorted by revenue_per_visit, but this table
         // doesn't have this column; defaults with nb_visits
         $column = Metrics::INDEX_NB_VISITS;
-        $value = $row->getColumn($column);
-        if ($value !== false) {
+        $value = $row->hasColumn($column);
+        if ($value) {
             return $column;
         }
 
@@ -220,8 +220,9 @@ Sort extends BaseFilter
 
         $this->columnToSort = $this->selectColumnToSort($row);
 
-        $value = $row->getColumn($this->columnToSort);
-        if (is_numeric($value)) {
+        $value = $this->getFirstValueFromDataTable($table);
+
+        if (is_numeric($value) && $this->columnToSort !== 'label') {
             $methodToUse = "numberSort";
         } else {
             if ($this->naturalSort) {
@@ -232,6 +233,16 @@ Sort extends BaseFilter
         }
 
         $this->sort($table, $methodToUse);
+    }
+
+    private function getFirstValueFromDataTable($table)
+    {
+        foreach ($table->getRows() as $row) {
+            $value = $this->getColumnValue($row);
+            if (!is_null($value)) {
+                return $value;
+            }
+        }
     }
 
     /**

--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -189,6 +189,13 @@ class Report
     protected $recursiveLabelSeparator = ' - ';
 
     /**
+     * Default sort column. Either a column name or a column id.
+     *
+     * @var string|int
+     */
+    protected $defaultSortColumn = '';
+
+    /**
      * @var array
      * @ignore
      */
@@ -576,6 +583,14 @@ class Report
         $report['order'] = $this->order;
 
         return $report;
+    }
+
+    /**
+     * @ignore
+     */
+    public function getDefaultSortColumn()
+    {
+        return $this->defaultSortColumn;
     }
 
     /**

--- a/plugins/DevicePlugins/API.php
+++ b/plugins/DevicePlugins/API.php
@@ -32,7 +32,6 @@ class API extends \Piwik\Plugin\API
         Piwik::checkUserHasViewAccess($idSite);
         $archive = Archive::build($idSite, $period, $date, $segment);
         $dataTable = $archive->getDataTable($name);
-        $dataTable->filter('Sort', array(Metrics::INDEX_NB_VISITS));
         $dataTable->queueFilter('ReplaceColumnNames');
         $dataTable->queueFilter('ReplaceSummaryRowLabel');
         return $dataTable;

--- a/plugins/DevicePlugins/Reports/Base.php
+++ b/plugins/DevicePlugins/Reports/Base.php
@@ -13,6 +13,8 @@ use Piwik\Plugins\CoreVisualizations\Visualizations\Graph;
 
 abstract class Base extends \Piwik\Plugin\Report
 {
+    protected $defaultSortColumn = 'nb_visits';
+
     protected function init()
     {
         $this->category = 'General_VisitorSettings';

--- a/plugins/DevicesDetection/API.php
+++ b/plugins/DevicesDetection/API.php
@@ -34,7 +34,6 @@ class API extends \Piwik\Plugin\API
         Piwik::checkUserHasViewAccess($idSite);
         $archive = Archive::build($idSite, $period, $date, $segment);
         $dataTable = $archive->getDataTable($name);
-        $dataTable->filter('Sort', array(Metrics::INDEX_NB_VISITS));
         $dataTable->queueFilter('ReplaceColumnNames');
         $dataTable->queueFilter('ReplaceSummaryRowLabel');
         return $dataTable;

--- a/plugins/DevicesDetection/Reports/Base.php
+++ b/plugins/DevicesDetection/Reports/Base.php
@@ -8,8 +8,12 @@
  */
 namespace Piwik\Plugins\DevicesDetection\Reports;
 
+use Piwik\Metrics;
+
 abstract class Base extends \Piwik\Plugin\Report
 {
+    protected $defaultSortColumn = 'nb_visits';
+
     protected function init()
     {
         $this->category = 'DevicesDetection_DevicesDetection';

--- a/plugins/Resolution/API.php
+++ b/plugins/Resolution/API.php
@@ -28,7 +28,6 @@ class API extends \Piwik\Plugin\API
         Piwik::checkUserHasViewAccess($idSite);
         $archive = Archive::build($idSite, $period, $date, $segment);
         $dataTable = $archive->getDataTable($name);
-        $dataTable->filter('Sort', array(Metrics::INDEX_NB_VISITS));
         $dataTable->queueFilter('ReplaceColumnNames');
         $dataTable->queueFilter('ReplaceSummaryRowLabel');
         return $dataTable;

--- a/plugins/Resolution/Reports/Base.php
+++ b/plugins/Resolution/Reports/Base.php
@@ -13,6 +13,8 @@ use Piwik\Plugins\CoreVisualizations\Visualizations\Graph;
 
 abstract class Base extends \Piwik\Plugin\Report
 {
+    protected $defaultSortColumn = 'nb_visits';
+
     protected function init()
     {
         $this->category = 'General_VisitorSettings';

--- a/plugins/UserCountry/API.php
+++ b/plugins/UserCountry/API.php
@@ -203,7 +203,6 @@ class API extends \Piwik\Plugin\API
         Piwik::checkUserHasViewAccess($idSite);
         $archive = Archive::build($idSite, $period, $date, $segment);
         $dataTable = $archive->getDataTable($name);
-        $dataTable->filter('Sort', array(Metrics::INDEX_NB_VISITS));
         $dataTable->queueFilter('ReplaceColumnNames');
         return $dataTable;
     }

--- a/plugins/UserCountry/Reports/Base.php
+++ b/plugins/UserCountry/Reports/Base.php
@@ -15,6 +15,8 @@ use Piwik\Url;
 
 abstract class Base extends \Piwik\Plugin\Report
 {
+    protected $defaultSortColumn = 'nb_visits';
+
     protected function init()
     {
         $this->category = 'General_Visitors';

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getType_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getType_month.xml
@@ -39,28 +39,10 @@
 		<logo>plugins/DevicesDetection/images/screens/smartphone.png</logo>
 	</row>
 	<row>
-		<label>Tablet</label>
+		<label>Camera</label>
 		<nb_visits>0</nb_visits>
-		<segment>deviceType==tablet</segment>
-		<logo>plugins/DevicesDetection/images/screens/tablet.png</logo>
-	</row>
-	<row>
-		<label>Feature phone</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==feature+phone</segment>
-		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
-	</row>
-	<row>
-		<label>Console</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==console</segment>
-		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
-	</row>
-	<row>
-		<label>Tv</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==tv</segment>
-		<logo>plugins/DevicesDetection/images/screens/tv.png</logo>
+		<segment>deviceType==camera</segment>
+		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
 	</row>
 	<row>
 		<label>Car browser</label>
@@ -69,21 +51,39 @@
 		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
 	</row>
 	<row>
-		<label>Smart display</label>
+		<label>Console</label>
 		<nb_visits>0</nb_visits>
-		<segment>deviceType==smart+display</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+		<segment>deviceType==console</segment>
+		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
 	</row>
 	<row>
-		<label>Camera</label>
+		<label>Feature phone</label>
 		<nb_visits>0</nb_visits>
-		<segment>deviceType==camera</segment>
-		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
+		<segment>deviceType==feature+phone</segment>
+		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
 	</row>
 	<row>
 		<label>Portable media player</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==portable+media+player</segment>
 		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
+		<label>Smart display</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==smart+display</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
+		<label>Tablet</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==tablet</segment>
+		<logo>plugins/DevicesDetection/images/screens/tablet.png</logo>
+	</row>
+	<row>
+		<label>Tv</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==tv</segment>
+		<logo>plugins/DevicesDetection/images/screens/tv.png</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getContinent_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getContinent_month.xml
@@ -21,6 +21,26 @@
 		<code>Asia</code>
 	</row>
 	<row>
+		<label>North America</label>
+		<nb_visits>11</nb_visits>
+		<nb_actions>14</nb_actions>
+		<max_actions>3</max_actions>
+		<sum_visit_length>4</sum_visit_length>
+		<bounce_count>9</bounce_count>
+		<goals>
+			<row idgoal='1'>
+				<nb_conversions>11</nb_conversions>
+				<nb_visits_converted>11</nb_visits_converted>
+				<revenue>55</revenue>
+			</row>
+		</goals>
+		<nb_conversions>11</nb_conversions>
+		<revenue>55</revenue>
+		<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
+		<sum_daily_nb_users>2</sum_daily_nb_users>
+		<code>North America</code>
+	</row>
+	<row>
 		<label>Unknown</label>
 		<nb_visits>11</nb_visits>
 		<nb_actions>12</nb_actions>
@@ -40,26 +60,6 @@
 		<sum_daily_nb_users>0</sum_daily_nb_users>
 		<nb_visits_converted>0</nb_visits_converted>
 		<code>Unknown</code>
-	</row>
-	<row>
-		<label>North America</label>
-		<nb_visits>11</nb_visits>
-		<nb_actions>14</nb_actions>
-		<max_actions>3</max_actions>
-		<sum_visit_length>4</sum_visit_length>
-		<bounce_count>9</bounce_count>
-		<goals>
-			<row idgoal='1'>
-				<nb_conversions>11</nb_conversions>
-				<nb_visits_converted>11</nb_visits_converted>
-				<revenue>55</revenue>
-			</row>
-		</goals>
-		<nb_conversions>11</nb_conversions>
-		<revenue>55</revenue>
-		<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
-		<sum_daily_nb_users>2</sum_daily_nb_users>
-		<code>North America</code>
 	</row>
 	<row>
 		<label>South America</label>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserSettings.getMobileVsDesktop_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserSettings.getMobileVsDesktop_month.xml
@@ -39,28 +39,10 @@
 		<logo>plugins/DevicesDetection/images/screens/smartphone.png</logo>
 	</row>
 	<row>
-		<label>Tablet</label>
+		<label>Camera</label>
 		<nb_visits>0</nb_visits>
-		<segment>deviceType==tablet</segment>
-		<logo>plugins/DevicesDetection/images/screens/tablet.png</logo>
-	</row>
-	<row>
-		<label>Feature phone</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==feature+phone</segment>
-		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
-	</row>
-	<row>
-		<label>Console</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==console</segment>
-		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
-	</row>
-	<row>
-		<label>Tv</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==tv</segment>
-		<logo>plugins/DevicesDetection/images/screens/tv.png</logo>
+		<segment>deviceType==camera</segment>
+		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
 	</row>
 	<row>
 		<label>Car browser</label>
@@ -69,21 +51,39 @@
 		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
 	</row>
 	<row>
-		<label>Smart display</label>
+		<label>Console</label>
 		<nb_visits>0</nb_visits>
-		<segment>deviceType==smart+display</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+		<segment>deviceType==console</segment>
+		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
 	</row>
 	<row>
-		<label>Camera</label>
+		<label>Feature phone</label>
 		<nb_visits>0</nb_visits>
-		<segment>deviceType==camera</segment>
-		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
+		<segment>deviceType==feature+phone</segment>
+		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
 	</row>
 	<row>
 		<label>Portable media player</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==portable+media+player</segment>
 		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
+		<label>Smart display</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==smart+display</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
+		<label>Tablet</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==tablet</segment>
+		<logo>plugins/DevicesDetection/images/screens/tablet.png</logo>
+	</row>
+	<row>
+		<label>Tv</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==tv</segment>
+		<logo>plugins/DevicesDetection/images/screens/tv.png</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest__UserCountry.getCity_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest__UserCountry.getCity_month.xml
@@ -257,6 +257,37 @@
 		<logo>plugins/UserCountry/images/flags/gb.png</logo>
 	</row>
 	<row>
+		<label>Stratford-upon-Avon, Kent, United Kingdom</label>
+		<nb_visits>2</nb_visits>
+		<nb_actions>4</nb_actions>
+		<max_actions>3</max_actions>
+		<sum_visit_length>1261</sum_visit_length>
+		<bounce_count>1</bounce_count>
+		<goals>
+			<row idgoal='1'>
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>2</nb_visits_converted>
+				<revenue>10</revenue>
+			</row>
+			<row idgoal='2'>
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>5</revenue>
+			</row>
+		</goals>
+		<nb_conversions>3</nb_conversions>
+		<revenue>15</revenue>
+		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<segment>city==Stratford-upon-Avon;regionCode==G5;countryCode==gb</segment>
+		<city_name>Stratford-upon-Avon</city_name>
+		<region>G5</region>
+		<country>gb</country>
+		<country_name>United Kingdom</country_name>
+		<region_name>Kent</region_name>
+		<logo>plugins/UserCountry/images/flags/gb.png</logo>
+	</row>
+	<row>
 		<label>Stratford-upon-Avon, Miravci, Macedonia, the Former Yugoslav Republic of</label>
 		<nb_visits>2</nb_visits>
 		<nb_actions>3</nb_actions>
@@ -317,37 +348,6 @@
 		<country_name>Russian Federation</country_name>
 		<region_name>Saint Petersburg City</region_name>
 		<logo>plugins/UserCountry/images/flags/ru.png</logo>
-	</row>
-	<row>
-		<label>Stratford-upon-Avon, Kent, United Kingdom</label>
-		<nb_visits>2</nb_visits>
-		<nb_actions>4</nb_actions>
-		<max_actions>3</max_actions>
-		<sum_visit_length>1261</sum_visit_length>
-		<bounce_count>1</bounce_count>
-		<goals>
-			<row idgoal='1'>
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>2</nb_visits_converted>
-				<revenue>10</revenue>
-			</row>
-			<row idgoal='2'>
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>5</revenue>
-			</row>
-		</goals>
-		<nb_conversions>3</nb_conversions>
-		<revenue>15</revenue>
-		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<sum_daily_nb_users>0</sum_daily_nb_users>
-		<segment>city==Stratford-upon-Avon;regionCode==G5;countryCode==gb</segment>
-		<city_name>Stratford-upon-Avon</city_name>
-		<region>G5</region>
-		<country>gb</country>
-		<country_name>United Kingdom</country_name>
-		<region_name>Kent</region_name>
-		<logo>plugins/UserCountry/images/flags/gb.png</logo>
 	</row>
 	<row>
 		<label>not a city, California, United States</label>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest__UserCountry.getRegion_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest__UserCountry.getRegion_month.xml
@@ -120,66 +120,6 @@
 		<logo>plugins/UserCountry/images/flags/ru.png</logo>
 	</row>
 	<row>
-		<label>Unknown, Tibet</label>
-		<nb_visits>2</nb_visits>
-		<nb_actions>3</nb_actions>
-		<max_actions>2</max_actions>
-		<sum_visit_length>1261</sum_visit_length>
-		<bounce_count>1</bounce_count>
-		<goals>
-			<row idgoal='1'>
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>2</nb_visits_converted>
-				<revenue>10</revenue>
-			</row>
-			<row idgoal='2'>
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>5</revenue>
-			</row>
-		</goals>
-		<nb_conversions>3</nb_conversions>
-		<revenue>15</revenue>
-		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<sum_daily_nb_users>0</sum_daily_nb_users>
-		<segment>regionCode==1;countryCode==ti</segment>
-		<region>1</region>
-		<country>ti</country>
-		<country_name>Tibet</country_name>
-		<region_name>Unknown</region_name>
-		<logo>plugins/UserCountry/images/flags/ti.png</logo>
-	</row>
-	<row>
-		<label>Miravci, Macedonia, the Former Yugoslav Republic of</label>
-		<nb_visits>2</nb_visits>
-		<nb_actions>3</nb_actions>
-		<max_actions>2</max_actions>
-		<sum_visit_length>1261</sum_visit_length>
-		<bounce_count>1</bounce_count>
-		<goals>
-			<row idgoal='1'>
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>2</nb_visits_converted>
-				<revenue>10</revenue>
-			</row>
-			<row idgoal='2'>
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>5</revenue>
-			</row>
-		</goals>
-		<nb_conversions>3</nb_conversions>
-		<revenue>15</revenue>
-		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<sum_daily_nb_users>0</sum_daily_nb_users>
-		<segment>regionCode==66;countryCode==mk</segment>
-		<region>66</region>
-		<country>mk</country>
-		<country_name>Macedonia, the Former Yugoslav Republic of</country_name>
-		<region_name>Miravci</region_name>
-		<logo>plugins/UserCountry/images/flags/mk.png</logo>
-	</row>
-	<row>
 		<label>Franche-Comte, France</label>
 		<nb_visits>2</nb_visits>
 		<nb_actions>4</nb_actions>
@@ -268,6 +208,66 @@
 		<country_name>United Kingdom</country_name>
 		<region_name>London, City of</region_name>
 		<logo>plugins/UserCountry/images/flags/gb.png</logo>
+	</row>
+	<row>
+		<label>Miravci, Macedonia, the Former Yugoslav Republic of</label>
+		<nb_visits>2</nb_visits>
+		<nb_actions>3</nb_actions>
+		<max_actions>2</max_actions>
+		<sum_visit_length>1261</sum_visit_length>
+		<bounce_count>1</bounce_count>
+		<goals>
+			<row idgoal='1'>
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>2</nb_visits_converted>
+				<revenue>10</revenue>
+			</row>
+			<row idgoal='2'>
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>5</revenue>
+			</row>
+		</goals>
+		<nb_conversions>3</nb_conversions>
+		<revenue>15</revenue>
+		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<segment>regionCode==66;countryCode==mk</segment>
+		<region>66</region>
+		<country>mk</country>
+		<country_name>Macedonia, the Former Yugoslav Republic of</country_name>
+		<region_name>Miravci</region_name>
+		<logo>plugins/UserCountry/images/flags/mk.png</logo>
+	</row>
+	<row>
+		<label>Unknown, Tibet</label>
+		<nb_visits>2</nb_visits>
+		<nb_actions>3</nb_actions>
+		<max_actions>2</max_actions>
+		<sum_visit_length>1261</sum_visit_length>
+		<bounce_count>1</bounce_count>
+		<goals>
+			<row idgoal='1'>
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>2</nb_visits_converted>
+				<revenue>10</revenue>
+			</row>
+			<row idgoal='2'>
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>5</revenue>
+			</row>
+		</goals>
+		<nb_conversions>3</nb_conversions>
+		<revenue>15</revenue>
+		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<segment>regionCode==1;countryCode==ti</segment>
+		<region>1</region>
+		<country>ti</country>
+		<country_name>Tibet</country_name>
+		<region_name>Unknown</region_name>
+		<logo>plugins/UserCountry/images/flags/ti.png</logo>
 	</row>
 	<row>
 		<label>California, United States</label>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__DevicesDetection.getType_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__DevicesDetection.getType_day.xml
@@ -13,6 +13,42 @@
 		<logo>plugins/DevicesDetection/images/screens/normal.gif</logo>
 	</row>
 	<row>
+		<label>Camera</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==camera</segment>
+		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
+	</row>
+	<row>
+		<label>Car browser</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==car+browser</segment>
+		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
+	</row>
+	<row>
+		<label>Console</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==console</segment>
+		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
+	</row>
+	<row>
+		<label>Feature phone</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==feature+phone</segment>
+		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
+	</row>
+	<row>
+		<label>Portable media player</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==portable+media+player</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
+		<label>Smart display</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==smart+display</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
 		<label>Smartphone</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==smartphone</segment>
@@ -25,45 +61,9 @@
 		<logo>plugins/DevicesDetection/images/screens/tablet.png</logo>
 	</row>
 	<row>
-		<label>Feature phone</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==feature+phone</segment>
-		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
-	</row>
-	<row>
-		<label>Console</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==console</segment>
-		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
-	</row>
-	<row>
 		<label>Tv</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==tv</segment>
 		<logo>plugins/DevicesDetection/images/screens/tv.png</logo>
-	</row>
-	<row>
-		<label>Car browser</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==car+browser</segment>
-		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
-	</row>
-	<row>
-		<label>Smart display</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==smart+display</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
-	</row>
-	<row>
-		<label>Camera</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==camera</segment>
-		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
-	</row>
-	<row>
-		<label>Portable media player</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==portable+media+player</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__UserSettings.getMobileVsDesktop_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__UserSettings.getMobileVsDesktop_day.xml
@@ -13,6 +13,42 @@
 		<logo>plugins/DevicesDetection/images/screens/normal.gif</logo>
 	</row>
 	<row>
+		<label>Camera</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==camera</segment>
+		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
+	</row>
+	<row>
+		<label>Car browser</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==car+browser</segment>
+		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
+	</row>
+	<row>
+		<label>Console</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==console</segment>
+		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
+	</row>
+	<row>
+		<label>Feature phone</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==feature+phone</segment>
+		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
+	</row>
+	<row>
+		<label>Portable media player</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==portable+media+player</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
+		<label>Smart display</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==smart+display</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
 		<label>Smartphone</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==smartphone</segment>
@@ -25,45 +61,9 @@
 		<logo>plugins/DevicesDetection/images/screens/tablet.png</logo>
 	</row>
 	<row>
-		<label>Feature phone</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==feature+phone</segment>
-		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
-	</row>
-	<row>
-		<label>Console</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==console</segment>
-		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
-	</row>
-	<row>
 		<label>Tv</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==tv</segment>
 		<logo>plugins/DevicesDetection/images/screens/tv.png</logo>
-	</row>
-	<row>
-		<label>Car browser</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==car+browser</segment>
-		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
-	</row>
-	<row>
-		<label>Smart display</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==smart+display</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
-	</row>
-	<row>
-		<label>Camera</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==camera</segment>
-		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
-	</row>
-	<row>
-		<label>Portable media player</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==portable+media+player</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__DevicesDetection.getType_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__DevicesDetection.getType_day.xml
@@ -14,6 +14,42 @@
 		<logo>plugins/DevicesDetection/images/screens/normal.gif</logo>
 	</row>
 	<row>
+		<label>Camera</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==camera</segment>
+		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
+	</row>
+	<row>
+		<label>Car browser</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==car+browser</segment>
+		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
+	</row>
+	<row>
+		<label>Console</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==console</segment>
+		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
+	</row>
+	<row>
+		<label>Feature phone</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==feature+phone</segment>
+		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
+	</row>
+	<row>
+		<label>Portable media player</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==portable+media+player</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
+		<label>Smart display</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==smart+display</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
 		<label>Smartphone</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==smartphone</segment>
@@ -26,45 +62,9 @@
 		<logo>plugins/DevicesDetection/images/screens/tablet.png</logo>
 	</row>
 	<row>
-		<label>Feature phone</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==feature+phone</segment>
-		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
-	</row>
-	<row>
-		<label>Console</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==console</segment>
-		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
-	</row>
-	<row>
 		<label>Tv</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==tv</segment>
 		<logo>plugins/DevicesDetection/images/screens/tv.png</logo>
-	</row>
-	<row>
-		<label>Car browser</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==car+browser</segment>
-		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
-	</row>
-	<row>
-		<label>Smart display</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==smart+display</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
-	</row>
-	<row>
-		<label>Camera</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==camera</segment>
-		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
-	</row>
-	<row>
-		<label>Portable media player</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==portable+media+player</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__UserSettings.getMobileVsDesktop_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__UserSettings.getMobileVsDesktop_day.xml
@@ -14,6 +14,42 @@
 		<logo>plugins/DevicesDetection/images/screens/normal.gif</logo>
 	</row>
 	<row>
+		<label>Camera</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==camera</segment>
+		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
+	</row>
+	<row>
+		<label>Car browser</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==car+browser</segment>
+		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
+	</row>
+	<row>
+		<label>Console</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==console</segment>
+		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
+	</row>
+	<row>
+		<label>Feature phone</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==feature+phone</segment>
+		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
+	</row>
+	<row>
+		<label>Portable media player</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==portable+media+player</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
+		<label>Smart display</label>
+		<nb_visits>0</nb_visits>
+		<segment>deviceType==smart+display</segment>
+		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
+	</row>
+	<row>
 		<label>Smartphone</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==smartphone</segment>
@@ -26,45 +62,9 @@
 		<logo>plugins/DevicesDetection/images/screens/tablet.png</logo>
 	</row>
 	<row>
-		<label>Feature phone</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==feature+phone</segment>
-		<logo>plugins/DevicesDetection/images/screens/mobile.gif</logo>
-	</row>
-	<row>
-		<label>Console</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==console</segment>
-		<logo>plugins/DevicesDetection/images/screens/console.gif</logo>
-	</row>
-	<row>
 		<label>Tv</label>
 		<nb_visits>0</nb_visits>
 		<segment>deviceType==tv</segment>
 		<logo>plugins/DevicesDetection/images/screens/tv.png</logo>
-	</row>
-	<row>
-		<label>Car browser</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==car+browser</segment>
-		<logo>plugins/DevicesDetection/images/screens/carbrowser.png</logo>
-	</row>
-	<row>
-		<label>Smart display</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==smart+display</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
-	</row>
-	<row>
-		<label>Camera</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==camera</segment>
-		<logo>plugins/DevicesDetection/images/screens/camera.png</logo>
-	</row>
-	<row>
-		<label>Portable media player</label>
-		<nb_visits>0</nb_visits>
-		<segment>deviceType==portable+media+player</segment>
-		<logo>plugins/DevicesDetection/images/screens/unknown.gif</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getContinent_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__UserCountry.getContinent_day.xml
@@ -10,6 +10,11 @@
 		<sum_visit_length>5403</sum_visit_length>
 		<bounce_count>0</bounce_count>
 		<goals>
+			<row idgoal='1'>
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>10</revenue>
+			</row>
 			<row idgoal='ecommerceAbandonedCart'>
 				<nb_conversions>2</nb_conversions>
 				<nb_visits_converted>2</nb_visits_converted>
@@ -25,11 +30,6 @@
 				<revenue_shipping>100.11</revenue_shipping>
 				<revenue_discount>666</revenue_discount>
 				<items>10</items>
-			</row>
-			<row idgoal='1'>
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>10</revenue>
 			</row>
 		</goals>
 		<nb_conversions>3</nb_conversions>

--- a/tests/PHPUnit/System/expected/test_reportLimiting__UserCountry.getRegion_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting__UserCountry.getRegion_day.xml
@@ -1,23 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
-		<label>Victoria, Australia</label>
-		<nb_uniq_visitors>4</nb_uniq_visitors>
-		<nb_visits>20</nb_visits>
-		<nb_actions>20</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>20</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-		<segment>regionCode==07;countryCode==au</segment>
-		<region>07</region>
-		<country>au</country>
-		<country_name>Australia</country_name>
-		<region_name>Victoria</region_name>
-		<logo>plugins/UserCountry/images/flags/au.png</logo>
-	</row>
-	<row>
 		<label>Provence-Alpes-Cote d&amp;#039;Azur, France</label>
 		<nb_uniq_visitors>4</nb_uniq_visitors>
 		<nb_visits>20</nb_visits>
@@ -33,6 +16,23 @@
 		<country_name>France</country_name>
 		<region_name>Provence-Alpes-Cote d'Azur</region_name>
 		<logo>plugins/UserCountry/images/flags/fr.png</logo>
+	</row>
+	<row>
+		<label>Victoria, Australia</label>
+		<nb_uniq_visitors>4</nb_uniq_visitors>
+		<nb_visits>20</nb_visits>
+		<nb_actions>20</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
+		<bounce_count>20</bounce_count>
+		<nb_visits_converted>0</nb_visits_converted>
+		<segment>regionCode==07;countryCode==au</segment>
+		<region>07</region>
+		<country>au</country>
+		<country_name>Australia</country_name>
+		<region_name>Victoria</region_name>
+		<logo>plugins/UserCountry/images/flags/au.png</logo>
 	</row>
 	<row>
 		<label>Others</label>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__DevicesDetection.getBrowserVersions_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__DevicesDetection.getBrowserVersions_day.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
+		<label>Others</label>
+		<nb_uniq_visitors>9</nb_uniq_visitors>
+		<nb_visits>45</nb_visits>
+		<nb_actions>45</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
+		<bounce_count>45</bounce_count>
+		<nb_visits_converted>0</nb_visits_converted>
+		<logo>plugins/DevicesDetection/images/browsers/UNK.gif</logo>
+	</row>
+	<row>
 		<label>Firefox 6.0</label>
 		<nb_uniq_visitors>3</nb_uniq_visitors>
 		<nb_visits>15</nb_visits>
@@ -25,17 +37,5 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<segment>browserCode==IE;browserVersion==9.0</segment>
 		<logo>plugins/DevicesDetection/images/browsers/IE.gif</logo>
-	</row>
-	<row>
-		<label>Others</label>
-		<nb_uniq_visitors>9</nb_uniq_visitors>
-		<nb_visits>45</nb_visits>
-		<nb_actions>45</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>45</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-		<logo>plugins/DevicesDetection/images/browsers/UNK.gif</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__DevicesDetection.getOsVersions_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__DevicesDetection.getOsVersions_day.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
+		<label>Others</label>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_visits>40</nb_visits>
+		<nb_actions>40</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
+		<bounce_count>40</bounce_count>
+		<nb_visits_converted>0</nb_visits_converted>
+		<logo>plugins/DevicesDetection/images/os/UNK.gif</logo>
+	</row>
+	<row>
 		<label>GNU/Linux</label>
 		<nb_uniq_visitors>4</nb_uniq_visitors>
 		<nb_visits>20</nb_visits>
@@ -25,17 +37,5 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<segment>operatingSystemCode==AND;operatingSystemVersion==4.0</segment>
 		<logo>plugins/DevicesDetection/images/os/AND.gif</logo>
-	</row>
-	<row>
-		<label>Others</label>
-		<nb_uniq_visitors>8</nb_uniq_visitors>
-		<nb_visits>40</nb_visits>
-		<nb_actions>40</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>40</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-		<logo>plugins/DevicesDetection/images/os/UNK.gif</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Resolution.getConfiguration_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Resolution.getConfiguration_day.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
+		<label>Others</label>
+		<nb_uniq_visitors>12</nb_uniq_visitors>
+		<nb_visits>60</nb_visits>
+		<nb_actions>60</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
+		<bounce_count>60</bounce_count>
+		<nb_visits_converted>0</nb_visits_converted>
+	</row>
+	<row>
 		<label>GNU/Linux / Firefox / 1920x1080</label>
 		<nb_uniq_visitors>2</nb_uniq_visitors>
 		<nb_visits>10</nb_visits>
@@ -20,17 +31,6 @@
 		<max_actions>1</max_actions>
 		<sum_visit_length>0</sum_visit_length>
 		<bounce_count>5</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-	</row>
-	<row>
-		<label>Others</label>
-		<nb_uniq_visitors>12</nb_uniq_visitors>
-		<nb_visits>60</nb_visits>
-		<nb_actions>60</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>60</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Resolution.getResolution_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Resolution.getResolution_day.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
+		<label>Others</label>
+		<nb_uniq_visitors>8</nb_uniq_visitors>
+		<nb_visits>40</nb_visits>
+		<nb_actions>40</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
+		<bounce_count>40</bounce_count>
+		<nb_visits_converted>0</nb_visits_converted>
+	</row>
+	<row>
 		<label>1920x1080</label>
 		<nb_uniq_visitors>4</nb_uniq_visitors>
 		<nb_visits>20</nb_visits>
@@ -23,16 +34,5 @@
 		<bounce_count>15</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<segment>resolution==1280x1024</segment>
-	</row>
-	<row>
-		<label>Others</label>
-		<nb_uniq_visitors>8</nb_uniq_visitors>
-		<nb_visits>40</nb_visits>
-		<nb_actions>40</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>40</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__UserCountry.getCity_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__UserCountry.getCity_day.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
+		<label>Others</label>
+		<nb_uniq_visitors>7</nb_uniq_visitors>
+		<nb_visits>35</nb_visits>
+		<nb_actions>35</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
+		<bounce_count>35</bounce_count>
+		<nb_visits_converted>0</nb_visits_converted>
+		<logo>plugins/UserCountry/images/flags/xx.png</logo>
+	</row>
+	<row>
 		<label>Melbourne, Victoria, Australia</label>
 		<nb_uniq_visitors>4</nb_uniq_visitors>
 		<nb_visits>20</nb_visits>
@@ -35,17 +47,5 @@
 		<country_name>France</country_name>
 		<region_name>Provence-Alpes-Cote d'Azur</region_name>
 		<logo>plugins/UserCountry/images/flags/fr.png</logo>
-	</row>
-	<row>
-		<label>Others</label>
-		<nb_uniq_visitors>7</nb_uniq_visitors>
-		<nb_visits>35</nb_visits>
-		<nb_actions>35</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>35</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-		<logo>plugins/UserCountry/images/flags/xx.png</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__UserCountry.getRegion_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__UserCountry.getRegion_day.xml
@@ -1,21 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
-		<label>Victoria, Australia</label>
-		<nb_uniq_visitors>4</nb_uniq_visitors>
-		<nb_visits>20</nb_visits>
-		<nb_actions>20</nb_actions>
+		<label>Others</label>
+		<nb_uniq_visitors>7</nb_uniq_visitors>
+		<nb_visits>35</nb_visits>
+		<nb_actions>35</nb_actions>
 		<nb_users>0</nb_users>
 		<max_actions>1</max_actions>
 		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>20</bounce_count>
+		<bounce_count>35</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
-		<segment>regionCode==07;countryCode==au</segment>
-		<region>07</region>
-		<country>au</country>
-		<country_name>Australia</country_name>
-		<region_name>Victoria</region_name>
-		<logo>plugins/UserCountry/images/flags/au.png</logo>
+		<logo>plugins/UserCountry/images/flags/xx.png</logo>
 	</row>
 	<row>
 		<label>Provence-Alpes-Cote d&amp;#039;Azur, France</label>
@@ -35,15 +30,20 @@
 		<logo>plugins/UserCountry/images/flags/fr.png</logo>
 	</row>
 	<row>
-		<label>Others</label>
-		<nb_uniq_visitors>7</nb_uniq_visitors>
-		<nb_visits>35</nb_visits>
-		<nb_actions>35</nb_actions>
+		<label>Victoria, Australia</label>
+		<nb_uniq_visitors>4</nb_uniq_visitors>
+		<nb_visits>20</nb_visits>
+		<nb_actions>20</nb_actions>
 		<nb_users>0</nb_users>
 		<max_actions>1</max_actions>
 		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>35</bounce_count>
+		<bounce_count>20</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
-		<logo>plugins/UserCountry/images/flags/xx.png</logo>
+		<segment>regionCode==07;countryCode==au</segment>
+		<region>07</region>
+		<country>au</country>
+		<country_name>Australia</country_name>
+		<region_name>Victoria</region_name>
+		<logo>plugins/UserCountry/images/flags/au.png</logo>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__UserCountry.getRegion_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__UserCountry.getRegion_day.xml
@@ -1,23 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>
-		<label>Victoria, Australia</label>
-		<nb_uniq_visitors>4</nb_uniq_visitors>
-		<nb_visits>20</nb_visits>
-		<nb_actions>20</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>20</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-		<segment>regionCode==07;countryCode==au</segment>
-		<region>07</region>
-		<country>au</country>
-		<country_name>Australia</country_name>
-		<region_name>Victoria</region_name>
-		<logo>plugins/UserCountry/images/flags/au.png</logo>
-	</row>
-	<row>
 		<label>Provence-Alpes-Cote d&amp;#039;Azur, France</label>
 		<nb_uniq_visitors>4</nb_uniq_visitors>
 		<nb_visits>20</nb_visits>
@@ -33,6 +16,23 @@
 		<country_name>France</country_name>
 		<region_name>Provence-Alpes-Cote d'Azur</region_name>
 		<logo>plugins/UserCountry/images/flags/fr.png</logo>
+	</row>
+	<row>
+		<label>Victoria, Australia</label>
+		<nb_uniq_visitors>4</nb_uniq_visitors>
+		<nb_visits>20</nb_visits>
+		<nb_actions>20</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
+		<bounce_count>20</bounce_count>
+		<nb_visits_converted>0</nb_visits_converted>
+		<segment>regionCode==07;countryCode==au</segment>
+		<region>07</region>
+		<country>au</country>
+		<country_name>Australia</country_name>
+		<region_name>Victoria</region_name>
+		<logo>plugins/UserCountry/images/flags/au.png</logo>
 	</row>
 	<row>
 		<label>Others</label>


### PR DESCRIPTION
see #7388 

We should only apply a sort filter once, meaning it will be much faster since a sort takes a long time on many rows (many seconds under circumstances). The only way to apply the filter only once is by applying it in GenericFilters. This means we will fallback to a default sort column, specified in a report class, if no column was specifically set.

This does not yet actually fix the issue #7388 . We should probably also apply the default sort column to more reports such as Actions. We might also expose more settings to a report like "defaultSortOrder", "preferNaturalSort", ... This is to be discussed. I do not want to expose this `Report::$defaultSortColumn` as an API yet since I am not sure whether this is the best solution. We probably need a 'DefaultSortConfig` for reports that allows to specify "defaultSortOrder", "preferNaturalSort", "defaultSortColumn", "defaultSecondarySortColumn", ... once we merge #7420 and work on #7401. Further steps are to be discussed.

Please note that this also fixes some issues in the Sort filter. I could have created a separate pull request for it, but it was kinda needed to fix it here since otherwise it would sometimes return a wrong result. Some fixed bugs include:
- make sure to select correct column (the column value might be false which is valid, meaning column actually exists whereas we assumed before it does not exist)
- use correct sort algorithm (if value of first column was false we picked under circumstances a string comparison instead of number)
- If we sort by label, use always a string or natural comparison even if the label is numeric

I had to update the expected system tests but it seems to be a valid change. By default we do now sort by `nb_visits` and as a secondary column by `label`. This was not the case before.
