### PR TITLE
Feat/callbacks error and success

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -418,16 +418,16 @@ class CronArchive
         $this->logger->info("Archived today's reports for {$this->websitesWithVisitsSinceLastRun} websites");
         $this->logger->info("Archived week/month/year for {$this->archivedPeriodsArchivesWebsite} websites");
         $this->logger->info("Skipped {$this->skipped} websites");
-        $this->logger->info("- Skipped {$this->skippedDayNoRecentData} websites: no new visit since the last script execution");
-        $this->logger->info("- Skipped {$this->skippedDayArchivesWebsites} websites: existing daily reports are less than {$this->todayArchiveTimeToLive} seconds old");
-        $this->logger->info("- Skipped {$this->skippedPeriodsArchivesWebsite} websites: existing week/month/year periods reports are less than {$this->processPeriodsMaximumEverySeconds} seconds old");
+        $this->logger->info("- {$this->skippedDayNoRecentData} skipped because no new visit since the last script execution");
+        $this->logger->info("- {$this->skippedDayArchivesWebsites} skipped because existing daily reports are less than {$this->todayArchiveTimeToLive} seconds old");
+        $this->logger->info("- {$this->skippedPeriodsArchivesWebsite} skipped because existing week/month/year periods reports are less than {$this->processPeriodsMaximumEverySeconds} seconds old");
 
         if($this->skippedPeriodsNoDataInPeriod) {
-            $this->logger->info("- Skipped {$this->skippedPeriodsNoDataInPeriod} websites week/month/year archiving: no visit in recent days");
+            $this->logger->info("- {$this->skippedPeriodsNoDataInPeriod} skipped periods archiving because no visit in recent days");
         }
 
         if($this->skippedDayOnApiError) {
-            $this->logger->info("- Skipped {$this->skippedDayOnApiError} websites: got an error while querying reporting API");
+            $this->logger->info("- {$this->skippedDayOnApiError} skipped because got an error while querying reporting API");
         }
         $this->logger->info("Total API requests: {$this->requests}");
 

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2661,23 +2661,30 @@ if (typeof Piwik !== 'object') {
              */
             function sendRequest(request, delay, callbacks) {
 
-                var callbacks = {};
+                var cb = callbacks || {};
 
-                if(callback) {
+                // Compatibility for eventLink
+                if('function' === typeof cb) {
+                    cb = {
+                        success: callbacks,
+                        error: callbacks
+                    };
+                }
 
-                    if('function' !== callback) {
-                        callbacks = callback;
-                    }else{
-                        callbacks.error = callbacks.success = callback;
-                    }
+                if(!cb.error) {
+                    cb.error = function() {};
+                }
+
+                if(!cb.success) {
+                    cb.success = function() {};
                 }
 
                 if (!configDoNotTrack && request) {
                     makeSureThereIsAGapAfterFirstTrackingRequestToPreventMultipleVisitorCreation(function () {
                         if (configRequestMethod === 'POST') {
-                            sendXmlHttpRequest(request, callbacks);
+                            sendXmlHttpRequest(request, cb);
                         } else {
-                            getImage(request, callbacks);
+                            getImage(request, cb);
                         }
 
                         setExpireDateTime(delay);

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2661,10 +2661,16 @@ if (typeof Piwik !== 'object') {
              */
             function sendRequest(request, delay, callbacks) {
 
-                callbacks = callbacks || {
-                    success: function() {},
-                    error: function() {}
-                };
+                var callbacks = {};
+
+                if(callback) {
+
+                    if('function' !== callback) {
+                        callbacks = callback;
+                    }else{
+                        callbacks.error = callbacks.success = callback;
+                    }
+                }
 
                 if (!configDoNotTrack && request) {
                     makeSureThereIsAGapAfterFirstTrackingRequestToPreventMultipleVisitorCreation(function () {

--- a/plugins/MobileMessaging/Controller.php
+++ b/plugins/MobileMessaging/Controller.php
@@ -94,7 +94,7 @@ class Controller extends ControllerAdmin
             $view->creditLeft = $mobileMessagingAPI->getCreditLeft();
         }
 
-        $view->smsProviders = SMSProvider::$availableSMSProviders;
+        $view->smsProviders = SMSProvider::getAvailableSMSProviders();
 
         // construct the list of countries from the lang files
         $countries = array();

--- a/plugins/MobileMessaging/SMSProvider.php
+++ b/plugins/MobileMessaging/SMSProvider.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\MobileMessaging;
 
 use Exception;
+use Piwik\Development;
 use Piwik\Piwik;
 use Piwik\BaseFactory;
 
@@ -23,7 +24,7 @@ abstract class SMSProvider extends BaseFactory
     const MAX_UCS2_CHARS_IN_ONE_UNIQUE_SMS = 70;
     const MAX_UCS2_CHARS_IN_ONE_CONCATENATED_SMS = 67;
 
-    public static $availableSMSProviders = array(
+    protected static $availableSMSProviders = array(
         'Clockwork' => 'You can use <a target="_blank" href="?module=Proxy&action=redirect&url=http://www.clockworksms.com/platforms/piwik/"><img src="plugins/MobileMessaging/images/Clockwork.png"/></a> to send SMS Reports from Piwik.<br/>
 			<ul>
 			<li> First, <a target="_blank" href="?module=Proxy&action=redirect&url=http://www.clockworksms.com/platforms/piwik/">get an API Key from Clockwork</a> (Signup is free!)
@@ -46,8 +47,24 @@ abstract class SMSProvider extends BaseFactory
     protected static function getInvalidClassIdExceptionMessage($id)
     {
         return Piwik::translate('MobileMessaging_Exception_UnknownProvider',
-            array($id, implode(', ', array_keys(self::$availableSMSProviders)))
+            array($id, implode(', ', array_keys(self::getAvailableSMSProviders())))
         );
+    }
+
+    /**
+     * Returns all available SMS Providers
+     * 
+     * @return array
+     */
+    public static function getAvailableSMSProviders()
+    {
+        $smsProviders = self::$availableSMSProviders;
+
+        if (Development::isEnabled()) {
+            $smsProviders['Development'] = 'Development SMS Provider<br />All sent SMS will be displayed as Notification';
+        }
+
+        return $smsProviders;
     }
 
     /**
@@ -65,7 +82,7 @@ abstract class SMSProvider extends BaseFactory
             throw new Exception(
                 Piwik::translate(
                     'MobileMessaging_Exception_UnknownProvider',
-                    array($providerName, implode(', ', array_keys(self::$availableSMSProviders)))
+                    array($providerName, implode(', ', array_keys(self::getAvailableSMSProviders())))
                 )
             );
         }

--- a/plugins/MobileMessaging/SMSProvider.php
+++ b/plugins/MobileMessaging/SMSProvider.php
@@ -39,6 +39,25 @@ abstract class SMSProvider extends BaseFactory
 			',
     );
 
+    /**
+     * Creates a new instance of a class using a string ID.
+     *
+     * @param string $classId The ID of the class.
+     * @return BaseFactory
+     * @throws Exception if $classId is invalid.
+     */
+    public static function factory($classId)
+    {
+        $className = static::getClassNameFromClassId($classId);
+
+        if(class_exists($className) &&
+            !is_subclass_of($className, __NAMESPACE__ . '\\SMSProvider')) {
+            throw new Exception("SMS Provider $classId must inherit SMSProvider class.");
+        }
+
+        return parent::factory($classId);
+    }
+
     protected static function getClassNameFromClassId($id)
     {
         return __NAMESPACE__ . '\\SMSProvider\\' . $id;

--- a/plugins/MobileMessaging/SMSProvider.php
+++ b/plugins/MobileMessaging/SMSProvider.php
@@ -68,29 +68,6 @@ abstract class SMSProvider extends BaseFactory
     }
 
     /**
-     * Return the SMSProvider associated to the provider name $providerName
-     *
-     * @throws Exception If the provider is unknown
-     * @param string $providerName
-     * @return \Piwik\Plugins\MobileMessaging\SMSProvider
-     */
-    public static function factory($providerName)
-    {
-        $className = __NAMESPACE__ . '\\SMSProvider\\' . $providerName;
-
-        if (!class_exists($className)) {
-            throw new Exception(
-                Piwik::translate(
-                    'MobileMessaging_Exception_UnknownProvider',
-                    array($providerName, implode(', ', array_keys(self::getAvailableSMSProviders())))
-                )
-            );
-        }
-
-        return new $className;
-    }
-
-    /**
      * Assert whether a given String contains UCS2 characters
      *
      * @param string $string

--- a/plugins/MobileMessaging/SMSProvider/Development.php
+++ b/plugins/MobileMessaging/SMSProvider/Development.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\MobileMessaging\SMSProvider;
+
+use Piwik\Notification;
+use Piwik\Plugins\MobileMessaging\SMSProvider;
+
+/**
+ * Used for development only
+ *
+ */
+class Development extends SMSProvider
+{
+
+    public function verifyCredential($apiKey)
+    {
+        return true;
+    }
+
+    public function sendSMS($apiKey, $smsText, $phoneNumber, $from)
+    {
+        $message = sprintf('An SMS was sent:<br />From: %s<br />To: %s<br />Message: %s', $from, $phoneNumber, $smsText);
+
+        $notification = new Notification($message);
+        $notification->raw = true;
+        $notification->context = Notification::CONTEXT_INFO;
+        Notification\Manager::notify('StubbedSMSProvider'.preg_replace('/[^a-z0-9]/', '', $phoneNumber), $notification);
+    }
+
+    public function getCreditLeft($apiKey)
+    {
+        return 'Balance: 42';
+    }
+}

--- a/plugins/MobileMessaging/templates/reportParametersScheduledReports.twig
+++ b/plugins/MobileMessaging/templates/reportParametersScheduledReports.twig
@@ -6,15 +6,16 @@
     <td>
     <div class="entityInlineHelp">
     {% if phoneNumbers|length == 0 %}
-        {{ 'MobileMessaging_MobileReport_NoPhoneNumbers'|translate }}
+        <div><span class="icon-info"></span> {{ 'MobileMessaging_MobileReport_NoPhoneNumbers'|translate }}
     {% else %}
+        <ul class="clearfix">
         {% for phoneNumber in phoneNumbers %}
-        <label><input name='phoneNumbers' type='checkbox' id='{{ phoneNumber }}'/>{{ phoneNumber }}</label>
-        <br/>
+            <li class="clear"><label><input name='phoneNumbers' type='checkbox' id='{{ phoneNumber }}'/>{{ phoneNumber }}</label></li>
         {% endfor %}
-        {{ 'MobileMessaging_MobileReport_AdditionalPhoneNumbers'|translate }}
+        </ul>
+        <div><span class="icon-info"></span> {{ 'MobileMessaging_MobileReport_AdditionalPhoneNumbers'|translate }}
     {% endif %}
-        <a href='{{ linkTo({'module':"MobileMessaging", 'action': 'index', 'updated':null}) }}'>{{ 'MobileMessaging_MobileReport_MobileMessagingSettingsLink'|translate }}</a>
+        <a href="{{ linkTo({'module':"MobileMessaging", 'action': 'index', 'updated':null}) }}">{{ 'MobileMessaging_MobileReport_MobileMessagingSettingsLink'|translate }}</a></div>
     </div>
     <script>
     $(function () {

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -129,9 +129,9 @@ Total visits for today across archived websites: 1
 Archived today's reports for 1 websites
 Archived week/month/year for 1 websites
 Skipped 0 websites
-- Skipped 0 websites: no new visit since the last script execution
-- Skipped 0 websites: existing daily reports are less than 150 seconds old
-- Skipped 0 websites: existing week/month/year periods reports are less than 3600 seconds old
+- 0 skipped because no new visit since the last script execution
+- 0 skipped because existing daily reports are less than 150 seconds old
+- 0 skipped because existing week/month/year periods reports are less than 3600 seconds old
 Total API requests: %s
 done: 1/1 100%, 1 vtoday, 1 wtoday, 1 wperiods, %s req, %s ms, no error
 Time elapsed: %s


### PR DESCRIPTION
Hi,

We cannot add a callback to detect both error and success for GET and POST.
Now, with trackEvent we can set an object as the fifth argument to set callbacks.

``` js
tracker
  .trackEvent('test',null,null,null,{
    success: function(isXhr) {
      console.log('Success', isXhr)
    },
    error: function(isXhr) {
      console.log('Error', isXhr)
    }
  });
```
