### PR TITLE
Not setting $resultCheck[false] in core/Filechecks.php function checkDirectoriesWritable.

### DIFF
--- a/core/Filechecks.php
+++ b/core/Filechecks.php
@@ -48,11 +48,8 @@ class Filechecks
             Filesystem::mkdir($directoryToCheck);
 
             $directory = Filesystem::realpath($directoryToCheck);
-            $resultCheck[$directory] = false;
-            if ($directory !== false // realpath() returns FALSE on failure
-                && is_writable($directoryToCheck)
-            ) {
-                $resultCheck[$directory] = true;
+            if ($directory !== false) {
+                $resultCheck[$directory] = is_writable($directoryToCheck);
             }
         }
         return $resultCheck;


### PR DESCRIPTION
It seems like this code could be shortened and corrected. I made some test run to confirm that the error page will be triggered by making the tmp directory non-writable.
