### PR TITLE
Make the installation of Piwik work with HHVM.

### DIFF
--- a/core/Db/Adapter/Pdo/Mssql.php
+++ b/core/Db/Adapter/Pdo/Mssql.php
@@ -185,8 +185,7 @@ class Mssql extends Zend_Db_Adapter_Pdo_Mssql implements AdapterInterface
      */
     public static function isEnabled()
     {
-        $extensions = @get_loaded_extensions();
-        return in_array('PDO', $extensions) && in_array('pdo_sqlsrv', $extensions);
+        return extension_loaded('PDO') && extension_loaded('pdo_sqlsrv');
     }
 
     /**

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -125,8 +125,7 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      */
     public static function isEnabled()
     {
-        $extensions = @get_loaded_extensions();
-        return in_array('PDO', $extensions) && in_array('pdo_mysql', $extensions) && in_array('mysql', PDO::getAvailableDrivers());
+        return extension_loaded('PDO') && extension_loaded('pdo_mysql') && in_array('mysql', PDO::getAvailableDrivers());
     }
 
     /**

--- a/core/Db/Adapter/Pdo/Pgsql.php
+++ b/core/Db/Adapter/Pdo/Pgsql.php
@@ -67,8 +67,7 @@ class Pgsql extends Zend_Db_Adapter_Pdo_Pgsql implements AdapterInterface
      */
     public static function isEnabled()
     {
-        $extensions = @get_loaded_extensions();
-        return in_array('PDO', $extensions) && in_array('pdo_pgsql', $extensions);
+        return extension_loaded('PDO') && extension_loaded('pdo_pgsql');
     }
 
     /**

--- a/plugins/Diagnostics/Diagnostic/DbAdapterCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DbAdapterCheck.php
@@ -34,7 +34,7 @@ class DbAdapterCheck implements Diagnostic
     {
         $label = 'PDO ' . $this->translator->translate('Installation_Extension');
 
-        if (in_array('PDO', $this->getPhpExtensionsLoaded())) {
+        if (extension_loaded('PDO')) {
             $status = DiagnosticResult::STATUS_OK;
         } else {
             $status = DiagnosticResult::STATUS_WARNING;
@@ -65,11 +65,6 @@ class DbAdapterCheck implements Diagnostic
         }
 
         return $results;
-    }
-
-    private function getPhpExtensionsLoaded()
-    {
-        return @get_loaded_extensions();
     }
 
     private function getLongErrorMessage()

--- a/plugins/Diagnostics/Diagnostic/PhpExtensionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpExtensionsCheck.php
@@ -57,12 +57,8 @@ class PhpExtensionsCheck implements Diagnostic
             'iconv',
             'json',
             'mbstring',
+            'Reflection',
         );
-
-        if (! defined('HHVM_VERSION')) {
-            // HHVM provides the required subset of Reflection but lists Reflections as missing
-            $requiredExtensions[] = 'Reflection';
-        }
 
         return $requiredExtensions;
     }

--- a/plugins/Diagnostics/Diagnostic/PhpExtensionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpExtensionsCheck.php
@@ -27,10 +27,9 @@ class PhpExtensionsCheck implements Diagnostic
         $longErrorMessage = '';
 
         $requiredExtensions = $this->getRequiredExtensions();
-        $loadedExtensions = @get_loaded_extensions();
 
         foreach ($requiredExtensions as $extension) {
-            if (! in_array($extension, $loadedExtensions)) {
+            if (! extension_loaded($extension)) {
                 $status = DiagnosticResult::STATUS_ERROR;
                 $comment = $extension . ': ' . $this->translator->translate('Installation_RestartWebServer');
                 $longErrorMessage .= '<p>' . $this->getHelpMessage($extension) . '</p>';

--- a/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
@@ -60,7 +60,7 @@ class PhpSettingsCheck implements Diagnostic
             'session.auto_start=0',
         );
 
-        if ($this->isPhpVersionAtLeast56()) {
+        if ($this->isPhpVersionAtLeast56() && ! defined("HHVM_VERSION")) {
             // always_populate_raw_post_data must be -1
             $requiredSettings[] = 'always_populate_raw_post_data=-1';
         }


### PR DESCRIPTION
In conjunction with the issue #8108 on checking the loaded extensions, this pull request changes the check functions (ie in_array and get_extensions_loaded) by extension_loaded which is case insensitive.

This occurred in the systemCheck action for files PhpExtensionsCheck.php and DbAdapterCheck.php and in the databaseSetup action for files Mssql.php, Pgsql.php and Mysql.php.

This request also fixes a verification problem of the directive "always_populate_raw_post_data" which is considered as a boolean by HHVM (see http://docs.hhvm.com/manual/en/ini.core.php#ini.always-populate-raw-post-data).

Below are two screenshots showing the result before and after. You may also notice that the verification of the Reflection extension is present again (They are in french but the name of the extensions doesn't change).

![piwik_hhvm_before](https://cloud.githubusercontent.com/assets/1565272/8208228/c8068b58-1506-11e5-9bcd-028d9e60bf05.png)

![piwik_hhvm](https://cloud.githubusercontent.com/assets/1565272/8208234/ccb4b76a-1506-11e5-93c1-ce8a2338c0d3.PNG)
