### PR TITLE
Resolve problem with route to no exists action

### DIFF
--- a/plugins/CorePluginsAdmin/templates/updatePlugin.twig
+++ b/plugins/CorePluginsAdmin/templates/updatePlugin.twig
@@ -34,7 +34,7 @@
                 |
                 <a href="{{ linkTo({'action': 'themes'}) }}">{{ 'CorePluginsAdmin_Themes'|translate }}</a>
                 |
-                <a href="{{ linkTo({'action': 'extend'}) }}">{{ 'CorePluginsAdmin_Marketplace'|translate }}</a></p>
+                <a href="{{ linkTo({'action': 'marketplace'}) }}">{{ 'CorePluginsAdmin_Marketplace'|translate }}</a></p>
         </div>
     </div>
 

--- a/plugins/CorePluginsAdmin/templates/uploadPlugin.twig
+++ b/plugins/CorePluginsAdmin/templates/uploadPlugin.twig
@@ -19,7 +19,7 @@
 
                         |
                     {% endif %}
-                    <a href="{{ linkTo({'action': 'extend'}) }}">{{ 'CorePluginsAdmin_BackToExtendPiwik'|translate }}</a>
+                    <a href="{{ linkTo({'action': 'marketplace'}) }}">{{ 'CorePluginsAdmin_BackToExtendPiwik'|translate }}</a>
                 </p>
 
             {% else %}
@@ -34,7 +34,7 @@
 
                         |
                     {% endif %}
-                    <a href="{{ linkTo({'action': 'extend'}) }}">{{ 'CorePluginsAdmin_BackToExtendPiwik'|translate }}</a>
+                    <a href="{{ linkTo({'action': 'marketplace'}) }}">{{ 'CorePluginsAdmin_BackToExtendPiwik'|translate }}</a>
                 </p>
 
             {% endif %}


### PR DESCRIPTION
Trying to resolve issue: https://github.com/piwik/piwik/issues/8136

I have changed route from `extend` to `marketplace`. @piwik/core-team Could you confirm, if it is a good solution ? because i'm not sure about it - maybe the name `extend` is mapping to another action ? 

This change is the first thing that I thought.
