### PR TITLE
#7978 - fix for user agent quotes issue

### DIFF
--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -856,6 +856,10 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasSuperUserAccess();
 
+        // converts html entities back to original form & removes quotes if present.
+        $excludedUserAgents = html_entity_decode($excludedUserAgents);
+        $excludedUserAgents = trim($excludedUserAgents, '"');
+        
         // update option
         $excludedUserAgents = $this->checkAndReturnCommaSeparatedStringList($excludedUserAgents);
         Option::set(self::OPTION_EXCLUDED_USER_AGENTS_GLOBAL, $excludedUserAgents);


### PR DESCRIPTION
Fix for issue https://github.com/piwik/piwik/issues/7978.
- Removes if double quotes present after checking each user-agent string. If quotes is not present, the user-agent is left as such.
