### PR TITLE
Log warning but do not throw if trying to log a non-string message

### DIFF
--- a/core/Log.php
+++ b/core/Log.php
@@ -209,8 +209,12 @@ class Log extends Singleton
             $parameters['exception'] = $message;
             $message = $message->getMessage();
         }
+
         if (! is_string($message)) {
-            throw new \InvalidArgumentException('Trying to log a message that is not a string');
+            $this->logger->warning('Trying to log a message that is not a string', array(
+                'exception' => new \InvalidArgumentException
+            ));
+            return;
         }
 
         $this->logger->log($level, $message, $parameters);

--- a/plugins/Monolog/Processor/SprintfProcessor.php
+++ b/plugins/Monolog/Processor/SprintfProcessor.php
@@ -18,7 +18,7 @@ class SprintfProcessor
         $message = $record['message'];
         $parameters = $record['context'];
 
-        if (is_string($message) && !empty($parameters)) {
+        if (is_string($message) && !empty($parameters) && strpos($message, '%') !== false) {
             $parameters = $this->ensureParametersAreStrings($parameters);
 
             $record['message'] = vsprintf($message, $parameters);
@@ -32,6 +32,8 @@ class SprintfProcessor
         foreach ($parameters as &$param) {
             if (is_array($param)) {
                 $param = json_encode($param);
+            } elseif (is_object($param)) {
+                $param = get_class($param);
             }
         }
 

--- a/plugins/Monolog/config/config.php
+++ b/plugins/Monolog/config/config.php
@@ -31,10 +31,10 @@ return array(
     }),
 
     'log.processors' => array(
+        DI\link('Piwik\Plugins\Monolog\Processor\SprintfProcessor'),
         DI\link('Piwik\Plugins\Monolog\Processor\ClassNameProcessor'),
         DI\link('Piwik\Plugins\Monolog\Processor\RequestIdProcessor'),
         DI\link('Piwik\Plugins\Monolog\Processor\ExceptionToTextProcessor'),
-        DI\link('Piwik\Plugins\Monolog\Processor\SprintfProcessor'),
         DI\link('Monolog\Processor\PsrLogMessageProcessor'),
         DI\link('Piwik\Plugins\Monolog\Processor\TokenProcessor'),
     ),


### PR DESCRIPTION
Fixes #7535 
