### PR TITLE
New design for alerts and notifications

### DIFF
--- a/plugins/CoreAdminHome/stylesheets/generalSettings.less
+++ b/plugins/CoreAdminHome/stylesheets/generalSettings.less
@@ -69,16 +69,6 @@ table.admin  tbody td:hover, table.admin  tbody th:hover {
     text-decoration: none;
 }
 
-.warning {
-    border: 1px dotted gray;
-    padding: 15px;
-    font-size: .8em;
-}
-
-.warning ul {
-    margin-left: 50px;
-}
-
 .access_error {
     font-size: .7em;
     padding: 15px;

--- a/plugins/CoreHome/angularjs/notification/notification.directive.less
+++ b/plugins/CoreHome/angularjs/notification/notification.directive.less
@@ -1,90 +1,34 @@
-.admin .system.notification {
-  a {
-    color: #9b7a44;
-  }
-}
-
 .system.notification {
-  color: #9b7a44;
-  float: none;
+  .alert;
 
-  padding: 15px 35px 15px 15px;
-  text-shadow: 0 1px 0 rgba(255,255,255,.5);
-  background-color: #ffffe0;
-  border: 1px solid #e6db55;
-  border-radius: 3px;
-  font-size: 14px;
-  margin: 0px;
-  margin-bottom: 16px;
-
-  a {
-    color: #9b7a44;
-    text-decoration: underline;
-  }
-
+  // We have to use !important because the default button style is crazy
   .close {
     position: relative;
     top: -5px;
-    right: -28px;
-    line-height: 20px;
-  }
-
-  button.close {
-    padding: 0;
-    cursor: pointer;
-    background: transparent;
-    border: 0;
-    -webkit-appearance: none;
-  }
-  .close {
+    right: -10px;
+    padding: 0 !important;
+    background: transparent !important;
+    border: none !important;
     float: right;
-    font-size: 20px;
+    font-size: 20px !important;
     font-weight: bold;
-    line-height: 20px;
-    color: #000000;
-    text-shadow: 0 1px 0 #ffffff;
-    opacity: 0.2;
-    filter: alpha(opacity=20);
+    line-height: 20px !important;
+    color: inherit !important;
+    opacity: 0.3;
+    filter: alpha(opacity=30);
   }
 
   &.notification-success {
-    background-color: #dff0d8;
-    border-color: #c3d6b7;
-    color: #468847;
-
-    a {
-      color: #468847
-    }
+    .alert-success;
+  }
+  &.notification-warning {
+    .alert-warning;
   }
   &.notification-danger,
   &.notification-error {
-    background-color: #f2dede;
-    border-color: #d5bfc4;
-    color: #b94a48;
-
-    a {
-      color: #b94a48
-    }
+    .alert-danger;
   }
   &.notification-info {
-    background-color: #d9edf7;
-    border-color: #a7d3e3;
-    color: #3a87ad;
-
-    a {
-      color: #3a87ad
-    }
-  }
-
-  &.notification-block {
-    padding-top: 14px;
-    padding-bottom: 14px;
-  }
-  &.notification-block > p,
-  &.notification-block > ul {
-    margin-bottom: 0;
-  }
-  &.notification-block p + p {
-    margin-top: 5px;
+    .alert-info;
   }
 }

--- a/plugins/Morpheus/stylesheets/ui/_alerts.less
+++ b/plugins/Morpheus/stylesheets/ui/_alerts.less
@@ -4,11 +4,15 @@
     margin-bottom: 20px;
     border: 1px solid transparent;
     border-radius: 2px;
+    font-size: 14px;
+    a {
+        color: inherit;
+        text-decoration: underline;
+    }
 }
 .alert-success {
-    color: #3c763d;
-    background-color: #dff0d8;
-    border-color: #d6e9c6;
+    color: #009874;
+    border-color: #1AA282;
 }
 .alert-info {
     color: #B3B3B3;
@@ -18,12 +22,10 @@
     padding: 15px 20px;
 }
 .alert-warning {
-    color: #8a6d3b;
-    background-color: #fcf8e3;
-    border-color: #faebcc;
+    color: #DF9D27;
+    border-color: #DF9D27;
 }
 .alert-danger {
-    color: #E0645D;
-    background: none;
-    border-color: #D4291F;
+    color: #D4291F;
+    border-color: #D73F36;
 }

--- a/plugins/Morpheus/templates/demo.twig
+++ b/plugins/Morpheus/templates/demo.twig
@@ -181,22 +181,22 @@
         <h2>Alerts</h2>
 
         <div class="demo">
-            <div class="alert alert-success">
-                <strong>Well done!</strong> You successfully read this important alert message.
-            </div>
             <div class="alert alert-info">
-                <strong>Heads up!</strong> This alert needs your attention, but it's not super important.
+                <strong>Info!</strong> This alert needs <a>your attention</a>, but it's not super important.
+            </div>
+            <div class="alert alert-success">
+                <strong>Success!</strong> You successfully read this important <a>alert message</a>.
             </div>
             <div class="alert alert-warning">
-                <strong>Warning!</strong> Better check yourself, you're not looking too good.
+                <strong>Warning!</strong> Better <a>check</a> yourself, you're not looking too good.
             </div>
             <div class="alert alert-danger">
-                <strong>Oh snap!</strong> Change a few things up and try submitting again.
+                <strong>Error!</strong> Change <a>a few things</a> up and try submitting again.
             </div>
         </div>
         <div class="demo-code">
-            <pre>&lt;div class=&quot;alert alert-success&quot;&gt;...&lt;/div&gt;
-&lt;div class=&quot;alert alert-info&quot;&gt;...&lt;/div&gt;
+            <pre>&lt;div class=&quot;alert alert-info&quot;&gt;...&lt;/div&gt;
+&lt;div class=&quot;alert alert-success&quot;&gt;...&lt;/div&gt;
 &lt;div class=&quot;alert alert-warning&quot;&gt;...&lt;/div&gt;
 &lt;div class=&quot;alert alert-danger&quot;&gt;...&lt;/div&gt;</pre>
         </div>

--- a/plugins/Morpheus/templates/genericForm.twig
+++ b/plugins/Morpheus/templates/genericForm.twig
@@ -1,6 +1,5 @@
 {% if form_data.errors %}
-	<div class="warning">
-		<img src="plugins/Morpheus/images/warning_medium.png">
+	<div class="alert alert-warning">
 		<strong>{{ 'Installation_PleaseFixTheFollowingErrors'|translate }}:</strong>
 		<ul>
             {% for data in form_data.errors %}

--- a/plugins/SegmentEditor/stylesheets/segmentation.less
+++ b/plugins/SegmentEditor/stylesheets/segmentation.less
@@ -652,10 +652,6 @@ a.metric_category {
   content: ".";
 }
 
-.notification {
-  float: left;
-}
-
 .metricValueBlock input {
   padding: 8px !important;
 }


### PR DESCRIPTION
#7585

The new design was proposed by Rafa's mockup for the installer, updater and admin screens (example [here](https://github.com/piwik/piwik/issues/7584#issuecomment-100681915)): I have applied the same consistent style everywhere.

I have also simplified Less rules as much as possible: UI notifications now use alert CSS classes. To make things clear:
- alert CSS classes allow to create alert blocks anywhere in the page (e.g. used in the installer, updater, admin screens, etc.), these are part of the content and are static
- notifications are used using JS or the PHP api and are displayed dynamically at the top of the page to notify the user of something: notifications are currently styled using alert CSS classes (which could change in the future)

Screenshot:

![capture d ecran 2015-05-11 a 07 51 25](https://cloud.githubusercontent.com/assets/720328/7555784/a370cc8e-f7b2-11e4-91c4-925f6e1216f7.png)

Code:

``` html
<div class="alert alert-info">...</div>
<div class="alert alert-success">...</div>
<div class="alert alert-warning">...</div>
<div class="alert alert-danger">...</div>
```

Those are based on [Bootstrap alerts](http://getbootstrap.com/components/#alerts) (but FYI we are still not using Bootstrap).

The alerts currently lack the icons, the new icon set is under development.
