### PR TITLE
Remove App-ID setting for mobile apps

### DIFF
--- a/plugins/MobileAppMeasurable/Type.php
+++ b/plugins/MobileAppMeasurable/Type.php
@@ -19,17 +19,5 @@ class Type extends \Piwik\Measurable\Type
     protected $description = 'MobileAppMeasurable_MobileAppDescription';
     protected $howToSetupUrl = 'http://developer.piwik.org/guides/tracking-api-clients#mobile-sdks';
 
-    public function configureMeasurableSettings(MeasurableSettings $settings)
-    {
-        $appId = new MeasurableSetting('app_id', 'App-ID');
-        $appId->validate = function ($value) {
-            if (strlen($value) > 100) {
-                throw new \Exception('Only 100 characters are allowed');
-            }
-        };
-
-        $settings->addSetting($appId);
-    }
-
 }
 

--- a/plugins/MobileAppMeasurable/Type.php
+++ b/plugins/MobileAppMeasurable/Type.php
@@ -8,9 +8,6 @@
  */
 namespace Piwik\Plugins\MobileAppMeasurable;
 
-use Piwik\Measurable\MeasurableSetting;
-use Piwik\Measurable\MeasurableSettings;
-
 class Type extends \Piwik\Measurable\Type
 {
     const ID = 'mobileapp';


### PR DESCRIPTION
It's not needed to define an app-id as the app-id can be different for each platform and some might want to track the same app for different platforms under one "Measurable" and use then segmentation.
