### PR TITLE
Regression test for themes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require": {
         "php": ">=5.3.3",
         "twig/twig": "~1.0",
-        "leafo/lessphp": "~0.4.0",
+        "leafo/lessphp": "~0.5.0",
         "symfony/console": "~2.6",
         "tedivm/jshrink": "~0.5.1",
         "mustangostang/spyc": "~0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "38059fad1036bf805aa3fd11b0788731",
+    "hash": "c0dde90f5435a41a37e93c69b0518cd6",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -227,22 +227,22 @@
         },
         {
             "name": "leafo/lessphp",
-            "version": "v0.4.0",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/leafo/lessphp.git",
-                "reference": "51f3f06f0fe78a722dabfd14578444bdd078d9de"
+                "reference": "0f5a7f5545d2bcf4e9fad9a228c8ad89cc9aa283"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/leafo/lessphp/zipball/51f3f06f0fe78a722dabfd14578444bdd078d9de",
-                "reference": "51f3f06f0fe78a722dabfd14578444bdd078d9de",
+                "url": "https://api.github.com/repos/leafo/lessphp/zipball/0f5a7f5545d2bcf4e9fad9a228c8ad89cc9aa283",
+                "reference": "0f5a7f5545d2bcf4e9fad9a228c8ad89cc9aa283",
                 "shasum": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.3-dev"
+                    "dev-master": "0.4.x-dev"
                 }
             },
             "autoload": {
@@ -264,7 +264,7 @@
             ],
             "description": "lessphp is a compiler for LESS written in PHP.",
             "homepage": "http://leafo.net/lessphp/",
-            "time": "2013-08-09 17:09:19"
+            "time": "2014-11-24 18:39:20"
         },
         {
             "name": "mnapoli/php-di",

--- a/plugins/Dashboard/stylesheets/widget.less
+++ b/plugins/Dashboard/stylesheets/widget.less
@@ -3,7 +3,7 @@
     background: @theme-color-background-base;
     border: 1px solid @color-silver-l85;
     .border-radius();
-    .box-shadow-1(0 1px 1px rgba(204,204,204,.5));
+    box-shadow: 0 1px 1px rgba(204,204,204,.5);
     overflow: hidden;
     z-index: 1;
 

--- a/plugins/ExampleTheme/stylesheets/theme.less
+++ b/plugins/ExampleTheme/stylesheets/theme.less
@@ -1,5 +1,8 @@
 @theme-fontFamily-base: Verdana, sans-serif;
 
+@theme-color-background-base: #b8ffe3;
+@theme-color-brand: #70cad4;
+
 /*
 @theme-color-brand:                    #d4291f;
 @theme-color-brand-contrast:           #ffffff;

--- a/plugins/ExampleTheme/stylesheets/theme.less
+++ b/plugins/ExampleTheme/stylesheets/theme.less
@@ -1,7 +1,7 @@
 @theme-fontFamily-base: Verdana, sans-serif;
 
-@theme-color-background-base: #b8ffe3;
-@theme-color-brand: #70cad4;
+@theme-color-brand: #5793d4;
+@theme-color-background-base: #d9e0e3;
 
 /*
 @theme-color-brand:                    #d4291f;

--- a/plugins/Morpheus/stylesheets/base/mixins.less
+++ b/plugins/Morpheus/stylesheets/base/mixins.less
@@ -27,24 +27,6 @@
     background-clip:         padding-box;
 }
 
-.box-shadow (@string, @string1) {
-    -webkit-box-shadow: @string @string1;
-    -moz-box-shadow:    @string @string1;
-    box-shadow:         @string @string1;
-}
-
-.box-shadow-1 (@string) {
-    -webkit-box-shadow: @string;
-    -moz-box-shadow:    @string;
-    box-shadow:         @string;
-}
-
-.no-box-shadow () {
-    -webkit-box-shadow: none;
-    -moz-box-shadow:    none;
-    box-shadow:         none;
-}
-
 #gradient {
 
   .horizontal(@start-color: #555, @end-color: #333, @start-percent: 0%, @end-percent: 100%) {

--- a/plugins/Morpheus/stylesheets/general/_forms.less
+++ b/plugins/Morpheus/stylesheets/general/_forms.less
@@ -17,7 +17,6 @@ button[type="button"],
     .border-radius(3px) !important;
     background: none !important;
     background-color: @theme-color-brand !important;
-    box-shadow: 0 1px 1px rgba(13,13,13,.3), inset 0 -1px 0 rgba(13,13,13,.1);
     #gradient > .vertical(rgba(255,255,255,.15), rgba(255,255,255,0)) !important;
     .font-default(12px, 16px) !important;
     color: @theme-color-brand-contrast !important;;
@@ -89,7 +88,6 @@ button[type="button"],
         border-color: @theme-color-background-lowContrast;
         .border-radius(0px);
         background: @theme-color-background-base;
-        box-shadow: inset 1px 1px 3px #d8d8d8;
         padding: 0;
         color: @theme-color-text;
         text-transform: uppercase;

--- a/plugins/Morpheus/stylesheets/general/_forms.less
+++ b/plugins/Morpheus/stylesheets/general/_forms.less
@@ -17,7 +17,7 @@ button[type="button"],
     .border-radius(3px) !important;
     background: none !important;
     background-color: @theme-color-brand !important;
-    .box-shadow(~"0 1px 1px rgba(13,13,13,.3), inset 0 -1px 0 rgba(13,13,13,.1)");
+    box-shadow: 0 1px 1px rgba(13,13,13,.3), inset 0 -1px 0 rgba(13,13,13,.1);
     #gradient > .vertical(rgba(255,255,255,.15), rgba(255,255,255,0)) !important;
     .font-default(12px, 16px) !important;
     color: @theme-color-brand-contrast !important;;
@@ -89,7 +89,7 @@ button[type="button"],
         border-color: @theme-color-background-lowContrast;
         .border-radius(0px);
         background: @theme-color-background-base;
-        .box-shadow(~"inset 1px 1px 3px #d8d8d8");
+        box-shadow: inset 1px 1px 3px #d8d8d8;
         padding: 0;
         color: @theme-color-text;
         text-transform: uppercase;

--- a/plugins/Morpheus/stylesheets/main.less
+++ b/plugins/Morpheus/stylesheets/main.less
@@ -173,7 +173,7 @@ table.entityTable tr td a:hover {
         border-top: 0px !important;
         border-right: 0px !important;
         border-left: 0px !important;
-        .box-shadow-1(~"inset 0 2px 4px #d8d8d8");
+        box-shadow: inset 0 2px 4px #d8d8d8;
     }
 
     .widgetize {
@@ -604,7 +604,7 @@ div.sparkline {
 }
 
 .visitor-profile-info {
-    .no-box-shadow() !important;
+    box-shadow: none !important;
 }
 
 .visitor-profile-latest-visit-loc {
@@ -691,13 +691,13 @@ div.sparkline {
 
 .visitor-profile {
     background: none;
-    .box-shadow(none);
+    box-shadow: none;
     border: 0;
     .border-radius(0px);
     .visitor-profile-info {
         .border-radius(0px);
         border: 0px;
-        .box-shadow(none) !important;
+        box-shadow: none !important;
 
         > div {
             border: 0px !important;

--- a/plugins/Morpheus/stylesheets/main.less
+++ b/plugins/Morpheus/stylesheets/main.less
@@ -173,7 +173,6 @@ table.entityTable tr td a:hover {
         border-top: 0px !important;
         border-right: 0px !important;
         border-left: 0px !important;
-        box-shadow: inset 0 2px 4px #d8d8d8;
     }
 
     .widgetize {

--- a/plugins/Morpheus/stylesheets/main.less
+++ b/plugins/Morpheus/stylesheets/main.less
@@ -173,6 +173,7 @@ table.entityTable tr td a:hover {
         border-top: 0px !important;
         border-right: 0px !important;
         border-left: 0px !important;
+        box-shadow: inset 0 2px 4px #d8d8d8;
     }
 
     .widgetize {
@@ -690,13 +691,11 @@ div.sparkline {
 
 .visitor-profile {
     background: none;
-    box-shadow: none;
     border: 0;
     .border-radius(0px);
     .visitor-profile-info {
         .border-radius(0px);
         border: 0px;
-        box-shadow: none !important;
 
         > div {
             border: 0px !important;

--- a/plugins/Morpheus/stylesheets/ui/_components.less
+++ b/plugins/Morpheus/stylesheets/ui/_components.less
@@ -13,7 +13,6 @@
 
     .ui-state-default {
         border-color: @calendarBorder !important;
-        background: @brad-black !important;
     }
 
     .ui-datepicker-header {

--- a/plugins/Morpheus/stylesheets/ui/_components.less
+++ b/plugins/Morpheus/stylesheets/ui/_components.less
@@ -206,7 +206,7 @@
 
     #date {
         .border-radius(0px);
-        .box-shadow(~"inset 1px 1px 3px #d8d8d8");
+        box-shadow: inset 1px 1px 3px #d8d8d8;
         padding: 8px 10px;
         color: @theme-color-text-lighter;
         text-transform: uppercase;
@@ -276,14 +276,14 @@
 }
 
 .jqplot-seriespicker-popover {
-    .box-shadow-1(none);
+    box-shadow: none;
 }
 
 // transition box
 #Transitions_Container {
     #Transitions_CenterBox {
         border: 1px solid @color-gray;
-        .box-shadow-1(none);
+        box-shadow: none;
         .border-radius(6px);
         margin: 27px 0 0 319px;
         width: 258px;

--- a/plugins/Morpheus/stylesheets/ui/_components.less
+++ b/plugins/Morpheus/stylesheets/ui/_components.less
@@ -205,7 +205,6 @@
 
     #date {
         .border-radius(0px);
-        box-shadow: inset 1px 1px 3px #d8d8d8;
         padding: 8px 10px;
         color: @theme-color-text-lighter;
         text-transform: uppercase;

--- a/plugins/Morpheus/stylesheets/ui/_tooltip.less
+++ b/plugins/Morpheus/stylesheets/ui/_tooltip.less
@@ -2,7 +2,7 @@ body .ui-tooltip,
 body .ui-tooltip.Transitions_Tooltip_Small {
     border: 0px !important;
     background: #000000 !important;
-    .box-shadow-1(none) !important;
+    box-shadow: none !important;
     .border-radius(3px);
     .ui-tooltip-content {
         background: #000000;

--- a/tests/UI/specs/Theme_spec.js
+++ b/tests/UI/specs/Theme_spec.js
@@ -1,0 +1,22 @@
+/*!
+ * Piwik - free/libre analytics platform
+ *
+ * Tests that theming works.
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+describe("Theme", function () {
+    this.timeout(0);
+
+    before(function () {
+        testEnvironment.pluginsToLoad = ['ExampleTheme'];
+        testEnvironment.save();
+    });
+
+    it("should use the current theme", function (done) {
+        expect.screenshot("load").to.be.capture(function (page) {
+            page.load("");
+        }, done);
+    });
+});

--- a/tests/UI/specs/Theme_spec.js
+++ b/tests/UI/specs/Theme_spec.js
@@ -15,8 +15,14 @@ describe("Theme", function () {
     });
 
     it("should use the current theme", function (done) {
-        expect.screenshot("load").to.be.capture(function (page) {
+        expect.screenshot("home").to.be.capture(function (page) {
             page.load("");
+        }, done);
+    });
+
+    it("should theme the UI demo page", function (done) {
+        expect.screenshot("load").to.be.capture(function (page) {
+            page.load("?module=Morpheus&action=demo");
         }, done);
     });
 });

--- a/tests/UI/specs/Theme_spec.js
+++ b/tests/UI/specs/Theme_spec.js
@@ -11,6 +11,14 @@ describe("Theme", function () {
 
     before(function () {
         testEnvironment.pluginsToLoad = ['ExampleTheme'];
+
+        // Enable development mode to be able to see the UI demo page
+        testEnvironment.configOverride = {
+            Development: {
+                enabled: true
+            }
+        };
+
         testEnvironment.save();
     });
 
@@ -21,7 +29,7 @@ describe("Theme", function () {
     });
 
     it("should theme the UI demo page", function (done) {
-        expect.screenshot("load").to.be.capture(function (page) {
+        expect.screenshot("demo").to.be.capture(function (page) {
             page.load("?module=Morpheus&action=demo");
         }, done);
     });


### PR DESCRIPTION
Themes were broken because of new code now affected by this existing bug: leafo/lessphp#302. I bumped to v0.5.0 and checked the changelog, it was one of the 2 only significant change. The only other significant change is that syntax errors in Less now throw an exception (which allowed to fix a few existing bugs in our Less files). I think it's good to have (definitely help in when developing, I know I've raged a lot against mixins like `.box-shadow()` that weren't doing working without any explanation), however it might break plugins that have errors in their less files. Do we consider that a problem or a very small risk (for example we only had 2 Less bugs in our whole codebase)?

I added a UI test that checks that themes work so that we avoid any regression in the future.

Edit: FYI I removed the `.box-shadow` mixins for the following reasons:

> They are useless since box-shadow is supported in all browsers except IE 8 (in which using a prefix doesn't help anyway).
