### PR TITLE
Smaller website manager table to fit in smaller screens

### DIFF
--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -260,6 +260,7 @@ class SitesManager extends \Piwik\Plugin
     {
         $translationKeys[] = "General_Save";
         $translationKeys[] = "General_OrCancel";
+        $translationKeys[] = "General_Actions";
         $translationKeys[] = "Actions_SubmenuSitesearch";
         $translationKeys[] = "SitesManager_OnlyOneSiteAtTime";
         $translationKeys[] = "SitesManager_DeleteConfirm";

--- a/plugins/SitesManager/templates/sites-list/site-fields.html
+++ b/plugins/SitesManager/templates/sites-list/site-fields.html
@@ -148,9 +148,8 @@
     </span>
 </td>
 
-<td ng-switch="site.editMode">
-
-    <span ng-switch-default class="link_but" ng-click="editSite()">
+<td>
+    <span ng-if="!site.editMode" class="link_but" ng-click="editSite()">
         <img src='plugins/Morpheus/images/ico_edit.png'
              title="{{ 'General_Edit'|translate }}"
              border="0"
@@ -158,14 +157,14 @@
         <span>{{ 'General_Edit'|translate }}</span>
     </span>
 
-    <span ng-switch-when="true">
+    <span ng-if="site.editMode">
 
         <input type="submit" class="submit" value="{{ 'General_Save' | translate }}" ng-click="saveSite()"/>
     </span>
-</td>
 
-<td>
-    <span ng-show="site.idsite" class="link_but" ng-click="openDeleteDialog()">
+    <br/>
+
+    <span ng-show="site.idsite && !site.editMode" class="link_but" ng-click="openDeleteDialog()">
         <img
                 src='plugins/Morpheus/images/ico_delete.png'
                 title="{{ 'General_Delete'|translate }}"

--- a/plugins/SitesManager/templates/sites-list/sites-list.html
+++ b/plugins/SitesManager/templates/sites-list/sites-list.html
@@ -19,8 +19,7 @@
             <th>{{ 'SitesManager_Timezone'|translate }}</th>
             <th>{{ 'SitesManager_Currency'|translate }}</th>
             <th>{{ 'Goals_Ecommerce'|translate }}</th>
-            <th>{{ 'General_Edit'|translate }}</th>
-            <th>{{ 'General_Delete'|translate }}</th>
+            <th>{{ 'General_Actions'|translate }}</th>
             <th>{{ 'General_JsTrackingTag'|translate }}</th>
         </tr>
         </thead>


### PR DESCRIPTION
The website manager is pretty large and doesn't fit in small screens (even my 13" laptop).

While waiting for the admin redesign in #7492 I simply merged "Edit" and "Delete" (like in the proposed redesign) into a single column.

It's not a full fix but it improves the current situation a little bit.
### Before

![capture d ecran 2015-03-23 a 16 48 33](https://cloud.githubusercontent.com/assets/720328/6773899/99ed5b20-d17c-11e4-91f8-b3daa395f8d8.png)
### After

![capture d ecran 2015-03-23 a 16 46 12](https://cloud.githubusercontent.com/assets/720328/6773898/92052f5a-d17c-11e4-83bd-18642b3f100b.png)
