### PR TITLE
Fix missing variable escaping in the JS tracking code generator

### DIFF
--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -25,6 +25,7 @@ use Piwik\SettingsServer;
 use Piwik\Site;
 use Piwik\Tracker;
 use Piwik\Tracker\Cache;
+use Piwik\Tracker\TrackerCodeGenerator;
 use Piwik\Url;
 use Piwik\UrlHelper;
 
@@ -84,15 +85,22 @@ class API extends \Piwik\Plugin\API
         if (empty($piwikUrl)) {
             $piwikUrl = SettingsPiwik::getPiwikUrl();
         }
-        $piwikUrl = Common::sanitizeInputValues($piwikUrl);
 
-        $javascriptGenerator = new Tracker\TrackerCodeGenerator();
-        $htmlEncoded = $javascriptGenerator->generate($idSite, $piwikUrl, $mergeSubdomains, $groupPageTitlesByDomain,
-                                                $mergeAliasUrls, $visitorCustomVariables, $pageCustomVariables,
-                                                $customCampaignNameQueryParam, $customCampaignKeywordParam,
-                                                $doNotTrack, $disableCookies);
-        $htmlEncoded = str_replace(array('<br>', '<br />', '<br/>'), '', $htmlEncoded);
-        return $htmlEncoded;
+        // Revert the automatic encoding
+        // TODO remove that when https://github.com/piwik/piwik/issues/4231 is fixed
+        $piwikUrl = Common::unsanitizeInputValue($piwikUrl);
+        $visitorCustomVariables = Common::unsanitizeInputValues($visitorCustomVariables);
+        $pageCustomVariables = Common::unsanitizeInputValues($pageCustomVariables);
+        $customCampaignNameQueryParam = Common::unsanitizeInputValue($customCampaignNameQueryParam);
+        $customCampaignKeywordParam = Common::unsanitizeInputValue($customCampaignKeywordParam);
+
+        $generator = new TrackerCodeGenerator();
+        $code = $generator->generate($idSite, $piwikUrl, $mergeSubdomains, $groupPageTitlesByDomain,
+                                     $mergeAliasUrls, $visitorCustomVariables, $pageCustomVariables,
+                                     $customCampaignNameQueryParam, $customCampaignKeywordParam,
+                                     $doNotTrack, $disableCookies);
+        $code = str_replace(array('<br>', '<br />', '<br/>'), '', $code);
+        return $code;
     }
 
     /**

--- a/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
@@ -151,4 +151,47 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
 
         $this->assertEquals($expected, $jsTag);
     }
+
+    public function testStringsAreEscaped()
+    {
+        $generator = new TrackerCodeGenerator();
+
+        $jsTag = $generator->generate(
+            $idSite = 1,
+            $piwikUrl = 'abc"def',
+            $mergeSubdomains = true,
+            $groupPageTitlesByDomain = true,
+            $mergeAliasUrls = true,
+            $visitorCustomVariables = array(array('abc"def', 'abc"def')),
+            $pageCustomVariables = array(array('abc"def', 'abc"def')),
+            $customCampaignNameQueryParam = 'abc"def',
+            $customCampaignKeywordParam = 'abc"def'
+        );
+
+        $expected = '&lt;!-- Piwik --&gt;
+&lt;script type=&quot;text/javascript&quot;&gt;
+  var _paq = _paq || [];
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+  // you can set up to 5 custom variables for each visitor
+  _paq.push(["setCustomVariable", 1, "abc\"def", "abc\"def", "visit"]);
+  // you can set up to 5 custom variables for each action (page view, download, click, site search)
+  _paq.push(["setCustomVariable", 1, "abc\"def", "abc\"def", "page"]);
+  _paq.push(["setCampaignNameKey", "abc\"def"]);
+  _paq.push(["setCampaignKeywordKey", "abc\"def"]);
+  _paq.push([\'trackPageView\']);
+  _paq.push([\'enableLinkTracking\']);
+  (function() {
+    var u=&quot;//abc&quot;def/&quot;;
+    _paq.push([\'setTrackerUrl\', u+\'piwik.php\']);
+    _paq.push([\'setSiteId\', 1]);
+    var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
+    g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src=u+\'piwik.js\'; s.parentNode.insertBefore(g,s);
+  })();
+&lt;/script&gt;
+&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//abc&quot;def/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
+&lt;!-- End Piwik Code --&gt;
+';
+
+        $this->assertEquals($expected, $jsTag);
+    }
 }


### PR DESCRIPTION
The tracking code generator was not escaping quotes in string values (e.g. tracking custom variables).

Was reported in #8035 

>  JS Tracking Code > Advanced > "Track Custom variables for this visitor" -> set Name to `hello"world` -> in the JS code Expected to get `"hello\"world"`, Got instead: `"hello"world"`

Also the automatic HTML entities encoding for API parameters was messing things up (yet another #4231 win), I added a temporary fix to remove later.

Reviewers: please give another look for XSS issues.
