### PR TITLE
The menu doesn't intercept middle mouse clicks anymore

### DIFF
--- a/plugins/CoreHome/javascripts/menu.js
+++ b/plugins/CoreHome/javascripts/menu.js
@@ -39,7 +39,7 @@ menu.prototype =
     },
 
     onItemClick: function (e) {
-        if (e.which !== 1) {
+        if (e.which === 2) {
             return;
         }
         $('.Menu--dashboard').trigger('piwikSwitchPage', this);
@@ -84,7 +84,7 @@ menu.prototype =
             }
         });
 
-        this.menuNode.find('a.item').click(this.onItemClick);
+        this.menuNode.find('a.menuItem').click(this.onItemClick);
 
         menu.prototype.adaptSubMenuHeight();
     },

--- a/plugins/CoreHome/javascripts/menu.js
+++ b/plugins/CoreHome/javascripts/menu.js
@@ -38,9 +38,12 @@ menu.prototype =
         }, 2000);
     },
 
-    onItemClick: function (item) {
-        $('.Menu--dashboard').trigger('piwikSwitchPage', item);
-        broadcast.propagateAjax( $(item).attr('href').substr(1) );
+    onItemClick: function (e) {
+        if (e.which !== 1) {
+            return;
+        }
+        $('.Menu--dashboard').trigger('piwikSwitchPage', this);
+        broadcast.propagateAjax( $(this).attr('href').substr(1) );
         return false;
     },
 
@@ -80,6 +83,8 @@ menu.prototype =
                 $(this).attr({id: module + '_' + action});
             }
         });
+
+        this.menuNode.find('a.item').click(this.onItemClick);
 
         menu.prototype.adaptSubMenuHeight();
     },

--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -1,8 +1,7 @@
 {% macro submenuItem(name, url) %}
     {% if name|slice(0,1) != '_' %}
         <li>
-            <a href='#{{ url|urlRewriteWithParameters|slice(1) }}'
-               onclick='return piwikMenu.onItemClick(this);'>
+            <a class="item" href='#{{ url|urlRewriteWithParameters|slice(1) }}'>
                 {{ name|translate }}
             </a>
         </li>
@@ -15,8 +14,7 @@
             {% for item in group.getItems %}
                 <a class="item"
                    href='#{{ item.url|urlRewriteWithParameters|slice(1) }}'
-                   {% if item.tooltip %}title="{{ item.tooltip|e('html_attr') }}"{% endif %}
-                   onclick='return piwikMenu.onItemClick(this);'>
+                   {% if item.tooltip %}title="{{ item.tooltip|e('html_attr') }}"{% endif %}>
                     {{ item.name|translate }}
                 </a>
             {% endfor %}
@@ -41,8 +39,8 @@
     <ul class="Menu-tabList">
         {% for level1,level2 in menu %}
             <li id="{% if level2._url is defined %}{{ _self.getId(level2._url) }}{% endif %}">
-                <a {% if level2._url is defined %}href="#{{ _self.getFirstUrl(level2._url) }}"{% endif %}
-                   onclick="return piwikMenu.onItemClick(this);">{{ level1|translate }}
+                <a class="item" {% if level2._url is defined %}href="#{{ _self.getFirstUrl(level2._url) }}"{% endif %}>
+                    {{ level1|translate }}
                    <span class="hidden">
                      {{ 'CoreHome_Menu'|translate }}
                    </span>

--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -1,7 +1,7 @@
 {% macro submenuItem(name, url) %}
     {% if name|slice(0,1) != '_' %}
         <li>
-            <a class="item" href='#{{ url|urlRewriteWithParameters|slice(1) }}'>
+            <a class="menuItem" href='#{{ url|urlRewriteWithParameters|slice(1) }}'>
                 {{ name|translate }}
             </a>
         </li>
@@ -39,7 +39,7 @@
     <ul class="Menu-tabList">
         {% for level1,level2 in menu %}
             <li id="{% if level2._url is defined %}{{ _self.getId(level2._url) }}{% endif %}">
-                <a class="item" {% if level2._url is defined %}href="#{{ _self.getFirstUrl(level2._url) }}"{% endif %}>
+                <a class="menuItem" {% if level2._url is defined %}href="#{{ _self.getFirstUrl(level2._url) }}"{% endif %}>
                     {{ level1|translate }}
                    <span class="hidden">
                      {{ 'CoreHome_Menu'|translate }}


### PR DESCRIPTION
This PR fixes #7466: re-applies the changes of #7478 (which were reverted in master) by reverting the revert (oh yeah) and fixing the problem in the original fix (oh yeah).

The first PR contained a bug: on load a `click` is simulated by `menu.js` and that results in an event object that didn't carry the information of "which button was clicked". Silly me did `ignore clicks that are not on the left button`, so if no button was clicked then the ajax handling was ignored.

Let's put this in 2.13.
