### PR TITLE
Allow setting empty userId, refs #7402

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -4246,11 +4246,12 @@ if (typeof Piwik !== 'object') {
                  * @param string User ID
                  */
                 setUserId: function (userId) {
-                    if(!isDefined(userId) || !userId.length) {
-                        return;
+                    if (!userId) {
+                        configUserId = visitorUUID = ''
+                    } else {
+                        configUserId = userId;
+                        visitorUUID = hash(configUserId).substr(0, 16);
                     }
-                    configUserId = userId;
-                    visitorUUID = hash(configUserId).substr(0, 16);
                 },
 
                 /**

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -4247,7 +4247,7 @@ if (typeof Piwik !== 'object') {
                  */
                 setUserId: function (userId) {
                     if (!userId) {
-                        configUserId = visitorUUID = ''
+                        configUserId = visitorUUID = '';
                     } else {
                         configUserId = userId;
                         visitorUUID = hash(configUserId).substr(0, 16);


### PR DESCRIPTION
With this change we can clear `userId` by calling `setUserId` with falsy value, like `null`, `undefined` or empty string `''`.
#7402
