### PR TITLE
Injection Inception, Change #4: Using DI as primary mechanism in setting up Test environment

### DIFF
--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -74,6 +74,14 @@ return array(
             \Piwik\Plugins\CoreVisualizations\Visualizations\Cloud::$debugDisableShuffle = true;
             \Piwik\Visualization\Sparkline::$enableSparklineImages = false;
             \Piwik\Plugins\ExampleUI\API::$disableRandomness = true;
+
+            $testingEnvironment = new TestingEnvironment();
+            if ($testingEnvironment->deleteArchiveTables
+                && !$testingEnvironment->_archivingTablesDeleted
+            ) {
+                $testingEnvironment->_archivingTablesDeleted = true;
+                DbHelper::deleteArchiveTables();
+            }
         }),
 
         array('AssetManager.getStylesheetFiles', function (&$stylesheets) {
@@ -110,16 +118,6 @@ return array(
                 'contents' => $outputContent
             );
             file_put_contents($outputFile, json_encode($outputContents));
-        }),
-
-        array('Platform.initialized', function () {
-            $testingEnvironment = new TestingEnvironment();
-            if ($testingEnvironment->deleteArchiveTables
-                && !$testingEnvironment->_archivingTablesDeleted
-            ) {
-                $testingEnvironment->_archivingTablesDeleted = true;
-                DbHelper::deleteArchiveTables();
-            }
         }),
     )),
 );

--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -50,7 +50,6 @@ return array(
 
         array('Environment.bootstrapped', function () {
             $testingEnvironment = new TestingEnvironment();
-            $testingEnvironment->logVariables();
             $testingEnvironment->executeSetupTestEnvHook();
         }),
 

--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -51,9 +51,7 @@ return array(
         array('Environment.bootstrapped', function () {
             $testingEnvironment = new TestingEnvironment();
             $testingEnvironment->executeSetupTestEnvHook();
-        }),
 
-        array('Request.dispatch', function () {
             if (empty($_GET['ignoreClearAllViewDataTableParameters'])) { // TODO: should use testingEnvironment variable, not query param
                 try {
                     \Piwik\ViewDataTable\Manager::clearAllViewDataTableParameters();

--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -19,8 +19,14 @@ return array(
     'cache.eager.cache_id' => 'eagercache-test-',
 
     // Disable loading core translations
-    'Piwik\Translation\Translator' => DI\object()
-        ->constructorParameter('directories', array()),
+    'Piwik\Translation\Translator' => DI\decorate(function ($previous, ContainerInterface $c) {
+        $testingEnvironment = $c->get('Piwik\Tests\Framework\TestingEnvironment');
+        if (!$testingEnvironment->loadRealTranslations) {
+            return new \Piwik\Translation\Translator($c->get('Piwik\Translation\Loader\LoaderInterface'), $directories = array());
+        } else {
+            return $previous;
+        }
+    }),
 
     'Piwik\Config' => DI\decorate(function ($previous, ContainerInterface $c) {
         $testingEnvironment = $c->get('Piwik\Tests\Framework\TestingEnvironment');

--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -116,13 +116,11 @@ return array(
         }),
 
         array('Platform.initialized', function () {
-            static $archivingTablesDeleted = false;
-
             $testingEnvironment = new TestingEnvironment();
             if ($testingEnvironment->deleteArchiveTables
-                && !$archivingTablesDeleted
+                && !$testingEnvironment->_archivingTablesDeleted
             ) {
-                $archivingTablesDeleted = true;
+                $testingEnvironment->_archivingTablesDeleted = true;
                 DbHelper::deleteArchiveTables();
             }
         }),

--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -42,7 +42,7 @@ return array(
 
         array('Access.createAccessSingleton', function ($access) {
             $testingEnvironment = new TestingEnvironment();
-            if (!$testingEnvironment->testUseRegularAuth) {
+            if ($testingEnvironment->testUseMockAuth) {
                 $access = new Piwik_MockAccess($access);
                 \Piwik\Access::setSingletonInstance($access);
             }

--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -1,5 +1,13 @@
 <?php
 
+use Interop\Container\ContainerInterface;
+use Piwik\Common;
+use Piwik\DbHelper;
+use Piwik\Option;
+use Piwik\Tests\Framework\Mock\TestConfig;
+use Piwik\Tests\Framework\Piwik_MockAccess;
+use Piwik\Tests\Framework\TestingEnvironment;
+
 return array(
 
     // Disable logging
@@ -14,5 +22,103 @@ return array(
     'Piwik\Translation\Translator' => DI\object()
         ->constructorParameter('directories', array()),
 
-    'Piwik\Config' => DI\object('Piwik\Tests\Framework\Mock\TestConfig'),
+    'Piwik\Config' => DI\decorate(function ($previous, ContainerInterface $c) {
+        $testingEnvironment = $c->get('Piwik\Tests\Framework\TestingEnvironment');
+        if (!$testingEnvironment->dontUseTestConfig) {
+            $settingsProvider = $c->get('Piwik\Application\Kernel\GlobalSettingsProvider');
+            return new TestConfig($settingsProvider, $testingEnvironment, $allowSave = false, $doSetTestEnvironment = true);
+        } else {
+            return $previous;
+        }
+    }),
+
+    'observers.global' => DI\add(array(
+
+        array('Access.createAccessSingleton', function ($access) {
+            $testingEnvironment = new TestingEnvironment();
+            if (!$testingEnvironment->testUseRegularAuth) {
+                $access = new Piwik_MockAccess($access);
+                \Piwik\Access::setSingletonInstance($access);
+            }
+        }),
+
+        array('Environment.bootstrapped', function () {
+            $testingEnvironment = new TestingEnvironment();
+            $testingEnvironment->logVariables();
+            $testingEnvironment->executeSetupTestEnvHook();
+        }),
+
+        array('Request.dispatch', function () {
+            if (empty($_GET['ignoreClearAllViewDataTableParameters'])) { // TODO: should use testingEnvironment variable, not query param
+                try {
+                    \Piwik\ViewDataTable\Manager::clearAllViewDataTableParameters();
+                } catch (\Exception $ex) {
+                    // ignore (in case DB is not setup)
+                }
+            }
+
+            $testingEnvironment = new TestingEnvironment();
+            if ($testingEnvironment->optionsOverride) {
+                try {
+                    foreach ($testingEnvironment->optionsOverride as $name => $value) {
+                        Option::set($name, $value);
+                    }
+                } catch (\Exception $ex) {
+                    // ignore (in case DB is not setup)
+                }
+            }
+
+            \Piwik\Plugins\CoreVisualizations\Visualizations\Cloud::$debugDisableShuffle = true;
+            \Piwik\Visualization\Sparkline::$enableSparklineImages = false;
+            \Piwik\Plugins\ExampleUI\API::$disableRandomness = true;
+        }),
+
+        array('AssetManager.getStylesheetFiles', function (&$stylesheets) {
+            $testingEnvironment = new TestingEnvironment();
+            if ($testingEnvironment->useOverrideCss) {
+                $stylesheets[] = 'tests/resources/screenshot-override/override.css';
+            }
+        }),
+
+        array('AssetManager.getJavaScriptFiles', function (&$jsFiles) {
+            $testingEnvironment = new TestingEnvironment();
+            if ($testingEnvironment->useOverrideJs) {
+                $jsFiles[] = 'tests/resources/screenshot-override/override.js';
+            }
+        }),
+
+        array('Updater.checkForUpdates', function () {
+            try {
+                @\Piwik\Filesystem::deleteAllCacheOnUpdate();
+            } catch (Exception $ex) {
+                // pass
+            }
+        }),
+
+        array('Test.Mail.send', function (\Zend_Mail $mail) {
+            $outputFile = PIWIK_INCLUDE_PATH . '/tmp/' . Common::getRequestVar('module', '') . '.' . Common::getRequestVar('action', '') . '.mail.json';
+            $outputContent = str_replace("=\n", "", $mail->getBodyText($textOnly = true));
+            $outputContent = str_replace("=0A", "\n", $outputContent);
+            $outputContent = str_replace("=3D", "=", $outputContent);
+            $outputContents = array(
+                'from' => $mail->getFrom(),
+                'to' => $mail->getRecipients(),
+                'subject' => $mail->getSubject(),
+                'contents' => $outputContent
+            );
+            file_put_contents($outputFile, json_encode($outputContents));
+        }),
+
+        array('Platform.initialized', function () {
+            static $archivingTablesDeleted = false;
+
+            $testingEnvironment = new TestingEnvironment();
+            if ($testingEnvironment->deleteArchiveTables
+                && !$archivingTablesDeleted
+            ) {
+                $archivingTablesDeleted = true;
+                DbHelper::deleteArchiveTables();
+            }
+        }),
+    )),
 );

--- a/core/Application/Environment.php
+++ b/core/Application/Environment.php
@@ -112,7 +112,7 @@ class Environment
     {
         $pluginList = $this->getPluginListCached();
         $settings = $this->getGlobalSettingsCached();
-        $definitions = array_merge(StaticContainer::getDefinitions(), $this->definitions);
+        $definitions = array_merge(StaticContainer::getDefinitions(), array($this->definitions));
 
         $containerFactory = new ContainerFactory($pluginList, $settings, $this->environment, $definitions);
         return $containerFactory->create();

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -307,7 +307,7 @@ class CliMulti
 
     private function appendTestmodeParamToUrlIfNeeded($url)
     {
-        $isTestMode = class_exists('Piwik_TestingEnvironment');
+        $isTestMode = class_exists('Piwik\Tests\Framework\TestingEnvironment');
 
         if ($isTestMode && false === strpos($url, '?')) {
             $url .= "?testmode=1";

--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -13,7 +13,6 @@ use DI\ContainerBuilder;
 use Doctrine\Common\Cache\ArrayCache;
 use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Application\Kernel\PluginList;
-use Piwik\Development;
 use Piwik\Plugin\Manager;
 
 /**
@@ -89,7 +88,12 @@ class ContainerFactory
         }
 
         // Environment config
-        $this->addEnvironmentConfig($builder);
+        $this->addEnvironmentConfig($builder, $this->environment);
+
+        // Test config
+        if (defined('PIWIK_TEST_MODE')) {
+            $this->addEnvironmentConfig($builder, 'test');
+        }
 
         if (!empty($this->definitions)) {
             $builder->addDefinitions($this->definitions);
@@ -102,13 +106,13 @@ class ContainerFactory
         return $container;
     }
 
-    private function addEnvironmentConfig(ContainerBuilder $builder)
+    private function addEnvironmentConfig(ContainerBuilder $builder, $environment)
     {
-        if (!$this->environment) {
+        if (!$environment) {
             return;
         }
 
-        $file = sprintf('%s/config/environment/%s.php', PIWIK_USER_PATH, $this->environment);
+        $file = sprintf('%s/config/environment/%s.php', PIWIK_USER_PATH, $environment);
 
         if (file_exists($file)) {
             $builder->addDefinitions($file);

--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -38,7 +38,7 @@ class ContainerFactory
     private $environment;
 
     /**
-     * @var array
+     * @var array[]
      */
     private $definitions;
 
@@ -46,7 +46,7 @@ class ContainerFactory
      * @param PluginList $pluginList
      * @param GlobalSettingsProvider $settings
      * @param string|null $environment Optional environment config to load.
-     * @param array $definitions
+     * @param array[] $definitions
      */
     public function __construct(PluginList $pluginList, GlobalSettingsProvider $settings, $environment = null, array $definitions = array())
     {
@@ -96,7 +96,9 @@ class ContainerFactory
         }
 
         if (!empty($this->definitions)) {
-            $builder->addDefinitions($this->definitions);
+            foreach ($this->definitions as $definitionArray) {
+                $builder->addDefinitions($definitionArray);
+            }
         }
 
         $container = $builder->build();

--- a/core/Container/StaticContainer.php
+++ b/core/Container/StaticContainer.php
@@ -27,7 +27,7 @@ class StaticContainer
     /**
      * Definitions to register in the container.
      *
-     * @var array
+     * @var array[]
      */
     private static $definitions = array();
 
@@ -60,7 +60,7 @@ class StaticContainer
 
     public static function addDefinitions(array $definitions)
     {
-        self::$definitions = $definitions;
+        self::$definitions[] = $definitions;
     }
 
     /**

--- a/misc/cron/updatetoken.php
+++ b/misc/cron/updatetoken.php
@@ -33,6 +33,8 @@ if (!Common::isPhpCliMode()) {
 
 $testmode = in_array('--testmode', $_SERVER['argv']);
 if ($testmode) {
+    define('PIWIK_TEST_MODE', true);
+
     Tests\Framework\TestingEnvironment::addHooks();
 }
 

--- a/misc/cron/updatetoken.php
+++ b/misc/cron/updatetoken.php
@@ -33,10 +33,8 @@ if (!Common::isPhpCliMode()) {
 
 $testmode = in_array('--testmode', $_SERVER['argv']);
 if ($testmode) {
-    require_once PIWIK_INCLUDE_PATH . "/tests/PHPUnit/TestingEnvironment.php";
-    \Piwik_TestingEnvironment::addHooks();
+    Tests\Framework\TestingEnvironment::addHooks();
 }
-
 
 function getPiwikDomain()
 {

--- a/plugins/ExamplePlugin/tests/System/SimpleSystemTest.php
+++ b/plugins/ExamplePlugin/tests/System/SimpleSystemTest.php
@@ -8,7 +8,7 @@
 
 namespace Piwik\Plugins\ExamplePlugin\tests\System;
 
-use Piwik\Plugins\ExamplePlugin\tests\fixtures\SimpleFixtureTrackFewVisits;
+use Piwik\Plugins\ExamplePlugin\tests\Fixtures\SimpleFixtureTrackFewVisits;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
 /**

--- a/plugins/Monolog/Test/Integration/LogTest.php
+++ b/plugins/Monolog/Test/Integration/LogTest.php
@@ -249,13 +249,6 @@ class LogTest extends IntegrationTestCase
         return StaticContainer::get('path.tmp') . '/logs/piwik.test.log';
     }
 
-    public function provideContainerConfig()
-    {
-        return array(
-            'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger')
-        );
-    }
-
     private function recreateLogSingleton($backend, $level = 'INFO')
     {
         $newEnv = new Environment('test', array(

--- a/plugins/MultiSites/tests/Integration/ControllerTest.php
+++ b/plugins/MultiSites/tests/Integration/ControllerTest.php
@@ -9,7 +9,7 @@
 namespace Piwik\Plugins\MultiSites\tests\Integration;
 
 use Piwik\FrontController;
-use Piwik\Plugins\MultiSites\tests\fixtures\ManySitesWithVisits;
+use Piwik\Plugins\MultiSites\tests\Fixtures\ManySitesWithVisits;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
 /**

--- a/plugins/TestRunner/Commands/TestsSetupFixture.php
+++ b/plugins/TestRunner/Commands/TestsSetupFixture.php
@@ -88,6 +88,10 @@ class TestsSetupFixture extends ConsoleCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (!defined('PIWIK_TEST_MODE')) {
+            define('PIWIK_TEST_MODE', true);
+        }
+
         $serverGlobal = $input->getOption('server-global');
         if ($serverGlobal) {
             $_SERVER = json_decode($serverGlobal, true);

--- a/plugins/TestRunner/Commands/TestsSetupFixture.php
+++ b/plugins/TestRunner/Commands/TestsSetupFixture.php
@@ -230,7 +230,6 @@ class TestsSetupFixture extends ConsoleCommand
     private function requireFixtureFiles(InputInterface $input)
     {
         require_once PIWIK_INCLUDE_PATH . '/libs/PiwikTracker/PiwikTracker.php';
-        require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/TestingEnvironment.php';
 
         $fixturesToLoad = array(
             '/tests/PHPUnit/Fixtures/*.php',

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -913,7 +913,7 @@ class Fixture extends \PHPUnit_Framework_Assert
 
     public function createEnvironmentInstance()
     {
-        $this->piwikEnvironment = new Environment('test', array_merge($this->provideContainerConfig(), $this->extraDefinitions));
+        $this->piwikEnvironment = new Environment($environment = null, array_merge($this->provideContainerConfig(), $this->extraDefinitions));
         $this->piwikEnvironment->init();
     }
 }

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -255,6 +255,7 @@ class Fixture extends \PHPUnit_Framework_Assert
             return;
         }
 
+        $this->getTestEnvironment()->testCaseClass = $this->testCaseClass;
         $this->getTestEnvironment()->save();
         $this->getTestEnvironment()->executeSetupTestEnvHook();
 

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -46,7 +46,7 @@ use Piwik\Tracker\Cache;
 use Piwik\Translate;
 use Piwik\Url;
 use PHPUnit_Framework_Assert;
-use Piwik_TestingEnvironment;
+use Piwik\Tests\Framework\TestingEnvironment;
 use PiwikTracker;
 use Piwik_LocalTracker;
 use Piwik\Updater;
@@ -275,7 +275,7 @@ class Fixture extends \PHPUnit_Framework_Assert
     public function getTestEnvironment()
     {
         if ($this->testEnvironment === null) {
-            $this->testEnvironment = new Piwik_TestingEnvironment();
+            $this->testEnvironment = new TestingEnvironment();
             $this->testEnvironment->delete();
 
             if (getenv('PIWIK_USE_XHPROF') == 1) {
@@ -336,7 +336,7 @@ class Fixture extends \PHPUnit_Framework_Assert
     public static function loadAllPlugins($testEnvironment = null, $testCaseClass = false, $extraPluginsToLoad = array())
     {
         if (empty($testEnvironment)) {
-            $testEnvironment = new Piwik_TestingEnvironment();
+            $testEnvironment = new TestingEnvironment();
         }
 
         DbHelper::createTables();

--- a/tests/PHPUnit/Framework/Mock/FakeAccess.php
+++ b/tests/PHPUnit/Framework/Mock/FakeAccess.php
@@ -23,6 +23,14 @@ class FakeAccess
     public static $identity = 'superUserLogin';
     public static $superUserLogin = 'superUserLogin';
 
+    public static function clearAccess()
+    {
+        self::$superUser    = false;
+        self::$idSitesAdmin = array();
+        self::$idSitesView  = array();
+        self::$identity     = 'superUserLogin';
+    }
+
     public function getTokenAuth()
     {
         return false;
@@ -30,10 +38,7 @@ class FakeAccess
 
     public function __construct()
     {
-        self::$superUser    = false;
-        self::$idSitesAdmin = array();
-        self::$idSitesView  = array();
-        self::$identity     = 'superUserLogin';
+        self::clearAccess();
     }
 
     public static function setIdSitesAdmin($ids)

--- a/tests/PHPUnit/Framework/Mock/TestConfig.php
+++ b/tests/PHPUnit/Framework/Mock/TestConfig.php
@@ -25,7 +25,7 @@ class TestConfig extends Config
 
         $this->reload();
 
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
         $this->setFromTestEnvironment($testingEnvironment);
     }
 
@@ -73,7 +73,7 @@ class TestConfig extends Config
         $chain->set('PluginsInstalled', array('PluginsInstalled' => array()));
     }
 
-    private function setFromTestEnvironment(\Piwik_TestingEnvironment $testingEnvironment)
+    private function setFromTestEnvironment(\Piwik\Tests\Framework\TestingEnvironment $testingEnvironment)
     {
         $pluginsToLoad = $testingEnvironment->getCoreAndSupportedPlugins();
         if (!empty($testingEnvironment->pluginsToLoad)) {

--- a/tests/PHPUnit/Framework/Mock/TestConfig.php
+++ b/tests/PHPUnit/Framework/Mock/TestConfig.php
@@ -108,7 +108,24 @@ class TestConfig extends Config
 
         if ($testingEnvironment->configOverride) {
             $cache =& $chain->getAll();
-            $cache = $testingEnvironment->arrayMergeRecursiveDistinct($cache, $testingEnvironment->configOverride);
+            $cache = $this->arrayMergeRecursiveDistinct($cache, $testingEnvironment->configOverride);
         }
+    }
+
+    private function arrayMergeRecursiveDistinct(array $array1, array $array2)
+    {
+        $result = $array1;
+
+        foreach ($array2 as $key => $value) {
+            if (is_array($value)) {
+                $result[$key] = isset($result[$key]) && is_array($result[$key])
+                    ? $this->arrayMergeRecursiveDistinct($result[$key], $value)
+                    : $value;
+            } else {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
     }
 }

--- a/tests/PHPUnit/Framework/Mock/TestConfig.php
+++ b/tests/PHPUnit/Framework/Mock/TestConfig.php
@@ -10,13 +10,14 @@ namespace Piwik\Tests\Framework\Mock;
 
 use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Config;
+use Piwik\Tests\Framework\TestingEnvironment;
 
 class TestConfig extends Config
 {
     private $allowSave = false;
     private $doSetTestEnvironment = false;
 
-    public function __construct(GlobalSettingsProvider $provider, $allowSave = false, $doSetTestEnvironment = true)
+    public function __construct(GlobalSettingsProvider $provider, TestingEnvironment $testingEnvironment, $allowSave = false, $doSetTestEnvironment = true)
     {
         parent::__construct($provider);
 
@@ -25,7 +26,6 @@ class TestConfig extends Config
 
         $this->reload();
 
-        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
         $this->setFromTestEnvironment($testingEnvironment);
     }
 

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -77,7 +77,7 @@ abstract class IntegrationTestCase extends SystemTestCase
         self::$fixture->extraDefinitions = array_merge(static::provideContainerConfigBeforeClass(), $this->provideContainerConfig());
         self::$fixture->createEnvironmentInstance();
 
-        Fixture::loadAllPlugins(new \Piwik_TestingEnvironment(), get_class($this), self::$fixture->extraPluginsToLoad);
+        Fixture::loadAllPlugins(new \Piwik\Tests\Framework\TestingEnvironment(), get_class($this), self::$fixture->extraPluginsToLoad);
 
         if (!empty(self::$tableData)) {
             self::restoreDbTables(self::$tableData);

--- a/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
@@ -39,7 +39,7 @@ abstract class UnitTestCase extends \PHPUnit_Framework_TestCase
 
         // make sure the global container exists for the next test case that is executed (since logging can be done
         // before a test sets up an environment)
-        $nextTestEnviornment = new Environment('test', array(), $postBootstrappedEvent = false);
+        $nextTestEnviornment = new Environment($environment = null, array(), $postBootstrappedEvent = false);
         $nextTestEnviornment->init();
 
         parent::tearDown();
@@ -57,7 +57,7 @@ abstract class UnitTestCase extends \PHPUnit_Framework_TestCase
 
     protected function initEnvironment()
     {
-        $this->environment = new Environment('test', $this->provideContainerConfig(), $postBootstrappedEvent = false);
+        $this->environment = new Environment($environment = null, $this->provideContainerConfig(), $postBootstrappedEvent = false);
         $this->environment->init();
     }
 }

--- a/tests/PHPUnit/Framework/TestingEnvironment.php
+++ b/tests/PHPUnit/Framework/TestingEnvironment.php
@@ -18,10 +18,6 @@ use Piwik\DbHelper;
 use Piwik\Piwik;
 use Piwik\Application\Environment;
 
-if (!defined('PIWIK_TEST_MODE')) {
-    define('PIWIK_TEST_MODE', true);
-}
-
 class Piwik_MockAccess
 {
     private $access;

--- a/tests/PHPUnit/Framework/TestingEnvironment.php
+++ b/tests/PHPUnit/Framework/TestingEnvironment.php
@@ -85,19 +85,6 @@ class TestingEnvironment
         $this->save();
     }
 
-    public function logVariables()
-    {
-        try {
-            if (isset($_SERVER['QUERY_STRING'])
-                && !$this->dontUseTestConfig
-            ) {
-                @\Piwik\Log::debug("Test Environment Variables for (%s):\n%s", $_SERVER['QUERY_STRING'], print_r($this->behaviorOverrideProperties, true));
-            }
-        } catch (Exception $ex) {
-            // ignore
-        }
-    }
-
     public function getCoreAndSupportedPlugins()
     {
         $settings = new \Piwik\Application\Kernel\GlobalSettingsProvider();

--- a/tests/PHPUnit/Framework/TestingEnvironment.php
+++ b/tests/PHPUnit/Framework/TestingEnvironment.php
@@ -1,17 +1,22 @@
 <?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
 
-use Piwik\Application\Environment;
-use Piwik\Common;
-use Piwik\Config;
-use Piwik\Container\StaticContainer;
-use Piwik\Piwik;
-use Piwik\Option;
+namespace Piwik\Tests\Framework;
+
 use Piwik\Plugin\Manager as PluginManager;
-use Piwik\DbHelper;
-use Piwik\Tests\Framework\Fixture;
+use Exception;
+use Piwik\Container\StaticContainer;
 use Piwik\Tests\Framework\TestingEnvironment\MakeGlobalSettingsWithFile;
-
-require_once PIWIK_INCLUDE_PATH . "/core/Config.php";
+use Piwik\Common;
+use Piwik\Option;
+use Piwik\DbHelper;
+use Piwik\Piwik;
+use Piwik\Application\Environment;
 
 if (!defined('PIWIK_TEST_MODE')) {
     define('PIWIK_TEST_MODE', true);
@@ -46,7 +51,7 @@ class Piwik_MockAccess
 /**
  * Sets the test environment.
  */
-class Piwik_TestingEnvironment
+class TestingEnvironment
 {
     private $behaviorOverrideProperties = array();
 
@@ -119,7 +124,7 @@ class Piwik_TestingEnvironment
             }
 
             return $pluginManager->isPluginBundledWithCore($pluginName)
-                || $pluginManager->isPluginOfficialAndNotBundledWithCore($pluginName);
+            || $pluginManager->isPluginOfficialAndNotBundledWithCore($pluginName);
         });
 
         sort($plugins);
@@ -129,7 +134,7 @@ class Piwik_TestingEnvironment
 
     public static function addHooks($globalObservers = array())
     {
-        $testingEnvironment = new Piwik_TestingEnvironment();
+        $testingEnvironment = new TestingEnvironment();
 
         if ($testingEnvironment->queryParamOverride) {
             foreach ($testingEnvironment->queryParamOverride as $key => $value) {
@@ -185,7 +190,7 @@ class Piwik_TestingEnvironment
             $diConfig['Piwik\Config'] = \DI\object('Piwik\Tests\Framework\Mock\TestConfig');
         }
 
-        $globalObservers[] = array('Access.createAccessSingleton', function($access) use ($testingEnvironment) {
+        $globalObservers[] = array('Access.createAccessSingleton', function ($access) use ($testingEnvironment) {
             if (!$testingEnvironment->testUseRegularAuth) {
                 $access = new Piwik_MockAccess($access);
                 \Piwik\Access::setSingletonInstance($access);
@@ -271,9 +276,8 @@ class Piwik_TestingEnvironment
         foreach ($array2 as $key => $value) {
             if (is_array($value)) {
                 $result[$key] = isset($result[$key]) && is_array($result[$key])
-                              ? $this->arrayMergeRecursiveDistinct($result[$key], $value)
-                              : $value
-                              ;
+                    ? $this->arrayMergeRecursiveDistinct($result[$key], $value)
+                    : $value;
             } else {
                 $result[$key] = $value;
             }

--- a/tests/PHPUnit/Framework/TestingEnvironment.php
+++ b/tests/PHPUnit/Framework/TestingEnvironment.php
@@ -184,23 +184,6 @@ class TestingEnvironment
         StaticContainer::addDefinitions($diConfig);
     }
 
-    public function arrayMergeRecursiveDistinct(array $array1, array $array2)
-    {
-        $result = $array1;
-
-        foreach ($array2 as $key => $value) {
-            if (is_array($value)) {
-                $result[$key] = isset($result[$key]) && is_array($result[$key])
-                    ? $this->arrayMergeRecursiveDistinct($result[$key], $value)
-                    : $value;
-            } else {
-                $result[$key] = $value;
-            }
-        }
-
-        return $result;
-    }
-
     /**
      * for plugins that need to inject special testing logic
      */

--- a/tests/PHPUnit/Framework/TestingEnvironment.php
+++ b/tests/PHPUnit/Framework/TestingEnvironment.php
@@ -166,9 +166,8 @@ class TestingEnvironment
 
         Environment::addEnvironmentManipulator(new MakeGlobalSettingsWithFile($testingEnvironment));
 
-        $diConfig['observers.global'] = \DI\add($globalObservers);
-
         StaticContainer::addDefinitions($diConfig);
+        StaticContainer::addDefinitions(array('observers.global' => \DI\add($globalObservers)));
     }
 
     /**

--- a/tests/PHPUnit/Framework/TestingEnvironment/MakeGlobalSettingsWithFile.php
+++ b/tests/PHPUnit/Framework/TestingEnvironment/MakeGlobalSettingsWithFile.php
@@ -17,7 +17,7 @@ class MakeGlobalSettingsWithFile implements EnvironmentManipulator
     private $configFileLocal;
     private $configFileCommon;
 
-    public function __construct(\Piwik_TestingEnvironment $testingEnvironment)
+    public function __construct(\Piwik\Tests\Framework\TestingEnvironment $testingEnvironment)
     {
         $this->configFileGlobal = $testingEnvironment->configFileGlobal;
         $this->configFileLocal = $testingEnvironment->configFileLocal;

--- a/tests/PHPUnit/Integration/AccessTest.php
+++ b/tests/PHPUnit/Integration/AccessTest.php
@@ -53,14 +53,14 @@ class AccessTest extends IntegrationTestCase
 
     public function testHasSuperUserAccessWithSuperUserAccess()
     {
-        $access = Access::getInstance();
+        $access = new Access();
         $access->setSuperUserAccess(true);
         $this->assertTrue($access->hasSuperUserAccess());
     }
 
     public function test_GetLogin_UserIsNotAnonymous_WhenSuperUserAccess()
     {
-        $access = Access::getInstance();
+        $access = new Access();
         $access->setSuperUserAccess(true);
         $this->assertNotEmpty($access->getLogin());
         $this->assertNotSame('anonymous', $access->getLogin());
@@ -68,7 +68,7 @@ class AccessTest extends IntegrationTestCase
 
     public function testHasSuperUserAccessWithNoSuperUserAccess()
     {
-        $access = Access::getInstance();
+        $access = new Access();
         $access->setSuperUserAccess(false);
         $this->assertFalse($access->hasSuperUserAccess());
     }
@@ -102,7 +102,7 @@ class AccessTest extends IntegrationTestCase
 
     public function testCheckUserHasSuperUserAccessWithSuperUserAccess()
     {
-        $access = Access::getInstance();
+        $access = new Access();
         $access->setSuperUserAccess(true);
         $access->checkUserHasSuperUserAccess();
     }
@@ -118,7 +118,7 @@ class AccessTest extends IntegrationTestCase
 
     public function testCheckUserHasSomeAdminAccessWithSuperUserAccess()
     {
-        $access = Access::getInstance();
+        $access = new Access();
         $access->setSuperUserAccess(true);
         $access->checkUserHasSomeAdminAccess();
     }
@@ -181,7 +181,7 @@ class AccessTest extends IntegrationTestCase
 
     public function testCheckUserHasSomeViewAccessWithSuperUserAccess()
     {
-        $access = Access::getInstance();
+        $access = new Access();
         $access->setSuperUserAccess(true);
         $access->checkUserHasSomeViewAccess();
     }
@@ -256,7 +256,7 @@ class AccessTest extends IntegrationTestCase
 
     public function testCheckUserHasAdminAccessWithSuperUserAccess()
     {
-        $access = Access::getInstance();
+        $access = new Access();
         $access->setSuperUserAccess(true);
         $access->checkUserHasAdminAccess(array());
     }
@@ -327,7 +327,7 @@ class AccessTest extends IntegrationTestCase
 
     public function testReloadAccessWithEmptyAuthSuperUser()
     {
-        $access = Access::getInstance();
+        $access = new Access();
         $access->setSuperUserAccess(true);
         $this->assertTrue($access->reloadAccess(null));
     }
@@ -335,7 +335,7 @@ class AccessTest extends IntegrationTestCase
     public function testReloadAccess_ShouldResetTokenAuthAndLogin_IfAuthIsNotValid()
     {
         $mock = $this->createAuthMockWithAuthResult(AuthResult::SUCCESS);
-        $access = Access::getInstance();
+        $access = new Access();
 
         $this->assertTrue($access->reloadAccess($mock));
         $this->assertSame('login', $access->getLogin());
@@ -357,7 +357,7 @@ class AccessTest extends IntegrationTestCase
 
         $mock->expects($this->any())->method('getName')->will($this->returnValue("test name"));
 
-        $access = Access::getInstance();
+        $access = new Access();
         $this->assertTrue($access->reloadAccess($mock));
         $this->assertFalse($access->hasSuperUserAccess());
     }

--- a/tests/PHPUnit/Integration/Plugin/SettingsTest.php
+++ b/tests/PHPUnit/Integration/Plugin/SettingsTest.php
@@ -299,10 +299,12 @@ class SettingsTest extends IntegrationTestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage General_ExceptionPrivilege
+     * @expectedExceptionMessage checkUserHasSuperUserAccess Fake exception
      */
     public function test_removeAllPluginSettings_shouldThrowException_InCaseAnonymousUser()
     {
+        $this->setAnonymousUser();
+
         $this->settings->removeAllPluginSettings();
     }
 

--- a/tests/PHPUnit/Integration/Settings/IntegrationTestCase.php
+++ b/tests/PHPUnit/Integration/Settings/IntegrationTestCase.php
@@ -93,6 +93,12 @@ class IntegrationTestCase extends \Piwik\Tests\Framework\TestCase\IntegrationTes
         Access::setSingletonInstance($pseudoMockAccess);
     }
 
+    protected function setAnonymousUser()
+    {
+        FakeAccess::clearAccess();
+        Access::setSingletonInstance(new FakeAccess());
+    }
+
     protected function createSettingsInstance()
     {
         return new CorePluginTestSettings('ExampleSettingsPlugin');

--- a/tests/PHPUnit/Integration/Settings/SystemSettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/SystemSettingTest.php
@@ -46,6 +46,7 @@ class SystemSettingTest extends IntegrationTestCase
      */
     public function test_setSettingValue_shouldThrowException_IfAnonymousIsTryingToSetASettingWhichNeedsSuperUserPermission()
     {
+        $this->setAnonymousUser();
         $setting = $this->addSystemSetting('mysystem', 'mytitle');
 
         $setting->setValue(2);
@@ -91,6 +92,7 @@ class SystemSettingTest extends IntegrationTestCase
      */
     public function test_getSettingValue_shouldThrowException_IfAnonymousTriedToReadValue()
     {
+        $this->setAnonymousUser();
         $setting = $this->addSystemSetting('myusersetting', 'mytitle');
         $setting->getValue();
     }
@@ -128,6 +130,7 @@ class SystemSettingTest extends IntegrationTestCase
      */
     public function test_removeSettingValue_shouldThrowException_IfAnonymousTriesToRemoveValue()
     {
+        $this->setAnonymousUser();
         $setting = $this->addSystemSetting('mysystemsetting', 'mytitle');
         $setting->removeValue();
     }

--- a/tests/PHPUnit/Integration/Settings/UserSettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/UserSettingTest.php
@@ -64,6 +64,7 @@ class UserSettingTest extends IntegrationTestCase
      */
     public function test_setSettingValue_shouldThrowException_IfAnonymousIsTryingToSetASettingWhichNeedsUserPermission()
     {
+        $this->setAnonymousUser();
         $setting = $this->addUserSetting('mysystem', 'mytitle');
 
         $setting->setValue(2);
@@ -170,6 +171,7 @@ class UserSettingTest extends IntegrationTestCase
      */
     public function test_getSettingValue_shouldThrowException_IfGivenSettingDoesNotExist()
     {
+        $this->setAnonymousUser();
         $setting = $this->buildUserSetting('myusersetting', 'mytitle');
         $setting->getValue();
     }
@@ -190,6 +192,7 @@ class UserSettingTest extends IntegrationTestCase
      */
     public function test_removeSettingValue_shouldThrowException_IfUserHasNotEnoughUserPermissions()
     {
+        $this->setAnonymousUser();
         $setting = $this->addUserSetting('myusersetting', 'mytitle');
         $setting->removeValue();
     }

--- a/tests/PHPUnit/System/ArchiveCronTest.php
+++ b/tests/PHPUnit/System/ArchiveCronTest.php
@@ -158,6 +158,13 @@ class ArchiveCronTest extends SystemTestCase
             $this->comparisonFailures[] = $ex;
         }
     }
+
+    public static function provideContainerConfigBeforeClass()
+    {
+        return array(
+            'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger')
+        );
+    }
 }
 
 ArchiveCronTest::$fixture = new ManySitesImportedLogs();

--- a/tests/PHPUnit/System/ArchiveCronTest.php
+++ b/tests/PHPUnit/System/ArchiveCronTest.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik\Tests\System;
 
+use Interop\Container\ContainerInterface;
 use Piwik\Date;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
@@ -162,7 +163,13 @@ class ArchiveCronTest extends SystemTestCase
     public static function provideContainerConfigBeforeClass()
     {
         return array(
-            'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger')
+            'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger'),
+
+            // for some reason, w/o real translations archiving segments in CronArchive fails. the data returned by CliMulti
+            // is a translation token, and nothing else.
+            'Piwik\Translation\Translator' => function (ContainerInterface $c) {
+                return new \Piwik\Translation\Translator($c->get('Piwik\Translation\Loader\LoaderInterface'));
+            }
         );
     }
 }

--- a/tests/PHPUnit/System/ArchiveWebTest.php
+++ b/tests/PHPUnit/System/ArchiveWebTest.php
@@ -96,6 +96,13 @@ class ArchiveWebTest extends SystemTestCase
 
         return array($returnCode, $output);
     }
+
+    public static function provideContainerConfigBeforeClass()
+    {
+        return array(
+            'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger')
+        );
+    }
 }
 
 ArchiveWebTest::$fixture = new ManySitesImportedLogs();

--- a/tests/PHPUnit/System/EnvironmentValidationTest.php
+++ b/tests/PHPUnit/System/EnvironmentValidationTest.php
@@ -30,7 +30,7 @@ class EnvironmentValidationTest extends SystemTestCase
     {
         parent::setUp();
 
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
         $testingEnvironment->configFileGlobal = null;
         $testingEnvironment->configFileLocal = null;
         $testingEnvironment->configFileCommon = null;
@@ -138,7 +138,7 @@ class EnvironmentValidationTest extends SystemTestCase
 
     private function simulateAbsentConfigFile($fileName)
     {
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
 
         if ($fileName == 'global.ini.php') {
             $testingEnvironment->configFileGlobal = PIWIK_INCLUDE_PATH . '/tmp/nonexistant/global.ini.php';
@@ -153,7 +153,7 @@ class EnvironmentValidationTest extends SystemTestCase
 
     private function simulateBadConfigFile($fileName)
     {
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
 
         if ($fileName == 'global.ini.php') {
             $testingEnvironment->configFileGlobal = PIWIK_INCLUDE_PATH . '/piwik.php';
@@ -168,7 +168,7 @@ class EnvironmentValidationTest extends SystemTestCase
 
     private function simulateHost($host)
     {
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
         $testingEnvironment->hostOverride = $host;
         $testingEnvironment->save();
     }

--- a/tests/PHPUnit/System/EnvironmentValidationTest.php
+++ b/tests/PHPUnit/System/EnvironmentValidationTest.php
@@ -34,6 +34,7 @@ class EnvironmentValidationTest extends SystemTestCase
         $testingEnvironment->configFileGlobal = null;
         $testingEnvironment->configFileLocal = null;
         $testingEnvironment->configFileCommon = null;
+        $testingEnvironment->loadRealTranslations = true;
         $testingEnvironment->save();
     }
 

--- a/tests/PHPUnit/System/ImportLogsTest.php
+++ b/tests/PHPUnit/System/ImportLogsTest.php
@@ -12,6 +12,7 @@ use Piwik\Plugins\SitesManager\API;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tests\Fixtures\ManySitesImportedLogs;
+use Piwik\Tests\Framework\TestingEnvironment;
 
 /**
  * Tests the log importer.
@@ -118,7 +119,7 @@ class ImportLogsTest extends SystemTestCase
 
         $options = array(
             '--idsite'                    => self::$fixture->idSite,
-            '--token-auth'                => 'asldfjksd',
+            '--token-auth'                => Fixture::getTokenAuth(),
             '--retry-max-attempts'        => 5,
             '--retry-delay'               => 1
         );
@@ -137,10 +138,8 @@ class ImportLogsTest extends SystemTestCase
 
     private function simulateTrackerFailure()
     {
-        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
-        $testingEnvironment->configOverride = array(
-            'Tracker' => array('bulk_requests_require_authentication' => 1)
-        );
+        $testingEnvironment = new TestingEnvironment();
+        $testingEnvironment->_triggerTrackerFailure = true;
         $testingEnvironment->save();
     }
 
@@ -151,9 +150,26 @@ class ImportLogsTest extends SystemTestCase
 
     private function resetTestingEnvironmentChanges()
     {
-        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
-        $testingEnvironment->configOverride = null;
+        $testingEnvironment = new TestingEnvironment();
+        $testingEnvironment->_triggerTrackerFailure = null;
         $testingEnvironment->save();
+    }
+
+    public static function provideContainerConfigBeforeClass()
+    {
+        $result = array();
+
+        $testingEnvironment = new TestingEnvironment();
+        if ($testingEnvironment->_triggerTrackerFailure) {
+            $result['observers.global'] = \DI\add(array(
+                array('Tracker.newHandler', function () {
+                    @http_response_code(500);
+
+                    throw new \Exception("injected exception");
+                })
+            ));
+        }
+        return $result;
     }
 }
 

--- a/tests/PHPUnit/System/ImportLogsTest.php
+++ b/tests/PHPUnit/System/ImportLogsTest.php
@@ -137,7 +137,7 @@ class ImportLogsTest extends SystemTestCase
 
     private function simulateTrackerFailure()
     {
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
         $testingEnvironment->configOverride = array(
             'Tracker' => array('bulk_requests_require_authentication' => 1)
         );
@@ -151,7 +151,7 @@ class ImportLogsTest extends SystemTestCase
 
     private function resetTestingEnvironmentChanges()
     {
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
         $testingEnvironment->configOverride = null;
         $testingEnvironment->save();
     }

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -36,7 +36,7 @@ class TrackerTest extends IntegrationTestCase
 
         Fixture::createWebsite('2014-02-04');
 
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
         $testingEnvironment->testCaseClass = null;
         $testingEnvironment->addFailingScheduledTask = false;
         $testingEnvironment->addScheduledTask = false;
@@ -291,7 +291,7 @@ class TrackerTest extends IntegrationTestCase
 
     private function setScheduledTasksToRunInTracker()
     {
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
         $testingEnvironment->testCaseClass = 'Piwik\Tests\System\TrackerTest';
         $testingEnvironment->addScheduledTask = true;
         $testingEnvironment->configOverride = array('Tracker' => array('scheduled_tasks_min_interval' => 1, 'debug_on_demand' => 1));
@@ -300,7 +300,7 @@ class TrackerTest extends IntegrationTestCase
 
     private function addFailingScheduledTaskToTracker($doFatalError)
     {
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
         $testingEnvironment->addFailingScheduledTask = true;
         $testingEnvironment->scheduledTaskFailureShouldBeFatal = $doFatalError;
         $testingEnvironment->save();
@@ -312,7 +312,7 @@ class TrackerTest extends IntegrationTestCase
             define('DEBUG_FORCE_SCHEDULED_TASKS', 1);
         }
 
-        $testingEnvironment = new \Piwik_TestingEnvironment();
+        $testingEnvironment = new \Piwik\Tests\Framework\TestingEnvironment();
 
         $tasksToAdd = array();
 

--- a/tests/PHPUnit/Unit/AssetManagerTest.php
+++ b/tests/PHPUnit/Unit/AssetManagerTest.php
@@ -107,8 +107,6 @@ class AssetManagerTest extends UnitTestCase
 
     private function setUpConfig()
     {
-        $this->initEnvironment();
-
         Config::getInstance()->Plugins = array('Plugins' => array('MockCorePlugin', 'CoreThemePlugin'));
         Config::getInstance()->Development['enabled'] = 1;
         Config::getInstance()->General['default_language'] = 'en';

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -109,7 +109,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         // This will write the file
         $config->forceSave();
 
-        $config = new TestConfig(new GlobalSettingsProvider($globalFile, $userFile));
+        $config = new Config(new GlobalSettingsProvider($globalFile, $userFile));
 
         $this->assertEquals($stringWritten, $config->Category['test']);
         $config->Category = array(

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -43,7 +43,7 @@ if (getenv('PIWIK_USE_XHPROF') == 1) {
 
 // setup container for tests
 function setupRootContainer() {
-    $rootTestEnvironment = new \Piwik\Application\Environment('test');
+    $rootTestEnvironment = new \Piwik\Application\Environment(null);
     $rootTestEnvironment->init();
 }
 

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -36,7 +36,6 @@ if (!defined('PIWIK_INCLUDE_SEARCH_PATH')) {
 require_once PIWIK_INCLUDE_PATH . '/core/bootstrap.php';
 
 require_once PIWIK_INCLUDE_PATH . '/libs/PiwikTracker/PiwikTracker.php';
-require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/TestingEnvironment.php';
 
 if (getenv('PIWIK_USE_XHPROF') == 1) {
     \Piwik\Profiler::setupProfilerXHProf();

--- a/tests/PHPUnit/proxy/archive.php
+++ b/tests/PHPUnit/proxy/archive.php
@@ -3,7 +3,7 @@ define('PIWIK_ARCHIVE_NO_TRUNCATE', true);
 
 require realpath(dirname(__FILE__)) . "/includes.php";
 
-Piwik_TestingEnvironment::addHooks();
+\Piwik\Tests\Framework\TestingEnvironment::addHooks();
 
 // include archive.php, and let 'er rip
 require_once PIWIK_INCLUDE_PATH . "/misc/cron/archive.php";

--- a/tests/PHPUnit/proxy/console
+++ b/tests/PHPUnit/proxy/console
@@ -2,6 +2,6 @@
 <?php
 require realpath(dirname(__FILE__)) . "/includes.php";
 
-Piwik_TestingEnvironment::addHooks();
+\Piwik\Tests\Framework\TestingEnvironment::addHooks();
 
 require_once PIWIK_INCLUDE_PATH . "/console";

--- a/tests/PHPUnit/proxy/includes.php
+++ b/tests/PHPUnit/proxy/includes.php
@@ -6,6 +6,9 @@ if (!defined('PIWIK_INCLUDE_PATH')) {
 if (!defined('PIWIK_USER_PATH')) {
     define('PIWIK_USER_PATH', PIWIK_INCLUDE_PATH);
 }
+if (!defined('PIWIK_TEST_MODE')) {
+    define('PIWIK_TEST_MODE', true);
+}
 
 require_once PIWIK_INCLUDE_PATH . '/core/bootstrap.php';
 

--- a/tests/PHPUnit/proxy/includes.php
+++ b/tests/PHPUnit/proxy/includes.php
@@ -9,6 +9,4 @@ if (!defined('PIWIK_USER_PATH')) {
 
 require_once PIWIK_INCLUDE_PATH . '/core/bootstrap.php';
 
-require_once PIWIK_INCLUDE_PATH . '/tests/PHPUnit/TestingEnvironment.php';
-
 Piwik\SettingsServer::setMaxExecutionTime(0);

--- a/tests/PHPUnit/proxy/index.php
+++ b/tests/PHPUnit/proxy/index.php
@@ -6,6 +6,6 @@
 
 require realpath(dirname(__FILE__)) . "/includes.php";
 
-Piwik_TestingEnvironment::addHooks();
+\Piwik\Tests\Framework\TestingEnvironment::addHooks();
 
 include PIWIK_INCLUDE_PATH . '/index.php';

--- a/tests/PHPUnit/proxy/piwik.php
+++ b/tests/PHPUnit/proxy/piwik.php
@@ -29,7 +29,7 @@ try {
         })
     );
 
-    Piwik_TestingEnvironment::addHooks($globalObservers);
+    \Piwik\Tests\Framework\TestingEnvironment::addHooks($globalObservers);
 
     GeoIp::$geoIPDatabaseDir = 'tests/lib/geoip-files';
 

--- a/tests/UI/specs/Installation_spec.js
+++ b/tests/UI/specs/Installation_spec.js
@@ -14,7 +14,7 @@ describe("Installation", function () {
     this.fixture = null;
 
     before(function () {
-        testEnvironment.testUseRegularAuth = 1;
+        testEnvironment.testUseMockAuth = 0;
         testEnvironment.configFileLocal = path.join(PIWIK_INCLUDE_PATH, "/tmp/test.config.ini.php");
         testEnvironment.dontUseTestConfig = true;
         testEnvironment.tablesPrefix = 'piwik_';
@@ -29,7 +29,7 @@ describe("Installation", function () {
         delete testEnvironment.configFileLocal;
         delete testEnvironment.dontUseTestConfig;
         delete testEnvironment.tablesPrefix;
-        delete testEnvironment.testUseRegularAuth;
+        delete testEnvironment.testUseMockAuth;
         testEnvironment.save();
     });
 

--- a/tests/UI/specs/Login_spec.js
+++ b/tests/UI/specs/Login_spec.js
@@ -14,13 +14,13 @@ describe("Login", function () {
         formlessLoginUrl = "?module=Login&action=logme&login=oliverqueen&password=" + md5Pass;
 
     before(function () {
-        testEnvironment.testUseRegularAuth = 1;
+        testEnvironment.testUseMockAuth = 0;
         testEnvironment.queryParamOverride = {date: "2012-01-01", period: "year"};
         testEnvironment.save();
     });
 
     after(function () {
-        testEnvironment.testUseRegularAuth = 0;
+        testEnvironment.testUseMockAuth = 1;
         delete testEnvironment.queryParamOverride;
         testEnvironment.save();
     });

--- a/tests/UI/specs/Overlay_spec.js
+++ b/tests/UI/specs/Overlay_spec.js
@@ -1,4 +1,4 @@
-/*!
+    /*!
  * Piwik - free/libre analytics platform
  *
  * Overlay screenshot tests.

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -31,13 +31,13 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
 
     beforeEach(function () {
         delete testEnvironment.configOverride;
-        testEnvironment.testUseRegularAuth = 0;
+        testEnvironment.testUseMockAuth = 1;
         testEnvironment.save();
     });
 
     after(function () {
         delete testEnvironment.queryParamOverride;
-        testEnvironment.testUseRegularAuth = 0;
+        testEnvironment.testUseMockAuth = 1;
         testEnvironment.save();
     });
 
@@ -593,7 +593,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
     // opt out page
     it('should load the opt out page correctly', function (done) {
         expect.screenshot('opt_out').to.be.capture(function (page) {
-            testEnvironment.testUseRegularAuth = 1;
+            testEnvironment.testUseMockAuth = 0;
             testEnvironment.save();
 
             page.load("?module=CoreAdminHome&action=optOut&language=en");

--- a/tests/lib/screenshot-testing/support/test-environment.js
+++ b/tests/lib/screenshot-testing/support/test-environment.js
@@ -22,6 +22,7 @@ TestingEnvironment.prototype.reload = function () {
     this['useOverrideCss'] = true;
     this['useOverrideJs'] = true;
     this['loadRealTranslations'] = true; // UI tests should test w/ real translations, not translation keys
+    this['testUseMockAuth'] = true;
 
     if (fs.exists(testingEnvironmentOverridePath)) {
         var data = JSON.parse(fs.read(testingEnvironmentOverridePath));

--- a/tests/lib/screenshot-testing/support/test-environment.js
+++ b/tests/lib/screenshot-testing/support/test-environment.js
@@ -21,6 +21,7 @@ TestingEnvironment.prototype.reload = function () {
 
     this['useOverrideCss'] = true;
     this['useOverrideJs'] = true;
+    this['loadRealTranslations'] = true; // UI tests should test w/ real translations, not translation keys
 
     if (fs.exists(testingEnvironmentOverridePath)) {
         var data = JSON.parse(fs.read(testingEnvironmentOverridePath));

--- a/tests/lib/screenshot-testing/support/test-environment.js
+++ b/tests/lib/screenshot-testing/support/test-environment.js
@@ -19,6 +19,9 @@ TestingEnvironment.prototype.reload = function () {
         delete this[key];
     }
 
+    this['useOverrideCss'] = true;
+    this['useOverrideJs'] = true;
+
     if (fs.exists(testingEnvironmentOverridePath)) {
         var data = JSON.parse(fs.read(testingEnvironmentOverridePath));
         for (var key in data) {


### PR DESCRIPTION
Includes various changes to how the test environment is setup, focusing on using DI as the primary overriding mechanism.

Changes include:
- Moved all static DI config overrides from TestingEnvironment.php to `config/environment/test.php`.
- Slightly cleaned up the test event observers (now defined in `config/environment/test.php`) by merging some together.
- Unified test environment logic for unit/integration/system tests & UI tests. TestingEnvironment.php was created initially for UI tests only, so there were clashes when doing this. For example, UI tests requires translations to be loaded, but they should not be loaded (by default) for other tests. To solve these conflicts, I added new TestingEnvironment properties that let the system default to unit/integration/system test behaviour, and let UI tests override the behaviour. The UI test overrides are added in test-environment.js.
- Modified StaticContainer::addDefinitions() to stack. Instead of holding one array of definitions, it now holds an array of definition arrays. In ContainerFactory, we loop through the outer array and add each definition array on one by one. This allows us to override `observers.global` in individual tests.
- Moved the TestingEnvironment class to the `Piwik\Tests\Framework` namespace.
- The test.php environment file is now applied automatically if PIWIK_TEST_MODE is defined. This means we don't have to inject the `'test'` environment string into normal Piwik entry points AND means we can combine the test environment w/ other environments (like the tracker one).
- Fixed an issue w/ `provideContainerConfigBeforeClass` not being recognized by TestingEnvironment.php. The `testCaseClass` TestingEnvironment property was not set in Fixture.php, so it didn't get propagated to other child processes.
- Added the method `FakeAccess::clearAccess()` so it could be explicitly cleared.
- Added TestingEnvironment to DI (TestConfig now gets it from the constructor instead of creating an instance).

Everything else are fixes for tests. Individual commit messages should explain what the changes were and why they were added.
