### PR TITLE
All websites dashboard lists website names double encoded

### DIFF
--- a/plugins/MultiSites/angularjs/site/site.controller.js
+++ b/plugins/MultiSites/angularjs/site/site.controller.js
@@ -14,6 +14,7 @@
         $scope.period = piwik.period;
         $scope.date   = piwik.broadcast.getValueFromUrl('date');
         $scope.sparklineImage = sparklineImage;
+        $scope.website.label  = piwik.helper.htmlDecode($scope.website.label);
 
         this.getWebsite = function () {
             return $scope.website;

--- a/tests/UI/specs/MultiSites_spec.js
+++ b/tests/UI/specs/MultiSites_spec.js
@@ -16,7 +16,12 @@ describe("MultiSitesTest", function () {
     var createdSiteId = null;
 
     before(function (done) {
-        var callback = function (undefined, response) {
+        var callback = function (error, response) {
+            if (error) {
+                done(error, response);
+                return;
+            }
+            
             createdSiteId = response.value;
             done();
         };

--- a/tests/UI/specs/MultiSites_spec.js
+++ b/tests/UI/specs/MultiSites_spec.js
@@ -13,9 +13,35 @@ describe("MultiSitesTest", function () {
     var generalParams = 'idSite=1&period=year&date=2012-08-09';
     var selector = '.pageWrap,.expandDataTableFooterDrawer';
 
+    var createdSiteId = null;
+
+    before(function (done) {
+        var callback = function (undefined, response) {
+            createdSiteId = response.value;
+            done();
+        };
+
+        testEnvironment.callApi("SitesManager.addSite", {
+            siteName: '%3CMy%20website%22%27%3E%3B%2C%3F',
+            urls: 'http%3A%2F%2Fpiwik.org'},
+        callback);
+    });
+
+    after(function (done) {
+        if (createdSiteId) {
+            testEnvironment.callApi("SitesManager.deleteSite", {idSite: createdSiteId}, done);
+        }
+    });
+
     it('should load the all websites dashboard correctly', function (done) {
         expect.screenshot('all_websites').to.be.captureSelector(selector, function (page) {
             page.load("?" + generalParams + "&module=MultiSites&action=index");
+        }, done);
+    });
+
+    it('should load next page correctly', function (done) {
+        expect.screenshot('all_websites_page_1').to.be.captureSelector(selector, function (page) {
+            page.click('.paging .next');
         }, done);
     });
 


### PR DESCRIPTION
refs #7806 

Should be XSS safe. We do HTML decode in the browser but when outputting it in the browser, it will be encoded again by AngularJS
