### PR TITLE
Fix label filter does not work on all reports or depending on used parameters

### DIFF
--- a/core/API/DataTableManipulator/LabelFilter.php
+++ b/core/API/DataTableManipulator/LabelFilter.php
@@ -67,6 +67,10 @@ class LabelFilter extends DataTableManipulator
         // search for the first part of the tree search
         $labelPart = array_shift($labelParts);
 
+        // we need to make sure to rebuild the index as some filters change the label column directly via
+        // $row->setColumn('label', '') which would not be noticed in the label index otherwise.
+        $dataTable->rebuildIndex();
+
         $row = false;
         foreach ($this->getLabelVariations($labelPart) as $labelPart) {
             $row = $dataTable->getRowFromLabel($labelPart);

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -607,7 +607,6 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function getRowIdFromLabel($label)
     {
-        $this->rebuildIndexContinuously = true;
         if ($this->indexNotUpToDate) {
             $this->rebuildIndex();
         }
@@ -643,9 +642,12 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
     /**
      * Rebuilds the index used to lookup a row by label
+     * @internal
      */
-    private function rebuildIndex()
+    public function rebuildIndex()
     {
+        $this->rebuildIndexContinuously = true;
+
         foreach ($this->getRows() as $id => $row) {
             $label = $row->getColumn('label');
             if ($label !== false) {


### PR DESCRIPTION
I noticed sometimes a label filter does not work. This is because the DataTable thinks the `IndexFromLabelToId` is up to date but it is not. It will then fail to get the row by label.

Here it [https://github.com/piwik/piwik/blob/2.12.0-b5/core/API/DataTableManipulator/LabelFilter.php#L72](tries to get the row by label) and [https://github.com/piwik/piwik/blob/2.12.0-b5/core/DataTable.php#L610](here it thinks the index is up to date which it is not).

How can this happen? 

When we update the label on a row directly eg via `$row->setColumn('labe'l, 'newvalue')` the dataTable won't notice that the index has to be updated. Same when doing eg `$table->queueFilter('ColumnCallbackReplace', array('label', 'Piwik\Plugins\Referrers\getPathFromUrl'));` or `$table->queueFilter('GroupBy', array('label', 'Piwik\Plugins\Referrers\getPathFromUrl'));` for example here: https://github.com/piwik/piwik/blob/2.12.0-b5/plugins/Referrers/DataTable/Filter/UrlsFromWebsiteId.php

For now the only way to make sure the index is up date when applying the label filter is to rebuild it. In another pull request I will on top invalidate the index for those 2 filters but this does not actually solve all problems. Only by rebuilding the index we can be sure to have the correct index.
