### PR TITLE
New design for code blocks

### DIFF
--- a/plugins/CoreUpdater/stylesheets/updateLayout.css
+++ b/plugins/CoreUpdater/stylesheets/updateLayout.css
@@ -18,20 +18,6 @@
     margin-left: 0;
 }
 
-code {
-    font-size: 13px;
-    color: #F3F3F3;
-    background-color: #4D4D4D;
-    border: none;
-    border-radius: 3px;
-    direction: ltr;
-    display: block;
-    margin: 2px 2px 20px;
-    padding: 20px;
-    text-align: left;
-    overflow-x: hidden;
-}
-
 li {
     margin-top: 10px;
     margin-left: 30px;

--- a/plugins/CoreUpdater/templates/runUpdaterAndExit_welcome.twig
+++ b/plugins/CoreUpdater/templates/runUpdaterAndExit_welcome.twig
@@ -50,18 +50,12 @@
                     </div>
                 {% endif %}
                 <p>{{ 'CoreUpdater_TheUpgradeProcessMayFailExecuteCommand'|translate('') }}</p>
-                <code>{{ commandUpgradePiwik }}</code>
+                <pre>{{ commandUpgradePiwik }}</pre>
                 <p>{{ 'CoreUpdater_HighTrafficPiwikServerEnableMaintenance'|translate('<a target="_blank" href="?module=Proxy&action=redirect&url=http%3A%2F%2Fpiwik.org%2Ffaq%2Fhow-to%2F%23faq_111">', '</a>')|raw }}</p>
                 <p>{{ 'CoreUpdater_YouCouldManuallyExecuteSqlQueries'|translate }}</p>
                 <p><a href="#" id="showSql">› {{ 'CoreUpdater_ClickHereToViewSqlQueries'|translate }}</a></p>
                 <div id="sqlQueries" style="display:none;">
-                    <code>
-                        # {{ 'CoreUpdater_NoteItIsExpectedThatQueriesFail'|translate }}<br/><br/>
-                        {% for query in queries %}
-                            {{ query }}
-                            <br/><br/>
-                        {% endfor %}
-                    </code>
+                    <pre># {{ 'CoreUpdater_NoteItIsExpectedThatQueriesFail'|translate }}<br/>{% for query in queries %}{{ query }}<br/>{% endfor %}</pre>
                 </div>
 
                 <h2>{{ 'CoreUpdater_ReadyToGo'|translate }}</h2>

--- a/plugins/Morpheus/stylesheets/base.less
+++ b/plugins/Morpheus/stylesheets/base.less
@@ -37,4 +37,5 @@
 
 @import "bootstrap.css";
 
+@import "ui/_code";
 @import "ui/_alerts";

--- a/plugins/Morpheus/stylesheets/general/_admin.less
+++ b/plugins/Morpheus/stylesheets/general/_admin.less
@@ -116,11 +116,6 @@
     }
 }
 
-code {
-    border-color: @color-silver-l80;
-    border-left: 5px solid @theme-color-brand;
-}
-
 #geoipdb-screen1>div>p {
     line-height: 1.4em;
     height: 6em;

--- a/plugins/Morpheus/stylesheets/general/_default.less
+++ b/plugins/Morpheus/stylesheets/general/_default.less
@@ -31,24 +31,6 @@ blockquote, q {
     quotes: none;
 }
 
-code {
-  background-color:@theme-color-background-base;
-  border: 1px dashed;
-  border-left: 5px solid  #4B4BD5;
-  direction:ltr;
-  display:table;
-  font-size:100%;
-  margin:12px 2px 0;
-  padding:5px 50px 5px 15px;
-  text-align:left;
-  line-height:1.3em;
-  font-family: "Courier New" Courier monospace;
-}
-
-pre.code-pre {
-  white-space:pre-wrap;
-}
-
 /* remember to define focus styles! */
 :focus {
     outline: auto;

--- a/plugins/Morpheus/stylesheets/less/_variables.less
+++ b/plugins/Morpheus/stylesheets/less/_variables.less
@@ -22,6 +22,8 @@
 @theme-color-menu-contrast-background: @theme-color-background-tinyContrast;
 @theme-color-widget-title-text: @theme-color-text;
 @theme-color-widget-title-background: @theme-color-background-tinyContrast;
+@theme-color-code: #F3F3F3;
+@theme-color-code-background: #4D4D4D;
 
 // Other theme variables
 // Variable pattern: @theme-type-<role>

--- a/plugins/Morpheus/stylesheets/simple_structure.css
+++ b/plugins/Morpheus/stylesheets/simple_structure.css
@@ -76,11 +76,6 @@ body#simple  {
 #simple .box .content h2:first-child {
 	margin-top: 0;
 }
-#simple .box .content pre {
-	overflow-x: scroll;
-	font-size: 11px;
-	text-align: left;
-}
 
 #simple .box .footer {
     background-color: #f0f0f0;

--- a/plugins/Morpheus/stylesheets/ui/_code.less
+++ b/plugins/Morpheus/stylesheets/ui/_code.less
@@ -1,0 +1,19 @@
+code {
+    padding: 2px 4px;
+    font-size: 90%;
+    color: @theme-color-code;
+    background-color: @theme-color-code-background;
+    border-radius: 4px;
+}
+
+pre {
+    font-size: 13px;
+    color: @theme-color-code;
+    background-color: @theme-color-code-background;
+    border: none;
+    border-radius: 3px;
+    direction: ltr;
+    margin: 0 0 15px;
+    padding: 20px;
+    text-align: left;
+}

--- a/plugins/Morpheus/templates/demo.twig
+++ b/plugins/Morpheus/templates/demo.twig
@@ -22,13 +22,19 @@
             padding: 25px;
         }
         .demo-code {
-            font-size: 14px;
             padding: 9px 14px;
             background-color: #f7f7f9;
             border: 1px solid #e1e1e8;
             margin: -16px 0 15px;
             border-bottom-right-radius: 4px;
             border-bottom-left-radius: 4px;
+        }
+        .demo-code pre {
+            color: inherit;
+            font-size: 14px;
+            padding: 0;
+            background-color: transparent;
+            margin: 0;
         }
         .demo .div-block {
             max-width: 400px;
@@ -252,6 +258,7 @@
         <h3>Block</h3>
 
         <div class="demo">
+            <p>Or you can display a code block:</p>
             <pre>&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
 &lt;/script&gt;

--- a/plugins/PrivacyManager/templates/privacySettings.twig
+++ b/plugins/PrivacyManager/templates/privacySettings.twig
@@ -302,11 +302,13 @@
 {% endif %}
 
 <h2 id="optOutAnchor">{{ 'CoreAdminHome_OptOutForYourVisitors'|translate }}</h2>
-<p>{{ 'CoreAdminHome_OptOutExplanation'|translate }}
+<p>
+    {{ 'CoreAdminHome_OptOutExplanation'|translate }}
     {% set optOutUrl %}{{ piwikUrl }}index.php?module=CoreAdminHome&action=optOut&language={{ language }}{% endset %}
     {% set iframeOptOut %}<iframe style="border: 0; height: 200px; width: 600px;" src="{{ optOutUrl }}"></iframe>{% endset %}
-    <code>{{ iframeOptOut|e('html') }}</code>
-    <br/>
+</p>
+<pre>{{ iframeOptOut|e('html') }}</pre>
+<p>
     {{ 'CoreAdminHome_OptOutExplanationBis'|translate("<a href='" ~ optOutUrl ~ "' rel='noreferrer' target='_blank'>","</a>")|raw }}
 </p>
 

--- a/plugins/SitesManager/templates/_displayJavascriptCode.twig
+++ b/plugins/SitesManager/templates/_displayJavascriptCode.twig
@@ -9,9 +9,8 @@
 
     <p>{{ 'CoreAdminHome_JSTracking_CodeNote'|translate("&lt;/body&gt;")|raw }}</p>
 
-    <pre class="code-pre"><code>{{ jsTag|raw }}</code></pre>
+    <pre>{{ jsTag|raw }}</pre>
 
-    <br/>
     <p>{{ 'CoreAdminHome_JSTrackingIntro5'|translate('<a rel="noreferrer" target="_blank" href="http://piwik.org/docs/javascript-tracking/">','</a>')|raw }}</p>
 
     <p>{{ 'Installation_JSTracking_EndNote'|translate('<em>','</em>')|raw }}</p>


### PR DESCRIPTION
Related to #7585 

Applied the new `<code>` and `<pre>` design (which is in #7450 or #7584 or #7587 too) and made it consistent everywhere. I was able to removed every custom CSS/Less for these tags which is quite great!

It was also the occasion to fix `<code>` which was used for code blocks: it's an inline tag, `<pre>` should used for code blocks instead. I changed templates where it was used as a block and replaced it with `<pre>`.

Below are screenshots of the new UI demo introduced in #7787.
### Before

![capture d ecran 2015-04-30 a 16 40 12](https://cloud.githubusercontent.com/assets/720328/7406493/b5cba77c-ef57-11e4-9c22-0cfbf2e34e18.png)
### After

![capture d ecran 2015-04-30 a 16 39 52](https://cloud.githubusercontent.com/assets/720328/7406494/ba5abf3a-ef57-11e4-96ad-fac0795ac541.png)
