### PR TITLE
Injection Inception, Change #5: Add Access and Auth objects to DI

### DIFF
--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -38,15 +38,16 @@ return array(
         }
     }),
 
-    'observers.global' => DI\add(array(
+    'Piwik\Access' => DI\decorate(function ($previous, ContainerInterface $c) {
+        $testingEnvironment = $c->get('Piwik\Tests\Framework\TestingEnvironment');
+        if ($testingEnvironment->testUseMockAuth) {
+            return new Piwik_MockAccess($previous);
+        } else {
+            return $previous;
+        }
+    }),
 
-        array('Access.createAccessSingleton', function ($access) {
-            $testingEnvironment = new TestingEnvironment();
-            if ($testingEnvironment->testUseMockAuth) {
-                $access = new Piwik_MockAccess($access);
-                \Piwik\Access::setSingletonInstance($access);
-            }
-        }),
+    'observers.global' => DI\add(array(
 
         array('Environment.bootstrapped', function () {
             $testingEnvironment = new TestingEnvironment();

--- a/core/Access.php
+++ b/core/Access.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\Container\StaticContainer;
 
 /**
  * Singleton that manages user access to Piwik resources.
@@ -77,27 +78,14 @@ class Access
      */
     private $auth = null;
 
-    private static $instance = null;
-
     /**
      * Gets the singleton instance. Creates it if necessary.
+     *
+     * @return self
      */
     public static function getInstance()
     {
-        if (self::$instance == null) {
-            self::$instance = new self;
-
-            Piwik::postEvent('Access.createAccessSingleton', array(&self::$instance));
-        }
-        return self::$instance;
-    }
-
-    /**
-     * Sets the singleton instance. For testing purposes.
-     */
-    public static function setSingletonInstance($instance)
-    {
-        self::$instance = $instance;
+        return StaticContainer::get('Piwik\Access');
     }
 
     /**

--- a/core/CliMulti/RequestCommand.php
+++ b/core/CliMulti/RequestCommand.php
@@ -67,7 +67,13 @@ class RequestCommand extends ConsoleCommand
         }
 
         if ($input->getOption('superuser')) {
-            Access::getInstance()->setSuperUserAccess(true);
+            StaticContainer::addDefinitions(array(
+                'observers.global' => \DI\add(array(
+                    array('Environment.bootstrapped', function () {
+                        Access::getInstance()->setSuperUserAccess(true);
+                    })
+                )),
+            ));
         }
 
         require_once PIWIK_INCLUDE_PATH . $indexFile;

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -160,6 +160,8 @@ class Request
         $auth = StaticContainer::get('Piwik\Auth');
         $auth->setTokenAuth($tokenAuth);
         $auth->setLogin(null);
+        $auth->setPassword(null);
+        $auth->setPasswordHash(null);
         $access = $auth->authenticate();
 
         if (!empty($access) && $access->hasSuperUserAccess()) {

--- a/plugins/API/tests/Integration/RssRendererTest.php
+++ b/plugins/API/tests/Integration/RssRendererTest.php
@@ -30,9 +30,7 @@ class RssRendererTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $pseudoMockAccess = new FakeAccess();
         FakeAccess::setSuperUserAccess(true);
-        Access::setSingletonInstance($pseudoMockAccess);
 
         $idSite = Fixture::createWebsite('2014-01-01 00:00:00');
 
@@ -190,5 +188,12 @@ class RssRendererTest extends IntegrationTestCase
     private function makeBuilder($request)
     {
         return new Rss($request);
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/plugins/CoreHome/tests/Integration/Column/UserIdTest.php
+++ b/plugins/CoreHome/tests/Integration/Column/UserIdTest.php
@@ -256,9 +256,13 @@ class UserIdTest extends IntegrationTestCase
 
     private function setSuperUser()
     {
-        $pseudoMockAccess = new FakeAccess();
-        $pseudoMockAccess::setSuperUserAccess(true);
-        Access::setSingletonInstance($pseudoMockAccess);
+        FakeAccess::setSuperUserAccess(true);
     }
 
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
 }

--- a/plugins/Goals/tests/Integration/APITest.php
+++ b/plugins/Goals/tests/Integration/APITest.php
@@ -225,11 +225,15 @@ class APITest extends IntegrationTestCase
 
     protected function setNonAdminUser()
     {
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::setSuperUserAccess(false);
         FakeAccess::$idSitesView = array(99);
         FakeAccess::$identity = 'aUser';
-        Access::setSingletonInstance($pseudoMockAccess);
     }
 
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
 }

--- a/plugins/LeftMenu/tests/Integration/APITest.php
+++ b/plugins/LeftMenu/tests/Integration/APITest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\LeftMenu\tests\Integration;
 
-use Piwik\Access;
 use Piwik\Plugins\LeftMenu\API;
 use Piwik\Plugins\LeftMenu\Settings;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -103,25 +102,23 @@ class APITest extends IntegrationTestCase
 
     private function setSuperUser()
     {
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
         FakeAccess::$superUserLogin = 'superUserLogin';
-        Access::setSingletonInstance($pseudoMockAccess);
+
         $this->createSettings();
     }
 
     private function setAnonymous()
     {
-        Access::setSingletonInstance(null);
+        FakeAccess::clearAccess();
         $this->createSettings();
     }
 
     private function setUser()
     {
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$idSitesView = array(1);
         FakeAccess::$identity    = 'userLogin';
-        Access::setSingletonInstance($pseudoMockAccess);
+
         $this->createSettings();
     }
 
@@ -141,5 +138,12 @@ class APITest extends IntegrationTestCase
     {
         $this->settings->userEnabled->setValue($value);
         $this->settings->save();
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\Live\tests\Integration;
 
-use Piwik\Access;
 use Piwik\Common;
 use Piwik\Plugins\Live\Model;
 use Piwik\Tests\Framework\Fixture;
@@ -152,12 +151,15 @@ class ModelTest extends IntegrationTestCase
         $this->assertEquals(SegmentTest::removeExtraWhiteSpaces($expectedBind), SegmentTest::removeExtraWhiteSpaces($bind));
     }
 
-
     protected function setSuperUser()
     {
-        $pseudoMockAccess = new FakeAccess();
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
     }
 
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
 }

--- a/plugins/Live/tests/System/APITest.php
+++ b/plugins/Live/tests/System/APITest.php
@@ -169,16 +169,18 @@ class APITest extends SystemTestCase
 
     private function setSuperUser()
     {
-        $pseudoMockAccess = new FakeAccess();
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
     }
 
     private function setAnonymous()
     {
-        $pseudoMockAccess = new FakeAccess();
-        FakeAccess::$superUser = false;
-        Access::setSingletonInstance($pseudoMockAccess);
+        FakeAccess::clearAccess();
     }
 
+    public static function provideContainerConfigBeforeClass()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
 }

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -119,7 +119,11 @@ class Auth implements \Piwik\Auth
      */
     public function setPassword($password)
     {
-        $this->md5Password = md5($password);
+        if (empty($password)) {
+            $this->md5Password = null;
+        } else {
+            $this->md5Password = md5($password);
+        }
     }
 
     /**
@@ -130,6 +134,11 @@ class Auth implements \Piwik\Auth
      */
     public function setPasswordHash($passwordHash)
     {
+        if ($passwordHash === null) {
+            $this->md5Password = null;
+            return;
+        }
+
         if (strlen($passwordHash) != 32) {
             throw new Exception("Invalid hash: incorrect length " . strlen($passwordHash));
         }

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -82,10 +82,7 @@ class Login extends \Piwik\Plugin
      */
     function initAuthenticationObject($activateCookieAuth = false)
     {
-        $auth = new Auth();
-        StaticContainer::getContainer()->set('Piwik\Auth', $auth);
-
-        $this->initAuthenticationFromCookie($auth, $activateCookieAuth);
+        $this->initAuthenticationFromCookie(StaticContainer::getContainer()->get('Piwik\Auth'), $activateCookieAuth);
     }
 
     /**

--- a/plugins/Login/config/config.php
+++ b/plugins/Login/config/config.php
@@ -1,0 +1,5 @@
+<?php
+
+return array(
+    'Piwik\Auth' => DI\object('Piwik\Plugins\Login\Auth')
+);

--- a/plugins/Login/tests/Integration/LoginTest.php
+++ b/plugins/Login/tests/Integration/LoginTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\Login\tests\Integration;
 
-use Piwik\Access;
 use Piwik\AuthResult;
 use Piwik\DbHelper;
 use Piwik\Plugins\Login\Auth;
@@ -37,13 +36,11 @@ class LoginTest extends IntegrationTestCase
         parent::setUp();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::setIdSitesView(array(1, 2));
         FakeAccess::setIdSitesAdmin(array(3, 4));
 
         //finally we set the user as a Super User by default
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         $this->auth = new Auth();
     }
@@ -401,4 +398,10 @@ class LoginTest extends IntegrationTestCase
         $this->assertEquals($tokenLength, strlen($authResult->getTokenAuth()));
     }
 
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
 }

--- a/plugins/MobileMessaging/tests/Integration/MobileMessagingTest.php
+++ b/plugins/MobileMessaging/tests/Integration/MobileMessagingTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\MobileMessaging\tests\Integration;
 
-use Piwik\Access;
 use Piwik\Plugins\MobileMessaging\API as APIMobileMessaging;
 use Piwik\Plugins\MobileMessaging\MobileMessaging;
 use Piwik\Plugins\MobileMessaging\SMSProvider;
@@ -31,10 +30,7 @@ class MobileMessagingTest extends IntegrationTestCase
         parent::setUp();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        //finally we set the user as a Super User by default
-        Access::setSingletonInstance($pseudoMockAccess);
 
         $this->idSiteAccess = APISitesManager::getInstance()->addSite("test", "http://test");
 
@@ -258,5 +254,12 @@ class MobileMessagingTest extends IntegrationTestCase
         $mobileMessaging->sendReport(MobileMessaging::MOBILE_TYPE, $report, $reportContent, null, null, $reportSubject, null, null, null, false);
 
         \Piwik\Plugins\MobileMessaging\API::unsetInstance();
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/plugins/SEO/tests/Integration/SEOTest.php
+++ b/plugins/SEO/tests/Integration/SEOTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\SEO\tests\Integration;
 
-use Piwik\Access;
 use Piwik\DataTable\Renderer;
 use Piwik\Plugins\SEO\API;
 use Exception;
@@ -26,13 +25,11 @@ class SEOTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::setIdSitesView(array(1, 2));
         FakeAccess::setIdSitesAdmin(array(3, 4));
 
         //finally we set the user as a Super User by default
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         $user_agents = array(
             'Mozilla/6.0 (Macintosh; I; Intel Mac OS X 11_7_9; de-LI; rv:1.9b4) Gecko/2012010317 Firefox/10.0a4',
@@ -64,5 +61,12 @@ class SEOTest extends \PHPUnit_Framework_TestCase
             }
             $this->assertNotEmpty($rank['rank'], $message);
         }
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\ScheduledReports\tests;
 
-use Piwik\Access;
 use Piwik\Plugins\MobileMessaging\API as APIMobileMessaging;
 use Piwik\Plugins\MobileMessaging\MobileMessaging;
 use Piwik\Plugins\ScheduledReports\API as APIScheduledReports;
@@ -222,9 +221,7 @@ class ApiTest extends IntegrationTestCase
      */
     public function testGetTopMenuTranslationKeyUserIsAnonymous()
     {
-        $anonymousAccess = new FakeAccess;
-        FakeAccess::$identity = 'anonymous';
-        Access::setSingletonInstance($anonymousAccess);
+        $this->setAnonymous();
 
         $pdfReportPlugin = new Menu();
         $this->assertEquals(
@@ -492,7 +489,7 @@ class ApiTest extends IntegrationTestCase
 
     private static function updateReport($idReport, $data)
     {
-        $idReport = APIScheduledReports::getInstance()->updateReport(
+        APIScheduledReports::getInstance()->updateReport(
             $idReport,
             $data['idsite'],
             $data['description'],
@@ -507,8 +504,19 @@ class ApiTest extends IntegrationTestCase
 
     private static function setSuperUser()
     {
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
+
+    private function setAnonymous()
+    {
+        FakeAccess::clearAccess();
+        FakeAccess::$identity = 'anonymous';
     }
 }

--- a/plugins/ScheduledReports/tests/Integration/ScheduledReportsTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ScheduledReportsTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\ScheduledReports\tests;
 
-use Piwik\Access;
 use Piwik\Db;
 use Piwik\Piwik;
 use Piwik\Plugins\ScheduledReports\API;
@@ -157,10 +156,14 @@ class ScheduledReportsTest extends IntegrationTestCase
 
     private function setIdentity($login)
     {
-        $pseudoMockAccess = new FakeAccess();
-        $pseudoMockAccess::$identity  = $login;
-        $pseudoMockAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
+        FakeAccess::$identity  = $login;
+        FakeAccess::$superUser = true;
     }
 
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
 }

--- a/plugins/SegmentEditor/tests/Integration/SegmentEditorTest.php
+++ b/plugins/SegmentEditor/tests/Integration/SegmentEditorTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\SegmentEditor\tests\Integration;
 
-use Piwik\Access;
 use Piwik\Date;
 use Piwik\Piwik;
 use Piwik\Plugins\SegmentEditor\API;
@@ -33,14 +32,12 @@ class SegmentEditorTest extends IntegrationTestCase
         \Piwik\Plugin\Manager::getInstance()->installLoadedPlugins();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::setIdSitesView(array(1, 2));
         FakeAccess::setIdSitesAdmin(array(3, 4));
 
         //finally we set the user as a Super User by default
         FakeAccess::$superUser = true;
         FakeAccess::$superUserLogin = 'superusertest';
-        Access::setSingletonInstance($pseudoMockAccess);
 
         APISitesManager::getInstance()->addSite('test', 'http://example.org');
     }
@@ -206,5 +203,12 @@ class SegmentEditorTest extends IntegrationTestCase
                 $segmentInfo[$propertyName] = substr($segmentInfo[$propertyName], 0, strlen($segmentInfo[$propertyName] - 2));
             }
         }
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\SitesManager\tests\Integration;
 
-use Piwik\Access;
 use Piwik\Piwik;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\Plugins\SitesManager\Model;
@@ -33,9 +32,7 @@ class ApiTest extends IntegrationTestCase
         parent::setUp();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
     }
 
     /**
@@ -1011,8 +1008,6 @@ class ApiTest extends IntegrationTestCase
         API::getInstance()->addSite("site2", array("http://piwik.com", "http://piwik.net"));
         API::getInstance()->addSite("site3", array("http://piwik.com", "http://piwik.org"));
 
-        $saveAccess = Access::getInstance();
-
         APIUsersManager::getInstance()->addUser("user1", "geqgegagae", "tegst@tesgt.com", "alias");
         APIUsersManager::getInstance()->setUserAccess("user1", "view", array(1));
 
@@ -1024,12 +1019,11 @@ class ApiTest extends IntegrationTestCase
         APIUsersManager::getInstance()->setUserAccess("user3", "view", array(1, 2));
         APIUsersManager::getInstance()->setUserAccess("user3", "admin", array(3));
 
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = false;
         FakeAccess::$identity = 'user1';
         FakeAccess::setIdSitesView(array(1));
         FakeAccess::setIdSitesAdmin(array());
-        Access::setSingletonInstance($pseudoMockAccess);
+
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.com');
         $this->assertEquals(1, count($idsites));
 
@@ -1039,25 +1033,21 @@ class ApiTest extends IntegrationTestCase
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.net');
         $this->assertEquals(1, count($idsites));
 
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = false;
         FakeAccess::$identity = 'user2';
         FakeAccess::setIdSitesView(array(1));
         FakeAccess::setIdSitesAdmin(array(3));
-        Access::setSingletonInstance($pseudoMockAccess);
+
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.com');
         $this->assertEquals(2, count($idsites));
 
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = false;
         FakeAccess::$identity = 'user3';
         FakeAccess::setIdSitesView(array(1, 2));
         FakeAccess::setIdSitesAdmin(array(3));
-        Access::setSingletonInstance($pseudoMockAccess);
+
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.com');
         $this->assertEquals(3, count($idsites));
-
-        Access::setSingletonInstance($saveAccess);
     }
 
     public function testGetSitesFromTimezones()
@@ -1068,5 +1058,12 @@ class ApiTest extends IntegrationTestCase
         $idsite4 = API::getInstance()->addSite("site3", array("http://piwik.org"), null, $siteSearch = 1, $searchKeywordParameters = null, $searchCategoryParameters = null, null, null, 'UTC+10');
         $result = API::getInstance()->getSitesIdFromTimezones(array('UTC+10', 'Pacific/Auckland'));
         $this->assertEquals(array($idsite2, $idsite3, $idsite4), $result);
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/plugins/SitesManager/tests/Integration/SitesManagerTest.php
+++ b/plugins/SitesManager/tests/Integration/SitesManagerTest.php
@@ -36,9 +36,7 @@ class SitesManagerTest extends IntegrationTestCase
         parent::setUp();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         $this->manager = new SitesManager();
         $this->siteId  = Fixture::createWebsite('2014-03-03 00:00:00');
@@ -76,4 +74,10 @@ class SitesManagerTest extends IntegrationTestCase
         $this->assertEquals($expected, $archive->getRememberedArchivedReportsThatShouldBeInvalidated());
     }
 
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
 }

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -7,7 +7,7 @@
  */
 
 namespace Piwik\Plugins\UsersManager\tests;
-use Piwik\Access;
+
 use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugins\UsersManager\API;
@@ -35,9 +35,7 @@ class APITest extends IntegrationTestCase
 
         $this->api = API::getInstance();
 
-        $pseudoMockAccess = new FakeAccess();
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         Fixture::createWebsite('2014-01-01 00:00:00');
         Fixture::createWebsite('2014-01-01 00:00:00');
@@ -51,7 +49,7 @@ class APITest extends IntegrationTestCase
         $self = $this;
         Piwik::addAction('UsersManager.removeSiteAccess', function ($login, $idSites) use (&$eventTriggered, $self) {
             $eventTriggered = true;
-            $self->assertEquals($this->login, $login);
+            $self->assertEquals($self->login, $login);
             $self->assertEquals(array(1, 2), $idSites);
         });
 
@@ -213,5 +211,12 @@ class APITest extends IntegrationTestCase
     private function getPreferenceId($preferenceName)
     {
         return $this->login . '_' . $preferenceName;
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/plugins/UsersManager/tests/Integration/UserPreferencesTest.php
+++ b/plugins/UsersManager/tests/Integration/UserPreferencesTest.php
@@ -136,16 +136,12 @@ class UserPreferencesTest extends IntegrationTestCase
 
     private function setSuperUser()
     {
-        $pseudoMockAccess = new FakeAccess();
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
     }
 
     private function setAnonymous()
     {
-        $pseudoMockAccess = new FakeAccess();
-        FakeAccess::$superUser = false;
-        Access::setSingletonInstance($pseudoMockAccess);
+        FakeAccess::clearAccess();
     }
 
     private function createSite()
@@ -168,6 +164,13 @@ class UserPreferencesTest extends IntegrationTestCase
             Piwik::getCurrentUserLogin(),
             APIUsersManager::PREFERENCE_DEFAULT_REPORT_DATE,
             $date
+        );
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
         );
     }
 }

--- a/plugins/UsersManager/tests/Integration/UsersManagerTest.php
+++ b/plugins/UsersManager/tests/Integration/UsersManagerTest.php
@@ -8,12 +8,10 @@
 
 namespace Piwik\Plugins\UsersManager\tests\Integration;
 
-use Piwik\Access;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Plugins\UsersManager\API;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Tests\Framework\Mock\FakeAccess;
-use Piwik\Translate;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Exception;
 
@@ -48,14 +46,12 @@ class UsersManagerTest extends IntegrationTestCase
         \Piwik\Plugin\Manager::getInstance()->installLoadedPlugins();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::setIdSitesView(array(1, 2));
         FakeAccess::setIdSitesAdmin(array(3, 4));
 
         //finally we set the user as a Super User by default
         FakeAccess::$superUser = true;
         FakeAccess::$superUserLogin = 'superusertest';
-        Access::setSingletonInstance($pseudoMockAccess);
 
         $this->api   = API::getInstance();
         $this->model = new Model();
@@ -915,5 +911,12 @@ class UsersManagerTest extends IntegrationTestCase
         }
 
         return $idSites;
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/plugins/VisitsSummary/tests/Integration/VisitsSummaryTest.php
+++ b/plugins/VisitsSummary/tests/Integration/VisitsSummaryTest.php
@@ -8,11 +8,9 @@
 
 namespace Piwik\Plugins\VisitsSummary\tests\Integration;
 
-use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Db;
-use Piwik\Plugins\Live\API;
 use Piwik\Plugins\VisitsSummary\VisitsSummary;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -175,8 +173,13 @@ class VisitsSummaryTest extends IntegrationTestCase
 
     private function setSuperUser()
     {
-        $pseudoMockAccess = new FakeAccess();
-        $pseudoMockAccess::setSuperUserAccess(true);
-        Access::setSingletonInstance($pseudoMockAccess);
+        FakeAccess::setSuperUserAccess(true);
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/tests/PHPUnit/Fixtures/ManySitesImportedLogs.php
+++ b/tests/PHPUnit/Fixtures/ManySitesImportedLogs.php
@@ -34,12 +34,6 @@ class ManySitesImportedLogs extends Fixture
     public $includeNginxJson = false;
     public $includeApiCustomVarMapping = false;
 
-    public static function createAccessInstance()
-    {
-        Access::setSingletonInstance($access = new OverrideLogin());
-        \Piwik\Piwik::postEvent('Request.initAuthenticationObject');
-    }
-
     public function setUp()
     {
         $this->setUpWebsitesAndGoals();

--- a/tests/PHPUnit/Fixtures/OmniFixture.php
+++ b/tests/PHPUnit/Fixtures/OmniFixture.php
@@ -111,10 +111,4 @@ class OmniFixture extends Fixture
             $fixture->tearDown();
         }
     }
-
-    public static function createAccessInstance()
-    {
-        Access::setSingletonInstance($access = new OverrideLogin());
-        \Piwik\Piwik::postEvent('Request.initAuthenticationObject');
-    }
 }

--- a/tests/PHPUnit/Fixtures/TwoSitesWithAnnotations.php
+++ b/tests/PHPUnit/Fixtures/TwoSitesWithAnnotations.php
@@ -35,11 +35,6 @@ class TwoSitesWithAnnotations extends Fixture
 
     private function addAnnotations()
     {
-        // create fake access for fake username
-        $access = new FakeAccess();
-        FakeAccess::$superUser = true;
-        Access::setSingletonInstance($access);
-
         // add two annotations per week for three months, starring every third annotation
         // first month in 2011, second two in 2012
         $count = 0;

--- a/tests/PHPUnit/Fixtures/UITestFixture.php
+++ b/tests/PHPUnit/Fixtures/UITestFixture.php
@@ -298,10 +298,4 @@ class UITestFixture extends SqlDump
         APISegmentEditor::getInstance()->add(
             "Multiple actions", "actions>=2", $idSite = 1, $autoArchive = false, $enabledAllUsers = true);
     }
-
-    public static function createAccessInstance()
-    {
-        Access::setSingletonInstance($access = new OverrideLogin());
-        \Piwik\Piwik::postEvent('Request.initAuthenticationObject');
-    }
 }

--- a/tests/PHPUnit/Fixtures/UITestFixture.php
+++ b/tests/PHPUnit/Fixtures/UITestFixture.php
@@ -19,6 +19,7 @@ use Piwik\Option;
 use Piwik\Plugins\SegmentEditor\API as APISegmentEditor;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
+use Piwik\Tests\Framework\Fixture;
 use Piwik\WidgetsList;
 use Piwik\Tests\Framework\OverrideLogin;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
@@ -192,6 +193,7 @@ class UITestFixture extends SqlDump
 
         $oldGet = $_GET;
         $_GET['idSite'] = 1;
+        $_GET['token_auth'] = Fixture::getTokenAuth();
 
         // collect widgets & sort them so widget order is not important
         $allWidgets = array();

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -10,10 +10,12 @@ namespace Piwik\Tests\Framework;
 use Piwik\Access;
 use Piwik\Application\Environment;
 use Piwik\Archive;
+use Piwik\Auth;
 use Piwik\Cache\Backend\File;
 use Piwik\Cache as PiwikCache;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\DataTable\Manager as DataTableManager;
 use Piwik\Date;
@@ -128,6 +130,16 @@ class Fixture extends \PHPUnit_Framework_Assert
         }
 
         return 'python';
+    }
+
+    public function loginAsSuperUser()
+    {
+        /** @var Auth $auth */
+        $auth = $this->piwikEnvironment->getContainer()->get('Piwik\Auth');
+        $auth->setLogin(Fixture::ADMIN_USER_LOGIN);
+        $auth->setPassword(Fixture::ADMIN_USER_PASSWORD);
+        Access::getInstance()->setSuperUserAccess(false);
+        Access::getInstance()->reloadAccess(StaticContainer::get('Piwik\Auth'));
     }
 
     /** Adds data to Piwik. Creates sites, tracks visits, imports log files, etc. */
@@ -245,6 +257,7 @@ class Fixture extends \PHPUnit_Framework_Assert
 
         if ($this->createSuperUser) {
             self::createSuperUser($this->removeExistingSuperUser);
+            $this->loginAsSuperUser();
         }
 
         SettingsPiwik::overwritePiwikUrl(self::getRootUrl() . 'tests/PHPUnit/proxy/');

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -213,8 +213,6 @@ class Fixture extends \PHPUnit_Framework_Assert
             DbHelper::truncateAllTables();
         }
 
-        static::createAccessInstance();
-
         // We need to be SU to create websites for tests
         Access::getInstance()->setSuperUserAccess();
 
@@ -623,11 +621,6 @@ class Fixture extends \PHPUnit_Framework_Assert
      */
     public static function setUpScheduledReports($idSite)
     {
-        // fake access is needed so API methods can call Piwik::getCurrentUserLogin(), e.g: 'ScheduledReports.addReport'
-        $pseudoMockAccess = new FakeAccess;
-        FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
-
         // retrieve available reports
         $availableReportMetadata = APIScheduledReports::getReportMetadata($idSite, ScheduledReports::EMAIL_TYPE);
 
@@ -825,13 +818,10 @@ class Fixture extends \PHPUnit_Framework_Assert
     }
 
     /**
-     * Sets up access instance.
+     * @deprecated
      */
     public static function createAccessInstance()
     {
-        Access::setSingletonInstance(null);
-        Access::getInstance();
-        Piwik::postEvent('Request.initAuthenticationObject');
     }
 
     public function dropDatabase($dbName = null)

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Framework\TestCase;
 
+use Piwik\Access;
 use Piwik\Config;
 use Piwik\Db;
 use Piwik\Tests\Framework\Fixture;
@@ -79,6 +80,8 @@ abstract class IntegrationTestCase extends SystemTestCase
 
         Fixture::loadAllPlugins(new \Piwik\Tests\Framework\TestingEnvironment(), get_class($this), self::$fixture->extraPluginsToLoad);
 
+        Access::getInstance()->setSuperUserAccess(true);
+        
         if (!empty(self::$tableData)) {
             self::restoreDbTables(self::$tableData);
         }

--- a/tests/PHPUnit/Integration/API/RequestTest.php
+++ b/tests/PHPUnit/Integration/API/RequestTest.php
@@ -117,8 +117,6 @@ class RequestTest extends IntegrationTestCase
                  ->method('authenticate')
                  ->will($this->returnValue(new AuthResult(AuthResult::SUCCESS, 'login', $this->userAuthToken)));
 
-        StaticContainer::getContainer()->set('Piwik\Auth', $authMock);
-
         return $authMock;
     }
 
@@ -138,6 +136,7 @@ class RequestTest extends IntegrationTestCase
         $this->auth   = $this->createAuthMock();
         $this->access = $this->createAccessMock($this->auth);
         return array(
+            'Piwik\Auth'     => $this->auth,
             'Piwik\Access' => $this->access
         );
     }

--- a/tests/PHPUnit/Integration/API/RequestTest.php
+++ b/tests/PHPUnit/Integration/API/RequestTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration\API;
 
-use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\AuthResult;
 use Piwik\Container\StaticContainer;
@@ -26,15 +25,6 @@ class RequestTest extends IntegrationTestCase
     private $access;
 
     private $userAuthToken = 'token';
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->auth   = $this->createAuthMock();
-        $this->access = $this->createAccessMock($this->auth);
-        Access::setSingletonInstance($this->access);
-    }
 
     public function test_process_shouldNotReloadAccessIfNoTokenAuthIsGiven()
     {
@@ -143,4 +133,12 @@ class RequestTest extends IntegrationTestCase
         return $mock;
     }
 
+    public function provideContainerConfig()
+    {
+        $this->auth   = $this->createAuthMock();
+        $this->access = $this->createAccessMock($this->auth);
+        return array(
+            'Piwik\Access' => $this->access
+        );
+    }
 }

--- a/tests/PHPUnit/Integration/AccessTest.php
+++ b/tests/PHPUnit/Integration/AccessTest.php
@@ -20,12 +20,6 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class AccessTest extends IntegrationTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Access::setSingletonInstance(null);
-    }
-
     public function testGetListAccess()
     {
         $accessList = Access::getListAccess();

--- a/tests/PHPUnit/Integration/Archive/ChunksTest.php
+++ b/tests/PHPUnit/Integration/Archive/ChunksTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration\Archive;
 
-use Piwik\Access;
 use Piwik\Archive;
 use Piwik\ArchiveProcessor;
 use Piwik\ArchiveProcessor\Parameters;
@@ -39,17 +38,9 @@ class ChunksTest extends IntegrationTestCase
         parent::setUp();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         Fixture::createWebsite('2015-01-01 00:00:00');
-    }
-
-    public function tearDown()
-    {
-        Access::setSingletonInstance(null);
-        parent::tearDown();
     }
 
     public function test_subtables_willBeSplitIntoChunks()
@@ -149,5 +140,12 @@ class ChunksTest extends IntegrationTestCase
         $params = $this->createArchiveProcessorParamaters();
 
         return new ArchiveProcessor\PluginsArchiver($params, $isTemporary = false);
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/tests/PHPUnit/Integration/Archive/DataTableFactoryTest.php
+++ b/tests/PHPUnit/Integration/Archive/DataTableFactoryTest.php
@@ -8,16 +8,13 @@
 
 namespace Piwik\Tests\Integration\Archive;
 
-use Piwik\Access;
 use Piwik\Archive;
 use Piwik\ArchiveProcessor;
 use Piwik\DataTable;
-use Piwik\DataTable\DataTableInterface;
 use Piwik\DataTable\Row;
 use Piwik\Db;
 use Piwik\Period;
 use Piwik\Segment;
-use Piwik\Site;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -49,9 +46,7 @@ class DataTableFactoryTest extends IntegrationTestCase
         parent::setUp();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         for ($i = 0; $i < $this->site2; $i++) {
             Fixture::createWebsite('2015-01-01 00:00:00');
@@ -356,5 +351,10 @@ class DataTableFactoryTest extends IntegrationTestCase
         return $indices;
     }
 
-
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
 }

--- a/tests/PHPUnit/Integration/ArchiveProcessingTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessingTest.php
@@ -54,16 +54,13 @@ class ArchiveProcessingTest extends IntegrationTestCase
         parent::setUp();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         ArchiveTableCreator::$tablesAlreadyInstalled = null;
     }
 
     public function tearDown()
     {
-        Access::setSingletonInstance(null);
         ArchiveTableCreator::$tablesAlreadyInstalled = null;
     }
 
@@ -497,5 +494,12 @@ class ArchiveProcessingTest extends IntegrationTestCase
         $array[] = array(4, 'lorem ipsum compressed', 1, '2011-03-31', '2011-03-31', Piwik::$idPeriods['day'], $ts, gzcompress($str));
 
         return $array;
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -9,7 +9,6 @@
 namespace Piwik\Tests\Integration;
 
 use Exception;
-use Piwik\Access;
 use Piwik\Common;
 use Piwik\Segment;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -26,9 +25,7 @@ class SegmentTest extends IntegrationTestCase
         parent::setUp();
 
         // setup the access layer (required in Segment contrustor testing if anonymous is allowed to use segments)
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
     }
 
     public function tearDown()
@@ -501,5 +498,12 @@ class SegmentTest extends IntegrationTestCase
             "bind" => array(1, 'Test'));
 
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/tests/PHPUnit/Integration/Settings/IntegrationTestCase.php
+++ b/tests/PHPUnit/Integration/Settings/IntegrationTestCase.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration\Settings;
 
-use Piwik\Access;
 use Piwik\Db;
 use Piwik\Settings\Setting;
 use Piwik\Settings\Storage;
@@ -29,7 +28,6 @@ class IntegrationTestCase extends \Piwik\Tests\Framework\TestCase\IntegrationTes
     public function setUp()
     {
         parent::setUp();
-        Access::setSingletonInstance(null);
         Db::destroyDatabaseObject();
         $this->settings = $this->createSettingsInstance();
     }
@@ -81,22 +79,18 @@ class IntegrationTestCase extends \Piwik\Tests\Framework\TestCase\IntegrationTes
 
     protected function setSuperUser()
     {
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
     }
 
     protected function setUser()
     {
-        $pseudoMockAccess = new FakeAccess();
+        FakeAccess::clearAccess();
         FakeAccess::$idSitesView = array(1);
-        Access::setSingletonInstance($pseudoMockAccess);
     }
 
     protected function setAnonymousUser()
     {
         FakeAccess::clearAccess();
-        Access::setSingletonInstance(new FakeAccess());
     }
 
     protected function createSettingsInstance()
@@ -127,5 +121,12 @@ class IntegrationTestCase extends \Piwik\Tests\Framework\TestCase\IntegrationTes
         $verifySettings->addSetting($setting);
 
         $this->assertEquals($expectedValue, $setting->getValue());
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/tests/PHPUnit/Integration/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ActionTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration\Tracker;
 
-use Piwik\Access;
 use Piwik\Config;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -50,9 +49,7 @@ class ActionTest extends IntegrationTestCase
 
     protected function setUpRootAccess()
     {
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
     }
 
     public function getTestUrls()
@@ -385,5 +382,12 @@ class ActionTest extends IntegrationTestCase
         );
 
         $this->assertEquals($processed, $expected);
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration\Tracker;
 
-use Piwik\Access;
 use Piwik\Cache;
 use Piwik\CacheId;
 use Piwik\Archive\ArchiveInvalidator;
@@ -35,9 +34,7 @@ class VisitTest extends IntegrationTestCase
         parent::setUp();
 
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         Manager::getInstance()->loadTrackerPlugins();
         Manager::getInstance()->loadPlugin('SitesManager');
@@ -452,6 +449,13 @@ class VisitTest extends IntegrationTestCase
         $cache = Cache::getTransientCache();
         $cache->save(CacheId::pluginAware('VisitDimensions'), $dimensions);
         Visit::$dimensions = null;
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }
 

--- a/tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php
+++ b/tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration\ViewDataTable;
 
-use Piwik\Access;
 use Piwik\ViewDataTable\Manager as ViewDataTableManager;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -18,12 +17,6 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class ManagerTest extends IntegrationTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Access::setSingletonInstance(null);
-    }
-
     public function test_getViewDataTableParameters_shouldReturnEmptyArray_IfNothingPersisted()
     {
         $login        = 'mylogin';

--- a/tests/PHPUnit/Integration/WidgetsListTest.php
+++ b/tests/PHPUnit/Integration/WidgetsListTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration;
 
-use Piwik\Access;
 use Piwik\Plugins\Goals\API;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Translate;
@@ -24,9 +23,7 @@ class WidgetsListTest extends IntegrationTestCase
     public function testGet()
     {
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         Fixture::createWebsite('2009-01-04 00:11:42');
 
@@ -64,9 +61,7 @@ class WidgetsListTest extends IntegrationTestCase
     public function testGetWithGoals()
     {
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         Fixture::createWebsite('2009-01-04 00:11:42');
         API::getInstance()->addGoal(1, 'Goal 1 - Thank you', 'title', 'Thank you', 'contains', $caseSensitive = false, $revenue = 10, $allowMultipleConversions = 1);
@@ -93,9 +88,7 @@ class WidgetsListTest extends IntegrationTestCase
     public function testGetWithGoalsAndEcommerce()
     {
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         Fixture::createWebsite('2009-01-04 00:11:42', true);
         API::getInstance()->addGoal(1, 'Goal 1 - Thank you', 'title', 'Thank you', 'contains', $caseSensitive = false, $revenue = 10, $allowMultipleConversions = 1);
@@ -123,9 +116,7 @@ class WidgetsListTest extends IntegrationTestCase
     public function testRemove()
     {
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         Fixture::createWebsite('2009-01-04 00:11:42', true);
         API::getInstance()->addGoal(1, 'Goal 1 - Thank you', 'title', 'Thank you', 'contains', $caseSensitive = false, $revenue = 10, $allowMultipleConversions = 1);
@@ -160,9 +151,7 @@ class WidgetsListTest extends IntegrationTestCase
     public function testIsDefined()
     {
         // setup the access layer
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         Translate::loadAllTranslations();
 
@@ -177,5 +166,12 @@ class WidgetsListTest extends IntegrationTestCase
         $this->assertFalse(WidgetsList::isDefined('Actions', 'inValiD'));
 
         Translate::reset();
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }

--- a/tests/PHPUnit/System/AnnotationsTest.php
+++ b/tests/PHPUnit/System/AnnotationsTest.php
@@ -7,7 +7,6 @@
  */
 namespace Piwik\Tests\System;
 
-use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Plugins\Annotations\API;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -262,11 +261,9 @@ class AnnotationsTest extends SystemTestCase
     public function testMethodPermissions($hasAdminAccess, $hasViewAccess, $request, $checkException, $failMessage)
     {
         // create fake access that denies user access
-        $access = new FakeAccess();
         FakeAccess::$superUser = false;
         FakeAccess::$idSitesAdmin = $hasAdminAccess ? array(self::$fixture->idSite1) : array();
         FakeAccess::$idSitesView = $hasViewAccess ? array(self::$fixture->idSite1) : array();
-        Access::setSingletonInstance($access);
 
         if ($checkException) {
             try {
@@ -281,6 +278,13 @@ class AnnotationsTest extends SystemTestCase
             $request->process();
 
         }
+    }
+
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
     }
 }
 

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -143,6 +143,7 @@ class CliMultiTest extends SystemTestCase
     public function test_request_shouldDetectFinishOfRequest_IfNoParamsAreGiven()
     {
         $this->skipWhenPhp53();
+        $this->cliMulti->runAsSuperUser();
         $response = $this->cliMulti->request(array($this->completeUrl('')));
         $this->assertStringStartsWith('Error in Piwik: Error: no website was found', $response[0]);
     }

--- a/tests/PHPUnit/Unit/Menu/MenuReportingTest.php
+++ b/tests/PHPUnit/Unit/Menu/MenuReportingTest.php
@@ -8,12 +8,9 @@
 
 namespace Piwik\Tests\Unit\Menu;
 
-use Piwik\Access;
 use Piwik\Plugin\Report;
 use Piwik\Piwik;
 use Piwik\Metrics;
-use Piwik\Tests\Framework\Mock\FakeAccess;
-use Piwik\Translate;
 use Piwik\Menu\MenuReporting;
 use Piwik\Plugin\Manager as PluginManager;
 
@@ -31,14 +28,11 @@ class ReportingTest extends \PHPUnit_Framework_TestCase
     {
         PluginManager::getInstance()->unloadPlugins();
         $this->menu = MenuReporting::getInstance();
-
-        Access::setSingletonInstance(new FakeAccess());
     }
 
     public function tearDown()
     {
         MenuReporting::getInstance()->unsetInstance();
-        Access::setSingletonInstance(null);
         parent::tearDown();
     }
 

--- a/tests/PHPUnit/Unit/MetricsTest.php
+++ b/tests/PHPUnit/Unit/MetricsTest.php
@@ -8,12 +8,12 @@
 
 namespace Piwik\Tests\Unit;
 
-use Piwik\Access;
 use Piwik\Metrics;
 use Piwik\Site;
 use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
 
-class MetricsTest extends \PHPUnit_Framework_TestCase
+class MetricsTest extends UnitTestCase
 {
     /**
      * @group Core
@@ -127,12 +127,16 @@ class MetricsTest extends \PHPUnit_Framework_TestCase
             1 => array('name' => 'TestSite', 'currency' => 'EUR')
         ));
 
-        $pseudoMockAccess = new FakeAccess;
         FakeAccess::$superUser = true;
-        Access::setSingletonInstance($pseudoMockAccess);
 
         $actual = Metrics::getUnit($column, 1);
         $this->assertEquals($expected, $actual);
     }
 
+    public function provideContainerConfig()
+    {
+        return array(
+            'Piwik\Access' => new FakeAccess()
+        );
+    }
 }


### PR DESCRIPTION
This PR is based off of https://github.com/piwik/piwik/pull/8008, so that PR must be merged first.

This PR includes the following changes:
- Change Access from being a singleton to being in DI.
- Change the Login plugin so it defines the Auth implementation in DI, instead of the Request.initAuthenticationObject event.
- Fixed lots and lots of tests.
