### PR TITLE
Update SitesManager.getSitesFromGroup API method to accept an empty group

### DIFF
--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -142,7 +142,7 @@ class API extends \Piwik\Plugin\API
      * @param string $group Group name
      * @return array of sites
      */
-    public function getSitesFromGroup($group)
+    public function getSitesFromGroup($group = '')
     {
         Piwik::checkUserHasSuperUserAccess();
 


### PR DESCRIPTION
Closes #7975. Thanks to reflection used for an API metadata description, it's that easy :)
