### PR TITLE
Visit Overview (with graph) widget targets correct graph

### DIFF
--- a/plugins/VisitsSummary/Controller.php
+++ b/plugins/VisitsSummary/Controller.php
@@ -44,13 +44,13 @@ class Controller extends \Piwik\Plugin\Controller
         return $view->render();
     }
 
-	// sparkline.js:81 dataTable.trigger('reload', …); does not remove the old headline,
-	// so when updating this graph (such as when selecting a different metric)
-	// ONLY the graph should be returned
-	public function getIndexGraph()
-	{
-		return $this->getEvolutionGraph(array(), array(), __FUNCTION__);
-	}
+    // sparkline.js:81 dataTable.trigger('reload', …); does not remove the old headline,
+    // so when updating this graph (such as when selecting a different metric)
+    // ONLY the graph should be returned
+    public function getIndexGraph()
+    {
+        return $this->getEvolutionGraph(array(), array(), __FUNCTION__);
+    }
 
     public function getSparklines()
     {
@@ -114,8 +114,8 @@ class Controller extends \Piwik\Plugin\Controller
             $selectableColumns[] = 'nb_searches';
             $selectableColumns[] = 'nb_keywords';
         }
-		// $callingAction may be specified to distinguish between
-		// "VisitsSummary_WidgetLastVisits" and "VisitsSummary_WidgetOverviewGraph"
+        // $callingAction may be specified to distinguish between
+        // "VisitsSummary_WidgetLastVisits" and "VisitsSummary_WidgetOverviewGraph"
         $view = $this->getLastUnitGraphAcrossPlugins($this->pluginName, $callingAction, $columns,
             $selectableColumns, $documentation);
 

--- a/plugins/VisitsSummary/Controller.php
+++ b/plugins/VisitsSummary/Controller.php
@@ -39,7 +39,7 @@ class Controller extends \Piwik\Plugin\Controller
     {
         $view = new View('@VisitsSummary/index');
         $this->setPeriodVariablesView($view);
-        $view->graphEvolutionVisitsSummary = $this->getEvolutionGraph(array(), array('nb_visits'));
+        $view->graphEvolutionVisitsSummary = $this->getEvolutionGraph(array(), array('nb_visits'), __FUNCTION__);
         $this->setSparklinesAndNumbers($view);
         return $view->render();
     }
@@ -52,7 +52,7 @@ class Controller extends \Piwik\Plugin\Controller
         return $view->render();
     }
 
-    public function getEvolutionGraph(array $columns = array(), array $defaultColumns = array())
+    public function getEvolutionGraph(array $columns = array(), array $defaultColumns = array(), $callingAction = __FUNCTION__)
     {
         if (empty($columns)) {
             $columns = Common::getRequestVar('columns', false);
@@ -106,8 +106,7 @@ class Controller extends \Piwik\Plugin\Controller
             $selectableColumns[] = 'nb_searches';
             $selectableColumns[] = 'nb_keywords';
         }
-
-        $view = $this->getLastUnitGraphAcrossPlugins($this->pluginName, __FUNCTION__, $columns,
+        $view = $this->getLastUnitGraphAcrossPlugins($this->pluginName, $callingAction, $columns,
             $selectableColumns, $documentation);
 
         if (empty($view->config->columns_to_display) && !empty($defaultColumns)) {

--- a/plugins/VisitsSummary/Controller.php
+++ b/plugins/VisitsSummary/Controller.php
@@ -39,10 +39,18 @@ class Controller extends \Piwik\Plugin\Controller
     {
         $view = new View('@VisitsSummary/index');
         $this->setPeriodVariablesView($view);
-        $view->graphEvolutionVisitsSummary = $this->getEvolutionGraph(array(), array('nb_visits'), __FUNCTION__);
+        $view->graphEvolutionVisitsSummary = $this->getEvolutionGraph(array(), array('nb_visits'), 'getIndexGraph');
         $this->setSparklinesAndNumbers($view);
         return $view->render();
     }
+
+	// sparkline.js:81 dataTable.trigger('reload', …); does not remove the old headline,
+	// so when updating this graph (such as when selecting a different metric)
+	// ONLY the graph should be returned
+	public function getIndexGraph()
+	{
+		return $this->getEvolutionGraph(array(), array(), __FUNCTION__);
+	}
 
     public function getSparklines()
     {
@@ -106,6 +114,8 @@ class Controller extends \Piwik\Plugin\Controller
             $selectableColumns[] = 'nb_searches';
             $selectableColumns[] = 'nb_keywords';
         }
+		// $callingAction may be specified to distinguish between
+		// "VisitsSummary_WidgetLastVisits" and "VisitsSummary_WidgetOverviewGraph"
         $view = $this->getLastUnitGraphAcrossPlugins($this->pluginName, $callingAction, $columns,
             $selectableColumns, $documentation);
 

--- a/plugins/VisitsSummary/templates/index.twig
+++ b/plugins/VisitsSummary/templates/index.twig
@@ -1,6 +1,6 @@
 {# This graphId must be unique for this report #}
 <h2 piwik-enriched-headline
-    data-graph-id="VisitsSummary.index"
+    data-graph-id="VisitsSummary.getIndexGraph"
         >{{ 'General_EvolutionOverPeriod'|translate }}</h2>
 
 {{ graphEvolutionVisitsSummary|raw }}

--- a/plugins/VisitsSummary/templates/index.twig
+++ b/plugins/VisitsSummary/templates/index.twig
@@ -1,6 +1,6 @@
 {# This graphId must be unique for this report #}
 <h2 piwik-enriched-headline
-    data-graph-id="VisitsSummary.getEvolutionGraph"
+    data-graph-id="VisitsSummary.index"
         >{{ 'General_EvolutionOverPeriod'|translate }}</h2>
 
 {{ graphEvolutionVisitsSummary|raw }}


### PR DESCRIPTION
"Visit Overview (with graph)" and "Visits Over Time" widgets use the same action name when calling `getLastUnitGraphAcrossPlugins`, which can lead to "Visit Overview (with graph)" targeting the wrong graph when clicking on one of the metrics listed under "Report". This not only leads to the scrolling behavior described in #7086, but it also updates the wrong graph!

By adding an optional parameter to the `getEvolutionGraph` method, the actual calling action can be specified. In this case, by passing through the "index" action name, "Visits Overview (with graph)" can be distinguished from "Visits Over Time".
