### PR TITLE
Allow events to use a bulk Request

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2322,7 +2322,10 @@ if (typeof Piwik !== 'object') {
                 hash = sha1,
 
                 // Domain hash value
-                domainHash;
+                domainHash,
+
+                // Cache for events
+                listEventToBulk = [];
 
             /*
              * Set cookie value
@@ -5345,9 +5348,6 @@ if (typeof Piwik !== 'object') {
                     });
                 },
 
-                // Cache for events
-                listEventToBulk: [],
-
                 /**
                  * Records an event and store it into a list
                  *
@@ -5358,7 +5358,7 @@ if (typeof Piwik !== 'object') {
                  */
                 trackEventList: function (category, action, name, value) {
                     var request = createRequestEventUrl(category, action, name, value, customData);
-                    this.listEventToBulk.push(request);
+                    listEventToBulk.push(request);
                 },
 
                 /**
@@ -5368,11 +5368,11 @@ if (typeof Piwik !== 'object') {
                 bulkEventList: function() {
                     var self = this;
                     sendBulkRequest(
-                        self.listEventToBulk,
+                        listEventToBulk,
                         configTrackerPause,
                         function() {
                             // Flush event already send after the request
-                            self.listEventToBulk = [];
+                            listEventToBulk = [];
                         }
                     );
                 },


### PR DESCRIPTION
Allow events to use a [Bulk API Request](http://developer.piwik.org/api-reference/reporting-api#advanced-users-send-multiple-api-requests-at-once).

Usefull on a mobile device. 
### API
#### Record an event

``` js
trackEventList(category, action, [name], [value])
```
#### Send events

``` js
bulkEventList();
```
