### PR TITLE
Deactivating a plugin: clear the caches before unloading the plugin

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -339,14 +339,14 @@ class Manager
      */
     public function deactivatePlugin($pluginName)
     {
+        $this->clearCache($pluginName);
+
         // execute deactivate() to let the plugin do cleanups
         $this->executePluginDeactivate($pluginName);
 
         $this->unloadPluginFromMemory($pluginName);
 
         $this->removePluginFromConfig($pluginName);
-
-        $this->clearCache($pluginName);
 
         /**
          * Event triggered after a plugin has been deactivated.

--- a/tests/PHPUnit/Integration/Plugin/ManagerTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ManagerTest.php
@@ -75,6 +75,15 @@ class ManagerTest extends IntegrationTestCase
         $this->assertEquals(array(), $this->manager->getLoadedPlugins());
     }
 
+    public function test_deactivatePlugin()
+    {
+        $this->assertFalse($this->manager->isPluginActivated('ExampleTheme'));
+        $this->manager->activatePlugin('ExampleTheme');
+        $this->assertTrue($this->manager->isPluginActivated('ExampleTheme'));
+        $this->manager->deactivatePlugin('ExampleTheme');
+        $this->assertFalse($this->manager->isPluginActivated('ExampleTheme'));
+    }
+
     private function getCacheForTrackerPlugins()
     {
         return PiwikCache::getEagerCache();


### PR DESCRIPTION
Fixes #8007

The plugin instance is used for clearing the caches, so it needs to be unloaded _after_ the caches are cleared. I'm opening for review because I am not certain what I'm doing isn't affecting other parts :/ (and maybe there's a better solution)

For the record it started to show the warning after a20e71c61aa9ae74dac9e1b899772357d4d3a64c fixed a bug (unloading plugins wasn't really unloading before) which made this bug more visible (so it may have been partially broken for some time before).
