### PR TITLE
Fixes #7708, in summary of XHProf output message, display warning if development mode is enabled.

### DIFF
--- a/core/Profiler.php
+++ b/core/Profiler.php
@@ -273,6 +273,12 @@ class Profiler
                 $out .= "<a href='$baseUrl'>$baseUrl</a>";
                 $out .= "\n\n";
 
+                if (Development::isEnabled()) {
+                    $out .= "WARNING: Development mode is enabled. Many runtime optimizations are not applied in development mode. ";
+                    $out .= "Unless you intend to profile Piwik in development mode, your profile may not be accurate.";
+                    $out .= "\n\n";
+                }
+
                 echo $out;
             } else {
                 Profiler::setProfilingRunIds($runs);


### PR DESCRIPTION
As title.

Refs #7708 
