### PR TITLE
Encode/decode INI properties in IniFileChain

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -334,9 +334,6 @@ class Config extends Singleton
             }
         }
 
-        // decode section datas
-        $this->decodeValues($this->settings->getAll());
-
         // Check config.ini.php last
         if (!$inTrackerRequest) {
             $this->checkLocalConfigFound();
@@ -359,46 +356,6 @@ class Config extends Singleton
         if (!$this->existsLocalConfig()) {
             throw new ConfigNotFoundException(Piwik::translate('General_ExceptionConfigurationFileNotFound', array($this->pathLocal)));
         }
-    }
-
-    /**
-     * Decode HTML entities
-     *
-     * @param mixed $values
-     * @return mixed
-     */
-    protected function decodeValues(&$values)
-    {
-        if (is_array($values)) {
-            foreach ($values as &$value) {
-                $value = $this->decodeValues($value);
-            }
-            return $values;
-        } elseif (is_string($values)) {
-            return html_entity_decode($values, ENT_COMPAT, 'UTF-8');
-        }
-        return $values;
-    }
-
-    /**
-     * Encode HTML entities
-     *
-     * @param mixed $values
-     * @return mixed
-     */
-    protected function encodeValues(&$values)
-    {
-        if (is_array($values)) {
-            foreach ($values as &$value) {
-                $value = $this->encodeValues($value);
-            }
-        } elseif (is_float($values)) {
-            $values = Common::forceDotAsSeparatorForDecimalPoint($values);
-        } elseif (is_string($values)) {
-            $values = htmlentities($values, ENT_COMPAT, 'UTF-8');
-            $values = str_replace('$', '&#36;', $values);
-        }
-        return $values;
     }
 
     /**
@@ -455,21 +412,9 @@ class Config extends Singleton
      */
     public function dumpConfig()
     {
-        $this->encodeValues($this->settings->getAll());
-
-        try {
-            $header = "; <?php exit; ?> DO NOT REMOVE THIS LINE\n";
-            $header .= "; file automatically generated or modified by Piwik; you can manually override the default values in global.ini.php by redefining them in this file.\n";
-            $dumpedString = $this->settings->dumpChanges($header);
-
-            $this->decodeValues($this->settings->getAll());
-        } catch (Exception $ex) {
-            $this->decodeValues($this->settings->getAll());
-
-            throw $ex;
-        }
-
-        return $dumpedString;
+        $header = "; <?php exit; ?> DO NOT REMOVE THIS LINE\n";
+        $header .= "; file automatically generated or modified by Piwik; you can manually override the default values in global.ini.php by redefining them in this file.\n";
+        return $this->settings->dumpChanges($header);
     }
 
     /**

--- a/core/Config/IniFileChain.php
+++ b/core/Config/IniFileChain.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik\Config;
 
+use Piwik\Common;
 use Piwik\Ini\IniReader;
 use Piwik\Ini\IniReadingException;
 use Piwik\Ini\IniWriter;
@@ -113,8 +114,7 @@ class IniFileChain
      */
     public function dump($header = '')
     {
-        $writer = new IniWriter();
-        return $writer->writeToString($this->mergedSettings, $header);
+        return $this->dumpSettings($this->mergedSettings, $header);
     }
 
     /**
@@ -184,8 +184,7 @@ class IniFileChain
                 }
             });
 
-            $writer = new IniWriter();
-            return $writer->writeToString($configToWrite, $header);
+            return $this->dumpSettings($configToWrite, $header);
         } else {
             return null;
         }
@@ -206,7 +205,8 @@ class IniFileChain
         foreach ($this->settingsChain as $file => $ignore) {
             if (is_readable($file)) {
                 try {
-                    $this->settingsChain[$file] = $reader->readFile($file);
+                    $contents = $reader->readFile($file);
+                    $this->settingsChain[$file] = $this->decodeValues($contents);
                 } catch (IniReadingException $ex) {
                     $message = Piwik::translate('General_ExceptionUnreadableFileDisabledMethod', array($file, "parse_ini_file()"));
                     throw new IniReadingException($message, $code = 0, $ex);
@@ -398,5 +398,53 @@ class IniFileChain
         $settingsDataSectionNames = array_keys($settingsData);
 
         return array_search($sectionName, $settingsDataSectionNames);
+    }
+
+    /**
+     * Encode HTML entities
+     *
+     * @param mixed $values
+     * @return mixed
+     */
+    protected function encodeValues(&$values)
+    {
+        if (is_array($values)) {
+            foreach ($values as &$value) {
+                $value = $this->encodeValues($value);
+            }
+        } elseif (is_float($values)) {
+            $values = Common::forceDotAsSeparatorForDecimalPoint($values);
+        } elseif (is_string($values)) {
+            $values = htmlentities($values, ENT_COMPAT, 'UTF-8');
+            $values = str_replace('$', '&#36;', $values);
+        }
+        return $values;
+    }
+
+    /**
+     * Decode HTML entities
+     *
+     * @param mixed $values
+     * @return mixed
+     */
+    protected function decodeValues(&$values)
+    {
+        if (is_array($values)) {
+            foreach ($values as &$value) {
+                $value = $this->decodeValues($value);
+            }
+            return $values;
+        } elseif (is_string($values)) {
+            return html_entity_decode($values, ENT_COMPAT, 'UTF-8');
+        }
+        return $values;
+    }
+
+    private function dumpSettings($values, $header)
+    {
+        $values = $this->encodeValues($values);
+
+        $writer = new IniWriter();
+        return $writer->writeToString($values, $header);
     }
 }

--- a/tests/PHPUnit/Unit/Config/IniFileChainTest.php
+++ b/tests/PHPUnit/Unit/Config/IniFileChainTest.php
@@ -141,7 +141,7 @@ class IniFileChainTest extends PHPUnit_Framework_TestCase
                         )
                     ),
                     'Section2' => array(
-                        'var4' => 'value5'
+                        'var4' => 'val$ue5'
                     )
                 )
             ),
@@ -160,7 +160,7 @@ class IniFileChainTest extends PHPUnit_Framework_TestCase
                         )
                     ),
                     'Section2' => array(
-                        'var4' => 'value5'
+                        'var4' => 'val$ue5'
                     )
                 )
             )
@@ -194,7 +194,7 @@ class IniFileChainTest extends PHPUnit_Framework_TestCase
 
         $data =& $fileChain->get('Section1');
 
-        $this->assertEquals(array('var1' => 'value2', 'var3' => array('value3', 'value4')), $data);
+        $this->assertEquals(array('var1' => 'val"ue2', 'var3' => array('value3', 'value4')), $data);
 
         $data['var1'] = 'changed';
         $data['var3'][] = 'newValue';
@@ -241,7 +241,17 @@ class IniFileChainTest extends PHPUnit_Framework_TestCase
             __DIR__ . '/test_files/default_settings_2.ini.php'
         );
 
-        $this->assertEquals(array('var1' => 'value2', 'var3' => array('value3', 'value4')), $fileChain->getFrom($defaultSettingsPath, 'Section1'));
+        $this->assertEquals(array('var1' => 'val"ue2', 'var3' => array('value3', 'value4')), $fileChain->getFrom($defaultSettingsPath, 'Section1'));
+    }
+
+    public function test_getFrom_CorrectlyReturnsUnencodedValue()
+    {
+        $userSettingsPath = __DIR__ . '/test_files/special_values.ini.php';
+        $fileChain = new IniFileChain(array(), $userSettingsPath);
+
+        $this->assertEquals(array(
+            'value1' => 'a"bc', 'value2' => array('<script>', '${@piwik(crash))}'
+        )), $fileChain->getFrom($userSettingsPath, 'Section'));
     }
 
     public function getTestDataForDumpTest()
@@ -253,7 +263,7 @@ class IniFileChainTest extends PHPUnit_Framework_TestCase
                 ),
                 __DIR__ . '/test_files/default_settings_2.ini.php', // user settings
                 "; some header\n",
-                "; some header\n[Section1]\nvar1 = \"overriddenValue1\"\nvar3[] = \"overriddenValue2\"\nvar3[] = \"overriddenValue3\"\n\n[Section2]\nvar4 = \"value5\"\n\n",
+                "; some header\n[Section1]\nvar1 = \"overriddenValue1\"\nvar3[] = \"overriddenValue2\"\nvar3[] = \"overriddenValue3\"\n\n[Section2]\nvar4 = \"val&#36;ue5\"\n\n",
                 "; some header\n[Section1]\nvar1 = \"overriddenValue1\"\nvar3[] = \"overriddenValue2\"\nvar3[] = \"overriddenValue3\"\n\n"
             )
         );

--- a/tests/PHPUnit/Unit/Config/test_files/default_settings_1.ini.php
+++ b/tests/PHPUnit/Unit/Config/test_files/default_settings_1.ini.php
@@ -1,9 +1,9 @@
 [Section1]
 
-var1 = "value2"
+var1 = "val&quot;ue2"
 var3[] = "value3"
 var3[] = "value4"
 
 [Section2]
 
-var4 = "value5"
+var4 = "val&#36;ue5"

--- a/tests/PHPUnit/Unit/Config/test_files/special_values.ini.php
+++ b/tests/PHPUnit/Unit/Config/test_files/special_values.ini.php
@@ -1,0 +1,4 @@
+[Section]
+value1 = "a&quot;bc"
+value2[] = "&lt;script&gt;"
+value2[] = "&#36;{@piwik(crash))}"

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -145,7 +145,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
     /**
      * Dataprovider for testDumpConfig
-     */
+$     */
     public function getDumpConfigData()
     {
         $header = "; <?php exit; ?> DO NOT REMOVE THIS LINE\n" .

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -145,7 +145,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
     /**
      * Dataprovider for testDumpConfig
-$     */
+     */
     public function getDumpConfigData()
     {
         $header = "; <?php exit; ?> DO NOT REMOVE THIS LINE\n" .


### PR DESCRIPTION
As title. Changed since the encoding/decoding is used to avoid issues w/ parse_ini_file() use.

Also fixes bug in getFromGlobal which doesn't correctly decode values.
