### PR TITLE
Injection Inception, Change #1: Adding EventDispatcher to DI

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -62,4 +62,7 @@ return array(
     'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\LoaderCache')
         ->constructor(DI\get('Piwik\Translation\Loader\JsonFileLoader')),
 
+    'observers.global' => array(),
+
+    'Piwik\EventDispatcher' => DI\object()->constructorParameter('globalObservers', DI\get('observers.global'))
 );

--- a/config/global.php
+++ b/config/global.php
@@ -64,5 +64,5 @@ return array(
 
     'observers.global' => array(),
 
-    'Piwik\EventDispatcher' => DI\object()->constructorParameter('globalObservers', DI\get('observers.global'))
+    'Piwik\EventDispatcher' => DI\object()->constructorParameter('observers', DI\get('observers.global'))
 );

--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -64,11 +64,11 @@ class EventDispatcher
     /**
      * Constructor.
      */
-    public function __construct(Plugin\Manager $pluginManager, array $globalObservers = array())
+    public function __construct(Plugin\Manager $pluginManager, array $observers = array())
     {
         $this->pluginManager = $pluginManager;
 
-        foreach ($globalObservers as $observerInfo) {
+        foreach ($observers as $observerInfo) {
             list($eventName, $callback) = $observerInfo;
             $this->extraObservers[$eventName][] = $callback;
         }

--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -64,9 +64,14 @@ class EventDispatcher
     /**
      * Constructor.
      */
-    public function __construct($pluginManager = null)
+    public function __construct(Plugin\Manager $pluginManager, array $globalObservers = array())
     {
         $this->pluginManager = $pluginManager;
+
+        foreach ($globalObservers as $observerInfo) {
+            list($eventName, $callback) = $observerInfo;
+            $this->extraObservers[$eventName][] = $callback;
+        }
     }
 
     /**

--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -92,7 +92,7 @@ class EventDispatcher
             $this->pendingEvents[] = array($eventName, $params);
         }
 
-        $manager = $this->getPluginManager();
+        $manager = $this->pluginManager;
 
         if (empty($plugins)) {
             $plugins = $manager->getPluginsLoadedAndActivated();
@@ -200,19 +200,5 @@ class EventDispatcher
         }
 
         return array($pluginFunction, $callbackGroup);
-    }
-
-    /**
-     * Returns the Plugin\Manager instance used by the event dispatcher.
-     *
-     * @return Plugin\Manager
-     */
-    private function getPluginManager()
-    {
-        if ($this->pluginManager === null) {
-            return Plugin\Manager::getInstance(); // caching the var breaks DI for now since only Plugin\Manager is in the container.
-        } else {
-            return $this->pluginManager;
-        }
     }
 }

--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -9,16 +9,23 @@
 
 namespace Piwik;
 
+use Piwik\Container\StaticContainer;
 use Piwik\Plugin;
 
 /**
  * This class allows code to post events from anywhere in Piwik and for
  * plugins to associate callbacks to be executed when events are posted.
- *
- * @method static \Piwik\EventDispatcher getInstance()
  */
-class EventDispatcher extends Singleton
+class EventDispatcher
 {
+    /**
+     * @return EventDispatcher
+     */
+    public static function getInstance()
+    {
+        return StaticContainer::get('Piwik\EventDispatcher');
+    }
+
     // implementation details for postEvent
     const EVENT_CALLBACK_GROUP_FIRST = 0;
     const EVENT_CALLBACK_GROUP_SECOND = 1;
@@ -155,30 +162,6 @@ class EventDispatcher extends Singleton
     public function addObserver($eventName, $callback)
     {
         $this->extraObservers[$eventName][] = $callback;
-    }
-
-    /**
-     * Removes all registered extra observers for an event name. Only used for testing.
-     *
-     * @param string $eventName
-     */
-    public function clearObservers($eventName)
-    {
-        $this->extraObservers[$eventName] = array();
-    }
-
-    /**
-     * Removes all registered extra observers. Only used for testing.
-     */
-    public function clearAllObservers()
-    {
-        foreach ($this->extraObservers as $eventName => $eventObservers) {
-            if (strpos($eventName, 'Log.format') === 0) {
-                continue;
-            }
-
-            $this->extraObservers[$eventName] = array();
-        }
     }
 
     /**

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -154,8 +154,7 @@ class Fixture extends \PHPUnit_Framework_Assert
             GlobalSettingsProvider::unsetSingletonInstance();
         }
 
-        $this->piwikEnvironment = new Environment('test');
-        $this->piwikEnvironment->init();
+        $this->createEnvironmentInstance();
 
         if ($this->createConfig) {
             Config::setSingletonInstance(new TestConfig());
@@ -912,5 +911,11 @@ class Fixture extends \PHPUnit_Framework_Assert
     public function provideContainerConfig()
     {
         return array();
+    }
+
+    public function createEnvironmentInstance()
+    {
+        $this->piwikEnvironment = new Environment('test');
+        $this->piwikEnvironment->init();
     }
 }

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -257,7 +257,6 @@ class Fixture extends \PHPUnit_Framework_Assert
 
         $this->getTestEnvironment()->save();
         $this->getTestEnvironment()->executeSetupTestEnvHook();
-        Piwik_TestingEnvironment::addSendMailHook();
 
         PiwikCache::getTransientCache()->flushAll();
 

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -326,7 +326,6 @@ class Fixture extends \PHPUnit_Framework_Assert
         PiwikCache::getEagerCache()->flushAll();
         ArchiveTableCreator::clear();
         \Piwik\Plugins\ScheduledReports\API::$cache = array();
-        EventDispatcher::getInstance()->clearAllObservers();
 
         $_GET = $_REQUEST = array();
         Translate::reset();

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -74,6 +74,10 @@ abstract class IntegrationTestCase extends SystemTestCase
     {
         parent::setUp();
 
+        self::$fixture->createEnvironmentInstance();
+
+        Fixture::loadAllPlugins(new \Piwik_TestingEnvironment(), get_class($this), self::$fixture->extraPluginsToLoad);
+
         if (!empty(self::$tableData)) {
             self::restoreDbTables(self::$tableData);
         }

--- a/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
@@ -35,7 +35,6 @@ abstract class UnitTestCase extends \PHPUnit_Framework_TestCase
         $this->initEnvironment();
 
         File::reset();
-        EventDispatcher::getInstance()->clearAllObservers();
     }
 
     public function tearDown()

--- a/tests/PHPUnit/Integration/Plugin/ManagerTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ManagerTest.php
@@ -55,7 +55,7 @@ class ManagerTest extends IntegrationTestCase
 
     public function test_loadTrackerPlugins_shouldBeAbleToLoadPluginsCorrectWhenItIsCached()
     {
-        $pluginsToLoad = array('CoreHome', 'UserLanguage', 'Login', 'CoreAdminHome');
+        $pluginsToLoad = array('CoreAdminHome', 'CoreHome', 'UserLanguage', 'Login');
         $this->getCacheForTrackerPlugins()->save($this->trackerCacheId, $pluginsToLoad);
 
         $pluginsToLoad = $this->manager->loadTrackerPlugins();

--- a/tests/PHPUnit/Integration/Tracker/Handler/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Tracker/Handler/FactoryTest.php
@@ -23,13 +23,6 @@ use Piwik\Tracker\Handler\Factory;
  */
 class FactoryTest extends IntegrationTestCase
 {
-
-    public function tearDown()
-    {
-        EventDispatcher::getInstance()->clearObservers('Tracker.initRequestSet');
-        parent::tearDown();
-    }
-
     public function test_make_shouldCreateDefaultInstance()
     {
         $handler = Factory::make();

--- a/tests/PHPUnit/Integration/Tracker/RequestSetTest.php
+++ b/tests/PHPUnit/Integration/Tracker/RequestSetTest.php
@@ -64,7 +64,6 @@ class RequestSetTest extends IntegrationTestCase
         $_GET  = $this->get;
         $_POST = $this->post;
 
-        EventDispatcher::getInstance()->clearObservers('Tracker.initRequestSet');
         parent::tearDown();
     }
 

--- a/tests/PHPUnit/Integration/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Integration/Tracker/RequestTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration\Tracker;
 
-use Piwik\EventDispatcher;
 use Piwik\Piwik;
 use Piwik\Plugins\CustomVariables\CustomVariables;
 use Piwik\Plugins\UsersManager\API;
@@ -50,12 +49,6 @@ class RequestTest extends IntegrationTestCase
         Cache::deleteTrackerCache();
 
         $this->request = $this->buildRequest(array('idsite' => '1'));
-    }
-
-    public function tearDown()
-    {
-        EventDispatcher::getInstance()->clearObservers('Request.initAuthenticationObject');
-        parent::tearDown();
     }
 
     public function test_getCustomVariablesInVisitScope_ShouldReturnNoCustomVars_IfNoWerePassedInParams()

--- a/tests/PHPUnit/Integration/Tracker/Visit/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit/FactoryTest.php
@@ -24,13 +24,6 @@ use Piwik\Tracker\Visit\Factory;
  */
 class FactoryTest extends IntegrationTestCase
 {
-
-    public function tearDown()
-    {
-        EventDispatcher::getInstance()->clearObservers('Tracker.makeNewVisitObject');
-        parent::tearDown();
-    }
-
     public function test_make_shouldCreateDefaultInstance()
     {
         $visit = Factory::make();

--- a/tests/PHPUnit/Integration/Tracker/Visit2Test.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit2Test.php
@@ -148,12 +148,6 @@ class Visit2Test extends IntegrationTestCase
         });
     }
 
-    public function tearDown()
-    {
-        EventDispatcher::getInstance()->clearObservers('Tracker.Request.getIdSite');
-        parent::tearDown();
-    }
-
     public function test_handleNewVisitWithoutConversion_shouldTriggerDimensions()
     {
         $request = new Request(array());

--- a/tests/PHPUnit/Integration/TrackerTest.php
+++ b/tests/PHPUnit/Integration/TrackerTest.php
@@ -74,7 +74,6 @@ class TrackerTest extends IntegrationTestCase
         if($this->tracker) {
             $this->tracker->disconnectDatabase();
         }
-        EventDispatcher::getInstance()->clearObservers('Tracker.makeNewVisitObject');
         if (array_key_exists('PIWIK_TRACKER_DEBUG', $GLOBALS)) {
             unset($GLOBALS['PIWIK_TRACKER_DEBUG']);
         }

--- a/tests/PHPUnit/TestingEnvironment.php
+++ b/tests/PHPUnit/TestingEnvironment.php
@@ -127,7 +127,7 @@ class Piwik_TestingEnvironment
         return $plugins;
     }
 
-    public static function addHooks()
+    public static function addHooks($globalObservers = array())
     {
         $testingEnvironment = new Piwik_TestingEnvironment();
 
@@ -199,7 +199,7 @@ class Piwik_TestingEnvironment
         sort($pluginsToLoad);
 
         if (!$testingEnvironment->dontUseTestConfig) {
-            Piwik::addAction('Config.createConfigSingleton', function(IniFileChain $chain) use ($testingEnvironment, $pluginsToLoad) {
+            $globalObservers[] = array('Config.createConfigSingleton', function(IniFileChain $chain) use ($testingEnvironment, $pluginsToLoad) {
                 $general =& $chain->get('General');
                 $plugins =& $chain->get('Plugins');
                 $log =& $chain->get('log');
@@ -233,12 +233,18 @@ class Piwik_TestingEnvironment
             ));
         } else {
             \Piwik\Application\Kernel\GlobalSettingsProvider::unsetSingletonInstance();
-            
+
             Config::setSingletonInstance(new Config(
                 $testingEnvironment->configFileGlobal, $testingEnvironment->configFileLocal, $testingEnvironment->configFileCommon
             ));
         }
-        Piwik::addAction('Request.dispatch', function() use ($testingEnvironment) {
+
+        $globalObservers[] = array('Environment.bootstrapped', function () use ($testingEnvironment) {
+            $testingEnvironment->logVariables();
+            $testingEnvironment->executeSetupTestEnvHook();
+        });
+
+        $globalObservers[] = array('Request.dispatch', function () use ($testingEnvironment) {
             if (empty($_GET['ignoreClearAllViewDataTableParameters'])) { // TODO: should use testingEnvironment variable, not query param
                 try {
                     \Piwik\ViewDataTable\Manager::clearAllViewDataTableParameters();
@@ -246,7 +252,6 @@ class Piwik_TestingEnvironment
                     // ignore (in case DB is not setup)
                 }
             }
-
             if ($testingEnvironment->optionsOverride) {
                 try {
                     foreach ($testingEnvironment->optionsOverride as $name => $value) {
@@ -256,28 +261,43 @@ class Piwik_TestingEnvironment
                     // ignore (in case DB is not setup)
                 }
             }
-
             \Piwik\Plugins\CoreVisualizations\Visualizations\Cloud::$debugDisableShuffle = true;
             \Piwik\Visualization\Sparkline::$enableSparklineImages = false;
             \Piwik\Plugins\ExampleUI\API::$disableRandomness = true;
         });
-        Piwik::addAction('AssetManager.getStylesheetFiles', function(&$stylesheets) {
+
+        $globalObservers[] = array('AssetManager.getStylesheetFiles', function (&$stylesheets) {
             $stylesheets[] = 'tests/resources/screenshot-override/override.css';
         });
-        Piwik::addAction('AssetManager.getJavaScriptFiles', function(&$jsFiles) {
+
+        $globalObservers[] = array('AssetManager.getJavaScriptFiles', function (&$jsFiles) {
             $jsFiles[] = 'tests/resources/screenshot-override/override.js';
         });
-        self::addSendMailHook();
-        Piwik::addAction('Updater.checkForUpdates', function () {
+
+        $globalObservers[] = array('Updater.checkForUpdates', function () {
             try {
                 @\Piwik\Filesystem::deleteAllCacheOnUpdate();
             } catch (Exception $ex) {
                 // pass
             }
         });
-        Piwik::addAction('Platform.initialized', function () use ($testingEnvironment) {
-            static $archivingTablesDeleted = false;
 
+        $globalObservers[] = array('Test.Mail.send', function (\Zend_Mail $mail) {
+            $outputFile = PIWIK_INCLUDE_PATH . '/tmp/' . Common::getRequestVar('module', '') . '.' . Common::getRequestVar('action', '') . '.mail.json';
+            $outputContent = str_replace("=\n", "", $mail->getBodyText($textOnly = true));
+            $outputContent = str_replace("=0A", "\n", $outputContent);
+            $outputContent = str_replace("=3D", "=", $outputContent);
+            $outputContents = array(
+                'from' => $mail->getFrom(),
+                'to' => $mail->getRecipients(),
+                'subject' => $mail->getSubject(),
+                'contents' => $outputContent
+            );
+            file_put_contents($outputFile, json_encode($outputContents));
+        });
+
+        $globalObservers[] = array('Platform.initialized', function () use ($testingEnvironment) {
+            static $archivingTablesDeleted = false;
             if ($testingEnvironment->deleteArchiveTables
                 && !$archivingTablesDeleted
             ) {
@@ -285,30 +305,8 @@ class Piwik_TestingEnvironment
                 DbHelper::deleteArchiveTables();
             }
         });
-        Piwik::addAction('Environment.bootstrapped', function () use ($testingEnvironment) {
-            $testingEnvironment->logVariables();
-            $testingEnvironment->executeSetupTestEnvHook();
-        });
-    }
 
-    public static function addSendMailHook()
-    {
-        Piwik::addAction('Test.Mail.send', function($mail) {
-            $outputFile = PIWIK_INCLUDE_PATH . '/tmp/' . Common::getRequestVar('module', '') . '.' . Common::getRequestVar('action', '') . '.mail.json';
-
-            $outputContent = str_replace("=\n", "", $mail->getBodyText($textOnly = true));
-            $outputContent = str_replace("=0A", "\n", $outputContent);
-            $outputContent = str_replace("=3D", "=", $outputContent);
-
-            $outputContents = array(
-                'from'     => $mail->getFrom(),
-                'to'       => $mail->getRecipients(),
-                'subject'  => $mail->getSubject(),
-                'contents' => $outputContent
-            );
-
-            file_put_contents($outputFile, json_encode($outputContents));
-        });
+        $diConfig['observers.global'] = \DI\add($globalObservers);
     }
 
     public function arrayMergeRecursiveDistinct(array $array1, array $array2)

--- a/tests/PHPUnit/Unit/AssetManagerTest.php
+++ b/tests/PHPUnit/Unit/AssetManagerTest.php
@@ -139,8 +139,6 @@ class AssetManagerTest extends UnitTestCase
     private function setUpPluginManager()
     {
         $this->pluginManager = Manager::getInstance();
-
-        EventDispatcher::unsetInstance(); // EventDispatcher stores a reference to Plugin Manager
     }
 
     private function setUpPlugins()

--- a/tests/PHPUnit/Unit/TrackerTest.php
+++ b/tests/PHPUnit/Unit/TrackerTest.php
@@ -69,12 +69,6 @@ class TrackerTest extends UnitTestCase
         $this->requestSet->setRequests(array($this->buildRequest(1), $this->buildRequest(1)));
     }
 
-    public function tearDown()
-    {
-        EventDispatcher::getInstance()->clearObservers('Tracker.end');
-        parent::tearDown();
-    }
-
     public function test_isDebugModeEnabled_shouldReturnFalse_ByDefault()
     {
         unset($GLOBALS['PIWIK_TRACKER_DEBUG']);

--- a/tests/PHPUnit/proxy/piwik.php
+++ b/tests/PHPUnit/proxy/piwik.php
@@ -20,16 +20,18 @@ require realpath(dirname(__FILE__)) . "/includes.php";
 ob_start();
 
 try {
-    Piwik_TestingEnvironment::addHooks();
+    $globalObservers = array(
+        array('Environment.bootstrapped', function () {
+            Tracker::setTestEnvironment();
+            Manager::getInstance()->deleteAll();
+            Option::clearCache();
+            Site::clearCache();
+        })
+    );
+
+    Piwik_TestingEnvironment::addHooks($globalObservers);
 
     GeoIp::$geoIPDatabaseDir = 'tests/lib/geoip-files';
-
-    \Piwik\Piwik::addAction('Environment.bootstrapped', function () {
-        Tracker::setTestEnvironment();
-        Manager::getInstance()->deleteAll();
-        Option::clearCache();
-        Site::clearCache();
-    });
 
     include PIWIK_INCLUDE_PATH . '/piwik.php';
 } catch (Exception $ex) {


### PR DESCRIPTION
As the title states, this PR puts the EventDispatcher singleton into the DI container.

It includes the addition of a new config entry `'observers.global'` that allows defining observers before the container is created. This is necessary for test environment setup, since we register event observers before the actual entry scripts create the container. It can also be useful to users who want to augment their Piwik, without actually creating a plugin (they can define observers in config/config.php).

Tests may not pass yet, travis is still having a hard time.
