### PR TITLE
Refs #7560, avoid array to string conversion notice in DistributedList & descendents.

### DIFF
--- a/core/Concurrency/DistributedList.php
+++ b/core/Concurrency/DistributedList.php
@@ -62,8 +62,12 @@ class DistributedList
      */
     public function setAll($items)
     {
-        foreach ($items as &$item) {
-            $item = (string)$item;
+        foreach ($items as $key => &$item) {
+            if (is_array($item)) {
+                throw new \InvalidArgumentException("Array item encountered in DistributedList::setAll() [ key = $key ].");
+            } else {
+                $item = (string)$item;
+            }
         }
 
         Option::set($this->optionName, serialize($items));

--- a/core/CronArchive/SitesToReprocessDistributedList.php
+++ b/core/CronArchive/SitesToReprocessDistributedList.php
@@ -32,7 +32,7 @@ class SitesToReprocessDistributedList extends DistributedList
      */
     public function setAll($items)
     {
-        $items = array_unique($items);
+        $items = array_unique($items, SORT_REGULAR);
         $items = array_values($items);
 
         parent::setAll($items);

--- a/plugins/CoreAdminHome/Tasks/ArchivesToPurgeDistributedList.php
+++ b/plugins/CoreAdminHome/Tasks/ArchivesToPurgeDistributedList.php
@@ -37,7 +37,7 @@ class ArchivesToPurgeDistributedList extends DistributedList
      */
     public function setAll($yearMonths)
     {
-        $yearMonths = array_unique($yearMonths);
+        $yearMonths = array_unique($yearMonths, SORT_REGULAR);
         parent::setAll($yearMonths);
     }
 


### PR DESCRIPTION
Throws exception instead so a stack trace can be found.

@mattab Can you review? I can't reproduce the exact issue, and there's no stack trace in the error report, so maybe this isn't the best solution.

Refs #7560
