### PR TITLE
Faster archiving by calculating the recursive count only if needed

### DIFF
--- a/core/Archive/DataTableFactory.php
+++ b/core/Archive/DataTableFactory.php
@@ -326,7 +326,7 @@ class DataTableFactory
             && $treeLevel >= $this->maxSubtableDepth
         ) {
             // unset the subtables so DataTableManager doesn't throw
-            foreach ($dataTable->getRows() as $row) {
+            foreach ($dataTable->getRowsWithoutSummaryRow() as $row) {
                 $row->removeSubtable();
             }
 
@@ -335,7 +335,7 @@ class DataTableFactory
 
         $dataName = reset($this->dataNames);
 
-        foreach ($dataTable->getRows() as $row) {
+        foreach ($dataTable->getRowsWithoutSummaryRow() as $row) {
             $sid = $row->getIdSubDataTable();
             if ($sid === null) {
                 continue;

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -187,6 +187,8 @@ class ArchiveProcessor
      * @param array $columnsToRenameAfterAggregation Columns mapped to new names for columns that must change names
      *                                               when summed because they cannot be summed, eg,
      *                                               `array('nb_uniq_visitors' => 'sum_daily_nb_uniq_visitors')`.
+     * @param bool $countRowsRecursive if set to false, will not calculate the recursive rows count which results in
+     *                                 faster aggregation
      * @return array Returns the row counts of each aggregated report before truncation, eg,
      *
      *                   array(
@@ -203,7 +205,8 @@ class ArchiveProcessor
                                               $maximumRowsInSubDataTable = null,
                                               $columnToSortByBeforeTruncation = null,
                                               &$columnsAggregationOperation = null,
-                                              $columnsToRenameAfterAggregation = null)
+                                              $columnsToRenameAfterAggregation = null,
+                                              $countRowsRecursive = true)
     {
         if (!is_array($recordNames)) {
             $recordNames = array($recordNames);
@@ -216,8 +219,9 @@ class ArchiveProcessor
             $table = $this->aggregateDataTableRecord($recordName, $columnsAggregationOperation, $columnsToRenameAfterAggregation);
 
             $nameToCount[$recordName]['level0'] = $table->getRowsCount();
-
-            $nameToCount[$recordName]['recursive'] = $table->getRowsCountRecursive();
+            if ($countRowsRecursive) {
+                $nameToCount[$recordName]['recursive'] = $table->getRowsCountRecursive();
+            }
 
             $blob = $table->getSerialized($maximumRowsInDataTableLevelZero, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation);
             Common::destroy($table);

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -187,8 +187,9 @@ class ArchiveProcessor
      * @param array $columnsToRenameAfterAggregation Columns mapped to new names for columns that must change names
      *                                               when summed because they cannot be summed, eg,
      *                                               `array('nb_uniq_visitors' => 'sum_daily_nb_uniq_visitors')`.
-     * @param bool $countRowsRecursive if set to false, will not calculate the recursive rows count which results in
-     *                                 faster aggregation
+     * @param bool|array $countRowsRecursive if set to true, will calculate the recursive rows count for all record names
+     *                                       which makes it slower. If you only need it for some records pass an array of
+     *                                       recordNames that defines for which ones you need a recursive row count.
      * @return array Returns the row counts of each aggregated report before truncation, eg,
      *
      *                   array(
@@ -219,7 +220,7 @@ class ArchiveProcessor
             $table = $this->aggregateDataTableRecord($recordName, $columnsAggregationOperation, $columnsToRenameAfterAggregation);
 
             $nameToCount[$recordName]['level0'] = $table->getRowsCount();
-            if ($countRowsRecursive) {
+            if ($countRowsRecursive === true || (is_array($countRowsRecursive) && in_array($recordName, $countRowsRecursive))) {
                 $nameToCount[$recordName]['recursive'] = $table->getRowsCountRecursive();
             }
 

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -475,7 +475,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
                 continue;
             }
 
-            $thisColumnValue = &$this->getColumn($columnToSumName);
+            $thisColumnValue = $this->getColumn($columnToSumName);
 
             $operation = 'sum';
             if (is_array($aggregationOperations) && isset($aggregationOperations[$columnToSumName])) {

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -229,11 +229,6 @@ class Row implements \ArrayAccess, \IteratorAggregate
         return $this->c[self::METADATA][$name];
     }
 
-    private function getColumnsRaw()
-    {
-        return $this->c[self::COLUMNS];
-    }
-
     /**
      * Returns true if a column having the given name is already registered. The value will not be evaluated, it will
      * just check whether a column exists independent of its value.
@@ -475,12 +470,12 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function sumRow(Row $rowToSum, $enableCopyMetadata = true, $aggregationOperations = false)
     {
-        foreach ($rowToSum->getColumnsRaw() as $columnToSumName => $columnToSumValue) {
+        foreach ($rowToSum->getColumns() as $columnToSumName => $columnToSumValue) {
             if (!$this->isSummableColumn($columnToSumName)) {
                 continue;
             }
 
-            $thisColumnValue = $this->getColumn($columnToSumName);
+            $thisColumnValue = &$this->getColumn($columnToSumName);
 
             $operation = 'sum';
             if (is_array($aggregationOperations) && isset($aggregationOperations[$columnToSumName])) {

--- a/plugins/Actions/Archiver.php
+++ b/plugins/Actions/Archiver.php
@@ -498,7 +498,7 @@ class Archiver extends \Piwik\Plugin\Archiver
             ArchivingHelper::$columnToSortByBeforeTruncation,
             Metrics::$columnsAggregationOperation,
             Metrics::$columnsToRenameAfterAggregation,
-            $countRowsRecursive = false
+            $countRowsRecursive = array()
         );
 
         $dataTableToSum = array(
@@ -512,7 +512,8 @@ class Archiver extends \Piwik\Plugin\Archiver
             ArchivingHelper::$maximumRowsInSubDataTable,
             ArchivingHelper::$columnToSortByBeforeTruncation,
             $aggregation,
-            Metrics::$columnsToRenameAfterAggregation
+            Metrics::$columnsToRenameAfterAggregation,
+            $countRowsRecursive = array()
         );
 
         $this->getProcessor()->aggregateNumericMetrics($this->getMetricNames());

--- a/plugins/Actions/Archiver.php
+++ b/plugins/Actions/Archiver.php
@@ -497,7 +497,8 @@ class Archiver extends \Piwik\Plugin\Archiver
             ArchivingHelper::$maximumRowsInSubDataTable,
             ArchivingHelper::$columnToSortByBeforeTruncation,
             Metrics::$columnsAggregationOperation,
-            Metrics::$columnsToRenameAfterAggregation
+            Metrics::$columnsToRenameAfterAggregation,
+            $countRowsRecursive = false
         );
 
         $dataTableToSum = array(

--- a/plugins/Contents/Archiver.php
+++ b/plugins/Contents/Archiver.php
@@ -48,7 +48,14 @@ class Archiver extends \Piwik\Plugin\Archiver
     public function aggregateMultipleReports()
     {
         $dataTableToSum = $this->getRecordNames();
-        $this->getProcessor()->aggregateDataTableRecords($dataTableToSum, $this->maximumRowsInDataTable, $this->maximumRowsInSubDataTable, $this->columnToSortByBeforeTruncation);
+        $this->getProcessor()->aggregateDataTableRecords(
+            $dataTableToSum,
+            $this->maximumRowsInDataTable,
+            $this->maximumRowsInSubDataTable,
+            $this->columnToSortByBeforeTruncation,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false);
     }
 
     private function getRecordNames()

--- a/plugins/Contents/Archiver.php
+++ b/plugins/Contents/Archiver.php
@@ -48,14 +48,15 @@ class Archiver extends \Piwik\Plugin\Archiver
     public function aggregateMultipleReports()
     {
         $dataTableToSum = $this->getRecordNames();
+        $columnsAggregationOperation = null;
         $this->getProcessor()->aggregateDataTableRecords(
             $dataTableToSum,
             $this->maximumRowsInDataTable,
             $this->maximumRowsInSubDataTable,
             $this->columnToSortByBeforeTruncation,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false);
+            $countRowsRecursive = array());
     }
 
     private function getRecordNames()

--- a/plugins/CustomVariables/Archiver.php
+++ b/plugins/CustomVariables/Archiver.php
@@ -50,14 +50,16 @@ class Archiver extends \Piwik\Plugin\Archiver
 
     public function aggregateMultipleReports()
     {
+        $columnsAggregationOperation = null;
+
         $this->getProcessor()->aggregateDataTableRecords(
             self::CUSTOM_VARIABLE_RECORD_NAME,
             $this->maximumRowsInDataTableLevelZero,
             $this->maximumRowsInSubDataTable,
             $columnToSort = Metrics::INDEX_NB_VISITS,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false);
+            $countRowsRecursive = array());
     }
 
     public function aggregateDayReport()

--- a/plugins/CustomVariables/Archiver.php
+++ b/plugins/CustomVariables/Archiver.php
@@ -51,8 +51,13 @@ class Archiver extends \Piwik\Plugin\Archiver
     public function aggregateMultipleReports()
     {
         $this->getProcessor()->aggregateDataTableRecords(
-            self::CUSTOM_VARIABLE_RECORD_NAME, $this->maximumRowsInDataTableLevelZero, $this->maximumRowsInSubDataTable,
-            $columnToSort = Metrics::INDEX_NB_VISITS);
+            self::CUSTOM_VARIABLE_RECORD_NAME,
+            $this->maximumRowsInDataTableLevelZero,
+            $this->maximumRowsInSubDataTable,
+            $columnToSort = Metrics::INDEX_NB_VISITS,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false);
     }
 
     public function aggregateDayReport()

--- a/plugins/DevicePlugins/Archiver.php
+++ b/plugins/DevicePlugins/Archiver.php
@@ -40,7 +40,15 @@ class Archiver extends \Piwik\Plugin\Archiver
         $dataTableRecords = array(
             self::PLUGIN_RECORD_NAME,
         );
-        $this->getProcessor()->aggregateDataTableRecords($dataTableRecords, $this->maximumRows);
+        $this->getProcessor()->aggregateDataTableRecords(
+            $dataTableRecords,
+            $this->maximumRows,
+            $maximumRowsInSubDataTable = null,
+            $columnToSortByBeforeTruncation = null,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false
+        );
     }
 
     protected function aggregateByPlugin()

--- a/plugins/DevicePlugins/Archiver.php
+++ b/plugins/DevicePlugins/Archiver.php
@@ -40,14 +40,15 @@ class Archiver extends \Piwik\Plugin\Archiver
         $dataTableRecords = array(
             self::PLUGIN_RECORD_NAME,
         );
+        $columnsAggregationOperation = null;
         $this->getProcessor()->aggregateDataTableRecords(
             $dataTableRecords,
             $this->maximumRows,
             $maximumRowsInSubDataTable = null,
             $columnToSortByBeforeTruncation = null,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false
+            $countRowsRecursive = array()
         );
     }
 

--- a/plugins/DevicesDetection/Archiver.php
+++ b/plugins/DevicesDetection/Archiver.php
@@ -56,15 +56,18 @@ class Archiver extends \Piwik\Plugin\Archiver
             self::BROWSER_ENGINE_RECORD_NAME,
             self::BROWSER_VERSION_RECORD_NAME
         );
+
+        $columnsAggregationOperation = null;
+
         foreach ($dataTablesToSum as $dt) {
             $this->getProcessor()->aggregateDataTableRecords(
                 $dt,
                 $this->maximumRows,
                 $this->maximumRows,
                 $columnToSort = 'nb_visits',
-                $columnsAggregationOperation = null,
+                $columnsAggregationOperation,
                 $columnsToRenameAfterAggregation = null,
-                $countRowsRecursive = false);
+                $countRowsRecursive = array());
         }
     }
 

--- a/plugins/DevicesDetection/Archiver.php
+++ b/plugins/DevicesDetection/Archiver.php
@@ -58,7 +58,13 @@ class Archiver extends \Piwik\Plugin\Archiver
         );
         foreach ($dataTablesToSum as $dt) {
             $this->getProcessor()->aggregateDataTableRecords(
-                $dt, $this->maximumRows, $this->maximumRows, $columnToSort = "nb_visits");
+                $dt,
+                $this->maximumRows,
+                $this->maximumRows,
+                $columnToSort = 'nb_visits',
+                $columnsAggregationOperation = null,
+                $columnsToRenameAfterAggregation = null,
+                $countRowsRecursive = false);
         }
     }
 

--- a/plugins/Events/Archiver.php
+++ b/plugins/Events/Archiver.php
@@ -98,14 +98,16 @@ class Archiver extends \Piwik\Plugin\Archiver
     public function aggregateMultipleReports()
     {
         $dataTableToSum = $this->getRecordNames();
+        $columnsAggregationOperation = null;
+
         $this->getProcessor()->aggregateDataTableRecords(
             $dataTableToSum,
             $this->maximumRowsInDataTable,
             $this->maximumRowsInSubDataTable,
             $this->columnToSortByBeforeTruncation,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false);
+            $countRowsRecursive = array());
     }
 
     protected function getRecordNames()

--- a/plugins/Events/Archiver.php
+++ b/plugins/Events/Archiver.php
@@ -98,7 +98,14 @@ class Archiver extends \Piwik\Plugin\Archiver
     public function aggregateMultipleReports()
     {
         $dataTableToSum = $this->getRecordNames();
-        $this->getProcessor()->aggregateDataTableRecords($dataTableToSum, $this->maximumRowsInDataTable, $this->maximumRowsInSubDataTable, $this->columnToSortByBeforeTruncation);
+        $this->getProcessor()->aggregateDataTableRecords(
+            $dataTableToSum,
+            $this->maximumRowsInDataTable,
+            $this->maximumRowsInSubDataTable,
+            $this->columnToSortByBeforeTruncation,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false);
     }
 
     protected function getRecordNames()

--- a/plugins/Goals/Archiver.php
+++ b/plugins/Goals/Archiver.php
@@ -361,13 +361,15 @@ class Archiver extends \Piwik\Plugin\Archiver
         foreach ($this->dimensionRecord as $recordName) {
             $dataTableToSum[] = self::getItemRecordNameAbandonedCart($recordName);
         }
+        $columnsAggregationOperation = null;
+
         $this->getProcessor()->aggregateDataTableRecords($dataTableToSum,
             $maximumRowsInDataTableLevelZero = null,
             $maximumRowsInSubDataTable = null,
             $columnToSortByBeforeTruncation = null,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false);
+            $countRowsRecursive = array());
 
         /*
          *  Archive General Goal metrics
@@ -389,6 +391,8 @@ class Archiver extends \Piwik\Plugin\Archiver
         }
         $this->getProcessor()->aggregateNumericMetrics($fieldsToSum);
 
+        $columnsAggregationOperation = null;
+
         foreach ($goalIdsToSum as $goalId) {
             // sum up the visits to conversion data table & the days to conversion data table
             $this->getProcessor()->aggregateDataTableRecords(
@@ -397,11 +401,12 @@ class Archiver extends \Piwik\Plugin\Archiver
                 $maximumRowsInDataTableLevelZero = null,
                 $maximumRowsInSubDataTable = null,
                 $columnToSortByBeforeTruncation = null,
-                $columnsAggregationOperation = null,
+                $columnsAggregationOperation,
                 $columnsToRenameAfterAggregation = null,
-                $countRowsRecursive = false);
+                $countRowsRecursive = array());
         }
 
+        $columnsAggregationOperation = null;
         // sum up goal overview reports
         $this->getProcessor()->aggregateDataTableRecords(
                 array(self::getRecordName(self::VISITS_UNTIL_RECORD_NAME),
@@ -409,8 +414,8 @@ class Archiver extends \Piwik\Plugin\Archiver
                 $maximumRowsInDataTableLevelZero = null,
                 $maximumRowsInSubDataTable = null,
                 $columnToSortByBeforeTruncation = null,
-                $columnsAggregationOperation = null,
+                $columnsAggregationOperation,
                 $columnsToRenameAfterAggregation = null,
-                $countRowsRecursive = false);
+                $countRowsRecursive = array());
     }
 }

--- a/plugins/Goals/Archiver.php
+++ b/plugins/Goals/Archiver.php
@@ -361,7 +361,13 @@ class Archiver extends \Piwik\Plugin\Archiver
         foreach ($this->dimensionRecord as $recordName) {
             $dataTableToSum[] = self::getItemRecordNameAbandonedCart($recordName);
         }
-        $this->getProcessor()->aggregateDataTableRecords($dataTableToSum);
+        $this->getProcessor()->aggregateDataTableRecords($dataTableToSum,
+            $maximumRowsInDataTableLevelZero = null,
+            $maximumRowsInSubDataTable = null,
+            $columnToSortByBeforeTruncation = null,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false);
 
         /*
          *  Archive General Goal metrics
@@ -385,14 +391,26 @@ class Archiver extends \Piwik\Plugin\Archiver
 
         foreach ($goalIdsToSum as $goalId) {
             // sum up the visits to conversion data table & the days to conversion data table
-            $this->getProcessor()->aggregateDataTableRecords(array(
-                                                                  self::getRecordName(self::VISITS_UNTIL_RECORD_NAME, $goalId),
-                                                                  self::getRecordName(self::DAYS_UNTIL_CONV_RECORD_NAME, $goalId)));
+            $this->getProcessor()->aggregateDataTableRecords(
+                array(self::getRecordName(self::VISITS_UNTIL_RECORD_NAME, $goalId),
+                      self::getRecordName(self::DAYS_UNTIL_CONV_RECORD_NAME, $goalId)),
+                $maximumRowsInDataTableLevelZero = null,
+                $maximumRowsInSubDataTable = null,
+                $columnToSortByBeforeTruncation = null,
+                $columnsAggregationOperation = null,
+                $columnsToRenameAfterAggregation = null,
+                $countRowsRecursive = false);
         }
 
         // sum up goal overview reports
-        $this->getProcessor()->aggregateDataTableRecords(array(
-                                                              self::getRecordName(self::VISITS_UNTIL_RECORD_NAME),
-                                                              self::getRecordName(self::DAYS_UNTIL_CONV_RECORD_NAME)));
+        $this->getProcessor()->aggregateDataTableRecords(
+                array(self::getRecordName(self::VISITS_UNTIL_RECORD_NAME),
+                      self::getRecordName(self::DAYS_UNTIL_CONV_RECORD_NAME)),
+                $maximumRowsInDataTableLevelZero = null,
+                $maximumRowsInSubDataTable = null,
+                $columnToSortByBeforeTruncation = null,
+                $columnsAggregationOperation = null,
+                $columnsToRenameAfterAggregation = null,
+                $countRowsRecursive = false);
     }
 }

--- a/plugins/Provider/Archiver.php
+++ b/plugins/Provider/Archiver.php
@@ -24,6 +24,14 @@ class Archiver extends \Piwik\Plugin\Archiver
 
     public function aggregateMultipleReports()
     {
-        $this->getProcessor()->aggregateDataTableRecords(array(self::PROVIDER_RECORD_NAME), $this->maximumRows);
+        $this->getProcessor()->aggregateDataTableRecords(
+            array(self::PROVIDER_RECORD_NAME),
+            $this->maximumRows,
+            $maximumRowsInSubDataTable = null,
+            $columnToSortByBeforeTruncation = null,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false
+        );
     }
 }

--- a/plugins/Provider/Archiver.php
+++ b/plugins/Provider/Archiver.php
@@ -24,14 +24,16 @@ class Archiver extends \Piwik\Plugin\Archiver
 
     public function aggregateMultipleReports()
     {
+        $columnsAggregationOperation = null;
+
         $this->getProcessor()->aggregateDataTableRecords(
             array(self::PROVIDER_RECORD_NAME),
             $this->maximumRows,
             $maximumRowsInSubDataTable = null,
             $columnToSortByBeforeTruncation = null,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false
+            $countRowsRecursive = array()
         );
     }
 }

--- a/plugins/Referrers/Archiver.php
+++ b/plugins/Referrers/Archiver.php
@@ -217,14 +217,15 @@ class Archiver extends \Piwik\Plugin\Archiver
     public function aggregateMultipleReports()
     {
         $dataTableToSum = $this->getRecordNames();
+        $columnsAggregationOperation = null;
         $nameToCount = $this->getProcessor()->aggregateDataTableRecords(
             $dataTableToSum,
             $this->maximumRowsInDataTableLevelZero,
             $this->maximumRowsInSubDataTable,
             $this->columnToSortByBeforeTruncation,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false
+            $countRowsRecursive = array(self::WEBSITES_RECORD_NAME)
         );
 
         $mappingFromArchiveName = array(

--- a/plugins/Referrers/Archiver.php
+++ b/plugins/Referrers/Archiver.php
@@ -217,7 +217,15 @@ class Archiver extends \Piwik\Plugin\Archiver
     public function aggregateMultipleReports()
     {
         $dataTableToSum = $this->getRecordNames();
-        $nameToCount = $this->getProcessor()->aggregateDataTableRecords($dataTableToSum, $this->maximumRowsInDataTableLevelZero, $this->maximumRowsInSubDataTable, $this->columnToSortByBeforeTruncation);
+        $nameToCount = $this->getProcessor()->aggregateDataTableRecords(
+            $dataTableToSum,
+            $this->maximumRowsInDataTableLevelZero,
+            $this->maximumRowsInSubDataTable,
+            $this->columnToSortByBeforeTruncation,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false
+        );
 
         $mappingFromArchiveName = array(
             self::METRIC_DISTINCT_SEARCH_ENGINE_RECORD_NAME =>

--- a/plugins/Resolution/Archiver.php
+++ b/plugins/Resolution/Archiver.php
@@ -39,7 +39,14 @@ class Archiver extends \Piwik\Plugin\Archiver
             self::RESOLUTION_RECORD_NAME,
             self::CONFIGURATION_RECORD_NAME,
         );
-        $this->getProcessor()->aggregateDataTableRecords($dataTableRecords, $this->maximumRows);
+        $this->getProcessor()->aggregateDataTableRecords(
+            $dataTableRecords,
+            $this->maximumRows,
+            $maximumRowsInSubDataTable = null,
+            $columnToSortByBeforeTruncation = null,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false);
     }
 
     protected function aggregateByConfiguration()

--- a/plugins/Resolution/Archiver.php
+++ b/plugins/Resolution/Archiver.php
@@ -39,14 +39,15 @@ class Archiver extends \Piwik\Plugin\Archiver
             self::RESOLUTION_RECORD_NAME,
             self::CONFIGURATION_RECORD_NAME,
         );
+        $columnsAggregationOperation = null;
         $this->getProcessor()->aggregateDataTableRecords(
             $dataTableRecords,
             $this->maximumRows,
             $maximumRowsInSubDataTable = null,
             $columnToSortByBeforeTruncation = null,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false);
+            $countRowsRecursive = array());
     }
 
     protected function aggregateByConfiguration()

--- a/plugins/UserCountry/Archiver.php
+++ b/plugins/UserCountry/Archiver.php
@@ -62,7 +62,15 @@ class Archiver extends \Piwik\Plugin\Archiver
             self::CITY_RECORD_NAME,
         );
 
-        $nameToCount = $this->getProcessor()->aggregateDataTableRecords($dataTableToSum);
+        $nameToCount = $this->getProcessor()->aggregateDataTableRecords(
+            $dataTableToSum,
+            $maximumRowsInDataTableLevelZero = null,
+            $maximumRowsInSubDataTable = null,
+            $columnToSortByBeforeTruncation = null,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false
+        );
         $this->getProcessor()->insertNumericRecord(self::DISTINCT_COUNTRIES_METRIC,
             $nameToCount[self::COUNTRY_RECORD_NAME]['level0']);
     }

--- a/plugins/UserCountry/Archiver.php
+++ b/plugins/UserCountry/Archiver.php
@@ -61,15 +61,16 @@ class Archiver extends \Piwik\Plugin\Archiver
             self::REGION_RECORD_NAME,
             self::CITY_RECORD_NAME,
         );
+        $columnsAggregationOperation = null;
 
         $nameToCount = $this->getProcessor()->aggregateDataTableRecords(
             $dataTableToSum,
             $maximumRowsInDataTableLevelZero = null,
             $maximumRowsInSubDataTable = null,
             $columnToSortByBeforeTruncation = null,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false
+            $countRowsRecursive = array()
         );
         $this->getProcessor()->insertNumericRecord(self::DISTINCT_COUNTRIES_METRIC,
             $nameToCount[self::COUNTRY_RECORD_NAME]['level0']);

--- a/plugins/UserLanguage/Archiver.php
+++ b/plugins/UserLanguage/Archiver.php
@@ -46,7 +46,14 @@ class Archiver extends \Piwik\Plugin\Archiver
         $dataTableRecords = array(
             self::LANGUAGE_RECORD_NAME,
         );
-        $this->getProcessor()->aggregateDataTableRecords($dataTableRecords, $this->maximumRows);
+        $this->getProcessor()->aggregateDataTableRecords(
+            $dataTableRecords,
+            $this->maximumRows,
+            $maximumRowsInSubDataTable = null,
+            $columnToSortByBeforeTruncation = null,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false);
     }
 
     protected function aggregateByLanguage()

--- a/plugins/UserLanguage/Archiver.php
+++ b/plugins/UserLanguage/Archiver.php
@@ -46,14 +46,15 @@ class Archiver extends \Piwik\Plugin\Archiver
         $dataTableRecords = array(
             self::LANGUAGE_RECORD_NAME,
         );
+        $columnsAggregationOperation = null;
         $this->getProcessor()->aggregateDataTableRecords(
             $dataTableRecords,
             $this->maximumRows,
             $maximumRowsInSubDataTable = null,
             $columnToSortByBeforeTruncation = null,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false);
+            $countRowsRecursive = array());
     }
 
     protected function aggregateByLanguage()

--- a/plugins/VisitTime/Archiver.php
+++ b/plugins/VisitTime/Archiver.php
@@ -30,7 +30,14 @@ class Archiver extends \Piwik\Plugin\Archiver
             self::LOCAL_TIME_RECORD_NAME,
             self::SERVER_TIME_RECORD_NAME,
         );
-        $this->getProcessor()->aggregateDataTableRecords($dataTableRecords);
+        $this->getProcessor()->aggregateDataTableRecords(
+            $dataTableRecords,
+            $maximumRowsInDataTableLevelZero = null,
+            $maximumRowsInSubDataTable = null,
+            $columnToSortByBeforeTruncation = null,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false);
     }
 
     protected function aggregateByServerTime()

--- a/plugins/VisitTime/Archiver.php
+++ b/plugins/VisitTime/Archiver.php
@@ -30,14 +30,15 @@ class Archiver extends \Piwik\Plugin\Archiver
             self::LOCAL_TIME_RECORD_NAME,
             self::SERVER_TIME_RECORD_NAME,
         );
+        $columnsAggregationOperation = null;
         $this->getProcessor()->aggregateDataTableRecords(
             $dataTableRecords,
             $maximumRowsInDataTableLevelZero = null,
             $maximumRowsInSubDataTable = null,
             $columnToSortByBeforeTruncation = null,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false);
+            $countRowsRecursive = array());
     }
 
     protected function aggregateByServerTime()

--- a/plugins/VisitorInterest/Archiver.php
+++ b/plugins/VisitorInterest/Archiver.php
@@ -128,14 +128,15 @@ class Archiver extends \Piwik\Plugin\Archiver
             self::VISITS_COUNT_RECORD_NAME,
             self::DAYS_SINCE_LAST_RECORD_NAME
         );
+        $columnsAggregationOperation = null;
         $this->getProcessor()->aggregateDataTableRecords(
             $dataTableRecords,
             $maximumRowsInDataTableLevelZero = null,
             $maximumRowsInSubDataTable = null,
             $columnToSortByBeforeTruncation = null,
-            $columnsAggregationOperation = null,
+            $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
-            $countRowsRecursive = false);
+            $countRowsRecursive = array());
     }
 
     /**

--- a/plugins/VisitorInterest/Archiver.php
+++ b/plugins/VisitorInterest/Archiver.php
@@ -128,7 +128,14 @@ class Archiver extends \Piwik\Plugin\Archiver
             self::VISITS_COUNT_RECORD_NAME,
             self::DAYS_SINCE_LAST_RECORD_NAME
         );
-        $this->getProcessor()->aggregateDataTableRecords($dataTableRecords);
+        $this->getProcessor()->aggregateDataTableRecords(
+            $dataTableRecords,
+            $maximumRowsInDataTableLevelZero = null,
+            $maximumRowsInSubDataTable = null,
+            $columnToSortByBeforeTruncation = null,
+            $columnsAggregationOperation = null,
+            $columnsToRenameAfterAggregation = null,
+            $countRowsRecursive = false);
     }
 
     /**


### PR DESCRIPTION
The method `ArchiveProcessor::aggregateDataTableRecords` counts by default the number of rows recursive. I noticed this takes a lot of time especially on large dataTables: https://github.com/piwik/piwik/blob/2.12.0-b7/core/ArchiveProcessor.php#L220

We're calling this method 17 times but it is only actually used once. Therefore I added a parameter to disable it (not enabled by default to stay BC. I failed to find a better solution. Only solution I could think of alternatively would be to add another method that does not count recursive.

In the following example run you can see that it takes 13.5 seconds (with xhprof and only no_builtins flag) which is 15% of the total time to get the rows count recursive. And this is only for 5 records. Those 17 calls easily make 30 records. Meaning we will save a lot of time when generating week, month, year and range archives.

![getrowscountrecursive](https://cloud.githubusercontent.com/assets/273120/6702302/5e420afe-cd8e-11e4-904c-85cd7262dec6.png)
)
