### PR TITLE
By default show all available device types

### DIFF
--- a/plugins/DevicesDetection/Reports/GetType.php
+++ b/plugins/DevicesDetection/Reports/GetType.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\DevicesDetection\Reports;
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\DevicesDetection\Columns\DeviceType;
+use DeviceDetector\Parser\Device\DeviceParserAbstract as DeviceParser;
 
 class GetType extends Base
 {
@@ -26,6 +27,8 @@ class GetType extends Base
 
     public function configureView(ViewDataTable $view)
     {
+        $unknownTypeCount = 1;
+        $view->requestConfig->filter_limit = $unknownTypeCount + count(DeviceParser::getAvailableDeviceTypeNames());
         $view->config->show_search = false;
         $view->config->show_exclude_low_population = false;
         $view->config->addTranslation('label', Piwik::translate("DevicesDetection_dataTableLabelTypes"));


### PR DESCRIPTION
fixes #7920 

By default it will show all device types, currently 12. As soon as one changes the limit, the configured limit will be used.
