### PR TITLE
Fixes #7912, add --force-idsegments parameter and --skip-all-segments parameter to core:archive command.

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -773,7 +773,7 @@ class CronArchive
 
         $this->requests += count($urls);
 
-        $cliMulti = new CliMulti();
+        $cliMulti = $this->makeCliMulti();
         $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
         $cliMulti->setConcurrentProcessesLimit($this->getConcurrentRequestsPerWebsite());
         $cliMulti->runAsSuperUser();
@@ -856,7 +856,7 @@ class CronArchive
         }
 
         try {
-            $cliMulti  = new CliMulti();
+            $cliMulti  = $this->makeCliMulti();
             $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
             $cliMulti->runAsSuperUser();
             $responses = $cliMulti->request(array($url));
@@ -1527,5 +1527,13 @@ class CronArchive
         foreach ($this->segmentsToForce as $segmentDefinition) {
             $this->logger->info("  * " . $segmentDefinition);
         }
+    }
+
+    /**
+     * @return CliMulti
+     */
+    private function makeCliMulti()
+    {
+        return StaticContainer::get('Piwik\CliMulti');
     }
 }

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -198,6 +198,11 @@ class CronArchive
      */
     public $segmentsToForce = array();
 
+    /**
+     * @var bool
+     */
+    public $disableSegmentsArchiving = false;
+
     private $websitesWithVisitsSinceLastRun = 0;
     private $skippedPeriodsArchivesWebsite = 0;
     private $skippedDayArchivesWebsites = 0;
@@ -1514,6 +1519,10 @@ class CronArchive
 
     private function shouldSkipSegmentArchiving($segment)
     {
+        if ($this->disableSegmentsArchiving) {
+            return true;
+        }
+
         return !empty($this->segmentsToForce) && !in_array($segment, $this->segmentsToForce);
     }
 

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -99,7 +99,7 @@ class SettingsPiwik
      * cron archiving.
      *
      * @param int $idSite The ID of the site to get stored segments for.
-     * @return string The list of stored segments that apply to the requested site.
+     * @return string[] The list of stored segments that apply to the requested site.
      */
     public static function getKnownSegmentsToArchiveForSite($idSite)
     {

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -49,6 +49,8 @@ class CoreArchiver extends ConsoleCommand
         $archiver->dateLastForced = $input->getOption('force-date-last-n');
         $archiver->concurrentRequestsPerWebsite = $input->getOption('concurrent-requests-per-website');
 
+        $archiver->disableSegmentsArchiving = $input->getOption('skip-all-segments');
+
         $segmentIds = $input->getOption('force-idsegments');
         $segmentIds = explode(',', $segmentIds);
         $segmentIds = array_map('trim', $segmentIds);
@@ -101,6 +103,8 @@ class CoreArchiver extends ConsoleCommand
             'If specified, only these segments will be processed (if the segment should be applied to a site in the '
             . "first place). Specify stored segment IDs, not the segments themselves, eg, 1,2,3. Note: if identical "
             . "segments exist w/ different IDs, they will both be skipped, even if you only supply one ID.");
+        $command->addOption('skip-all-segments', null, InputOption::VALUE_NONE,
+            'If specified, all segments will be skipped during archiving.');
         $command->addOption('concurrent-requests-per-website', null, InputOption::VALUE_OPTIONAL,
             "When processing a website and its segments, number of requests to process in parallel", CronArchive::MAX_CONCURRENT_API_REQUESTS);
         $command->addOption('disable-scheduled-tasks', null, InputOption::VALUE_NONE,

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -51,6 +51,11 @@ class CoreArchiver extends ConsoleCommand
         $archiver->dateLastForced = $input->getOption('force-date-last-n');
         $archiver->concurrentRequestsPerWebsite = $input->getOption('concurrent-requests-per-website');
 
+        $segmentIds = $input->getOption('force-idsegments');
+        $segmentIds = explode(',', $segmentIds);
+        $segmentIds = array_map('trim', $segmentIds);
+        $archiver->setSegmentsToForceFromSegmentIds($segmentIds);
+
         return $archiver;
     }
 
@@ -80,6 +85,7 @@ class CoreArchiver extends ConsoleCommand
         $command->addOption('force-periods', null, InputOption::VALUE_OPTIONAL, "If specified, archiving will be processed only for these Periods (comma separated eg. day,week,month)");
         $command->addOption('force-date-last-n', null, InputOption::VALUE_REQUIRED, "This script calls the API with period=lastN. You can force the N in lastN by specifying this value.");
         $command->addOption('force-date-range', null, InputOption::VALUE_OPTIONAL, "If specified, archiving will be processed only for periods included in this date range. Format: YYYY-MM-DD,YYYY-MM-DD");
+        $command->addOption('force-idsegments', null, InputOption::VALUE_REQUIRED, 'If specified, only these segments will be processed (if the segment should be applied to a site in the first place). Specify stored segment IDs, not the segments themselves, eg, 1,2,3');
         $command->addOption('concurrent-requests-per-website', null, InputOption::VALUE_OPTIONAL, "When processing a website and its segments, number of requests to process in parallel", CronArchive::MAX_CONCURRENT_API_REQUESTS);
         $command->addOption('disable-scheduled-tasks', null, InputOption::VALUE_NONE, "Skips executing Scheduled tasks (sending scheduled reports, db optimization, etc.).");
         $command->addOption('accept-invalid-ssl-certificate', null, InputOption::VALUE_NONE, "It is _NOT_ recommended to use this argument. Instead, you should use a valid SSL certificate!\nIt can be useful if you specified --url=https://... or if you are using Piwik with force_ssl=1");

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -8,13 +8,11 @@
 namespace Piwik\Plugins\CoreConsole\Commands;
 
 use Piwik\CronArchive;
-use Piwik\Log;
 use Piwik\Plugin\ConsoleCommand;
 use Piwik\Site;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Exception;
 
 class CoreArchiver extends ConsoleCommand
 {
@@ -77,17 +75,38 @@ class CoreArchiver extends ConsoleCommand
 * If you have any suggestion about this script, please let the team know at feedback@piwik.org
 * Enjoy!");
         $command->addOption('url', null, InputOption::VALUE_REQUIRED, "Deprecated.");
-        $command->addOption('force-all-websites', null, InputOption::VALUE_NONE, "If specified, the script will trigger archiving on all websites.\nUse with --force-all-periods=[seconds] to also process those websites that had visits in the last [seconds] seconds.\nLaunching several processes with this option will make them share the list of sites to process.");
-        $command->addOption('force-all-periods', null, InputOption::VALUE_OPTIONAL, "Limits archiving to websites with some traffic in the last [seconds] seconds. \nFor example --force-all-periods=86400 will archive websites that had visits in the last 24 hours. \nIf [seconds] is not specified, all websites with visits in the last " . CronArchive::ARCHIVE_SITES_WITH_TRAFFIC_SINCE . " seconds (" . round(CronArchive::ARCHIVE_SITES_WITH_TRAFFIC_SINCE / 86400) . " days) will be archived.");
-        $command->addOption('force-timeout-for-periods', null, InputOption::VALUE_OPTIONAL, "The current week/ current month/ current year will be processed at most every [seconds].\nIf not specified, defaults to " . CronArchive::SECONDS_DELAY_BETWEEN_PERIOD_ARCHIVES . ".");
-        $command->addOption('skip-idsites', null, InputOption::VALUE_OPTIONAL, 'If specified, archiving will be skipped for these websites (in case these website ids would have been archived).');
-        $command->addOption('force-idsites', null, InputOption::VALUE_OPTIONAL, 'If specified, archiving will be processed only for these Sites Ids (comma separated)');
-        $command->addOption('force-periods', null, InputOption::VALUE_OPTIONAL, "If specified, archiving will be processed only for these Periods (comma separated eg. day,week,month)");
-        $command->addOption('force-date-last-n', null, InputOption::VALUE_REQUIRED, "This script calls the API with period=lastN. You can force the N in lastN by specifying this value.");
-        $command->addOption('force-date-range', null, InputOption::VALUE_OPTIONAL, "If specified, archiving will be processed only for periods included in this date range. Format: YYYY-MM-DD,YYYY-MM-DD");
-        $command->addOption('force-idsegments', null, InputOption::VALUE_REQUIRED, 'If specified, only these segments will be processed (if the segment should be applied to a site in the first place). Specify stored segment IDs, not the segments themselves, eg, 1,2,3');
-        $command->addOption('concurrent-requests-per-website', null, InputOption::VALUE_OPTIONAL, "When processing a website and its segments, number of requests to process in parallel", CronArchive::MAX_CONCURRENT_API_REQUESTS);
-        $command->addOption('disable-scheduled-tasks', null, InputOption::VALUE_NONE, "Skips executing Scheduled tasks (sending scheduled reports, db optimization, etc.).");
-        $command->addOption('accept-invalid-ssl-certificate', null, InputOption::VALUE_NONE, "It is _NOT_ recommended to use this argument. Instead, you should use a valid SSL certificate!\nIt can be useful if you specified --url=https://... or if you are using Piwik with force_ssl=1");
+        $command->addOption('force-all-websites', null, InputOption::VALUE_NONE,
+            "If specified, the script will trigger archiving on all websites.\nUse with --force-all-periods=[seconds] "
+            . "to also process those websites that had visits in the last [seconds] seconds.\nLaunching several processes"
+            . " with this option will make them share the list of sites to process.");
+        $command->addOption('force-all-periods', null, InputOption::VALUE_OPTIONAL,
+            "Limits archiving to websites with some traffic in the last [seconds] seconds. \nFor example "
+            . "--force-all-periods=86400 will archive websites that had visits in the last 24 hours. \nIf [seconds] is "
+            . "not specified, all websites with visits in the last " . CronArchive::ARCHIVE_SITES_WITH_TRAFFIC_SINCE
+            . " seconds (" . round(CronArchive::ARCHIVE_SITES_WITH_TRAFFIC_SINCE / 86400) . " days) will be archived.");
+        $command->addOption('force-timeout-for-periods', null, InputOption::VALUE_OPTIONAL,
+            "The current week/ current month/ current year will be processed at most every [seconds].\nIf not "
+            . "specified, defaults to " . CronArchive::SECONDS_DELAY_BETWEEN_PERIOD_ARCHIVES . ".");
+        $command->addOption('skip-idsites', null, InputOption::VALUE_OPTIONAL,
+            'If specified, archiving will be skipped for these websites (in case these website ids would have been archived).');
+        $command->addOption('force-idsites', null, InputOption::VALUE_OPTIONAL,
+            'If specified, archiving will be processed only for these Sites Ids (comma separated)');
+        $command->addOption('force-periods', null, InputOption::VALUE_OPTIONAL,
+            "If specified, archiving will be processed only for these Periods (comma separated eg. day,week,month)");
+        $command->addOption('force-date-last-n', null, InputOption::VALUE_REQUIRED,
+            "This script calls the API with period=lastN. You can force the N in lastN by specifying this value.");
+        $command->addOption('force-date-range', null, InputOption::VALUE_OPTIONAL,
+            "If specified, archiving will be processed only for periods included in this date range. Format: YYYY-MM-DD,YYYY-MM-DD");
+        $command->addOption('force-idsegments', null, InputOption::VALUE_REQUIRED,
+            'If specified, only these segments will be processed (if the segment should be applied to a site in the '
+            . "first place). Specify stored segment IDs, not the segments themselves, eg, 1,2,3. Note: if identical "
+            . "segments exist w/ different IDs, they will both be skipped, even if you only supply one ID.");
+        $command->addOption('concurrent-requests-per-website', null, InputOption::VALUE_OPTIONAL,
+            "When processing a website and its segments, number of requests to process in parallel", CronArchive::MAX_CONCURRENT_API_REQUESTS);
+        $command->addOption('disable-scheduled-tasks', null, InputOption::VALUE_NONE,
+            "Skips executing Scheduled tasks (sending scheduled reports, db optimization, etc.).");
+        $command->addOption('accept-invalid-ssl-certificate', null, InputOption::VALUE_NONE,
+            "It is _NOT_ recommended to use this argument. Instead, you should use a valid SSL certificate!\nIt can be "
+            . "useful if you specified --url=https://... or if you are using Piwik with force_ssl=1");
     }
 }

--- a/tests/PHPUnit/Framework/Mock/FakeLogger.php
+++ b/tests/PHPUnit/Framework/Mock/FakeLogger.php
@@ -2,6 +2,7 @@
 
 namespace Piwik\Tests\Framework\Mock;
 
+use Monolog\Processor\PsrLogMessageProcessor;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 
@@ -12,8 +13,20 @@ class FakeLogger extends AbstractLogger implements LoggerInterface
      */
     public $output = '';
 
+    /**
+     * @var PsrLogMessageProcessor
+     */
+    private $processor;
+
+    public function __construct()
+    {
+        $this->processor = new PsrLogMessageProcessor();
+    }
+
     public function log($level, $message, array $context = array())
     {
-        $this->output .= $message . PHP_EOL;
+        $record = $this->processor->__invoke(array('message' => $message, 'context' => $context));
+
+        $this->output .= $record['message'] . PHP_EOL;
     }
 }


### PR DESCRIPTION
As title.

Also includes a change to CronArchive/CronArchiveTest.php which allows using a mock CliMulti instance with CronArchive. Speeds CronArchiveTest.php by ~10s.

Refs #7912 
