### PR TITLE
Make sure to apply the limit filter on sites and groups

### DIFF
--- a/plugins/MultiSites/DataTable/Filter/NestedSitesLimiter.php
+++ b/plugins/MultiSites/DataTable/Filter/NestedSitesLimiter.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\MultiSites\DataTable\Filter;
+
+use Piwik\DataTable\BaseFilter;
+use Piwik\DataTable\Row;
+use Piwik\DataTable;
+
+/**
+ * Makes sure to not have any subtables anymore and applies the limit to the flattened table.
+ *
+ * So if $table is
+ * array(
+ *    site1
+ *    group2
+ *        subtable => site3
+ *                    site4
+ *                    site5
+ *    site6
+ *    site7
+ * )
+ *
+ * it will format this to
+ *
+ * array(
+ *    site1
+ *    group2
+ *    site3
+ *    site4
+ *    site5
+ *    site6
+ *    site7
+ * )
+ *
+ * and then apply the limit filter.
+ *
+ * Each group will not count into the limit/offset. This way, if one requests a limit of 50 sites,
+ * we make sure to return 50 sites.
+ *
+ * @param $sites
+ * @return array
+ */
+class NestedSitesLimiter extends BaseFilter
+{
+    private $offset = 0;
+    private $limit  = 0;
+    /**
+     * @var Row[]
+     */
+    private $rows   = array();
+
+    /**
+     * Constructor.
+     *
+     * @param DataTable $table The table to eventually filter.
+     */
+    public function __construct($table, $offset, $limit)
+    {
+        parent::__construct($table);
+        $this->offset = $offset;
+        $this->limit  = $limit;
+    }
+
+    /**
+     * @param DataTable $table
+     */
+    public function filter($table)
+    {
+        $numRows = 0;
+        $lastGroupFromPreviousPage = null;
+
+        foreach ($table->getRows() as $row) {
+
+            $this->addRowIfNeeded($row, $numRows);
+            $numRows++;
+
+            $subtable = $row->getSubtable();
+            if ($subtable) {
+                if (!$this->hasRows()) {
+                    $lastGroupFromPreviousPage = $row;
+                }
+                foreach ($subtable->getRows() as $subRow) {
+                    $this->addRowIfNeeded($subRow, $numRows);
+                    $numRows++;
+                }
+                $row->removeSubtable();
+            }
+
+            if ($this->hasNumberOfRequestedRowsFound()) {
+                break;
+            }
+        }
+
+        $this->prependGroupIfFirstSiteBelongsToAGroupButGroupIsMissingInRows($lastGroupFromPreviousPage);
+
+        $table->setRows($this->rows);
+    }
+
+    private function hasNumberOfRequestedRowsFound()
+    {
+        return count($this->rows) >= $this->limit;
+    }
+
+    private function hasRows()
+    {
+        return count($this->rows) !== 0;
+    }
+
+    private function addRowIfNeeded(Row $row, $numRows)
+    {
+        $inOffset = $numRows >= $this->offset;
+
+        if ($inOffset && !$this->hasNumberOfRequestedRowsFound()) {
+            $this->rows[] = $row;
+        }
+    }
+
+    /**
+     * @param Row $lastGroupFromPreviousPage
+     */
+    private function prependGroupIfFirstSiteBelongsToAGroupButGroupIsMissingInRows($lastGroupFromPreviousPage)
+    {
+        if ($lastGroupFromPreviousPage && !empty($this->rows)) {
+            // the result starts with a row that does belong to a group, we make sure to show this group before that site
+            $group = reset($this->rows)->getMetadata('group');
+            if ($group && $lastGroupFromPreviousPage->getColumn('label') === $group) {
+                array_unshift($this->rows, $lastGroupFromPreviousPage);
+                // we do not remove the last item as it could result in errors, instead we show $limit+1 entries
+            }
+        }
+    }
+}


### PR DESCRIPTION
fixes #7854

Apart from this it also fixes the following issues:
- Make dashboard much faster again if having many sites
- Show the correct number of available sites in the All Websites Dashboard (groups were not counted)
- If the first site of a dashboard belongs to a group, we make sure this group will be shown as well at the very beginning. 

Roughly the problem was the following:

When requesting all the sites we move the sites having a group into group rows. This is basically a structure like this:

```
 * array(
 *    site1
 *    group2
 *        subtable => site3
 *                    site4
 *                    site5
 *    site6
 *    site7
 * )
```

When eg `offset 3, limit 2` was requested, only the `site 7` was returned as the offset was applied only on the first level. I tried different implementations and ways to solve this. I do now implement a custom limit filter that is applied after sort (generic filter) and before all others. Basically I turn this array into a flat structure like this

```
 * array(
 *    site1
 *    group2
 *    site3
 *    site4
 *    site5
 *    site6
 *    site7
 * )
```

and then apply the filter. In the past logic we turned all the sites into such a flat array after all filters were run but we have to do it actually after the generic filters were run to make sure we do not apply all the queued filters and processed metrics on all rows.

I tested it with 33k sites and it was quite fast. Especially since people usually do not page through 100 pages.
