### PR TITLE
Fix segmentation fault caused by Dashboard_spec.js in travis + related changes

### DIFF
--- a/plugins/Morpheus/javascripts/ajaxHelper.js
+++ b/plugins/Morpheus/javascripts/ajaxHelper.js
@@ -359,7 +359,11 @@ function ajaxHelper() {
             async:    this.async !== false,
             url:      url,
             dataType: this.format || 'json',
-            error:    this.errorCallback,
+            error:    function () {
+                --globalAjaxQueue.active;
+
+                that.errorCallback.apply(this, arguments);
+            },
             success:  function (response) {
                 if (that.loadingElement) {
                     $(that.loadingElement).hide();

--- a/plugins/UserCountryMap/Controller.php
+++ b/plugins/UserCountryMap/Controller.php
@@ -18,6 +18,8 @@ use Piwik\Site;
 use Piwik\Translation\Translator;
 use Piwik\View;
 
+require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/functions.php';
+
 /**
  *
  */

--- a/tests/UI/specs/Dashboard_spec.js
+++ b/tests/UI/specs/Dashboard_spec.js
@@ -37,6 +37,14 @@ describe("Dashboard", function () {
     };
 
     var setup = function (done) {
+        // make sure live widget doesn't refresh constantly for UI tests
+        testEnvironment.configOverride = {
+            General: {
+                'live_widget_refresh_after_seconds': 1000000
+            }
+        };
+        testEnvironment.save();
+
         // save empty layout for dashboard ID = 5
         var layout = [
             [
@@ -149,12 +157,9 @@ describe("Dashboard", function () {
             page.click('.dashboard-manager');
             page.click('li[data-action=renameDashboard]');
             page.evaluate(function () {
-                $('#newDashboardName').val('');
+                $('#newDashboardName:visible').val('newname'); // don't use sendKeys or click, since in this test it appears to trigger a seg fault on travis
+                $('.ui-dialog[aria-describedby=renameDashboardConfirm] button>span:contains(Save):visible').click();
             });
-            page.sendKeys('#newDashboardName', 'newname');
-
-            // sending a mouse event doesn't seem to work...
-            page.click('.ui-dialog[aria-describedby=renameDashboardConfirm] button>span:contains(Save)');
         }, done);
     });
 

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -257,8 +257,14 @@ PageRenderer.prototype.contains = function (selector) {
 PageRenderer.prototype.capture = function (outputPath, callback, selector) {
     var self = this,
         timeout = setTimeout(function () {
+            var timeoutDetails = "";
+            timeoutDetails += "Page not ready: " + self._isLoading + "\n";
+            timeoutDetails += "Pending AJAX request count: " + self._getAjaxRequestCount() + "\n";
+            timeoutDetails += "Loading images count: " + self._getImageLoadingCount() + "\n";
+
             self.abort();
-            callback(new Error("Screenshot load timeout."));
+
+            callback(new Error("Screenshot load timeout. Details:\n" + timeoutDetails));
         }, 120 * 1000);
 
     if (this.webpage === null) {


### PR DESCRIPTION
Includes the following changes:
- Switch to evaluating JavaScript in the offending test in Dashboard_spec.js instead of sending events through qtwebkit (which appears to cause the seg fault in this case).
- Fix a bug in UserCountryMap, where for some reason in the widgetized dashboard, the UserCountry functions.php file is not loaded (at least for the test) and so one of the functions used is not available.
- In ajaxHelper, decrement the active number of AJAX requests on request error.
- In the event of a page loading timeout, display the number of pending AJAX requests, loading images & whether the page is ready or not for better debugging.

NOTE: This will cause some failures in the Dashboard spec. These failures occur because the current test is broken, some of the expected screenshots are wrong.

Refs #7147 
