### PR TITLE
Small visual change in the visitor log (mainly for UI tests)

### DIFF
--- a/plugins/Live/stylesheets/live.less
+++ b/plugins/Live/stylesheets/live.less
@@ -272,10 +272,13 @@ span.visitorLogIcons:after {
 }
 
 .visitorLogIcons .visitorDetails {
+    float: left;
     display: block;
+    height: 100px;
 }
 
 .visitorLogIcons .visitorType {
+    float: right;
     display: block;
     margin-bottom: 1em;
 }

--- a/plugins/Live/stylesheets/live.less
+++ b/plugins/Live/stylesheets/live.less
@@ -272,13 +272,10 @@ span.visitorLogIcons:after {
 }
 
 .visitorLogIcons .visitorDetails {
-    float: left;
     display: block;
-    height: 100px;
 }
 
 .visitorLogIcons .visitorType {
-    float: right;
     display: block;
     margin-bottom: 1em;
 }

--- a/plugins/Live/templates/_dataTableViz_visitorLog.twig
+++ b/plugins/Live/templates/_dataTableViz_visitorLog.twig
@@ -26,13 +26,6 @@
     <span class="visitorLogIcons">
 
         <span class="visitorType">
-        {% if visitor.getColumn('visitorTypeIcon') %}
-            <span>
-                <img src="{{ visitor.getColumn('visitorTypeIcon') }}"
-                     title="{{ 'General_ReturningVisitor'|translate }} - {{ 'General_NVisits'|translate(visitor.getColumn('visitCount')) }}"/>
-            </span>
-        {% endif %}
-
         {# Goals, and/or Ecommerce activity #}
         {% if visitor.getColumn('visitConverted') %}
             <span title="{{ 'General_VisitConvertedNGoals'|translate(visitor.getColumn('goalConversions')) }}" class='visitorRank'
@@ -52,16 +45,6 @@
         </span>
 
         <span class="visitorDetails">
-        {% if visitor.getColumn('countryFlag') %}
-            <span class="visitorLogIconWithDetails">
-                <img src="{{ visitor.getColumn('countryFlag') }}"/>
-                <ul class="details">
-                    <li>{{ 'UserCountry_Country'|translate }}: {{ visitor.getColumn('country') }}</li>
-                    {% if visitor.getColumn('region') %}<li>{{ 'UserCountry_Region'|translate }}: {{ visitor.getColumn('region') }}</li>{% endif %}
-                    {% if visitor.getColumn('city') %}<li>{{ 'UserCountry_City'|translate }}: {{ visitor.getColumn('city') }}</li>{% endif %}
-                </ul>
-            </span>
-        {% endif %}
         {% if visitor.getColumn('browserIcon') %}
             <span class="visitorLogIconWithDetails">
                 <img src="{{ visitor.getColumn('browserIcon') }}"/>
@@ -167,6 +150,23 @@ GPS (lat/long): {{ visitor.getColumn('latitude') }},{{ visitor.getColumn('longit
                     <a href="{{ visitor.getColumn('providerUrl') }}" rel="noreferrer" target="_blank" title="{{ visitor.getColumn('providerName') }} {{ visitor.getColumn('providerUrl') }}" style="text-decoration:underline;">
                         {{ visitor.getColumn('providerName') }}
                     </a>
+                {% endif %}
+                {% if visitor.getColumn('visitorTypeIcon') or visitor.getColumn('countryFlag') %}
+                    <br/>
+                {% endif %}
+                {% if visitor.getColumn('visitorTypeIcon') %}
+                    <img src="{{ visitor.getColumn('visitorTypeIcon') }}"
+                         title="{{ 'General_ReturningVisitor'|translate }} - {{ 'General_NVisits'|translate(visitor.getColumn('visitCount')) }}"/>
+                {% endif %}
+                {% if visitor.getColumn('countryFlag') %}
+                    <span class="visitorLogIconWithDetails">
+                        <img src="{{ visitor.getColumn('countryFlag') }}"/>
+                        <ul class="details">
+                            <li>{{ 'UserCountry_Country'|translate }}: {{ visitor.getColumn('country') }}</li>
+                            {% if visitor.getColumn('region') %}<li>{{ 'UserCountry_Region'|translate }}: {{ visitor.getColumn('region') }}</li>{% endif %}
+                            {% if visitor.getColumn('city') %}<li>{{ 'UserCountry_City'|translate }}: {{ visitor.getColumn('city') }}</li>{% endif %}
+                        </ul>
+                    </span>
                 {% endif %}
                 {% if visitor.getColumn('customVariables') %}
                     <br/>


### PR DESCRIPTION
Changed slightly the position of icons in the visitor log so that it's visually a little better and it will not cause screenshot tests to randomly fail (at least that's what I hope…).

Basically what I've done is remove the float left/float right for the 2 groups of icons and instead display them on top of one another.

You can see the diff here: http://builds-artifacts.piwik.org/ui-tests.fix-ui-tests-visitor-log/13240.7/screenshot-diffs/diffviewer.html
### Before

![capture d ecran 2015-06-11 a 14 03 18](https://cloud.githubusercontent.com/assets/720328/8106575/a60191c4-1042-11e5-94a1-8a868f0028ba.png)
### After

![capture d ecran 2015-06-11 a 14 03 14](https://cloud.githubusercontent.com/assets/720328/8106579/ab13a53a-1042-11e5-9326-0f0fb22e8ee8.png)
