### PR TITLE
Revert "Remove App-ID setting for mobile apps"

### DIFF
--- a/plugins/MobileAppMeasurable/Type.php
+++ b/plugins/MobileAppMeasurable/Type.php
@@ -8,6 +8,9 @@
  */
 namespace Piwik\Plugins\MobileAppMeasurable;
 
+use Piwik\Measurable\MeasurableSetting;
+use Piwik\Measurable\MeasurableSettings;
+
 class Type extends \Piwik\Measurable\Type
 {
     const ID = 'mobileapp';
@@ -15,6 +18,18 @@ class Type extends \Piwik\Measurable\Type
     protected $namePlural = 'MobileAppMeasurable_MobileApps';
     protected $description = 'MobileAppMeasurable_MobileAppDescription';
     protected $howToSetupUrl = 'http://developer.piwik.org/guides/tracking-api-clients#mobile-sdks';
+
+    public function configureMeasurableSettings(MeasurableSettings $settings)
+    {
+        $appId = new MeasurableSetting('app_id', 'App-ID');
+        $appId->validate = function ($value) {
+            if (strlen($value) > 100) {
+                throw new \Exception('Only 100 characters are allowed');
+            }
+        };
+
+        $settings->addSetting($appId);
+    }
 
 }
 


### PR DESCRIPTION
The tests are failing, reverting because of that for now
