### PR TITLE
Fixes overlapping issue in visitor log (see #7089)

### DIFF
--- a/plugins/Live/javascripts/visitorLog.js
+++ b/plugins/Live/javascripts/visitorLog.js
@@ -52,7 +52,7 @@
                         if (repeat.length) {
                             repeat.html((parseInt(repeat.html()) + 1) + "x");
                         } else {
-                            prevelement.append($("<em>2x</em>").attr({'class': 'repeat', 'title': _pk_translate('Live_PageRefreshed')}));
+                            prevelement.find('>div').prepend($("<em>2x</em>").attr({'class': 'repeat', 'title': _pk_translate('Live_PageRefreshed')}));
                         }
                         $(this).hide();
                     } else {

--- a/plugins/Live/stylesheets/live.less
+++ b/plugins/Live/stylesheets/live.less
@@ -142,6 +142,9 @@ ol.visitorLog li {
     border: 1px solid @theme-color-text-light;
     border-radius: 3px;
     padding: 2px;
+    display: block;
+    margin: 5px;
+    float: left;
 }
 
 .dataTableVizVisitorLog hr {


### PR DESCRIPTION
This PR aims to fix #7089

As the number counter weren't positioned very good at all, I've moved them in front of the action, so they can directly be seen

the problem:
![visitor_log_profile_link_overlaps](https://cloud.githubusercontent.com/assets/273120/5928829/f2ece96c-a6e2-11e4-9162-8e9e97d22eaa.png)

Before:
![image](https://cloud.githubusercontent.com/assets/1579355/6998950/4611b740-dbf3-11e4-9e6b-0c4fa0d7a7d0.png)

After:
![image](https://cloud.githubusercontent.com/assets/1579355/6998926/07ad7da0-dbf2-11e4-87d2-ded5e7b279e4.png)
