### PR TITLE
When searching for websites in the Sites Manger show all fields

### DIFF
--- a/plugins/SitesManager/.gitignore
+++ b/plugins/SitesManager/.gitignore
@@ -1,0 +1,1 @@
+tests/System/processed/*xml

--- a/plugins/SitesManager/Model.php
+++ b/plugins/SitesManager/Model.php
@@ -378,7 +378,7 @@ class Model
             $where  = 'OR s.idsite = ?';
         }
 
-        $query = "SELECT idsite, name, main_url, `group`
+        $query = "SELECT *
                   FROM " . $this->table . " s
                   WHERE (    s.name like ?
                           OR s.main_url like ?

--- a/plugins/SitesManager/tests/System/ApiTest.php
+++ b/plugins/SitesManager/tests/System/ApiTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\SitesManager\tests\System;
+
+use Piwik\Plugins\SitesManager\tests\Fixtures\ManySites;
+use Piwik\Plugins\SitesManager\tests\Fixtures\SimpleFixtureTrackFewVisits;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+
+/**
+ * @group SitesManager
+ * @group ApiTest
+ * @group Plugins
+ */
+class ApiTest extends SystemTestCase
+{
+    /**
+     * @var ManySites
+     */
+    public static $fixture = null; // initialized below class definition
+
+    /**
+     * @dataProvider getApiForTesting
+     */
+    public function testApi($api, $params)
+    {
+        $this->runApiTests($api, $params);
+    }
+
+    public function getApiForTesting()
+    {
+        $api = array(
+            'SitesManager.getPatternMatchSites',
+        );
+
+        $apiToTest   = array();
+        $apiToTest[] = array($api,
+            array(
+                'idSite'     => 1,
+                'date'       => self::$fixture->dateTime,
+                'periods'    => array('day'),
+                'otherRequestParameters' => array('pattern' => 'SiteTest1')
+            )
+        );
+
+        return $apiToTest;
+    }
+
+    public static function getOutputPrefix()
+    {
+        return 'SitesManager';
+    }
+
+    public static function getPathToTestDirectory()
+    {
+        return dirname(__FILE__);
+    }
+
+}
+
+ApiTest::$fixture = new ManySites();

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getPatternMatchSites.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getPatternMatchSites.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<idsite>1</idsite>
+		<name>SiteTest1</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>10</idsite>
+		<name>SiteTest10</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>11</idsite>
+		<name>SiteTest11</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>12</idsite>
+		<name>SiteTest12</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>13</idsite>
+		<name>SiteTest13</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>14</idsite>
+		<name>SiteTest14</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>15</idsite>
+		<name>SiteTest15</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>16</idsite>
+		<name>SiteTest16</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>17</idsite>
+		<name>SiteTest17</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>18</idsite>
+		<name>SiteTest18</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>19</idsite>
+		<name>SiteTest19</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+</result>


### PR DESCRIPTION
It does now show all the information see http://builds-artifacts.piwik.org/ui-tests.sites_manager_search_fix/13568.7/screenshot-diffs/singlediff.html?processed=../processed-ui-screenshots/SitesManager_search.png&expected=SitesManager_search.png&github=SitesManager_search.png

I was a bit surprised that no system tests fail. I presume there is no test for this method.
