### PR TITLE
In API requests if the current user is already authenticated, do not authenticate the user again

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -263,7 +263,9 @@ class Request
     {
         // if a token_auth is specified in the API request, we load the right permissions
         $token_auth = Common::getRequestVar('token_auth', '', 'string', $request);
-        if ($token_auth) {
+        $access = Access::getInstance();
+
+        if ($token_auth && $token_auth !== $access->getTokenAuth()) {
 
             /**
              * Triggered when authenticating an API request, but only if the **token_auth**


### PR DESCRIPTION
This improves performance. For example `reloadAccess()` can otherwise cause fetching all sites the user has permission to over and over again. Even in a simple report we often do reload the same access > 5 times. Sometimes much more.

It should not be done in `reloadAccess()` itself since there are actually reasons when you want to reload the access if though the current user is already authenticated. For example when adding a new site: https://github.com/piwik/piwik/blob/master/plugins/SitesManager/API.php#L564
