### PR TITLE
Improved the Timer and tagged it as API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is a changelog for Piwik platform developers. All changes for our HTTP API's, Plugins, Themes, etc will be listed here.
 
+## Piwik 2.14.0
+
+### New features
+* `Piwik\Timer\Timer` can now be used by plugins to measure the time spent in some parts of the code (the class has been tagged as `@api`).
+
 ## Piwik 2.13.0
 
 ### Deprecations

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -113,9 +113,9 @@ class PluginsArchiver
                     $archiver->aggregateMultipleReports();
                 }
 
-                Log::debug("PluginsArchiver::%s: %s while archiving %s reports for plugin '%s'.",
+                Log::debug("PluginsArchiver::%s: Memory delta: %s while archiving %s reports for plugin '%s'.",
                     __FUNCTION__,
-                    $timer->getMemoryLeak(),
+                    $timer->getMemoryDelta(true),
                     $this->params->getPeriod()->getLabel(),
                     $pluginName
                 );

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -16,7 +16,7 @@ use Piwik\DataTable\Manager;
 use Piwik\Metrics;
 use Piwik\Plugin\Archiver;
 use Piwik\Log;
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 
 /**
  * This class creates the Archiver objects found in plugins and will trigger aggregation,

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -379,7 +379,7 @@ class CronArchive
         $this->logger->info("done: " .
             $this->processed . "/" . $this->websites->getNumSites() . "" . $percent . ", " .
             $this->visitsToday . " vtoday, $this->websitesWithVisitsSinceLastRun wtoday, {$this->archivedPeriodsArchivesWebsite} wperiods, " .
-            $this->requests . " req, " . round($timer->getTimeMs()) . " ms, " .
+            $this->requests . " req, " . round($timer->getTimeElapsed() * 1000) . " ms, " .
             (empty($this->errors)
                 ? self::NO_ERROR
                 : (count($this->errors) . " errors."))

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -24,6 +24,7 @@ use Piwik\Plugins\CoreAdminHome\API as CoreAdminHomeAPI;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 use Piwik\Plugins\UsersManager\UserPreferences;
+use Piwik\Timer\Timer;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/core/Scheduler/Scheduler.php
+++ b/core/Scheduler/Scheduler.php
@@ -9,7 +9,7 @@
 namespace Piwik\Scheduler;
 
 use Exception;
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/core/Timer.php
+++ b/core/Timer.php
@@ -4,63 +4,66 @@
  *
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- *
  */
+
 namespace Piwik;
+
 use Piwik\Metrics\Formatter;
 
 /**
- *
+ * Utility class for timing.
  */
 class Timer
 {
-    private $timerStart;
-    private $memoryStart;
+    /**
+     * @var Formatter
+     */
     private $formatter;
 
     /**
-     * @return \Piwik\Timer
+     * @var float Time in seconds.
+     */
+    private $timeStart;
+
+    /**
+     * @var int
+     */
+    private $memoryStart;
+
+    /**
+     * Starts the timer
      */
     public function __construct()
     {
         $this->formatter = new Formatter();
 
-        $this->init();
-    }
-
-    /**
-     * @return void
-     */
-    public function init()
-    {
-        $this->timerStart = $this->getMicrotime();
+        $this->timeStart = microtime(true);
         $this->memoryStart = $this->getMemoryUsage();
     }
 
     /**
-     * @param int $decimals
-     * @return string
+     * Returns the time elapsed since the start in seconds.
+     *
+     * @return float
      */
-    public function getTime($decimals = 3)
+    public function getTimeElapsed()
     {
-        return number_format($this->getMicrotime() - $this->timerStart, $decimals, '.', '');
+        return microtime(true) - $this->timeStart;
     }
 
     /**
-     * @param int $decimals
-     * @return string
+     * @param string $formatted If true will format the result, e.g.: `256 Kb`. If false, returns an int.
+     * @return int|string
      */
-    public function getTimeMs($decimals = 3)
+    public function getMemoryDelta($formatted = false)
     {
-        return number_format(1000 * ($this->getMicrotime() - $this->timerStart), $decimals, '.', '');
-    }
+        $delta = $this->getMemoryUsage() - $this->memoryStart;
 
-    /**
-     * @return string
-     */
-    public function getMemoryLeak()
-    {
-        return "Memory delta: " . $this->formatter->getPrettySizeFromBytes($this->getMemoryUsage() - $this->memoryStart);
+        if ($formatted) {
+            return $this->formatter->getPrettySizeFromBytes($this->getMemoryUsage() - $this->memoryStart);
+        }
+
+        return $delta;
     }
 
     /**
@@ -68,16 +71,9 @@ class Timer
      */
     public function __toString()
     {
-        return "Time elapsed: " . $this->getTime() . "s";
-    }
+        $timeFormatted = number_format(microtime(true) - $this->timeStart, 3, '.', '');
 
-    /**
-     * @return float
-     */
-    private function getMicrotime()
-    {
-        list($micro_seconds, $seconds) = explode(" ", microtime());
-        return ((float)$micro_seconds + (float)$seconds);
+        return 'Time elapsed: ' . $timeFormatted . 's';
     }
 
     /**

--- a/core/Timer/Timer.php
+++ b/core/Timer/Timer.php
@@ -6,12 +6,14 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik;
+namespace Piwik\Timer;
 
 use Piwik\Metrics\Formatter;
 
 /**
  * Utility class for timing.
+ *
+ * @api
  */
 class Timer
 {
@@ -52,6 +54,8 @@ class Timer
     }
 
     /**
+     * Returns the memory usage difference between now and when the timer was started.
+     *
      * @param string $formatted If true will format the result, e.g.: `256 Kb`. If false, returns an int.
      * @return int|string
      */

--- a/core/Tracker/Db.php
+++ b/core/Tracker/Db.php
@@ -86,7 +86,7 @@ abstract class Db
             $this->queriesProfiling[$query] = array('sum_time_ms' => 0, 'count' => 0);
         }
 
-        $time  = $timer->getTimeMs(2);
+        $time  = $timer->getTimeElapsed() * 1000;
         $time += $this->queriesProfiling[$query]['sum_time_ms'];
         $count = $this->queriesProfiling[$query]['count'] + 1;
 

--- a/core/Tracker/Db.php
+++ b/core/Tracker/Db.php
@@ -13,7 +13,7 @@ use PDOStatement;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Piwik;
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 use Piwik\Tracker;
 use Piwik\Tracker\Db\DbException;
 use Piwik\Tracker\Db\Mysqli;

--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -11,7 +11,7 @@ namespace Piwik\Tracker;
 use Exception;
 use Piwik\Common;
 use Piwik\Profiler;
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 use Piwik\Tracker;
 use Piwik\Tracker\Db as TrackerDb;
 

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -436,7 +436,7 @@ class ProcessedReport
             'reportTotal'    => $totals
         );
         if ($showTimer) {
-            $return['timerMillis'] = $timer->getTimeMs(0);
+            $return['timerMillis'] = $timer->getTimeElapsed() * 1000;
         }
         return $return;
     }

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -24,7 +24,7 @@ use Piwik\Period;
 use Piwik\Piwik;
 use Piwik\Plugin\Report;
 use Piwik\Site;
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 use Piwik\Url;
 
 class ProcessedReport

--- a/plugins/CoreAdminHome/Commands/FixDuplicateLogActions.php
+++ b/plugins/CoreAdminHome/Commands/FixDuplicateLogActions.php
@@ -14,7 +14,7 @@ use Piwik\DataAccess\Actions;
 use Piwik\Archive\ArchiveInvalidator;
 use Piwik\Plugin\ConsoleCommand;
 use Piwik\Plugins\CoreAdminHome\Model\DuplicateActionRemover;
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
+++ b/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
@@ -14,7 +14,7 @@ use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\Plugin\ConsoleCommand;
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php
+++ b/plugins/UserCountry/Commands/AttributeHistoricalDataWithLocations.php
@@ -12,7 +12,7 @@ use Piwik\Plugin\ConsoleCommand;
 use Piwik\Plugins\UserCountry\VisitorGeolocator;
 use Piwik\Plugins\UserCountry\LocationProvider;
 use Piwik\DataAccess\RawLogDao;
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -12,7 +12,7 @@ use Piwik\Common;
 use Piwik\DataTable\Manager;
 use Piwik\DataTable\Row;
 use Piwik\DataTable;
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 use Symfony\Component\VarDumper\Cloner\Data;
 
 /**

--- a/tests/PHPUnit/Unit/FactoryTest.php
+++ b/tests/PHPUnit/Unit/FactoryTest.php
@@ -17,10 +17,10 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreatingExistingClassSucceeds()
     {
-        $instance = BaseFactory::factory('Piwik\Timer');
+        $instance = BaseFactory::factory('Piwik\Timer\Timer');
 
         $this->assertNotNull($instance);
-        $this->assertInstanceOf('Piwik\Timer', $instance);
+        $this->assertInstanceOf('Piwik\Timer\Timer', $instance);
     }
 
     /**

--- a/tests/PHPUnit/Unit/Timer/TimerTest.php
+++ b/tests/PHPUnit/Unit/Timer/TimerTest.php
@@ -8,7 +8,7 @@
 
 namespace Piwik\Tests\Unit\Timer;
 
-use Piwik\Timer;
+use Piwik\Timer\Timer;
 
 class TimerTest extends \PHPUnit_Framework_TestCase
 {
@@ -48,7 +48,7 @@ class TimerTest extends \PHPUnit_Framework_TestCase
         $timer = new Timer();
 
         $this->assertInternalType('string', $timer->getMemoryDelta(true));
-        $this->assertStringMatchesFormat('%i B', $timer->getMemoryDelta(true));
+        $this->assertStringMatchesFormat('%i %s', $timer->getMemoryDelta(true));
     }
 
     /**

--- a/tests/PHPUnit/Unit/Timer/TimerTest.php
+++ b/tests/PHPUnit/Unit/Timer/TimerTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Timer;
+
+use Piwik\Timer;
+
+class TimerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function should_measure_time_elapsed()
+    {
+        $timer = new Timer();
+
+        usleep(2000); // sleep 2 ms
+
+        $duration = $timer->getTimeElapsed();
+
+        $this->assertInternalType('float', $duration);
+        $this->assertGreaterThan(0.002, $duration);
+    }
+
+    /**
+     * @test
+     */
+    public function should_measure_memory_delta()
+    {
+        $timer = new Timer();
+
+        $this->assertInternalType('int', $timer->getMemoryDelta());
+
+        $a = $timer->getMemoryDelta();
+        $this->assertGreaterThanOrEqual($a, $timer->getMemoryDelta());
+    }
+
+    /**
+     * @test
+     */
+    public function should_format_measured_memory_delta()
+    {
+        $timer = new Timer();
+
+        $this->assertInternalType('string', $timer->getMemoryDelta(true));
+        $this->assertStringMatchesFormat('%i B', $timer->getMemoryDelta(true));
+    }
+
+    /**
+     * @test
+     */
+    public function should_cast_to_string()
+    {
+        $timer = new Timer();
+        usleep(1000);
+        $this->assertStringMatchesFormat('Time elapsed: %fs', (string) $timer);
+    }
+}


### PR DESCRIPTION
While working on #7569 (removing calls to non-api stuff) I saw that the Timer was used in some plugins but it's not tagged as `@api`.

I tagged the Timer as API but before that I cleaned it up a bit:
- moving it to a `Piwik\Timer` namespace: it avoids cluttering the root `Piwik\` namespace with stuff unrelated to Piwik itself, and it allows to move it to an external component later without any bc break
- simplifying the API a little bit based on how it was used: a method wasn't used, others where returning formatted number but used as int (e.g. used in math operation), etc.
- I added unit tests

By the way I now realize that git didn't pick up the "move" operation and instead deleted/recreated the file, that wasn't planned sometimes git can be a bit difficult about that :/

PR targeted at 2.14, don't merge in 2.13?
