### PR TITLE
Prevent useless ajax requests in live widgets (fixes #7404)

### DIFF
--- a/plugins/Live/javascripts/live.js
+++ b/plugins/Live/javascripts/live.js
@@ -211,7 +211,7 @@
 $(function() {
     var refreshWidget = function (element, refreshAfterXSecs) {
         // if the widget has been removed from the DOM, abort
-        if ($(element).parent().length == 0) {
+        if ($(element).closest('body').length == 0) {
             return;
         }
 

--- a/plugins/Live/javascripts/live.js
+++ b/plugins/Live/javascripts/live.js
@@ -82,7 +82,7 @@
 
                 if (that.isStarted) {
                     window.clearTimeout(that.updateInterval);
-                    if ($(that.element).closest('body').length) {
+                    if (that.element.length && $.contains(document, that.element[0])) {
                         that.updateInterval = window.setTimeout(function() { that._update() }, that.currentInterval);
                     }
                 }
@@ -211,7 +211,7 @@
 $(function() {
     var refreshWidget = function (element, refreshAfterXSecs) {
         // if the widget has been removed from the DOM, abort
-        if ($(element).closest('body').length == 0) {
+        if (!element.length || !$.contains(document, element[0])) {
             return;
         }
 

--- a/plugins/UserCountryMap/javascripts/realtime-map.js
+++ b/plugins/UserCountryMap/javascripts/realtime-map.js
@@ -359,7 +359,7 @@
                  */
                 function gotNewReport(report) {
                     // if the map has been destroyed, do nothing
-                    if (!self.map || !$(self.$element).closest('body').length) {
+                    if (!self.map || !self.$element.length || !$.contains(document, self.$element[0])) {
                         return;
                     }
 

--- a/plugins/UserCountryMap/javascripts/realtime-map.js
+++ b/plugins/UserCountryMap/javascripts/realtime-map.js
@@ -359,7 +359,7 @@
                  */
                 function gotNewReport(report) {
                     // if the map has been destroyed, do nothing
-                    if (!self.map) {
+                    if (!self.map || !$(self.$element).closest('body').length) {
                         return;
                     }
 


### PR DESCRIPTION
This PR aims to fix #7404.
I've improved the js code of the live widgets to ensure the elements are still present in body before new ajax calls are triggered. Before there were only checks if the element were still kind of present, which was the case, even when not within the body.
