### PR TITLE
Fixes #7728, in calendar widget disable highlighting of any date if a date was selected and the content is reloading.

### DIFF
--- a/plugins/CoreHome/javascripts/calendar.js
+++ b/plugins/CoreHome/javascripts/calendar.js
@@ -47,6 +47,10 @@
 // we start w/ the current period
     var selectedPeriod = piwik.period;
 
+    // set to true when changing the page so the UI will look a bit cleaner. shouldn't be set
+    // for any other reason.
+    var disableHighlightChange = false;
+
     function isDateInCurrentPeriod(date) {
         // if the selected period isn't the current period, don't highlight any dates
         if (selectedPeriod != piwik.period) {
@@ -218,6 +222,11 @@
 
         // 'this' is the table cell
         var highlightCurrentPeriod = function () {
+            if (disableHighlightChange) {
+                $('a', $(this)).removeClass('ui-state-hover'); // remove the hover added for the hovered day
+                return;
+            }
+
             switch (selectedPeriod) {
                 case 'day':
                     // highlight this link
@@ -280,6 +289,8 @@
             // Let broadcast do its job:
             // It will replace date value to both search query and hash and load the new page.
             broadcast.propagateNewPage('date=' + dateText + '&period=' + selectedPeriod);
+
+            disableHighlightChange = true;
         };
 
         var toggleMonthDropdown = function (disable) {


### PR DESCRIPTION
 Fixes #7728
As title.

Downside of this solution is that if we use the calendar somewhere else and want to reload part of the page that the calendar isn't part of, the calendar will be stuck in the disabled highlight mode.

We could fix this later if the calendar widget is converted to an angular directive.
