### PR TITLE
Fix two regressions where language would not change in installer and where language would reset to english in the middle of the install process.

### DIFF
--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -13,6 +13,7 @@ use Piwik\Access;
 use Piwik\AssetManager;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Db;
 use Piwik\Db\Adapter;
@@ -31,6 +32,7 @@ use Piwik\Plugins\UsersManager\API as APIUsersManager;
 use Piwik\ProxyHeaders;
 use Piwik\SettingsPiwik;
 use Piwik\Tracker\TrackerCodeGenerator;
+use Piwik\Translation\Translator;
 use Piwik\Updater;
 use Piwik\Url;
 use Piwik\Version;
@@ -547,6 +549,17 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         }
 
         $config->forceSave();
+
+        // re-save the currently viewed language (since we saved the config file, there is now a salt which makes the
+        // existing session cookie invalid)
+        $this->resetLanguageCookie();
+    }
+
+    private function resetLanguageCookie()
+    {
+        /** @var Translator $translator */
+        $translator = StaticContainer::get('Piwik\Translation\Translator');
+        LanguagesManager::setLanguageForSession($translator->getCurrentLanguage());
     }
 
     private function checkPiwikIsNotInstalled()
@@ -675,6 +688,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $config = Config::getInstance();
         if ($config->existsLocalConfig()) {
             $config->deleteLocalConfig();
+
+            // deleting the config file removes the salt, which in turns invalidates existing cookies (including the
+            // one for selected language), so we re-save that cookie now
+            $this->resetLanguageCookie();
         }
     }
 

--- a/plugins/LanguagesManager/LanguagesManager.php
+++ b/plugins/LanguagesManager/LanguagesManager.php
@@ -34,6 +34,7 @@ class LanguagesManager extends \Piwik\Plugin
         return array(
             'AssetManager.getStylesheetFiles'            => 'getStylesheetFiles',
             'AssetManager.getJavaScriptFiles'            => 'getJsFiles',
+            'Config.NoConfigurationFile'                 => 'initLanguage',
             'Request.dispatchCoreAndPluginUpdatesScreen' => 'initLanguage',
             'Platform.initialized'                       => 'initLanguage',
             'UsersManager.deleteUser'                    => 'deleteUserLanguage',


### PR DESCRIPTION
First regression is caused by Config.NoConfigurationFile event. This event ends up being fired while loading plugins, and LanguagesManager changes the language only on Platform.initialized event and Request.dispatchCoreAndPluginUpdatesScreen event. Fixed by listening to Config.NoConfigurationFile event.

Second regression is caused by the config being saved/deleted in the middle of the installation process. This sets or removes the salt, which invalidates current cookies. This causes the piwik_lang cookie to not be recognized. Fixed by resetting the cookie after the config salt is set and after the config file is removed in the Installation controller.
