### PR TITLE
Do not preserve keys when applying filter_limit/offset

### DIFF
--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -202,7 +202,7 @@ class ResponseBuilder
             $offset = Common::getRequestVar('filter_offset', '0', 'integer', $this->request);
 
             if ($this->shouldApplyLimitOnArray($limit, $offset)) {
-                $array = array_slice($array, $offset, $limit, $firstKey !== 0);
+                $array = array_slice($array, $offset, $limit, $preserveKeys = false);
             }
         }
 


### PR DESCRIPTION
Just recently I added "preserve array keys" if the first array key is not `0` when using `filter_limit/offset` but now I noticed it is not a good idea for now. For example if the first array key is `2` we should still not preserve the keys otherwise we would return an object instead of an array in JSON etc. 

Output of eg `SitesManager.getAllSites` before was: 

```
{"2":{"idsite":"2","name":"Botsford Inc","main_url":"http:\/\/www.howell.org","ts_created":"2015-01-25 22:36:51","ecommerce":"0","sitesearch":"1","s...
```

Output after this fix:

```
[{"idsite":"2","name":"Botsford Inc","main_url":"http:\/\/www.howell.org","ts_created":"2015-01-25 22:36:51","ecommerce":"0","sitesearch":"1","s...
```
