### PR TITLE
"Manage goals" page in the reporting menu

### DIFF
--- a/plugins/Goals/Controller.php
+++ b/plugins/Goals/Controller.php
@@ -168,27 +168,7 @@ class Controller extends \Piwik\Plugin\Controller
 
         $view = new View('@Goals/manageGoals');
         $this->setGeneralVariablesView($view);
-
-        $goals = $this->goals;
-        $view->goals = $goals;
-
-        $idGoal = Common::getRequestVar('idGoal', 0, 'int');
-        $view->idGoal = 0;
-        if ($idGoal && array_key_exists($idGoal, $goals)) {
-            $view->idGoal = $idGoal;
-        }
-
-        // unsanitize goal names and other text data (not done in API so as not to break
-        // any other code/cause security issues)
-
-        foreach ($goals as &$goal) {
-            $goal['name'] = Common::unsanitizeInputValue($goal['name']);
-            if (isset($goal['pattern'])) {
-                $goal['pattern'] = Common::unsanitizeInputValue($goal['pattern']);
-            }
-        }
-        $view->goalsJSON = json_encode($goals);
-        $view->ecommerceEnabled = $this->site->isEcommerceEnabled();
+        $this->setEditGoalsViewVariables($view);
         return $view->render();
     }
 
@@ -260,6 +240,15 @@ class Controller extends \Piwik\Plugin\Controller
         $this->setGeneralVariablesView($view);
         $view->userCanEditGoals = Piwik::isUserHasAdminAccess($this->idSite);
         $view->onlyShowAddNewGoal = true;
+        return $view->render();
+    }
+
+    public function editGoals()
+    {
+        $view = new View('@Goals/editGoals');
+        $this->setGeneralVariablesView($view);
+        $this->setEditGoalsViewVariables($view);
+        $view->userCanEditGoals = Piwik::isUserHasAdminAccess($this->idSite);
         return $view->render();
     }
 
@@ -485,5 +474,29 @@ class Controller extends \Piwik\Plugin\Controller
         }
 
         return $goalReportsByDimension->render();
+    }
+
+    private function setEditGoalsViewVariables($view)
+    {
+        $goals = $this->goals;
+        $view->goals = $goals;
+
+        $idGoal = Common::getRequestVar('idGoal', 0, 'int');
+        $view->idGoal = 0;
+        if ($idGoal && array_key_exists($idGoal, $goals)) {
+            $view->idGoal = $idGoal;
+        }
+
+        // unsanitize goal names and other text data (not done in API so as not to break
+        // any other code/cause security issues)
+
+        foreach ($goals as &$goal) {
+            $goal['name'] = Common::unsanitizeInputValue($goal['name']);
+            if (isset($goal['pattern'])) {
+                $goal['pattern'] = Common::unsanitizeInputValue($goal['pattern']);
+            }
+        }
+        $view->goalsJSON = json_encode($goals);
+        $view->ecommerceEnabled = $this->site->isEcommerceEnabled();
     }
 }

--- a/plugins/Goals/Menu.php
+++ b/plugins/Goals/Menu.php
@@ -24,15 +24,13 @@ class Menu extends \Piwik\Plugin\Menu
         $goals  = API::getInstance()->getGoals($idSite);
         $mainGoalMenu = 'Goals_Goals';
 
-        $linkToAddNewGoal = $this->urlForAction('addNewGoal', array(
-            'idGoal' => null
-        ));
+        $linkToManageGoals = $this->urlForAction('editGoals');
 
         $order = 1;
 
         if (count($goals) == 0) {
 
-            $menu->addItem($mainGoalMenu, '', $linkToAddNewGoal, 25);
+            $menu->addItem($mainGoalMenu, '', $linkToManageGoals, 25);
 
         } else {
 
@@ -60,7 +58,7 @@ class Menu extends \Piwik\Plugin\Menu
 
         }
 
-        $menu->addItem($mainGoalMenu, 'Goals_AddNewGoal', $linkToAddNewGoal, ++$order);
+        $menu->addItem($mainGoalMenu, 'Goals_ManageGoals', $linkToManageGoals, ++$order);
     }
 
     public function configureUserMenu(MenuUser $menu)

--- a/plugins/Goals/Menu.php
+++ b/plugins/Goals/Menu.php
@@ -24,41 +24,40 @@ class Menu extends \Piwik\Plugin\Menu
         $goals  = API::getInstance()->getGoals($idSite);
         $mainGoalMenu = 'Goals_Goals';
 
-        $linkToManageGoals = $this->urlForAction('editGoals');
+        if (count($goals) == 0) {
+            $linkToAddNewGoal = $this->urlForAction('addNewGoal', array(
+                'idGoal' => null,
+            ));
+            $menu->addItem($mainGoalMenu, '', $linkToAddNewGoal, 25);
+            $menu->addItem($mainGoalMenu, 'Goals_AddNewGoal', $linkToAddNewGoal, 1);
+            return;
+        }
 
         $order = 1;
 
-        if (count($goals) == 0) {
+        $url = $this->urlForAction('index', array('idGoal' => null));
 
-            $menu->addItem($mainGoalMenu, '', $linkToManageGoals, 25);
+        $menu->addItem($mainGoalMenu, '', $url, 25);
+        $menu->addItem($mainGoalMenu, 'General_Overview', $url, ++$order);
 
-        } else {
-
-            $url = $this->urlForAction('index', array('idGoal' => null));
-
-            $menu->addItem($mainGoalMenu, '', $url, 25);
-            $menu->addItem($mainGoalMenu, 'General_Overview', $url, ++$order);
-
-            $group = new Group();
-            foreach ($goals as $goal) {
-                $subMenuName = str_replace('%', '%%', Translate::clean($goal['name']));
-                $params      = $this->urlForAction('goalReport', array('idGoal' => $goal['idgoal']));
-                $tooltip     = sprintf('%s (id = %d)', $subMenuName, $goal['idgoal']);
-
-                if (count($goals) > 3) {
-                    $group->add($subMenuName, $params, $tooltip);
-                } else {
-                    $menu->addItem($mainGoalMenu, $subMenuName, $params, ++$order, $tooltip);
-                }
-            }
+        $group = new Group();
+        foreach ($goals as $goal) {
+            $subMenuName = str_replace('%', '%%', Translate::clean($goal['name']));
+            $params      = $this->urlForAction('goalReport', array('idGoal' => $goal['idgoal']));
+            $tooltip     = sprintf('%s (id = %d)', $subMenuName, $goal['idgoal']);
 
             if (count($goals) > 3) {
-                $menu->addGroup($mainGoalMenu, 'Goals_ChooseGoal', $group, ++$order, $tooltip = false);
+                $group->add($subMenuName, $params, $tooltip);
+            } else {
+                $menu->addItem($mainGoalMenu, $subMenuName, $params, ++$order, $tooltip);
             }
-
         }
 
-        $menu->addItem($mainGoalMenu, 'Goals_ManageGoals', $linkToManageGoals, ++$order);
+        if (count($goals) > 3) {
+            $menu->addGroup($mainGoalMenu, 'Goals_ChooseGoal', $group, ++$order, $tooltip = false);
+        }
+
+        $menu->addItem($mainGoalMenu, 'Goals_ManageGoals', $this->urlForAction('editGoals'), ++$order);
     }
 
     public function configureUserMenu(MenuUser $menu)

--- a/plugins/Goals/templates/addNewGoal.twig
+++ b/plugins/Goals/templates/addNewGoal.twig
@@ -2,7 +2,7 @@
     <h2 piwik-enriched-headline>{{ 'Goals_AddNewGoal'|translate }}</h2>
     <p>{{ 'Goals_NewGoalIntro'|translate }}</p>
     <p>{{ 'Goals_LearnMoreAboutGoalTrackingDocumentation'|translate("<a href='?module=Proxy&action=redirect&url=http://piwik.org/docs/tracking-goals-web-analytics/' target='_blank'>","</a>")|raw }}
-       {{ 'Goals_ManageGoalsOrCreateANewGoal'|translate("<a href='" ~ linkTo({'module':'Goals','action':'manage'}) ~ "'>","</a>")|raw }}
+       {{ 'Goals_ManageGoalsOrCreateANewGoal'|translate("<a href='#module=Goals&action=editGoals'>","</a>")|raw }}
     </p>
 
     {% include "@Goals/_addEditGoal.twig" %}

--- a/plugins/Goals/templates/editGoals.twig
+++ b/plugins/Goals/templates/editGoals.twig
@@ -1,0 +1,17 @@
+{% if userCanEditGoals %}
+
+    <h2 piwik-enriched-headline>{{ 'Goals_ManageGoals'|translate }}</h2>
+
+    {% include "@Goals/_addEditGoal.twig" %}
+
+{% else %}
+
+    <h2>{{ 'Goals_CreateNewGOal'|translate }}</h2>
+    <p>
+        {{ 'Goals_NoGoalsNeedAccess'|translate|raw }}
+    </p>
+    <p>
+        {{ 'Goals_LearnMoreAboutGoalTrackingDocumentation'|translate("<a href='?module=Proxy&action=redirect&url=http://piwik.org/docs/tracking-goals-web-analytics/' target='_blank'>","</a>")|raw }}
+    </p>
+
+{% endif %}


### PR DESCRIPTION
Fixes #7345

This replaces the "Add a new goal" link with "Manage goals" instead:

![capture d ecran 2015-04-20 a 01 51 48](https://cloud.githubusercontent.com/assets/720328/7219688/043d9eca-e700-11e4-974d-cb761fc465b1.png)
