### PR TITLE
Show a nicer error message if trying to edit website access when not admin

### DIFF
--- a/plugins/UsersManager/templates/index.twig
+++ b/plugins/UsersManager/templates/index.twig
@@ -25,6 +25,8 @@
     </section>
 </div>
 
+{% block websiteAccessTable %}
+
 {% import 'ajaxMacros.twig' as ajax %}
 {{ ajax.errorDiv }}
 {{ ajax.loadingDiv }}
@@ -207,4 +209,6 @@
     </div>
 
 {% endif %}
+{% endblock %}
+
 {% endblock %}

--- a/plugins/UsersManager/templates/noWebsiteAdminAccess.twig
+++ b/plugins/UsersManager/templates/noWebsiteAdminAccess.twig
@@ -1,0 +1,9 @@
+{% extends '@UsersManager/index.twig' %}
+
+{% block websiteAccessTable %}
+
+    <div class="notification system notification-error">
+        {{ message }}
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
Fixes #7436 and #7161

Currently if we select a site to which we don't have admin access we get redirected to the login, and it's hard to go back. With the new behavior we get a simple message and we can select another website with the selector.
### Current behavior

![capture d ecran 2015-03-23 a 15 15 42](https://cloud.githubusercontent.com/assets/720328/6773052/d7135b74-d16f-11e4-8e7b-9c5d96350026.png)
### New behavior

![capture d ecran 2015-03-23 a 15 14 51](https://cloud.githubusercontent.com/assets/720328/6773037/6b0e092e-d16f-11e4-9f81-6923b7a8c370.png)
