### PR TITLE
updated text to Taiwan in language files

### DIFF
--- a/plugins/UserCountry/lang/da.json
+++ b/plugins/UserCountry/lang/da.json
@@ -268,7 +268,7 @@
         "country_tr": "Tyrkiet",
         "country_tt": "Trinidad og Tobago",
         "country_tv": "Tuvalu",
-        "country_tw": "Republikken Kina Taiwan",
+        "country_tw": "Taiwan",
         "country_tz": "Tanzania",
         "country_ua": "Ukraine",
         "country_ug": "Uganda",

--- a/plugins/UserCountry/lang/en.json
+++ b/plugins/UserCountry/lang/en.json
@@ -268,7 +268,7 @@
         "country_tr": "Turkey",
         "country_tt": "Trinidad and Tobago",
         "country_tv": "Tuvalu",
-        "country_tw": "Taiwan, Province of China",
+        "country_tw": "Taiwan",
         "country_tz": "Tanzania, United Republic of",
         "country_ua": "Ukraine",
         "country_ug": "Uganda",

--- a/plugins/UserCountry/lang/it.json
+++ b/plugins/UserCountry/lang/it.json
@@ -268,7 +268,7 @@
         "country_tr": "Turchia",
         "country_tt": "Trinidad e Tobago",
         "country_tv": "Tuvalu",
-        "country_tw": "Repubblica di Cina",
+        "country_tw": "Taiwan",
         "country_tz": "Tanzania",
         "country_ua": "Ucraina",
         "country_ug": "Uganda",

--- a/plugins/UserCountry/lang/tl.json
+++ b/plugins/UserCountry/lang/tl.json
@@ -266,7 +266,7 @@
         "country_tr": "Turkey",
         "country_tt": "Trinidad at Tobago",
         "country_tv": "Tuvalu",
-        "country_tw": "Taiwan probinsya ng China",
+        "country_tw": "Taiwan",
         "country_tz": "Tanzania Sama-samang republika ng",
         "country_ua": "Ukraina",
         "country_ug": "Uganda",


### PR DESCRIPTION
This is a fix for the issue https://github.com/piwik/piwik/issues/7479 Updated text as 'Taiwan' in respective languages and cross-checked  "country_tw"  in all language files for text correctness.
