### PR TITLE
Prevent message "could not find layer regions" when clicking on "Cities" in VisitorMap

### DIFF
--- a/plugins/UserCountryMap/javascripts/visitor-map.js
+++ b/plugins/UserCountryMap/javascripts/visitor-map.js
@@ -811,7 +811,8 @@
                  */
                 function updateCitySymbols() {
                     // color regions in white as background for symbols
-                    if (map.getLayer('regions')) map.getLayer('regions').style('fill', invisibleRegionBackgroundColor);
+                    var layerName = self.mode != "region" ? "regions2" : "regions";
+                    if (map.getLayer(layerName)) map.getLayer(layerName).style('fill', invisibleRegionBackgroundColor);
 
                     indicateLoading();
 


### PR DESCRIPTION
refs #8061

See issue. Not sure re any side effects but it stops triggering the `console.warn` (or alert on IE 8) and "seems" to work
