### PR TITLE
Build fix for recent DI change

### DIFF
--- a/core/Application/Environment.php
+++ b/core/Application/Environment.php
@@ -139,7 +139,8 @@ class Environment
     protected function getPluginListCached()
     {
         if ($this->pluginList === null) {
-            $this->pluginList = $this->getPluginList();
+            $pluginList = $this->getPluginListOverride();
+            $this->pluginList = $pluginList ?: $this->getPluginList();
         }
         return $this->pluginList;
     }
@@ -221,6 +222,15 @@ class Environment
             return self::$globalEnvironmentManipulator->getExtraEnvironments();
         } else {
             return array();
+        }
+    }
+
+    private function getPluginListOverride()
+    {
+        if (self::$globalEnvironmentManipulator) {
+            return self::$globalEnvironmentManipulator->makePluginList($this->getGlobalSettingsCached());
+        } else {
+            return null;
         }
     }
 }

--- a/core/Application/EnvironmentManipulator.php
+++ b/core/Application/EnvironmentManipulator.php
@@ -9,6 +9,7 @@
 namespace Piwik\Application;
 
 use Piwik\Application\Kernel\GlobalSettingsProvider;
+use Piwik\Application\Kernel\PluginList;
 
 /**
  * Used to manipulate Environment instances before the container is created.
@@ -23,6 +24,14 @@ interface EnvironmentManipulator
      * @return GlobalSettingsProvider
      */
     public function makeGlobalSettingsProvider();
+
+    /**
+     * Create a custom PluginList kernel object, overriding the default behavior.@deprecated
+     *
+     * @param GlobalSettingsProvider $globalSettingsProvider
+     * @return PluginList
+     */
+    public function makePluginList(GlobalSettingsProvider $globalSettingsProvider);
 
     /**
      * Invoked before the container is created.

--- a/tests/PHPUnit/Framework/Mock/FakeAccess.php
+++ b/tests/PHPUnit/Framework/Mock/FakeAccess.php
@@ -72,6 +72,7 @@ class FakeAccess
 
     public static function reloadAccess()
     {
+        return true;
     }
 
     public static function checkUserHasAdminAccess($idSites)

--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -10,14 +10,37 @@ namespace Piwik\Tests\Framework;
 
 use Piwik\Application\EnvironmentManipulator;
 use Piwik\Application\Kernel\GlobalSettingsProvider;
+use Piwik\Application\Kernel\PluginList;
 use Piwik\DbHelper;
 use Piwik\Option;
+use Piwik\Plugin;
+
+class FakePluginList extends PluginList
+{
+    private $plugins;
+
+    public function __construct(GlobalSettingsProvider $globalSettingsProvider, $plugins)
+    {
+        parent::__construct($globalSettingsProvider);
+        $this->plugins = $plugins;
+    }
+
+    public function getActivatedPlugins()
+    {
+        return $this->plugins;
+    }
+}
 
 /**
  * Manipulates an environment for tests.
  */
 class TestingEnvironmentManipulator implements EnvironmentManipulator
 {
+    /**
+     * @var string[]
+     */
+    public static $extraPluginsToLoad = array();
+
     /**
      * @var TestingEnvironmentVariables
      */
@@ -34,6 +57,11 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
     public function makeGlobalSettingsProvider()
     {
         return new GlobalSettingsProvider($this->vars->configFileGlobal, $this->vars->configFileLocal, $this->vars->configFileCommon);
+    }
+
+    public function makePluginList(GlobalSettingsProvider $globalSettingsProvider)
+    {
+        return new FakePluginList($globalSettingsProvider, $this->getPluginsToLoadDuringTest());
     }
 
     public function beforeContainerCreated()
@@ -133,5 +161,30 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
     public function getExtraEnvironments()
     {
         return array('test');
+    }
+
+    private function getPluginsToLoadDuringTest()
+    {
+        $plugins = $this->vars->getCoreAndSupportedPlugins();
+
+        // make sure the plugin that executed this method is included in the plugins to load
+        $extraPlugins = array_merge(self::$extraPluginsToLoad, array(
+            Plugin::getPluginNameFromBacktrace(debug_backtrace()),
+            Plugin::getPluginNameFromNamespace($this->vars->testCaseClass),
+            Plugin::getPluginNameFromNamespace(get_called_class())
+        ));
+        foreach ($extraPlugins as $pluginName) {
+            if (empty($pluginName)) {
+                continue;
+            }
+
+            if (in_array($pluginName, $plugins)) {
+                continue;
+            }
+
+            $plugins[] = $pluginName;
+        }
+
+        return $plugins;
     }
 }


### PR DESCRIPTION
Includes two changes:
- Determine plugins to load in tests through TestingEnvironmentManipulator instead of in manual call to Fixture::loadPlugins.
- Make sure FakeAccess::reloadAccess returns true to signal successful reload.
