### PR TITLE
Make website manager take 100% of width on a big screen

### DIFF
--- a/plugins/SitesManager/stylesheets/SitesManager.less
+++ b/plugins/SitesManager/stylesheets/SitesManager.less
@@ -16,6 +16,17 @@
 }
 
 .SitesManager {
+    
+  .entityContainer {
+    width: 100%;
+  }
+
+  @media (max-width: 1700px) {
+    .entityContainer {
+      width: 800px;
+    }
+  }
+
   .wideColumn {
     min-width: 250px;
   }


### PR DESCRIPTION
refs #7747 

Use more available space on a big screen. It won't always use 100% but it should be better than it is currently
