### PR TITLE
Fixed double last last messages in core:archive

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1340,6 +1340,7 @@ class CronArchive
     private function logArchivedWebsite($idSite, $period, $date, $segmentsCount, $visitsInLastPeriods, $visitsToday, Timer $timer)
     {
         if (strpos($date, 'last') === 0 || strpos($date, 'previous') === 0) {
+            $date = str_replace ("last", "", $date);
             $visitsInLastPeriods = (int)$visitsInLastPeriods . " visits in last " . $date . " " . $period . "s, ";
             $thisPeriod = $period == "day" ? "today" : "this " . $period;
             $visitsInLastPeriod = (int)$visitsToday . " visits " . $thisPeriod . ", ";


### PR DESCRIPTION
Running console `core:archive` outputs messages like this:

> Archived website id = 12, period = day, 2 segments, 0 visits in **last last52** days, 0 visits today, Time elapsed: 1.699s

This edit removes the second _last_ to become:

> Archived website id = 12, period = day, 2 segments, 0 visits in **last 52** days, 0 visits today, Time elapsed: 1.699s
