### PR TITLE
 Transitions > Exits metric should count Downloads and Outlinks as exit path

### DIFF
--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -489,7 +489,7 @@ class API extends \Piwik\Plugin\API
     }
 
     private $limitBeforeGrouping = 5;
-    private $totalTransitionsToFollowingActions = 0;
+    private $totalTransitionsToFollowingPages = 0;
 
     /**
      * Get the sum of all transitions to following actions (pages, outlinks, downloads).
@@ -497,7 +497,7 @@ class API extends \Piwik\Plugin\API
      */
     protected function getTotalTransitionsToFollowingActions()
     {
-        return $this->totalTransitionsToFollowingActions;
+        return $this->totalTransitionsToFollowingPages;
     }
 
     /**
@@ -578,7 +578,7 @@ class API extends \Piwik\Plugin\API
 
     protected function makeDataTablesFollowingActions($types, $data)
     {
-        $this->totalTransitionsToFollowingActions = 0;
+        $this->totalTransitionsToFollowingPages = 0;
         $dataTables = array();
         foreach ($types as $type => $recordName) {
             $dataTable = new DataTable;
@@ -591,11 +591,25 @@ class API extends \Piwik\Plugin\API
                                                         Metrics::INDEX_NB_ACTIONS => $actions
                                                     )
                                                )));
-                    $this->totalTransitionsToFollowingActions += $actions;
+
+                    $this->processTransitionsToFollowingPages($type, $actions);
                 }
             }
             $dataTables[$recordName] = $dataTable;
         }
         return $dataTables;
+    }
+
+    protected function processTransitionsToFollowingPages($type, $actions)
+    {
+        // Downloads and Outlinks are not included as these actions count towards a Visit Exit
+        $actionTypesNotExitActions = array(
+            Action::TYPE_SITE_SEARCH,
+            Action::TYPE_PAGE_TITLE,
+            Action::TYPE_PAGE_URL
+        );
+        if(in_array($type, $actionTypesNotExitActions)) {
+            $this->totalTransitionsToFollowingPages += $actions;
+        }
     }
 }

--- a/tests/PHPUnit/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_day.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_day.xml
@@ -25,7 +25,7 @@
 		<loops>2</loops>
 		<pageviews>18</pageviews>
 		<entries>4</entries>
-		<exits>2</exits>
+		<exits>6</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>

--- a/tests/PHPUnit/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_month.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_month.xml
@@ -25,7 +25,7 @@
 		<loops>2</loops>
 		<pageviews>21</pageviews>
 		<entries>4</entries>
-		<exits>1</exits>
+		<exits>7</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>

--- a/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageTitle_day.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageTitle_day.xml
@@ -33,7 +33,7 @@
 		<loops>5</loops>
 		<pageviews>17</pageviews>
 		<entries>3</entries>
-		<exits>-1</exits>
+		<exits>3</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>

--- a/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageTitle_month.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageTitle_month.xml
@@ -37,7 +37,7 @@
 		<loops>7</loops>
 		<pageviews>20</pageviews>
 		<entries>3</entries>
-		<exits>-3</exits>
+		<exits>3</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>

--- a/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_day.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_day.xml
@@ -25,7 +25,7 @@
 		<loops>2</loops>
 		<pageviews>18</pageviews>
 		<entries>4</entries>
-		<exits>2</exits>
+		<exits>6</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>

--- a/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_month.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_month.xml
@@ -25,7 +25,7 @@
 		<loops>2</loops>
 		<pageviews>21</pageviews>
 		<entries>4</entries>
-		<exits>1</exits>
+		<exits>7</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>


### PR DESCRIPTION
fixes  #7539 
