### PR TITLE
Refreshed the copy of "Help" page

### DIFF
--- a/plugins/Feedback/lang/en.json
+++ b/plugins/Feedback/lang/en.json
@@ -1,8 +1,6 @@
 {
     "Feedback": {
-        "ContactThePiwikTeam": "Contact the Piwik team!",
         "DoYouHaveBugReportOrFeatureRequest": "Do you have a bug to report or a feature request?",
-        "GetInTouch": "We appreciate your feedback and always read all messages. Maybe you would like to share a business opportunity, hire a Piwik consultant, tell us a success story or simply say Hello!",
         "HowToCreateTicket": "Please read the recommendations on writing a good %1$sbug report%2$s or %3$sfeature request%4$s. Then register or login on %5$sour issue tracker%6$s and create a %7$snew issue%8$s.",
         "IWantTo": "I want to:",
         "LearnWaysToParticipate": "Learn about all the ways you can %s participate%s",
@@ -15,12 +13,22 @@
         "RateFeatureThankYouTitle": "Thank you for rating '%s'!",
         "RateFeatureTitle": "Do you like the '%s' feature? Please rate and leave a comment",
         "SendFeedback": "Send Feedback",
-        "SpecialRequest": "Do you have a special request for the Piwik team?",
         "ThankYou": "Thank you for helping us to make Piwik better!",
         "TopLinkTooltip": "Tell us what you think, or request Professional Support.",
         "ViewAnswersToFAQ": "View answers to %sFrequently Asked Questions%s",
         "ViewUserGuides": "Learn how to configure Piwik and how to effectively analyze your data with our %1$suser guides%2$s",
-        "VisitTheForums": "Visit the %s Forums%s and get help from the community of Piwik users",
-        "WantToThankConsiderDonating": "Do you think Piwik is awesome and want to thank us?"
+        "CommunityHelp": "Community Help",
+        "ProfessionalHelp": "Professional Help",
+        "PiwikProIntro": "Piwik PRO provides expert support and consulting to clients who host Piwik on their own infrastructure.",
+        "PiwikProOfferIntro": "Our offer includes",
+        "PiwikProReviewPiwikSetup": "A review of your Piwik setup",
+        "PiwikProOptimizationMaintenance": "Piwik optimization & maintenance services",
+        "PiwikProPhoneEmailSupport": "Phone and Email support",
+        "PiwikProTraining": "User, Technical and Developer training",
+        "PiwikProPremiumFeatures": "Premium features",
+        "PiwikProCustomDevelopment": "Custom Development services",
+        "PiwikProAnalystConsulting": "Analyst consulting services",
+        "ContactUs": "Contact us",
+        "VisitTheForums": "Visit the %s Forums%s and get help from the community of Piwik users"
     }
 }

--- a/plugins/Feedback/templates/index.twig
+++ b/plugins/Feedback/templates/index.twig
@@ -25,7 +25,7 @@
             <br/>
         </div>
 
-        <h2>{{ 'Do you need help?'|translate }}</h2>
+        <h2>{{ 'Feedback_CommunityHelp'|translate }}</h2>
 
         <div class="header_full">
             <p> &bull; {{ 'Feedback_ViewUserGuides'|translate("<a target='_blank' href='?module=Proxy&action=redirect&url=http://piwik.org/docs/'>","</a>")|raw }}.</p>
@@ -34,10 +34,32 @@
             <br/>
         </div>
 
+        <h2>{{ 'Feedback_ProfessionalHelp'|translate }}</h2>
+
+        <div class="header_full">
+            <p>{{ 'Feedback_PiwikProIntro'|translate }}</p>
+
+            <p>{{ 'Feedback_PiwikProOfferIntro'|translate }}:</p>
+            <p> &bull; {{ 'Feedback_PiwikProReviewPiwikSetup'|translate }}</p>
+            <p> &bull; {{ 'Feedback_PiwikProOptimizationMaintenance'|translate }}</p>
+            <p> &bull; {{ 'Feedback_PiwikProPhoneEmailSupport'|translate }}</p>
+            <p> &bull; {{ 'Feedback_PiwikProTraining'|translate }}</p>
+            <p> &bull; {{ 'Feedback_PiwikProPremiumFeatures'|translate }}</p>
+            <p> &bull; {{ 'Feedback_PiwikProCustomDevelopment'|translate }}</p>
+            <p> &bull; {{ 'Feedback_PiwikProAnalystConsulting'|translate }}</p>
+            <br/>
+        </div>
+
+        <form target="_blank" action="https://piwik.pro/contact#contact-form">
+            <input type="hidden" name="pk_campaign" value="piwikui-help">
+            <input type="hidden" name="pk_source" value="selfhosted">
+            <input type="submit" value="{{ 'Feedback_ContactUs'|translate }}">
+        </form>
+
         <h2>{{ 'Feedback_DoYouHaveBugReportOrFeatureRequest'|translate }}</h2>
 
         <div class="header_full">
-            <p>{{ 'Feedback_HowToCreateTicket'|translate(
+                <p>{{ 'Feedback_HowToCreateTicket'|translate(
                 "<a target='_blank' href='?module=Proxy&action=redirect&url=http://developer.piwik.org/guides/core-team-workflow%23submitting-a-bug-report'>",
                 "</a>",
                 "<a target='_blank' href='?module=Proxy&action=redirect&url=http://developer.piwik.org/guides/core-team-workflow%23submitting-a-feature-request'>",
@@ -50,26 +72,12 @@
             <br/>
         </div>
 
-        <h2>{{ 'Feedback_SpecialRequest'|translate }}</h2>
-
-        <div class="header_full">
-            <p>{{ 'Feedback_GetInTouch'|translate }}
-                <a target='_blank' href="?module=Proxy&action=redirect&url=http://piwik.org/contact/"
-                    >{{ 'Feedback_ContactThePiwikTeam'|translate }}</a>
-            </p>
-            <br/>
-        </div>
-
-        <h2 id="donate">{{ 'Feedback_WantToThankConsiderDonating'|translate }}</h2>
-        {% include "@CoreHome/_donate.twig" with { 'msg':""} %}
-        <br/>
-
         <div class="footer">
             <hr/>
             <ul class="social">
                 <li>
-                    <a rel="noreferrer"  target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/newsletter/"><img class="icon" src="plugins/Feedback/images/newsletter.png"></a>
-                    <a rel="noreferrer"  target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/newsletter/">Newsletter</a>
+                    <a target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/newsletter/"><img class="icon" src="plugins/Feedback/images/newsletter.png"></a>
+                    <a target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/newsletter/">Newsletter</a>
                 </li>
                 <li>
                     <a rel="noreferrer"  target="_blank" href="http://www.facebook.com/Piwik"><img class="icon" src="plugins/Feedback/images/facebook.png"></a>
@@ -89,11 +97,11 @@
                 </li>
             </ul>
             <ul class="menu">
-                <li><a rel="noreferrer"  target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/blog/">Blog</a></li>
-                <li><a rel="noreferrer"  target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/about/sponsors/">Sponsors</a></li>
-                <li><a rel="noreferrer"  target="_blank" href="?module=Proxy&action=redirect&url=http://developer.piwik.org">Developers</a></li>
-                <li><a rel="noreferrer"  target="_blank" href="?module=Proxy&action=redirect&url=http://plugins.piwik.org">Marketplace</a></li>
-                <li><a rel="noreferrer"  target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/thank-you-all/">Credits</a></li>
+                <li><a target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/blog/">Blog</a></li>
+                <li><a target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/about/sponsors/">Sponsors</a></li>
+                <li><a target="_blank" href="?module=Proxy&action=redirect&url=http://developer.piwik.org">Developers</a></li>
+                <li><a target="_blank" href="?module=Proxy&action=redirect&url=http://plugins.piwik.org">Marketplace</a></li>
+                <li><a target="_blank" href="?module=Proxy&action=redirect&url=http://piwik.org/thank-you-all/">Credits</a></li>
             </ul>
             <p class="claim"><small>{{ 'Feedback_PrivacyClaim'|translate(
                     "<a target='_blank' href='?module=Proxy&action=redirect&url=http://piwik.org/privacy/'>",


### PR DESCRIPTION
Goal: simplify the Help page, drive more users  when they could actually need Professional Help for their self-hosted Piwik server. 

(it was also suggested to add `Help` to the top menu but i'm not 100% sure of this change yet)
#### Before

![help before](https://cloud.githubusercontent.com/assets/466765/7016810/83653326-dd40-11e4-9fd7-4b49bd389930.png)
#### After

![help after](https://cloud.githubusercontent.com/assets/466765/7016819/b7504612-dd40-11e4-988a-6951e4770ce4.png)
