### PR TITLE
Improve performance of BulkTracking and QueuedTracking

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -379,9 +379,13 @@ class Common
      */
     private static function undoMagicQuotes($value)
     {
-        if (version_compare(PHP_VERSION, '5.4', '<') &&
-            get_magic_quotes_gpc()) {
+        static $shouldUndo;
 
+        if (!isset($shouldUndo)) {
+            $shouldUndo = version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc();
+        }
+
+        if ($shouldUndo) {
             $value = stripslashes($value);
         }
 
@@ -470,7 +474,7 @@ class Common
         }
 
         $value = self::sanitizeInputValues($requestArrayToUse[$varName]);
-        if (!is_null($varType)) {
+        if (isset($varType)) {
             $ok = false;
 
             if ($varType === 'string') {

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -132,8 +132,6 @@ class Tracker
         if ($request->isEmptyRequest()) {
             Common::printDebug("The request is empty");
         } else {
-            $this->loadTrackerPlugins();
-
             Common::printDebug("Current datetime: " . date("Y-m-d H:i:s", $request->getCurrentTimestamp()));
 
             $visit = Visit\Factory::make();
@@ -168,6 +166,13 @@ class Tracker
             }
 
             PluginManager::getInstance()->loadCorePluginsDuringTracker();
+        }
+    }
+
+    public static function restoreTrackerPlugins()
+    {
+        if (SettingsServer::isTrackerApiRequest() && Tracker::$initTrackerMode) {
+            Plugin\Manager::getInstance()->loadTrackerPlugins();
         }
     }
 

--- a/core/Tracker/Action.php
+++ b/core/Tracker/Action.php
@@ -125,7 +125,12 @@ abstract class Action
 
     private static function getAllActions(Request $request)
     {
-        $actions   = Manager::getInstance()->findMultipleComponents('Actions', '\\Piwik\\Tracker\\Action');
+        static $actions;
+
+        if (is_null($actions)) {
+            $actions = Manager::getInstance()->findMultipleComponents('Actions', '\\Piwik\\Tracker\\Action');
+        }
+
         $instances = array();
 
         foreach ($actions as $action) {

--- a/core/Tracker/Cache.php
+++ b/core/Tracker/Cache.php
@@ -15,6 +15,8 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Option;
 use Piwik\Piwik;
+use Piwik\Plugin;
+use Piwik\SettingsServer;
 use Piwik\Tracker;
 
 /**
@@ -105,6 +107,8 @@ class Cache
             $cache->save($cacheId, $content, self::getTtl());
         }
 
+        Tracker::restoreTrackerPlugins();
+
         return $content;
     }
 
@@ -160,6 +164,9 @@ class Cache
         Piwik::postEvent('Tracker.setTrackerCacheGeneral', array(&$cacheContent));
         self::setCacheGeneral($cacheContent);
         Common::printDebug("General tracker cache was re-created.");
+
+        Tracker::restoreTrackerPlugins();
+
         return $cacheContent;
     }
 

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -54,6 +54,8 @@ class Visit implements VisitInterface
     protected $userSettings;
     protected $visitorCustomVariables = array();
 
+    public static $dimensions;
+
     /**
      * @param Request $request
      */
@@ -584,16 +586,18 @@ class Visit implements VisitInterface
 
     protected function getAllVisitDimensions()
     {
-        $dimensions = VisitDimension::getAllDimensions();
+        if (is_null(self::$dimensions)) {
+            self::$dimensions = VisitDimension::getAllDimensions();
 
-        $dimensionNames = array();
-        foreach($dimensions as $dimension) {
-            $dimensionNames[] = $dimension->getColumnName();
+            $dimensionNames = array();
+            foreach(self::$dimensions as $dimension) {
+                $dimensionNames[] = $dimension->getColumnName();
+            }
+
+            Common::printDebug("Following dimensions have been collected from plugins: " . implode(", ", $dimensionNames));
         }
 
-        Common::printDebug("Following dimensions have been collected from plugins: " . implode(", ", $dimensionNames));
-
-        return $dimensions;
+        return self::$dimensions;
     }
 
     private function getVisitStandardLength()

--- a/core/Tracker/Visit/Factory.php
+++ b/core/Tracker/Visit/Factory.php
@@ -37,7 +37,7 @@ class Factory
          */
         Piwik::postEvent('Tracker.makeNewVisitObject', array(&$visit));
 
-        if (is_null($visit)) {
+        if (!isset($visit)) {
             $visit = new Visit();
         } elseif (!($visit instanceof VisitInterface)) {
             throw new Exception("The Visit object set in the plugin must implement VisitInterface");

--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -155,6 +155,14 @@ class UrlHelper
         if (strlen($urlQuery) == 0) {
             return array();
         }
+
+        $cache    = Cache::getTransientCache();
+        $cacheKey = 'arrayFromQuery' . $urlQuery;
+
+        if ($cache->contains($cacheKey)) {
+            return $cache->fetch($cacheKey);
+        }
+
         if ($urlQuery[0] == '?') {
             $urlQuery = substr($urlQuery, 1);
         }
@@ -200,6 +208,9 @@ class UrlHelper
                 $nameToValue[$name] = $value;
             }
         }
+
+        $cache->save($cacheKey, $nameToValue);
+
         return $nameToValue;
     }
 
@@ -214,6 +225,7 @@ class UrlHelper
     public static function getParameterFromQueryString($urlQuery, $parameter)
     {
         $nameToValue = self::getArrayFromQueryString($urlQuery);
+
         if (isset($nameToValue[$parameter])) {
             return $nameToValue[$parameter];
         }

--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -70,7 +70,7 @@ abstract class Base extends VisitDimension
     {
         $cacheKey = $referrerUrl . $currentUrl . $idSite;
 
-        if (array_key_exists($cacheKey, self::$cachedReferrer)) {
+        if (isset(self::$cachedReferrer[$cacheKey])) {
             return self::$cachedReferrer[$cacheKey];
         }
 
@@ -108,9 +108,7 @@ abstract class Base extends VisitDimension
             }
         }
 
-        if (!empty($this->referrerHost)
-            && !$referrerDetected
-        ) {
+        if (!$referrerDetected && !empty($this->referrerHost)) {
             $this->typeReferrerAnalyzed = Common::REFERRER_TYPE_WEBSITE;
             $this->nameReferrerAnalyzed = Common::mb_strtolower($this->referrerHost);
         }
@@ -345,7 +343,6 @@ abstract class Base extends VisitDimension
         $type    = $visitor->getVisitorColumn('referer_type');
         $name    = $visitor->getVisitorColumn('referer_name');
         $keyword = $visitor->getVisitorColumn('referer_keyword');
-        $time    = $visitor->getVisitorColumn('visit_first_action_time');
 
         // 0) In some (unknown!?) cases the campaign is not found in the attribution cookie, but the URL ref was found.
         //    In this case we look up if the current visit is credited to a campaign and will credit this campaign rather than the URL ref (since campaigns have higher priority)
@@ -359,7 +356,6 @@ abstract class Base extends VisitDimension
             $type    = Common::REFERRER_TYPE_CAMPAIGN;
             $name    = $referrerCampaignName;
             $keyword = $referrerCampaignKeyword;
-            $time    = $referrerTimestamp;
         } // 2) Referrer URL parsing
         elseif (!empty($referrerUrl)) {
 
@@ -371,7 +367,6 @@ abstract class Base extends VisitDimension
                 $type    = $referrer['referer_type'];
                 $name    = $referrer['referer_name'];
                 $keyword = $referrer['referer_keyword'];
-                $time    = $referrerTimestamp;
             }
         }
 

--- a/tests/LocalTracker.php
+++ b/tests/LocalTracker.php
@@ -45,6 +45,7 @@ class Piwik_LocalTracker extends PiwikTracker
 
         // unset cached values
         Cache::$cache = null;
+        Tracker\Visit::$dimensions = null;
 
         // save some values
         $plugins = Config::getInstance()->Plugins['Plugins'];
@@ -77,6 +78,7 @@ class Piwik_LocalTracker extends PiwikTracker
         $request = new Tracker\RequestSet();
         $request->setRequests($requests);
 
+        \Piwik\Plugin\Manager::getInstance()->loadTrackerPlugins();
         $handler = Tracker\Handler\Factory::make();
 
         $response = $localTracker->main($handler, $request);

--- a/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
+++ b/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
@@ -15,6 +15,7 @@ use Piwik\Plugins\UserCountry\LocationProvider;
 use Piwik\Tests\Framework\Fixture;
 use Exception;
 use Piwik\Tests\Framework\Mock\LocationProvider as MockLocationProvider;
+use Piwik\Tracker\Visit;
 
 require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/Framework/Mock/LocationProvider.php';
 
@@ -93,6 +94,7 @@ class ManyVisitsWithGeoIP extends Fixture
 
         if ($useLocal) {
             Cache::getTransientCache()->flushAll(); // make sure dimension cache is empty between local tracking runs
+            Visit::$dimensions = null;
         }
 
         // use local tracker so mock location provider can be used

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -41,6 +41,7 @@ class VisitTest extends IntegrationTestCase
 
         Manager::getInstance()->loadTrackerPlugins();
         Manager::getInstance()->loadPlugin('SitesManager');
+        Visit::$dimensions = null;
     }
 
     /**
@@ -450,6 +451,7 @@ class VisitTest extends IntegrationTestCase
 
         $cache = Cache::getTransientCache();
         $cache->save(CacheId::pluginAware('VisitDimensions'), $dimensions);
+        Visit::$dimensions = null;
     }
 }
 

--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik\Tests\System;
 
+use Piwik\Cache;
 use Piwik\Config;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
@@ -27,6 +28,12 @@ class BlobReportLimitingTest extends SystemTestCase
     {
         self::setUpConfigOptions();
         parent::setUpBeforeClass();
+    }
+
+    public function setUp()
+    {
+        Cache::getTransientCache()->flushAll();
+        parent::setUp();
     }
 
     public function getApiForTesting()


### PR DESCRIPTION
I profiled QueuedTracking with Redis (actually inserting the requests from Redis to DB) and made some improvements that as well effect mainly BulkTracking but also normal tracking. In some cases it improved performance by 30-70%.

For example 50% of the total time (180seconds) is spent in https://github.com/piwik/piwik/blob/2.13.0-b2/core/UrlHelper.php#L153 (down to 20% wall time now) . 33.3% of total time is spent in `Common::sanitizeInputValue` https://github.com/piwik/piwik/blob/2.13.0-b2/core/Common.php#L342 (which is also called by UrlHelper partially), 21% is spent in `Common::sanitizeString` https://github.com/piwik/piwik/blob/2.13.0-b2/core/Common.php#L314 . 

Also `Common::getRequestVar` is very expensive when performed a million times (eg 20% wall time easily), same for `Piwik::postEvent()` (> 10% of the time) etc. 

Those changes are needed by Thursday/Friday for a client to make inserting tracking requests fast enough. 
