### PR TITLE
Marketplace UI tweaks: display "Search 47 plugins..." in search input + lean Themes browsing 

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -88,6 +88,7 @@ class Twig
         $this->addFilter_safeDecodeRaw();
         $this->twig->addFilter(new Twig_SimpleFilter('implode', 'implode'));
         $this->twig->addFilter(new Twig_SimpleFilter('ucwords', 'ucwords'));
+        $this->twig->addFilter(new Twig_SimpleFilter('lcfirst', 'lcfirst'));
 
         $this->addFunction_includeAssets();
         $this->addFunction_linkTo();

--- a/plugins/CorePluginsAdmin/templates/browsePluginsActions.twig
+++ b/plugins/CorePluginsAdmin/templates/browsePluginsActions.twig
@@ -21,7 +21,7 @@
     <a href="{{ linkTo({'sort': 'alpha', 'query': ''}) }}" {% if 'alpha' == sort %}class="active"{% endif %}>{{ 'CorePluginsAdmin_SortByAlpha'|translate }}</a>
     |
     <form action="{{ linkTo({'sort': ''}) }}" method="POST">
-        <input value="{{ query }}" placeholder="{{ 'General_Search'|translate }}" type="text" name="query"/>
+        <input value="{{ query }}" placeholder="{{ 'General_Search'|translate }} {{ plugins|length }} {{ 'General_Plugins'|translate|lcfirst }}..." type="text" name="query"/>
         <button type="submit">{{ 'General_Search'|translate }}</button>
     </form>
 </div>

--- a/plugins/CorePluginsAdmin/templates/browseThemes.twig
+++ b/plugins/CorePluginsAdmin/templates/browseThemes.twig
@@ -15,7 +15,6 @@
             {{ 'CorePluginsAdmin_BeCarefulUsingThemes'|translate }}
         </div>
 
-        {% include "@CorePluginsAdmin/browsePluginsActions.twig" %}
     </div>
 
     {% if not isSuperUser %}


### PR DESCRIPTION
- Now that we're approching 50 plugins on the Marketplace it was time to display the number of plugins somewhere in the page.
- when I  saw @lemu renamed the input field `Search` to `Search Plugins` in #7586 - the simple idea to display plugin count there came up and show `Search 47 plugins`
- On the Marketplace for Themes we don't need to display "newest/popular" sort and search field. there are currently 2 available themes so removing these elements will give more importance to the themes themselves.
## Screenshots

Before

![before](https://cloud.githubusercontent.com/assets/466765/7244725/eaa09ee2-e833-11e4-861a-8f752750e9ed.png)

After (Search input text changed)

![after](https://cloud.githubusercontent.com/assets/466765/7244726/f07375c4-e833-11e4-8f5a-a5073c2ab372.png)

After (Themes - bar removed)

![after themes](https://cloud.githubusercontent.com/assets/466765/7244728/f85c6e4e-e833-11e4-9da5-aa834cc571a2.png)
