### PR TITLE
Visible subtableId in system tests

### DIFF
--- a/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentNames_lastN__API.getProcessedReport_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentNames_lastN__API.getProcessedReport_day.xml
@@ -59,17 +59,17 @@
 			<row>
 				<contentTarget>http://www.example.com</contentTarget>
 				<segment>contentName==ImageAd</segment>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 			<row>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<segment>contentName==Text+Ad</segment>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
 				<contentTarget />
 				<segment>contentName==Video+Ad</segment>
-				
+				<idsubdatatable>3</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010" />

--- a/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentPieces_lastN__API.getProcessedReport_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentPieces_lastN__API.getProcessedReport_day.xml
@@ -83,36 +83,36 @@
 			<row>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<segment>contentPiece==Click+to+download+Piwik+now</segment>
-				
+				<idsubdatatable>5</idsubdatatable>
 			</row>
 			<row>
 				<contentTarget>http://www.example.com</contentTarget>
 				<segment>contentPiece==%2Fpath%2Fad.jpg</segment>
-				
+				<idsubdatatable>3</idsubdatatable>
 			</row>
 			<row>
 				<contentTarget>http://www.example.com</contentTarget>
 				<segment>contentPiece==%2Fpath%2Fad2.jpg</segment>
-				
+				<idsubdatatable>4</idsubdatatable>
 			</row>
 			<row>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<segment>contentPiece==Click+NOW</segment>
-				
+				<idsubdatatable>6</idsubdatatable>
 			</row>
 			<row>
 				<contentTarget />
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 			<row>
 				<contentTarget />
 				<segment>contentPiece==movie.mov</segment>
-				
+				<idsubdatatable>7</idsubdatatable>
 			</row>
 			<row>
 				<contentTarget />
 				<segment>contentPiece==Unknown</segment>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010" />

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -275,7 +275,7 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         return $apiCalls;
     }
 
-    protected function _testApiUrl($testName, $apiId, $requestUrl, $compareAgainst, $xmlFieldsToRemove = array(), $params = array())
+    protected function _testApiUrl($testName, $apiId, $requestUrl, $compareAgainst, $params = array())
     {
         list($processedFilePath, $expectedFilePath) =
             $this->getProcessedAndExpectedPaths($testName, $apiId, $format = null, $compareAgainst);
@@ -440,7 +440,7 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         $testRequests = $this->getTestRequestsCollection($api, $testConfig, $api);
 
         foreach ($testRequests->getRequestUrls() as $apiId => $requestUrl) {
-            $this->_testApiUrl($testName . $testConfig->testSuffix, $apiId, $requestUrl, $testConfig->compareAgainst, $testConfig->xmlFieldsToRemove, $params);
+            $this->_testApiUrl($testName . $testConfig->testSuffix, $apiId, $requestUrl, $testConfig->compareAgainst, $params);
         }
 
         // change the language back to en

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -197,8 +197,10 @@ class Response
             $fieldsToRemove = @$this->params['xmlFieldsToRemove'];
         }
 
-        $fieldsToRemove[] = 'idsubdatatable';
-
+        if (!is_array($fieldsToRemove)) {
+            $fieldsToRemove = array();
+        }
+        
         foreach ($fieldsToRemove as $xml) {
             $input = $this->removeXmlElement($input, $xml);
         }

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -107,11 +107,6 @@ class Response
             $apiResponse = preg_replace($regex, 'date=', $apiResponse);
         }
 
-        // if idSubtable is in request URL, make sure idSubtable values are not in any urls
-        if (!empty($this->requestUrl['idSubtable'])) {
-            $apiResponse = $this->removeIdSubtableParamFromUrlsInResponse($apiResponse);
-        }
-
         $apiResponse = $this->normalizePdfContent($apiResponse);
         $apiResponse = $this->removeXmlFields($apiResponse);
         $apiResponse = $this->normalizeDecimalFields($apiResponse);
@@ -128,11 +123,6 @@ class Response
             return $apiResponse;
         }
         return str_replace('&amp;#039;', "'", $apiResponse);
-    }
-
-    private function removeIdSubtableParamFromUrlsInResponse($apiResponse)
-    {
-        return preg_replace("/idSubtable=[0-9]+/", 'idSubtable=', $apiResponse);
     }
 
     private function removeAllIdsFromXml($apiResponse)

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
@@ -162,47 +162,47 @@
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
 				<segment>eventAction==playTrailer</segment>
-				
+				<idsubdatatable>8</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==Search</segment>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==play25%25</segment>
-				
+				<idsubdatatable>3</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==play50%25</segment>
-				
+				<idsubdatatable>4</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==play75%25</segment>
-				
+				<idsubdatatable>5</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==playEnd</segment>
-				
+				<idsubdatatable>6</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==rating</segment>
-				
+				<idsubdatatable>7</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==clickBuyNow</segment>
-				
+				<idsubdatatable>9</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==event+action+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+---%26gt%3B+SHOULD+APPEAR+IN+TEST+OUTPUT+NOT+TRUNCATED+%26lt%3B---</segment>
-				
+				<idsubdatatable>11</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==play</segment>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==playStart</segment>
-				
+				<idsubdatatable>10</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==Purchase</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
@@ -81,15 +81,15 @@
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
 				<segment>eventCategory==Movie</segment>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventCategory==Music</segment>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventCategory==event+category+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+---%26gt%3B+SHOULD+APPEAR+IN+TEST+OUTPUT+NOT+TRUNCATED+%26lt%3B---</segment>
-				
+				<idsubdatatable>3</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010" />

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
@@ -117,30 +117,30 @@
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
 				<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
-				
+				<idsubdatatable>3</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventName==event+name+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+---%26gt%3B+SHOULD+APPEAR+IN+TEST+OUTPUT+NOT+TRUNCATED+%26lt%3B---</segment>
-				
+				<idsubdatatable>7</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
-				
+				<idsubdatatable>5</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
-				
+				<idsubdatatable>4</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventName==Search+query+here</segment>
-				
+				<idsubdatatable>6</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010" />

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric__API.getProcessedReport_day.xml
@@ -59,10 +59,10 @@
 	</reportData>
 	<reportMetadata>
 		<row>
-			
+			<idsubdatatable>1</idsubdatatable>
 		</row>
 		<row>
-			
+			<idsubdatatable>2</idsubdatatable>
 		</row>
 	</reportMetadata>
 	<reportTotal>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__subtable__API.getProcessedReport_week.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__subtable__API.getProcessedReport_week.xml
@@ -28,8 +28,8 @@
 			<avg_time_generation>Avg. generation time</avg_time_generation>
 		</processedMetrics>
 		<actionToLoadSubTables>getPageUrls</actionToLoadSubTables>
-		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getPageUrls&amp;period=week&amp;date=2010-03-06&amp;idSubtable=</imageGraphUrl>
-		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getPageUrls&amp;period=week&amp;date=2009-08-10,2010-03-07&amp;idSubtable=</imageGraphEvolutionUrl>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getPageUrls&amp;period=week&amp;date=2010-03-06&amp;idSubtable=1</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=Actions&amp;apiAction=getPageUrls&amp;period=week&amp;date=2009-08-10,2010-03-07&amp;idSubtable=1</imageGraphEvolutionUrl>
 		<uniqueId>Actions_getPageUrls</uniqueId>
 	</metadata>
 	<columns>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
@@ -44,7 +44,7 @@
 	</reportData>
 	<reportMetadata>
 		<row>
-			
+			<idsubdatatable>1</idsubdatatable>
 		</row>
 	</reportMetadata>
 	<reportTotal>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumns___API.getProcessedReport_day.xml
@@ -53,7 +53,7 @@
 	</reportData>
 	<reportMetadata>
 		<row>
-			
+			<idsubdatatable>1</idsubdatatable>
 		</row>
 	</reportMetadata>
 	<reportTotal>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_day.xml
@@ -107,18 +107,18 @@
 	<reportMetadata>
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010">
 			<row>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Tuesday 5 January 2010" />

--- a/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_month.xml
@@ -76,10 +76,10 @@
 	<reportMetadata>
 		<result prettyDate="2010, January">
 			<row>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="2010, February" />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
@@ -170,42 +170,42 @@
 		<result prettyDate="Monday 4 January 2010" />
 		<result prettyDate="Tuesday 5 January 2010">
 			<row>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Wednesday 6 January 2010">
 			<row>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Thursday 7 January 2010">
 			<row>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Friday 8 January 2010">
 			<row>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Saturday 9 January 2010">
 			<row>
-				
+				<idsubdatatable>2</idsubdatatable>
 			</row>
 			<row>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 	</reportMetadata>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Referrers.getWebsites_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Referrers.getWebsites_firstSite_lastN__API.getProcessedReport_day.xml
@@ -110,13 +110,13 @@
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
 				<segment>referrerName==referrer.com</segment>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010">
 			<row>
 				<segment>referrerName==referrer.com</segment>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Tuesday 5 January 2010" />
@@ -125,13 +125,13 @@
 		<result prettyDate="Friday 8 January 2010">
 			<row>
 				<segment>referrerName==referrer.com</segment>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Saturday 9 January 2010">
 			<row>
 				<segment>referrerName==referrer.com</segment>
-				
+				<idsubdatatable>1</idsubdatatable>
 			</row>
 		</result>
 	</reportMetadata>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables__subtable__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables__subtable__API.getProcessedReport_day.xml
@@ -28,8 +28,8 @@
 			<bounce_rate>Bounce Rate</bounce_rate>
 			<conversion_rate>Conversion Rate</conversion_rate>
 		</processedMetrics>
-		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=CustomVariables&amp;apiAction=getCustomVariablesValuesFromNameId&amp;period=day&amp;date=2010-01-03&amp;idSubtable=</imageGraphUrl>
-		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=CustomVariables&amp;apiAction=getCustomVariablesValuesFromNameId&amp;period=day&amp;date=2009-12-05,2010-01-03&amp;idSubtable=</imageGraphEvolutionUrl>
+		<imageGraphUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=CustomVariables&amp;apiAction=getCustomVariablesValuesFromNameId&amp;period=day&amp;date=2010-01-03&amp;idSubtable=1</imageGraphUrl>
+		<imageGraphEvolutionUrl>index.php?module=API&amp;method=ImageGraph.get&amp;idSite=1&amp;apiModule=CustomVariables&amp;apiAction=getCustomVariablesValuesFromNameId&amp;period=day&amp;date=2009-12-05,2010-01-03&amp;idSubtable=1</imageGraphEvolutionUrl>
 		<uniqueId>CustomVariables_getCustomVariablesValuesFromNameId</uniqueId>
 	</metadata>
 	<columns>


### PR DESCRIPTION
Now that subtableIds are consecutive in each serialized DataTable we could test for them in the API output of system tests. Not sure if it has any downsides apart from breaking existing tests of other plugins etc since the subtable would show now. Are there any? 

I was surprised not more tests actually contain a subtableId. Maybe something is missing?
