### PR TITLE
When segment sub-expression does not match any action, replace the SQL WHERE statement by (1 = 0)

### DIFF
--- a/core/Plugin/Segment.php
+++ b/core/Plugin/Segment.php
@@ -124,6 +124,8 @@ class Segment
      * or callable: `string $valueToMatch`, `string $segment` (see {@link setSegment()}), `string $matchType`
      * (eg SegmentExpression::MATCH_EQUAL or any other match constant of this class) and `$segmentName`.
      *
+     * If the closure returns NULL, then Piwik assumes the segment sub-string will not match any visitor.
+     *
      * @param string|\Closure $sqlFilter
      * @api
      */

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -179,12 +179,19 @@ class Segment
                 if (isset($segment['sqlFilter'])) {
                     $value = call_user_func($segment['sqlFilter'], $value, $segment['sqlSegment'], $matchType, $name);
 
+                    if(is_null($value)) {
+                        // eg. see TableLogAction::getIdActionFromSegment() defined
+                        return array();
+                    }
+
                     // sqlFilter-callbacks might return arrays for more complex cases
                     // e.g. see TableLogAction::getIdActionFromSegment()
                     if (is_array($value) && isset($value['SQL'])) {
                         // Special case: returned value is a sub sql expression!
                         $matchType = SegmentExpression::MATCH_ACTIONS_CONTAINS;
                     }
+
+
                 }
             }
             break;

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -179,9 +179,8 @@ class Segment
                 if (isset($segment['sqlFilter'])) {
                     $value = call_user_func($segment['sqlFilter'], $value, $segment['sqlSegment'], $matchType, $name);
 
-                    if(is_null($value)) {
-                        // eg. see TableLogAction::getIdActionFromSegment() defined
-                        return array();
+                    if(is_null($value)) { // null is returned in TableLogAction::getIdActionFromSegment()
+                        return array(null, $matchType, null);
                     }
 
                     // sqlFilter-callbacks might return arrays for more complex cases

--- a/core/Segment/SegmentExpression.php
+++ b/core/Segment/SegmentExpression.php
@@ -40,6 +40,8 @@ class SegmentExpression
     const INDEX_BOOL_OPERATOR = 0;
     const INDEX_OPERAND = 1;
 
+    const SQL_WHERE_DO_NOT_MATCH_ANY_ROW = "(1 = 0)";
+
     public function __construct($string)
     {
         $this->string = $string;
@@ -138,13 +140,21 @@ class SegmentExpression
             $operator = $leaf[self::INDEX_BOOL_OPERATOR];
             $operandDefinition = $leaf[self::INDEX_OPERAND];
 
-            $operand = $this->getSqlMatchFromDefinition($operandDefinition, $availableTables);
 
-            if ($operand[1] !== null) {
-                $this->valuesBind[] = $operand[1];
+            // in case we know already the segment won't match any row...
+            if($operandDefinition === array() ) { // see getCleanedExpression()
+                $operand = self::SQL_WHERE_DO_NOT_MATCH_ANY_ROW;
+
+            } else {
+                $operand = $this->getSqlMatchFromDefinition($operandDefinition, $availableTables);
+
+                if ($operand[1] !== null) {
+                    $this->valuesBind[] = $operand[1];
+                }
+
+                $operand = $operand[0];
             }
 
-            $operand = $operand[0];
             $sqlSubExpressions[] = array(
                 self::INDEX_BOOL_OPERATOR => $operator,
                 self::INDEX_OPERAND       => $operand,
@@ -381,3 +391,4 @@ class SegmentExpression
         );
     }
 }
+

--- a/core/Tracker/TableLogAction.php
+++ b/core/Tracker/TableLogAction.php
@@ -177,10 +177,9 @@ class TableLogAction
             || $matchType == SegmentExpression::MATCH_NOT_EQUAL
         ) {
             $idAction = self::getModel()->getIdActionMatchingNameAndType($valueToMatch, $actionType);
-            // if the action is not found, we hack -100 to ensure it tries to match against an integer
-            // otherwise binding idaction_name to "false" returns some rows for some reasons (in case &segment=pageTitle==Větrnásssssss)
+            // Action is not found (eg. &segment=pageTitle==Větrnásssssss)
             if (empty($idAction)) {
-                $idAction = -100;
+                $idAction = null;
             }
             return $idAction;
         }

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -10,9 +10,12 @@ namespace Piwik\Tests\Integration;
 
 use Exception;
 use Piwik\Common;
+use Piwik\Db;
 use Piwik\Segment;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tracker\Action;
+use Piwik\Tracker\TableLogAction;
 
 /**
  * @group Core
@@ -496,6 +499,114 @@ class SegmentTest extends IntegrationTestCase
                     ) AS log_inner
                 LIMIT 33",
             "bind" => array(1, 'Test'));
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function test_getSelectQuery_whenPageUrlExists_asStatementAND()
+    {
+        $select = 'log_visit.*';
+        $from = 'log_visit';
+        $where = false;
+        $bind = array();
+
+        $pageUrlFoundInDb = 'example.com/page.html?hello=world';
+
+        TableLogAction::loadIdsAction( array(
+            'idaction_url' => array($pageUrlFoundInDb, Action::TYPE_PAGE_URL)
+        ));
+
+        $actionIdFoundInDb = Db::fetchOne("SELECT idaction from " . Common::prefixTable('log_action') . " WHERE name = ?", $pageUrlFoundInDb);
+        $this->assertNotEmpty( $actionIdFoundInDb, "Action $pageUrlFoundInDb was not found in the ". Common::prefixTable('log_action') ." table.");
+
+        $segment = 'visitServerHour==3;pageUrl==' . urlencode($pageUrlFoundInDb);
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind);
+
+        $expected = array(
+            "sql"  => "
+                SELECT
+                    log_inner.*
+                FROM
+                    (
+                SELECT
+                    log_visit.*
+                FROM
+                    " . Common::prefixTable('log_visit') . " AS log_visit
+                    LEFT JOIN " . Common::prefixTable('log_link_visit_action') . " AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                WHERE HOUR(log_visit.visit_last_action_time) = ?
+                      AND log_link_visit_action.idaction_url = ?
+                GROUP BY log_visit.idvisit
+                ORDER BY NULL
+                    ) AS log_inner",
+            "bind" => array(3, $actionIdFoundInDb));
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function test_getSelectQuery_whenPageUrlDoesNotExist_asStatementAND()
+    {
+        $select = 'log_visit.*';
+        $from = 'log_visit';
+        $where = false;
+        $bind = array();
+
+        $segment = 'visitServerHour==12;pageUrl==xyz';
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind);
+
+        $expected = array(
+            "sql"  => "
+                SELECT
+                    log_inner.*
+                FROM
+                    (
+                SELECT
+                    log_visit.*
+                FROM
+                    " . Common::prefixTable('log_visit') . " AS log_visit
+                    LEFT JOIN " . Common::prefixTable('log_link_visit_action') . " AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                WHERE HOUR(log_visit.visit_last_action_time) = ?
+                      AND log_link_visit_action.idaction_url = ?
+                GROUP BY log_visit.idvisit
+                ORDER BY NULL
+                    ) AS log_inner",
+            "bind" => array(12, -100));
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function test_getSelectQuery_whenPageUrlDoesNotExist_asStatementOR()
+    {
+        $select = 'log_visit.*';
+        $from = 'log_visit';
+        $where = false;
+        $bind = array();
+
+        $segment = 'visitServerHour==12,pageUrl==xyz';
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind);
+
+        $expected = array(
+            "sql"  => "
+                SELECT
+                    log_inner.*
+                FROM
+                    (
+                SELECT
+                    log_visit.*
+                FROM
+                    " . Common::prefixTable('log_visit') . " AS log_visit
+                    LEFT JOIN " . Common::prefixTable('log_link_visit_action') . " AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                WHERE (HOUR(log_visit.visit_last_action_time) = ?
+                      OR log_link_visit_action.idaction_url = ? )
+                GROUP BY log_visit.idvisit
+                ORDER BY NULL
+                    ) AS log_inner",
+            "bind" => array(12, -100));
 
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__Goals.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__Goals.get_range.xml
@@ -4,9 +4,9 @@
 	<nb_visits_converted>2</nb_visits_converted>
 	<revenue>1000</revenue>
 	<conversion_rate>66.67%</conversion_rate>
-	<nb_conversions_new_visit>0</nb_conversions_new_visit>
+	<nb_conversions_new_visit>3</nb_conversions_new_visit>
 	<nb_visits_converted_new_visit>2</nb_visits_converted_new_visit>
-	<revenue_new_visit>0</revenue_new_visit>
+	<revenue_new_visit>1000</revenue_new_visit>
 	<conversion_rate_new_visit>66.67%</conversion_rate_new_visit>
 	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
 	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>


### PR DESCRIPTION
- first we add some integration tests for the SQL generator to cover existing logic: https://github.com/piwik/piwik/commit/abefedee76c37450b011a5a29cb9beec1aceff94
- then we fix the bug and the tests show that SQL becomes simpler, and therefore should be faster
- then System tests helped me find a bug fixed in: https://github.com/piwik/piwik/commit/1b87342a820c1f1a89fad83ba5a119fdc5c726ca

fixes #8102
