### PR TITLE
Added 'mbstring.func_overload = 0' check as installation requirement

### DIFF
--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -38,6 +38,12 @@ if ($minimumPhpInvalid) {
 					To enjoy Piwik, you need remove <pre>ini_set</pre> from your <pre>disable_functions</pre> directive in php.ini, and restart your webserver.</p>";
     }
 
+    if (ini_get('mbstring.func_overload')) {
+        $piwik_errorMessage .= "<p><strong>Piwik does not works when PHP is configured with <pre>mbstring.func_overload = " . ini_get('mbstring.func_overload') . "</pre></strong></p>
+					<p>It appears your mbstring extension in PHP is configured to override string functions.
+					To enjoy Piwik, you need to modify php.ini <pre>mbstring.func_overload = 0</pre>, and restart your webserver.</p>";
+    }
+
     if (!function_exists('json_encode')) {
         $piwik_errorMessage .= "<p><strong>Piwik requires the php5-json extension which provides the functions <code>json_encode()</code> and <code>json_decode()</code></strong></p>
 					<p>It appears your PHP has not yet installed the php5-json extension.


### PR DESCRIPTION
There is a problem with installing Piwik when `mbstring.func_overload` in php.ini is not `0`. 

Piwik just throws exception like `Can't install Piwik: An exception has been thrown during the rendering of a template ("parse error: failed at content: ; line: 3682"winking smiley in "@Installation/layout.twig" at line 40.`. And it's not so easy to understand what is wrong.

It's kind of popular issue:

https://github.com/piwik/piwik/issues/5338
http://forum.piwik.org/read.php?2,117181,117181
https://discussion.heroku.com/t/piwik-installation-problems-push-fails-configuration-not-correct/1073
