### PR TITLE
Log segments that are being archived

### DIFF
--- a/core/Archiver/Request.php
+++ b/core/Archiver/Request.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Piwik\Archiver;
+
+class Request
+{
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var callable|null
+     */
+    private $before;
+
+    /**
+     * @param string $url
+     */
+    public function __construct($url)
+    {
+        $this->url = $url;
+    }
+
+    public function before($callable)
+    {
+        $this->before = $callable;
+    }
+
+    public function start()
+    {
+        if ($this->before) {
+            $callable = $this->before;
+            $callable();
+        }
+    }
+
+    public function __toString()
+    {
+        return $this->url;
+    }
+}

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik;
 
+use Piwik\Archiver\Request;
 use Piwik\CliMulti\CliPhp;
 use Piwik\CliMulti\Output;
 use Piwik\CliMulti\Process;
@@ -96,6 +97,10 @@ class CliMulti {
     private function start($piwikUrls)
     {
         foreach ($piwikUrls as $index => $url) {
+            if ($url instanceof Request) {
+                $url->start();
+            }
+
             $cmdId = $this->generateCommandId($url) . $index;
             $this->executeUrlCommand($cmdId, $url);
         }

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -786,6 +786,8 @@ class CronArchive
 
         $this->requests += count($urls);
 
+        $this->log('- pre-processing all visits');
+
         $cliMulti = new CliMulti();
         $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
         $cliMulti->setConcurrentProcessesLimit($this->getConcurrentRequestsPerWebsite());

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -24,6 +24,7 @@ use Piwik\Plugins\CoreAdminHome\API as CoreAdminHomeAPI;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 use Piwik\Plugins\UsersManager\UserPreferences;
+use Psr\Log\LoggerInterface;
 
 /**
  * ./console core:archive runs as a cron and is a useful tool for general maintenance,
@@ -84,7 +85,6 @@ class CronArchive
     private $validTokenAuths = array();
     private $visitsToday = 0;
     private $requests = 0;
-    private $output = '';
     private $archiveAndRespectTTL = true;
 
     private $lastSuccessRunTimestamp = false;
@@ -207,6 +207,11 @@ class CronArchive
     private $segmentArchivingRequestUrlProvider;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * Returns the option name of the option that stores the time core:archive was last executed.
      *
      * @param int $idSite
@@ -228,8 +233,9 @@ class CronArchive
      * @param string|null $processNewSegmentsFrom When to archive new segments from. See [General] process_new_segments_from
      *                                            for possible values.
      */
-    public function __construct($piwikUrl = false, $processNewSegmentsFrom = null)
+    public function __construct($piwikUrl = false, $processNewSegmentsFrom = null, LoggerInterface $logger = null)
     {
+        $this->logger = $logger ?: StaticContainer::get('Psr\Log\LoggerInterface');
         $this->formatter = new Formatter();
 
         $this->initPiwikHost($piwikUrl);
@@ -270,7 +276,7 @@ class CronArchive
         $this->allWebsites = APISitesManager::getInstance()->getAllSitesId();
 
         if (!empty($this->shouldArchiveOnlySpecificPeriods)) {
-            $this->log("- Will only process the following periods: " . implode(", ", $this->shouldArchiveOnlySpecificPeriods) . " (--force-periods)");
+            $this->logger->info("- Will only process the following periods: " . implode(", ", $this->shouldArchiveOnlySpecificPeriods) . " (--force-periods)");
         }
 
         $this->invalidateArchivedReportsForSitesThatNeedToBeArchivedAgain();
@@ -281,7 +287,7 @@ class CronArchive
         $this->websites = $this->createSitesToArchiveQueue($websitesIds);
 
         if ($this->websites->getInitialSiteIds() != $websitesIds) {
-            $this->log('Will ignore websites and help finish a previous started queue instead. IDs: ' . implode(', ', $this->websites->getInitialSiteIds()));
+            $this->logger->info('Will ignore websites and help finish a previous started queue instead. IDs: ' . implode(', ', $this->websites->getInitialSiteIds()));
         }
 
         /**
@@ -311,7 +317,7 @@ class CronArchive
         $timer = new Timer;
 
         $this->logSection("START");
-        $this->log("Starting Piwik reports archiving...");
+        $this->logger->info("Starting Piwik reports archiving...");
 
         do {
             $idSite = $this->websites->getNextSiteId();
@@ -328,7 +334,7 @@ class CronArchive
 
             $skipWebsiteForced = in_array($idSite, $this->shouldSkipSpecifiedSites);
             if ($skipWebsiteForced) {
-                $this->log("Skipped website id $idSite, found in --skip-idsites ");
+                $this->logger->info("Skipped website id $idSite, found in --skip-idsites ");
                 $this->skipped++;
                 continue;
             }
@@ -352,25 +358,25 @@ class CronArchive
             Piwik::postEvent('CronArchive.archiveSingleSite.finish', array($idSite, $completed));
         } while (!empty($idSite));
 
-        $this->log("Done archiving!");
+        $this->logger->info("Done archiving!");
 
         $this->logSection("SUMMARY");
-        $this->log("Total visits for today across archived websites: " . $this->visitsToday);
+        $this->logger->info("Total visits for today across archived websites: " . $this->visitsToday);
 
         $totalWebsites = count($this->allWebsites);
         $this->skipped = $totalWebsites - $this->websitesWithVisitsSinceLastRun;
-        $this->log("Archived today's reports for {$this->websitesWithVisitsSinceLastRun} websites");
-        $this->log("Archived week/month/year for {$this->archivedPeriodsArchivesWebsite} websites");
-        $this->log("Skipped {$this->skipped} websites: no new visit since the last script execution");
-        $this->log("Skipped {$this->skippedDayArchivesWebsites} websites day archiving: existing daily reports are less than {$this->todayArchiveTimeToLive} seconds old");
-        $this->log("Skipped {$this->skippedPeriodsArchivesWebsite} websites week/month/year archiving: existing periods reports are less than {$this->processPeriodsMaximumEverySeconds} seconds old");
-        $this->log("Total API requests: {$this->requests}");
+        $this->logger->info("Archived today's reports for {$this->websitesWithVisitsSinceLastRun} websites");
+        $this->logger->info("Archived week/month/year for {$this->archivedPeriodsArchivesWebsite} websites");
+        $this->logger->info("Skipped {$this->skipped} websites: no new visit since the last script execution");
+        $this->logger->info("Skipped {$this->skippedDayArchivesWebsites} websites day archiving: existing daily reports are less than {$this->todayArchiveTimeToLive} seconds old");
+        $this->logger->info("Skipped {$this->skippedPeriodsArchivesWebsite} websites week/month/year archiving: existing periods reports are less than {$this->processPeriodsMaximumEverySeconds} seconds old");
+        $this->logger->info("Total API requests: {$this->requests}");
 
         //DONE: done/total, visits, wtoday, wperiods, reqs, time, errors[count]: first eg.
         $percent = $this->websites->getNumSites() == 0
             ? ""
             : " " . round($this->processed * 100 / $this->websites->getNumSites(), 0) . "%";
-        $this->log("done: " .
+        $this->logger->info("done: " .
             $this->processed . "/" . $this->websites->getNumSites() . "" . $percent . ", " .
             $this->visitsToday . " vtoday, $this->websitesWithVisitsSinceLastRun wtoday, {$this->archivedPeriodsArchivesWebsite} wperiods, " .
             $this->requests . " req, " . round($timer->getTimeMs()) . " ms, " .
@@ -378,7 +384,7 @@ class CronArchive
                 ? self::NO_ERROR
                 : (count($this->errors) . " errors."))
         );
-        $this->log($timer->__toString());
+        $this->logger->info($timer->__toString());
     }
 
     /**
@@ -395,7 +401,7 @@ class CronArchive
         $this->logSection("SUMMARY OF ERRORS");
         foreach ($this->errors as $error) {
             // do not logError since errors are already in stderr
-            $this->log("Error: " . $error);
+            $this->logger->info("Error: " . $error);
         }
 
         $summary = count($this->errors) . " total errors during this script execution, please investigate and try and fix these errors.";
@@ -414,7 +420,7 @@ class CronArchive
         $this->logSection("SCHEDULED TASKS");
 
         if ($this->disableScheduledTasks) {
-            $this->log("Scheduled tasks are disabled with --disable-scheduled-tasks");
+            $this->logger->info("Scheduled tasks are disabled with --disable-scheduled-tasks");
             return;
         }
 
@@ -502,7 +508,7 @@ class CronArchive
         }
 
         if ($skipDayArchive) {
-            $this->log("Skipped website id $idSite, already done "
+            $this->logger->info("Skipped website id $idSite, already done "
                 . $this->formatter->getPrettyTimeFromSeconds($elapsedSinceLastArchiving, true)
                 . " ago, " . $timerWebsite->__toString());
             $this->skippedDayArchivesWebsites++;
@@ -515,7 +521,7 @@ class CronArchive
         } catch(UnexpectedWebsiteFoundException $e) {
             // this website was deleted in the meantime
             $shouldProceed = false;
-            $this->log("Skipped website id $idSite, got: UnexpectedWebsiteFoundException, " . $timerWebsite->__toString());
+            $this->logger->info("Skipped website id $idSite, got: UnexpectedWebsiteFoundException, " . $timerWebsite->__toString());
         }
 
         if (!$shouldProceed) {
@@ -523,7 +529,7 @@ class CronArchive
         }
 
         if (!$shouldArchivePeriods) {
-            $this->log("Skipped website id $idSite periods processing, already done "
+            $this->logger->info("Skipped website id $idSite periods processing, already done "
                 . $this->formatter->getPrettyTimeFromSeconds($elapsedSinceLastArchiving, true)
                 . " ago, " . $timerWebsite->__toString());
             $this->skippedDayArchivesWebsites++;
@@ -549,7 +555,7 @@ class CronArchive
         $this->archivedPeriodsArchivesWebsite++;
 
         $requestsWebsite = $this->requests - $requestsBefore;
-        Log::info("Archived website id = $idSite, "
+        $this->logger->info("Archived website id = $idSite, "
             . $requestsWebsite . " API requests, "
             . $timerWebsite->__toString()
             . " [" . $this->websites->getNumProcessedWebsites() . "/"
@@ -634,7 +640,7 @@ class CronArchive
             return array();
         }
 
-        $this->log("- Will pre-process " . count($segments) . " Segments for each website and each period: " . implode(", ", $segments));
+        $this->logger->info("- Will pre-process " . count($segments) . " Segments for each website and each period: " . implode(", ", $segments));
         return $segments;
     }
 
@@ -708,7 +714,7 @@ class CronArchive
         if (0 == $visitsToday
             && !$shouldArchivePeriods
         ) {
-            $this->log("Skipped website id $idSite, no visit today, " . $timerWebsite->__toString());
+            $this->logger->info("Skipped website id $idSite, no visit today, " . $timerWebsite->__toString());
             $this->skipped++;
             return false;
         }
@@ -717,7 +723,7 @@ class CronArchive
             && !$shouldArchivePeriods
             && $this->shouldArchiveAllSites
         ) {
-            $this->log("Skipped website id $idSite, no visits in the last " . $date . " days, " . $timerWebsite->__toString());
+            $this->logger->info("Skipped website id $idSite, no visits in the last " . $date . " days, " . $timerWebsite->__toString());
             $this->skipped++;
             return false;
         }
@@ -736,7 +742,7 @@ class CronArchive
         $segmentsAllSites = $this->segments;
         $segmentsThisSite = SettingsPiwik::getKnownSegmentsToArchiveForSite($idSite);
         if (!empty($segmentsThisSite)) {
-            $this->log(sprintf(
+            $this->logger->info(sprintf(
                 "Will pre-process for website id = %s, %s period, %d segments",
                 $idSite,
                 $period,
@@ -786,7 +792,7 @@ class CronArchive
 
         $this->requests += count($urls);
 
-        $this->log('- pre-processing all visits');
+        $this->logger->info('- pre-processing all visits');
 
         $cliMulti = new CliMulti();
         $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
@@ -828,16 +834,10 @@ class CronArchive
      */
     private function logSection($title = "")
     {
-        $this->log("---------------------------");
+        $this->logger->info("---------------------------");
         if (!empty($title)) {
-            $this->log($title);
+            $this->logger->info($title);
         }
-    }
-
-    public function log($m)
-    {
-        $this->output .= $m . "\n";
-        Log::info($m);
     }
 
     public function logError($m)
@@ -847,7 +847,7 @@ class CronArchive
         }
         $m = str_replace(array("\n", "\t"), " ", $m);
         $this->errors[] = $m;
-        Log::error($m);
+        $this->logger->error($m);
     }
 
     private function logNetworkError($url, $response)
@@ -993,10 +993,10 @@ class CronArchive
             $listSiteIds = implode(',', $siteIds);
 
             try {
-                $this->log('Will invalidate archived reports for ' . $date . ' for following siteIds: ' . $listSiteIds);
+                $this->logger->info('Will invalidate archived reports for ' . $date . ' for following siteIds: ' . $listSiteIds);
                 $this->getApiToInvalidateArchivedReport()->invalidateArchivedReports($siteIds, $date);
             } catch (Exception $e) {
-                $this->log('Failed to invalidate archived reports: ' . $e->getMessage());
+                $this->logger->info('Failed to invalidate archived reports: ' . $e->getMessage());
             }
         }
     }
@@ -1008,12 +1008,12 @@ class CronArchive
     public function initWebsiteIds()
     {
         if (count($this->shouldArchiveSpecifiedSites) > 0) {
-            $this->log("- Will process " . count($this->shouldArchiveSpecifiedSites) . " websites (--force-idsites)");
+            $this->logger->info("- Will process " . count($this->shouldArchiveSpecifiedSites) . " websites (--force-idsites)");
 
             return $this->shouldArchiveSpecifiedSites;
         }
         if ($this->shouldArchiveAllSites) {
-            $this->log("- Will process all " . count($this->allWebsites) . " websites");
+            $this->logger->info("- Will process all " . count($this->allWebsites) . " websites");
             return $this->allWebsites;
         }
 
@@ -1110,7 +1110,7 @@ class CronArchive
 
         if (count($this->idSitesInvalidatedOldReports) > 0) {
             $ids = ", IDs: " . implode(", ", $this->idSitesInvalidatedOldReports);
-            $this->log("- Will process " . count($this->idSitesInvalidatedOldReports)
+            $this->logger->info("- Will process " . count($this->idSitesInvalidatedOldReports)
                 . " other websites because some old data reports have been invalidated (eg. using the Log Import script) "
                 . $ids);
         }
@@ -1128,7 +1128,7 @@ class CronArchive
         $sitesIdWithVisits = APISitesManager::getInstance()->getSitesIdWithVisits(time() - $this->shouldArchiveOnlySitesWithTrafficSince);
         $websiteIds = !empty($sitesIdWithVisits) ? ", IDs: " . implode(", ", $sitesIdWithVisits) : "";
         $prettySeconds = $this->formatter->getPrettyTimeFromSeconds( $this->shouldArchiveOnlySitesWithTrafficSince, true);
-        $this->log("- Will process " . count($sitesIdWithVisits) . " websites with new visits since "
+        $this->logger->info("- Will process " . count($sitesIdWithVisits) . " websites with new visits since "
             . $prettySeconds
             . " "
             . $websiteIds);
@@ -1189,7 +1189,7 @@ class CronArchive
 
         if (count($websiteDayHasFinishedSinceLastRun) > 0) {
             $ids = !empty($websiteDayHasFinishedSinceLastRun) ? ", IDs: " . implode(", ", $websiteDayHasFinishedSinceLastRun) : "";
-            $this->log("- Will process " . count($websiteDayHasFinishedSinceLastRun)
+            $this->logger->info("- Will process " . count($websiteDayHasFinishedSinceLastRun)
                 . " other websites because the last time they were archived was on a different day (in the website's timezone) "
                 . $ids);
         }
@@ -1214,8 +1214,8 @@ class CronArchive
     private function logInitInfo()
     {
         $this->logSection("INIT");
-        $this->log("Piwik is installed at: {$this->piwikUrl}");
-        $this->log("Running Piwik " . Version::VERSION . " as Super User");
+        $this->logger->info("Piwik is installed at: {$this->piwikUrl}");
+        $this->logger->info("Running Piwik " . Version::VERSION . " as Super User");
     }
 
     private function logArchiveTimeoutInfo()
@@ -1224,18 +1224,18 @@ class CronArchive
 
         // Recommend to disable browser archiving when using this script
         if (Rules::isBrowserTriggerEnabled()) {
-            $this->log("- If you execute this script at least once per hour (or more often) in a crontab, you may disable 'Browser trigger archiving' in Piwik UI > Settings > General Settings. ");
-            $this->log("  See the doc at: http://piwik.org/docs/setup-auto-archiving/");
+            $this->logger->info("- If you execute this script at least once per hour (or more often) in a crontab, you may disable 'Browser trigger archiving' in Piwik UI > Settings > General Settings.");
+            $this->logger->info("  See the doc at: http://piwik.org/docs/setup-auto-archiving/");
         }
-        $this->log("- Reports for today will be processed at most every " . $this->todayArchiveTimeToLive
+        $this->logger->info("- Reports for today will be processed at most every " . $this->todayArchiveTimeToLive
             . " seconds. You can change this value in Piwik UI > Settings > General Settings.");
-        $this->log("- Reports for the current week/month/year will be refreshed at most every "
+        $this->logger->info("- Reports for the current week/month/year will be refreshed at most every "
             . $this->processPeriodsMaximumEverySeconds . " seconds.");
 
         // Try and not request older data we know is already archived
         if ($this->lastSuccessRunTimestamp !== false) {
             $dateLast = time() - $this->lastSuccessRunTimestamp;
-            $this->log("- Archiving was last executed without error "
+            $this->logger->info("- Archiving was last executed without error "
                 . $this->formatter->getPrettyTimeFromSeconds($dateLast, true) . " ago");
         }
     }
@@ -1257,7 +1257,7 @@ class CronArchive
             return $this->forceTimeoutPeriod;
         }
 
-        $this->log("WARNING: Automatically increasing --force-timeout-for-periods from {$this->forceTimeoutPeriod} to "
+        $this->logger->info("WARNING: Automatically increasing --force-timeout-for-periods from {$this->forceTimeoutPeriod} to "
             . $this->todayArchiveTimeToLive
             . " to match the cache timeout for Today's report specified in Piwik UI > Settings > General Settings");
 
@@ -1354,7 +1354,7 @@ class CronArchive
             $visitsInLastPeriod = '';
         }
 
-        $this->log("Archived website id = $idSite, period = $period, "
+        $this->logger->info("Archived website id = $idSite, period = $period, "
             . $visitsInLastPeriods
             . $visitsInLastPeriod
             . $timer->__toString());
@@ -1592,10 +1592,10 @@ class CronArchive
             $urlWithSegment = $this->makeRequestUrl($urlWithSegment);
 
             $request = new Request($urlWithSegment);
-            $self = $this;
-            $request->before(function () use ($self, $segment, $segmentCount, &$processedSegmentCount) {
+            $logger = $this->logger;
+            $request->before(function () use ($logger, $segment, $segmentCount, &$processedSegmentCount) {
                 $processedSegmentCount++;
-                $self->log(sprintf(
+                $logger->info(sprintf(
                     '- pre-processing segment %d/%d %s',
                     $processedSegmentCount,
                     $segmentCount,

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1581,7 +1581,11 @@ class CronArchive
     private function getUrlsWithSegment($idSite, $period, $date)
     {
         $urlsWithSegment = array();
-        foreach ($this->getSegmentsForSite($idSite, $period) as $segment) {
+        $segments = $this->getSegmentsForSite($idSite, $period);
+        $segmentCount = count($segments);
+        $processedSegmentCount = 0;
+
+        foreach ($segments as $segment) {
             $dateParamForSegment = $this->segmentArchivingRequestUrlProvider->getUrlParameterDateString($idSite, $period, $date, $segment);
 
             $urlWithSegment = $this->getVisitsRequestUrl($idSite, $period, $dateParamForSegment, $segment);
@@ -1589,12 +1593,19 @@ class CronArchive
 
             $request = new Request($urlWithSegment);
             $self = $this;
-            $request->before(function () use ($self, $segment) {
-                $self->log('- pre-processing segment ' . $segment);
+            $request->before(function () use ($self, $segment, $segmentCount, &$processedSegmentCount) {
+                $processedSegmentCount++;
+                $self->log(sprintf(
+                    '- pre-processing segment %d/%d %s',
+                    $processedSegmentCount,
+                    $segmentCount,
+                    $segment
+                ));
             });
 
             $urlsWithSegment[] = $request;
         }
+
         return $urlsWithSegment;
     }
 

--- a/tests/PHPUnit/Framework/Mock/FakeLogger.php
+++ b/tests/PHPUnit/Framework/Mock/FakeLogger.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Piwik\Tests\Framework\Mock;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+class FakeLogger extends AbstractLogger implements LoggerInterface
+{
+    /**
+     * @var string
+     */
+    public $output = '';
+
+    public function log($level, $message, array $context = array())
+    {
+        $this->output .= $message . PHP_EOL;
+    }
+}

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -79,20 +79,20 @@ Starting Piwik reports archiving...
 Will pre-process for website id = 1, day period, 1 segments
 - pre-processing all visits
 - pre-processing segment 1/1 actions>=2
-Archived website id = 1, period = day, 0 visits in last last52 days, 0 visits today, Time elapsed: %s
+Archived website id = 1, period = day, 0 visits in last %s days, 0 visits today, Time elapsed: %s
 Will pre-process for website id = 1, week period, 1 segments
 - pre-processing all visits
 - pre-processing segment 1/1 actions>=2
-Archived website id = 1, period = week, 0 visits in last last133 weeks, 0 visits this week, Time elapsed: %s
+Archived website id = 1, period = week, 0 visits in last %s weeks, 0 visits this week, Time elapsed: %s
 Will pre-process for website id = 1, month period, 1 segments
 - pre-processing all visits
 - pre-processing segment 1/1 actions>=2
-Archived website id = 1, period = month, 0 visits in last last52 months, 0 visits this month, Time elapsed: %s
+Archived website id = 1, period = month, 0 visits in last %s months, 0 visits this month, Time elapsed: %s
 Will pre-process for website id = 1, year period, 1 segments
 - pre-processing all visits
 - pre-processing segment 1/1 actions>=2
-Archived website id = 1, period = year, 0 visits in last last7 years, 0 visits this year, Time elapsed: %s
-Archived website id = 1, 8 API requests, Time elapsed: %s [1/1 done]
+Archived website id = 1, period = year, 0 visits in last %s years, 0 visits this year, Time elapsed: %s
+Archived website id = 1, %s API requests, Time elapsed: %s [1/1 done]
 Done archiving!
 ---------------------------
 SUMMARY
@@ -102,8 +102,8 @@ Archived week/month/year for 1 websites
 Skipped 0 websites: no new visit since the last script execution
 Skipped 0 websites day archiving: existing daily reports are less than 150 seconds old
 Skipped 0 websites week/month/year archiving: existing periods reports are less than 3600 seconds old
-Total API requests: 8
-done: 1/1 100%, 0 vtoday, 1 wtoday, 1 wperiods, 8 req, %s ms, no error
+Total API requests: %s
+done: 1/1 100%, 0 vtoday, 1 wtoday, 1 wperiods, %s req, %s ms, no error
 Time elapsed: %s
 
 LOG;

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -14,21 +14,9 @@ use Piwik\Date;
 use Piwik\Db;
 use Piwik\Plugins\CoreAdminHome\tests\Framework\Mock\API;
 use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\Mock\FakeLogger;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
-
-class TestCronArchive extends CronArchive
-{
-
-    protected function checkPiwikUrlIsValid()
-    {
-
-    }
-
-    protected function initPiwikHost($piwikUrl = false)
-    {
-
-    }
-}
+use Piwik\Plugins\SegmentEditor\API as SegmentAPI;
 
 /**
  * @group Archiver
@@ -36,16 +24,11 @@ class TestCronArchive extends CronArchive
  */
 class CronArchiveTest extends IntegrationTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        Fixture::createWebsite('2014-12-12 00:01:02');
-        Fixture::createWebsite('2014-12-12 00:01:02');
-    }
-
     public function test_getColumnNamesFromTable()
     {
+        Fixture::createWebsite('2014-12-12 00:01:02');
+        Fixture::createWebsite('2014-12-12 00:01:02');
+
         $ar = new ArchiveInvalidator();
         $ar->rememberToInvalidateArchivedReportsLater(1, Date::factory('2014-04-05'));
         $ar->rememberToInvalidateArchivedReportsLater(2, Date::factory('2014-04-05'));
@@ -53,11 +36,9 @@ class CronArchiveTest extends IntegrationTestCase
 
         $api = API::getInstance();
 
-        ob_start();
         $cronarchive = new TestCronArchive(Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php');
         $cronarchive->setApiToInvalidateArchivedReport($api);
         $cronarchive->init();
-        ob_end_clean();
 
         $expectedInvalidations = array(
             array(array(1,2), '2014-04-05'),
@@ -65,5 +46,78 @@ class CronArchiveTest extends IntegrationTestCase
         );
 
         $this->assertEquals($expectedInvalidations, $api->getInvalidatedReports());
+    }
+
+    public function test_output()
+    {
+        Fixture::createWebsite('2014-12-12 00:01:02');
+        SegmentAPI::getInstance()->add('foo', 'actions>=2', 1, true, true);
+
+        $logger = new FakeLogger();
+
+        $archiver = new CronArchive(Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php', null, $logger);
+        $archiver->shouldArchiveAllSites = true;
+        $archiver->shouldArchiveAllPeriodsSince = true;
+        $archiver->init();
+        $archiver->run();
+
+        $expected = <<<LOG
+---------------------------
+INIT
+Piwik is installed at: %s
+Running Piwik %s as Super User
+---------------------------
+NOTES
+- If you execute this script at least once per hour (or more often) in a crontab, you may disable 'Browser trigger archiving' in Piwik UI > Settings > General Settings.
+  See the doc at: http://piwik.org/docs/setup-auto-archiving/
+- Reports for today will be processed at most every %s seconds. You can change this value in Piwik UI > Settings > General Settings.
+- Reports for the current week/month/year will be refreshed at most every %s seconds.
+- Will process all 1 websites
+---------------------------
+START
+Starting Piwik reports archiving...
+Will pre-process for website id = 1, day period, 1 segments
+- pre-processing all visits
+- pre-processing segment 1/1 actions>=2
+Archived website id = 1, period = day, 0 visits in last last52 days, 0 visits today, Time elapsed: %s
+Will pre-process for website id = 1, week period, 1 segments
+- pre-processing all visits
+- pre-processing segment 1/1 actions>=2
+Archived website id = 1, period = week, 0 visits in last last133 weeks, 0 visits this week, Time elapsed: %s
+Will pre-process for website id = 1, month period, 1 segments
+- pre-processing all visits
+- pre-processing segment 1/1 actions>=2
+Archived website id = 1, period = month, 0 visits in last last52 months, 0 visits this month, Time elapsed: %s
+Will pre-process for website id = 1, year period, 1 segments
+- pre-processing all visits
+- pre-processing segment 1/1 actions>=2
+Archived website id = 1, period = year, 0 visits in last last7 years, 0 visits this year, Time elapsed: %s
+Archived website id = 1, 8 API requests, Time elapsed: %s [1/1 done]
+Done archiving!
+---------------------------
+SUMMARY
+Total visits for today across archived websites: 0
+Archived today's reports for 1 websites
+Archived week/month/year for 1 websites
+Skipped 0 websites: no new visit since the last script execution
+Skipped 0 websites day archiving: existing daily reports are less than 150 seconds old
+Skipped 0 websites week/month/year archiving: existing periods reports are less than 3600 seconds old
+Total API requests: 8
+done: 1/1 100%, 0 vtoday, 1 wtoday, 1 wperiods, 8 req, %s ms, no error
+Time elapsed: %s
+
+LOG;
+        $this->assertStringMatchesFormat($expected, $logger->output);
+    }
+}
+
+class TestCronArchive extends CronArchive
+{
+    protected function checkPiwikUrlIsValid()
+    {
+    }
+
+    protected function initPiwikHost($piwikUrl = false)
+    {
     }
 }

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -6,6 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
+use Piwik\Archiver\Request;
 use Piwik\CliMulti;
 use Piwik\Version;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
@@ -194,6 +195,19 @@ class CliMultiTest extends SystemTestCase
 
         $this->assertFileNotExists($tmpDir . 'toberemoved.output');
         $this->assertFileNotExists($tmpDir . 'toberemoved.output');
+    }
+
+    public function test_shouldSupportRequestObjects()
+    {
+        $wasCalled = false;
+        $request = new Request('url');
+        $request->before(function () use (&$wasCalled) {
+            $wasCalled = true;
+        });
+
+        $this->cliMulti->request(array($request));
+
+        $this->assertTrue($wasCalled, 'The request "before" handler was not called');
     }
 
     private function assertRequestReturnsValidResponses($urls, $expectedResponseIds)


### PR DESCRIPTION
Fixes #7536

Example:

```
INFO CoreConsole[2015-04-16 23:22:25] Starting Piwik reports archiving...
INFO CoreConsole[2015-04-16 23:22:25] Will pre-process for website id = 1, day period, 2 segments
INFO CoreConsole[2015-04-16 23:22:25] - pre-processing all visits
INFO CoreConsole[2015-04-16 23:22:25] - pre-processing segment entryPageTitle=@Web%20Analytics
INFO CoreConsole[2015-04-16 23:22:26] - pre-processing segment pageTitle=@Piwik
INFO CoreConsole[2015-04-16 23:22:26] Archived website id = 1, period = day, 6 visits in last last2 days, 0 visits today, Time elapsed: 1.380s
INFO CoreConsole[2015-04-16 23:22:26] Will pre-process for website id = 1, week period, 2 segments
INFO CoreConsole[2015-04-16 23:22:26] - pre-processing all visits
INFO CoreConsole[2015-04-16 23:22:26] - pre-processing segment entryPageTitle=@Web%20Analytics
INFO CoreConsole[2015-04-16 23:22:26] - pre-processing segment pageTitle=@Piwik
INFO CoreConsole[2015-04-16 23:22:36] Archived website id = 1, period = week, 459 visits in last last3 weeks, 301 visits this week, Time elapsed: 9.440s
```
