### PR TITLE
Should fix recoverable error missing $dataAccess parameter

### DIFF
--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -18,6 +18,7 @@ use Piwik\Nonce;
 use Piwik\Notification;
 use Piwik\Option;
 use Piwik\Piwik;
+use Piwik\Plugins\DBStats\MySQLMetadataDataAccess;
 use Piwik\Plugins\DBStats\MySQLMetadataProvider;
 use Piwik\Plugins\LanguagesManager\LanguagesManager;
 use Piwik\Scheduler\Scheduler;
@@ -191,7 +192,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $doDatabaseSizeEstimate = PiwikConfig::getInstance()->Deletelogs['enable_auto_database_size_estimate'];
 
         // determine the DB size & purged DB size
-        $metadataProvider = new MySQLMetadataProvider();
+        $metadataProvider = new MySQLMetadataProvider(new MySQLMetadataDataAccess());
         $tableStatuses = $metadataProvider->getAllTablesStatus();
 
         $totalBytes = 0;

--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -18,8 +18,6 @@ use Piwik\Nonce;
 use Piwik\Notification;
 use Piwik\Option;
 use Piwik\Piwik;
-use Piwik\Plugins\DBStats\MySQLMetadataDataAccess;
-use Piwik\Plugins\DBStats\MySQLMetadataProvider;
 use Piwik\Plugins\LanguagesManager\LanguagesManager;
 use Piwik\Scheduler\Scheduler;
 use Piwik\View;
@@ -192,7 +190,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $doDatabaseSizeEstimate = PiwikConfig::getInstance()->Deletelogs['enable_auto_database_size_estimate'];
 
         // determine the DB size & purged DB size
-        $metadataProvider = new MySQLMetadataProvider(new MySQLMetadataDataAccess());
+        $metadataProvider = StaticContainer::get('Piwik\Plugins\DBStats\MySQLMetadataProvider');
         $tableStatuses = $metadataProvider->getAllTablesStatus();
 
         $totalBytes = 0;


### PR DESCRIPTION
To reproduce go to Administration -> Privacy then click on another page. You should see the following error:

```
WARNING: /home/piwik-demo2/www/plugins/DBStats/MySQLMetadataProvider.php(43): Notice - Undefined variable: dataAccess - Piwik 2.14.0-b2 - Please report this message in the Piwik forums: http://forum.piwik.org (please do a search first as it might have been reported already)
×WARNING: /home/piwik-demo2/www/plugins/DBStats/MySQLMetadataProvider.php(41): Recoverable Error - Argument 1 passed to Piwik\Plugins\DBStats\MySQLMetadataProvider::__construct() must be an instance of Piwik\Plugins\DBStats\MySQLMetadataDataAccess, none given, called in /home/piwik-demo2/www/plugins/PrivacyManager/Controller.php on line 194 and defined - Piwik 2.14.0-b2 - Please report this message in the Piwik forums: http://forum.piwik.org (please do a search first as it might have been reported already)
```
