### PR TITLE
New design for default tables

### DIFF
--- a/plugins/Installation/stylesheets/installation.css
+++ b/plugins/Installation/stylesheets/installation.css
@@ -65,16 +65,9 @@ p.next-step:first-child {
     margin-top: 0;
 }
 
-table {
-    margin: 20px 0;
-    width: 100%;
-}
-th, td {
-    border-top: 1px solid #cccccc;
-    padding: 8px;
-}
-tr:nth-of-type(odd) {
-    background-color: #FAFAFA;
+/* This rule is duplicated here from systemCheckPage.less */
+.system-check td:first-child {
+    width: 40%;
 }
 
 /* Form classes that we can't change */

--- a/plugins/Installation/stylesheets/systemCheckPage.less
+++ b/plugins/Installation/stylesheets/systemCheckPage.less
@@ -1,24 +1,5 @@
-#systemCheckOptional,
-#systemCheckRequired {
-    width: 100%;
-    max-width: 900px;
-}
-
-#systemCheckOptional {
-    margin-bottom: 2em;
-}
-
-#systemCheckOptional td,
-#systemCheckRequired td {
-    padding: 1em .5em 1em 2em;
-    vertical-align: middle;
-    margin: 0;
-    min-width: 200px;
-}
-
-#systemCheckOptional tr,
-#systemCheckRequired tr {
-    background-color: #f2f2f2;
+.system-check td:first-child {
+    width: 40%;
 }
 
 .error {

--- a/plugins/Installation/templates/_systemCheckSection.twig
+++ b/plugins/Installation/templates/_systemCheckSection.twig
@@ -1,12 +1,12 @@
 {% import _self as local %}
 
-<table class="table system-check" id="systemCheckRequired">
+<table class="simple-table system-check" id="systemCheckRequired">
     {{ local.diagnosticTable(diagnosticReport.getMandatoryDiagnosticResults()) }}
 </table>
 
 <h3>{{ 'Installation_Optional'|translate }}</h3>
 
-<table class="table system-check" id="systemCheckOptional">
+<table class="simple-table system-check" id="systemCheckOptional">
     {{ local.diagnosticTable(diagnosticReport.getOptionalDiagnosticResults()) }}
 </table>
 

--- a/plugins/Installation/templates/_systemCheckSection.twig
+++ b/plugins/Installation/templates/_systemCheckSection.twig
@@ -1,12 +1,12 @@
 {% import _self as local %}
 
-<table class="infosServer" id="systemCheckRequired">
+<table class="table system-check" id="systemCheckRequired">
     {{ local.diagnosticTable(diagnosticReport.getMandatoryDiagnosticResults()) }}
 </table>
 
 <h3>{{ 'Installation_Optional'|translate }}</h3>
 
-<table class="infos" id="systemCheckOptional">
+<table class="table system-check" id="systemCheckOptional">
     {{ local.diagnosticTable(diagnosticReport.getOptionalDiagnosticResults()) }}
 </table>
 
@@ -21,7 +21,7 @@
 
     {% for result in results %}
         <tr>
-            <td class="label">{{ result.label }}</td>
+            <td>{{ result.label }}</td>
             <td>
                 {% for item in result.items %}
 

--- a/plugins/Morpheus/stylesheets/base.less
+++ b/plugins/Morpheus/stylesheets/base.less
@@ -38,6 +38,7 @@
 @import "bootstrap.css";
 
 @import "ui/_code";
+@import "ui/_tables";
 @import "ui/_alerts";
 @import "ui/_list-group";
 @import "ui/_progress-bars";

--- a/plugins/Morpheus/stylesheets/ui/_tables.less
+++ b/plugins/Morpheus/stylesheets/ui/_tables.less
@@ -1,0 +1,15 @@
+// We have to use a class (and not <table> directly) because HTML tables
+// are used for layouts (e.g. forms in the admin section use tables)
+.table {
+    margin: 20px 0;
+    width: 100%;
+    border-top: 1px solid @theme-color-border;
+
+    th, td {
+        border-bottom: 1px solid @theme-color-border;
+        padding: 14px;
+    }
+    th {
+        text-align: left;
+    }
+}

--- a/plugins/Morpheus/stylesheets/ui/_tables.less
+++ b/plugins/Morpheus/stylesheets/ui/_tables.less
@@ -1,6 +1,7 @@
 // We have to use a class (and not <table> directly) because HTML tables
 // are used for layouts (e.g. forms in the admin section use tables)
-.table {
+// TODO refactor that: https://github.com/piwik/piwik/issues/8023
+.simple-table {
     margin: 20px 0;
     width: 100%;
     border-top: 1px solid @theme-color-border;

--- a/plugins/Morpheus/templates/demo.twig
+++ b/plugins/Morpheus/templates/demo.twig
@@ -271,7 +271,7 @@
         <h2>Tables</h2>
 
         <div class="demo">
-            <table class="table">
+            <table>
                 <thead>
                 <tr>
                     <th>First Name</th>
@@ -299,7 +299,7 @@
             </table>
         </div>
         <div class="demo-code">
-            <pre>&lt;table class="table"&gt;...&lt;/table&gt;</pre>
+            <pre>&lt;table&gt;...&lt;/table&gt;</pre>
         </div>
 
     </div>

--- a/plugins/Morpheus/templates/demo.twig
+++ b/plugins/Morpheus/templates/demo.twig
@@ -271,7 +271,7 @@
         <h2>Tables</h2>
 
         <div class="demo">
-            <table>
+            <table class="table">
                 <thead>
                 <tr>
                     <th>First Name</th>
@@ -297,6 +297,9 @@
                 </tr>
                 </tbody>
             </table>
+        </div>
+        <div class="demo-code">
+            <pre>&lt;table class="table"&gt;...&lt;/table&gt;</pre>
         </div>
 
     </div>

--- a/plugins/Morpheus/templates/genericForm.twig
+++ b/plugins/Morpheus/templates/genericForm.twig
@@ -11,7 +11,7 @@
 
 <form {{ form_data.attributes|raw }}>
 	<div class="centrer">
-		<table class="centrer">
+		<table class="centrer simple-table">
             {% for fieldname in element_list %}
 				{% if form_data[fieldname].type == 'checkbox' %}
 					<tr>


### PR DESCRIPTION
This PR introduces a base `table` CSS class that can be used to create simple tables:

``` html
<table class="table">...</table>
```

I have not styled all `<table>` tags directly because it would affect anywhere else we use tables for not displaying tables (which shouldn't happen in theory ;) but actually happens a lot, e.g. all admin forms…).

The need for this is the system check in the installer/admin (see #7875): it has been redesigned during the Installer redesign, and rather to have a specific CSS for that it's better to have a simple CSS class for tables (since currently it's not possible to create a simple table in Piwik: as you can see in the demo it looks broken).
### Current system check

![capture d ecran 2015-05-13 a 11 32 06](https://cloud.githubusercontent.com/assets/720328/7600889/25372daa-f964-11e4-879a-d2c6648943bc.png)
### Target (redesign mockup)

This is Rafa's mockup I have used as target:

![](https://cloud.githubusercontent.com/assets/720328/7555815/2cb844d0-f7b4-11e4-9058-2eed0faf93e9.png)
### New system check/simple tables

![capture d ecran 2015-05-13 a 11 31 25](https://cloud.githubusercontent.com/assets/720328/7600892/2b863660-f964-11e4-83c3-94dd92969b12.png)

Icons haven't been changed yet because #7618 is still open.

Once the build has finished I will also post a link to the UI demo screenshot diff so that you can see what the simple table looks like.
