### PR TITLE
Instant log output for failing UI tests and some tweaks on detection of page activity

### DIFF
--- a/tests/UI/specs/Login_spec.js
+++ b/tests/UI/specs/Login_spec.js
@@ -49,8 +49,6 @@ describe("Login", function () {
 
     it("should redirect to login when logout link clicked", function (done) {
         expect.screenshot("login_form").to.be.capture("logout_form", function (page) {
-            page.click("#topBars span.title:contains(superUserLogin)");
-            page.wait(250);
             page.click("#topBars a:contains(Sign out)");
         }, done);
     });

--- a/tests/UI/specs/Menus_spec.js
+++ b/tests/UI/specs/Menus_spec.js
@@ -33,10 +33,23 @@ describe("Menus", function () {
         }, done);
     });
 
+    // user menu tests
+    it('should load the user reporting menu correctly', function (done) {
+        expect.screenshot('user_loaded').to.be.captureSelector('.Menu--admin', function (page) {
+            page.load("?" + generalParams + "&module=UsersManager&action=userSettings");
+        }, done);
+    });
+
+    it('should change the user page correctly when a user menu item is clicked', function (done) {
+        expect.screenshot('user_changed').to.be.captureSelector('.Menu--admin', function (page) {
+            page.click('.Menu--admin a:contains(API)');
+        }, done);
+    });
+
     // admin menu tests
     it('should load the admin reporting menu correctly', function (done) {
         expect.screenshot('admin_loaded').to.be.captureSelector('.Menu--admin', function (page) {
-            page.load("?" + generalParams + "&module=UsersManager&action=userSettings");
+            page.load("?" + generalParams + "&module=CoreAdminHome&action=generalSettings");
         }, done);
     });
 

--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -222,6 +222,15 @@ Application.prototype.doRunTests = function () {
             self.finish();
         });
     });
+
+    this.runner.on('fail', function(test, err) {
+        var indent = "     ";
+
+        var message = "\n";
+        message += err && err.stack ? err.stack : err;
+        message = message.replace(/\n/g, "\n" + indent);
+        console.log(indent + message + "\n\n");
+    });
 };
 
 Application.prototype.finish = function () {

--- a/tests/lib/screenshot-testing/support/chai-extras.js
+++ b/tests/lib/screenshot-testing/support/chai-extras.js
@@ -42,6 +42,13 @@ function getPageLogsString(pageLogs, indent) {
     return result;
 }
 
+function logErrorMessage(message, indent) {
+    var indent = "     ";
+    console.log("\n\n" + indent + 'This message usually belongs to the next test');
+    message = message.replace(/\n/g, "\n" + indent);
+    console.log(indent + message);
+}
+
 // add capture assertion
 var pageRenderer = new PageRenderer(config.piwikUrl + path.join("tests", "PHPUnit", "proxy"));
 
@@ -87,6 +94,7 @@ function capture(screenName, compareAgainst, selector, pageSetupFn, comparisonTh
             if (err) {
                 var indent = "     ";
                 err.stack = err.message + "\n" + indent + getPageLogsString(pageRenderer.pageLogs, indent);
+                logErrorMessage(err.stack);
 
                 done(err);
                 return;
@@ -119,6 +127,7 @@ function capture(screenName, compareAgainst, selector, pageSetupFn, comparisonTh
 
                 // stack traces are useless so we avoid the clutter w/ this
                 error.stack = failureInfo;
+                logErrorMessage(failureInfo);
 
                 done(error);
             };
@@ -170,6 +179,7 @@ function capture(screenName, compareAgainst, selector, pageSetupFn, comparisonTh
     } catch (ex) {
         var err = new Error(ex.message);
         err.stack = ex.message;
+        logErrorMessage(err.stack);
         done(err);
     }
 }
@@ -195,6 +205,7 @@ function compareContents(compareAgainst, pageSetupFn, done) {
             if (err) {
                 var indent = "     ";
                 err.stack = err.message + "\n" + indent + getPageLogsString(pageRenderer.pageLogs, indent);
+                logErrorMessage(err.stack);
 
                 done(err);
                 return;
@@ -210,6 +221,7 @@ function compareContents(compareAgainst, pageSetupFn, done) {
 
                 // stack traces are useless so we avoid the clutter w/ this
                 error.stack = failureInfo;
+                logErrorMessage(failureInfo);
 
                 done(error);
             };
@@ -242,6 +254,7 @@ function compareContents(compareAgainst, pageSetupFn, done) {
     } catch (ex) {
         var err = new Error(ex.message);
         err.stack = ex.message;
+        logErrorMessage(err.stack);
         done(err);
     }
 }
@@ -322,6 +335,7 @@ chai.Assertion.addChainableMethod('contains', function () {
 
         if (err) {
             err.stack = err.message + "\n" + indent + getPageLogsString(pageRenderer.pageLogs, indent);
+            logErrorMessage(err.stack);
 
             done(err);
             return;
@@ -348,6 +362,7 @@ chai.Assertion.addChainableMethod('contains', function () {
 
             var error = new AssertionError(originalError.message);
             error.stack = stack;
+            logErrorMessage(stack);
 
             done(error);
         }

--- a/tests/lib/screenshot-testing/support/chai-extras.js
+++ b/tests/lib/screenshot-testing/support/chai-extras.js
@@ -42,13 +42,6 @@ function getPageLogsString(pageLogs, indent) {
     return result;
 }
 
-function logErrorMessage(message, indent) {
-    var indent = "     ";
-    console.log("\n\n" + indent + 'This message usually belongs to the next test');
-    message = message.replace(/\n/g, "\n" + indent);
-    console.log(indent + message);
-}
-
 // add capture assertion
 var pageRenderer = new PageRenderer(config.piwikUrl + path.join("tests", "PHPUnit", "proxy"));
 
@@ -94,7 +87,6 @@ function capture(screenName, compareAgainst, selector, pageSetupFn, comparisonTh
             if (err) {
                 var indent = "     ";
                 err.stack = err.message + "\n" + indent + getPageLogsString(pageRenderer.pageLogs, indent);
-                logErrorMessage(err.stack);
 
                 done(err);
                 return;
@@ -127,7 +119,6 @@ function capture(screenName, compareAgainst, selector, pageSetupFn, comparisonTh
 
                 // stack traces are useless so we avoid the clutter w/ this
                 error.stack = failureInfo;
-                logErrorMessage(failureInfo);
 
                 done(error);
             };
@@ -179,7 +170,6 @@ function capture(screenName, compareAgainst, selector, pageSetupFn, comparisonTh
     } catch (ex) {
         var err = new Error(ex.message);
         err.stack = ex.message;
-        logErrorMessage(err.stack);
         done(err);
     }
 }
@@ -205,7 +195,6 @@ function compareContents(compareAgainst, pageSetupFn, done) {
             if (err) {
                 var indent = "     ";
                 err.stack = err.message + "\n" + indent + getPageLogsString(pageRenderer.pageLogs, indent);
-                logErrorMessage(err.stack);
 
                 done(err);
                 return;
@@ -221,7 +210,6 @@ function compareContents(compareAgainst, pageSetupFn, done) {
 
                 // stack traces are useless so we avoid the clutter w/ this
                 error.stack = failureInfo;
-                logErrorMessage(failureInfo);
 
                 done(error);
             };
@@ -254,7 +242,6 @@ function compareContents(compareAgainst, pageSetupFn, done) {
     } catch (ex) {
         var err = new Error(ex.message);
         err.stack = ex.message;
-        logErrorMessage(err.stack);
         done(err);
     }
 }
@@ -335,7 +322,6 @@ chai.Assertion.addChainableMethod('contains', function () {
 
         if (err) {
             err.stack = err.message + "\n" + indent + getPageLogsString(pageRenderer.pageLogs, indent);
-            logErrorMessage(err.stack);
 
             done(err);
             return;
@@ -362,7 +348,6 @@ chai.Assertion.addChainableMethod('contains', function () {
 
             var error = new AssertionError(originalError.message);
             error.stack = stack;
-            logErrorMessage(stack);
 
             done(error);
         }

--- a/tests/lib/screenshot-testing/support/diff-viewer.js
+++ b/tests/lib/screenshot-testing/support/diff-viewer.js
@@ -90,13 +90,18 @@ DiffViewerGenerator.prototype.generate = function (callback) {
                 entryLocationHint = ' <em>(for ' + m[1] + ' plugin)</em>';
             }
 
+            var processedEntryPath = '';
+            if (entry.processed) {
+                processedEntryPath = path.basename(entry.processed);
+            }
+
             diffViewerContent += '\
     <tr>\
         <td>' + entry.name + entryLocationHint + '</td>\
         <td>' + expectedHtml + '</td>\
         <td>' + githubUrl + '</td>\
         <td>' + (entry.processed ? ('<a href="' + entry.processedUrl + '">Processed</a>') : '<em>Not found</em>') + '</td>\
-        <td>' + (expectedUrl ? ('<a href="singlediff.html?processed=' + entry.processedUrl + '&expected=' + expectedUrl + '&github=' + path.basename(entry.processed) + '">Difference</a>') : '<em>Could not create diff.</em>') + '</td>\
+        <td>' + (expectedUrl ? ('<a href="singlediff.html?processed=' + entry.processedUrl + '&expected=' + expectedUrl + '&github=' + processedEntryPath + '">Difference</a>') : '<em>Could not create diff.</em>') + '</td>\
     </tr>';
         }
 

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -22,6 +22,10 @@ var PageRenderer = function (baseUrl) {
 
     this.defaultWaitTime = 1000;
     this._isLoading = false;
+    this._isInitializing = false;
+    this._isNavigationRequested = false;
+    this._requestedUrl = 'about:blank';
+    this._resourcesRequested = {};
 
     if (this.baseUrl.substring(-1) != '/') {
         this.baseUrl = this.baseUrl + '/';
@@ -183,7 +187,16 @@ PageRenderer.prototype._load = function (url, callback) {
     }
 
     this._recreateWebPage(); // calling open a second time never calls the callback
+
+    this._requestedUrl   = url;
+    this._isInitializing = true;
+    this._resourcesRequested = {};
+
+    var self = this;
     this.webpage.open(url, function (status) {
+
+        self._isInitializing = false;
+
         this.evaluate(function () {
             var $ = window.jQuery;
             if ($) {
@@ -258,9 +271,12 @@ PageRenderer.prototype.capture = function (outputPath, callback, selector) {
     var self = this,
         timeout = setTimeout(function () {
             var timeoutDetails = "";
-            timeoutDetails += "Page not ready: " + self._isLoading + "\n";
+            timeoutDetails += "Page is loading: " + self._isLoading + "\n";
+            timeoutDetails += "Initializing: " + self._isInitializing + "\n";
+            timeoutDetails += "Navigation requested: " + self._isNavigationRequested + "\n";
             timeoutDetails += "Pending AJAX request count: " + self._getAjaxRequestCount() + "\n";
             timeoutDetails += "Loading images count: " + self._getImageLoadingCount() + "\n";
+            timeoutDetails += "Remaining resources: " + JSON.stringify(self._resourcesRequested) + "\n";
 
             self.abort();
 
@@ -414,14 +430,25 @@ PageRenderer.prototype._executeEvents = function (events, callback, i) {
     try {
         impl.apply(this, evt);
     } catch (err) {
-        self.pageLogs.push("Error: " + err.stack);
+        self._logMessage("Error: " + err.stack);
         waitForNextEvent();
     }
 };
 
 PageRenderer.prototype._getAjaxRequestCount = function () {
     return this.webpage.evaluate(function () {
-        return window.globalAjaxQueue ? window.globalAjaxQueue.active : 0;
+        var active = window.globalAjaxQueue ? window.globalAjaxQueue.active : 0;
+
+        if ('undefined' !== (typeof angular)
+            && angular && document && angular.element(document)
+            && angular.element(document).injector()) {
+            var $http = angular.element(document).injector().get('$http');
+            if ($http && $http.pendingRequests) {
+                active += $http.pendingRequests.length;
+            }
+        }
+
+        return active;
     });
 };
 
@@ -486,12 +513,26 @@ PageRenderer.prototype._getImageLoadingCount = function () {
 };
 
 PageRenderer.prototype._waitForNextEvent = function (events, callback, i, waitTime) {
+
+    function isEmpty(obj) {
+        for (var key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) return false;
+        }
+
+        return true;
+    }
+
     var self = this;
     setTimeout(function () {
-        if (self._getAjaxRequestCount() == 0
-            && self._getImageLoadingCount() == 0
-            && !self._isLoading
-        ) {
+        if (!self._isLoading && !self._isInitializing && !self._isNavigationRequested
+            && (
+                isEmpty(self._resourcesRequested)
+                || (!self._getAjaxRequestCount() && !self._getImageLoadingCount())
+                )
+            ) {
+            // why isEmpty(self._resourcesRequested) || !self._getAjaxRequestCount()) ?
+            // if someone sends a sync XHR we only get a resoruceRequested event but not a responseEvent so we need to
+            // fall back for ajaxRequestCount as a safety net. See https://github.com/ariya/phantomjs/issues/11284
             self._executeEvents(events, callback, i + 1);
         } else {
             self._waitForNextEvent(events, callback, i, waitTime);
@@ -509,9 +550,31 @@ PageRenderer.prototype._setCorrectViewportSize = function () {
     this.webpage.viewportSize = {width: viewportSize.width, height: height};
 };
 
+PageRenderer.prototype._logMessage = function (message) {
+    this.pageLogs.push(message);
+};
+
+PageRenderer.prototype._addUrlToQueue = function (url) {
+    if (this._resourcesRequested[url]){
+        this._resourcesRequested[url]++;
+    } else {
+        this._resourcesRequested[url] = 1;
+    }
+};
+
+PageRenderer.prototype._removeUrlFromQueue = function (url) {
+    if (this._resourcesRequested[url]){
+        this._resourcesRequested[url]--;
+        if (0 === this._resourcesRequested[url]) {
+            delete this._resourcesRequested[url];
+        }
+    }
+};
+
 PageRenderer.prototype._setupWebpageEvents = function () {
     var self = this;
     this.webpage.onError = function (message, trace) {
+
         var msgStack = ['Webpage error: ' + message];
         if (trace && trace.length) {
             msgStack.push('trace:');
@@ -520,36 +583,107 @@ PageRenderer.prototype._setupWebpageEvents = function () {
             });
         }
 
-        self.pageLogs.push(msgStack.join('\n'));
+        self._logMessage(msgStack.join('\n'));
     };
 
-    if (VERBOSE) {
-        this.webpage.onResourceReceived = function (response) {
-            self.pageLogs.push('Response (#' + response.id + ', stage "' + response.stage + '", size "' +
-                               response.bodySize + '", status "' + response.status + '"): ' + response.url);
-        };
-    }
+    this.webpage.onResourceRequested = function (requestData, networkRequest) {
+        self._addUrlToQueue(requestData.url);
+
+        if (VERBOSE) {
+            self._logMessage('Requesting resource (#' + requestData.id + 'URL:' + requestData.url + ')');
+        }
+    };
+
+    this.webpage.onResourceTimeout = function (request) {
+        self._removeUrlFromQueue(request.url);
+
+        if (!self.aborted && VERBOSE) {
+            self._logMessage('Unable to load resource because of timeout (#' + request.id + 'URL:' + request.url + ')');
+            self._logMessage('Error code: ' + request.errorCode + '. Description: ' + request.errorString);
+        }
+    };
+
+    this.webpage.onResourceReceived = function (response) {
+        var isStartStage = (response.stage === 'start');
+
+        if (!isStartStage){
+            self._removeUrlFromQueue(response.url);
+        }
+
+        if (VERBOSE || (isStartStage && response.status >= 400)) {
+            var message = 'Response (#' + response.id + ', stage "' + response.stage + '", size "' +
+                response.bodySize + '", status "' + response.status + '"): ' + response.url;
+            self._logMessage(message);
+        }
+    };
 
     this.webpage.onResourceError = function (resourceError) {
+        self._removeUrlFromQueue(resourceError.url);
+
         if (!self.aborted) {
-            self.pageLogs.push('Unable to load resource (#' + resourceError.id + 'URL:' + resourceError.url + ')');
-            self.pageLogs.push('Error code: ' + resourceError.errorCode + '. Description: ' + resourceError.errorString);
+            var isUrlThatWeCareAbout = function (url)
+            {
+                return -1 === url.indexOf('proxy/misc/user/favicon.png?r=') && -1 === url.indexOf('proxy/misc/user/logo.png?r=');
+            }
+
+            if (isUrlThatWeCareAbout(resourceError.url)) {
+                self._logMessage('Unable to load resource (#' + resourceError.id + 'URL:' + resourceError.url + ')');
+                self._logMessage('Error code: ' + resourceError.errorCode + '. Description: ' + resourceError.errorString);
+            }
         }
     };
 
     this.webpage.onConsoleMessage = function (message) {
-        self.pageLogs.push('Log: ' + message);
+        self._logMessage('Log: ' + message);
     };
 
     this.webpage.onAlert = function (message) {
-        self.pageLogs.push('Alert: ' + message);
+        self._logMessage('Alert: ' + message);
     };
 
     this.webpage.onLoadStarted = function () {
+        self._isInitializing = false;
         self._isLoading = true;
     };
 
-    this.webpage.onLoadFinished = function () {
+    this.webpage.onPageCreated = function onPageCreated(popupPage) {
+        popupPage.onLoadFinished = function onLoadFinished() {
+            self._isNavigationRequested = false;
+        };
+    };
+
+    this.webpage.onUrlChanged = function onUrlChanged(url) {
+        self._isNavigationRequested = false;
+    };
+
+    this.webpage.onNavigationRequested = function (url, type, willNavigate, isMainFrame) {
+        self._isInitializing = false;
+
+        if (isMainFrame && self._requestedUrl !== url && willNavigate) {
+            var currentUrl = self._requestedUrl;
+            var newUrl = url;
+            var pos = currentUrl.indexOf('#');
+            if (pos !== -1) {
+                currentUrl = currentUrl.substring(0, pos);
+            }
+            pos = newUrl.indexOf('#');
+            if (pos !== -1) {
+                newUrl = newUrl.substring(0, pos);
+            }
+            if (currentUrl !== newUrl) {
+                self._isNavigationRequested = true;
+            }
+
+            self._requestedUrl = url;
+        }
+    }
+
+    this.webpage.onLoadFinished = function (status) {
+        if (status !== 'success' && VERBOSE) {
+            self._logMessage('Page did not load successfully (it could be on purpose if a tests wants to test this behaviour): ' + status);
+        }
+
+        self._isInitializing = false;
         self._isLoading = false;
     };
 };

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -524,16 +524,15 @@ PageRenderer.prototype._waitForNextEvent = function (events, callback, i, waitTi
 
     var self = this;
     setTimeout(function () {
-        if (!self._isLoading && !self._isInitializing && !self._isNavigationRequested
-            && (
-                isEmpty(self._resourcesRequested)
-                || (!self._getAjaxRequestCount() && !self._getImageLoadingCount())
-                )
-            ) {
-            // why isEmpty(self._resourcesRequested) || !self._getAjaxRequestCount()) ?
-            // if someone sends a sync XHR we only get a resoruceRequested event but not a responseEvent so we need to
-            // fall back for ajaxRequestCount as a safety net. See https://github.com/ariya/phantomjs/issues/11284
-            self._executeEvents(events, callback, i + 1);
+        if (!self._isLoading && !self._isInitializing && !self._isNavigationRequested) {
+            var hasPhantomNoPendingRequests = isEmpty(self._resourcesRequested)
+
+            if (hasPhantomNoPendingRequests || (!self._getAjaxRequestCount() && !self._getImageLoadingCount())) {
+                // why isEmpty(self._resourcesRequested) || !self._getAjaxRequestCount()) ?
+                // if someone sends a sync XHR we only get a resoruceRequested event but not a responseEvent so we need to
+                // fall back for ajaxRequestCount as a safety net. See https://github.com/ariya/phantomjs/issues/11284
+                self._executeEvents(events, callback, i + 1);
+            }
         } else {
             self._waitForNextEvent(events, callback, i, waitTime);
         }

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -514,25 +514,35 @@ PageRenderer.prototype._getImageLoadingCount = function () {
 
 PageRenderer.prototype._waitForNextEvent = function (events, callback, i, waitTime) {
 
-    function isEmpty(obj) {
-        for (var key in obj) {
-            if (Object.prototype.hasOwnProperty.call(obj, key)) return false;
+    function hasPendingResources(self)
+    {
+        function isEmpty(obj) {
+            for (var key in obj) {
+                if (Object.prototype.hasOwnProperty.call(obj, key)) return false;
+            }
+
+            return true;
         }
 
-        return true;
+        var hasPhantomPendingResources = !isEmpty(self._resourcesRequested);
+
+        if (!hasPhantomPendingResources) {
+            // why isEmpty(self._resourcesRequested) || !self._getAjaxRequestCount()) ?
+            // if someone sends a sync XHR we only get a resourceRequested event but not a responseEvent so we need
+            // to fall back for ajaxRequestCount as a safety net. See https://github.com/ariya/phantomjs/issues/11284
+            return false;
+        }
+
+        var hasPendingResourcesInCore = (self._getAjaxRequestCount() || self._getImageLoadingCount());
+
+        return hasPendingResourcesInCore;
     }
 
     var self = this;
-    setTimeout(function () {
-        if (!self._isLoading && !self._isInitializing && !self._isNavigationRequested) {
-            var hasPhantomNoPendingRequests = isEmpty(self._resourcesRequested)
 
-            if (hasPhantomNoPendingRequests || (!self._getAjaxRequestCount() && !self._getImageLoadingCount())) {
-                // why isEmpty(self._resourcesRequested) || !self._getAjaxRequestCount()) ?
-                // if someone sends a sync XHR we only get a resoruceRequested event but not a responseEvent so we need to
-                // fall back for ajaxRequestCount as a safety net. See https://github.com/ariya/phantomjs/issues/11284
-                self._executeEvents(events, callback, i + 1);
-            }
+    setTimeout(function () {
+        if (!self._isLoading && !self._isInitializing && !self._isNavigationRequested && !hasPendingResources(self)) {
+            self._executeEvents(events, callback, i + 1);
         } else {
             self._waitForNextEvent(events, callback, i, waitTime);
         }

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -625,11 +625,9 @@ PageRenderer.prototype._setupWebpageEvents = function () {
     this.webpage.onResourceError = function (resourceError) {
         self._removeUrlFromQueue(resourceError.url);
 
-        if (!self.aborted) {
-            if (self._isUrlThatWeCareAbout(resourceError.url)) {
-                self._logMessage('Unable to load resource (#' + resourceError.id + 'URL:' + resourceError.url + ')');
-                self._logMessage('Error code: ' + resourceError.errorCode + '. Description: ' + resourceError.errorString);
-            }
+        if (!self.aborted && self._isUrlThatWeCareAbout(resourceError.url)) {
+            self._logMessage('Unable to load resource (#' + resourceError.id + 'URL:' + resourceError.url + ')');
+            self._logMessage('Error code: ' + resourceError.errorCode + '. Description: ' + resourceError.errorString);
         }
     };
 

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -554,6 +554,11 @@ PageRenderer.prototype._logMessage = function (message) {
     this.pageLogs.push(message);
 };
 
+PageRenderer.prototype._isUrlThatWeCareAbout = function (url) {
+
+    return -1 === url.indexOf('proxy/misc/user/favicon.png?r=') && -1 === url.indexOf('proxy/misc/user/logo.png?r=');
+};
+
 PageRenderer.prototype._addUrlToQueue = function (url) {
     if (this._resourcesRequested[url]){
         this._resourcesRequested[url]++;
@@ -610,7 +615,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
             self._removeUrlFromQueue(response.url);
         }
 
-        if (VERBOSE || (isStartStage && response.status >= 400)) {
+        if (VERBOSE || (isStartStage && response.status >= 400 && self._isUrlThatWeCareAbout(response.url))) {
             var message = 'Response (#' + response.id + ', stage "' + response.stage + '", size "' +
                 response.bodySize + '", status "' + response.status + '"): ' + response.url;
             self._logMessage(message);
@@ -621,12 +626,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
         self._removeUrlFromQueue(resourceError.url);
 
         if (!self.aborted) {
-            var isUrlThatWeCareAbout = function (url)
-            {
-                return -1 === url.indexOf('proxy/misc/user/favicon.png?r=') && -1 === url.indexOf('proxy/misc/user/logo.png?r=');
-            }
-
-            if (isUrlThatWeCareAbout(resourceError.url)) {
+            if (self._isUrlThatWeCareAbout(resourceError.url)) {
                 self._logMessage('Unable to load resource (#' + resourceError.id + 'URL:' + resourceError.url + ')');
                 self._logMessage('Error code: ' + resourceError.errorCode + '. Description: ' + resourceError.errorString);
             }

--- a/tests/lib/screenshot-testing/support/test-environment.js
+++ b/tests/lib/screenshot-testing/support/test-environment.js
@@ -80,11 +80,15 @@ TestingEnvironment.prototype._call = function (params, done) {
             try {
                 response = JSON.parse(response);
             } catch (e) {
+                page.close();
+
                 done(new Error("Unable to parse JSON response: " + response));
                 return;
             }
 
             if (response.result == "error") {
+                page.close();
+
                 done(new Error("API returned error: " + response.message));
                 return;
             }


### PR DESCRIPTION
- If there is a failure we do now output JS errors, not loaded resources, ... immediately within the tests. Even if the UI tests do not finish within 50 minutes we still get an idea of what is going on. It prints the result at the bottom of the test again but as it is only for failing tests shouldn't matter so much. Code wise we could have copied the `mocha spec reporter` and adjusted this one but can still do it later if needed. There's no coloured output for this yet so hope that's okay. It should help us to troubleshoot things.
- I noticed we detect whether there are any ajax requests running and capture a screenshot only if all ajax requests and images are loaded. We did not check for JS resources and neither for AngularJS requests (there are quite a few of them) which can lead to random test results. I added a check for the AngularJS requests. As the detection of loaded images and requests can be buggy I thought it would be nice to use PhantomJS's events `onResourceRequested`, `onResourceReceived`, ... This way we would not have to take care of this in core and we can easily print a list of not finished requests at the end of the test. Unfortunately we have some `synchronous` requests and for those requests no "response" event will be triggered meaning we cannot detected that the sync request is finished. Therefore I do now check whether either phantomjs detected that all resources are loaded or our core logic. Once we refactored https://github.com/piwik/piwik/issues/8020 we can trust PhanomJS. This will allow us to detect more accurately when a page is loaded or stopped being active etc.
- While working on this I noticed the Menu tests were wrong. There was a test for Admin Menu but it was actually User Menu tests so I changed it and added a test.

An example can be seen here : 
- https://travis-ci.org/piwik/piwik/jobs/66323509#L728
- https://travis-ci.org/piwik/piwik/jobs/66323509#L781
- Cannot find an example currently where it fails to load a page within 2 minutes. There we will now see a list of still loading resources

The tests that fail seem to also fail on master?!?
