### PR TITLE
Fixing geoloc title for visitors submenu

### DIFF
--- a/plugins/Provider/lang/en.json
+++ b/plugins/Provider/lang/en.json
@@ -4,6 +4,7 @@
         "PluginDescription": "Reports the Internet Service Provider of the visitors.",
         "ProviderReportDocumentation": "This report shows which Internet Service Providers your visitors used to access the website. You can click on a provider name for more details. %s If Piwik can't determine a visitor's provider, it is listed as IP.",
         "WidgetProviders": "Providers",
-        "ProviderReportFooter": "Unknown provider means the IP address could not be looked up."
+        "ProviderReportFooter": "Unknown provider means the IP address could not be looked up.",
+        "SubmenuLocationsProvider": "Geoloc and Providers"
     }
 }


### PR DESCRIPTION
Somehow piwik was displaying Provider_SubmenuLocationsProvider instead of the actual menu title.

Fixed for english language.
