### PR TITLE
Use `getRowsWithoutSummaryRow` when iterating over subtables

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -374,7 +374,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         usort($this->rows, $functionCallback);
 
         if ($this->isSortRecursiveEnabled()) {
-            foreach ($this->getRows() as $row) {
+            foreach ($this->getRowsWithoutSummaryRow() as $row) {
 
                 $subTable = $row->getSubtable();
                 if ($subTable) {
@@ -487,7 +487,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function filterSubtables($className, $parameters = array())
     {
-        foreach ($this->getRows() as $row) {
+        foreach ($this->getRowsWithoutSummaryRow() as $row) {
             $subtable = $row->getSubtable();
             if ($subtable) {
                 $subtable->filter($className, $parameters);
@@ -508,7 +508,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function queueFilterSubtables($className, $parameters = array())
     {
-        foreach ($this->getRows() as $row) {
+        foreach ($this->getRowsWithoutSummaryRow() as $row) {
             $subtable = $row->getSubtable();
             if ($subtable) {
                 $subtable->queueFilter($className, $parameters);
@@ -1601,7 +1601,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     public function mergeSubtables($labelColumn = false, $useMetadataColumn = false)
     {
         $result = new DataTable();
-        foreach ($this->getRows() as $row) {
+        foreach ($this->getRowsWithoutSummaryRow() as $row) {
             $subtable = $row->getSubtable();
             if ($subtable !== false) {
                 $parentLabel = $row->getColumn('label');

--- a/core/DataTable/Filter/Sort.php
+++ b/core/DataTable/Filter/Sort.php
@@ -279,7 +279,7 @@ class Sort extends BaseFilter
         unset($sortedRows);
 
         if ($table->isSortRecursiveEnabled()) {
-            foreach ($table->getRows() as $row) {
+            foreach ($table->getRowsWithoutSummaryRow() as $row) {
 
                 $subTable = $row->getSubtable();
                 if ($subTable) {

--- a/core/DataTable/Filter/Truncate.php
+++ b/core/DataTable/Filter/Truncate.php
@@ -77,7 +77,7 @@ class Truncate extends BaseFilter
         $table->queueFilter('ReplaceSummaryRowLabel', array($this->labelSummaryRow));
 
         if ($this->filterRecursive) {
-            foreach ($table->getRows() as $row) {
+            foreach ($table->getRowsWithoutSummaryRow() as $row) {
                 if ($row->isSubtableLoaded()) {
                     $this->filter($row->getSubtable());
                 }

--- a/plugins/Actions/DataTable/Filter/Actions.php
+++ b/plugins/Actions/DataTable/Filter/Actions.php
@@ -43,7 +43,7 @@ class Actions extends BaseFilter
             return urldecode($label);
         }));
 
-        foreach ($table->getRows() as $row) {
+        foreach ($table->getRowsWithoutSummaryRow() as $row) {
             $subtable = $row->getSubtable();
             if ($subtable) {
                 $this->filter($subtable);

--- a/plugins/Referrers/DataTable/Filter/UrlsFromWebsiteId.php
+++ b/plugins/Referrers/DataTable/Filter/UrlsFromWebsiteId.php
@@ -36,7 +36,7 @@ class UrlsFromWebsiteId extends BaseFilter
         }));
         $table->queueFilter('ColumnCallbackReplace', array('label', 'Piwik\Plugins\Referrers\getPathFromUrl'));
 
-        foreach ($table->getRows() as $row) {
+        foreach ($table->getRowsWithoutSummaryRow() as $row) {
             $subtable = $row->getSubtable();
             if ($subtable) {
                 $this->filter($subtable);


### PR DESCRIPTION
A summary row does not have a subtable, so we can simply get the rows without summary row and avoid creating many new arrays in `getRows()`. This improves performance quite a bit.
