### PR TITLE
Fix when flattening the processed metrics are not displayed

### DIFF
--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -399,6 +399,8 @@ class Visualization extends ViewDataTable
 
         $postProcessor->setCallbackBeforeGenericFilters(function (DataTable\DataTableInterface $dataTable) use ($self, $postProcessor) {
 
+            $self->setDataTable($dataTable);
+
             // First, filters that delete rows
             foreach ($self->config->getPriorityFilters() as $filter) {
                 $dataTable->filter($filter[0], $filter[1]);
@@ -416,6 +418,8 @@ class Visualization extends ViewDataTable
         });
 
         $postProcessor->setCallbackAfterGenericFilters(function (DataTable\DataTableInterface $dataTable) use ($self) {
+
+            $self->setDataTable($dataTable);
 
             $self->afterGenericFiltersAreAppliedToLoadedDataTable();
 


### PR DESCRIPTION
We always need to update the dataTable in our callbacks since the dataTable might get copied in GenericFilter and then the visualizations dataTable is outdated
