### PR TITLE
Implement HTTP-Authentication for transport methods socket & fopen

### DIFF
--- a/tests/PHPUnit/Integration/Http/HttpAuthentication.php
+++ b/tests/PHPUnit/Integration/Http/HttpAuthentication.php
@@ -1,0 +1,11 @@
+<?php
+
+if (isset($_SERVER['PHP_AUTH_USER']) && $_SERVER['PHP_AUTH_USER'] == 'test' && $_SERVER['PHP_AUTH_PW'] == 'test') {
+    echo 'Authentication successful';
+    exit;
+} else {
+    header('WWW-Authenticate: Basic realm="TestAuth"');
+    header('HTTP/1.0 401 Unauthorized');
+    echo 'Authentication required';
+    exit;
+}

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -119,6 +119,57 @@ class HttpTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getMethodsToTest
      */
+    public function testHttpAuthentication($method)
+    {
+        $result = Http::sendHttpRequestBy(
+            $method,
+            Fixture::getRootUrl() . 'tests/PHPUnit/Integration/Http/HttpAuthentication.php',
+            30,
+            $userAgent = null,
+            $destinationPath = null,
+            $file = null,
+            $followDepth = 0,
+            $acceptLanguage = false,
+            $acceptInvalidSslCertificate = false,
+            $byteRange = false,
+            $getExtendedInfo = true,
+            $httpMethod = 'GET',
+            $httpUsername = 'test',
+            $httpPassword = 'test'
+        );
+
+        $this->assertEquals('Authentication successful', $result['data']);
+        $this->assertEquals(200, $result['status']);
+    }
+
+    /**
+     * @dataProvider getMethodsToTest
+     */
+    public function testHttpAuthenticationInvalid($method)
+    {
+        $result = Http::sendHttpRequestBy(
+            $method,
+            Fixture::getRootUrl() . 'tests/PHPUnit/Integration/Http/HttpAuthentication.php',
+            30,
+            $userAgent = null,
+            $destinationPath = null,
+            $file = null,
+            $followDepth = 0,
+            $acceptLanguage = false,
+            $acceptInvalidSslCertificate = false,
+            $byteRange = false,
+            $getExtendedInfo = true,
+            $httpMethod = 'GET',
+            $httpUsername = '',
+            $httpPassword = ''
+        );
+
+        $this->assertEquals(401, $result['status']);
+    }
+
+    /**
+     * @dataProvider getMethodsToTest
+     */
     public function testHttpsWorksWithValidCertificate($method)
     {
         $result = Http::sendHttpRequestBy($method, 'https://builds.piwik.org/LATEST', 10);


### PR DESCRIPTION
Currently Http-Auth is only possible using curl. Otherwise an exception is raised.

I've implemented Http-Auth for the other transport methods. That is required to let plugin developers update their translations locally if curl is **not** installed. _(The Transifex API requires Http-Auth)_

See Thomas--F/BotTracker#20
