### PR TITLE
Injection Inception, Change #2: Adding Config to DI

### DIFF
--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -14,4 +14,5 @@ return array(
     'Piwik\Translation\Translator' => DI\object()
         ->constructorParameter('directories', array()),
 
+    'Piwik\Config' => DI\object('Piwik\Tests\Framework\Mock\TestConfig'),
 );

--- a/core/Application/EnvironmentManipulator.php
+++ b/core/Application/EnvironmentManipulator.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Application;
+
+use Piwik\Application\Kernel\GlobalSettingsProvider;
+
+/**
+ * Used to manipulate Environment instances before the container is created.
+ * Only used by the testing environment setup code, shouldn't be used anywhere
+ * else.
+ */
+interface EnvironmentManipulator
+{
+    /**
+     * Create a custom GlobalSettingsProvider kernel object, overriding the default behavior.
+     *
+     * @return GlobalSettingsProvider
+     */
+    public function makeGlobalSettingsProvider();
+}

--- a/core/Application/Kernel/GlobalSettingsProvider.php
+++ b/core/Application/Kernel/GlobalSettingsProvider.php
@@ -22,8 +22,6 @@ use Piwik\Config\IniFileChain;
  */
 class GlobalSettingsProvider
 {
-    private static $instance = null;
-
     /**
      * @var IniFileChain
      */
@@ -109,31 +107,5 @@ class GlobalSettingsProvider
     public function getPathCommon()
     {
         return $this->pathCommon;
-    }
-
-    public static function getSingletonInstance($pathGlobal = null, $pathLocal = null, $pathCommon = null)
-    {
-        if (self::$instance === null) {
-            self::$instance = new GlobalSettingsProvider($pathGlobal, $pathLocal, $pathCommon);
-        } else {
-            // sanity check. the parameters should only be non-null when creating the GlobalSettingsProvider the first time.
-            // if it's done after, it may point to a problem in the tests. (tests are the only place where these arguments
-            // should be specified)
-            if ($pathGlobal !== null
-                || $pathLocal !== null
-                || $pathCommon !== null
-            ) {
-                $message = "Unexpected state in GlobalSettingsProvider::getSingletonInstance: singleton already created but paths supplied:\n";
-                $message .= "global = '$pathGlobal', local = '$pathLocal', common = '$pathCommon'\n";
-                throw new \Exception($message);
-            }
-        }
-
-        return self::$instance;
-    }
-
-    public static function unsetSingletonInstance()
-    {
-        self::$instance = null;
     }
 }

--- a/core/CliMulti/RequestCommand.php
+++ b/core/CliMulti/RequestCommand.php
@@ -49,7 +49,6 @@ class RequestCommand extends ConsoleCommand
         $this->initHostAndQueryString($input);
 
         if ($this->isTestModeEnabled()) {
-            Config::setSingletonInstance(new TestConfig());
             $indexFile = '/tests/PHPUnit/proxy/';
 
             $this->resetDatabase();

--- a/core/Config.php
+++ b/core/Config.php
@@ -55,8 +55,6 @@ class Config extends Singleton
      */
     protected $settings;
 
-    private $initialized = false;
-
     public function __construct($pathGlobal = null, $pathLocal = null, $pathCommon = null)
     {
         $this->settings = GlobalSettingsProvider::getSingletonInstance($pathGlobal, $pathLocal, $pathCommon);
@@ -130,11 +128,6 @@ class Config extends Singleton
         // for unit tests, we set that no plugin is installed. This will force
         // the test initialization to create the plugins tables, execute ALTER queries, etc.
         $chain->set('PluginsInstalled', array('PluginsInstalled' => array()));
-    }
-
-    protected function postConfigTestEvent()
-    {
-        Piwik::postTestEvent('Config.createConfigSingleton', array($this->settings->getIniFileChain(), $this)  );
     }
 
     /**
@@ -291,7 +284,6 @@ class Config extends Singleton
      */
     public function clear()
     {
-        $this->initialized = false;
         $this->reload();
     }
 
@@ -314,7 +306,6 @@ class Config extends Singleton
      */
     protected function reload($pathLocal = null, $pathGlobal = null, $pathCommon = null)
     {
-        $this->initialized = false;
         $this->settings->reload($pathGlobal, $pathLocal, $pathCommon);
     }
 
@@ -343,12 +334,6 @@ class Config extends Singleton
      */
     public function &__get($name)
     {
-        if (!$this->initialized) {
-            $this->initialized = true;
-
-            $this->postConfigTestEvent();
-        }
-
         $section =& $this->settings->getIniFileChain()->get($name);
         return $section;
     }

--- a/core/Config.php
+++ b/core/Config.php
@@ -38,7 +38,7 @@ use Piwik\Container\StaticContainer;
  *     Config::getInstance()->MySection = array('myoption' => 1);
  *     Config::getInstance()->forceSave();
  */
-class Config extends Singleton
+class Config
 {
     const DEFAULT_LOCAL_CONFIG_PATH = '/config/config.ini.php';
     const DEFAULT_COMMON_CONFIG_PATH = '/config/common.config.ini.php';

--- a/core/Config.php
+++ b/core/Config.php
@@ -11,6 +11,7 @@ namespace Piwik;
 
 use Exception;
 use Piwik\Application\Kernel\GlobalSettingsProvider;
+use Piwik\Container\StaticContainer;
 
 /**
  * Singleton that provides read & write access to Piwik's INI configuration.
@@ -36,8 +37,6 @@ use Piwik\Application\Kernel\GlobalSettingsProvider;
  *
  *     Config::getInstance()->MySection = array('myoption' => 1);
  *     Config::getInstance()->forceSave();
- *
- * @method static Config getInstance()
  */
 class Config extends Singleton
 {
@@ -55,9 +54,17 @@ class Config extends Singleton
      */
     protected $settings;
 
-    public function __construct($pathGlobal = null, $pathLocal = null, $pathCommon = null)
+    /**
+     * @return Config
+     */
+    public static function getInstance()
     {
-        $this->settings = GlobalSettingsProvider::getSingletonInstance($pathGlobal, $pathLocal, $pathCommon);
+        return StaticContainer::get('Piwik\Config');
+    }
+
+    public function __construct(GlobalSettingsProvider $settings)
+    {
+        $this->settings = $settings;
     }
 
     /**

--- a/core/Config.php
+++ b/core/Config.php
@@ -91,46 +91,6 @@ class Config extends Singleton
     }
 
     /**
-     * Enable test environment
-     *
-     * @param string $pathLocal
-     * @param string $pathGlobal
-     * @param string $pathCommon
-     * @deprecated
-     */
-    public function setTestEnvironment($pathLocal = null, $pathGlobal = null, $pathCommon = null, $allowSaving = false)
-    {
-        if (!$allowSaving) {
-            $this->doNotWriteConfigInTests = true;
-        }
-
-        $this->reload($pathLocal, $pathGlobal, $pathCommon);
-
-        $chain = $this->settings->getIniFileChain();
-
-        $databaseTestsSettings = $chain->get('database_tests'); // has to be __get otherwise when called from TestConfig, PHP will issue a NOTICE
-        if (!empty($databaseTestsSettings)) {
-            $chain->set('database', $databaseTestsSettings);
-        }
-
-        // Ensure local mods do not affect tests
-        if (empty($pathGlobal)) {
-            $chain->set('Debug', $chain->getFrom($this->getGlobalPath(), 'Debug'));
-            $chain->set('mail', $chain->getFrom($this->getGlobalPath(), 'mail'));
-            $chain->set('General', $chain->getFrom($this->getGlobalPath(), 'General'));
-            $chain->set('Segments', $chain->getFrom($this->getGlobalPath(), 'Segments'));
-            $chain->set('Tracker', $chain->getFrom($this->getGlobalPath(), 'Tracker'));
-            $chain->set('Deletelogs', $chain->getFrom($this->getGlobalPath(), 'Deletelogs'));
-            $chain->set('Deletereports', $chain->getFrom($this->getGlobalPath(), 'Deletereports'));
-            $chain->set('Development', $chain->getFrom($this->getGlobalPath(), 'Development'));
-        }
-
-        // for unit tests, we set that no plugin is installed. This will force
-        // the test initialization to create the plugins tables, execute ALTER queries, etc.
-        $chain->set('PluginsInstalled', array('PluginsInstalled' => array()));
-    }
-
-    /**
      * Returns absolute path to the global configuration file
      *
      * @return string

--- a/core/Container/ContainerDoesNotExistException.php
+++ b/core/Container/ContainerDoesNotExistException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Container;
+
+use RuntimeException;
+
+/**
+ * Thrown if the root container has not been created and set in StaticContainer.
+ */
+class ContainerDoesNotExistException extends RuntimeException
+{
+}

--- a/core/Container/StaticContainer.php
+++ b/core/Container/StaticContainer.php
@@ -37,7 +37,7 @@ class StaticContainer
     public static function getContainer()
     {
         if (self::$container === null) {
-            throw new \Exception("The root container has not been created yet.");
+            throw new ContainerDoesNotExistException("The root container has not been created yet.");
         }
 
         return self::$container;

--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\Container\ContainerDoesNotExistException;
 use Piwik\Plugins\CoreAdminHome\CustomLogo;
 
 /**
@@ -87,16 +88,20 @@ class ExceptionHandler
 
         $result = Piwik_GetErrorMessagePage($message, $debugTrace, true, true, $logoHeaderUrl, $logoFaviconUrl);
 
-        /**
-         * Triggered before a Piwik error page is displayed to the user.
-         *
-         * This event can be used to modify the content of the error page that is displayed when
-         * an exception is caught.
-         *
-         * @param string &$result The HTML of the error page.
-         * @param Exception $ex The Exception displayed in the error page.
-         */
-        Piwik::postEvent('FrontController.modifyErrorPage', array(&$result, $ex));
+        try {
+            /**
+             * Triggered before a Piwik error page is displayed to the user.
+             *
+             * This event can be used to modify the content of the error page that is displayed when
+             * an exception is caught.
+             *
+             * @param string &$result The HTML of the error page.
+             * @param Exception $ex The Exception displayed in the error page.
+             */
+            Piwik::postEvent('FrontController.modifyErrorPage', array(&$result, $ex));
+        } catch (ContainerDoesNotExistException $ex) {
+            // this can happen when an error occurs before the Piwik environment is created
+        }
 
         return $result;
     }

--- a/plugins/TestRunner/Commands/TestsSetupFixture.php
+++ b/plugins/TestRunner/Commands/TestsSetupFixture.php
@@ -225,12 +225,6 @@ class TestsSetupFixture extends ConsoleCommand
             $fixture->extraPluginsToLoad = explode(',', $extraPluginsToLoad);
         }
 
-        if ($fixture->createConfig) {
-            Config::getInstance()->setTestEnvironment($pathLocal = null, $pathGlobal = null, $pathCommon = null, $allowSave);
-        }
-
-        $fixture->createConfig = false;
-
         return $fixture;
     }
 

--- a/plugins/TestRunner/Commands/TestsSetupFixture.php
+++ b/plugins/TestRunner/Commands/TestsSetupFixture.php
@@ -124,7 +124,6 @@ class TestsSetupFixture extends ConsoleCommand
 
         // perform setup and/or teardown
         if ($input->getOption('teardown')) {
-            exit;
             $fixture->getTestEnvironment()->save();
             $fixture->performTearDown();
         } else {

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -9,7 +9,6 @@ namespace Piwik\Tests\Framework;
 
 use Piwik\Access;
 use Piwik\Application\Environment;
-use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Archive;
 use Piwik\Cache\Backend\File;
 use Piwik\Cache as PiwikCache;
@@ -20,7 +19,6 @@ use Piwik\DataTable\Manager as DataTableManager;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\DbHelper;
-use Piwik\EventDispatcher;
 use Piwik\Ini\IniReader;
 use Piwik\Log;
 use Piwik\Option;
@@ -42,7 +40,6 @@ use Piwik\SettingsPiwik;
 use Piwik\SettingsServer;
 use Piwik\Site;
 use Piwik\Tests\Framework\Mock\FakeAccess;
-use Piwik\Tests\Framework\Mock\TestConfig;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tracker;
 use Piwik\Tracker\Cache;
@@ -53,7 +50,6 @@ use Piwik_TestingEnvironment;
 use PiwikTracker;
 use Piwik_LocalTracker;
 use Piwik\Updater;
-use Piwik\Plugins\CoreUpdater\CoreUpdater;
 use Exception;
 use ReflectionClass;
 
@@ -83,7 +79,12 @@ class Fixture extends \PHPUnit_Framework_Assert
     const ADMIN_USER_PASSWORD = 'superUserPass';
 
     public $dbName = false;
+
+    /**
+     * @deprecated has no effect now.
+     */
     public $createConfig = true;
+
     public $dropDatabaseInSetUp = true;
     public $dropDatabaseInTearDown = true;
     public $loadTranslations = true;
@@ -158,15 +159,7 @@ class Fixture extends \PHPUnit_Framework_Assert
 
     public function performSetUp($setupEnvironmentOnly = false)
     {
-        if ($this->createConfig) {
-            GlobalSettingsProvider::unsetSingletonInstance();
-        }
-
         $this->createEnvironmentInstance();
-
-        if ($this->createConfig) {
-            Config::setSingletonInstance(new TestConfig());
-        }
 
         try {
             $this->dbName = $this->getDbName();
@@ -335,9 +328,6 @@ class Fixture extends \PHPUnit_Framework_Assert
 
         $_GET = $_REQUEST = array();
         Translate::reset();
-
-        GlobalSettingsProvider::unsetSingletonInstance();
-        Config::setSingletonInstance(new TestConfig());
 
         Config::getInstance()->Plugins; // make sure Plugins exists in a config object for next tests that use Plugin\Manager
         // since Plugin\Manager uses getFromGlobalConfig which doesn't init the config object

--- a/tests/PHPUnit/Framework/Mock/TestConfig.php
+++ b/tests/PHPUnit/Framework/Mock/TestConfig.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Framework\Mock;
 
+use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Config;
 
 class TestConfig extends Config
@@ -15,16 +16,14 @@ class TestConfig extends Config
     private $allowSave = false;
     private $doSetTestEnvironment = false;
 
-    public function __construct($pathGlobal = null, $pathLocal = null, $pathCommon = null, $allowSave = false, $doSetTestEnvironment = true)
+    public function __construct(GlobalSettingsProvider $provider, $allowSave = false, $doSetTestEnvironment = true)
     {
-        \Piwik\Application\Kernel\GlobalSettingsProvider::unsetSingletonInstance();
-
-        parent::__construct($pathGlobal, $pathLocal, $pathCommon);
+        parent::__construct($provider);
 
         $this->allowSave = $allowSave;
         $this->doSetTestEnvironment = $doSetTestEnvironment;
 
-        $this->reload($pathGlobal, $pathLocal, $pathCommon);
+        $this->reload();
 
         $testingEnvironment = new \Piwik_TestingEnvironment();
         $this->setFromTestEnvironment($testingEnvironment);

--- a/tests/PHPUnit/Framework/Mock/TestConfig.php
+++ b/tests/PHPUnit/Framework/Mock/TestConfig.php
@@ -14,7 +14,6 @@ class TestConfig extends Config
 {
     private $allowSave = false;
     private $isSettingTestEnv = false;
-    private $isConfigTestEventPosted = false;
     private $doSetTestEnvironment = false;
 
     public function __construct($pathGlobal = null, $pathLocal = null, $pathCommon = null, $allowSave = false, $doSetTestEnvironment = true)
@@ -40,17 +39,6 @@ class TestConfig extends Config
             $this->isSettingTestEnv = true;
             $this->setTestEnvironment($pathLocal, $pathGlobal, $pathCommon, $this->allowSave);
             $this->isSettingTestEnv = false;
-        }
-    }
-
-    protected function postConfigTestEvent()
-    {
-        if ($this->isConfigTestEventPosted) { // avoid infinite recursion in case setTestEnvironment is called from within Config.setSingletonInstance test event
-            return;
-        } else {
-            $this->isConfigTestEventPosted = true;
-            parent::postConfigTestEvent();
-            $this->isConfigTestEventPosted = false;
         }
     }
 

--- a/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
@@ -9,8 +9,6 @@
 namespace Piwik\Tests\Framework\TestCase;
 
 use Piwik\Application\Environment;
-use Piwik\Application\Kernel\GlobalSettingsProvider;
-use Piwik\Container\StaticContainer;
 use Piwik\EventDispatcher;
 use Piwik\Tests\Framework\Mock\File;
 
@@ -30,8 +28,6 @@ abstract class UnitTestCase extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        GlobalSettingsProvider::unsetSingletonInstance();
-
         $this->initEnvironment();
 
         File::reset();
@@ -40,8 +36,6 @@ abstract class UnitTestCase extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         File::reset();
-
-        GlobalSettingsProvider::unsetSingletonInstance();
 
         // make sure the global container exists for the next test case that is executed (since logging can be done
         // before a test sets up an environment)

--- a/tests/PHPUnit/Framework/TestingEnvironment/MakeGlobalSettingsWithFile.php
+++ b/tests/PHPUnit/Framework/TestingEnvironment/MakeGlobalSettingsWithFile.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\Framework\TestingEnvironment;
+
+use Piwik\Application\EnvironmentManipulator;
+use Piwik\Application\Kernel\GlobalSettingsProvider;
+use Piwik\Tests\Framework\TestingEnvironment;
+
+class MakeGlobalSettingsWithFile implements EnvironmentManipulator
+{
+    private $configFileGlobal;
+    private $configFileLocal;
+    private $configFileCommon;
+
+    public function __construct(\Piwik_TestingEnvironment $testingEnvironment)
+    {
+        $this->configFileGlobal = $testingEnvironment->configFileGlobal;
+        $this->configFileLocal = $testingEnvironment->configFileLocal;
+        $this->configFileCommon = $testingEnvironment->configFileCommon;
+    }
+
+    public function makeGlobalSettingsProvider()
+    {
+        return new GlobalSettingsProvider($this->configFileGlobal, $this->configFileLocal, $this->configFileCommon);
+    }
+}

--- a/tests/PHPUnit/Integration/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ActionTest.php
@@ -12,7 +12,6 @@ use Piwik\Access;
 use Piwik\Config;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\Tests\Framework\Mock\FakeAccess;
-use Piwik\Tests\Framework\Mock\TestConfig;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\PageUrl;
 use Piwik\Tracker\Request;
@@ -29,7 +28,7 @@ class ActionTest extends IntegrationTestCase
     public function setUp()
     {
         parent::setUp();
-        Config::setSingletonInstance(new TestConfig());
+
         $section = Config::getInstance()->Tracker;
         $section['default_action_url'] = '/';
         $section['campaign_var_name']  = 'campaign_param_name,piwik_campaign,utm_campaign,test_campaign_name';

--- a/tests/PHPUnit/Integration/TrackerTest.php
+++ b/tests/PHPUnit/Integration/TrackerTest.php
@@ -59,7 +59,6 @@ class TrackerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        GlobalSettingsProvider::unsetSingletonInstance();
         Config::unsetInstance();
 
         Fixture::createWebsite('2014-01-01 00:00:00');

--- a/tests/PHPUnit/Integration/TrackerTest.php
+++ b/tests/PHPUnit/Integration/TrackerTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration;
 
-use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\EventDispatcher;
@@ -58,8 +57,6 @@ class TrackerTest extends IntegrationTestCase
     public function setUp()
     {
         parent::setUp();
-
-        Config::unsetInstance();
 
         Fixture::createWebsite('2014-01-01 00:00:00');
 
@@ -151,8 +148,6 @@ class TrackerTest extends IntegrationTestCase
         $this->removeConfigFile();
 
         $this->assertFalse(is_readable(Config::getInstance()->getLocalPath()));
-
-        Config::unsetInstance();
 
         Tracker::loadTrackerEnvironment();
 

--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -174,8 +174,6 @@ class BlobReportLimitingTest extends SystemTestCase
 
     protected static function setUpConfigOptions()
     {
-        Config::setSingletonInstance(new TestConfig());
-
         $generalConfig =& Config::getInstance()->General;
         $generalConfig['datatable_archiving_maximum_rows_referers'] = 3;
         $generalConfig['datatable_archiving_maximum_rows_subtable_referers'] = 2;

--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -29,12 +29,6 @@ class BlobReportLimitingTest extends SystemTestCase
      */
     public static $fixture = null; // initialized below class definition
 
-    public static function setUpBeforeClass()
-    {
-        self::setUpConfigOptions();
-        parent::setUpBeforeClass();
-    }
-
     public function setUp()
     {
         Cache::getTransientCache()->flushAll();
@@ -103,6 +97,8 @@ class BlobReportLimitingTest extends SystemTestCase
      */
     public function testApi($api, $params)
     {
+        self::setUpConfigOptions();
+
         $this->runApiTests($api, $params);
     }
 
@@ -187,4 +183,3 @@ class BlobReportLimitingTest extends SystemTestCase
 }
 
 BlobReportLimitingTest::$fixture = new ManyVisitsWithMockLocationProvider();
-BlobReportLimitingTest::$fixture->createConfig = false;

--- a/tests/PHPUnit/TestingEnvironment.php
+++ b/tests/PHPUnit/TestingEnvironment.php
@@ -1,15 +1,15 @@
 <?php
 
+use Piwik\Application\Environment;
 use Piwik\Common;
 use Piwik\Config;
-use Piwik\Config\IniFileChain;
 use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Option;
 use Piwik\Plugin\Manager as PluginManager;
 use Piwik\DbHelper;
 use Piwik\Tests\Framework\Fixture;
-use Piwik\Tests\Framework\Mock\TestConfig;
+use Piwik\Tests\Framework\TestingEnvironment\MakeGlobalSettingsWithFile;
 
 require_once PIWIK_INCLUDE_PATH . "/core/Config.php";
 
@@ -151,12 +151,6 @@ class Piwik_TestingEnvironment
             \Piwik\Profiler::setupProfilerXHProf($mainRun = false, $setupDuringTracking = true);
         }
 
-        \Piwik\Application\Kernel\GlobalSettingsProvider::getSingletonInstance(
-            $testingEnvironment->configFileGlobal,
-            $testingEnvironment->configFileLocal,
-            $testingEnvironment->configFileCommon
-        );
-
         // Apply DI config from the fixture
         $diConfig = array();
         if ($testingEnvironment->fixtureClass) {
@@ -185,24 +179,18 @@ class Piwik_TestingEnvironment
 
         \Piwik\Cache\Backend\File::$invalidateOpCacheBeforeRead = true;
 
+        Environment::addEnvironmentManipulator(new MakeGlobalSettingsWithFile($testingEnvironment));
+
+        if (!$testingEnvironment->dontUseTestConfig) {
+            $diConfig['Piwik\Config'] = \DI\object('Piwik\Tests\Framework\Mock\TestConfig');
+        }
+
         $globalObservers[] = array('Access.createAccessSingleton', function($access) use ($testingEnvironment) {
             if (!$testingEnvironment->testUseRegularAuth) {
                 $access = new Piwik_MockAccess($access);
                 \Piwik\Access::setSingletonInstance($access);
             }
         });
-
-        if (!$testingEnvironment->dontUseTestConfig) {
-            Config::setSingletonInstance(new TestConfig(
-                $testingEnvironment->configFileGlobal, $testingEnvironment->configFileLocal, $testingEnvironment->configFileCommon
-            ));
-        } else {
-            \Piwik\Application\Kernel\GlobalSettingsProvider::unsetSingletonInstance();
-
-            Config::setSingletonInstance(new Config(
-                $testingEnvironment->configFileGlobal, $testingEnvironment->configFileLocal, $testingEnvironment->configFileCommon
-            ));
-        }
 
         $globalObservers[] = array('Environment.bootstrapped', function () use ($testingEnvironment) {
             $testingEnvironment->logVariables();

--- a/tests/PHPUnit/Unit/AssetManager/PluginManagerMock.php
+++ b/tests/PHPUnit/Unit/AssetManager/PluginManagerMock.php
@@ -74,4 +74,9 @@ class PluginManagerMock extends Manager
     {
         $this->loadedTheme = $loadedTheme;
     }
+
+    public function isPluginBundledWithCore($name)
+    {
+        return stripos($name, 'NonCore') === false;
+    }
 }

--- a/tests/PHPUnit/Unit/AssetManager/configs/merged-assets-disabled.ini.php
+++ b/tests/PHPUnit/Unit/AssetManager/configs/merged-assets-disabled.ini.php
@@ -1,2 +1,0 @@
-[Development]
-disable_merged_assets = 1

--- a/tests/PHPUnit/Unit/AssetManager/configs/merged-assets-enabled.ini.php
+++ b/tests/PHPUnit/Unit/AssetManager/configs/merged-assets-enabled.ini.php
@@ -1,2 +1,0 @@
-[Development]
-disable_merged_assets = 0

--- a/tests/PHPUnit/Unit/AssetManager/configs/plugins.ini.php
+++ b/tests/PHPUnit/Unit/AssetManager/configs/plugins.ini.php
@@ -1,9 +1,0 @@
-[Plugins]
-Plugins[] = MockCorePlugin
-Plugins[] = CoreThemePlugin
-
-[Development]
-enabled = 1
-
-[General]
-default_language = en

--- a/tests/PHPUnit/Unit/AssetManagerTest.php
+++ b/tests/PHPUnit/Unit/AssetManagerTest.php
@@ -117,8 +117,6 @@ class AssetManagerTest extends UnitTestCase
         $userFile = PIWIK_INCLUDE_PATH . '/' . self::ASSET_MANAGER_TEST_DIR . 'configs/' . $filename;
         $globalFile = PIWIK_INCLUDE_PATH . '/' . self::ASSET_MANAGER_TEST_DIR . 'configs/plugins.ini.php';
 
-        Config::setSingletonInstance(new TestConfig($globalFile, $userFile));
-
         $this->initEnvironment();
     }
 

--- a/tests/PHPUnit/Unit/AssetManagerTest.php
+++ b/tests/PHPUnit/Unit/AssetManagerTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Unit;
 
-use PHPUnit_Framework_TestCase;
 use Piwik\AssetManager\UIAsset\OnDiskUIAsset;
 use Piwik\AssetManager\UIAsset;
 use Piwik\AssetManager;
@@ -16,10 +15,7 @@ use Piwik\AssetManager\UIAssetFetcher\StaticUIAssetFetcher;
 use Piwik\Config;
 use Piwik\Plugin;
 use Piwik\Plugin\Manager;
-use Piwik\EventDispatcher;
-use Piwik\Tests\Framework\Mock\TestConfig;
 use Piwik\Tests\Framework\TestCase\UnitTestCase;
-use Piwik\Tests\Unit\AssetManager\PluginManagerMock;
 use Piwik\Tests\Unit\AssetManager\PluginMock;
 use Piwik\Tests\Unit\AssetManager\ThemeMock;
 use Piwik\Tests\Unit\AssetManager\UIAssetCacheBusterMock;
@@ -68,7 +64,7 @@ class AssetManagerTest extends UnitTestCase
     {
         parent::setUp();
 
-        $this->setUpConfig('merged-assets-enabled.ini.php');
+        $this->setUpConfig();
 
         $this->activateMergedAssets();
 
@@ -109,15 +105,15 @@ class AssetManagerTest extends UnitTestCase
         Config::getInstance()->Development['disable_merged_assets'] = 1;
     }
 
-    /**
-     * @param string $filename
-     */
-    private function setUpConfig($filename)
+    private function setUpConfig()
     {
-        $userFile = PIWIK_INCLUDE_PATH . '/' . self::ASSET_MANAGER_TEST_DIR . 'configs/' . $filename;
-        $globalFile = PIWIK_INCLUDE_PATH . '/' . self::ASSET_MANAGER_TEST_DIR . 'configs/plugins.ini.php';
-
         $this->initEnvironment();
+
+        Config::getInstance()->Plugins = array('Plugins' => array('MockCorePlugin', 'CoreThemePlugin'));
+        Config::getInstance()->Development['enabled'] = 1;
+        Config::getInstance()->General['default_language'] = 'en';
+
+        $this->disableMergedAssets();
     }
 
     private function setUpCacheBuster()
@@ -127,7 +123,7 @@ class AssetManagerTest extends UnitTestCase
 
     private function setUpAssetManager()
     {
-        $this->assetManager = AssetManager::getInstance();
+        $this->assetManager = new AssetManager();
 
         $this->assetManager->removeMergedAssets();
 

--- a/tests/PHPUnit/Unit/Columns/DimensionTest.php
+++ b/tests/PHPUnit/Unit/Columns/DimensionTest.php
@@ -67,18 +67,10 @@ namespace Piwik\Tests\Unit\Columns
         {
             parent::setUp();
 
-            Config::unsetInstance();
-
             Manager::getInstance()->unloadPlugins();
             Manager::getInstance()->doNotLoadAlwaysActivatedPlugins();
 
             $this->dimension = new DimensionTest();
-        }
-
-        public function tearDown()
-        {
-            Config::unsetInstance();
-            parent::tearDown();
         }
 
         public function test_hasImplementedEvent_shouldDetectWhetherAMethodWasOverwrittenInTheActualPluginClass()

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -45,9 +45,7 @@ class DumpConfigTestMockConfig extends Config
 {
     public function __construct($configLocal, $configGlobal, $configCommon, $configCache)
     {
-        parent::__construct();
-
-        $this->settings = new MockIniSettingsProvider($configLocal, $configGlobal, $configCommon, $configCache);
+        parent::__construct(new MockIniSettingsProvider($configLocal, $configGlobal, $configCommon, $configCache));
     }
 }
 
@@ -56,19 +54,12 @@ class DumpConfigTestMockConfig extends Config
  */
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        GlobalSettingsProvider::unsetSingletonInstance();
-    }
-
     public function testUserConfigOverwritesSectionGlobalConfigValue()
     {
         $userFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/config.ini.php';
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
         $commonFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/common.ini.php';
-        $config = new Config($globalFile, $userFile, $commonFile);
+        $config = new Config(new GlobalSettingsProvider($globalFile, $userFile, $commonFile));
 
         $this->assertEquals("value_overwritten", $config->Category['key1']);
         $this->assertEquals("value2", $config->Category['key2']);
@@ -96,7 +87,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
         $commonFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/common.config.ini.php';
 
-        $config = new Config($globalFile, $userFile, $commonFile);
+        $config = new Config(new GlobalSettingsProvider($globalFile, $userFile, $commonFile));
 
         $this->assertEquals("valueCommon", $config->Category['key2'], var_export($config->Category['key2'], true));
         $this->assertEquals("test", $config->GeneralSection['password']);
@@ -109,7 +100,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $userFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/config.written.ini.php';
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
 
-        $config = new Config($globalFile, $userFile);
+        $config = new Config(new GlobalSettingsProvider($globalFile, $userFile));
 
         $stringWritten = '&6^ geagea\'\'\'";;&';
         $config->Category = array('test' => $stringWritten);
@@ -118,7 +109,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         // This will write the file
         $config->forceSave();
 
-        $config = new TestConfig($globalFile, $userFile);
+        $config = new TestConfig(new GlobalSettingsProvider($globalFile, $userFile));
 
         $this->assertEquals($stringWritten, $config->Category['test']);
         $config->Category = array(
@@ -134,7 +125,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $userFile = PIWIK_PATH_TEST_TO_ROOT . '/tests/resources/Config/config.ini.php';
         $globalFile = PIWIK_PATH_TEST_TO_ROOT . '/tests/resources/Config/global.ini.php';
 
-        $config = new Config($globalFile, $userFile);
+        $config = new Config(new GlobalSettingsProvider($globalFile, $userFile));
 
         $this->assertEquals("value_overwritten", $config->Category['key1']);
         $this->assertEquals("value2", $config->Category['key2']);
@@ -377,7 +368,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
         $commonFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/common.config.ini.php';
 
-        $config = new Config($globalFile, $userFile, $commonFile);
+        $config = new Config(new GlobalSettingsProvider($globalFile, $userFile, $commonFile));
 
         $this->assertEquals('${@piwik(crash))}', $config->Category['key3']);
     }
@@ -390,7 +381,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         @unlink($configFile);
         copy($sourceConfigFile, $configFile);
 
-        $config = new Config($sourceConfigFile, $configFile);
+        $config = new Config(new GlobalSettingsProvider($sourceConfigFile, $configFile));
         $config->forceSave();
 
         $this->assertEquals(file_get_contents($sourceConfigFile), file_get_contents($configFile));
@@ -404,7 +395,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
         $commonFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/common.config.ini.php';
         
-        $config = new Config($globalFile, $userFile, $commonFile);
+        $config = new Config(new GlobalSettingsProvider($globalFile, $userFile, $commonFile));
 
         $configCategory = $config->getFromGlobalConfig('Category');
         $this->assertEquals('value1', $configCategory['key1']);
@@ -418,7 +409,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
         $commonFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/common.config.ini.php';
     
-        $config = new Config($globalFile, $userFile, $commonFile);
+        $config = new Config(new GlobalSettingsProvider($globalFile, $userFile, $commonFile));
 
         $configCategory = $config->getFromCommonConfig('Category');
         $this->assertEquals(array('key2' => 'valueCommon', 'key3' => '${@piwik(crash))}'), $configCategory);
@@ -430,7 +421,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
         $commonFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/common.config.ini.php';
     
-        $config = new Config($globalFile, $userFile, $commonFile);
+        $config = new Config(new GlobalSettingsProvider($globalFile, $userFile, $commonFile));
 
         $configCategory = $config->getFromLocalConfig('Category');
         $this->assertEquals(array('key1' => 'value_overwritten'), $configCategory);

--- a/tests/PHPUnit/Unit/DataTable/Filter/PivotByDimensionTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PivotByDimensionTest.php
@@ -14,7 +14,6 @@ use Piwik\DataTable\Filter\PivotByDimension;
 use Piwik\DataTable\Row;
 use Piwik\Plugin\Manager as PluginManager;
 use Exception;
-use Piwik\Tests\Framework\Mock\TestConfig;
 use Piwik\Tests\Framework\TestCase\UnitTestCase;
 
 /**
@@ -59,8 +58,6 @@ class PivotByDimensionTest extends UnitTestCase
         Proxy::setSingletonInstance($proxyMock);
 
         $this->segmentTableCount = 0;
-
-        Config::setSingletonInstance(new TestConfig());
     }
 
     public function tearDown()

--- a/tests/PHPUnit/Unit/DataTable/MapTest.php
+++ b/tests/PHPUnit/Unit/DataTable/MapTest.php
@@ -16,7 +16,6 @@ class Test_DataTable_Map extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         parent::setUp();
-        Config::setSingletonInstance(new TestConfig());
         Manager::getInstance()->deleteAll();
     }
 

--- a/tests/PHPUnit/Unit/IPTest.php
+++ b/tests/PHPUnit/Unit/IPTest.php
@@ -87,8 +87,6 @@ class IPTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetIpFromHeader($description, $test)
     {
-        Config::setSingletonInstance(new TestConfig());
-
         $_SERVER['REMOTE_ADDR'] = $test[0];
         $_SERVER['HTTP_X_FORWARDED_FOR'] = $test[1];
         Config::getInstance()->General['proxy_client_headers'] = array($test[2]);

--- a/tests/PHPUnit/Unit/Plugin/ComponentFactoryTest.php
+++ b/tests/PHPUnit/Unit/Plugin/ComponentFactoryTest.php
@@ -25,7 +25,6 @@ class ComponentFactoryTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        Config::setSingletonInstance(new TestConfig());
         Config::getInstance()->Plugins['Plugins'] = array();
 
         $this->unloadAllPlugins();


### PR DESCRIPTION
This PR adds the Config singleton to DI (removing the use of the singleton). Additional changes include:
- The EnvironmentManipulator internal concept. Simplified from the previous monolithic PR. Allows TestingEnvironment to inject a GlobalSettingsProvider in all Environment instances, and is only a reasonably hacky solution. (Previous solution in commit of the last PR was three static members for config file locations.)
- Config::setTestEnvironment() is moved to TestConfig. Other plugins that use the method will have to be modified (I think only LoginLdap).
- The testing environment logic that is executed in a hook to Config.createConfigSingleton was moved to TestConfig.
- The Config.createConfigSIngleton event was removed. Only reason to have it was for doing TestingEnvironment setup, and now that that's in TestCOnfig, the event is not needed.

Note: tests won't pass, I need to fix them and include the changes in the correct commits.
