### PR TITLE
Responsive reports: 2 columns layouts now use Bootstrap CSS classes

### DIFF
--- a/plugins/Actions/templates/indexSiteSearch.twig
+++ b/plugins/Actions/templates/indexSiteSearch.twig
@@ -1,17 +1,21 @@
-<div id='leftcolumn'>
-    <h2 piwik-enriched-headline>{{ 'Actions_WidgetSearchKeywords'|translate }}</h2>
-    {{ keywords|raw }}
+<div class="row">
 
-    <h2 piwik-enriched-headline>{{ 'Actions_WidgetSearchNoResultKeywords'|translate }}</h2>
-    {{ noResultKeywords|raw }}
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'Actions_WidgetSearchKeywords'|translate }}</h2>
+        {{ keywords|raw }}
 
-    {% if categories is defined %}
-        <h2 piwik-enriched-headline>{{ 'Actions_WidgetSearchCategories'|translate }}</h2>
-        {{ categories|raw }}
-    {% endif %}
-</div>
+        <h2 piwik-enriched-headline>{{ 'Actions_WidgetSearchNoResultKeywords'|translate }}</h2>
+        {{ noResultKeywords|raw }}
 
-<div id='rightcolumn'>
-    <h2 piwik-enriched-headline>{{ 'Actions_WidgetPageUrlsFollowingSearch'|translate }}</h2>
-    {{ pagesUrlsFollowingSiteSearch|raw }}
+        {% if categories is defined %}
+            <h2 piwik-enriched-headline>{{ 'Actions_WidgetSearchCategories'|translate }}</h2>
+            {{ categories|raw }}
+        {% endif %}
+    </div>
+
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'Actions_WidgetPageUrlsFollowingSearch'|translate }}</h2>
+        {{ pagesUrlsFollowingSiteSearch|raw }}
+    </div>
+
 </div>

--- a/plugins/DevicesDetection/templates/devices.twig
+++ b/plugins/DevicesDetection/templates/devices.twig
@@ -1,15 +1,19 @@
-<div id='leftcolumn'>
-    <h2 piwik-enriched-headline>{{ "DevicesDetection_DeviceType"|translate }}</h2>
-    {{ deviceTypes  | raw}}
-    <h2 piwik-enriched-headline>{{ "DevicesDetection_DeviceBrand"|translate }}</h2>
-    {{ deviceBrands | raw }}
-</div>
+<div class="row">
 
-<div id='rightcolumn'>
-    <h2 piwik-enriched-headline>{{ "DevicesDetection_DeviceModel"|translate }}</h2>
-    {{ deviceModels | raw }}
-    {% if resolutions|default is not empty %}
-        <h2 piwik-enriched-headline>{{ 'Resolution_Resolutions'|translate }}</h2>
-        {{ resolutions|raw }}
-    {% endif %}
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ "DevicesDetection_DeviceType"|translate }}</h2>
+        {{ deviceTypes  | raw}}
+        <h2 piwik-enriched-headline>{{ "DevicesDetection_DeviceBrand"|translate }}</h2>
+        {{ deviceBrands | raw }}
+    </div>
+
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ "DevicesDetection_DeviceModel"|translate }}</h2>
+        {{ deviceModels | raw }}
+        {% if resolutions|default is not empty %}
+            <h2 piwik-enriched-headline>{{ 'Resolution_Resolutions'|translate }}</h2>
+            {{ resolutions|raw }}
+        {% endif %}
+    </div>
+
 </div>

--- a/plugins/DevicesDetection/templates/software.twig
+++ b/plugins/DevicesDetection/templates/software.twig
@@ -1,19 +1,23 @@
-<div id='leftcolumn'>
-    <h2 piwik-enriched-headline>{{ "DevicesDetection_OperatingSystems"|translate }}</h2>
-    {{ osReport | raw}}
-    {% if configurations|default is not empty %}
-        <h2 piwik-enriched-headline>{{ 'Resolution_Configurations'|translate }}</h2>
-        {{ configurations|raw }}
-    {% endif %}
-</div>
+<div class="row">
 
-<div id='rightcolumn'>
-    <h2 piwik-enriched-headline>{{ "DevicesDetection_Browsers"|translate }}</h2>
-    {{ browserReport | raw }}
-    <h2 piwik-enriched-headline>{{ "DevicesDetection_BrowserEngines"|translate }}</h2>
-    {{ browserEngineReport | raw }}
-    {% if browserPlugins|default is not empty %}
-        <h2 piwik-enriched-headline>{{ 'General_Plugins'|translate }}</h2>
-        {{ browserPlugins|raw }}
-    {% endif %}
+    <div id="col-md-6">
+        <h2 piwik-enriched-headline>{{ "DevicesDetection_OperatingSystems"|translate }}</h2>
+        {{ osReport | raw}}
+        {% if configurations|default is not empty %}
+            <h2 piwik-enriched-headline>{{ 'Resolution_Configurations'|translate }}</h2>
+            {{ configurations|raw }}
+        {% endif %}
+    </div>
+
+    <div id="col-md-6">
+        <h2 piwik-enriched-headline>{{ "DevicesDetection_Browsers"|translate }}</h2>
+        {{ browserReport | raw }}
+        <h2 piwik-enriched-headline>{{ "DevicesDetection_BrowserEngines"|translate }}</h2>
+        {{ browserEngineReport | raw }}
+        {% if browserPlugins|default is not empty %}
+            <h2 piwik-enriched-headline>{{ 'General_Plugins'|translate }}</h2>
+            {{ browserPlugins|raw }}
+        {% endif %}
+    </div>
+
 </div>

--- a/plugins/Goals/templates/getOverviewView.twig
+++ b/plugins/Goals/templates/getOverviewView.twig
@@ -15,20 +15,21 @@
             </a>
         </h2>
 
-        <div id='leftcolumn'>
-            <div class="sparkline">{{ sparkline(goal.urlSparklineConversions) }}
-                {{ 'Goals_Conversions'|translate("<strong>"~nb_conversions~"</strong>")|raw }}
-                {% if goal.goalAllowMultipleConversionsPerVisit %}
-                    ({{ 'General_NVisits'|translate("<strong>"~nb_visits_converted~"</strong>") | raw }})
-                {% endif %}
+        <div class="row">
+            <div class="col-md-6">
+                <div class="sparkline">{{ sparkline(goal.urlSparklineConversions) }}
+                    {{ 'Goals_Conversions'|translate("<strong>"~nb_conversions~"</strong>")|raw }}
+                    {% if goal.goalAllowMultipleConversionsPerVisit %}
+                        ({{ 'General_NVisits'|translate("<strong>"~nb_visits_converted~"</strong>") | raw }})
+                    {% endif %}
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="sparkline">{{ sparkline(goal.urlSparklineConversionRate) }}
+                    {{ 'Goals_ConversionRate'|translate("<strong>"~conversion_rate~"</strong>")|raw }}
+                </div>
             </div>
         </div>
-        <div id='rightcolumn'>
-            <div class="sparkline">{{ sparkline(goal.urlSparklineConversionRate) }}
-                {{ 'Goals_ConversionRate'|translate("<strong>"~conversion_rate~"</strong>")|raw }}
-            </div>
-        </div>
-        <br class="clear"/>
     </div>
 {% endfor %}
 

--- a/plugins/Referrers/templates/getSearchEnginesAndKeywords.twig
+++ b/plugins/Referrers/templates/getSearchEnginesAndKeywords.twig
@@ -1,9 +1,13 @@
-<div id='leftcolumn'>
-    <h2 piwik-enriched-headline>{{ 'Referrers_Keywords'|translate }}</h2>
-    {{ keywords|raw }}
-</div>
+<div class="row">
 
-<div id='rightcolumn'>
-    <h2 piwik-enriched-headline>{{ 'Referrers_SearchEngines'|translate }}</h2>
-    {{ searchEngines|raw }}
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'Referrers_Keywords'|translate }}</h2>
+        {{ keywords|raw }}
+    </div>
+
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'Referrers_SearchEngines'|translate }}</h2>
+        {{ searchEngines|raw }}
+    </div>
+
 </div>

--- a/plugins/Referrers/templates/index.twig
+++ b/plugins/Referrers/templates/index.twig
@@ -4,51 +4,51 @@
 
 <h2 piwik-enriched-headline>{{ 'Referrers_Type'|translate }}</h2>
 
-<div id='leftcolumn'>
-    <div class="sparkline" style="padding-left: 12px;">{{ sparkline(urlSparklineDirectEntry) }}
-        {{ 'Referrers_TypeDirectEntries'|translate("<strong>"~visitorsFromDirectEntry~"</strong>")|raw }}
-        {% if visitorsFromDirectEntryPercent|default is not empty %},
-            {{ 'Referrers_XPercentOfVisits'|translate("<strong>"~visitorsFromDirectEntryPercent~"</strong>")|raw }}
-        {% endif %}
-        {% if visitorsFromDirectEntryEvolution|default is not empty %}
-            {{ visitorsFromDirectEntryEvolution|raw }}
-        {% endif %}
+<div class="row">
+    <div class="col-md-6">
+        <div class="sparkline" style="padding-left: 12px;">{{ sparkline(urlSparklineDirectEntry) }}
+            {{ 'Referrers_TypeDirectEntries'|translate("<strong>"~visitorsFromDirectEntry~"</strong>")|raw }}
+            {% if visitorsFromDirectEntryPercent|default is not empty %},
+                {{ 'Referrers_XPercentOfVisits'|translate("<strong>"~visitorsFromDirectEntryPercent~"</strong>")|raw }}
+            {% endif %}
+            {% if visitorsFromDirectEntryEvolution|default is not empty %}
+                {{ visitorsFromDirectEntryEvolution|raw }}
+            {% endif %}
+        </div>
+        <div class="sparkline" style="padding-left: 12px;">{{ sparkline(urlSparklineSearchEngines) }}
+            {{ 'Referrers_TypeSearchEngines'|translate("<strong>"~visitorsFromSearchEngines~"</strong>")|raw }}
+            {% if visitorsFromSearchEnginesPercent|default is not empty %},
+                {{ 'Referrers_XPercentOfVisits'|translate("<strong>"~visitorsFromSearchEnginesPercent~"</strong>")|raw }}
+            {% endif %}
+            {% if visitorsFromSearchEnginesEvolution|default is not empty %}
+                {{ visitorsFromSearchEnginesEvolution|raw }}
+            {% endif %}
+        </div>
     </div>
-    <div class="sparkline" style="padding-left: 12px;">{{ sparkline(urlSparklineSearchEngines) }}
-        {{ 'Referrers_TypeSearchEngines'|translate("<strong>"~visitorsFromSearchEngines~"</strong>")|raw }}
-        {% if visitorsFromSearchEnginesPercent|default is not empty %},
-            {{ 'Referrers_XPercentOfVisits'|translate("<strong>"~visitorsFromSearchEnginesPercent~"</strong>")|raw }}
-        {% endif %}
-        {% if visitorsFromSearchEnginesEvolution|default is not empty %}
-            {{ visitorsFromSearchEnginesEvolution|raw }}
-        {% endif %}
-    </div>
-</div>
-<div id='rightcolumn'>
-    <div class="sparkline">{{ sparkline(urlSparklineWebsites) }}
-        {{ 'Referrers_TypeWebsites'|translate("<strong>"~visitorsFromWebsites~"</strong>")|raw }}
-        {% if visitorsFromWebsitesPercent|default is not empty %},
-            {{ 'Referrers_XPercentOfVisits'|translate("<strong>"~visitorsFromWebsitesPercent~"</strong>")|raw }}
-        {% endif %}
-        {% if visitorsFromWebsitesEvolution|default is not empty %}
-            {{ visitorsFromWebsitesEvolution|raw }}
-        {% endif %}
-    </div>
-    <div class="sparkline">{{ sparkline(urlSparklineCampaigns) }}
-        {{ 'Referrers_TypeCampaigns'|translate("<strong>"~visitorsFromCampaigns~"</strong>")|raw }}
-        {% if visitorsFromCampaignsPercent|default is not empty %},
-            {{ 'Referrers_XPercentOfVisits'|translate("<strong>"~visitorsFromCampaignsPercent~"</strong>")|raw }}
-        {% endif %}
-        {% if visitorsFromCampaignsEvolution|default is not empty %}
-            {{ visitorsFromCampaignsEvolution|raw }}
-        {% endif %}
+    <div class="col-md-6">
+        <div class="sparkline">{{ sparkline(urlSparklineWebsites) }}
+            {{ 'Referrers_TypeWebsites'|translate("<strong>"~visitorsFromWebsites~"</strong>")|raw }}
+            {% if visitorsFromWebsitesPercent|default is not empty %},
+                {{ 'Referrers_XPercentOfVisits'|translate("<strong>"~visitorsFromWebsitesPercent~"</strong>")|raw }}
+            {% endif %}
+            {% if visitorsFromWebsitesEvolution|default is not empty %}
+                {{ visitorsFromWebsitesEvolution|raw }}
+            {% endif %}
+        </div>
+        <div class="sparkline">{{ sparkline(urlSparklineCampaigns) }}
+            {{ 'Referrers_TypeCampaigns'|translate("<strong>"~visitorsFromCampaigns~"</strong>")|raw }}
+            {% if visitorsFromCampaignsPercent|default is not empty %},
+                {{ 'Referrers_XPercentOfVisits'|translate("<strong>"~visitorsFromCampaignsPercent~"</strong>")|raw }}
+            {% endif %}
+            {% if visitorsFromCampaignsEvolution|default is not empty %}
+                {{ visitorsFromCampaignsEvolution|raw }}
+            {% endif %}
+        </div>
     </div>
 </div>
 
-<div style="clear:both;"/>
-
-<div id="distinctReferrersByType">
-    <div id='leftcolumn'>
+<div id="distinctReferrersByType" class="row">
+    <div class="col-md-6">
         <div class="sparkline" style="padding-left: 12px;">{{ sparkline(urlSparklineDistinctSearchEngines) }}
             <strong>{{ numberDistinctSearchEngines }}</strong> {{ 'Referrers_DistinctSearchEngines'|translate }}
             {% if numberDistinctSearchEnginesEvolution|default is not empty %}
@@ -62,7 +62,7 @@
             {% endif %}
         </div>
     </div>
-    <div id='rightcolumn'>
+    <div class="col-md-6">
         <div class="sparkline">{{ sparkline(urlSparklineDistinctWebsites) }}
             <strong>{{ numberDistinctWebsites }}</strong> {{ 'Referrers_DistinctWebsites'|translate }}
             {{ 'Referrers_UsingNDistinctUrls'|translate("<strong>"~numberDistinctWebsitesUrls~"</strong>")|raw }}
@@ -79,8 +79,6 @@
     </div>
     <br/>
 </div>
-
-<p style="clear:both;"/>
 
 <div style="float:left;" class="relatedReferrerReports">{{ 'General_View'|translate }}
     <a href="javascript:broadcast.propagateAjax('module=Referrers&action=getSearchEnginesAndKeywords')">{{ 'Referrers_SubmenuSearchEngines'|translate }}</a>,

--- a/plugins/Referrers/templates/indexWebsites.twig
+++ b/plugins/Referrers/templates/indexWebsites.twig
@@ -1,9 +1,13 @@
-<div id='leftcolumn'>
-    <h2 piwik-enriched-headline>{{ 'Referrers_Websites'|translate }}</h2>
-    {{ websites|raw }}
-</div>
+<div class="row">
 
-<div id='rightcolumn'>
-    <h2 piwik-enriched-headline>{{ 'Referrers_Socials'|translate }}</h2>
-    {{ socials|raw }}
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'Referrers_Websites'|translate }}</h2>
+        {{ websites|raw }}
+    </div>
+
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'Referrers_Socials'|translate }}</h2>
+        {{ socials|raw }}
+    </div>
+
 </div>

--- a/plugins/UserCountry/templates/index.twig
+++ b/plugins/UserCountry/templates/index.twig
@@ -1,26 +1,28 @@
-<div id="leftcolumn">
-    {{ postEvent("Template.leftColumnUserCountry") }}
+<div class="row">
 
-    <h2 piwik-enriched-headline>{{ 'UserCountry_Continent'|translate }}</h2>
-    {{ dataTableContinent|raw }}
+    <div class="col-md-6">
+        {{ postEvent("Template.leftColumnUserCountry") }}
 
-    <div class="sparkline">
-        {{ sparkline(urlSparklineCountries) }}
-        {{ 'UserCountry_DistinctCountries'|translate("<strong>"~numberDistinctCountries~"</strong>")|raw }}
+        <h2 piwik-enriched-headline>{{ 'UserCountry_Continent'|translate }}</h2>
+        {{ dataTableContinent|raw }}
+
+        <div class="sparkline">
+            {{ sparkline(urlSparklineCountries) }}
+            {{ 'UserCountry_DistinctCountries'|translate("<strong>"~numberDistinctCountries~"</strong>")|raw }}
+        </div>
+
+        {{ postEvent("Template.footerUserCountry") }}
     </div>
 
-    {{ postEvent("Template.footerUserCountry") }}
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'UserCountry_Country'|translate }}</h2>
+        {{ dataTableCountry|raw }}
+
+        <h2 piwik-enriched-headline>{{ 'UserCountry_Region'|translate }}</h2>
+        {{ dataTableRegion|raw }}
+
+        <h2 piwik-enriched-headline>{{ 'UserCountry_City'|translate }}</h2>
+        {{ dataTableCity|raw }}
+    </div>
 
 </div>
-
-<div id="rightcolumn">
-    <h2 piwik-enriched-headline>{{ 'UserCountry_Country'|translate }}</h2>
-    {{ dataTableCountry|raw }}
-
-    <h2 piwik-enriched-headline>{{ 'UserCountry_Region'|translate }}</h2>
-    {{ dataTableRegion|raw }}
-
-    <h2 piwik-enriched-headline>{{ 'UserCountry_City'|translate }}</h2>
-    {{ dataTableCity|raw }}
-</div>
-

--- a/plugins/VisitFrequency/templates/_sparklines.twig
+++ b/plugins/VisitFrequency/templates/_sparklines.twig
@@ -1,26 +1,29 @@
-<div id="leftcolumn">
-    <div class="sparkline">
-        {{ sparkline(urlSparklineNbVisitsReturning) }}
-        {{ 'VisitFrequency_ReturnVisits'|translate("<strong>"~nbVisitsReturning~"</strong>")|raw }}
+<div class="row">
+
+    <div class="col-md-6">
+        <div class="sparkline">
+            {{ sparkline(urlSparklineNbVisitsReturning) }}
+            {{ 'VisitFrequency_ReturnVisits'|translate("<strong>"~nbVisitsReturning~"</strong>")|raw }}
+        </div>
+        <div class="sparkline">
+            {{ sparkline(urlSparklineNbActionsReturning) }}
+            {{ 'VisitFrequency_ReturnActions'|translate("<strong>"~nbActionsReturning~"</strong>")|raw }}
+        </div>
+        <div class="sparkline">
+            {{ sparkline(urlSparklineActionsPerVisitReturning) }}
+            {{ 'VisitFrequency_ReturnAvgActions'|translate("<strong>"~nbActionsPerVisitReturning~"</strong>")|raw }}
+        </div>
     </div>
-    <div class="sparkline">
-        {{ sparkline(urlSparklineNbActionsReturning) }}
-        {{ 'VisitFrequency_ReturnActions'|translate("<strong>"~nbActionsReturning~"</strong>")|raw }}
+    <div class="col-md-6">
+        <div class="sparkline">
+            {{ sparkline(urlSparklineAvgVisitDurationReturning) }}
+            {% set avgVisitDurationReturning=avgVisitDurationReturning|sumtime %}
+            {{ 'VisitFrequency_ReturnAverageVisitDuration'|translate("<strong>"~avgVisitDurationReturning~"</strong>")|raw }}
+        </div>
+        <div class="sparkline">
+            {{ sparkline(urlSparklineBounceRateReturning) }}
+            {{ 'VisitFrequency_ReturnBounceRate'|translate("<strong>"~bounceRateReturning~"</strong>")|raw }}
+        </div>
+        {% include "_sparklineFooter.twig" %}
     </div>
-    <div class="sparkline">
-        {{ sparkline(urlSparklineActionsPerVisitReturning) }}
-        {{ 'VisitFrequency_ReturnAvgActions'|translate("<strong>"~nbActionsPerVisitReturning~"</strong>")|raw }}
-    </div>
-</div><div id="rightcolumn">
-    <div class="sparkline">
-        {{ sparkline(urlSparklineAvgVisitDurationReturning) }}
-        {% set avgVisitDurationReturning=avgVisitDurationReturning|sumtime %}
-        {{ 'VisitFrequency_ReturnAverageVisitDuration'|translate("<strong>"~avgVisitDurationReturning~"</strong>")|raw }}
-    </div>
-    <div class="sparkline">
-        {{ sparkline(urlSparklineBounceRateReturning) }}
-        {{ 'VisitFrequency_ReturnBounceRate'|translate("<strong>"~bounceRateReturning~"</strong>")|raw }}
-    </div>
-    {% include "_sparklineFooter.twig" %}
 </div>
-<div style="clear:both"></div>

--- a/plugins/VisitTime/templates/index.twig
+++ b/plugins/VisitTime/templates/index.twig
@@ -1,9 +1,13 @@
-<div id='leftcolumn'>
-    <h2 piwik-enriched-headline>{{ 'VisitTime_LocalTime'|translate }}</h2>
-    {{ dataTableVisitInformationPerLocalTime|raw }}
-</div>
+<div class="row">
 
-<div id='rightcolumn'>
-    <h2 piwik-enriched-headline>{{ 'VisitTime_ServerTime'|translate }}</h2>
-    {{ dataTableVisitInformationPerServerTime|raw }}
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'VisitTime_LocalTime'|translate }}</h2>
+        {{ dataTableVisitInformationPerLocalTime|raw }}
+    </div>
+
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'VisitTime_ServerTime'|translate }}</h2>
+        {{ dataTableVisitInformationPerServerTime|raw }}
+    </div>
+
 </div>

--- a/plugins/VisitorInterest/templates/index.twig
+++ b/plugins/VisitorInterest/templates/index.twig
@@ -1,20 +1,21 @@
-<br />
-<div id="leftcolumn">
-    <h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsPerDuration'|translate }}</h2>
-    {{ dataTableNumberOfVisitsPerVisitDuration|raw }}
+<div class="row">
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsPerDuration'|translate }}</h2>
+        {{ dataTableNumberOfVisitsPerVisitDuration|raw }}
+    </div>
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsPerNbOfPages'|translate }}</h2>
+        {{ dataTableNumberOfVisitsPerPage|raw }}
+    </div>
 </div>
-<div id="rightcolumn">
-    <h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsPerNbOfPages'|translate }}</h2>
-    {{ dataTableNumberOfVisitsPerPage|raw }}
+
+<div class="row">
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'VisitorInterest_visitsByVisitCount'|translate }}</h2>
+        {{ dataTableNumberOfVisitsByVisitNum|raw }}
+    </div>
+    <div class="col-md-6">
+        <h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsByDaysSinceLast'|translate }}</h2>
+        {{ dataTableNumberOfVisitsByDaysSinceLast|raw }}
+    </div>
 </div>
-<div style="clear:both"></div>
-<br />
-<div id="leftcolumn">
-    <h2 piwik-enriched-headline>{{ 'VisitorInterest_visitsByVisitCount'|translate }}</h2>
-    {{ dataTableNumberOfVisitsByVisitNum|raw }}
-</div>
-<div id="rightcolumn">
-    <h2 piwik-enriched-headline>{{ 'VisitorInterest_VisitsByDaysSinceLast'|translate }}</h2>
-    {{ dataTableNumberOfVisitsByDaysSinceLast|raw }}
-</div>
-<div style="clear:both"></div>

--- a/plugins/VisitsSummary/templates/_sparklines.twig
+++ b/plugins/VisitsSummary/templates/_sparklines.twig
@@ -1,78 +1,81 @@
-<div id='leftcolumn'>
-    <div class="sparkline">
-        {{ sparkline(urlSparklineNbVisits)|raw }}
-        {{ 'General_NVisits'|translate("<strong>"~nbVisits~"</strong>")|raw }}{% if displayUniqueVisitors %},
-            {{ 'VisitsSummary_NbUniqueVisitors'|translate("<strong>"~nbUniqVisitors~"</strong>")|raw }}{% endif %}
-    </div>
-    {% if nbUsers > 0 %}
-        {# Most of users will not have used `setUserId` so this would be confusingly zero #}
-        <div class="sparkline">
-            {{ sparkline(urlSparklineNbUsers)|raw }}
-            {{ 'General_NUsers'|translate("<strong>"~nbUsers~"</strong>")|raw }}
-        </div>
-    {% endif %}
-    <div class="sparkline">
-        {{ sparkline(urlSparklineAvgVisitDuration)|raw }}
-        {% set averageVisitDuration=averageVisitDuration|sumtime %}
-        {{ 'VisitsSummary_AverageVisitDuration'|translate("<strong>"~averageVisitDuration~"</strong>")|raw }}
-    </div>
-    <div class="sparkline">
-        {{ sparkline(urlSparklineBounceRate)|raw }}
-        {{ 'VisitsSummary_NbVisitsBounced'|translate("<strong>"~bounceRate~"</strong>")|raw }}
-    </div>
-    <div class="sparkline">
-        {{ sparkline(urlSparklineActionsPerVisit)|raw }}
-        {{ 'VisitsSummary_NbActionsPerVisit'|translate("<strong>"~nbActionsPerVisit~"</strong>")|raw }}
-    </div>
-    {% if showActionsPluginReports|default(false) %}
-	<div class="sparkline">
-        {{ sparkline(urlSparklineAvgGenerationTime)|raw }}
-		{% set averageGenerationTime=averageGenerationTime|sumtime %}
-		{{ 'VisitsSummary_AverageGenerationTime'|translate("<strong>"~averageGenerationTime~"</strong>")|raw }}
-	</div>
-    {% endif %}
-</div>
+<div class="row">
 
-<div id='rightcolumn'>
-    {% if showActionsPluginReports|default(false) %}
-        {% if showOnlyActions %}
+    <div class="col-md-6">
+        <div class="sparkline">
+            {{ sparkline(urlSparklineNbVisits)|raw }}
+            {{ 'General_NVisits'|translate("<strong>"~nbVisits~"</strong>")|raw }}{% if displayUniqueVisitors %},
+                {{ 'VisitsSummary_NbUniqueVisitors'|translate("<strong>"~nbUniqVisitors~"</strong>")|raw }}{% endif %}
+        </div>
+        {% if nbUsers > 0 %}
+            {# Most of users will not have used `setUserId` so this would be confusingly zero #}
             <div class="sparkline">
-                {{ sparkline(urlSparklineNbActions)|raw }}
-                {{ 'VisitsSummary_NbActionsDescription'|translate("<strong>"~nbActions~"</strong>")|raw }}
+                {{ sparkline(urlSparklineNbUsers)|raw }}
+                {{ 'General_NUsers'|translate("<strong>"~nbUsers~"</strong>")|raw }}
             </div>
-        {% else %}
-            <div class="sparkline">
-                {{ sparkline(urlSparklineNbPageviews)|raw }}
-                {{ 'VisitsSummary_NbPageviewsDescription'|translate("<strong>"~nbPageviews~"</strong>")|trim|raw }},
-                {{ 'VisitsSummary_NbUniquePageviewsDescription'|translate("<strong>"~nbUniquePageviews~"</strong>")|raw }}
-            </div>
-            {% if displaySiteSearch %}
-                <div class="sparkline">
-                    {{ sparkline(urlSparklineNbSearches)|raw }}
-                    {{ 'VisitsSummary_NbSearchesDescription'|translate("<strong>"~nbSearches~"</strong>")|trim|raw }},
-                    {{ 'VisitsSummary_NbKeywordsDescription'|translate("<strong>"~nbKeywords~"</strong>")|raw }}
-                </div>
-            {% endif %}
-            <div class="sparkline">
-                    {{ sparkline(urlSparklineNbDownloads)|raw }}
-                    {{ 'VisitsSummary_NbDownloadsDescription'|translate("<strong>"~nbDownloads~"</strong>")|trim|raw }},
-                    {{ 'VisitsSummary_NbUniqueDownloadsDescription'|translate("<strong>"~nbUniqueDownloads~"</strong>")|raw }}
-            </div>
-            <div class="sparkline">
-                    {{ sparkline(urlSparklineNbOutlinks)|raw }}
-                    {{ 'VisitsSummary_NbOutlinksDescription'|translate("<strong>"~nbOutlinks~"</strong>")|trim|raw }},
-                    {{ 'VisitsSummary_NbUniqueOutlinksDescription'|translate("<strong>"~nbUniqueOutlinks~"</strong>")|raw }}
-            </div>
-            {% endif %}
-    {% endif %}
-    <div class="sparkline">
-            {{ sparkline(urlSparklineMaxActions)|raw }}
-            {{ 'VisitsSummary_MaxNbActions'|translate("<strong>"~maxActions~"</strong>")|raw }}
+        {% endif %}
+        <div class="sparkline">
+            {{ sparkline(urlSparklineAvgVisitDuration)|raw }}
+            {% set averageVisitDuration=averageVisitDuration|sumtime %}
+            {{ 'VisitsSummary_AverageVisitDuration'|translate("<strong>"~averageVisitDuration~"</strong>")|raw }}
+        </div>
+        <div class="sparkline">
+            {{ sparkline(urlSparklineBounceRate)|raw }}
+            {{ 'VisitsSummary_NbVisitsBounced'|translate("<strong>"~bounceRate~"</strong>")|raw }}
+        </div>
+        <div class="sparkline">
+            {{ sparkline(urlSparklineActionsPerVisit)|raw }}
+            {{ 'VisitsSummary_NbActionsPerVisit'|translate("<strong>"~nbActionsPerVisit~"</strong>")|raw }}
+        </div>
+        {% if showActionsPluginReports|default(false) %}
+        <div class="sparkline">
+            {{ sparkline(urlSparklineAvgGenerationTime)|raw }}
+            {% set averageGenerationTime=averageGenerationTime|sumtime %}
+            {{ 'VisitsSummary_AverageGenerationTime'|translate("<strong>"~averageGenerationTime~"</strong>")|raw }}
+        </div>
+        {% endif %}
     </div>
-    
-    {{ postEvent('Template.VisitsSummaryOverviewSparklines') }}
+
+    <div class="col-md-6">
+        {% if showActionsPluginReports|default(false) %}
+            {% if showOnlyActions %}
+                <div class="sparkline">
+                    {{ sparkline(urlSparklineNbActions)|raw }}
+                    {{ 'VisitsSummary_NbActionsDescription'|translate("<strong>"~nbActions~"</strong>")|raw }}
+                </div>
+            {% else %}
+                <div class="sparkline">
+                    {{ sparkline(urlSparklineNbPageviews)|raw }}
+                    {{ 'VisitsSummary_NbPageviewsDescription'|translate("<strong>"~nbPageviews~"</strong>")|trim|raw }},
+                    {{ 'VisitsSummary_NbUniquePageviewsDescription'|translate("<strong>"~nbUniquePageviews~"</strong>")|raw }}
+                </div>
+                {% if displaySiteSearch %}
+                    <div class="sparkline">
+                        {{ sparkline(urlSparklineNbSearches)|raw }}
+                        {{ 'VisitsSummary_NbSearchesDescription'|translate("<strong>"~nbSearches~"</strong>")|trim|raw }},
+                        {{ 'VisitsSummary_NbKeywordsDescription'|translate("<strong>"~nbKeywords~"</strong>")|raw }}
+                    </div>
+                {% endif %}
+                <div class="sparkline">
+                        {{ sparkline(urlSparklineNbDownloads)|raw }}
+                        {{ 'VisitsSummary_NbDownloadsDescription'|translate("<strong>"~nbDownloads~"</strong>")|trim|raw }},
+                        {{ 'VisitsSummary_NbUniqueDownloadsDescription'|translate("<strong>"~nbUniqueDownloads~"</strong>")|raw }}
+                </div>
+                <div class="sparkline">
+                        {{ sparkline(urlSparklineNbOutlinks)|raw }}
+                        {{ 'VisitsSummary_NbOutlinksDescription'|translate("<strong>"~nbOutlinks~"</strong>")|trim|raw }},
+                        {{ 'VisitsSummary_NbUniqueOutlinksDescription'|translate("<strong>"~nbUniqueOutlinks~"</strong>")|raw }}
+                </div>
+                {% endif %}
+        {% endif %}
+        <div class="sparkline">
+                {{ sparkline(urlSparklineMaxActions)|raw }}
+                {{ 'VisitsSummary_MaxNbActions'|translate("<strong>"~maxActions~"</strong>")|raw }}
+        </div>
+
+        {{ postEvent('Template.VisitsSummaryOverviewSparklines') }}
+    </div>
+
 </div>
-<div style="clear:both;"></div>
 
 {% include "_sparklineFooter.twig" %}
 


### PR DESCRIPTION
I have replaced the usage of CSS IDs `#leftcolumn` and `#rightcolumn` (used to create a 2 columns layout) with Bootstrap column classes.

Those 2 column layouts are now responsive and work on mobile (or any smaller screen).

To have an idea of the current problem, visit the current demo (e.g. http://demo.piwik.org/index.php?module=CoreHome&action=index&idSite=1&period=day&date=yesterday#/module=VisitTime&action=index&idSite=1&period=day&date=yesterday) and try to resize the page: not responsive. With this PR the right column goes under the left column when the window width is too small.
