### PR TITLE
Percentage fix in the "Browser plugin" report

### DIFF
--- a/core/DataTable/Filter/RangeCheck.php
+++ b/core/DataTable/Filter/RangeCheck.php
@@ -47,6 +47,19 @@ class RangeCheck extends BaseFilter
     {
         foreach ($table->getRows() as $row) {
             $value = $row->getColumn($this->columnToFilter);
+
+            if ($value === false) {
+                $value = $row->getMetadata($this->columnToFilter);
+                if ($value !== false) {
+                    if ($value < (float) self::$minimumValue) {
+                        $row->setMetadata($this->columnToFilter, self::$minimumValue);
+                    } elseif ($value > (float) self::$maximumValue) {
+                        $row->setMetadata($this->columnToFilter, self::$maximumValue);
+                    }
+                }
+                continue;
+            }
+
             if ($value !== false) {
                 if ($value < (float) self::$minimumValue) {
                     $row->setColumn($this->columnToFilter, self::$minimumValue);

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -3993,6 +3993,7 @@ if (typeof Piwik !== 'object') {
                     },
                     devicePixelRatio = (new RegExp('Mac OS X.*Safari/')).test(navigatorAlias.userAgent) ? windowAlias.devicePixelRatio || 1 : 1;
 
+                // detect browser features except IE < 11 (IE 11 user agent is no longer MSIE)
                 if (!((new RegExp('MSIE')).test(navigatorAlias.userAgent))) {
                     // general plugin detection
                     if (navigatorAlias.mimeTypes && navigatorAlias.mimeTypes.length) {

--- a/plugins/DevicePlugins/API.php
+++ b/plugins/DevicePlugins/API.php
@@ -92,6 +92,7 @@ class API extends \Piwik\Plugin\API
 
         $dataTable->queueFilter('ColumnCallbackAddMetadata', array('label', 'logo', __NAMESPACE__ . '\getPluginsLogo'));
         $dataTable->queueFilter('ColumnCallbackReplace', array('label', 'ucfirst'));
+        $dataTable->queueFilter('RangeCheck', array('nb_visits_percentage', 0, 1));
 
         return $dataTable;
     }

--- a/plugins/DevicePlugins/API.php
+++ b/plugins/DevicePlugins/API.php
@@ -41,18 +41,18 @@ class API extends \Piwik\Plugin\API
     {
         // fetch all archive data required
         $dataTable = $this->getDataTable(Archiver::PLUGIN_RECORD_NAME, $idSite, $period, $date, $segment);
-        $browserTypes = $this->getDataTable(DDArchiver::BROWSER_ENGINE_RECORD_NAME, $idSite, $period, $date, $segment);
+        $browserVersions = $this->getDataTable(DDArchiver::BROWSER_VERSION_RECORD_NAME, $idSite, $period, $date, $segment);
         $archive = Archive::build($idSite, $period, $date, $segment);
         $visitsSums = $archive->getDataTableFromNumeric('nb_visits');
 
         // check whether given tables are arrays
         if ($dataTable instanceof DataTable\Map) {
             $dataTableMap = $dataTable->getDataTables();
-            $browserTypesArray = $browserTypes->getDataTables();
+            $browserVersionsArray = $browserVersions->getDataTables();
             $visitSumsArray = $visitsSums->getDataTables();
         } else {
             $dataTableMap = array($dataTable);
-            $browserTypesArray = array($browserTypes);
+            $browserVersionsArray = array($browserVersions);
             $visitSumsArray = array($visitsSums);
         }
 
@@ -61,9 +61,18 @@ class API extends \Piwik\Plugin\API
             // Calculate percentage, but ignore IE users because plugin detection doesn't work on IE
             $ieVisits = 0;
 
-            $ieStats = $browserTypesArray[$key]->getRowFromLabel('Trident');
-            if ($ieStats !== false) {
-                $ieVisits = $ieStats->getColumn(Metrics::INDEX_NB_VISITS);
+            $browserVersionsToExclude = array(
+                'IE;10.0',
+                'IE;9.0',
+                'IE;8.0',
+                'IE;7.0',
+                'IE;6.0',
+            );
+            foreach ($browserVersionsToExclude as $browserVersionToExclude) {
+                $ieStats = $browserVersionsArray[$key]->getRowFromLabel($browserVersionToExclude);
+                if ($ieStats !== false) {
+                    $ieVisits += $ieStats->getColumn(Metrics::INDEX_NB_VISITS);
+                }
             }
 
             // get according visitsSum

--- a/tests/PHPUnit/Unit/DataTable/Filter/RangeCheckTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/RangeCheckTest.php
@@ -11,13 +11,13 @@ namespace Piwik\Tests\Unit\DataTable\Filter;
 use Piwik\DataTable\Filter\RangeCheck;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
+use Piwik\Plugins\CoreHome\Columns\Metrics\VisitsPercent;
 
 /**
  * @group DataTableTest
  */
 class DataTable_Filter_RangeCheckTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testRangeCheckNormalDataTable()
     {
         $table = new DataTable();
@@ -35,7 +35,6 @@ class DataTable_Filter_RangeCheckTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedOrder, $table->getColumn('count'));
     }
 
-
     public function testRangeCheckNormalDataTableNonIntegerValues()
     {
         $table = new DataTable();
@@ -52,5 +51,29 @@ class DataTable_Filter_RangeCheckTest extends \PHPUnit_Framework_TestCase
         $expectedOrder = array(3.97, 3.97, 10, 5, '9test', 3.97);
 
         $this->assertEquals($expectedOrder, $table->getColumn('count'));
+    }
+
+    public function testRangeCheckOnMetadata()
+    {
+        $table = new DataTable();
+        $table->addRowsFromArray(array(
+            array(
+                Row::COLUMNS  => array('label' => 'foo'),
+                Row::METADATA => array('count' => 5),
+            ),
+            array(
+                Row::COLUMNS  => array('label' => 'bar'),
+                Row::METADATA => array('count' => 10),
+            ),
+            array(
+                Row::COLUMNS  => array('label' => 'bar'),
+                Row::METADATA => array('count' => 15),
+            ),
+        ));
+
+        $filter = new RangeCheck($table, 'count', 0, 10);
+        $filter->filter($table);
+
+        $this->assertEquals(array(5, 10, 10), $table->getRowsMetadata('count'));
     }
 }


### PR DESCRIPTION
Fix for #7437
- Ignore IE 6-10 from total number of visits (was previously also ignoring IE 11, which caused the wrong percentage)
- Prevent any percentage in the "Browser plugins" report to be more than 100% (safeguard)
