### PR TITLE
A Row implementation that is based on ArrayObject which is faster

### DIFF
--- a/core/DataTable/Bridges.php
+++ b/core/DataTable/Bridges.php
@@ -16,6 +16,13 @@ namespace {
     use Piwik\DataTable\Row;
     use Piwik\DataTable\Row\DataTableSummaryRow;
 
+    // only used for BC to unserialize old archived Row instances. We cannot unserialize Row directly as it implements
+    // the Serializable interface and it would fail on PHP5.6+ when userializing the Row instance directly.
+    class Piwik_DataTable_SerializedRow
+    {
+        public $c;
+    }
+
     class Piwik_DataTable_Row_DataTableSummary extends DataTableSummaryRow
     {
     }

--- a/core/DataTable/Filter/ColumnDelete.php
+++ b/core/DataTable/Filter/ColumnDelete.php
@@ -103,6 +103,10 @@ class ColumnDelete extends BaseFilter
         if (!empty($this->columnsToRemove)) {
             foreach ($table as $index => $row) {
                 foreach ($this->columnsToRemove as $column) {
+                    if (!array_key_exists($column, $row)) {
+                        continue;
+                    }
+                    
                     if ($this->deleteIfZeroOnly) {
                         $value = $row[$column];
                         if ($value === false || !empty($value)) {
@@ -115,11 +119,13 @@ class ColumnDelete extends BaseFilter
             }
 
             $recurse = true;
+
         }
 
         // remove columns not specified in $columnsToKeep
         if (!empty($this->columnsToKeep)) {
             foreach ($table as $index => $row) {
+                $columnsToDelete = array();
                 foreach ($row as $name => $value) {
 
                     $keep = false;
@@ -134,8 +140,13 @@ class ColumnDelete extends BaseFilter
                         && $name != 'label' // label cannot be removed via whitelisting
                         && !isset($this->columnsToKeep[$name])
                     ) {
-                        unset($table[$index][$name]);
+                        // we cannot remove row directly to prevent notice "ArrayIterator::next(): Array was modified
+                        // outside object and internal position is no longer valid in /var/www..."
+                        $columnsToDelete[] = $name;
                     }
+                }
+                foreach ($columnsToDelete as $columnToDelete) {
+                    unset($table[$index][$columnToDelete]);
                 }
             }
 

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -22,7 +22,7 @@ use Piwik\Metrics;
  *
  * @api
  */
-class Row implements \ArrayAccess, \IteratorAggregate
+class Row extends \ArrayObject
 {
     /**
      * List of columns that cannot be summed. An associative array for speed.
@@ -34,23 +34,12 @@ class Row implements \ArrayAccess, \IteratorAggregate
         'full_url' => true // column used w/ old Piwik versions,
     );
 
-    /**
-     * This array contains the row information:
-     * - array indexed by self::COLUMNS contains the columns, pairs of (column names, value)
-     * - (optional) array indexed by self::METADATA contains the metadata,  pairs of (metadata name, value)
-     * - (optional) integer indexed by self::DATATABLE_ASSOCIATED contains the ID of the DataTable associated to this row.
-     *   This ID can be used to read the DataTable from the DataTable_Manager.
-     *
-     * @var array
-     * @see constructor for more information
-     * @ignore
-     */
-    public $c = array();
-
-    private $subtableIdWasNegativeBeforeSerialize = false;
-
     // @see sumRow - implementation detail
     public $maxVisitsSummed = 0;
+
+    private $metadata = array();
+    public $subtableId = null;
+    public $isSubtableLoaded = false;
 
     const COLUMNS = 0;
     const METADATA = 1;
@@ -73,60 +62,28 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function __construct($row = array())
     {
-        $this->c[self::COLUMNS] = array();
-        $this->c[self::METADATA] = array();
-        $this->c[self::DATATABLE_ASSOCIATED] = null;
-
         if (isset($row[self::COLUMNS])) {
-            $this->c[self::COLUMNS] = $row[self::COLUMNS];
+            $this->exchangeArray($row[self::COLUMNS]);
         }
         if (isset($row[self::METADATA])) {
-            $this->c[self::METADATA] = $row[self::METADATA];
+            $this->metadata = $row[self::METADATA];
         }
-        if (isset($row[self::DATATABLE_ASSOCIATED])
-            && $row[self::DATATABLE_ASSOCIATED] instanceof DataTable
-        ) {
-            $this->setSubtable($row[self::DATATABLE_ASSOCIATED]);
-        }
-    }
-
-    /**
-     * Because $this->c[self::DATATABLE_ASSOCIATED] is negative when the table is in memory,
-     * we must prior to serialize() call, make sure the ID is saved as positive integer
-     *
-     * Only serialize the "c" member
-     * @ignore
-     */
-    public function __sleep()
-    {
-        if (!empty($this->c[self::DATATABLE_ASSOCIATED])
-            && $this->c[self::DATATABLE_ASSOCIATED] < 0
-        ) {
-            $this->switchFlagSubtableIsLoaded();
-            $this->subtableIdWasNegativeBeforeSerialize = true;
-        }
-        return array('c');
-    }
-
-    /**
-     * Must be called after the row was serialized and __sleep was called.
-     * @ignore
-     */
-    public function cleanPostSerialize()
-    {
-        if ($this->subtableIdWasNegativeBeforeSerialize) {
-            $this->switchFlagSubtableIsLoaded();
-            $this->subtableIdWasNegativeBeforeSerialize = false;
+        if (isset($row[self::DATATABLE_ASSOCIATED])) {
+            if ($row[self::DATATABLE_ASSOCIATED] instanceof DataTable) {
+                $this->setSubtable($row[self::DATATABLE_ASSOCIATED]);
+            } else {
+                $this->subtableId = $row[self::DATATABLE_ASSOCIATED];
+            }
         }
     }
 
-    /**
-     * note: also used by unit tests
-     * @ignore
-     */
-    public function switchFlagSubtableIsLoaded()
+    public function export()
     {
-        $this->c[self::DATATABLE_ASSOCIATED] = -1 * $this->c[self::DATATABLE_ASSOCIATED];
+        return array(
+            self::COLUMNS => $this->getArrayCopy(),
+            self::METADATA => $this->metadata,
+            self::DATATABLE_ASSOCIATED => $this->subtableId,
+        );
     }
 
     /**
@@ -135,9 +92,10 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function __destruct()
     {
-        if ($this->isSubtableLoaded()) {
-            Manager::getInstance()->deleteTable($this->getIdSubDataTable());
-            $this->c[self::DATATABLE_ASSOCIATED] = null;
+        if ($this->isSubtableLoaded) {
+            Manager::getInstance()->deleteTable($this->subtableId);
+            $this->subtableId = null;
+            $this->isSubtableLoaded = false;
         }
     }
 
@@ -175,10 +133,11 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function deleteColumn($name)
     {
-        if (!$this->hasColumn($name)) {
+        if (!$this->offsetExists($name)) {
             return false;
         }
-        unset($this->c[self::COLUMNS][$name]);
+
+        unset($this[$name]);
         return true;
     }
 
@@ -190,11 +149,15 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function renameColumn($oldName, $newName)
     {
-        if (isset($this->c[self::COLUMNS][$oldName])) {
-            $this->c[self::COLUMNS][$newName] = $this->c[self::COLUMNS][$oldName];
+        if (isset($this[$oldName])) {
+            $this[$newName] = $this[$oldName];
+            unset($this[$oldName]);
+            return;
         }
+
         // outside the if () since we want to delete nulled columns
-        unset($this->c[self::COLUMNS][$oldName]);
+        $this[$oldName] = null; // prevent possible notice $oldName is not defined, should be fast
+        unset($this[$oldName]);
     }
 
     /**
@@ -205,11 +168,11 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function getColumn($name)
     {
-        if (!isset($this->c[self::COLUMNS][$name])) {
+        if (!isset($this[$name])) {
             return false;
         }
 
-        return $this->c[self::COLUMNS][$name];
+        return $this[$name];
     }
 
     /**
@@ -221,12 +184,12 @@ class Row implements \ArrayAccess, \IteratorAggregate
     public function getMetadata($name = null)
     {
         if (is_null($name)) {
-            return $this->c[self::METADATA];
+            return $this->metadata;
         }
-        if (!isset($this->c[self::METADATA][$name])) {
+        if (!isset($this->metadata[$name])) {
             return false;
         }
-        return $this->c[self::METADATA][$name];
+        return $this->metadata[$name];
     }
 
     /**
@@ -238,7 +201,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function hasColumn($name)
     {
-        return array_key_exists($name, $this->c[self::COLUMNS]);
+        return $this->offsetExists($name);
     }
 
     /**
@@ -254,7 +217,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function getColumns()
     {
-        return $this->c[self::COLUMNS];
+        return $this->getArrayCopy();
     }
 
     /**
@@ -265,10 +228,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function getIdSubDataTable()
     {
-        return !is_null($this->c[self::DATATABLE_ASSOCIATED])
-            // abs() is to ensure we return a positive int, @see isSubtableLoaded()
-            ? abs($this->c[self::DATATABLE_ASSOCIATED])
-            : null;
+        return $this->subtableId;
     }
 
     /**
@@ -278,9 +238,9 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function getSubtable()
     {
-        if ($this->isSubtableLoaded()) {
+        if ($this->isSubtableLoaded) {
             try {
-                return Manager::getInstance()->getTable($this->getIdSubDataTable());
+                return Manager::getInstance()->getTable($this->subtableId);
             } catch(TableNotFoundException $e) {
                 // edge case
             }
@@ -298,7 +258,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function sumSubtable(DataTable $subTable)
     {
-        if ($this->isSubtableLoaded()) {
+        if ($this->isSubtableLoaded) {
             $thisSubTable = $this->getSubtable();
         } else {
             $this->warnIfSubtableAlreadyExists();
@@ -320,9 +280,9 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function setSubtable(DataTable $subTable)
     {
-        // Hacking -1 to ensure value is negative, so we know the table was loaded
-        // @see isSubtableLoaded()
-        $this->c[self::DATATABLE_ASSOCIATED] = -1 * $subTable->getId();
+        $this->subtableId = $subTable->getId();
+        $this->isSubtableLoaded = true;
+
         return $subTable;
     }
 
@@ -335,8 +295,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
     {
         // self::DATATABLE_ASSOCIATED are set as negative values,
         // as a flag to signify that the subtable is loaded in memory
-        return !is_null($this->c[self::DATATABLE_ASSOCIATED])
-        && $this->c[self::DATATABLE_ASSOCIATED] < 0;
+        return $this->isSubtableLoaded;
     }
 
     /**
@@ -344,7 +303,8 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function removeSubtable()
     {
-        $this->c[self::DATATABLE_ASSOCIATED] = null;
+        $this->subtableId = null;
+        $this->isSubtableLoaded = false;
     }
 
     /**
@@ -354,7 +314,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function setColumns($columns)
     {
-        $this->c[self::COLUMNS] = $columns;
+        $this->exchangeArray($columns);
     }
 
     /**
@@ -365,7 +325,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function setColumn($name, $value)
     {
-        $this->c[self::COLUMNS][$name] = $value;
+        $this[$name] = $value;
     }
 
     /**
@@ -376,7 +336,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function setMetadata($name, $value)
     {
-        $this->c[self::METADATA][$name] = $value;
+        $this->metadata[$name] = $value;
     }
 
     /**
@@ -388,13 +348,13 @@ class Row implements \ArrayAccess, \IteratorAggregate
     public function deleteMetadata($name = false)
     {
         if ($name === false) {
-            $this->c[self::METADATA] = array();
+            $this->metadata = array();
             return true;
         }
-        if (!isset($this->c[self::METADATA][$name])) {
+        if (!isset($this->metadata[$name])) {
             return false;
         }
-        unset($this->c[self::METADATA][$name]);
+        unset($this->metadata[$name]);
         return true;
     }
 
@@ -407,7 +367,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function addColumn($name, $value)
     {
-        if (isset($this->c[self::COLUMNS][$name])) {
+        if (isset($this[$name])) {
             throw new Exception("Column $name already in the array!");
         }
         $this->setColumn($name, $value);
@@ -443,7 +403,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function addMetadata($name, $value)
     {
-        if (isset($this->c[self::METADATA][$name])) {
+        if (isset($this->metadata[$name])) {
             throw new Exception("Metadata $name already in the array!");
         }
         $this->setMetadata($name, $value);
@@ -470,7 +430,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function sumRow(Row $rowToSum, $enableCopyMetadata = true, $aggregationOperations = false)
     {
-        foreach ($rowToSum->getColumns() as $columnToSumName => $columnToSumValue) {
+        foreach ($rowToSum as $columnToSumName => $columnToSumValue) {
             if (!$this->isSummableColumn($columnToSumName)) {
                 continue;
             }
@@ -537,7 +497,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
      */
     public function sumRowMetadata($rowToSum)
     {
-        if (!empty($rowToSum->c[self::METADATA])
+        if (!empty($rowToSum->metadata)
             && !$this->isSummaryRow()
         ) {
             // We shall update metadata, and keep the metadata with the _most visits or pageviews_, rather than first or last seen
@@ -545,10 +505,10 @@ class Row implements \ArrayAccess, \IteratorAggregate
                 // Old format pre-1.2, @see also method doSumVisitsMetrics()
                 $rowToSum->getColumn('nb_actions') || $rowToSum->getColumn('nb_visits'));
             if (($visits && $visits > $this->maxVisitsSummed)
-                || empty($this->c[self::METADATA])
+                || empty($this->metadata)
             ) {
                 $this->maxVisitsSummed = $visits;
-                $this->c[self::METADATA] = $rowToSum->c[self::METADATA];
+                $this->metadata = $rowToSum->metadata;
             }
         }
     }
@@ -683,33 +643,9 @@ class Row implements \ArrayAccess, \IteratorAggregate
         return true;
     }
 
-    public function offsetExists($offset)
-    {
-        return $this->hasColumn($offset);
-    }
-
-    public function offsetGet($offset)
-    {
-        return $this->getColumn($offset);
-    }
-
-    public function offsetSet($offset, $value)
-    {
-        $this->setColumn($offset, $value);
-    }
-
-    public function offsetUnset($offset)
-    {
-        $this->deleteColumn($offset);
-    }
-
-    public function getIterator() {
-        return new \ArrayIterator($this->c[self::COLUMNS]);
-    }
-
     private function warnIfSubtableAlreadyExists()
     {
-        if (!is_null($this->c[self::DATATABLE_ASSOCIATED])) {
+        if (!is_null($this->subtableId)) {
             Log::warning(
                 "Row with label '%s' (columns = %s) has already a subtable id=%s but it was not loaded - overwriting the existing sub-table.",
                 $this->getColumn('label'),


### PR DESCRIPTION
Currently, a `Row`'s columns are accessed like this: `$this->c[self::COLUMNS][$columnName]`. When archiving a big year instance we spend about 900 seconds (33%) just in `getColumn()`. By changing this to `$this->columns[$columnName]` the time dropped to 450 seconds (17%). By using `ArrayObject` the time drops by another 250 seconds. A difference in speed is not really noticeable in normal reports but when archiving aggregated reports (week, month, year, ranges).

Unfortunately, there is a huge disadvantage when using `ArrayObject`. It is not debuggable in PHPStorm and other IDE's as it is not supported by Xdebug see http://bugs.xdebug.org/view.php?id=996 and also kinda related http://bugs.xdebug.org/view.php?id=686 . Those issues are open since 2013 and 2011 so we can't expect a fix for this soon.

I'm issuing this pull request so we still have the code in case those bugs are resolved.

Please note in this PR there are also some changes to subtableId etc. which will be probably in master soon anyway. I didn't make the effort to split those changes as we only wanted to still have the code in general in case those bugs will be fixed in Xdebug. It wasn't easy to implement it based on `ArrayObject` since it implements the `Serializable` interface and we need to make sure to stay BC with already serialized Row instances in a different format see code.
