### PR TITLE
Average order value graph does not display any data

### DIFF
--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -366,7 +366,7 @@ class API extends \Piwik\Plugin\API
                 'idGoal'  => $idGoal,
                 'columns' => $columns,
                 'serialize' => '0',
-                'format_metrics' => '0'
+                'format_metrics' => 'bc'
             ));
 
             $tableSegmented->filter('Piwik\Plugins\Goals\DataTable\Filter\AppendNameToColumnNames',

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -401,13 +401,16 @@ class API extends \Piwik\Plugin\API
         $isEcommerceGoal = $idGoal === GoalManager::IDGOAL_ORDER || $idGoal === GoalManager::IDGOAL_CART;
 
         $allMetrics = Goals::getGoalColumns($idGoal);
-        $requestedColumns = Piwik::getArrayFromApiParameter($columns);
+        $columnsToShow = Piwik::getArrayFromApiParameter($columns);
+        $requestedColumns = $columnsToShow;
 
         $shouldAddAverageOrderRevenue = (in_array('avg_order_revenue', $requestedColumns) || empty($requestedColumns)) && $isEcommerceGoal;
 
         if ($shouldAddAverageOrderRevenue && !empty($requestedColumns)) {
+
             $avgOrder = new AverageOrderRevenue();
             $metricsToAdd = $avgOrder->getDependentMetrics();
+
             $requestedColumns = array_unique(array_merge($requestedColumns, $metricsToAdd));
         }
 
@@ -441,13 +444,14 @@ class API extends \Piwik\Plugin\API
         }
 
         // remove temporary metrics that were not explicitly requested
-        $allColumns = $allMetrics;
-        $allColumns[] = 'conversion_rate';
-        if ($isEcommerceGoal) {
-            $allColumns[] = 'avg_order_revenue';
+        if (empty($columnsToShow)) {
+            $columnsToShow = $allMetrics;
+            $columnsToShow[] = 'conversion_rate';
+            if ($isEcommerceGoal) {
+                $columnsToShow[] = 'avg_order_revenue';
+            }
         }
 
-        $columnsToShow = $requestedColumns ?: $allColumns;
         $dataTable->queueFilter('ColumnDelete', array($columnsToRemove = array(), $columnsToShow));
 
         return $dataTable;

--- a/tests/PHPUnit/System/EcommerceOrderWithItemsTest.php
+++ b/tests/PHPUnit/System/EcommerceOrderWithItemsTest.php
@@ -245,6 +245,16 @@ class EcommerceOrderWithItemsTest extends SystemTestCase
                 array($goalWeekApi, array('idSite'     => $idSite2, 'date' => $dateTime, 'periods' => array('week'),
                                           'testSuffix' => '_Website2')),
 
+                // see https://github.com/piwik/piwik/issues/7851 make sure avg_order_revenue is calculated correct
+                // even if only this column is given
+                array('Goals.get', array('idSite' => $idSite,
+                                         'date' => $dateTime,
+                                         'periods' => array('week'),
+                                         'otherRequestParameters' => array(
+                                           'idGoal' => Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER,
+                                            'columns' => 'avg_order_revenue'),
+                                         'testSuffix' => '_AvgOrderRevenue')),
+
            ),
             self::getApiForTestingScheduledReports($dateTime, 'week')
         );

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_AvgOrderRevenue__Goals.get_week.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_AvgOrderRevenue__Goals.get_week.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<avg_order_revenue>3337.78</avg_order_revenue>
+	<avg_order_revenue_new_visit>0</avg_order_revenue_new_visit>
+	<avg_order_revenue_returning_visit>3337.78</avg_order_revenue_returning_visit>
+</result>


### PR DESCRIPTION
fixes  #7851

There were 2 problems:
- `avg_order_revenue` depends on `revenue` and `conversion_rate` but when selecting `avg_order_revenue` only that metric was fetched, the dependent ones were not fetched
- `avg_order_revenue` was formatted eg to `$ 12.04` which resulted in `0` when converting to float. 
