### PR TITLE
Refactoring CronArchive setup + use for less technical debt

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -252,7 +252,12 @@ class CliMulti {
 
     private function executeNotAsyncHttp($url, Output $output)
     {
-        $url = SettingsPiwik::getPiwikUrl() . $url;
+        $piwikUrl = SettingsPiwik::getPiwikUrl();
+        if (empty($piwikUrl)) {
+            $piwikUrl = 'http://' . Url::getHost() . '/';
+        }
+
+        $url = $piwikUrl . $url;
         if (Config::getInstance()->General['force_ssl'] == 1) {
             $url = str_replace("http://", "https://", $url);
         }

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -101,7 +101,7 @@ class CliMulti {
 
     public function runAsSuperUser($runAsSuperUser = true)
     {
-        $this->runAsSuperuser = $runAsSuperUser;
+        $this->runAsSuperUser = $runAsSuperUser;
     }
 
     private function start($piwikUrls)

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -274,7 +274,7 @@ class CliMulti {
         }
 
         if ($this->runAsSuperUser) {
-            $tokenAuths = CronArchive::getSuperUserTokenAuths();
+            $tokenAuths = self::getSuperUserTokenAuths();
             $tokenAuth = reset($tokenAuths);
 
             if (strpos($url, '?') === false) {
@@ -336,5 +336,19 @@ class CliMulti {
         self::cleanupNotRemovedFiles();
 
         return $results;
+    }
+
+    public static function getSuperUserTokenAuths()
+    {
+        $tokens = array();
+
+        /**
+         * Used to be in CronArchive, moved to CliMulti.
+         * 
+         * @ignore
+         */
+        Piwik::postEvent('CronArchive.getTokenAuth', array(&$tokens));
+
+        return $tokens;
     }
 }

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -338,7 +338,7 @@ class CliMulti {
         return $results;
     }
 
-    public static function getSuperUserTokenAuths()
+    private static function getSuperUserTokenAuths()
     {
         $tokens = array();
 

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -243,7 +243,7 @@ class CliMulti {
 
         $url      = $this->appendTestmodeParamToUrlIfNeeded($url);
         $query    = UrlHelper::getQueryFromUrl($url, array('pid' => $cmdId));
-        $hostname = UrlHelper::getHostFromUrl($url);
+        $hostname = Url::getHost($checkIfTrusted = false);
         $command  = $this->buildCommand($hostname, $query, $output->getPathToFile());
 
         Log::debug($command);
@@ -252,6 +252,11 @@ class CliMulti {
 
     private function executeNotAsyncHttp($url, Output $output)
     {
+        $url = SettingsPiwik::getPiwikUrl() . $url;
+        if (Config::getInstance()->General['force_ssl'] == 1) {
+            $url = str_replace("http://", "https://", $url);
+        }
+
         try {
             Log::debug("Execute HTTP API request: "  . $url);
             $response = Http::sendHttpRequestBy('curl', $url, $timeout = 0, $userAgent = null, $destinationPath = null, $file = null, $followDepth = 0, $acceptLanguage = false, $this->acceptInvalidSSLCertificate);
@@ -273,7 +278,7 @@ class CliMulti {
 
     private function appendTestmodeParamToUrlIfNeeded($url)
     {
-        $isTestMode = $url && false !== strpos($url, 'tests/PHPUnit/proxy');
+        $isTestMode = class_exists('Piwik_TestingEnvironment');
 
         if ($isTestMode && false === strpos($url, '?')) {
             $url .= "?testmode=1";

--- a/core/CliMulti/RequestCommand.php
+++ b/core/CliMulti/RequestCommand.php
@@ -9,6 +9,7 @@
 namespace Piwik\CliMulti;
 
 use Piwik\Application\Environment;
+use Piwik\Access;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Db;
@@ -20,6 +21,7 @@ use Piwik\Url;
 use Piwik\UrlHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -37,6 +39,7 @@ class RequestCommand extends ConsoleCommand
         $this->setName('climulti:request');
         $this->setDescription('Parses and executes the given query. See Piwik\CliMulti. Intended only for system usage.');
         $this->addArgument('url-query', InputArgument::REQUIRED, 'Piwik URL query string, for instance: "module=API&method=API.getPiwikVersion&token_auth=123456789"');
+        $this->addOption('superuser', null, InputOption::VALUE_NONE, 'If supplied, runs the code as superuser.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -64,6 +67,10 @@ class RequestCommand extends ConsoleCommand
             }
 
             $process->startProcess();
+        }
+
+        if ($input->getOption('superuser')) {
+            Access::getInstance()->setSuperUserAccess(true);
         }
 
         require_once PIWIK_INCLUDE_PATH . $indexFile;

--- a/core/CliMulti/RequestCommand.php
+++ b/core/CliMulti/RequestCommand.php
@@ -89,7 +89,7 @@ class RequestCommand extends ConsoleCommand
         Url::setHost($hostname);
 
         $query = $input->getArgument('url-query');
-        $query = UrlHelper::getArrayFromQueryString($query);
+        $query = UrlHelper::getArrayFromQueryString($query); // NOTE: this method can create the StaticContainer now
         foreach ($query as $name => $value) {
             $_GET[$name] = $value;
         }

--- a/core/Console.php
+++ b/core/Console.php
@@ -28,7 +28,7 @@ class Console extends Application
 
     public function __construct()
     {
-        $this->checkCompatibility();
+        $this->setServerArgsIfPhpCgi();
 
         parent::__construct();
 
@@ -130,13 +130,22 @@ class Console extends Application
         return $commands;
     }
 
-    private function checkCompatibility()
+    private function setServerArgsIfPhpCgi()
     {
         if (Common::isPhpCgiType()) {
-            echo 'Piwik Console is known to be not compatible with PHP-CGI (you are using '.php_sapi_name().'). ' .
-                 'Please execute console using PHP-CLI. For instance "/usr/bin/php-cli console ..."';
-            echo "\n";
-            exit(1);
+            $_SERVER['argv'] = array();
+            foreach ($_GET as $name => $value) {
+                $argument = $name;
+                if (!empty($value)) {
+                    $argument .= '=' . $value;
+                }
+
+                $_SERVER['argv'][] = $argument;
+            }
+
+            if (!defined('STDIN')) {
+                define('STDIN', fopen('php://stdin','r'));
+            }
         }
     }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -223,14 +223,10 @@ class CronArchive
     /**
      * Constructor.
      *
-     * @param string|false $piwikUrl The URL to the Piwik installation to initiate archiving for. If `false`,
-     *                               we determine it using the current request information. TODO: remove this param
-     *
-     *                               If invoked via the command line, $piwikUrl cannot be false.
      * @param string|null $processNewSegmentsFrom When to archive new segments from. See [General] process_new_segments_from
      *                                            for possible values.
      */
-    public function __construct($piwikUrl = false, $processNewSegmentsFrom = null, LoggerInterface $logger = null)
+    public function __construct($processNewSegmentsFrom = null, LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: StaticContainer::get('Psr\Log\LoggerInterface');
         $this->formatter = new Formatter();
@@ -1068,8 +1064,6 @@ class CronArchive
 
         return $websiteDayHasFinishedSinceLastRun;
     }
-
-    // TODO: test archiving w/ curl (ie, when piwik host is unreachable, is there a useful error message?
 
     private function logInitInfo()
     {

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -829,6 +829,7 @@ class CronArchive
 
             $cliMulti  = new CliMulti();
             $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
+            $cliMulti->runAsSuperUser();
             $responses = $cliMulti->request(array($url));
 
             $response  = !empty($responses) ? array_shift($responses) : null;

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -80,8 +80,6 @@ class CronArchive
     private $websites = array();
     private $allWebsites = array();
     private $segments = array();
-    private $token_auth = false;
-    private $validTokenAuths = array();
     private $visitsToday = 0;
     private $requests = 0;
     private $archiveAndRespectTTL = true;
@@ -236,8 +234,6 @@ class CronArchive
     {
         $this->logger = $logger ?: StaticContainer::get('Psr\Log\LoggerInterface');
         $this->formatter = new Formatter();
-
-        $this->initTokenAuth();
 
         $processNewSegmentsFrom = $processNewSegmentsFrom ?: StaticContainer::get('ini.General.process_new_segments_from');
         $this->segmentArchivingRequestUrlProvider = new SegmentArchivingRequestUrlProvider($processNewSegmentsFrom);
@@ -967,16 +963,6 @@ class CronArchive
         return array_unique($websiteIds);
     }
 
-    public function initTokenAuth()
-    {
-        $tokens = self::getSuperUserTokenAuths();
-
-        $this->validTokenAuths = $tokens;
-        $this->token_auth = array_shift($tokens);
-
-        return $this->token_auth;
-    }
-
     private function updateIdSitesInvalidatedOldReports()
     {
         $store = new SitesToReprocessDistributedList();
@@ -1425,18 +1411,6 @@ class CronArchive
     private function makeRequestUrl($url)
     {
         return $url . self::APPEND_TO_API_REQUEST;
-    }
-
-    public static function getSuperUserTokenAuths() // TODO: move this to CliMulti
-    {
-        $tokens = array();
-
-        /**
-         * @ignore
-         */
-        Piwik::postEvent('CronArchive.getTokenAuth', array(&$tokens));
-
-        return $tokens;
     }
 
     /**

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -585,7 +585,7 @@ class CronArchive
      */
     private function getVisitsRequestUrl($idSite, $period, $date, $segment = false)
     {
-        $request = "?module=API&method=API.get&idSite=$idSite&period=$period&date=" . $date . "&format=php&token_auth=" . $this->token_auth;
+        $request = "?module=API&method=API.get&idSite=$idSite&period=$period&date=" . $date . "&format=php";
         if($segment) {
             $request .= '&segment=' . urlencode($segment);;
         }
@@ -753,6 +753,7 @@ class CronArchive
         $cliMulti = new CliMulti();
         $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
         $cliMulti->setConcurrentProcessesLimit($this->getConcurrentRequestsPerWebsite());
+        $cliMulti->runAsSuperUser();
         $response = $cliMulti->request($urls);
 
         foreach ($urls as $index => $url) {
@@ -974,16 +975,6 @@ class CronArchive
         $this->token_auth = array_shift($tokens);
 
         return $this->token_auth;
-    }
-
-    public function isTokenAuthSuperUserToken($token_auth)
-    {
-        if(empty($token_auth)
-            || strlen($token_auth) != 32) {
-            return false;
-        }
-
-        return in_array($token_auth, $this->validTokenAuths);
     }
 
     private function updateIdSitesInvalidatedOldReports()
@@ -1436,7 +1427,7 @@ class CronArchive
         return $url . self::APPEND_TO_API_REQUEST;
     }
 
-    public static function getSuperUserTokenAuths()
+    public static function getSuperUserTokenAuths() // TODO: move this to CliMulti
     {
         $tokens = array();
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -80,7 +80,6 @@ class CronArchive
     private $websites = array();
     private $allWebsites = array();
     private $segments = array();
-    private $piwikUrl = false;
     private $token_auth = false;
     private $validTokenAuths = array();
     private $visitsToday = 0;
@@ -227,7 +226,7 @@ class CronArchive
      * Constructor.
      *
      * @param string|false $piwikUrl The URL to the Piwik installation to initiate archiving for. If `false`,
-     *                               we determine it using the current request information.
+     *                               we determine it using the current request information. TODO: remove this param
      *
      *                               If invoked via the command line, $piwikUrl cannot be false.
      * @param string|null $processNewSegmentsFrom When to archive new segments from. See [General] process_new_segments_from
@@ -238,7 +237,6 @@ class CronArchive
         $this->logger = $logger ?: StaticContainer::get('Psr\Log\LoggerInterface');
         $this->formatter = new Formatter();
 
-        $this->initPiwikHost($piwikUrl);
         $this->initCore();
         $this->initTokenAuth();
 
@@ -266,7 +264,6 @@ class CronArchive
         $this->initStateFromParameters();
 
         $this->logInitInfo();
-        $this->checkPiwikUrlIsValid();
         $this->logArchiveTimeoutInfo();
 
         // record archiving start time
@@ -298,15 +295,6 @@ class CronArchive
          *                          already been processed.
          */
         Piwik::postEvent('CronArchive.init.finish', array($this->websites->getInitialSiteIds()));
-    }
-
-    public function runScheduledTasksInTrackerMode()
-    {
-        $this->initCore();
-        $this->initTokenAuth();
-        $this->logInitInfo();
-        $this->checkPiwikUrlIsValid();
-        $this->runScheduledTasks();
     }
 
     /**
@@ -596,8 +584,6 @@ class CronArchive
         }
         return $success;
     }
-
-    // TODO: make sure core:archive + web archive is tested when host is for domain (need --dry-run parameter + some output to check for so test won't be super slow)
 
     /**
      * Returns base URL to process reports for the $idSite on a given $period
@@ -1017,50 +1003,6 @@ class CronArchive
         return in_array($token_auth, $this->validTokenAuths);
     }
 
-    /**
-     * @param string|bool $piwikUrl
-     */
-    protected function initPiwikHost($piwikUrl = false)
-    {
-        // If core:archive command run as a web cron, we use the current hostname+path
-        if (empty($piwikUrl)) {
-            if (!empty(self::$url)) {
-                $piwikUrl = self::$url;
-            } else {
-                // example.org/piwik/
-                $piwikUrl = SettingsPiwik::getPiwikUrl();
-            }
-        }
-
-        if (!$piwikUrl) {
-            $this->logFatalErrorUrlExpected();
-        }
-
-        if (!\Piwik\UrlHelper::isLookLikeUrl($piwikUrl)) {
-            // try adding http:// in case it's missing
-            $piwikUrl = "http://" . $piwikUrl;
-        }
-
-        if (!\Piwik\UrlHelper::isLookLikeUrl($piwikUrl)) {
-            $this->logFatalErrorUrlExpected($piwikUrl);
-        }
-
-        // ensure there is a trailing slash
-        if ($piwikUrl[strlen($piwikUrl) - 1] != '/' && !Common::stringEndsWith($piwikUrl, 'index.php')) {
-            $piwikUrl .= '/';
-        }
-
-        if (Config::getInstance()->General['force_ssl'] == 1) {
-            $piwikUrl = str_replace('http://', 'https://', $piwikUrl);
-        }
-
-        if (!Common::stringEndsWith($piwikUrl, 'index.php')) {
-            $piwikUrl .= 'index.php';
-        }
-
-        $this->piwikUrl = $piwikUrl;
-    }
-
     private function updateIdSitesInvalidatedOldReports()
     {
         $store = new SitesToReprocessDistributedList();
@@ -1167,24 +1109,11 @@ class CronArchive
         return $websiteDayHasFinishedSinceLastRun;
     }
 
-    /**
-     *  Test that the specified piwik URL is a valid Piwik endpoint.
-     */
-    protected function checkPiwikUrlIsValid()
-    {
-        $response = $this->request("?module=API&method=API.getDefaultMetricTranslations&format=original&serialize=1");
-        $responseUnserialized = @unserialize($response);
-        if ($response === false
-            || !is_array($responseUnserialized)
-        ) {
-            $this->logFatalError("The Piwik URL {$this->piwikUrl} does not seem to be pointing to a Piwik server. Response was '$response'.");
-        }
-    }
+    // TODO: test archiving w/ curl (no climulti processes) when piwik host is unreachable, is there a useful error message?
 
     private function logInitInfo()
     {
         $this->logSection("INIT");
-        $this->logger->info("Piwik is installed at: {$this->piwikUrl}");
         $this->logger->info("Running Piwik " . Version::VERSION . " as Super User");
     }
 
@@ -1247,13 +1176,6 @@ class CronArchive
         }
 
         return true;
-    }
-
-    private function logFatalErrorUrlExpected($piwikUrl = false)
-    {
-        $this->logFatalError("./console core:archive expects the argument 'url' to be set to your Piwik URL, for example: --url=http://example.org/piwik/"
-            . ($piwikUrl ? "\n '$piwikUrl' supplied" : "")
-            . "\nuse --help for more information");
     }
 
     private function getVisitsLastPeriodFromApiResponse($stats)
@@ -1528,7 +1450,7 @@ class CronArchive
      */
     private function makeRequestUrl($url)
     {
-        return $this->piwikUrl . $url . self::APPEND_TO_API_REQUEST;
+        return $url . self::APPEND_TO_API_REQUEST;
     }
 
     public static function getSuperUserTokenAuths()

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -411,9 +411,7 @@ class CronArchive
             return;
         }
 
-        Access::getInstance()->doAsSuperUser(function () {
-            CoreAdminHomeAPI::getInstance()->runScheduledTasks();
-        });
+        CoreAdminHomeAPI::getInstance()->runScheduledTasks();
 
         $this->logSection("");
     }

--- a/core/Tracker/ScheduledTasksRunner.php
+++ b/core/Tracker/ScheduledTasksRunner.php
@@ -81,8 +81,7 @@ class ScheduledTasksRunner
             $tokens = CronArchive::getSuperUserTokenAuths();
             $tokenAuth = reset($tokens);
 
-            $invokeScheduledTasksUrl = SettingsPiwik::getPiwikUrl()
-                . "?module=API&format=csv&convertToUnicode=0&method=CoreAdminHome.runScheduledTasks&trigger=archivephp&token_auth=$tokenAuth";
+            $invokeScheduledTasksUrl = "?module=API&format=csv&convertToUnicode=0&method=CoreAdminHome.runScheduledTasks&trigger=archivephp&token_auth=$tokenAuth";
 
             $cliMulti = new CliMulti();
             $responses = $cliMulti->request(array($invokeScheduledTasksUrl));

--- a/core/Tracker/ScheduledTasksRunner.php
+++ b/core/Tracker/ScheduledTasksRunner.php
@@ -68,15 +68,9 @@ class ScheduledTasksRunner
         ) {
             $cache['lastTrackerCronRun'] = $now;
             Cache::setCacheGeneral($cache);
-            Tracker::initCorePiwikInTrackerMode();
+
             Option::set('lastTrackerCronRun', $cache['lastTrackerCronRun']);
             Common::printDebug('-> Scheduled Tasks: Starting...');
-
-            // save current user privilege and temporarily assume Super User privilege
-            $isSuperUser = Piwik::hasUserSuperUserAccess();
-
-            // Scheduled tasks assume Super User is running
-            Piwik::setUserHasSuperUserAccess();
 
             $invokeScheduledTasksUrl = "?module=API&format=csv&convertToUnicode=0&method=CoreAdminHome.runScheduledTasks&trigger=archivephp";
 
@@ -84,9 +78,6 @@ class ScheduledTasksRunner
             $cliMulti->runAsSuperUser();
             $responses = $cliMulti->request(array($invokeScheduledTasksUrl));
             $resultTasks = reset($responses);
-
-            // restore original user privilege
-            Piwik::setUserHasSuperUserAccess($isSuperUser);
 
             Common::printDebug($resultTasks);
 

--- a/core/Tracker/ScheduledTasksRunner.php
+++ b/core/Tracker/ScheduledTasksRunner.php
@@ -78,12 +78,10 @@ class ScheduledTasksRunner
             // Scheduled tasks assume Super User is running
             Piwik::setUserHasSuperUserAccess();
 
-            $tokens = CronArchive::getSuperUserTokenAuths();
-            $tokenAuth = reset($tokens);
-
-            $invokeScheduledTasksUrl = "?module=API&format=csv&convertToUnicode=0&method=CoreAdminHome.runScheduledTasks&trigger=archivephp&token_auth=$tokenAuth";
+            $invokeScheduledTasksUrl = "?module=API&format=csv&convertToUnicode=0&method=CoreAdminHome.runScheduledTasks&trigger=archivephp";
 
             $cliMulti = new CliMulti();
+            $cliMulti->runAsSuperUser();
             $responses = $cliMulti->request(array($invokeScheduledTasksUrl));
             $resultTasks = reset($responses);
 

--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -156,6 +156,9 @@ class UrlHelper
             return array();
         }
 
+        // TODO: this method should not use a cache. callers should instead have their own cache, configured through DI.
+        //       one undesirable side effect of using a cache here, is that this method can now init the StaticContainer, which makes setting
+        //       test environment for RequestCommand more complicated.
         $cache    = Cache::getTransientCache();
         $cacheKey = 'arrayFromQuery' . $urlQuery;
 

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -42,8 +42,7 @@ try 'php archive.php --url=http://your.piwik/path'
 -------------------------------------------------------
 \n\n";
 }
-// TODO: manual test against php-cgi + ArchiveWebTest
-//       => test w/ token auth & w/o token auth
+
 if (Piwik\Common::isPhpCliMode()) {
     $console = new Piwik\Console();
 

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -20,8 +20,6 @@ if (!defined('PIWIK_USER_PATH')) {
 define('PIWIK_ENABLE_ERROR_HANDLER', false);
 define('PIWIK_ENABLE_SESSION_START', false);
 
-require_once PIWIK_INCLUDE_PATH . "/core/bootstrap.php";
-
 if (!empty($_SERVER['argv'][0])) {
     $callee = $_SERVER['argv'][0];
 } else {
@@ -44,6 +42,8 @@ try 'php archive.php --url=http://your.piwik/path'
 }
 
 if (Piwik\Common::isPhpCliMode()) {
+    require_once PIWIK_INCLUDE_PATH . "/core/bootstrap.php";
+
     $console = new Piwik\Console();
 
     // manipulate command line arguments so CoreArchiver command will be executed

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -9,6 +9,9 @@
  * @package Piwik
  */
 
+// TODO: this file should be moved to an API method that is only accessible to the super user.
+//       then we can finally deprecate this file.
+
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Piwik\Container\StaticContainer;
@@ -81,6 +84,8 @@ if (isset($_SERVER['argv']) && Piwik\Console::isSupported()) {
         $handler->setFormatter(StaticContainer::get('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter'));
         $logger->pushHandler($handler);
     }
+
+    \Piwik\FrontController::getInstance()->init();
 
     $archiver = new Piwik\CronArchive();
 

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -27,10 +27,10 @@ if (!defined('PIWIK_USER_PATH')) {
     define('PIWIK_USER_PATH', PIWIK_INCLUDE_PATH);
 }
 
-define('PIWIK_ENABLE_DISPATCH', false);
 define('PIWIK_ENABLE_ERROR_HANDLER', false);
 define('PIWIK_ENABLE_SESSION_START', false);
-require_once PIWIK_INCLUDE_PATH . "/index.php";
+
+require_once PIWIK_INCLUDE_PATH . "/core/bootstrap.php";
 
 if (!empty($_SERVER['argv'][0])) {
     $callee = $_SERVER['argv'][0];
@@ -52,8 +52,9 @@ try 'php archive.php --url=http://your.piwik/path'
 -------------------------------------------------------
 \n\n";
 }
-
-if (isset($_SERVER['argv']) && Piwik\Console::isSupported()) {
+// TODO: manual test against php-cgi + ArchiveWebTest
+//       => test w/ token auth & w/o token auth
+if (Piwik\Common::isPhpCliMode()) {
     $console = new Piwik\Console();
 
     // manipulate command line arguments so CoreArchiver command will be executed
@@ -64,41 +65,15 @@ if (isset($_SERVER['argv']) && Piwik\Console::isSupported()) {
     $console->run();
 } else { // if running via web request, use CronArchive directly
 
-    if (Piwik\Common::isPhpCliMode()) {
-        // We can run the archive in CLI with `php-cgi` so we have to configure the container/logger
-        // just like for CLI
-        $environment = new \Piwik\Application\Environment('cli');
-        $environment->init();
+    // HTTP request: logs needs to be dumped in the HTTP response (on top of existing log destinations)
+    /** @var \Monolog\Logger $logger */
+    $logger = StaticContainer::get('Psr\Log\LoggerInterface');
+    $handler = new StreamHandler('php://output', Logger::INFO);
+    $handler->setFormatter(StaticContainer::get('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter'));
+    $logger->pushHandler($handler);
 
-        /** @var ConsoleHandler $consoleLogHandler */
-        $consoleLogHandler = StaticContainer::get('Symfony\Bridge\Monolog\Handler\ConsoleHandler');
-        $consoleLogHandler->setOutput(new ConsoleOutput(OutputInterface::VERBOSITY_VERBOSE));
-    } else {
-        // HTTP request: logs needs to be dumped in the HTTP response (on top of existing log destinations)
-        $environment = new \Piwik\Application\Environment(null);
-        $environment->init();
+    $_GET['module'] = 'API';
+    $_GET['method'] = 'CoreAdminHome.runCronArchiving';
 
-        /** @var \Monolog\Logger $logger */
-        $logger = StaticContainer::get('Psr\Log\LoggerInterface');
-        $handler = new StreamHandler('php://output', Logger::INFO);
-        $handler->setFormatter(StaticContainer::get('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter'));
-        $logger->pushHandler($handler);
-    }
-
-    \Piwik\FrontController::getInstance()->init();
-
-    $archiver = new Piwik\CronArchive();
-
-    if (!Piwik\Common::isPhpCliMode()) {
-        $token_auth = Piwik\Common::getRequestVar('token_auth', '', 'string');
-
-        if (!$archiver->isTokenAuthSuperUserToken($token_auth)) {
-            die('<b>You must specify the Super User token_auth as a parameter to this script, eg. <code>?token_auth=XYZ</code> if you wish to run this script through the browser. </b><br>
-                    However it is recommended to run it <a href="http://piwik.org/docs/setup-auto-archiving/">via cron in the command line</a>, since it can take a long time to run.<br/>
-                    In a shell, execute for example the following to trigger archiving on the local Piwik server:<br/>
-                    <code>$ /path/to/php /path/to/piwik/console core:archive --url=http://your-website.org/path/to/piwik/</code>');
-        }
-    }
-
-    $archiver->main();
+    require_once PIWIK_INCLUDE_PATH . "/index.php";
 }

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -9,16 +9,6 @@
  * @package Piwik
  */
 
-// TODO: this file should be moved to an API method that is only accessible to the super user.
-//       then we can finally deprecate this file.
-
-use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
-use Piwik\Container\StaticContainer;
-use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
-use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\OutputInterface;
-
 if (!defined('PIWIK_INCLUDE_PATH')) {
     define('PIWIK_INCLUDE_PATH', realpath(dirname(__FILE__) . "/../.."));
 }
@@ -63,15 +53,7 @@ if (Piwik\Common::isPhpCliMode()) {
     array_unshift($_SERVER['argv'], $script);
 
     $console->run();
-} else { // if running via web request, use CronArchive directly
-
-    // HTTP request: logs needs to be dumped in the HTTP response (on top of existing log destinations)
-    /** @var \Monolog\Logger $logger */
-    $logger = StaticContainer::get('Psr\Log\LoggerInterface');
-    $handler = new StreamHandler('php://output', Logger::INFO);
-    $handler->setFormatter(StaticContainer::get('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter'));
-    $logger->pushHandler($handler);
-
+} else { // if running via web request, use CoreAdminHome.runCronArchiving method
     $_GET['module'] = 'API';
     $_GET['method'] = 'CoreAdminHome.runCronArchiving';
 

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -44,6 +44,7 @@ try 'php archive.php --url=http://your.piwik/path'
 }
 // TODO: manual test against php-cgi + ArchiveWebTest
 //       => test w/ token auth & w/o token auth
+// TODO: add test for CoreAdminHome.runCronArchiving in ArchiveWebTest (or replace existing?)
 if (Piwik\Common::isPhpCliMode()) {
     $console = new Piwik\Console();
 

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -44,7 +44,6 @@ try 'php archive.php --url=http://your.piwik/path'
 }
 // TODO: manual test against php-cgi + ArchiveWebTest
 //       => test w/ token auth & w/o token auth
-// TODO: add test for CoreAdminHome.runCronArchiving in ArchiveWebTest (or replace existing?)
 if (Piwik\Common::isPhpCliMode()) {
     $console = new Piwik\Console();
 

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -9,6 +9,8 @@
 namespace Piwik\Plugins\CoreAdminHome;
 
 use Exception;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
 use Piwik\Container\StaticContainer;
 use Piwik\Archive\ArchiveInvalidator;
 use Piwik\CronArchive;
@@ -94,6 +96,13 @@ class API extends \Piwik\Plugin\API
     public function runCronArchiving()
     {
         Piwik::checkUserHasSuperUserAccess();
+
+        // HTTP request: logs needs to be dumped in the HTTP response (on top of existing log destinations)
+        /** @var \Monolog\Logger $logger */
+        $logger = StaticContainer::get('Psr\Log\LoggerInterface');
+        $handler = new StreamHandler('php://output', Logger::INFO);
+        $handler->setFormatter(StaticContainer::get('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter'));
+        $logger->pushHandler($handler);
 
         $archiver = new CronArchive();
         $archiver->main();

--- a/plugins/CoreAdminHome/API.php
+++ b/plugins/CoreAdminHome/API.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\CoreAdminHome;
 use Exception;
 use Piwik\Container\StaticContainer;
 use Piwik\Archive\ArchiveInvalidator;
+use Piwik\CronArchive;
 use Piwik\Db;
 use Piwik\Piwik;
 use Piwik\Scheduler\Scheduler;
@@ -85,5 +86,16 @@ class API extends \Piwik\Plugin\API
         return $output;
     }
 
+    /**
+     * Initiates cron archiving via web request.
+     *
+     * @hideExceptForSuperUser
+     */
+    public function runCronArchiving()
+    {
+        Piwik::checkUserHasSuperUserAccess();
 
+        $archiver = new CronArchive();
+        $archiver->main();
+    }
 }

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -36,12 +36,7 @@ class CoreArchiver extends ConsoleCommand
         }
 
         $archiver = self::makeArchiver($url, $input);
-
-        try {
-            $archiver->main();
-        } catch (Exception $e) {
-            $archiver->logFatalError($e->getMessage());
-        }
+        $archiver->main();
     }
 
     // also used by another console command

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -25,24 +25,14 @@ class CoreArchiver extends ConsoleCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $url = $input->getOption('url') ?: $input->getOption('piwik-domain');
-        if (empty($url)) {
-            throw new \InvalidArgumentException("The --url argument is not set. It should be set to your Piwik URL, for example: --url=http://example.org/piwik/.");
-        }
-
-        if (is_string($url) && $url && in_array($url, array('http://', 'https://'))) {
-            // see https://github.com/piwik/piwik/issues/5180 and http://forum.piwik.org/read.php?2,115274
-            throw new \InvalidArgumentException('No valid URL given. If you have specified a valid URL try --piwik-domain instead of --url');
-        }
-
-        $archiver = self::makeArchiver($url, $input);
+        $archiver = self::makeArchiver("", $input);
         $archiver->main();
     }
 
     // also used by another console command
-    public static function makeArchiver($url, InputInterface $input)
+    public static function makeArchiver($url, InputInterface $input) // TODO: remove url from this function
     {
-        $archiver = new CronArchive($url);
+        $archiver = new CronArchive();
 
         $archiver->disableScheduledTasks = $input->getOption('disable-scheduled-tasks');
         $archiver->acceptInvalidSSLCertificate = $input->getOption("accept-invalid-ssl-certificate");
@@ -81,7 +71,7 @@ class CoreArchiver extends ConsoleCommand
   but it is recommended to run it via command line/CLI instead.
 * If you have any suggestion about this script, please let the team know at feedback@piwik.org
 * Enjoy!");
-        $command->addOption('url', null, InputOption::VALUE_REQUIRED, "Mandatory option as an alternative to '--piwik-domain'. Must be set to the Piwik base URL.\nFor example: --url=http://analytics.example.org/ or --url=https://example.org/piwik/");
+        $command->addOption('url', null, InputOption::VALUE_REQUIRED, "Deprecated.");
         $command->addOption('force-all-websites', null, InputOption::VALUE_NONE, "If specified, the script will trigger archiving on all websites.\nUse with --force-all-periods=[seconds] to also process those websites that had visits in the last [seconds] seconds.\nLaunching several processes with this option will make them share the list of sites to process.");
         $command->addOption('force-all-periods', null, InputOption::VALUE_OPTIONAL, "Limits archiving to websites with some traffic in the last [seconds] seconds. \nFor example --force-all-periods=86400 will archive websites that had visits in the last 24 hours. \nIf [seconds] is not specified, all websites with visits in the last " . CronArchive::ARCHIVE_SITES_WITH_TRAFFIC_SINCE . " seconds (" . round(CronArchive::ARCHIVE_SITES_WITH_TRAFFIC_SINCE / 86400) . " days) will be archived.");
         $command->addOption('force-timeout-for-periods', null, InputOption::VALUE_OPTIONAL, "The current week/ current month/ current year will be processed at most every [seconds].\nIf not specified, defaults to " . CronArchive::SECONDS_DELAY_BETWEEN_PERIOD_ARCHIVES . ".");

--- a/plugins/CorePluginsAdmin/tests/Integration/UpdateCommunicationTest.php
+++ b/plugins/CorePluginsAdmin/tests/Integration/UpdateCommunicationTest.php
@@ -130,7 +130,7 @@ CoreUpdater_ThereIsNewPluginVersionAvailableForUpdate
  * MyTest3 31.0.0
 
 CoreUpdater_NotificationClickToUpdatePlugins
-index.php?module=CorePluginsAdmin&action=plugins
+http://localhost/tests/PHPUnit/proxy/index.php?module=CorePluginsAdmin&action=plugins
 
 Installation_HappyAnalysing';
 

--- a/plugins/CoreUpdater/Test/Integration/UpdateCommunicationTest.php
+++ b/plugins/CoreUpdater/Test/Integration/UpdateCommunicationTest.php
@@ -92,7 +92,7 @@ http://piwik.org/contact/';
 CoreUpdater_ThereIsNewVersionAvailableForUpdate
 
 CoreUpdater_YouCanUpgradeAutomaticallyOrDownloadPackage
-index.php?module=CoreUpdater&action=newVersionAvailable
+http://localhost/tests/PHPUnit/proxy/index.php?module=CoreUpdater&action=newVersionAvailable
 
 CoreUpdater_FeedbackRequest
 http://piwik.org/contact/';

--- a/plugins/CoreUpdater/Test/Integration/UpdateCommunicationTest.php
+++ b/plugins/CoreUpdater/Test/Integration/UpdateCommunicationTest.php
@@ -74,7 +74,7 @@ class UpdateCommunicationTest extends IntegrationTestCase
 CoreUpdater_ThereIsNewVersionAvailableForUpdate
 
 CoreUpdater_YouCanUpgradeAutomaticallyOrDownloadPackage
-index.php?module=CoreUpdater&action=newVersionAvailable
+http://localhost/tests/PHPUnit/proxy/index.php?module=CoreUpdater&action=newVersionAvailable
 
 CoreUpdater_ViewVersionChangelog
 http://piwik.org/changelog/piwik-33-0-0/

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -249,6 +249,8 @@ class Fixture extends \PHPUnit_Framework_Assert
             self::createSuperUser($this->removeExistingSuperUser);
         }
 
+        SettingsPiwik::overwritePiwikUrl(self::getRootUrl() . 'tests/PHPUnit/proxy/');
+
         if ($setupEnvironmentOnly) {
             return;
         }

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -64,7 +64,6 @@ class CronArchiveTest extends IntegrationTestCase
         $expected = <<<LOG
 ---------------------------
 INIT
-Piwik is installed at: %s
 Running Piwik %s as Super User
 ---------------------------
 NOTES

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -55,7 +55,7 @@ class CronArchiveTest extends IntegrationTestCase
 
         $logger = new FakeLogger();
 
-        $archiver = new CronArchive(Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php', null, $logger);
+        $archiver = new CronArchive(null, $logger);
         $archiver->shouldArchiveAllSites = true;
         $archiver->shouldArchiveAllPeriodsSince = true;
         $archiver->init();

--- a/tests/PHPUnit/System/ArchiveCronTest.php
+++ b/tests/PHPUnit/System/ArchiveCronTest.php
@@ -128,7 +128,7 @@ class ArchiveCronTest extends SystemTestCase
         $urlToProxy = Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php';
 
         // create the command
-        $cmd = "php \"$archivePhpScript\" --url=\"$urlToProxy\" 2>&1";
+        $cmd = "php \"$archivePhpScript\" -vvv --url=\"$urlToProxy\" 2>&1";
 
         // run the command
         exec($cmd, $output, $result);

--- a/tests/PHPUnit/System/ArchiveCronTest.php
+++ b/tests/PHPUnit/System/ArchiveCronTest.php
@@ -128,7 +128,7 @@ class ArchiveCronTest extends SystemTestCase
         $urlToProxy = Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php';
 
         // create the command
-        $cmd = "php \"$archivePhpScript\" -vvv --url=\"$urlToProxy\" 2>&1";
+        $cmd = "php \"$archivePhpScript\" --url=\"$urlToProxy\" 2>&1";
 
         // run the command
         exec($cmd, $output, $result);

--- a/tests/PHPUnit/System/ArchiveCronTest.php
+++ b/tests/PHPUnit/System/ArchiveCronTest.php
@@ -133,9 +133,7 @@ class ArchiveCronTest extends SystemTestCase
         // run the command
         exec($cmd, $output, $result);
         if ($result !== 0 || stripos($result, "error")) {
-            $message = 'This failed once after a lunar eclipse, and it has again randomly failed.';
-            $message .= "\n\narchive cron failed: " . implode("\n", $output) . "\n\ncommand used: $cmd";
-            $this->markTestSkipped($message);
+            $this->fail("archive cron failed: " . implode("\n", $output) . "\n\ncommand used: $cmd");
         }
 
         return $output;

--- a/tests/PHPUnit/System/ArchiveWebTest.php
+++ b/tests/PHPUnit/System/ArchiveWebTest.php
@@ -41,10 +41,7 @@ class ArchiveWebTest extends SystemTestCase
 
         // ignore random build issues
         if (empty($output) || strpos($output, \Piwik\CronArchive::NO_ERROR) === false) {
-            $message = "This test has failed. Because it sometimes randomly fails, we skip the test, and ignore this failure.\n";
-            $message .= "If you see this message often, or in every build, please investigate as this should only be a random and rare occurence!\n";
-            $message .= "\n\narchive web failed: " . $output . "\n\nurl used: $url";
-            $this->markTestSkipped($message);
+            $this->fail("archive web failed: " . $output . "\n\nurl used: $url");
         }
 
         if (!empty($urlTmp)) {

--- a/tests/PHPUnit/System/ArchiveWebTest.php
+++ b/tests/PHPUnit/System/ArchiveWebTest.php
@@ -58,7 +58,7 @@ class ArchiveWebTest extends SystemTestCase
     {
         list($returnCode, $output) = $this->runArchivePhpScriptWithPhpCgi();
 
-        $this->assertEquals(0, $returnCode);
+        $this->assertEquals(0, $returnCode, "Output: " . $output);
         $this->assertWebArchivingDone($output, $checkArchivedSite = false);
     }
 

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -238,15 +238,13 @@ class CliMultiTest extends SystemTestCase
 
     private function completeUrl($query)
     {
-        $host = Fixture::getRootUrl();
-
         if (false === strpos($query, '?')) {
             $query .= '?';
         } else {
             $query .= '&';
         }
 
-        return $host . 'tests/PHPUnit/proxy/index.php' . $query . 'testmode=1&token_auth=' . $this->authToken;
+        return $query . 'testmode=1&token_auth=' . $this->authToken;
     }
 
     private function getFilesInTmpFolder()

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_month.original.html
@@ -4,7 +4,7 @@
 </head>
 <body style="font-family: dejavusans; color: rgb(13,13,13);line-height: 1.33;">
 
-<a id="reportTop" rel="noreferrer" target="_blank" href=""><img title="Go to Piwik" border="0" alt="Piwik" src='plugins/Morpheus/images/logo-header.png'/></a>
+<a id="reportTop" rel="noreferrer" target="_blank" href="http://localhost/tests/PHPUnit/proxy/"><img title="Go to Piwik" border="0" alt="Piwik" src='http://localhost/tests/PHPUnit/proxy/plugins/Morpheus/images/logo-header.png'/></a>
 
 <h1 style="font-weight:normal; color: rgb(13,13,13); font-size: 24pt;">
     Site 1
@@ -1961,7 +1961,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/cookie.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/cookie.gif'>
                                         &nbsp;
                                                                                                             Cookie                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -1974,7 +1974,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/flash.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/flash.gif'>
                                         &nbsp;
                                                                                                             Flash                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -1987,7 +1987,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/java.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/java.gif'>
                                         &nbsp;
                                                                                                             Java                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2000,7 +2000,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/director.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/director.gif'>
                                         &nbsp;
                                                                                                             Director                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2013,7 +2013,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/gears.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/gears.gif'>
                                         &nbsp;
                                                                                                             Gears                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2026,7 +2026,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/pdf.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/pdf.gif'>
                                         &nbsp;
                                                                                                             Pdf                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2039,7 +2039,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/quicktime.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/quicktime.gif'>
                                         &nbsp;
                                                                                                             Quicktime                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2052,7 +2052,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/realplayer.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/realplayer.gif'>
                                         &nbsp;
                                                                                                             Realplayer                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2065,7 +2065,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/silverlight.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/silverlight.gif'>
                                         &nbsp;
                                                                                                             Silverlight                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2078,7 +2078,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/windowsmedia.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/windowsmedia.gif'>
                                         &nbsp;
                                                                                                             Windowsmedia                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -3495,7 +3495,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/UserCountry/images/flags/xx.png'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -3520,7 +3520,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/UserCountry/images/flags/fr.png'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/fr.png'>
                                         &nbsp;
                                                                                                             France                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -3665,7 +3665,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/UserCountry/images/flags/xx.png'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -3727,7 +3727,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/UserCountry/images/flags/xx.png'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4467,7 +4467,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/screens/unknown.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/screens/unknown.gif'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4492,7 +4492,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/screens/normal.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/screens/normal.gif'>
                                         &nbsp;
                                                                                                             Desktop                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4554,7 +4554,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/browsers/UNK.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/UNK.gif'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4579,7 +4579,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/browsers/FF.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/FF.gif'>
                                         &nbsp;
                                                                                                             Firefox                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4604,7 +4604,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/browsers/OP.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/OP.gif'>
                                         &nbsp;
                                                                                                             Opera                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4666,7 +4666,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/brand/Unknown.ico'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/brand/Unknown.ico'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4788,7 +4788,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/browsers/UNK.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/UNK.gif'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4813,7 +4813,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/browsers/FF.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/FF.gif'>
                                         &nbsp;
                                                                                                             Firefox 3.6                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4838,7 +4838,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/browsers/OP.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/OP.gif'>
                                         &nbsp;
                                                                                                             Opera 9.63                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4900,7 +4900,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/os/UNK.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/UNK.gif'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4925,7 +4925,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/os/WIN.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/WIN.gif'>
                                         &nbsp;
                                                                                                             Windows                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -4987,7 +4987,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/os/UNK.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/UNK.gif'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -5012,7 +5012,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/os/WIN.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/WIN.gif'>
                                         &nbsp;
                                                                                                             Windows XP                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_week.original.html
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_week.original.html
@@ -4,7 +4,7 @@
 </head>
 <body style="font-family: dejavusans; color: rgb(13,13,13);line-height: 1.33;">
 
-<a id="reportTop" rel="noreferrer" target="_blank" href=""><img title="Go to Piwik" border="0" alt="Piwik" src='plugins/Morpheus/images/logo-header.png'/></a>
+<a id="reportTop" rel="noreferrer" target="_blank" href="http://localhost/tests/PHPUnit/proxy/"><img title="Go to Piwik" border="0" alt="Piwik" src='http://localhost/tests/PHPUnit/proxy/plugins/Morpheus/images/logo-header.png'/></a>
 
 <h1 style="font-weight:normal; color: rgb(13,13,13); font-size: 24pt;">
     Piwik test
@@ -1998,7 +1998,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/cookie.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/cookie.gif'>
                                         &nbsp;
                                                                                                             Cookie                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2011,7 +2011,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/flash.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/flash.gif'>
                                         &nbsp;
                                                                                                             Flash                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2024,7 +2024,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/java.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/java.gif'>
                                         &nbsp;
                                                                                                             Java                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2037,7 +2037,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/director.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/director.gif'>
                                         &nbsp;
                                                                                                             Director                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2050,7 +2050,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/gears.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/gears.gif'>
                                         &nbsp;
                                                                                                             Gears                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2063,7 +2063,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/pdf.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/pdf.gif'>
                                         &nbsp;
                                                                                                             Pdf                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2076,7 +2076,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/quicktime.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/quicktime.gif'>
                                         &nbsp;
                                                                                                             Quicktime                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2089,7 +2089,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/realplayer.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/realplayer.gif'>
                                         &nbsp;
                                                                                                             Realplayer                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2102,7 +2102,7 @@
                             
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/silverlight.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/silverlight.gif'>
                                         &nbsp;
                                                                                                             Silverlight                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -2115,7 +2115,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicePlugins/images/plugins/windowsmedia.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/windowsmedia.gif'>
                                         &nbsp;
                                                                                                             Windowsmedia                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -5104,7 +5104,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/UserCountry/images/flags/pl.png'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/pl.png'>
                                         &nbsp;
                                                                                                             Poland                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -5129,7 +5129,7 @@
                             
                                                                     <tr style=";line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/UserCountry/images/flags/fr.png'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/fr.png'>
                                         &nbsp;
                                                                                                             France                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -5251,7 +5251,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/UserCountry/images/flags/xx.png'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -5313,7 +5313,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/UserCountry/images/flags/xx.png'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -6154,7 +6154,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/screens/normal.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/screens/normal.gif'>
                                         &nbsp;
                                                                                                             Desktop                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -6216,7 +6216,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/browsers/FF.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/FF.gif'>
                                         &nbsp;
                                                                                                             Firefox                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -6278,7 +6278,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/brand/Unknown.ico'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/brand/Unknown.ico'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -6340,7 +6340,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/browsers/FF.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/FF.gif'>
                                         &nbsp;
                                                                                                             Firefox 3.6                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -6462,7 +6462,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/os/WIN.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/WIN.gif'>
                                         &nbsp;
                                                                                                             Windows                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
@@ -6524,7 +6524,7 @@
                                                     
                                                                     <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                                                        <img src='plugins/DevicesDetection/images/os/WIN.gif'>
+                                                                                                                                        <img src='http://localhost/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/WIN.gif'>
                                         &nbsp;
                                                                                                             Windows XP                                                                                                                        </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">


### PR DESCRIPTION
Includes following changes:
- Moved 'run as superuser' hacks in CronArchive to CliMulti. Instead of getting a token auth and appending it to the URL before using CliMulti, there's a method CliMulti::runAsSuperUser that will do this work transparently. The token auth is only used when doing web requests; RequestCommand now has a --superuser option.
- Moved web archiving to a superuser only API method in CoreAdminHome. This simplifies the archive.php script greatly, since we can rely on Piwik's infrastructure to setup & load plugins, and to authenticate the superuser.
- Added php-cgi specializations to Console (from an old incorrectly merged PR) so archive.php does not have to be aware of php-cgi.
- Removed the need to supply a host in the URL to CliMulti, which means the URL is no longer needed for CronArchive either.
- Removed the no longer used method CronArchive::runScheduledTasksInTrackerMode.
- Removed unnecessary setup code in CronArchive. FrontController init, for example, is not needed when going through Console, and no longer needed for web archiving since we use an API method.
- Removed the test skipping from ArchiveCronTest/ArchiveWebTest. If they randomly fail in the future, I will fix the random failure.
- Removed superuser access change and removed the call to Tracker::initCorePiwikInTrackerMode() in Piwik\Tracker\ScheduledTasksRunner.
