### PR TITLE
New design for buttons

### DIFF
--- a/plugins/CoreAdminHome/stylesheets/generalSettings.less
+++ b/plugins/CoreAdminHome/stylesheets/generalSettings.less
@@ -2,11 +2,6 @@
     vertical-align: middle;;
 }
 
-.admin a {
-    color: black;
-    text-decoration: underline;
-}
-
 .admin h2 + .top_bar_sites_selector {
   margin-top: -62px;
   margin-right: 0px !important;

--- a/plugins/CoreAdminHome/templates/generalSettings.twig
+++ b/plugins/CoreAdminHome/templates/generalSettings.twig
@@ -314,7 +314,7 @@
                 {% endfor %}
             </ul>
             <div class="add-trusted-host-container">
-                <a href="#" class="add-trusted-host"><em>{{ 'General_Add'|translate }}</em></a>
+                <a href="#" class="btn add-trusted-host"><em>{{ 'General_Add'|translate }}</em></a>
             </div>
         {% endif %}
     </div>

--- a/plugins/CoreHome/angularjs/siteselector/siteselector.directive.less
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.directive.less
@@ -126,11 +126,11 @@ table.dataTable tr td .sites_autocomplete a {
 .sites_autocomplete .custom_select_search .inp {
   vertical-align: top;
   width: 165px;
-  padding: 2px 6px;
+  padding: 2px 6px !important;
   border: 0;
-  background: transparent;
+  background: transparent !important;
   font-size: 10px;
-  color: #454545;
+  color: #454545 !important;
 
 }
 .sites_autocomplete {

--- a/plugins/CoreHome/stylesheets/_donate.less
+++ b/plugins/CoreHome/stylesheets/_donate.less
@@ -71,10 +71,10 @@
 }
 
 .piwik-donate-call .donate-submit input {
-    margin-left: 13px;
+    margin-left: 13px !important;
     border-style: none;
     background-image: none;
-    padding: 0;
+    padding: 0 !important;
 }
 
 .piwik-donate-call .donate-submit a {

--- a/plugins/CoreHome/stylesheets/dataTable/_dataTable.less
+++ b/plugins/CoreHome/stylesheets/dataTable/_dataTable.less
@@ -229,7 +229,7 @@ div.dataTable, div.dataTable > .dataTableWrapper {
   width: 114px;
   height: auto;
   overflow: visible;
-  padding: 2px 6px;
+  padding: 2px 6px !important;
   opacity: 1;
   cursor: text;
   filter: Alpha(opacity=100);

--- a/plugins/CoreHome/templates/_periodSelect.twig
+++ b/plugins/CoreHome/templates/_periodSelect.twig
@@ -26,7 +26,7 @@
                 <br/>
             {% endfor %}
 			</span>
-            <input tabindex="3" type="submit" value="{{ 'General_ApplyDateRange'|translate }}" id="calendarRangeApply"/>
+            <input tabindex="3" type="submit" value="{{ 'General_ApplyDateRange'|translate }}" id="calendarRangeApply" class="btn"/>
             {% import 'ajaxMacros.twig' as ajax %}
             {{ ajax.loadingDiv('ajaxLoadingCalendar') }}
         </div>

--- a/plugins/CorePluginsAdmin/stylesheets/plugins_admin.less
+++ b/plugins/CorePluginsAdmin/stylesheets/plugins_admin.less
@@ -78,18 +78,9 @@ table.entityTable tr td a.uninstall {
         font-weight: bold;
     }
 
-    a {
-        color: @theme-color-link;
-        text-decoration: none;
-    }
-
     a .counter {
         color: #999999;
         font-weight: normal;
-    }
-
-    a:hover {
-        text-decoration: underline;
     }
 
     .status {

--- a/plugins/Dashboard/stylesheets/dashboard.less
+++ b/plugins/Dashboard/stylesheets/dashboard.less
@@ -443,3 +443,13 @@ div.widgetpreview-preview {
     display:none;
   }
 }
+
+.ui-button, .ui-dialog-titlebar-close {
+  .btn;
+  color: @theme-color-brand-contrast !important;
+  background-color: @theme-color-brand !important;
+  &:hover {
+    background: none;
+    background-color: transparent;
+  }
+}

--- a/plugins/Morpheus/stylesheets/base.less
+++ b/plugins/Morpheus/stylesheets/base.less
@@ -34,6 +34,7 @@
 /* Remote components */
 @import "../../CoreHome/stylesheets/_donate.less";
 
+@import "ui/_buttons";
 @import "ui/_code";
 @import "ui/_tables";
 @import "ui/_alerts";

--- a/plugins/Morpheus/stylesheets/general/_forms.less
+++ b/plugins/Morpheus/stylesheets/general/_forms.less
@@ -1,4 +1,4 @@
-input:not([type="checkbox"]), select, textarea {
+input:not([type="checkbox"]):not([type="submit"]):not([type="button"]), select, textarea {
     color: @theme-color-text;
     .border-radius(0px);
     margin-left: 0;
@@ -7,7 +7,7 @@ input:not([type="checkbox"]), select, textarea {
     .box-sizing(border-box);
     background: @theme-color-background-base;
 }
-.add-trusted-host,
+a.add-trusted-host,
 .add-cors-host,
 .submit {
     .btn;

--- a/plugins/Morpheus/stylesheets/general/_forms.less
+++ b/plugins/Morpheus/stylesheets/general/_forms.less
@@ -7,71 +7,10 @@ input:not([type="checkbox"]), select, textarea {
     .box-sizing(border-box);
     background: @theme-color-background-base;
 }
-button,
 .add-trusted-host,
 .add-cors-host,
-input[type="submit"],
-button[type="button"],
-.btn,
 .submit {
-    .border-radius(3px) !important;
-    background: none !important;
-    background-color: @theme-color-brand !important;
-    #gradient > .vertical(rgba(255,255,255,.15), rgba(255,255,255,0)) !important;
-    .font-default(12px, 16px) !important;
-    color: @theme-color-brand-contrast !important;;
-    font-weight: normal;
-    padding: 5px 15px !important;
-    text-align: center;
-    text-decoration: none !important;
-    cursor: pointer;
-    border: 0px !important;
-    &:hover {
-        background: @theme-color-brand !important;
-        background-color: @theme-color-brand !important;
-    }
-
-    em {
-        font-style: normal;
-    }
-    &.ui-dialog-titlebar-close {
-        &:hover {
-            background: none !important;
-            background-color: none !important;
-        }
-    }
-}
-// Bootstrap classes (can be removed in the future)
-.btn {
-    display: inline-block;
-}
-.btn-lg {
-    padding: 12px 40px !important;;
-    font-size: 14px !important;;
-}
-.btn-block {
-    display: block;
-    width: 100%;
-}
-.btn.disabled, .btn[disabled], fieldset[disabled] .btn {
-    pointer-events: none;
-    cursor: not-allowed;
-    filter: alpha(opacity=65);
-    opacity: .65;
-}
-// See http://getbootstrap.com/css/#buttons-options
-.btn.btn-link {
-    // We have to use !important unfortunately because the default button style uses it...
-    background: transparent !important;
-    color: @theme-color-link !important;
-    text-decoration: underline !important;
-}
-.btn.btn-noop {
-    // We have to use !important unfortunately because the default button style uses it...
-    background: transparent !important;
-    color: @theme-color-text !important;
-    pointer-events: none;
-    cursor: not-allowed;
+    .btn;
 }
 
 .top_bar_sites_selector {

--- a/plugins/Morpheus/stylesheets/general/_forms.less
+++ b/plugins/Morpheus/stylesheets/general/_forms.less
@@ -7,7 +7,6 @@ input:not([type="checkbox"]):not([type="submit"]):not([type="button"]), select, 
     .box-sizing(border-box);
     background: @theme-color-background-base;
 }
-a.add-trusted-host,
 .add-cors-host,
 .submit {
     .btn;

--- a/plugins/Morpheus/stylesheets/main.less
+++ b/plugins/Morpheus/stylesheets/main.less
@@ -271,13 +271,6 @@ table.entityTable tr td a:hover {
       }
 
     }
-
-    .add_new_segment {
-      .submit();
-      .font-default(12px, 16px) !important;
-      width: auto;
-      padding: 7px 10px !important;
-    }
   }
 
   .segmentListContainer {
@@ -564,17 +557,16 @@ div.sparkline {
     input {
         color: @theme-color-text !important;
         .border-radius(0px);
-        border: 0px;
         margin-left: 0;
         padding: 8px 10px;
-        min-height: 30px;
+        min-height: 30px !important;
         .box-sizing(border-box);
         border: 1px solid @color-silver-l80;
         .opacity(1);
 
         &[type="text"] {
             width: 40% !important;
-            padding-right: 4%;
+            padding-right: 30px !important;
             &:focus {
                 border-color: @color-silver-l60;
             }
@@ -584,12 +576,15 @@ div.sparkline {
             margin: 0;
             float: none;
             .font-default(10px, 12px) !important;
-            padding: 0px !important;
+            padding: 0 !important;
             position: relative;
             right: 33px;
-            background: no-repeat 0px 7px url('plugins/Morpheus/images/search_ico.png') !important;
+            background: no-repeat 0 7px url('plugins/Morpheus/images/search_ico.png') !important;
             text-indent: 999999px;
             width: 17px !important;
+            -webkit-box-shadow: none;
+            -moz-box-shadow:    none;
+            box-shadow:         none;
         }
     }
 }

--- a/plugins/Morpheus/stylesheets/ui/_buttons.less
+++ b/plugins/Morpheus/stylesheets/ui/_buttons.less
@@ -56,6 +56,7 @@ input[type="submit"]:not(.btn),
     background: transparent !important;
     color: @theme-color-link !important;
     text-decoration: underline !important;
+    box-shadow: none;
 }
 .btn.btn-noop {
     // We have to use !important unfortunately because the default button style uses it...
@@ -63,4 +64,5 @@ input[type="submit"]:not(.btn),
     color: @theme-color-text !important;
     pointer-events: none;
     cursor: not-allowed;
+    box-shadow: none;
 }

--- a/plugins/Morpheus/stylesheets/ui/_buttons.less
+++ b/plugins/Morpheus/stylesheets/ui/_buttons.less
@@ -1,32 +1,31 @@
-button,
-input[type="submit"],
-button[type="button"],
+// We use `button:not(.btn)` because  `button` has a higher priority than CSS classes
+// which makes it impossible to use btn-lg or similar additional classes.
+button:not(.btn),
+input[type="submit"]:not(.btn),
 .btn {
-    .border-radius(3px) !important;
-    background: none !important;
-    background-color: @theme-color-brand !important;
-    #gradient > .vertical(rgba(255,255,255,.15), rgba(255,255,255,0)) !important;
-    .font-default(12px, 16px) !important;
-    color: @theme-color-brand-contrast !important;;
+    display: inline-block;
+    .border-radius(3px);
+    background: none;
+    color: @theme-color-brand-contrast;
+    background-color: @theme-color-brand;
+    box-shadow: 0 1px 1px 0 rgba(13, 13, 13, 0.3);
+    #gradient > .vertical(rgba(255,255,255,.15), rgba(255,255,255,0));
+    .font-default(12px, 16px);
     font-weight: normal;
-    padding: 5px 15px !important;
+    padding: 5px 15px;
     text-align: center;
-    text-decoration: none !important;
+    text-decoration: none;
     cursor: pointer;
-    border: 0px !important;
+    border: 0;
+
     &:hover {
-        background: @theme-color-brand !important;
-        background-color: @theme-color-brand !important;
+        color: @theme-color-brand-contrast;
+        background: @theme-color-brand;
+        text-decoration: none;
     }
 
     em {
         font-style: normal;
-    }
-    &.ui-dialog-titlebar-close {
-        &:hover {
-            background: none !important;
-            background-color: transparent !important;
-        }
     }
 }
 
@@ -35,12 +34,15 @@ button[type="button"],
     display: inline-block;
 }
 .btn-lg {
-    padding: 12px 40px !important;;
-    font-size: 14px !important;;
+    padding: 12px 40px;
+    font-size: 14px;
 }
 .btn-block {
     display: block;
     width: 100%;
+}
+.btn-block + .btn-block {
+    margin-top: 5px;
 }
 .btn.disabled, .btn[disabled], fieldset[disabled] .btn {
     pointer-events: none;

--- a/plugins/Morpheus/stylesheets/ui/_buttons.less
+++ b/plugins/Morpheus/stylesheets/ui/_buttons.less
@@ -1,0 +1,64 @@
+button,
+input[type="submit"],
+button[type="button"],
+.btn {
+    .border-radius(3px) !important;
+    background: none !important;
+    background-color: @theme-color-brand !important;
+    #gradient > .vertical(rgba(255,255,255,.15), rgba(255,255,255,0)) !important;
+    .font-default(12px, 16px) !important;
+    color: @theme-color-brand-contrast !important;;
+    font-weight: normal;
+    padding: 5px 15px !important;
+    text-align: center;
+    text-decoration: none !important;
+    cursor: pointer;
+    border: 0px !important;
+    &:hover {
+        background: @theme-color-brand !important;
+        background-color: @theme-color-brand !important;
+    }
+
+    em {
+        font-style: normal;
+    }
+    &.ui-dialog-titlebar-close {
+        &:hover {
+            background: none !important;
+            background-color: transparent !important;
+        }
+    }
+}
+
+// Bootstrap classes (can be removed in the future)
+.btn {
+    display: inline-block;
+}
+.btn-lg {
+    padding: 12px 40px !important;;
+    font-size: 14px !important;;
+}
+.btn-block {
+    display: block;
+    width: 100%;
+}
+.btn.disabled, .btn[disabled], fieldset[disabled] .btn {
+    pointer-events: none;
+    cursor: not-allowed;
+    filter: alpha(opacity=65);
+    opacity: .65;
+}
+// See http://getbootstrap.com/css/#buttons-options
+.btn.btn-link {
+    // We have to use !important unfortunately because the default button style uses it...
+    background: transparent !important;
+    color: @theme-color-link !important;
+    text-decoration: underline !important;
+}
+.btn.btn-noop {
+    // We have to use !important unfortunately because the default button style uses it...
+    background: transparent !important;
+    color: @theme-color-text !important;
+    pointer-events: none;
+    cursor: not-allowed;
+}

--- a/plugins/Morpheus/stylesheets/ui/_buttons.less
+++ b/plugins/Morpheus/stylesheets/ui/_buttons.less
@@ -18,7 +18,7 @@ input[type="submit"]:not(.btn),
     cursor: pointer;
     border: 0;
 
-    &:hover {
+    &:hover, &:focus {
         color: @theme-color-brand-contrast;
         background: @theme-color-brand;
         text-decoration: none;

--- a/plugins/Morpheus/stylesheets/ui/_components.less
+++ b/plugins/Morpheus/stylesheets/ui/_components.less
@@ -42,14 +42,6 @@
     background: @calendarCurrentStateHover;
 }
 
-//add new segment
-.add_new_segment,
-#calendarRangeApply {
-    font-size: 12px !important;
-    padding: 0 10px !important;
-    margin-left: 0px !important;
-}
-
 .segment-element {
     background: @color-white;
     border-color: @color-silver-l80;
@@ -146,11 +138,6 @@
     }
     .segment-footer {
         background: @color-white;
-        button {
-            height: auto;
-            font-weight: normal;
-            min-width: 100px;
-        }
 
         a.delete {
             color: @theme-color-brand;

--- a/plugins/Morpheus/stylesheets/ui/_popups.less
+++ b/plugins/Morpheus/stylesheets/ui/_popups.less
@@ -39,7 +39,3 @@ button.ui-state-default, .ui-widget-content button.ui-state-default, .ui-widget-
 .ui-menu .ui-menu-item a.ui-state-focus {
     background: @color-silver-l90;
 }
-
-button:hover, .add-trusted-host:hover, .add-cors-host:hover, input[type="submit"]:hover, button[type="button"]:hover, .submit:hover {
-    background-color: @theme-color-brand !important;
-}

--- a/plugins/Morpheus/templates/demo.twig
+++ b/plugins/Morpheus/templates/demo.twig
@@ -167,10 +167,12 @@
         </div>
 
         <div class="demo">
+            <button class="btn btn-lg">Large button</button>
             <a class="btn btn-lg" href="#">Large button</a>
         </div>
         <div class="demo-code">
-            <pre>&lt;a class=&quot;btn btn-lg&quot; href=&quot;#&quot;&gt;Large button&lt;/a&gt;</pre>
+            <pre>&lt;button class=&quot;btn btn-lg&quot;&gt;Large button&lt;/button&gt;
+&lt;a class=&quot;btn btn-lg&quot; href=&quot;#&quot;&gt;Large button&lt;/a&gt;
         </div>
 
         <div class="demo">

--- a/plugins/SegmentEditor/stylesheets/segmentation.less
+++ b/plugins/SegmentEditor/stylesheets/segmentation.less
@@ -98,11 +98,11 @@ div.scrollable {
 
 .segment-element .custom_select_search input[type="text"] {
   font: 11px Arial;
-  color: #454545;
+  color: #454545 !important;
   width: 125px;
-  padding: 4px 0 3px 7px;
+  padding: 4px 0 3px 7px !important;
   border: none;
-  background: none;
+  background: none !important;
 }
 
 .segment-element .custom_select_search a {
@@ -415,18 +415,6 @@ div.scrollable {
 }
 
 .segment-element .segment-footer button {
-  min-width: 178px;
-  height: 30px;
-  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/Pgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgdmlld0JveD0iMCAwIDE3OCAzMCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+PGxpbmVhckdyYWRpZW50IGlkPSJoYXQwIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjUwJSIgeTE9IjEwMCUiIHgyPSI1MCUiIHkyPSItMS40MjEwODU0NzE1MjAyZS0xNCUiPgo8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjODM3OTZiIiBzdG9wLW9wYWNpdHk9IjEiLz4KPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjYWJhMzkzIiBzdG9wLW9wYWNpdHk9IjEiLz4KICAgPC9saW5lYXJHcmFkaWVudD4KCjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxNzgiIGhlaWdodD0iMzAiIGZpbGw9InVybCgjaGF0MCkiIC8+Cjwvc3ZnPg==);
-  background-image: -moz-linear-gradient(bottom, #83796b 0%, #aba393 100%);
-  background-image: -o-linear-gradient(bottom, #83796b 0%, #aba393 100%);
-  background-image: -webkit-linear-gradient(bottom, #83796b 0%, #aba393 100%);
-  background-image: linear-gradient(bottom, #83796b 0%, #aba393 100%);
-  color: #fff;
-  font-size: 16px;
-  font-weight: bold;
-  border-radius: 4px 4px 4px 4px;
-  border: none;
   margin: 0 0 0 15px;
 }
 
@@ -550,13 +538,9 @@ div.scrollable {
 }
 
 .segmentEditorPanel.visible .add_new_segment {
-  display: block;
-  border: 0 none;
   clear: both;
   float: right;
   margin: 12px 0 10px;
-  text-decoration: none;
-  width: 130px;
 }
 
 .segmentationContainer > ul.submenu > li {
@@ -571,10 +555,6 @@ span.segmentationTitle {
   min-width: 180px;
   display: block;
   cursor: pointer;
-}
-
-.add_new_segment {
-  display: none;
 }
 
 .segmentList {
@@ -683,10 +663,6 @@ a.metric_category {
   span.segmentationTitle,
   .segmentEditorPanel.visible .segmentationContainer {
     width: auto;
-  }
-
-  .segmentEditorPanel.visible .add_new_segment {
-    float: left;
   }
 }
 

--- a/plugins/SegmentEditor/templates/_segmentSelector.twig
+++ b/plugins/SegmentEditor/templates/_segmentSelector.twig
@@ -16,7 +16,7 @@
             </ul>
 
             {% if authorizedToCreateSegments %}
-                <a class="add_new_segment">{{ 'SegmentEditor_AddNewSegment'|translate }}</a>
+                <a class="add_new_segment btn">{{ 'SegmentEditor_AddNewSegment'|translate }}</a>
             {% else %}
                 <ul class="submenu">
                 <li>

--- a/plugins/SitesManager/templates/sites-list/add-site-link.html
+++ b/plugins/SitesManager/templates/sites-list/add-site-link.html
@@ -5,7 +5,7 @@
         </a>
     </div>
     <div class="paging">
-        <a class="submit prev"
+        <a class="btn prev"
            ng-class="{'visible': adminSites.hasPrev, 'hide_only': !adminSites.hasPrev}"
            ng-click="adminSites.previousPage()">
             <span style="cursor:pointer;">&#171; {{ 'General_Previous'|translate }}</span>
@@ -18,7 +18,7 @@
                 {{ 'General_Pagination'|translate:adminSites.offsetStart:adminSites.offsetEnd:totalNumberOfSites }}
             </span>
         </span>
-        <a class="submit next"
+        <a class="btn next"
            ng-class="{'visible': adminSites.hasNext, 'hide_only': !adminSites.hasNext}"
            ng-click="adminSites.nextPage()">
             <span style="cursor:pointer;" class="pointer">{{ 'General_Next'|translate }} &#187;</span>


### PR DESCRIPTION
ref #7585
- applied small design changes that were in the redesign mockups for buttons (e.g. small shadow, …)
- simplified the Less rules, e.g. removed usage of `!important` which was making it very hard to customize the look of buttons in more specific places
- removed custom buttons styles to make buttons consistent in Piwik (it was mostly the date selector which had a slightly smaller button, I don't think there was another one…)
- put button styles in `_buttons.less` (were previously in `_forms.less`)
- links in the admin are now the same color as everywhere else in Piwik (blue instead of black)

I will update the description with screenshots once the UI tests have finished.
