### PR TITLE
Refs #7569 mark some methods/classes w/ @api

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -338,6 +338,7 @@ class Common
      *
      * @param string $value
      * @return string  unsanitized input
+     * @api
      */
     public static function unsanitizeInputValue($value)
     {


### PR DESCRIPTION
These are methods/classes used by plugins that are not currently marked as `@api`. They include:
1. `Common::unsanitizeInputValue`
2. `Piwik\Updates` methods getMigrationQueries & doUpdate.

Documentation changed where appropriate.
