### PR TITLE
Expand Outlinks / Downloads if only one domain given

### DIFF
--- a/plugins/Actions/javascripts/actionsDataTable.js
+++ b/plugins/Actions/javascripts/actionsDataTable.js
@@ -91,6 +91,36 @@
             self.handleExpandFooter(domElem);
             self.setFixWidthToMakeEllipsisWork(domElem);
             self.handleSummaryRow(domElem);
+            self.openSubtableFromLevel0IfOnlyOneSubtableGiven(domElem);
+        },
+
+        openSubtableFromLevel0IfOnlyOneSubtableGiven: function (domElem) {
+            var $subtables = domElem.find('.subDataTable');
+            var hasOnlyOneSubtable = $subtables.length === 1;
+
+            if (hasOnlyOneSubtable) {
+                var hasOnlyOneRow = domElem.find('tbody tr.level0').length === 1;
+                
+                if (hasOnlyOneRow) {
+                    var $labels = $subtables.find('.label');
+                    if ($labels.length) {
+                        $labels.first().click();
+                    }
+                }
+            }
+        },
+
+        openSubtableFromSubtableIfOnlyOneSubtableGiven: function (domElem) {
+            var hasOnlyOneRow = domElem.length === 1
+            var hasOnlyOneSubtable = domElem.hasClass('subDataTable');
+
+            if (hasOnlyOneRow && hasOnlyOneSubtable) {
+                // when subtable is loaded
+                var $labels = domElem.find('.label');
+                if ($labels.length) {
+                    $labels.first().click();
+                }
+            }
         },
 
         //see dataTable::applyCosmetics
@@ -323,6 +353,8 @@
                 function () {
                     self.onClickActionSubDataTable(this)
                 });
+
+            self.openSubtableFromSubtableIfOnlyOneSubtableGiven(response);
         }
     });
 

--- a/tests/UI/specs/ActionsDataTable_spec.js
+++ b/tests/UI/specs/ActionsDataTable_spec.js
@@ -91,4 +91,12 @@ describe("ActionsDataTable", function () {
             page.click('.dataTableSearchPattern>input[type=submit]');
         }, done);
     });
+    
+    it("should automatically expand subtables if it contains only one folder", function (done) {
+        expect.screenshot('auto_expand').to.be.capture(function (page) {
+            page.load(url + '&viewDataTable=table');
+            page.click('tr .value:contains("blog")');
+            page.click('tr .value:contains("2012")');
+        }, done);
+    });
 });


### PR DESCRIPTION
refs #7891

There are some failing UI tests but that's not caused by this. After merging we need to add a screenshot for this test: http://builds-artifacts.piwik.org/ui-tests.master/13016.7/processed-ui-screenshots/ActionsDataTable_auto_expand.png

As you can see we click on `blog` which has two directories so it does not open anything automatically but then it clicks on `2012` and all subfolders are opened automatically.
