### PR TITLE
Wait for 400ms before capturing a screenshot 

### DIFF
--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -382,18 +382,23 @@ PageRenderer.prototype.capture = function (outputPath, callback, selector) {
 
         try {
             if (outputPath) {
-                var previousClipRect = self.webpage.clipRect;
 
-                setClipRect(self.webpage, selector);
+                self._setCorrectViewportSize();
 
                 // _setCorrectViewportSize might cause a re-render. We should wait for a while for the re-render to
                 // finish before capturing a screenshot to avoid possible random failures.
                 var timeInMsToWaitForReRenderToFinish = 400;
                 setTimeout(function () {
+                    var previousClipRect = self.webpage.clipRect;
+
+                    setClipRect(self.webpage, selector);
+
                     self.webpage.render(outputPath);
                     self._viewportSizeOverride = null;
                     self.webpage.clipRect = previousClipRect;
+
                     callback();
+
                 }, timeInMsToWaitForReRenderToFinish);
                 
             } else {


### PR DESCRIPTION
Because PhantomJS might just re-render the whole page as we changed the viewport size just before.

This could fix some random build failures
