### PR TITLE
Some small website manager design tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,6 +157,10 @@ after_success:
   - cd $PIWIK_ROOT_DIR
   - ./tests/travis/generate_docs.sh
 
+sudo: required
+
+
+
 notifications:
   slack:
     rooms:

--- a/lang/en.json
+++ b/lang/en.json
@@ -32,6 +32,7 @@
         "ClickHere": "Click here for more information.",
         "ClickToChangePeriod": "Click again to change the period.",
         "Close": "Close",
+        "ClickToSearch": "Click to search",
         "ColumnActionsPerVisit": "Actions per Visit",
         "ColumnActionsPerVisitDocumentation": "The average number of actions (page views, site searches, downloads or outlinks) that were performed during the visits.",
         "ColumnAverageGenerationTime": "Avg. generation time",

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -264,6 +264,7 @@ class SitesManager extends \Piwik\Plugin
         $translationKeys[] = "General_Actions";
         $translationKeys[] = "General_Search";
         $translationKeys[] = "General_Pagination";
+        $translationKeys[] = "General_ClickToSearch";
         $translationKeys[] = "General_PaginationWithoutTotal";
         $translationKeys[] = "Actions_SubmenuSitesearch";
         $translationKeys[] = "SitesManager_OnlyOneSiteAtTime";

--- a/plugins/SitesManager/stylesheets/SitesManager.less
+++ b/plugins/SitesManager/stylesheets/SitesManager.less
@@ -17,14 +17,23 @@
 
 .SitesManager {
   .bottomButtonBar {
-    margin-top: 5px
+    margin-top: 9px
   }
 
   .visible {
     visibility: visible;
   }
-  .hidden {
+  .hide_only {
     visibility: hidden;
+  }
+
+  .search_ico {
+
+    cursor: pointer;
+    display: block;
+    left: 205px;
+    margin: -32px 0 17px -21px;
+    position: relative;
   }
 
   .sitesButtonBar {
@@ -38,6 +47,7 @@
 
     .addRowSite {
       font-size: 14px;
+      margin-top: 8px;
     }
   }
 
@@ -45,7 +55,7 @@
     text-align: center;
     display: inline-block;
     min-width: 400px;
-    margin-top: 7px;
+    margin-top: 10px;
 
     .counter {
       margin-left: 10px;
@@ -58,6 +68,12 @@
     display: inline-block;
     text-align: right;
     float: right;
+
+    input {
+      padding-right: 29px;
+      width: 205px;
+      margin-bottom: 7px;
+    }
   }
 }
 

--- a/plugins/SitesManager/templates/loading.html
+++ b/plugins/SitesManager/templates/loading.html
@@ -1,4 +1,4 @@
-<div ng-class="{'hidden': !loading && !adminSites.isLoading}">
+<div ng-class="{'hide_only': !loading && !adminSites.isLoading}">
     <div class="loadingPiwik">
         <img src="plugins/Morpheus/images/loading-blue.gif" alt="{{ 'General_LoadingData'|translate }}" />
         {{ 'General_LoadingData'|translate }}

--- a/plugins/SitesManager/templates/sites-list/add-site-link.html
+++ b/plugins/SitesManager/templates/sites-list/add-site-link.html
@@ -6,7 +6,7 @@
     </div>
     <div class="paging">
         <a class="submit prev"
-           ng-class="{'visible': adminSites.hasPrev, 'hidden': !adminSites.hasPrev}"
+           ng-class="{'visible': adminSites.hasPrev, 'hide_only': !adminSites.hasPrev}"
            ng-click="adminSites.previousPage()">
             <span style="cursor:pointer;">&#171; {{ 'General_Previous'|translate }}</span>
         </a>
@@ -19,7 +19,7 @@
             </span>
         </span>
         <a class="submit next"
-           ng-class="{'visible': adminSites.hasNext, 'hidden': !adminSites.hasNext}"
+           ng-class="{'visible': adminSites.hasNext, 'hide_only': !adminSites.hasNext}"
            ng-click="adminSites.nextPage()">
             <span style="cursor:pointer;" class="pointer">{{ 'General_Next'|translate }} &#187;</span>
         </a>
@@ -27,6 +27,8 @@
     <div class="search">
         <input ng-model="adminSites.search" piwik-onenter="adminSites.searchSite(adminSites.search)"
                placeholder="{{ 'Actions_SubmenuSitesearch' | translate }}" type="text">
-        <a class="submit" ng-click="adminSites.searchSite(adminSites.search)">{{ 'General_Search'|translate }}</a>
+        <img ng-click="adminSites.searchSite(adminSites.search)" title="{{ 'General_ClickToSearch' | translate }}"
+             class="search_ico"
+             src="plugins/Morpheus/images/search_ico.png"/>
     </div>
 </div>


### PR DESCRIPTION
fixes #7696 

The loading thing was caused by bootstrap as it defines a class `hidden` and `hide` that does not only do a `visibility:hidden` but also a `display:none`.

I removed the search button completely and made the search field look like in the all websites dashboard  (it will look like this once #7693 is merged) 
