### PR TITLE
If a GET piwik.php is done without any parameter, still return a HTTP 200

### DIFF
--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -74,7 +74,9 @@ class Response
             $this->outputApiResponse($tracker);
             Common::printDebug("Logging disabled, display transparent logo");
         } elseif (!$tracker->hasLoggedRequests()) {
-            Common::sendResponseCode(400);
+            if (!$this->isHttpGetRequest() || !empty($_GET) || !empty($_POST)) {
+                Common::sendResponseCode(400);
+            }
             Common::printDebug("Empty request => Piwik page");
             echo "<a href='/'>Piwik</a> is a free/libre web <a href='http://piwik.org'>analytics</a> that lets you keep control of your data.";
         } else {
@@ -100,13 +102,18 @@ class Response
 
     private function outputAccessControlHeaders()
     {
-        $requestMethod = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
-
-        if ($requestMethod !== 'GET') {
+        if (!$this->isHttpGetRequest()) {
             $origin = isset($_SERVER['HTTP_ORIGIN']) ? $_SERVER['HTTP_ORIGIN'] : '*';
             Common::sendHeader('Access-Control-Allow-Origin: ' . $origin);
             Common::sendHeader('Access-Control-Allow-Credentials: true');
         }
+    }
+
+    private function isHttpGetRequest()
+    {
+        $requestMethod = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
+
+        return strtoupper($requestMethod) === 'GET';
     }
 
     private function getOutputBuffer()

--- a/tests/PHPUnit/Integration/TrackerTest.php
+++ b/tests/PHPUnit/Integration/TrackerTest.php
@@ -19,7 +19,6 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Tracker;
 use Piwik\Tracker\RequestSet;
 use Piwik\Tracker\Request;
-use Piwik\Translate;
 
 class TestTracker extends Tracker
 {

--- a/tests/PHPUnit/System/TrackerResponseTest.php
+++ b/tests/PHPUnit/System/TrackerResponseTest.php
@@ -94,10 +94,21 @@ class TrackerResponseTest extends SystemTestCase
         $this->assertResponseCode(400, $url . '1'); // has to be 16 char, but is 17 now
     }
 
-    public function test_response_ShouldReturnPiwikMessage_InCaseOfEmptyRequest()
+    // See https://github.com/piwik/piwik/issues/7850 piwik.php is used by plugins and monitoring systems to test for Piwik installation.
+    // it is important to return a 200 if someone does a GET request with no parameters
+    public function test_response_ShouldReturnPiwikMessageWithHttp200_InCaseOfEmptyGETRequest()
     {
         $url = Fixture::getTrackerUrl();
-        $this->assertResponseCode(400, $url);
+        $this->assertResponseCode(200, $url);
+
+        $expected = "<a href='/'>Piwik</a> is a free/libre web <a href='http://piwik.org'>analytics</a> that lets you keep control of your data.";
+        $this->assertHttpResponseText($expected, $url);
+    }
+
+    public function test_response_ShouldReturnPiwikMessageWithHttp400_InCaseOfInvalidRequestOrIfNothingIsTracked()
+    {
+        $url = Fixture::getTrackerUrl();
+        $this->assertResponseCode(400, $url . '?rec=1');
 
         $expected = "<a href='/'>Piwik</a> is a free/libre web <a href='http://piwik.org'>analytics</a> that lets you keep control of your data.";
         $this->assertHttpResponseText($expected, $url);


### PR DESCRIPTION
As soon as it is not a HTTP GET or if there are any parameters given etc we will still return a HTTP 400 do indicate we did actually not track anything

refs #7850
