### PR TITLE
Fixes #7647 Variable overwriting itself

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1538,6 +1538,10 @@ class CronArchive
 
         foreach ($allUsersPreferences as $userLogin => $userPreferences) {
 
+            if (!isset($userPreferences[APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE])) {
+                continue;
+            }
+
             $defaultDate = $userPreferences[APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE];
             $preference = new UserPreferences();
             $period = $preference->getDefaultPeriod($defaultDate);

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1527,11 +1527,16 @@ class CronArchive
     private function loadCustomDateRangeToPreProcess()
     {
         $customDateRangesToProcessForSites = array();
+
         // For all users who have selected this website to load by default,
         // we load the default period/date that will be loaded for this user
         // and make sure it's pre-archived
-        $userPreferences = APIUsersManager::getInstance()->getAllUsersPreferences(array(APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE, APIUsersManager::PREFERENCE_DEFAULT_REPORT));
-        foreach ($userPreferences as $userLogin => $userPreferences) {
+        $allUsersPreferences = APIUsersManager::getInstance()->getAllUsersPreferences(array(
+            APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE,
+            APIUsersManager::PREFERENCE_DEFAULT_REPORT
+        ));
+
+        foreach ($allUsersPreferences as $userLogin => $userPreferences) {
 
             $defaultDate = $userPreferences[APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE];
             $preference = new UserPreferences();


### PR DESCRIPTION
Fixes #7647 

The original issue also mentioned:

> Also I think `getAllUsersPreferences` does not return default values so a key might be not set.

Not able to reproduce but just in case I have added some code to handle that case.
