### PR TITLE
Better tooltip for Live visitors button

### DIFF
--- a/plugins/Live/lang/en.json
+++ b/plugins/Live/lang/en.json
@@ -39,6 +39,8 @@
         "RowActionTooltipDefault": "Show Visitor Log segmented by this row",
         "RowActionTooltipWithDimension": "Show Visitor Log segmented by this %s",
         "RowActionTooltipTitle": "Open segmented Visitor Log",
-        "SegmentedVisitorLogTitle": "Visitor Log showing visits where %s is \"%s\""
+        "SegmentedVisitorLogTitle": "Visitor Log showing visits where %s is \"%s\"",
+        "OnClickPause": "%s is started. Click to pause.",
+        "OnClickStart": "%s is stopped. Click to start."
     }
 }

--- a/plugins/Live/templates/index.twig
+++ b/plugins/Live/templates/index.twig
@@ -35,10 +35,10 @@
 
 {% spaceless %}
 <div class="visitsLiveFooter">
-    <a title="Start Live!" href="javascript:void(0);" onclick="onClickPause();">
+    <a title="{{ 'Live_OnClickPause'|translate('Live_VisitorsInRealTime'|translate) }}" href="javascript:void(0);" onclick="onClickPause();">
         <img id="pauseImage" border="0" src="plugins/Live/images/pause.gif" />
     </a>
-    <a title="Pause Live!" href="javascript:void(0);" onclick="onClickPlay();">
+    <a title="{{ 'Live_OnClickStart'|translate('Live_VisitorsInRealTime'|translate) }}" href="javascript:void(0);" onclick="onClickPlay();">
         <img id="playImage" style="display: none;" border="0" src="plugins/Live/images/play.gif" />
     </a>
     {% if not disableLink %}


### PR DESCRIPTION
fixes #7474 

As suggested here: https://github.com/piwik/piwik/issues/7474#issuecomment-92021872

Although I did not use "Live! tracking is started/stopped" as I found it confusing as one could think one stops tracking when clicking on it.
