### PR TITLE
Set a user preference only if user has actually at least view permission to one site

### DIFF
--- a/core/Updates/2.13.1.php
+++ b/core/Updates/2.13.1.php
@@ -25,7 +25,7 @@ class Updates_2_13_1 extends Updates
     static function getSql()
     {
         $optionTable = Common::prefixTable('option');
-        $removeEmptyDefaultReportsSql = "delete from $optionTable where option_name like '%defaultReport%' and option_value=''";
+        $removeEmptyDefaultReportsSql = "delete from `$optionTable` where option_name like '%defaultReport%' and option_value=''";
 
         return array(
             $removeEmptyDefaultReportsSql => false

--- a/core/Updates/2.13.1.php
+++ b/core/Updates/2.13.1.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Common;
+use Piwik\Updater;
+use Piwik\Updates;
+
+/**
+ * Update for version 2.13.1.
+ */
+class Updates_2_13_1 extends Updates
+{
+    /**
+     * Here you can define one or multiple SQL statements that should be executed during the update.
+     * @return array
+     */
+    static function getSql()
+    {
+        $optionTable = Common::prefixTable('option');
+        $removeEmptyDefaultReportsSql = "delete from $optionTable where option_name like '%defaultReport%' and option_value=''";
+
+        return array(
+            $removeEmptyDefaultReportsSql => false
+        );
+    }
+
+    /**
+     * Here you can define any action that should be performed during the update. For instance executing SQL statements,
+     * renaming config entries, updating files, etc.
+     */
+    static function update()
+    {
+        Updater::updateDatabase(__FILE__, self::getSql());
+    }
+}

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -125,7 +125,9 @@ class API extends \Piwik\Plugin\API
         if ($optionValue === false) {
             $defaultValue = $this->getDefaultUserPreference($preferenceName, $userLogin);
 
-            $this->setUserPreference($userLogin, $preferenceName, $defaultValue);
+            if ($defaultValue !== false) {
+                $this->setUserPreference($userLogin, $preferenceName, $defaultValue);
+            }
         }
     }
 
@@ -172,7 +174,10 @@ class API extends \Piwik\Plugin\API
         switch ($preferenceName) {
             case self::PREFERENCE_DEFAULT_REPORT:
                 $viewableSiteIds = \Piwik\Plugins\SitesManager\API::getInstance()->getSitesIdWithAtLeastViewAccess($login);
-                return reset($viewableSiteIds);
+                if (!empty($viewableSiteIds)) {
+                    return reset($viewableSiteIds);
+                }
+                return false;
             case self::PREFERENCE_DEFAULT_REPORT_DATE:
                 return Config::getInstance()->General['default_day'];
             default:


### PR DESCRIPTION
refs #7839 

Background: There is a task that sets the default preference "Report To Load By Default" for each user if none is configured yet. In my Piwik I had many entries in the option table (this is where those values are stored for each user) with an empty value `''` because many users do not have access to any site. Instead we should only set the default preference when there is actually a site.

Otherwise following scenario possible I think: User has stored a default preference for `defaultReport =''` because at time, when the task ran, the user did not have access to any site. Now a user gets permission to a site but default preference is still `''` meaning because of this check it will return `''` as preference and not the default preference: https://github.com/piwik/piwik/blob/2.13.0-rc3/plugins/UsersManager/API.php#L106
