### PR TITLE
Fixes #7774 column headers missing in RowEvolution graph export.

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/Graph.php
+++ b/plugins/CoreVisualizations/Visualizations/Graph.php
@@ -59,7 +59,6 @@ abstract class Graph extends Visualization
             $this->requestConfig->request_parameters_to_modify['filter_truncate'] = $this->config->max_graph_elements - 1;
         }
 
-        // TODO: let's add UI tests for export links. they should not compare screenshots, but compare output. will need to use page renderer after a page is loaded.
         $this->requestConfig->request_parameters_to_modify['format_metrics'] = 1;
 
         $this->metricsFormatter = new Numeric();

--- a/plugins/CoreVisualizations/Visualizations/Graph.php
+++ b/plugins/CoreVisualizations/Visualizations/Graph.php
@@ -59,6 +59,7 @@ abstract class Graph extends Visualization
             $this->requestConfig->request_parameters_to_modify['filter_truncate'] = $this->config->max_graph_elements - 1;
         }
 
+        // TODO: let's add UI tests for export links. they should not compare screenshots, but compare output. will need to use page renderer after a page is loaded.
         $this->requestConfig->request_parameters_to_modify['format_metrics'] = 1;
 
         $this->metricsFormatter = new Numeric();

--- a/plugins/CoreVisualizations/Visualizations/Graph.php
+++ b/plugins/CoreVisualizations/Visualizations/Graph.php
@@ -59,7 +59,6 @@ abstract class Graph extends Visualization
             $this->requestConfig->request_parameters_to_modify['filter_truncate'] = $this->config->max_graph_elements - 1;
         }
 
-        $this->requestConfig->request_parameters_to_modify['disable_queued_filters'] = 1;
         $this->requestConfig->request_parameters_to_modify['format_metrics'] = 1;
 
         $this->metricsFormatter = new Numeric();

--- a/tests/UI/specs/ReportExporting_spec.js
+++ b/tests/UI/specs/ReportExporting_spec.js
@@ -1,0 +1,48 @@
+/*!
+ * Piwik - free/libre analytics platform
+ *
+ * Export link screenshot tests.
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe("ReportExporting", function () {
+    this.timeout(0);
+
+    var baseUrl = "?module=Widgetize&action=iframe&idSite=1&period=year&date=2012-08-09&isFooterExpandedInDashboard=1",
+        referrersGetWebsitesUrl = baseUrl + "&moduleToWidgetize=Referrers&actionToWidgetize=getWebsites&viewDataTable=table&filter_limit=5",
+        visitsSummaryGetUrl = baseUrl + "&moduleToWidgetize=VisitsSummary&actionToWidgetize=get&viewDataTable=graphEvolution";
+
+    function normalReportTest(format) {
+        it("should export a normal report correctly when the " + format + " export link is clicked", function (done) {
+            expect.file('Referrers.getWebsites_exported.' + format.toLowerCase() + '.txt').to.be.pageContents(function (page) {
+                if (page.getCurrentUrl() != referrersGetWebsitesUrl) {
+                    page.load(referrersGetWebsitesUrl);
+                }
+
+                page.click('a.tableIcon[var=export]');
+                page.click('a.tableIcon[var=export]'); // have to click twice in phantomjs
+                page.downloadLink('.exportToFormatItems a[format=' + format + ']');
+            }, done);
+        });
+    }
+
+    function evolutionReportTest(format) {
+        it("should export an evolution graph report correclty when the " + format + " export link is clicked", function (done) {
+            expect.file('VisitsSummary.get_exported.' + format.toLowerCase() + '.txt').to.be.pageContents(function (page) {
+                if (page.getCurrentUrl() != visitsSummaryGetUrl) {
+                    page.load(visitsSummaryGetUrl);
+                }
+
+                page.click('a.tableIcon[var=export]');
+                page.click('a.tableIcon[var=export]'); // have to click twice in phantomjs
+                page.downloadLink('.exportToFormatItems a[format=' + format + ']');
+            }, done);
+        });
+    }
+
+    var formats = ['CSV', 'TSV', 'XML', 'JSON', 'PHP'];
+    formats.forEach(normalReportTest);
+    formats.forEach(evolutionReportTest);
+});

--- a/tests/UI/specs/ReportExporting_spec.js
+++ b/tests/UI/specs/ReportExporting_spec.js
@@ -19,10 +19,10 @@ describe("ReportExporting", function () {
             expect.file('Referrers.getWebsites_exported.' + format.toLowerCase() + '.txt').to.be.pageContents(function (page) {
                 if (page.getCurrentUrl() != referrersGetWebsitesUrl) {
                     page.load(referrersGetWebsitesUrl);
+                    page.click('a.tableIcon[var=export]');
+                    page.click('a.tableIcon[var=export]'); // have to click twice in phantomjs
                 }
 
-                page.click('a.tableIcon[var=export]');
-                page.click('a.tableIcon[var=export]'); // have to click twice in phantomjs
                 page.downloadLink('.exportToFormatItems a[format=' + format + ']');
             }, done);
         });
@@ -33,11 +33,28 @@ describe("ReportExporting", function () {
             expect.file('VisitsSummary.get_exported.' + format.toLowerCase() + '.txt').to.be.pageContents(function (page) {
                 if (page.getCurrentUrl() != visitsSummaryGetUrl) {
                     page.load(visitsSummaryGetUrl);
+                    page.click('a.tableIcon[var=export]');
+                    page.click('a.tableIcon[var=export]'); // have to click twice in phantomjs
                 }
 
-                page.click('a.tableIcon[var=export]');
-                page.click('a.tableIcon[var=export]'); // have to click twice in phantomjs
                 page.downloadLink('.exportToFormatItems a[format=' + format + ']');
+            }, done);
+        });
+    }
+
+    function rowEvolutionReportTest(format) {
+        it("should export an row evolution graph report correclty when the " + format + " export link is clicked", function (done) {
+            expect.file('RowEvolution_exported.' + format.toLowerCase() + '.txt').to.be.pageContents(function (page) {
+                if (!page.getCurrentUrl() || page.getCurrentUrl().indexOf('popover') == -1) {
+                    page.load(referrersGetWebsitesUrl);
+                    page.mouseMove('tbody tr:first-child');
+                    page.mouseMove('a.actionRowEvolution:visible'); // necessary to get popover to display
+                    page.click('a.actionRowEvolution:visible');
+
+                    page.click('.ui-dialog a.tableIcon[var=export]');
+                }
+
+                page.downloadLink('.ui-dialog .exportToFormatItems a[format=' + format + ']');
             }, done);
         });
     }
@@ -45,4 +62,5 @@ describe("ReportExporting", function () {
     var formats = ['CSV', 'TSV', 'XML', 'JSON', 'PHP'];
     formats.forEach(normalReportTest);
     formats.forEach(evolutionReportTest);
+    formats.forEach(rowEvolutionReportTest);
 });


### PR DESCRIPTION
This PR includes the small fix mentioned in a comment by @tsteur as well as UI tests for the report exporting feature. The new tests download the export links in phantomjs and compare the contents w/ expected files. To do this, I've added a new keyword `file` and a new assertion `pageContents`, which can be used as follows:

```
expect.file('file.xml').to.be.pageContents(function (page) {
   // ...
});
```

There is also a new page renderer method `downloadLink` which hacks around one of phantomjs' limitations. phantomjs will not display non-HTML files by default, so we can't just click an export link. Instead, we have to download via AJAX and set the page contents manually.

Refs #7774
