### PR TITLE
Detect idaction columns automatically in LogDataPurger using ActionDimension

### DIFF
--- a/core/Plugin/Dimension/ActionDimension.php
+++ b/core/Plugin/Dimension/ActionDimension.php
@@ -209,6 +209,7 @@ abstract class ActionDimension extends Dimension
 
     /**
      * Get all action dimensions that are defined by all activated plugins.
+     * @return ActionDimension[]
      * @ignore
      */
     public static function getAllDimensions()

--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -167,7 +167,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         $settings = PrivacyManager::getPurgeDataSettings();
         if ($settings['delete_logs_enable']) {
-            $logDataPurger = LogDataPurger::make($settings);
+            /** @var LogDataPurger $logDataPurger */
+            $logDataPurger = StaticContainer::get('Piwik\Plugins\PrivacyManager\LogDataPurger');
             $logDataPurger->purgeData();
         }
         if ($settings['delete_reports_enable']) {

--- a/plugins/PrivacyManager/DimensionMetadataProvider.php
+++ b/plugins/PrivacyManager/DimensionMetadataProvider.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Plugins\PrivacyManager;
+
+/**
+ * Provides metadata about dimensions for the LogDataPurger class.
+ */
+class DimensionMetadataProvider
+{
+    /**
+     * Overrids for the result of the getActionReferenceColumnsByTable() method. Exists so Piwik
+     * instances can be monkey patched, in case there are idaction columns that this class does not
+     * naturally discover.
+     *
+     * @var array
+     */
+    private $actionReferenceColumnsOverride;
+
+    public function __construct(array $actionReferenceColumnsOverride = array())
+    {
+        $this->actionReferenceColumnsOverride = $actionReferenceColumnsOverride;
+    }
+
+    /**
+     * Returns a list of idaction column names organized by table name. Uses dimension metadata
+     * to find idaction columns dynamically.
+     *
+     * Note: It is not currently possible to use the Piwik platform to add idaction columns to tables
+     * other than log_link_visit_action (w/o doing something unsupported), so idaction columns in
+     * other tables are hard coded.
+     *
+     * @return array[]
+     */
+    public function getActionReferenceColumnsByTable()
+    {
+        return array(
+            'log_link_visit_action' => array('idaction_url',
+                'idaction_url_ref',
+                'idaction_name',
+                'idaction_name_ref',
+                'idaction_event_category',
+                'idaction_event_action'
+            ),
+
+            'log_conversion'        => array('idaction_url'),
+
+            'log_visit'             => array('visit_exit_idaction_url',
+                'visit_exit_idaction_name',
+                'visit_entry_idaction_url',
+                'visit_entry_idaction_name'),
+
+            'log_conversion_item'   => array('idaction_sku',
+                'idaction_name',
+                'idaction_category',
+                'idaction_category2',
+                'idaction_category3',
+                'idaction_category4',
+                'idaction_category5')
+        );
+    }
+}

--- a/plugins/PrivacyManager/LogDataPurger.php
+++ b/plugins/PrivacyManager/LogDataPurger.php
@@ -280,20 +280,4 @@ class LogDataPurger
         }
         return $result;
     }
-
-    /**
-     * Utility function. Creates a new instance of LogDataPurger with the supplied array
-     * of settings.
-     *
-     * $settings must contain values for the following keys:
-     * - 'delete_logs_older_than': The number of days after which log entries are considered
-     *                             old.
-     * - 'delete_logs_max_rows_per_query': Max number of rows to DELETE in one query.
-     *
-     * @return \Piwik\Plugins\PrivacyManager\LogDataPurger
-     */
-    public static function make()
-    {
-        return new LogDataPurger(new DimensionMetadataProvider());
-    }
 }

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -26,9 +26,6 @@ use Piwik\Plugins\Installation\FormDefaultSettings;
 use Piwik\Site;
 use Piwik\Tracker\GoalManager;
 
-require_once PIWIK_INCLUDE_PATH . '/plugins/PrivacyManager/LogDataPurger.php';
-require_once PIWIK_INCLUDE_PATH . '/plugins/PrivacyManager/ReportsPurger.php';
-
 /**
  * Specifically include this for Tracker API (which does not use autoloader)
  */

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\PrivacyManager;
 use HTML_QuickForm2_DataSource_Array;
 use Piwik\Common;
 use Piwik\Config as PiwikConfig;
+use Piwik\Container\StaticContainer;
 use Piwik\DataTable\DataTableInterface;
 use Piwik\Date;
 use Piwik\Db;
@@ -326,7 +327,8 @@ class PrivacyManager extends Plugin
         Option::set(self::OPTION_LAST_DELETE_PIWIK_LOGS, $lastDeleteDate);
 
         // execute the purge
-        $logDataPurger = LogDataPurger::make();
+        /** @var LogDataPurger $logDataPurger */
+        $logDataPurger = StaticContainer::get('Piwik\Plugins\PrivacyManager\LogDataPurger');
         $logDataPurger->purgeData($settings['delete_logs_older_than'], $settings['delete_logs_max_rows_per_query']);
 
         return true;
@@ -352,7 +354,8 @@ class PrivacyManager extends Plugin
         $result = array();
 
         if ($settings['delete_logs_enable']) {
-            $logDataPurger = LogDataPurger::make();
+            /** @var LogDataPurger $logDataPurger */
+            $logDataPurger = StaticContainer::get('Piwik\Plugins\PrivacyManager\LogDataPurger');
             $result = array_merge($result, $logDataPurger->getPurgeEstimate($settings['delete_logs_older_than']));
         }
 

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -326,7 +326,8 @@ class PrivacyManager extends Plugin
         Option::set(self::OPTION_LAST_DELETE_PIWIK_LOGS, $lastDeleteDate);
 
         // execute the purge
-        LogDataPurger::make($settings)->purgeData();
+        $logDataPurger = LogDataPurger::make();
+        $logDataPurger->purgeData($settings['delete_logs_older_than'], $settings['delete_logs_max_rows_per_query']);
 
         return true;
     }
@@ -351,8 +352,8 @@ class PrivacyManager extends Plugin
         $result = array();
 
         if ($settings['delete_logs_enable']) {
-            $logDataPurger = LogDataPurger::make($settings);
-            $result = array_merge($result, $logDataPurger->getPurgeEstimate());
+            $logDataPurger = LogDataPurger::make();
+            $result = array_merge($result, $logDataPurger->getPurgeEstimate($settings['delete_logs_older_than']));
         }
 
         if ($settings['delete_reports_enable']) {

--- a/plugins/PrivacyManager/tests/Unit/DimensionMetadataProviderTest.php
+++ b/plugins/PrivacyManager/tests/Unit/DimensionMetadataProviderTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\PrivacyManager\tests\Unit;
+
+use Piwik\Plugins\PrivacyManager\DimensionMetadataProvider;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
+use Piwik\Plugin\Manager as PluginManager;
+
+class DimensionMetadataProviderTest extends UnitTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        /** @var PluginManager $manager */
+        $manager = $this->environment->getContainer()->get('Piwik\Plugin\Manager');
+        $manager->loadPlugins(array('Events', 'Contents'));
+    }
+
+    public function test_getActionReferenceColumnsByTable_DetectsActionReferenceDimensions_AndIncludesHardocdedColumns()
+    {
+        $dimensionMetadataProvider = new DimensionMetadataProvider();
+
+        $actualColumns = $dimensionMetadataProvider->getActionReferenceColumnsByTable();
+
+        $expectedColumns = array(
+            'log_link_visit_action' => array(
+                'idaction_url',
+                'idaction_url_ref',
+                'idaction_name_ref',
+                'idaction_event_action',
+                'idaction_event_category',
+                'idaction_name',
+                'idaction_content_interaction',
+                'idaction_content_name',
+                'idaction_content_piece',
+                'idaction_content_target'
+            ),
+            'log_conversion' => array(
+                'idaction_url',
+            ),
+            'log_visit' => array(
+                'visit_exit_idaction_url',
+                'visit_exit_idaction_name',
+                'visit_entry_idaction_url',
+                'visit_entry_idaction_name',
+            ),
+            'log_conversion_item' => array(
+                'idaction_sku',
+                'idaction_name',
+                'idaction_category',
+                'idaction_category2',
+                'idaction_category3',
+                'idaction_category4',
+                'idaction_category5',
+            ),
+        );
+
+        $this->assertEquals($expectedColumns, $actualColumns);
+    }
+
+    public function test_getActionReferenceColumnsByTable_AppliesOverrideColumnsCorrectly_WithoutAllowingDuplicates()
+    {
+        $dimensionMetadataProvider = new DimensionMetadataProvider(array(
+            'log_link_visit_action' => array('idaction_url',
+                'idaction_event_category'
+            ),
+
+            'log_conversion' => array(),
+
+            'log_conversion_item' => array('some_unknown_idaction_column'),
+
+            'log_custom_table' => array('some_column1', 'some_column2')
+        ));
+
+        $actualColumns = $dimensionMetadataProvider->getActionReferenceColumnsByTable();
+
+        $expectedColumns = array(
+            'log_link_visit_action' => array(
+                'idaction_url',
+                'idaction_url_ref',
+                'idaction_name_ref',
+                'idaction_event_action',
+                'idaction_event_category',
+                'idaction_name',
+                'idaction_content_interaction',
+                'idaction_content_name',
+                'idaction_content_piece',
+                'idaction_content_target'
+            ),
+            'log_conversion' => array(
+                'idaction_url',
+            ),
+            'log_visit' => array(
+                'visit_exit_idaction_url',
+                'visit_exit_idaction_name',
+                'visit_entry_idaction_url',
+                'visit_entry_idaction_name',
+            ),
+            'log_conversion_item' => array(
+                'idaction_sku',
+                'idaction_name',
+                'idaction_category',
+                'idaction_category2',
+                'idaction_category3',
+                'idaction_category4',
+                'idaction_category5',
+                'some_unknown_idaction_column'
+            ),
+            'log_custom_table' => array(
+                'some_column1',
+                'some_column2'
+            )
+        );
+
+        $this->assertEquals($expectedColumns, $actualColumns);
+    }
+}

--- a/tests/PHPUnit/System/PrivacyManagerTest.php
+++ b/tests/PHPUnit/System/PrivacyManagerTest.php
@@ -8,7 +8,6 @@
 namespace Piwik\Tests\System;
 
 use Piwik\Archive;
-use Piwik\ArchiveProcessor\Rules;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\DataAccess\ArchiveTableCreator;
@@ -18,6 +17,7 @@ use Piwik\Db;
 use Piwik\Option;
 use Piwik\Plugins\Goals\API as APIGoals;
 use Piwik\Plugins\Goals\Archiver;
+use Piwik\Plugins\PrivacyManager\DimensionMetadataProvider;
 use Piwik\Plugins\PrivacyManager\LogDataPurger;
 use Piwik\Plugins\PrivacyManager\PrivacyManager;
 use Piwik\Plugins\PrivacyManager\ReportsPurger;
@@ -489,7 +489,7 @@ class PrivacyManagerTest extends SystemTestCase
     {
         \Piwik\Piwik::addAction("LogDataPurger.ActionsToKeepInserted.olderThan", array($this, 'addReferenceToUnusedAction'));
 
-        $purger = LogDataPurger::make();
+        $purger = new LogDataPurger(new DimensionMetadataProvider());
 
         $this->unusedIdAction = Db::fetchOne(
             "SELECT idaction FROM " . Common::prefixTable('log_action') . " WHERE name = ?",

--- a/tests/PHPUnit/System/PrivacyManagerTest.php
+++ b/tests/PHPUnit/System/PrivacyManagerTest.php
@@ -187,9 +187,10 @@ class PrivacyManagerTest extends IntegrationTestCase
 
         // perform checks on prediction
         $events = 3; // only the event action for the three purged day, dayAgo=x are purged (others are still in use)
+        $contents = 3; // one content impression per day, so 3 purged
         $expectedPrediction = array(
             Common::prefixTable('log_conversion')          => 6,
-            Common::prefixTable('log_link_visit_action')   => 6 + $events,
+            Common::prefixTable('log_link_visit_action')   => 6 + $events + $contents,
             Common::prefixTable('log_visit')               => 3,
             Common::prefixTable('log_conversion_item')     => 3,
             Common::prefixTable('archive_numeric_2012_01') => -1,
@@ -298,9 +299,10 @@ class PrivacyManagerTest extends IntegrationTestCase
 
         // perform checks on prediction
         $events = 3; // only the event action for the three purged day, dayAgo=x are purged (others are still in use)
+        $contents = 3; // one content impression per day, so 3 purged
         $expectedPrediction = array(
             Common::prefixTable('log_conversion')          => 6,
-            Common::prefixTable('log_link_visit_action')   => 6 + $events,
+            Common::prefixTable('log_link_visit_action')   => 6 + $events + $contents,
             Common::prefixTable('log_visit')               => 3,
             Common::prefixTable('log_conversion_item')     => 3,
             Common::prefixTable('archive_numeric_2012_01') => 1, // remove the garbage metric
@@ -352,9 +354,10 @@ class PrivacyManagerTest extends IntegrationTestCase
 
         // perform checks on prediction
         $events = 3; // only the event action for the three purged day, dayAgo=x are purged (others are still in use)
+        $contents = 3; // one content impression per day, so 3 purged
         $expectedPrediction = array(
             Common::prefixTable('log_conversion')          => 6,
-            Common::prefixTable('log_link_visit_action')   => 6 + $events,
+            Common::prefixTable('log_link_visit_action')   => 6 + $events + $contents,
             Common::prefixTable('log_visit')               => 3,
             Common::prefixTable('log_conversion_item')     => 3,
             Common::prefixTable('archive_numeric_2012_01') => -1,
@@ -386,9 +389,10 @@ class PrivacyManagerTest extends IntegrationTestCase
 
         // perform checks on prediction
         $events = 3; // only the event action for the three purged day, dayAgo=x are purged (others are still in use)
+        $contents = 3; // one content impression per day, so 3 purged
         $expectedPrediction = array(
             Common::prefixTable('log_conversion')          => 6,
-            Common::prefixTable('log_link_visit_action')   => 6 + $events,
+            Common::prefixTable('log_link_visit_action')   => 6 + $events + $contents,
             Common::prefixTable('log_visit')               => 3,
             Common::prefixTable('log_conversion_item')     => 3,
             Common::prefixTable('archive_numeric_2012_01') => -1,
@@ -420,9 +424,10 @@ class PrivacyManagerTest extends IntegrationTestCase
 
         // perform checks on prediction
         $events = 3; // only the event action for the three purged day, dayAgo=x are purged (others are still in use)
+        $contents = 3; // one content impression per day, so 3 purged
         $expectedPrediction = array(
             Common::prefixTable('log_conversion')          => 6,
-            Common::prefixTable('log_link_visit_action')   => 6 + $events,
+            Common::prefixTable('log_link_visit_action')   => 6 + $events + $contents,
             Common::prefixTable('log_visit')               => 3,
             Common::prefixTable('log_conversion_item')     => 3,
             Common::prefixTable('archive_numeric_2012_01') => -1,
@@ -454,9 +459,10 @@ class PrivacyManagerTest extends IntegrationTestCase
 
         // perform checks on prediction
         $events = 3; // only the event action for the three purged day, dayAgo=x are purged (others are still in use)
+        $contents = 3; // one content impression per day, so 3 purged
         $expectedPrediction = array(
             Common::prefixTable('log_conversion')          => 6,
-            Common::prefixTable('log_link_visit_action')   => 6 + $events,
+            Common::prefixTable('log_link_visit_action')   => 6 + $events + $contents,
             Common::prefixTable('log_visit')               => 3,
             Common::prefixTable('log_conversion_item')     => 3,
             Common::prefixTable('archive_numeric_2012_01') => -1,
@@ -492,7 +498,8 @@ class PrivacyManagerTest extends IntegrationTestCase
         $purger->purgeData($this->settings['delete_logs_older_than'], $this->settings['delete_logs_max_rows_per_query']);
 
         // check that actions were purged
-        $this->assertEquals(22 + $this->getCountEventIdsNotPurged(), $this->_getTableCount('log_action')); // January
+        $contentsNotPurged = 3;
+        $this->assertEquals(22 + $this->getCountEventIdsNotPurged() + $contentsNotPurged, $this->_getTableCount('log_action')); // January
 
         // check that the unused action still exists
         $count = Db::fetchOne(
@@ -517,9 +524,10 @@ class PrivacyManagerTest extends IntegrationTestCase
 
         // perform checks on prediction
         $events = 3; // only the event action for the three purged day, dayAgo=x are purged (others are still in use)
+        $contents = 3; // one content impression per day, so 3 purged
         $expectedPrediction = array(
             Common::prefixTable('log_conversion')          => 6,
-            Common::prefixTable('log_link_visit_action')   => 6 + $events,
+            Common::prefixTable('log_link_visit_action')   => 6 + $events + $contents,
             Common::prefixTable('log_visit')               => 3,
             Common::prefixTable('log_conversion_item')     => 3,
             Common::prefixTable('archive_numeric_2012_01') => -1,
@@ -552,9 +560,10 @@ class PrivacyManagerTest extends IntegrationTestCase
 
         // perform checks on prediction
         $events = 3; // only the event action for the three purged day, dayAgo=x are purged (others are still in use)
+        $contents = 3; // one content impression per day, so 3 purged
         $expectedPrediction = array(
             Common::prefixTable('log_conversion')          => 6,
-            Common::prefixTable('log_link_visit_action')   => 6 + $events,
+            Common::prefixTable('log_link_visit_action')   => 6 + $events + $contents,
             Common::prefixTable('log_visit')               => 3,
             Common::prefixTable('log_conversion_item')     => 3,
             Common::prefixTable('archive_numeric_2012_01') => -1,
@@ -624,9 +633,14 @@ class PrivacyManagerTest extends IntegrationTestCase
             $t->setUrl("http://whatever.com/42/$daysAgo");
             $t->doTrackPageView('Second page view');
 
+            // track an event to test event actions are purged/preserved
             $t->setForceVisitDateTime(Date::factory($dateTime)->addHour(0.1));
             $t->setUrl("http://whatever.com/event");
             $t->doTrackEvent('Event action', 'event cat', 'daysAgo=' . $daysAgo, 1000);
+
+            // track a content impression to test that content actions are purged/preserved
+            $t->setForceVisitDateTime(Date::factory($dateTime)->addHour(0.1));
+            $t->doTrackContentImpression('SugarTransportAd', '/path/ad.jpg', 'http://www.satsumaprovince.jp');
 
             $t->setForceVisitDateTime(Date::factory($dateTime)->addHour(0.2));
             $t->addEcommerceItem($sku = 'SKU2', $name = 'Canon SLR', $category = 'Electronics & Cameras',
@@ -634,6 +648,7 @@ class PrivacyManagerTest extends IntegrationTestCase
             $t->doTrackEcommerceOrder($orderId = '937nsjusu ' . $dateTime, $grandTotal = 1111.11, $subTotal = 1000,
                 $tax = 111, $shipping = 0.11, $discount = 666);
         }
+
         Fixture::checkBulkTrackingResponse($t->doBulkTrack());
     }
 
@@ -728,12 +743,12 @@ class PrivacyManagerTest extends IntegrationTestCase
 
     protected function _checkNoDataChanges()
     {
-        // 11 visits total w/ 2 actions per visit & 2 conversions per visit. 1 e-commerce order per visit.
+        // 11 visits total w/ 4 actions per visit & 2 conversions per visit. 1 e-commerce order per visit.
         $this->assertEquals(11, $this->_getTableCount('log_visit'));
         $this->assertEquals(22, $this->_getTableCount('log_conversion'));
-        $this->assertEquals(33, $this->_getTableCount('log_link_visit_action'));
+        $this->assertEquals(44, $this->_getTableCount('log_link_visit_action'));
         $this->assertEquals(11, $this->_getTableCount('log_conversion_item'));
-        $this->assertEquals(41, $this->_getTableCount('log_action'));
+        $this->assertEquals(45, $this->_getTableCount('log_action'));
 
         $archiveTables = self::_getArchiveTableNames();
         //var_export(Db::fetchAll("SELECT * FROM " . Common::prefixTable($archiveTables['numeric'][0])));
@@ -776,14 +791,16 @@ class PrivacyManagerTest extends IntegrationTestCase
     {
         // 3 days removed by purge, so 3 visits, 6 conversions, 6 visit actions, 3 e-commerce orders
         // & 6 actions removed
-        $events = 11 - 3; // 3 deleted;
+        $events = 11 - 3; // 3 deleted (1 per day purged)
+        $contents = 11 - 3; // 3 deleted (1 per day purged)
         $this->assertEquals(8, $this->_getTableCount('log_visit'));
         $this->assertEquals(16, $this->_getTableCount('log_conversion'));
-        $this->assertEquals(16 + $events, $this->_getTableCount('log_link_visit_action'));
+        $this->assertEquals(16 + $events + $contents, $this->_getTableCount('log_link_visit_action'));
         $this->assertEquals(8, $this->_getTableCount('log_conversion_item'));
 
         $eventsId = $this->getCountEventIdsNotPurged();
-        $this->assertEquals(21 + $eventsId, $this->_getTableCount('log_action'));
+        $contentsNotPurged = 3;
+        $this->assertEquals(21 + $eventsId + $contentsNotPurged, $this->_getTableCount('log_action'));
     }
 
     /**
@@ -878,8 +895,8 @@ class PrivacyManagerTest extends IntegrationTestCase
      */
     private function getCountEventIdsNotPurged()
     {
-        $eventsId = 11 /* days eventAction */ + 2 /* category+name */ + 1 /* event url */ - 3 /* days deleted */
-        ;
-        return $eventsId;
+        $count = 11 /* days eventAction */ + 2 /* category+name */ + 1 /* event url */ - 3 /* days deleted */;
+        $count += 1; // since content tracking is done after event tracking, a referrer action is generated for the event
+        return $count;
     }
 }

--- a/tests/PHPUnit/System/PrivacyManagerTest.php
+++ b/tests/PHPUnit/System/PrivacyManagerTest.php
@@ -489,7 +489,7 @@ class PrivacyManagerTest extends SystemTestCase
     {
         \Piwik\Piwik::addAction("LogDataPurger.ActionsToKeepInserted.olderThan", array($this, 'addReferenceToUnusedAction'));
 
-        $purger = LogDataPurger::make($this->settings, true);
+        $purger = LogDataPurger::make();
 
         $this->unusedIdAction = Db::fetchOne(
             "SELECT idaction FROM " . Common::prefixTable('log_action') . " WHERE name = ?",
@@ -497,7 +497,7 @@ class PrivacyManagerTest extends SystemTestCase
         $this->assertTrue($this->unusedIdAction > 0);
 
         // purge data
-        $purger->purgeData();
+        $purger->purgeData($this->settings['delete_logs_older_than'], $this->settings['delete_logs_max_rows_per_query']);
 
         // check that actions were purged
         $this->assertEquals(22 + $this->getCountEventIdsNotPurged(), $this->_getTableCount('log_action')); // January

--- a/tests/PHPUnit/System/PrivacyManagerTest.php
+++ b/tests/PHPUnit/System/PrivacyManagerTest.php
@@ -29,8 +29,6 @@ use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Translate;
 
-require_once PIWIK_INCLUDE_PATH . '/plugins/PrivacyManager/PrivacyManager.php';
-
 /**
  * @group PrivacyManagerTest
  * @group Plugins


### PR DESCRIPTION
This PR refactors the LogDataPurger, moving the idaction column detection logic to an new class DimensionMetadataProvider. This class detects idactions by going through Dimension metadata classes, in addition to specifying hardcoded columns.

Also includes the following changes:
- LogDataPurger was moved to DI. This allows plugin developers or Piwik users to manipulate it's creation (along w/ the DimensionMetadataProvider's creation).
- DimensionMetadataProvider allows users to specify custom idaction columns in the constructor. Since LogDataPurger is in DI, this means plugin developers or Piwik users can monkey patch the logic in the event that the logic does not select every idaction column that exists in a Piwik install.
- Converted PrivacyManagerTest to derive from IntegrationTestCase (since it uses a clean slate for each test). It still feels like a system test, but I can move it if necessary.
- Added a content impression to PrivacyManagerTest to make sure this case is tested.

Refs #7958
