### PR TITLE
Making the formatting of template files consistent with Piwik's styleguide and PSR-2

### DIFF
--- a/plugins/ExampleCommand/Commands/HelloWorld.php
+++ b/plugins/ExampleCommand/Commands/HelloWorld.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
 
 namespace Piwik\Plugins\ExampleCommand\Commands;
@@ -23,7 +22,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class HelloWorld extends ConsoleCommand
 {
-
     /**
      * This methods allows you to configure your command. Here you can define the name and description of your command
      * as well as all options and arguments you expect when executing it.
@@ -48,7 +46,7 @@ class HelloWorld extends ConsoleCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $name    = $input->getOption('name');
+        $name = $input->getOption('name');
 
         $message = sprintf('<info>HelloWorld: %s</info>', $name);
 

--- a/plugins/ExamplePlugin/API.php
+++ b/plugins/ExamplePlugin/API.php
@@ -4,8 +4,8 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
+
 namespace Piwik\Plugins\ExamplePlugin;
 
 use Piwik\DataTable;

--- a/plugins/ExamplePlugin/Archiver.php
+++ b/plugins/ExamplePlugin/Archiver.php
@@ -4,7 +4,6 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
 
 namespace Piwik\Plugins\ExamplePlugin;
@@ -20,7 +19,6 @@ namespace Piwik\Plugins\ExamplePlugin;
  *
  * For more detailed information about Archiver please visit Piwik developer guide
  * http://developer.piwik.org/api-reference/Piwik/Plugin/Archiver
- *
  */
 class Archiver extends \Piwik\Plugin\Archiver
 {
@@ -61,5 +59,4 @@ class Archiver extends \Piwik\Plugin\Archiver
          * $this->getProcessor()->aggregateDataTableRecords(self::EXAMPLEPLUGIN_ARCHIVE_RECORD);
          */
     }
-
 }

--- a/plugins/ExamplePlugin/Controller.php
+++ b/plugins/ExamplePlugin/Controller.php
@@ -4,8 +4,8 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
+
 namespace Piwik\Plugins\ExamplePlugin;
 
 use Piwik\View;
@@ -18,12 +18,11 @@ use Piwik\View;
  */
 class Controller extends \Piwik\Plugin\Controller
 {
-
     public function index()
     {
         // Render the Twig template templates/index.twig and assign the view variable answerToLife to the view.
         return $this->renderTemplate('index', array(
-             'answerToLife' => 42
+            'answerToLife' => 42
         ));
     }
 }

--- a/plugins/ExamplePlugin/ExamplePlugin.php
+++ b/plugins/ExamplePlugin/ExamplePlugin.php
@@ -4,12 +4,10 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
+
 namespace Piwik\Plugins\ExamplePlugin;
 
-/**
- */
 class ExamplePlugin extends \Piwik\Plugin
 {
 }

--- a/plugins/ExamplePlugin/Menu.php
+++ b/plugins/ExamplePlugin/Menu.php
@@ -4,8 +4,8 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
+
 namespace Piwik\Plugins\ExamplePlugin;
 
 use Piwik\Menu\MenuAdmin;

--- a/plugins/ExamplePlugin/README.md
+++ b/plugins/ExamplePlugin/README.md
@@ -7,6 +7,7 @@ Add your plugin description here.
 ## FAQ
 
 __My question?__
+
 My answer
 
 ## Changelog

--- a/plugins/ExamplePlugin/Tasks.php
+++ b/plugins/ExamplePlugin/Tasks.php
@@ -4,8 +4,8 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
+
 namespace Piwik\Plugins\ExamplePlugin;
 
 class Tasks extends \Piwik\Plugin\Tasks

--- a/plugins/ExamplePlugin/Widgets.php
+++ b/plugins/ExamplePlugin/Widgets.php
@@ -4,8 +4,8 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
+
 namespace Piwik\Plugins\ExamplePlugin;
 
 use Piwik\View;
@@ -34,8 +34,8 @@ class Widgets extends \Piwik\Plugin\Widgets
      */
     protected function init()
     {
-      // $this->addWidget('Example Widget Name', $method = 'myExampleWidget');
-      // $this->addWidget('Example Widget 2',    $method = 'myExampleWidget', $params = array('myparam' => 'myvalue'));
+        // $this->addWidget('Example Widget Name', $method = 'myExampleWidget');
+        // $this->addWidget('Example Widget 2', $method = 'myExampleWidget', $params = array('myparam' => 'myvalue'));
     }
 
     /**

--- a/plugins/ExamplePlugin/plugin.json
+++ b/plugins/ExamplePlugin/plugin.json
@@ -1,16 +1,16 @@
 {
- "name": "ExamplePlugin",
- "version": "0.1.0",
- "description": "Piwik Platform showcase: how to create widgets, menus, scheduled tasks, a custom archiver, plugin tests, and a AngularJS component.",
- "theme": false,
- "require": {
+  "name": "ExamplePlugin",
+  "version": "0.1.0",
+  "description": "Piwik Platform showcase: how to create widgets, menus, scheduled tasks, a custom archiver, plugin tests, and a AngularJS component.",
+  "theme": false,
+  "require": {
     "piwik": ">=PIWIK_VERSION"
- },
- "authors": [
-     {
-         "name": "Piwik",
-         "email": "",
-         "homepage": ""
-     }
- ]
+  },
+  "authors": [
+    {
+      "name": "Piwik",
+      "email": "",
+      "homepage": ""
+    }
+  ]
 }

--- a/plugins/ExampleReport/Reports/GetExampleReport.php
+++ b/plugins/ExampleReport/Reports/GetExampleReport.php
@@ -4,8 +4,8 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
+
 namespace Piwik\Plugins\ExampleReport\Reports;
 
 use Piwik\Piwik;
@@ -84,7 +84,7 @@ class GetExampleReport extends Base
      */
     public function getRelatedReports()
     {
-         return array(); // eg return array(new XyzReport());
+        return array(); // eg return array(new XyzReport());
     }
 
     /**

--- a/plugins/ExampleSettingsPlugin/Settings.php
+++ b/plugins/ExampleSettingsPlugin/Settings.php
@@ -4,8 +4,8 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
+
 namespace Piwik\Plugins\ExampleSettingsPlugin;
 
 use Piwik\Settings\SystemSetting;
@@ -18,7 +18,6 @@ use Piwik\Settings\UserSetting;
  * $settings = new Settings('ExampleSettingsPlugin');
  * $settings->autoRefresh->getValue();
  * $settings->metric->getValue();
- *
  */
 class Settings extends \Piwik\Plugin\Settings
 {


### PR DESCRIPTION
This is a really minor change but it's been scratching an itch of mine for some time. When we generate code, e.g. a controller, command, API, plugin, etc there are always tiny details off. We might as well have correct formatting from the start :)

Hopefully this PR makes all code template files consistent with Piwik's style guide and PSR-2. I'm opening it as a PR so that we can avoid a revert later if somebody disagrees with a change, let's discuss it now. Else :+1: and it's merged.
