### PR TITLE
Visitorlog: Use a tooltip to display additional information to avoid text truncation

### DIFF
--- a/plugins/Live/javascripts/visitorLog.js
+++ b/plugins/Live/javascripts/visitorLog.js
@@ -38,6 +38,25 @@
         init: function () {
             dataTablePrototype.init.call(this);
 
+            $('.visitorLogIconWithDetails>img').each(function () {
+                $(this).tooltip({
+                    items: 'img',
+                    track: true,
+                    show: false,
+                    hide: false,
+                    content: function () {
+                        return $('<ul>').html($('ul', $(this).closest('.visitorLogIconWithDetails')).html());
+                    },
+                    tooltipClass: 'small',
+                    open: function () {
+                        tooltipIsOpened = true;
+                    },
+                    close: function () {
+                        tooltipIsOpened = false;
+                    }
+                });
+            });
+
             // Replace duplicated page views by a NX count instead of using too much vertical space
             $("ol.visitorLog").each(function () {
                 var prevelement;

--- a/plugins/Live/stylesheets/live.less
+++ b/plugins/Live/stylesheets/live.less
@@ -256,9 +256,6 @@ span.visitorLogIcons:after {
 }
 
 .visitorLogIconWithDetails .details {
-    position: absolute;
-    left: 0;
-    margin-top: 5px;
     display: none;
 }
 
@@ -274,10 +271,6 @@ span.visitorLogIcons:after {
     margin: auto 0;
 }
 
-.visitorLogIconWithDetails:hover .details {
-    display: block;
-}
-
 .visitorLogIcons .visitorDetails {
     float: left;
     display: block;
@@ -288,8 +281,4 @@ span.visitorLogIcons:after {
     float: right;
     display: block;
     margin-bottom: 5px;
-}
-
-.visitorLogIconWithDetails .details li {
-    height: 20px;
 }


### PR DESCRIPTION
To avoid text truncation for showing more details when hovering the icons, I've switched to tooltips. 
That way the information will always be visible completely.

![image](https://cloud.githubusercontent.com/assets/1579355/7642210/944f6492-fa8f-11e4-97db-3878af5c285c.png)

Not sure if that is better that way.
Nevertheless I think the visitor log needs a complete redesign.

refs #7812
