### PR TITLE
Last DI changes, required for tests in some PRO builds

### DIFF
--- a/core/Application/Environment.php
+++ b/core/Application/Environment.php
@@ -138,8 +138,10 @@ class Environment
     protected function getGlobalSettingsCached()
     {
         if ($this->globalSettingsProvider === null) {
-            $globalSettingsProvider = $this->getGlobalSettingsProviderOverride();
-            $this->globalSettingsProvider = $globalSettingsProvider ?: $this->getGlobalSettings();
+            $original = $this->getGlobalSettings();
+            $globalSettingsProvider = $this->getGlobalSettingsProviderOverride($original);
+
+            $this->globalSettingsProvider = $globalSettingsProvider ?: $original;
         }
         return $this->globalSettingsProvider;
     }
@@ -192,10 +194,10 @@ class Environment
         self::$globalEnvironmentManipulator = $manipulator;
     }
 
-    private function getGlobalSettingsProviderOverride()
+    private function getGlobalSettingsProviderOverride(GlobalSettingsProvider $original)
     {
         if (self::$globalEnvironmentManipulator) {
-            return self::$globalEnvironmentManipulator->makeGlobalSettingsProvider();
+            return self::$globalEnvironmentManipulator->makeGlobalSettingsProvider($original);
         } else {
             return null;
         }

--- a/core/Application/Environment.php
+++ b/core/Application/Environment.php
@@ -89,13 +89,21 @@ class Environment
 
         $this->container = $this->createContainer();
 
-        StaticContainer::set($this->container);
+        StaticContainer::push($this->container);
 
         $this->validateEnvironment();
 
         $this->invokeEnvironmentBootstrappedHook();
 
         Piwik::postEvent('Environment.bootstrapped'); // this event should be removed eventually
+    }
+
+    /**
+     * Destroys an environment. MUST be called when embedding environments.
+     */
+    public function destroy()
+    {
+        StaticContainer::pop();
     }
 
     /**

--- a/core/Application/EnvironmentManipulator.php
+++ b/core/Application/EnvironmentManipulator.php
@@ -23,7 +23,7 @@ interface EnvironmentManipulator
      *
      * @return GlobalSettingsProvider
      */
-    public function makeGlobalSettingsProvider();
+    public function makeGlobalSettingsProvider(GlobalSettingsProvider $original);
 
     /**
      * Create a custom PluginList kernel object, overriding the default behavior.@deprecated

--- a/core/Container/StaticContainer.php
+++ b/core/Container/StaticContainer.php
@@ -20,9 +20,9 @@ use DI\Container;
 class StaticContainer
 {
     /**
-     * @var Container
+     * @var Container[]
      */
-    private static $container;
+    private static $containerStack = array();
 
     /**
      * Definitions to register in the container.
@@ -36,16 +36,16 @@ class StaticContainer
      */
     public static function getContainer()
     {
-        if (self::$container === null) {
+        if (empty(self::$containerStack)) {
             throw new ContainerDoesNotExistException("The root container has not been created yet.");
         }
 
-        return self::$container;
+        return end(self::$containerStack);
     }
 
     public static function clearContainer()
     {
-        self::$container = null;
+        self::pop();
     }
 
     /**
@@ -53,9 +53,14 @@ class StaticContainer
      *
      * @param Container $container
      */
-    public static function set(Container $container)
+    public static function push(Container $container)
     {
-        self::$container = $container;
+        self::$containerStack[] = $container;
+    }
+
+    public static function pop()
+    {
+        array_pop(self::$containerStack);
     }
 
     public static function addDefinitions(array $definitions)

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -11,6 +11,8 @@ namespace Piwik;
 use Exception;
 use Piwik\Plugins\BulkTracking\Tracker\Requests;
 use Piwik\Plugins\PrivacyManager\Config as PrivacyManagerConfig;
+use Piwik\Config;
+use Piwik\Tests\Framework\TestingEnvironmentVariables;
 use Piwik\Tracker\Db as TrackerDb;
 use Piwik\Tracker\Db\DbException;
 use Piwik\Tracker\Handler;

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -176,7 +176,12 @@ class Fixture extends \PHPUnit_Framework_Assert
 
     public function performSetUp($setupEnvironmentOnly = false)
     {
+        // TODO: don't use static var, use test env var for this
         TestingEnvironmentManipulator::$extraPluginsToLoad = $this->extraPluginsToLoad;
+
+        $this->getTestEnvironment()->testCaseClass = $this->testCaseClass;
+        $this->getTestEnvironment()->fixtureClass = get_class($this);
+        $this->getTestEnvironment()->save();
 
         $this->createEnvironmentInstance();
 
@@ -268,10 +273,6 @@ class Fixture extends \PHPUnit_Framework_Assert
         if ($setupEnvironmentOnly) {
             return;
         }
-
-        $this->getTestEnvironment()->testCaseClass = $this->testCaseClass;
-        $this->getTestEnvironment()->fixtureClass = get_class($this);
-        $this->getTestEnvironment()->save();
 
         PiwikCache::getTransientCache()->flushAll();
 

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -327,6 +327,8 @@ class Fixture extends \PHPUnit_Framework_Assert
         $this->clearInMemoryCaches();
 
         Log::unsetInstance();
+
+        $this->destroyEnvironment();
     }
 
     public function clearInMemoryCaches()
@@ -907,5 +909,15 @@ class Fixture extends \PHPUnit_Framework_Assert
     {
         $this->piwikEnvironment = new Environment($environment = null, $this->extraDefinitions);
         $this->piwikEnvironment->init();
+    }
+
+    public function destroyEnvironment()
+    {
+        if ($this->piwikEnvironment === null) {
+            return;
+        }
+
+        $this->piwikEnvironment->destroy();
+        $this->piwikEnvironment = null;
     }
 }

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -270,6 +270,7 @@ class Fixture extends \PHPUnit_Framework_Assert
         }
 
         $this->getTestEnvironment()->testCaseClass = $this->testCaseClass;
+        $this->getTestEnvironment()->fixtureClass = get_class($this);
         $this->getTestEnvironment()->save();
 
         PiwikCache::getTransientCache()->flushAll();
@@ -904,7 +905,7 @@ class Fixture extends \PHPUnit_Framework_Assert
 
     public function createEnvironmentInstance()
     {
-        $this->piwikEnvironment = new Environment($environment = null, array_merge($this->provideContainerConfig(), $this->extraDefinitions));
+        $this->piwikEnvironment = new Environment($environment = null, $this->extraDefinitions);
         $this->piwikEnvironment->init();
     }
 }

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -350,6 +350,11 @@ class Fixture extends \PHPUnit_Framework_Assert
         // since Plugin\Manager uses getFromGlobalConfig which doesn't init the config object
     }
 
+    /**
+     * @param \Piwik\Tests\Framework\TestingEnvironmentVariables|null $testEnvironment Ignored.
+     * @param bool|false $testCaseClass Ignored.
+     * @param array $extraPluginsToLoad Ignoerd.
+     */
     public static function loadAllPlugins(TestingEnvironmentVariables $testEnvironment = null, $testCaseClass = false, $extraPluginsToLoad = array())
     {
         DbHelper::createTables();

--- a/tests/PHPUnit/Framework/Mock/FakeAccess.php
+++ b/tests/PHPUnit/Framework/Mock/FakeAccess.php
@@ -23,12 +23,12 @@ class FakeAccess
     public static $identity = 'superUserLogin';
     public static $superUserLogin = 'superUserLogin';
 
-    public static function clearAccess()
+    public static function clearAccess($superUser = false, $idSitesAdmin = array(), $idSitesView = array(), $identity = 'superUserLogin')
     {
-        self::$superUser    = false;
-        self::$idSitesAdmin = array();
-        self::$idSitesView  = array();
-        self::$identity     = 'superUserLogin';
+        self::$superUser    = $superUser;
+        self::$idSitesAdmin = $idSitesAdmin;
+        self::$idSitesView  = $idSitesView;
+        self::$identity     = $identity;
     }
 
     public function getTokenAuth()
@@ -36,9 +36,9 @@ class FakeAccess
         return false;
     }
 
-    public function __construct()
+    public function __construct($superUser = false, $idSitesAdmin = array(), $idSitesView = array(), $identity = 'superUserLogin')
     {
-        self::clearAccess();
+        self::clearAccess($superUser, $idSitesAdmin, $idSitesView, $identity);
     }
 
     public static function setIdSitesAdmin($ids)

--- a/tests/PHPUnit/Framework/Mock/FakeCliMulti.php
+++ b/tests/PHPUnit/Framework/Mock/FakeCliMulti.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\Framework\Mock;
+
+use Piwik\Archiver\Request;
+use Piwik\CliMulti;
+
+class FakeCliMulti extends CliMulti
+{
+    public static $specifiedResults = null;
+
+    public function request(array $piwikUrls)
+    {
+        if (empty(FakeCliMulti::$specifiedResults)) {
+            return parent::request($piwikUrls);
+        }
+
+        $results = array();
+        foreach ($piwikUrls as $url) {
+            if ($url instanceof Request) {
+                $url->start();
+
+                $url = (string)$url;
+            }
+
+            $results[] = $this->getSpecifiedResult($url);
+        }
+        return $results;
+    }
+
+    private function getSpecifiedResult($url)
+    {
+        foreach (FakeCliMulti::$specifiedResults as $pattern => $result) {
+            if (substr($pattern, 0, 1) == '/'
+                && substr($pattern, strlen($pattern) - 1, 1) == '/'
+            ) {
+                $isMatch = preg_match($pattern, $url);
+            } else {
+                $isMatch = $pattern == $url;
+            }
+
+            if (!$isMatch) {
+                continue;
+            }
+
+            if (is_callable($result)) {
+                return $result($url);
+            } else {
+                return $result;
+            }
+        }
+        return null;
+    }
+}

--- a/tests/PHPUnit/Framework/Mock/LocationProvider.php
+++ b/tests/PHPUnit/Framework/Mock/LocationProvider.php
@@ -40,7 +40,7 @@ class LocationProvider extends CountryLocationProvider
 
     public function getInfo()
     {
-        return array('id' => self::ID, 'title' => 'mock provider', 'description' => 'mock provider');
+        return array('id' => self::ID, 'title' => 'mock provider', 'description' => 'mock provider', 'order' => 10);
     }
 
     public function isAvailable()

--- a/tests/PHPUnit/Framework/Mock/TestConfig.php
+++ b/tests/PHPUnit/Framework/Mock/TestConfig.php
@@ -75,25 +75,15 @@ class TestConfig extends Config
 
     private function setFromTestEnvironment(\Piwik\Tests\Framework\TestingEnvironmentVariables $testingEnvironment)
     {
-        $pluginsToLoad = $testingEnvironment->getCoreAndSupportedPlugins();
-        if (!empty($testingEnvironment->pluginsToLoad)) {
-            $pluginsToLoad = array_unique(array_merge($pluginsToLoad, $testingEnvironment->pluginsToLoad));
-        }
-
-        sort($pluginsToLoad);
-
         $chain = $this->settings->getIniFileChain();
 
         $general =& $chain->get('General');
-        $plugins =& $chain->get('Plugins');
         $log =& $chain->get('log');
         $database =& $chain->get('database');
 
         if ($testingEnvironment->configFileLocal) {
             $general['session_save_handler'] = 'dbtable';
         }
-
-        $plugins['Plugins'] = $pluginsToLoad;
 
         $log['log_writers'] = array('file');
 

--- a/tests/PHPUnit/Framework/Mock/TestConfig.php
+++ b/tests/PHPUnit/Framework/Mock/TestConfig.php
@@ -31,7 +31,7 @@ class TestConfig extends Config
 
     public function reload($pathLocal = null, $pathGlobal = null, $pathCommon = null)
     {
-        parent::reload($pathGlobal, $pathLocal, $pathCommon);
+        parent::reload($pathLocal, $pathGlobal, $pathCommon);
 
         $this->setTestEnvironment();
     }

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -76,9 +76,10 @@ abstract class IntegrationTestCase extends SystemTestCase
     {
         parent::setUp();
 
-        self::$fixture->extraDefinitions = array_merge(static::provideContainerConfigBeforeClass(), $this->provideContainerConfig());
-        self::$fixture->createEnvironmentInstance();
+        static::$fixture->extraDefinitions = array_merge(static::provideContainerConfigBeforeClass(), $this->provideContainerConfig());
+        static::$fixture->createEnvironmentInstance();
 
+        Db::createDatabaseObject();
         Fixture::loadAllPlugins(new TestingEnvironmentVariables(), get_class($this), self::$fixture->extraPluginsToLoad);
 
         Access::getInstance()->setSuperUserAccess(true);
@@ -98,6 +99,7 @@ abstract class IntegrationTestCase extends SystemTestCase
     public function tearDown()
     {
         static::$fixture->clearInMemoryCaches();
+        static::$fixture->destroyEnvironment();
 
         parent::tearDown();
     }

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -66,7 +66,7 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         $fixture->testCaseClass = get_called_class();
         $fixture->extraDefinitions = array_merge(
             array('test.vars.loadRealTranslations' => true), // load real translations for system tests
-            static::provideContainerConfigBeforeClass()
+            $fixture->extraDefinitions
         );
 
         try {

--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -67,6 +67,8 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
 
     public function beforeContainerCreated()
     {
+        $this->vars->reload();
+
         if ($this->vars->queryParamOverride) {
             foreach ($this->vars->queryParamOverride as $key => $value) {
                 $_GET[$key] = $value;

--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -24,11 +24,10 @@ class FakePluginList extends PluginList
         parent::__construct($globalSettingsProvider);
 
         $this->plugins = $this->sortPlugins($plugins);
-    }
 
-    public function getActivatedPlugins()
-    {
-        return $this->plugins;
+        $section = $globalSettingsProvider->getSection('Plugins');
+        $section['Plugins'] = $this->plugins;
+        $globalSettingsProvider->setSection('Plugins', $section);
     }
 }
 

--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -135,7 +135,7 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
     {
         $testVarDefinitionSource = new TestingEnvironmentVariablesDefinitionSource($this->vars);
 
-        $diConfig = array();
+        $diConfigs = array($testVarDefinitionSource);
         if ($this->vars->testCaseClass) {
             $testCaseClass = $this->vars->testCaseClass;
             if (class_exists($testCaseClass)) {
@@ -143,24 +143,22 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
 
                 // Apply DI config from the fixture
                 if (isset($testCaseClass::$fixture)) {
-                    $diConfig = array_merge($diConfig, $testCaseClass::$fixture->provideContainerConfig());
+                    $diConfigs[] = $testCaseClass::$fixture->provideContainerConfig();
                 }
 
                 if (method_exists($testCase, 'provideContainerConfigBeforeClass')) {
-                    $diConfig = array_merge($diConfig, $testCaseClass::provideContainerConfigBeforeClass());
+                    $diConfigs[] = $testCaseClass::provideContainerConfigBeforeClass();
                 }
 
                 if (method_exists($testCase, 'provideContainerConfig')) {
-                    $diConfig = array_merge($diConfig, $testCase->provideContainerConfig());
+                    $diConfigs[] = $testCase->provideContainerConfig();
                 }
             }
         }
 
-        return array(
-            $testVarDefinitionSource,
-            $diConfig,
-            array('observers.global' => \DI\add($this->globalObservers)),
-        );
+        $diConfigs[] = array('observers.global' => \DI\add($this->globalObservers));
+
+        return $diConfigs;
     }
 
     public function getExtraEnvironments()

--- a/tests/PHPUnit/Framework/TestingEnvironmentVariables.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentVariables.php
@@ -9,8 +9,6 @@
 namespace Piwik\Tests\Framework;
 
 use Piwik\Plugin\Manager as PluginManager;
-use Piwik\Piwik;
-use Piwik\Application\Environment;
 
 /**
  * Sets the test environment.
@@ -21,10 +19,7 @@ class TestingEnvironmentVariables
 
     public function __construct()
     {
-        $overridePath = PIWIK_INCLUDE_PATH . '/tmp/testingPathOverride.json';
-        if (file_exists($overridePath)) {
-            $this->behaviorOverrideProperties = json_decode(file_get_contents($overridePath), true);
-        }
+        $this->reload();
     }
 
     public function __get($key)
@@ -82,5 +77,13 @@ class TestingEnvironmentVariables
         sort($plugins);
 
         return $plugins;
+    }
+
+    public function reload()
+    {
+        $overridePath = PIWIK_INCLUDE_PATH . '/tmp/testingPathOverride.json';
+        if (file_exists($overridePath)) {
+            $this->behaviorOverrideProperties = json_decode(file_get_contents($overridePath), true);
+        }
     }
 }

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -20,54 +20,6 @@ use Piwik\Tests\Framework\Mock\FakeLogger;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Plugins\SegmentEditor\API as SegmentAPI;
 
-class FakeCliMulti extends CliMulti
-{
-    public static $specifiedResults = null;
-
-    public function request(array $piwikUrls)
-    {
-        if (empty(FakeCliMulti::$specifiedResults)) {
-            return parent::request($piwikUrls);
-        }
-
-        $results = array();
-        foreach ($piwikUrls as $url) {
-            if ($url instanceof Request) {
-                $url->start();
-
-                $url = (string)$url;
-            }
-
-            $results[] = $this->getSpecifiedResult($url);
-        }
-        return $results;
-    }
-
-    private function getSpecifiedResult($url)
-    {
-        foreach (FakeCliMulti::$specifiedResults as $pattern => $result) {
-            if (substr($pattern, 0, 1) == '/'
-                && substr($pattern, strlen($pattern) - 1, 1) == '/'
-            ) {
-                $isMatch = preg_match($pattern, $url);
-            } else {
-                $isMatch = $pattern == $url;
-            }
-
-            if (!$isMatch) {
-                continue;
-            }
-
-            if (is_callable($result)) {
-                return $result($url);
-            } else {
-                return $result;
-            }
-        }
-        return null;
-    }
-}
-
 /**
  * @group Archiver
  * @group CronArchive
@@ -115,7 +67,7 @@ class CronArchiveTest extends IntegrationTestCase
 
     public function test_output()
     {
-        FakeCliMulti::$specifiedResults = array(
+        \Piwik\Tests\Framework\Mock\FakeCliMulti::$specifiedResults = array(
             '/method=API.get/' => serialize(array(array('nb_visits' => 1)))
         );
 
@@ -190,7 +142,7 @@ LOG;
     public function provideContainerConfig()
     {
         return array(
-            'Piwik\CliMulti' => \DI\object('Piwik\Tests\Integration\FakeCliMulti')
+            'Piwik\CliMulti' => \DI\object('Piwik\Tests\Framework\Mock\FakeCliMulti')
         );
     }
 }

--- a/tests/PHPUnit/System/AnnotationsTest.php
+++ b/tests/PHPUnit/System/AnnotationsTest.php
@@ -279,13 +279,6 @@ class AnnotationsTest extends SystemTestCase
 
         }
     }
-
-    public function provideContainerConfig()
-    {
-        return array(
-            'Piwik\Access' => new FakeAccess()
-        );
-    }
 }
 
 AnnotationsTest::$fixture = new TwoSitesWithAnnotations();


### PR DESCRIPTION
This PR includes:
1. Ability for environments to stack in StaticContainer. This allows us to embed environments (to some level). When a new Environment is created, instead of replacing the StaticContainer instance, it pushes the instance to an internal stack. There is an Environment::destroy() method that must be explicitly called to remove the entry.
2. Fix the way Fixture::provideContainerConfig() results are used to override DI. Instead of creating a new Fixture instance, we use the instance in the test case class. This way, the fixture's properties will be set properly in child processes.
3. Reload test vars before manipulating an environment, so changes to test vars will be seen when creating new environments (ie, create Environment, change vars, create embedded Environment will use new vars instead of the original).
4. Allow embedded environments to override GlobalSettingsProvider in tests by making TestingEnvironmentManipulator only override the provider if it has to. Previously, it would always create its own GlobalSettingsProvider, so the embedded environment's custom one would be replaced.
5. Change to the way all provideContainerConfig() results are added. Instead of using array_merge, we add them to an array of definition arrays. This way, fixtures & tests can both use DI\add to the same array, and one won't overwrite the other. Also allows doing the same sort of thing w/ DI\decorate.
6. Moved FakeCliMulti to its own file so it can be reused.
7. Some other smaller bug fixes to DI test code. Commit messages have more info.

Going commit by commit to review might be hard for the first two or three commits, but I think is the best way to review.
