### PR TITLE
Force html templates to reload when development mode is enabled

### DIFF
--- a/core/View.php
+++ b/core/View.php
@@ -226,8 +226,15 @@ class View implements ViewInterface
             $this->latest_version_available = UpdateCheck::isNewestVersionAvailable();
             $this->disableLink = Common::getRequestVar('disableLink', 0, 'int');
             $this->isWidget = Common::getRequestVar('widget', 0, 'int');
-            $this->cacheBuster = UIAssetCacheBuster::getInstance()->piwikVersionBasedCacheBuster();
+            
+            if (Development::isEnabled()) {
+                $cacheBuster = rand(0, 10000);
+            } else {
+                $cacheBuster = UIAssetCacheBuster::getInstance()->piwikVersionBasedCacheBuster();
+            }
 
+            $this->cacheBuster = $cacheBuster;
+            
             $this->loginModule = Piwik::getLoginPluginName();
 
             $user = APIUsersManager::getInstance()->getUser($this->userLogin);


### PR DESCRIPTION
Depending on server configuration or browser some angular templates are sometimes not reloaded because the cacheBuster only changes if also a JS file changes.

This PR will create a random cache buster if development is enabled. The cache buster is for example used like this: https://github.com/piwik/piwik/blob/2.14.0-b1/plugins/MultiSites/angularjs/site/site.directive.js#L38

Disadvantage of this solution is that templates will be always reloaded even if a cached version (browser cache) could be used when development is enabled
