### PR TITLE
When selecting a disabled period, redirect to the default "yesterday" period

### DIFF
--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -116,8 +116,8 @@ class Factory
      */
     public static function isPeriodEnabledForAPI($period)
     {
-        $enabledPeriodsInAPI = self::getPeriodsEnabledForAPI();
-        return in_array($period, $enabledPeriodsInAPI);
+        $periodValidator = new PeriodValidator();
+        return $periodValidator->isPeriodAllowedForAPI($period);
     }
 
     /**
@@ -125,9 +125,7 @@ class Factory
      */
     public static function getPeriodsEnabledForAPI()
     {
-        $enabledPeriodsInAPI = Config::getInstance()->General['enabled_periods_API'];
-        $enabledPeriodsInAPI = explode(",", $enabledPeriodsInAPI);
-        $enabledPeriodsInAPI = array_map('trim', $enabledPeriodsInAPI);
-        return $enabledPeriodsInAPI;
+        $periodValidator = new PeriodValidator();
+        return $periodValidator->getPeriodsAllowedForAPI();
     }
 }

--- a/core/Period/PeriodValidator.php
+++ b/core/Period/PeriodValidator.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Period;
+
+use Piwik\Config;
+
+class PeriodValidator
+{
+    /**
+     * @param string $period
+     * @return bool
+     */
+    public function isPeriodAllowedForUI($period)
+    {
+        return in_array($period, $this->getPeriodsAllowedForUI());
+    }
+
+    /**
+     * @param string $period
+     * @return bool
+     */
+    public function isPeriodAllowedForAPI($period)
+    {
+        return in_array($period, $this->getPeriodsAllowedForAPI());
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPeriodsAllowedForUI()
+    {
+        $periodsAllowed = Config::getInstance()->General['enabled_periods_UI'];
+
+        return array_map('trim', explode(',', $periodsAllowed));
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPeriodsAllowedForAPI()
+    {
+        $periodsAllowed = Config::getInstance()->General['enabled_periods_API'];
+
+        return array_map('trim', explode(',', $periodsAllowed));
+    }
+}

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -828,13 +828,19 @@ abstract class Controller
         $currentPeriod = Common::getRequestVar('period');
         $view->displayUniqueVisitors = SettingsPiwik::isUniqueVisitorsEnabled($currentPeriod);
         $availablePeriods = self::getEnabledPeriodsInUI();
+
         if (!in_array($currentPeriod, $availablePeriods)) {
-            // Redirect to the day period
+            // Redirect to the default view
+            $defaultPeriod = Config::getInstance()->General['default_period'];
+            $defaultDay = Config::getInstance()->General['default_day'];
             Url::redirectToUrl(sprintf(
-                'index.php?module=CoreHome&action=index&idSite=%d&period=day&date=yesterday',
-                Common::getRequestVar('idSite')
+                'index.php?module=CoreHome&action=index&idSite=%d&period=%s&date=%s',
+                Common::getRequestVar('idSite'),
+                $defaultPeriod,
+                $defaultDay
             ));
         }
+
         $found = array_search($currentPeriod, $availablePeriods);
         unset($availablePeriods[$found]);
 

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -829,7 +829,11 @@ abstract class Controller
         $view->displayUniqueVisitors = SettingsPiwik::isUniqueVisitorsEnabled($currentPeriod);
         $availablePeriods = self::getEnabledPeriodsInUI();
         if (!in_array($currentPeriod, $availablePeriods)) {
-            throw new Exception("Period must be one of: " . implode(", ", $availablePeriods));
+            // Redirect to the day period
+            Url::redirectToUrl(sprintf(
+                'index.php?module=CoreHome&action=index&idSite=%d&period=day&date=yesterday',
+                Common::getRequestVar('idSite')
+            ));
         }
         $found = array_search($currentPeriod, $availablePeriods);
         unset($availablePeriods[$found]);

--- a/plugins/UsersManager/UserPreferences.php
+++ b/plugins/UsersManager/UserPreferences.php
@@ -9,12 +9,23 @@
 namespace Piwik\Plugins\UsersManager;
 
 use Piwik\Config;
+use Piwik\Period\PeriodValidator;
 use Piwik\Piwik;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 
 class UserPreferences
 {
+    /**
+     * @var APIUsersManager
+     */
+    private $api;
+
+    public function __construct()
+    {
+        $this->api = APIUsersManager::getInstance();
+    }
+
     /**
      * Returns default site ID that Piwik should load.
      *
@@ -51,7 +62,7 @@ class UserPreferences
     public function getDefaultReport()
     {
         // User preference: default website ID to load
-        $defaultReport = APIUsersManager::getInstance()->getUserPreference(Piwik::getCurrentUserLogin(), APIUsersManager::PREFERENCE_DEFAULT_REPORT);
+        $defaultReport = $this->api->getUserPreference(Piwik::getCurrentUserLogin(), APIUsersManager::PREFERENCE_DEFAULT_REPORT);
 
         if (!is_numeric($defaultReport)) {
             return $defaultReport;
@@ -74,8 +85,45 @@ class UserPreferences
      */
     public function getDefaultDate()
     {
+        list($defaultDate, $defaultPeriod) = $this->getDefaultDateAndPeriod();
+
+        return $defaultDate;
+    }
+
+    /**
+     * Returns default period type for Piwik reports.
+     *
+     * @param string $defaultDate the default date string from which the default period will be guessed
+     * @return string `'day'`, `'week'`, `'month'`, `'year'` or `'range'`
+     * @api
+     */
+    public function getDefaultPeriod($defaultDate = null)
+    {
+        list($defaultDate, $defaultPeriod) = $this->getDefaultDateAndPeriod($defaultDate);
+
+        return $defaultPeriod;
+    }
+
+    private function getDefaultDateAndPeriod($defaultDate = null)
+    {
+        if (! $defaultDate) {
+            $defaultDate = $this->getDefaultPeriodWithoutValidation($defaultDate);
+        }
+        $defaultPeriod = $this->getDefaultPeriodWithoutValidation($defaultDate);
+
+        $periodValidator = new PeriodValidator();
+        if (! $periodValidator->isPeriodAllowedForUI($defaultPeriod)) {
+            $defaultDate = $this->getSystemDefaultDate();
+            $defaultPeriod = $this->getSystemDefaultPeriod();
+        }
+
+        return array($defaultDate, $defaultPeriod);
+    }
+
+    public function getDefaultDateWithoutValidation()
+    {
         // NOTE: a change in this function might mean a change in plugins/UsersManager/javascripts/usersSettings.js as well
-        $userSettingsDate = APIUsersManager::getInstance()->getUserPreference(Piwik::getCurrentUserLogin(), APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE);
+        $userSettingsDate = $this->api->getUserPreference(Piwik::getCurrentUserLogin(), APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE);
         if ($userSettingsDate == 'yesterday') {
             return $userSettingsDate;
         }
@@ -89,17 +137,10 @@ class UserPreferences
         return 'today';
     }
 
-    /**
-     * Returns default period type for Piwik reports.
-     *
-     * @param $defaultDate string the default date string from which the default period will be guessed
-     * @return string `'day'`, `'week'`, `'month'`, `'year'` or `'range'`
-     * @api
-     */
-    public function getDefaultPeriod($defaultDate)
+    public function getDefaultPeriodWithoutValidation($defaultDate = null)
     {
         if (empty($defaultDate)) {
-            $defaultDate = APIUsersManager::getInstance()->getUserPreference(Piwik::getCurrentUserLogin(), APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE);
+            $defaultDate = $this->api->getUserPreference(Piwik::getCurrentUserLogin(), APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE);
         }
 
         if (empty($defaultDate)) {
@@ -119,9 +160,13 @@ class UserPreferences
         return $defaultDate;
     }
 
+    private function getSystemDefaultDate()
+    {
+        return Config::getInstance()->General['default_day'];
+    }
+
     private function getSystemDefaultPeriod()
     {
         return Config::getInstance()->General['default_period'];
     }
-
 }

--- a/plugins/UsersManager/UserPreferences.php
+++ b/plugins/UsersManager/UserPreferences.php
@@ -107,7 +107,7 @@ class UserPreferences
     private function getDefaultDateAndPeriod($defaultDate = null)
     {
         if (! $defaultDate) {
-            $defaultDate = $this->getDefaultPeriodWithoutValidation($defaultDate);
+            $defaultDate = $this->getDefaultDateWithoutValidation();
         }
         $defaultPeriod = $this->getDefaultPeriodWithoutValidation($defaultDate);
 

--- a/plugins/UsersManager/tests/Integration/UserPreferencesTest.php
+++ b/plugins/UsersManager/tests/Integration/UserPreferencesTest.php
@@ -102,6 +102,12 @@ class UserPreferencesTest extends IntegrationTestCase
         $this->assertEquals('day', $this->userPreferences->getDefaultPeriod());
     }
 
+    public function test_getDefaultDate()
+    {
+        $this->setDefaultDate('today');
+        $this->assertEquals('today', $this->userPreferences->getDefaultDate());
+    }
+
     public function test_getDefaultPeriod_ShouldOnlyReturnAllowedPeriods()
     {
         // Only allow for week period
@@ -109,6 +115,15 @@ class UserPreferencesTest extends IntegrationTestCase
         Config::getInstance()->General['default_period'] = 'week';
         $this->setDefaultDate('today');
         $this->assertEquals('week', $this->userPreferences->getDefaultPeriod());
+    }
+
+    public function test_getDefaultDate_ShouldOnlyReturnDateInAllowedPeriods()
+    {
+        // Only allow for week period
+        Config::getInstance()->General['enabled_periods_UI'] = 'day';
+        Config::getInstance()->General['default_period'] = 'day';
+        $this->setDefaultDate('last7');
+        $this->assertEquals('yesterday', $this->userPreferences->getDefaultDate());
     }
 
     private function setSuperUser()

--- a/plugins/UsersManager/tests/Integration/UserPreferencesTest.php
+++ b/plugins/UsersManager/tests/Integration/UserPreferencesTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\UsersManager\tests;
 
+use Piwik\Config;
 use Piwik\Piwik;
 use Piwik\Plugins\UsersManager\UserPreferences;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
@@ -89,6 +90,27 @@ class UserPreferencesTest extends IntegrationTestCase
         $this->assertEquals(1, $this->userPreferences->getDefaultWebsiteId());
     }
 
+    public function test_getDefaultPeriod_ShouldReturnDayIfToday()
+    {
+        $this->setDefaultDate('today');
+        $this->assertEquals('day', $this->userPreferences->getDefaultPeriod());
+    }
+
+    public function test_getDefaultPeriod_ShouldReturnDayIfYesterday()
+    {
+        $this->setDefaultDate('yesterday');
+        $this->assertEquals('day', $this->userPreferences->getDefaultPeriod());
+    }
+
+    public function test_getDefaultPeriod_ShouldOnlyReturnAllowedPeriods()
+    {
+        // Only allow for week period
+        Config::getInstance()->General['enabled_periods_UI'] = 'week';
+        Config::getInstance()->General['default_period'] = 'week';
+        $this->setDefaultDate('today');
+        $this->assertEquals('week', $this->userPreferences->getDefaultPeriod());
+    }
+
     private function setSuperUser()
     {
         $pseudoMockAccess = new FakeAccess();
@@ -110,9 +132,19 @@ class UserPreferencesTest extends IntegrationTestCase
 
     private function setDefaultReport($defaultReport)
     {
-        APIUsersManager::getInstance()->setUserPreference(Piwik::getCurrentUserLogin(),
+        APIUsersManager::getInstance()->setUserPreference(
+            Piwik::getCurrentUserLogin(),
             APIUsersManager::PREFERENCE_DEFAULT_REPORT,
-            $defaultReport);
+            $defaultReport
+        );
     }
 
+    private function setDefaultDate($date)
+    {
+        APIUsersManager::getInstance()->setUserPreference(
+            Piwik::getCurrentUserLogin(),
+            APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE,
+            $date
+        );
+    }
 }


### PR DESCRIPTION
Fixes #7615

I redirected to hardcoded "yesterday" because I don't want to overthink it, but if you think it's a bad idea let me know.
