### PR TITLE
Archiving with `--force-all-websites` now shares the site list with other processes

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -277,15 +277,16 @@ class CronArchive
         $websitesIds = $this->initWebsiteIds();
         $this->filterWebsiteIds($websitesIds);
 
-        if (!empty($this->shouldArchiveSpecifiedSites)
-            || !empty($this->shouldArchiveAllSites)
-            || !SharedSiteIds::isSupported()) {
+        if (!empty($this->shouldArchiveAllSites) && SharedSiteIds::isSupported()) {
+            $this->websites = new SharedSiteIds($websitesIds, SharedSiteIds::OPTION_ALL_WEBSITES);
+        } elseif (!empty($this->shouldArchiveSpecifiedSites) || !SharedSiteIds::isSupported()) {
             $this->websites = new FixedSiteIds($websitesIds);
         } else {
             $this->websites = new SharedSiteIds($websitesIds);
-            if ($this->websites->getInitialSiteIds() != $websitesIds) {
-                $this->log('Will ignore websites and help finish a previous started queue instead. IDs: ' . implode(', ', $this->websites->getInitialSiteIds()));
-            }
+        }
+
+        if ($this->websites->getInitialSiteIds() != $websitesIds) {
+            $this->log('Will ignore websites and help finish a previous started queue instead. IDs: ' . implode(', ', $this->websites->getInitialSiteIds()));
         }
 
         if ($this->shouldStartProfiler) {

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -277,13 +277,7 @@ class CronArchive
         $websitesIds = $this->initWebsiteIds();
         $this->filterWebsiteIds($websitesIds);
 
-        if (!empty($this->shouldArchiveAllSites) && SharedSiteIds::isSupported()) {
-            $this->websites = new SharedSiteIds($websitesIds, SharedSiteIds::OPTION_ALL_WEBSITES);
-        } elseif (!empty($this->shouldArchiveSpecifiedSites) || !SharedSiteIds::isSupported()) {
-            $this->websites = new FixedSiteIds($websitesIds);
-        } else {
-            $this->websites = new SharedSiteIds($websitesIds);
-        }
+        $this->websites = $this->createSitesToArchiveQueue($websitesIds);
 
         if ($this->websites->getInitialSiteIds() != $websitesIds) {
             $this->log('Will ignore websites and help finish a previous started queue instead. IDs: ' . implode(', ', $this->websites->getInitialSiteIds()));
@@ -1585,5 +1579,16 @@ class CronArchive
             $urlsWithSegment[] = $urlWithSegment;
         }
         return $urlsWithSegment;
+    }
+
+    private function createSitesToArchiveQueue($websitesIds)
+    {
+        if (!empty($this->shouldArchiveAllSites) && SharedSiteIds::isSupported()) {
+            return new SharedSiteIds($websitesIds, SharedSiteIds::OPTION_ALL_WEBSITES);
+        } elseif (!empty($this->shouldArchiveSpecifiedSites) || !SharedSiteIds::isSupported()) {
+            return new FixedSiteIds($websitesIds);
+        }
+
+        return new SharedSiteIds($websitesIds);
     }
 }

--- a/core/CronArchive/SharedSiteIds.php
+++ b/core/CronArchive/SharedSiteIds.php
@@ -18,12 +18,22 @@ use Piwik\Option;
  */
 class SharedSiteIds
 {
+    const OPTION_DEFAULT = 'SharedSiteIdsToArchive';
+    const OPTION_ALL_WEBSITES = 'SharedSiteIdsToArchive_AllWebsites';
+
+    /**
+     * @var string
+     */
+    private $optionName;
+
     private $siteIds = array();
     private $currentSiteId;
     private $done = false;
 
-    public function __construct($websiteIds)
+    public function __construct($websiteIds, $optionName = self::OPTION_DEFAULT)
     {
+        $this->optionName = $optionName;
+
         if (empty($websiteIds)) {
             $websiteIds = array();
         }
@@ -86,16 +96,16 @@ class SharedSiteIds
     public function setSiteIdsToArchive($siteIds)
     {
         if (!empty($siteIds)) {
-            Option::set('SharedSiteIdsToArchive', implode(',', $siteIds));
+            Option::set($this->optionName, implode(',', $siteIds));
         } else {
-            Option::delete('SharedSiteIdsToArchive');
+            Option::delete($this->optionName);
         }
     }
 
     public function getAllSiteIdsToArchive()
     {
-        Option::clearCachedOption('SharedSiteIdsToArchive');
-        $siteIdsToArchive = Option::get('SharedSiteIdsToArchive');
+        Option::clearCachedOption($this->optionName);
+        $siteIdsToArchive = Option::get($this->optionName);
 
         if (empty($siteIdsToArchive)) {
             return array();

--- a/tests/PHPUnit/Integration/CronArchive/SharedSiteIdsTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/SharedSiteIdsTest.php
@@ -55,9 +55,12 @@ class SharedSiteIdsTest extends IntegrationTestCase
         $this->assertNull($siteIds->getNextSiteId());
     }
 
-    public function test_isSupported()
+    public function test_construct_withCustomOptionName()
     {
-        $this->assertTrue(SharedSiteIds::isSupported());
+        $first = new SharedSiteIds(array(1, 2), 'SharedSiteIdsToArchive_Test');
+        $second = new SharedSiteIds(array(), 'SharedSiteIdsToArchive_Test');
+        $this->assertEquals(array(1, 2), $first->getAllSiteIdsToArchive());
+        $this->assertEquals(array(1, 2), $second->getAllSiteIdsToArchive());
     }
 
     public function test_getNumSites()


### PR DESCRIPTION
See #7614

Archiving with `--force-all-websites` now shares the site list. That allows to run a second archive process which will reuse the same (shared) site list.

To avoid a normal archiver sharing the site list with an archiver using `--force-all-websites`, we store the shared site list in a different option.

To sum up:

``` bash
# share the same site list
./console cron:archive
./console cron:archive

# share the same site list
./console cron:archive --force-all-websites
./console cron:archive --force-all-websites

# don't share the same site list
./console cron:archive
./console cron:archive --force-all-websites
```
