### PR TITLE
Reset viewport size after each UI test

### DIFF
--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -388,6 +388,7 @@ PageRenderer.prototype.capture = function (outputPath, callback, selector) {
 
                 self._setCorrectViewportSize();
                 self.webpage.render(outputPath);
+                self._viewportSizeOverride = null;
             }
 
             self.webpage.clipRect = previousClipRect;


### PR DESCRIPTION
After one test set a viewPortSize, all following tests were executed with the
same screenshot size. That means about 100 tests were actually executed with a
screenshot size of 480x320 because of https://github.com/piwik/piwik/blob/2.14.0-b4/tests/UI/specs/UIIntegration_spec.js#L76 a bit later on most tests were executed with a screenshot size of 320x320 by https://github.com/piwik/piwik/blob/master/tests/UI/specs/EvolutionGraph_spec.js#L146 causing failures like  http://builds-artifacts.piwik.org/ui-tests.master/13496.7/Installation_db_setup
