### PR TITLE
Refs #7560, if old list is found in DB for ArchivesToPurgeDistributedList, convert it to new list w/ only year-date to avoid error.

### DIFF
--- a/plugins/CoreAdminHome/Tasks/ArchivesToPurgeDistributedList.php
+++ b/plugins/CoreAdminHome/Tasks/ArchivesToPurgeDistributedList.php
@@ -41,6 +41,13 @@ class ArchivesToPurgeDistributedList extends DistributedList
         parent::setAll($yearMonths);
     }
 
+    protected function getListOptionValue()
+    {
+        $result = parent::getListOptionValue();
+        $this->convertOldDistributedList($result);
+        return $result;
+    }
+
     public function getAllAsDates()
     {
         $dates = array();
@@ -60,5 +67,21 @@ class ArchivesToPurgeDistributedList extends DistributedList
     {
         $yearMonth = $date->toString('Y_m');
         $this->remove($yearMonth);
+    }
+
+    /**
+     * Before 2.12.0 Piwik stored this list as an array mapping year months to arrays of site IDs. If this is
+     * found in the DB, we convert the array to an array of year months to avoid errors and to make sure
+     * the correct tables are still purged.
+     */
+    private function convertOldDistributedList(&$yearMonths)
+    {
+        foreach ($yearMonths as $key => $value) {
+            if (preg_match("/^[0-9]{4}_[0-9]{2}$/", $key)) {
+                unset($yearMonths[$key]);
+
+                $yearMonths[] = $key;
+            }
+        }
     }
 }

--- a/plugins/CoreAdminHome/tests/Integration/ArchivesToPurgeDistributedListTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/ArchivesToPurgeDistributedListTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Integration;
+
+use Piwik\Option;
+use Piwik\Plugins\CoreAdminHome\Tasks\ArchivesToPurgeDistributedList;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Core
+ */
+class ArchivesToPurgeDistributedListTest extends IntegrationTestCase
+{
+    public function test_construct_CorrectlyConvertsOldListValues()
+    {
+        $oldItems = array(
+            '2015_01' => array(1,2,3),
+            '2013_02' => array(3),
+            3 => '2015_03',
+            '2014_01' => array(),
+            4 => '2015_06'
+        );
+        Option::set(ArchivesToPurgeDistributedList::OPTION_INVALIDATED_DATES_SITES_TO_PURGE, serialize($oldItems));
+
+        $list = new ArchivesToPurgeDistributedList();
+        $items = $list->getAll();
+
+        $expected = array('2015_03', '2015_06', '2015_01', '2013_02', '2014_01');
+        $this->assertEquals($expected, array_values($items));
+    }
+}


### PR DESCRIPTION
As title.

Should fix UI tests. Could create an Update to change the option value, however if for some reason the update fails or doesn't run, users will get the error.

@piwik/core-team A quick review would be nice, though I'll merge later if no review shows up + tests pass.
