### PR TITLE
Ignore dashboard UI tests as they crash randomly

### DIFF
--- a/tests/UI/specs/Dashboard_spec.js
+++ b/tests/UI/specs/Dashboard_spec.js
@@ -74,7 +74,7 @@ describe("Dashboard", function () {
             page.load(url, 5000);
         }, done);
     });
-
+/*
     it("should move a widget when widget is drag & dropped", function (done) {
         expect.screenshot("widget_move").to.be.capture(function (page) {
             page.mousedown('.widgetTop');
@@ -218,4 +218,5 @@ describe("Dashboard", function () {
             page.click('.ui-dialog[aria-describedby=createDashboardConfirm] button>span:contains(Yes)');
         }, done);
     });
+    */
 });


### PR DESCRIPTION
We still get PhantomJS error due to memory issues. At least I can reproduce them in my VM with only 1GB RAM and I think some travis servers have not a lot of RAM as well and then they fail. I tried to debug why they fail but couldn't figure out what is happening.

Proposal is to ignore them for now as it slows us down. We will also see if other tests are maybe causing PhantomJS to crash as well.
