### PR TITLE
Make userId segment work for all operators (Is, is not, contains, does not contain, is null, is not null)

### DIFF
--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -161,11 +161,7 @@ class API extends \Piwik\Plugin\API
             'segment'        => 'userId',
             'acceptedValues' => 'any non empty unique string identifying the user (such as an email address or a username).',
             'sqlSegment'     => 'log_visit.user_id',
-            'sqlFilter'      => array($this, 'checkSegmentMatchTypeIsValidForUser'),
             'permission'     => $isAuthenticatedWithViewAccess,
-
-            // TODO specify that this segment is not compatible with some operators
-//            'unsupportedOperators' = array(MATCH_CONTAINS, MATCH_DOES_NOT_CONTAIN),
         );
 
         $segments[] = array(
@@ -239,32 +235,6 @@ class API extends \Piwik\Plugin\API
             }
         }
         return $compare;
-    }
-
-    /**
-     * Throw an exception if the User ID segment is used with an un-supported match type,
-     *
-     * @ignore
-     * @param $value
-     * @param $sqlSegment
-     * @param $matchType
-     * @param $name
-     * @return $value
-     * @throws \Exception
-     */
-    public function checkSegmentMatchTypeIsValidForUser($value, $sqlSegment, $matchType, $name)
-    {
-        $acceptedMatches = array(
-            SegmentExpression::MATCH_EQUAL,
-            SegmentExpression::MATCH_IS_NOT_NULL_NOR_EMPTY,
-            SegmentExpression::MATCH_IS_NULL_OR_EMPTY,
-            SegmentExpression::MATCH_NOT_EQUAL,
-        );
-        if (in_array($matchType, $acceptedMatches)) {
-            return $value;
-        }
-        $message = "Invalid Segment match type: try using 'userId' segment with one of the following match types: %s.";
-        throw new \Exception(sprintf($message, implode(", ", $acceptedMatches)));
     }
 
     /**

--- a/tests/PHPUnit/System/UserIdAndVisitorIdTest.php
+++ b/tests/PHPUnit/System/UserIdAndVisitorIdTest.php
@@ -75,16 +75,6 @@ class UserIdAndVisitorIdTest extends SystemTestCase
                                              'testSuffix' => '_segmentUserId',
             )),
 
-            // Test invalid segment match type throws exception
-            array('VisitsSummary.get',
-                  array('idSite'     => self::$fixture->idSite,
-                        'date'       => self::$fixture->dateTime,
-                        'periods'    => 'day',
-                        'segment'    => 'userId=@invalidSegment',
-                        'testSuffix' => '_invalidSegmentUserId',
-            )),
-
-
             // Testing userId segment matches both log_visits and log_conversion
             array('Goals.getItemsName',
                                         array('idSite'     => self::$fixture->idSite,

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId_invalidSegmentUserId__VisitsSummary.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId_invalidSegmentUserId__VisitsSummary.get_day.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<result>
-	<error message="Invalid Segment match type: try using 'userId' segment with one of the following match types: ==, ::NOT_NULL, ::NULL, !=.
- 
- --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
-</result>


### PR DESCRIPTION
fixes #8062
this reverts https://github.com/piwik/piwik/commit/252798d2d742cae998a1f42f50a5ba37c98069df

if tests pass, will be good to merge
