### PR TITLE
Refs #8060, fix bounce rate not appearing in legend or appearing incorrectly + some other bugs.

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -94,7 +94,7 @@ class Request
                 $defaultRequest['segment'] = $requestRaw['segment'];
             }
 
-            if (empty($defaultRequest['format_metrics'])) {
+            if (!isset($defaultRequest['format_metrics'])) {
                 $defaultRequest['format_metrics'] = 'bc';
             }
         }

--- a/core/Console.php
+++ b/core/Console.php
@@ -26,11 +26,13 @@ class Console extends Application
      */
     private $environment;
 
-    public function __construct()
+    public function __construct(Environment $environment = null)
     {
         $this->setServerArgsIfPhpCgi();
 
         parent::__construct();
+
+        $this->environment = $environment;
 
         $option = new InputOption('piwik-domain',
             null,
@@ -169,8 +171,10 @@ class Console extends Application
     protected function initEnvironment(OutputInterface $output)
     {
         try {
-            $this->environment = new Environment('cli');
-            $this->environment->init();
+            if ($this->environment === null) {
+                $this->environment = new Environment('cli');
+                $this->environment->init();
+            }
 
             $config = Config::getInstance();
             return $config;

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -348,11 +348,12 @@ class API extends \Piwik\Plugin\API
 
     public function getProcessedReport($idSite, $period, $date, $apiModule, $apiAction, $segment = false,
                                        $apiParameters = false, $idGoal = false, $language = false,
-                                       $showTimer = true, $hideMetricsDoc = false, $idSubtable = false, $showRawMetrics = false)
+                                       $showTimer = true, $hideMetricsDoc = false, $idSubtable = false, $showRawMetrics = false,
+                                       $format_metrics = null)
     {
         $reporter = new ProcessedReport();
         $processed = $reporter->getProcessedReport($idSite, $period, $date, $apiModule, $apiAction, $segment,
-            $apiParameters, $idGoal, $language, $showTimer, $hideMetricsDoc, $idSubtable, $showRawMetrics);
+            $apiParameters, $idGoal, $language, $showTimer, $hideMetricsDoc, $idSubtable, $showRawMetrics, $format_metrics);
 
         return $processed;
     }

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -393,7 +393,7 @@ class ProcessedReport
                                                        'serialize'  => '0',
                                                        'language'   => $language,
                                                        'idSubtable' => $idSubtable,
-                                                       'format_metrics' => 1,
+                                                       'format_metrics' => $showRawMetrics ? 'bc' : '1',
                                                   ));
 
         if (!empty($segment)) $parameters['segment'] = $segment;
@@ -668,7 +668,9 @@ class ProcessedReport
 
             foreach ($rowMetrics as $columnName => $columnValue) {
                 // filter metrics according to metadata definition
-                if (isset($metadataColumns[$columnName])) {
+                if (isset($metadataColumns[$columnName])
+                    && !$returnRawMetrics
+                ) {
                     // generate 'human readable' metric values
 
                     // if we handle MultiSites.getAll we do not always have the same idSite but different ones for

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -837,7 +837,8 @@ class ProcessedReport
         }
 
         // Add revenue symbol to revenues
-        if (strpos($columnName, 'revenue') !== false && strpos($columnName, 'evolution') === false) {
+        $isMoneyMetric = strpos($columnName, 'revenue') !== false || strpos($columnName, 'price') !== false;
+        if ($isMoneyMetric && strpos($columnName, 'evolution') === false) {
             return $formatter->getPrettyMoney($value, $idSite);
         }
 

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -363,7 +363,8 @@ class ProcessedReport
 
     public function getProcessedReport($idSite, $period, $date, $apiModule, $apiAction, $segment = false,
                                        $apiParameters = false, $idGoal = false, $language = false,
-                                       $showTimer = true, $hideMetricsDoc = false, $idSubtable = false, $showRawMetrics = false)
+                                       $showTimer = true, $hideMetricsDoc = false, $idSubtable = false, $showRawMetrics = false,
+                                       $formatMetrics = null)
     {
         $timer = new Timer();
         if (empty($apiParameters)) {
@@ -393,7 +394,6 @@ class ProcessedReport
                                                        'serialize'  => '0',
                                                        'language'   => $language,
                                                        'idSubtable' => $idSubtable,
-                                                       'format_metrics' => $showRawMetrics ? 'bc' : '1',
                                                   ));
 
         if (!empty($segment)) $parameters['segment'] = $segment;
@@ -416,7 +416,7 @@ class ProcessedReport
             throw new Exception("API returned an error: " . $e->getMessage() . " at " . basename($e->getFile()) . ":" . $e->getLine() . "\n");
         }
 
-        list($newReport, $columns, $rowsMetadata, $totals) = $this->handleTableReport($idSite, $dataTable, $reportMetadata, $showRawMetrics);
+        list($newReport, $columns, $rowsMetadata, $totals) = $this->handleTableReport($idSite, $dataTable, $reportMetadata, $showRawMetrics, $formatMetrics);
 
         foreach ($columns as &$name) {
             $name = ucfirst($name);
@@ -454,9 +454,10 @@ class ProcessedReport
      * @param \Piwik\DataTable\Map|\Piwik\DataTable\Simple $dataTable
      * @param array $reportMetadata
      * @param bool $showRawMetrics
+     * @param bool|null $formatMetrics
      * @return array Simple|Set $newReport with human readable format & array $columns list of translated column names & Simple|Set $rowsMetadata
      */
-    private function handleTableReport($idSite, $dataTable, &$reportMetadata, $showRawMetrics = false)
+    private function handleTableReport($idSite, $dataTable, &$reportMetadata, $showRawMetrics = false, $formatMetrics = null)
     {
         $hasDimension = isset($reportMetadata['dimension']);
         $columns = @$reportMetadata['metrics'] ?: array();
@@ -510,7 +511,7 @@ class ProcessedReport
             foreach ($dataTable->getDataTables() as $simpleDataTable) {
                 $this->removeEmptyColumns($columns, $reportMetadata, $simpleDataTable);
 
-                list($enhancedSimpleDataTable, $rowMetadata) = $this->handleSimpleDataTable($idSite, $simpleDataTable, $columns, $hasDimension, $showRawMetrics);
+                list($enhancedSimpleDataTable, $rowMetadata) = $this->handleSimpleDataTable($idSite, $simpleDataTable, $columns, $hasDimension, $showRawMetrics, $formatMetrics);
                 $enhancedSimpleDataTable->setAllTableMetadata($simpleDataTable->getAllTableMetadata());
 
                 $period = $simpleDataTable->getMetadata(DataTableFactory::TABLE_METADATA_PERIOD_INDEX)->getLocalizedLongString();
@@ -521,7 +522,7 @@ class ProcessedReport
             }
         } else {
             $this->removeEmptyColumns($columns, $reportMetadata, $dataTable);
-            list($newReport, $rowsMetadata) = $this->handleSimpleDataTable($idSite, $dataTable, $columns, $hasDimension, $showRawMetrics);
+            list($newReport, $rowsMetadata) = $this->handleSimpleDataTable($idSite, $dataTable, $columns, $hasDimension, $showRawMetrics, $formatMetrics);
 
             $totals = $this->aggregateReportTotalValues($dataTable, $totals);
         }
@@ -635,10 +636,10 @@ class ProcessedReport
      * @param array $metadataColumns
      * @param boolean $hasDimension
      * @param bool $returnRawMetrics If set to true, the original metrics will be returned
-     *
+     * @param bool|null $formatMetrics
      * @return array DataTable $enhancedDataTable filtered metrics with human readable format & Simple $rowsMetadata
      */
-    private function handleSimpleDataTable($idSite, $simpleDataTable, $metadataColumns, $hasDimension, $returnRawMetrics = false)
+    private function handleSimpleDataTable($idSite, $simpleDataTable, $metadataColumns, $hasDimension, $returnRawMetrics = false, $formatMetrics = null)
     {
         // new DataTable to store metadata
         $rowsMetadata = new DataTable();
@@ -668,9 +669,7 @@ class ProcessedReport
 
             foreach ($rowMetrics as $columnName => $columnValue) {
                 // filter metrics according to metadata definition
-                if (isset($metadataColumns[$columnName])
-                    && !$returnRawMetrics
-                ) {
+                if (isset($metadataColumns[$columnName])) {
                     // generate 'human readable' metric values
 
                     // if we handle MultiSites.getAll we do not always have the same idSite but different ones for
@@ -681,10 +680,18 @@ class ProcessedReport
                         $idSiteForRow = (int) $idSiteMetadata;
                     }
 
-                    $prettyValue = self::getPrettyValue($formatter, $idSiteForRow, $columnName, $columnValue, $htmlAllowed = false);
+                    // format metrics manually here to maintain API.getProcessedReport BC if format_metrics query parameter is
+                    // not supplied. TODO: should be removed for 3.0. should only rely on format_metrics query parameter.
+                    if ($formatMetrics === null
+                        || $formatMetrics == 'bc'
+                    ) {
+                        $prettyValue = self::getPrettyValue($formatter, $idSiteForRow, $columnName, $columnValue, $htmlAllowed = false);
+                    } else {
+                        $prettyValue = $columnValue;
+                    }
                     $enhancedRow->addColumn($columnName, $prettyValue);
                 } // For example the Maps Widget requires the raw metrics to do advanced datavis
-                elseif ($returnRawMetrics) {
+                else if ($returnRawMetrics) {
                     if (!isset($columnValue)) {
                         $columnValue = 0;
                     }

--- a/plugins/UserCountryMap/javascripts/visitor-map.js
+++ b/plugins/UserCountryMap/javascripts/visitor-map.js
@@ -155,13 +155,15 @@
                 var val = data[metric] % 1 === 0 || Number(data[metric]) != data[metric] ? data[metric] : data[metric].toFixed(1);
                 if (metric == 'bounce_rate') {
                     val += '%';
+                } else if (metric == 'avg_time_on_site') {
+                    val = new Date(0, 0, 0, val / 3600, val % 3600 / 60, val % 60)
+                        .toTimeString()
+                        .replace(/.*(\d{2}:\d{2}:\d{2}).*/, "$1");
                 }
 
                 var v = _[metric].replace('%s', '<strong>' + val + '</strong>');
 
                 if (val == 1 && metric == 'nb_visits') v = _.one_visit;
-
-                function avgTime(d) { return d['sum_visit_length'] / d['nb_visits']; }
 
                 if (metric.substr(0, 3) == 'nb_' && metric != 'nb_actions_per_visit') {
                     var total;
@@ -606,8 +608,6 @@
             function quantify(d, metric) {
                 if (!metric) metric = $$('.userCountryMapSelectMetrics').val();
                 switch (metric) {
-                    case 'avg_time_on_site':
-                        return d.sum_visit_length / d.nb_visits;
                     default:
                         return d[metric];
                 }

--- a/plugins/UserCountryMap/javascripts/visitor-map.js
+++ b/plugins/UserCountryMap/javascripts/visitor-map.js
@@ -96,7 +96,8 @@
                     apiModule: module,
                     apiAction: action,
                     filter_limit: -1,
-                    limit: -1
+                    limit: -1,
+                    format_metrics: 0
                 });
                 if (countryFilter) {
                     $.extend(params, {
@@ -701,7 +702,7 @@
                     // load data from Piwik API
                     ajax(_reportParams('UserCountry', 'getRegion', UserCountryMap.countriesByIso[iso].iso2))
                         .done(function (data) {
-                            convertBounceRatesToInts(data);
+                            convertBounceRatesToPercents(data);
 
                             loadingComplete();
 
@@ -832,7 +833,7 @@
                     // get visits per city from API
                     ajax(_reportParams('UserCountry', 'getCity', UserCountryMap.countriesByIso[iso].iso2))
                         .done(function (data) {
-                            convertBounceRatesToInts(data);
+                            convertBounceRatesToPercents(data);
 
                             loadingComplete();
 
@@ -1125,7 +1126,7 @@
             // now load the metrics for all countries
             ajax(_reportParams('UserCountry', 'getCountry'))
                 .done(function (report) {
-                    convertBounceRatesToInts(report);
+                    convertBounceRatesToPercents(report);
 
                     var metrics = $$('.userCountryMapSelectMetrics option');
                     var countryData = [], countrySelect = $$('.userCountryMapSelectCountry'),
@@ -1226,11 +1227,11 @@
             $$('.widgetUserCountryMapvisitorMap .widgetName span').remove();
             $$('.widgetUserCountryMapvisitorMap .widgetName').append('<span class="map-title"></span>');
 
-            // converts bounce rate percents to strings, eg, 12% => 12
-            function convertBounceRatesToInts(report) {
+            // converts bounce rate quotients to numeric percents, eg, .12 => 12
+            function convertBounceRatesToPercents(report) {
                 $.each(report.reportData, function (i, row) {
                     if (row['bounce_rate']) {
-                        row['bounce_rate'] = parseInt(row['bounce_rate']);
+                        row['bounce_rate'] = parseFloat(row['bounce_rate']) * 100;
                     }
                 });
             }

--- a/tests/PHPUnit/Framework/TestCase/ConsoleCommandTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/ConsoleCommandTestCase.php
@@ -75,7 +75,7 @@ class ConsoleCommandTestCase extends SystemTestCase
     {
         parent::setUp();
 
-        $this->application = new TestConsole();
+        $this->application = new TestConsole(self::$fixture->piwikEnvironment);
         $this->application->setAutoExit(false);
 
         $this->applicationTester = new ApplicationTester($this->application);

--- a/tests/UI/specs/VisitorMap_spec.js
+++ b/tests/UI/specs/VisitorMap_spec.js
@@ -1,0 +1,34 @@
+/*!
+ * Piwik - free/libre analytics platform
+ *
+ * Visitor Map screenshot tests.
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe("VisitorMap", function () {
+    this.timeout(0);
+
+    var url = "?module=Widgetize&action=iframe&moduleToWidgetize=UserCountryMap&idSite=1&period=year&date=2012-08-09&"
+        + "actionToWidgetize=visitorMap&viewDataTable=table&filter_limit=5&isFooterExpandedInDashboard=1";
+
+    it("should display the bounce rate metric correctly", function (done) {
+        expect.screenshot('bounce_rate').to.be.capture(function (page) {
+            page.load(url);
+            page.evaluate(function () {
+                $('.userCountryMapSelectMetrics').val('bounce_rate').trigger('change');
+            });
+            page.mouseMove('.UserCountryMap_map.kartograph');
+        }, done);
+    });
+
+    it("should display the average time on site metric correctly", function (done) {
+        expect.screenshot('avg_time_on_site').to.be.capture(function (page) {
+            page.evaluate(function () {
+                $('.userCountryMapSelectMetrics').val('avg_time_on_site').trigger('change');
+            });
+            page.mouseMove('.UserCountryMap_map.kartograph');
+        }, done);
+    });
+});


### PR DESCRIPTION
As title.

Use bounce_rate metric directly in visitor map instead of… calculating using bounce_count (which has to manually requested), and correctly format bounce_rate values in the legend. Also, use avg_time_on_site metric directly, and format in JS properly.

Also includes a bug fix in Request.php: if `format_metrics=0` is supplied, it will be overwritten to `format_metrics=bc`, because `if (empty($request['format_metrics']))` is used, instead of `isset`.

To use unformatted (but computed) processed metrics in the visitor map, the code now formats the code itself in JS, at least for bounce_rate + avg_time_on_site. Bounce rate must be multiplied by 100. Average time on site just has to convert to a time string when being displayed.

Best to review commit by commit, paying attention to commit messages.
