### PR TITLE
Make sure BulkTracking skips requests for nonexistant sites.

### DIFF
--- a/plugins/BulkTracking/Tracker/Response.php
+++ b/plugins/BulkTracking/Tracker/Response.php
@@ -15,6 +15,11 @@ use Piwik\Tracker;
 class Response extends Tracker\Response
 {
     /**
+     * @var int
+     */
+    private $invalidRequests = 0;
+
+    /**
      * Echos an error message & other information, then exits.
      *
      * @param Tracker $tracker
@@ -55,7 +60,8 @@ class Response extends Tracker\Response
         // when doing bulk tracking we return JSON so the caller will know how many succeeded
         $result = array(
             'status'  => 'error',
-            'tracked' => $tracker->getCountOfLoggedRequests()
+            'tracked' => $tracker->getCountOfLoggedRequests(),
+            'invalid' => $this->invalidRequests,
         );
 
         // send error when in debug mode
@@ -70,8 +76,13 @@ class Response extends Tracker\Response
     {
         return array(
             'status' => 'success',
-            'tracked' => $tracker->getCountOfLoggedRequests()
+            'tracked' => $tracker->getCountOfLoggedRequests(),
+            'invalid' => $this->invalidRequests,
         );
     }
 
+    public function setInvalidCount($invalidRequests)
+    {
+        $this->invalidRequests = $invalidRequests;
+    }
 }

--- a/plugins/BulkTracking/tests/Integration/HandlerTest.php
+++ b/plugins/BulkTracking/tests/Integration/HandlerTest.php
@@ -10,8 +10,8 @@ namespace Piwik\Plugins\BulkTracking\tests\Integration;
 
 use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
+use Piwik\Plugins\BulkTracking\tests\Mock\TrackerResponse;
 use Piwik\Tests\Framework\Fixture;
-use Piwik\Tests\Framework\Mock\Tracker\Response;
 use Piwik\Tests\Framework\Mock\Tracker\ScheduledTasksRunner;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Tracker;
@@ -32,7 +32,7 @@ class HandlerTest extends IntegrationTestCase
     private $handler;
 
     /**
-     * @var Response
+     * @var TrackerResponse
      */
     private $response;
 
@@ -53,7 +53,7 @@ class HandlerTest extends IntegrationTestCase
         Fixture::createWebsite('2014-01-01 00:00:00');
         Tracker\Cache::deleteTrackerCache();
 
-        $this->response = new Response();
+        $this->response = new TrackerResponse();
         $this->handler  = new Handler();
         $this->handler->setResponse($this->response);
         $this->tracker  = new Tracker();

--- a/plugins/BulkTracking/tests/Integration/TrackerTest.php
+++ b/plugins/BulkTracking/tests/Integration/TrackerTest.php
@@ -66,7 +66,7 @@ class TrackerTest extends BulkTrackingTestCase
     {
         $response = $this->tracker->main($this->getHandler(), $this->getEmptyRequestSet());
 
-        $this->assertSame('{"status":"success","tracked":2}', $response);
+        $this->assertSame('{"status":"success","tracked":2,"invalid":0}', $response);
     }
 
     public function test_main_shouldReturnErrorResponse_InCaseOfAnyError()
@@ -79,7 +79,7 @@ class TrackerTest extends BulkTrackingTestCase
 
         $response = $this->tracker->main($handler, $requestSet);
 
-        $this->assertSame('{"status":"error","tracked":0}', $response);
+        $this->assertSame('{"status":"error","tracked":0,"invalid":0}', $response);
     }
 
     public function test_main_shouldReturnErrorResponse_IfNotAuthorized()
@@ -91,7 +91,7 @@ class TrackerTest extends BulkTrackingTestCase
 
         $response = $this->tracker->main($handler, $this->getEmptyRequestSet());
 
-        $this->assertSame('{"status":"error","tracked":0}', $response);
+        $this->assertSame('{"status":"error","tracked":0,"invalid":0}', $response);
     }
 
     public function test_main_shouldActuallyTrack()

--- a/plugins/BulkTracking/tests/Mock/TrackerResponse.php
+++ b/plugins/BulkTracking/tests/Mock/TrackerResponse.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\BulkTracking\tests\Mock;
+
+use Piwik\Tests\Framework\Mock\Tracker\Response;
+
+class TrackerResponse extends Response
+{
+    private $invalidRequests = 0;
+
+    public function setInvalidCount($invalidRequests)
+    {
+        $this->invalidRequests = $invalidRequests;
+    }
+}

--- a/plugins/BulkTracking/tests/System/TrackerTest.php
+++ b/plugins/BulkTracking/tests/System/TrackerTest.php
@@ -46,8 +46,12 @@ class TrackerTest extends SystemTestCase
         $this->tracker->doTrackPageView('Test');
         $this->tracker->doTrackPageView('Test');
 
+        // test skipping invalid site errors
+        $this->tracker->setIdSite(5);
+        $this->tracker->doTrackPageView('Test');
+
         $response = $this->tracker->doBulkTrack();
 
-        $this->assertEquals('{"status":"success","tracked":2}', $response);
+        $this->assertEquals('{"status":"success","tracked":2,"invalid":1}', $response);
     }
 }

--- a/plugins/BulkTracking/tests/Unit/ResponseTest.php
+++ b/plugins/BulkTracking/tests/Unit/ResponseTest.php
@@ -48,7 +48,7 @@ class ResponseTest extends UnitTestCase
         $this->response->outputException($tracker, new Exception('My Custom Message'), 400);
         $content = $this->response->getOutput();
 
-        $this->assertEquals('{"status":"error","tracked":5}', $content);
+        $this->assertEquals('{"status":"error","tracked":5,"invalid":0}', $content);
     }
 
     public function test_outputException_shouldOutputDebugMessageIfEnabled()
@@ -59,7 +59,7 @@ class ResponseTest extends UnitTestCase
         $this->response->outputException($tracker, new Exception('My Custom Message'), 400);
         $content = $this->response->getOutput();
 
-        $this->assertStringStartsWith('{"status":"error","tracked":5,"message":"My Custom Message\n', $content);
+        $this->assertStringStartsWith('{"status":"error","tracked":5,"invalid":0,"message":"My Custom Message\n', $content);
     }
 
     public function test_outputResponse_shouldOutputBulkResponse()
@@ -69,7 +69,7 @@ class ResponseTest extends UnitTestCase
         $this->response->outputResponse($tracker);
         $content = $this->response->getOutput();
 
-        $this->assertEquals('{"status":"success","tracked":5}', $content);
+        $this->assertEquals('{"status":"success","tracked":5,"invalid":0}', $content);
     }
 
     public function test_outputResponse_shouldNotOutputAnything_IfExceptionResponseAlreadySent()
@@ -80,7 +80,18 @@ class ResponseTest extends UnitTestCase
         $this->response->outputResponse($tracker);
         $content = $this->response->getOutput();
 
-        $this->assertEquals('{"status":"error","tracked":5}', $content);
+        $this->assertEquals('{"status":"error","tracked":5,"invalid":0}', $content);
+    }
+
+    public function test_outputResponse_shouldOutputInvalidRequests_IfInvalidCountSet()
+    {
+        $tracker = $this->getTrackerWithCountedRequests();
+
+        $this->response->setInvalidCount(3);
+        $this->response->outputResponse($tracker);
+        $content = $this->response->getOutput();
+
+        $this->assertEquals('{"status":"success","tracked":5,"invalid":3}', $content);
     }
 
     private function getTrackerWithCountedRequests()

--- a/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
@@ -12,7 +12,8 @@ use Piwik\Application\Environment;
 use Piwik\Tests\Framework\Mock\File;
 
 /**
- * Base class for Unit tests.
+ * Base class for Unit tests. Use this if you need to use the DI container in tests. It will be created fresh
+ * before each test.
  *
  * @deprecated Unit tests don't need no environment.
  *


### PR DESCRIPTION
As title.

This is to fix https://github.com/piwik/piwik-log-analytics/issues/73

Since log importing uses bulk tracking, individual requests cannot be skipped in the python script, so the bug cannot be fixed in the script.
