### PR TITLE
"Next" link on Visitor log does not load the next results

### DIFF
--- a/core/ViewDataTable/Request.php
+++ b/core/ViewDataTable/Request.php
@@ -101,11 +101,11 @@ class Request
         }
 
         if ($this->requestConfig->disable_generic_filters) {
-            $requestArray['disable_generic_filters'] = '0';
+            $requestArray['disable_generic_filters'] = '1';
         }
 
         if ($this->requestConfig->disable_queued_filters) {
-            $requestArray['disable_queued_filters'] = 0;
+            $requestArray['disable_queued_filters'] = 1;
         }
 
         return $requestArray;

--- a/plugins/Live/VisitorLog.php
+++ b/plugins/Live/VisitorLog.php
@@ -41,13 +41,17 @@ class VisitorLog extends Visualization
             $this->requestConfig->filter_limit = 20;
         }
 
-        $this->requestConfig->filter_sort_column = 'lastActionTimestamp';
         $this->requestConfig->disable_generic_filters = true;
 
         $offset = Common::getRequestVar('filter_offset', 0);
         $limit  = Common::getRequestVar('filter_limit', $this->requestConfig->filter_limit);
 
         $this->config->filters[] = array('Limit', array($offset, $limit));
+    }
+
+    public function afterGenericFiltersAreAppliedToLoadedDataTable()
+    {
+        $this->requestConfig->filter_sort_column = 'lastActionTimestamp';
     }
 
     /**


### PR DESCRIPTION
refs  #7521

The failing UI tests look OK. Those entries have the same time.
