### PR TITLE
Injection Inception, Change #3: Allow integration + system tests to override DI

### DIFF
--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -101,6 +101,14 @@ class Fixture extends \PHPUnit_Framework_Assert
     public $testEnvironment = null;
 
     /**
+     * Extra DI configuration to use when creating the test environment. This will override configuration
+     * returned by the `provideContainerConfig()` method.
+     *
+     * @var array
+     */
+    public $extraDefinitions = array();
+
+    /**
      * @var Environment
      */
     public $piwikEnvironment;
@@ -915,7 +923,7 @@ class Fixture extends \PHPUnit_Framework_Assert
 
     public function createEnvironmentInstance()
     {
-        $this->piwikEnvironment = new Environment('test');
+        $this->piwikEnvironment = new Environment('test', array_merge($this->provideContainerConfig(), $this->extraDefinitions));
         $this->piwikEnvironment->init();
     }
 }

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -74,6 +74,7 @@ abstract class IntegrationTestCase extends SystemTestCase
     {
         parent::setUp();
 
+        self::$fixture->extraDefinitions = array_merge(static::provideContainerConfigBeforeClass(), $this->provideContainerConfig());
         self::$fixture->createEnvironmentInstance();
 
         Fixture::loadAllPlugins(new \Piwik_TestingEnvironment(), get_class($this), self::$fixture->extraPluginsToLoad);
@@ -106,6 +107,17 @@ abstract class IntegrationTestCase extends SystemTestCase
     protected static function beforeTableDataCached()
     {
         // empty
+    }
+
+    /**
+     * Use this method to return custom container configuration that you want to apply for the tests.
+     * This configuration will override Fixture config and config specified in SystemTestCase::provideContainerConfig().
+     *
+     * @return array
+     */
+    public function provideContainerConfig()
+    {
+        return array();
     }
 }
 

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -64,6 +64,7 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         }
 
         $fixture->testCaseClass = get_called_class();
+        $fixture->extraDefinitions = static::provideContainerConfigBeforeClass();
 
         try {
             $fixture->performSetUp();
@@ -617,6 +618,16 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         self::assertTrue(Db::hasDatabaseObject(), $message);
     }
 
+    /**
+     * Use this method to return custom container configuration that you want to apply for the tests.
+     * This configuration will override Fixture config.
+     *
+     * @return array
+     */
+    public static function provideContainerConfigBeforeClass()
+    {
+        return array();
+    }
 }
 
 SystemTestCase::$fixture = new \Piwik\Tests\Framework\Fixture();

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -308,7 +308,9 @@ class TrackerTest extends IntegrationTestCase
 
     public function provideContainerConfig()
     {
-        define('DEBUG_FORCE_SCHEDULED_TASKS', 1);
+        if (!defined('DEBUG_FORCE_SCHEDULED_TASKS')) {
+            define('DEBUG_FORCE_SCHEDULED_TASKS', 1);
+        }
 
         $testingEnvironment = new \Piwik_TestingEnvironment();
 

--- a/tests/PHPUnit/TestingEnvironment.php
+++ b/tests/PHPUnit/TestingEnvironment.php
@@ -172,6 +172,11 @@ class Piwik_TestingEnvironment
             $testCaseClass = $testingEnvironment->testCaseClass;
             if (class_exists($testCaseClass)) {
                 $testCase = new $testCaseClass();
+
+                if (method_exists($testCase, 'provideContainerConfigBeforeClass')) {
+                    $diConfig = array_merge($diConfig, $testCaseClass::provideContainerConfigBeforeClass());
+                }
+
                 if (method_exists($testCase, 'provideContainerConfig')) {
                     $diConfig = array_merge($diConfig, $testCase->provideContainerConfig());
                 }


### PR DESCRIPTION
This PR allows integration & system tests to override DI config. The overrides are applied in the test process, not just child processes (ie, web request, CLI multi, etc.).
