### PR TITLE
More flat UI tweaks

### DIFF
--- a/plugins/CoreAdminHome/stylesheets/menu.less
+++ b/plugins/CoreAdminHome/stylesheets/menu.less
@@ -19,7 +19,7 @@
     padding-left: 5px;
     margin-bottom: 0;
     margin-top: 0.1em;
-    border: 1px solid #ddd;
+    border: 1px solid @theme-color-background-lowContrast;
     border-radius: 5px;
     border-left: 0px;
 }

--- a/plugins/CoreHome/angularjs/siteselector/siteselector.directive.less
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.directive.less
@@ -40,7 +40,7 @@ table.dataTable tr td .sites_autocomplete a {
   position: relative;
   z-index: 19;
   background: @theme-color-background-base url(plugins/Morpheus/images/sites_selection.png) repeat-x 0 0;
-  border: 1px solid #d4d4d4;
+  border: 1px solid @color-silver-l85;
   color: #255792;
   border-radius: 4px;
   cursor: pointer;

--- a/plugins/Dashboard/stylesheets/dashboard.less
+++ b/plugins/Dashboard/stylesheets/dashboard.less
@@ -18,7 +18,7 @@
   }
 
   .top_controls #periodString,
-  .top_controls .dashboardSettings,  
+  .top_controls .dashboardSettings,
   .top_controls .segmentEditorPanel {
     position: static !important;
     margin: 0 0 10px;

--- a/plugins/LeftMenu/stylesheets/theme.less
+++ b/plugins/LeftMenu/stylesheets/theme.less
@@ -11,7 +11,7 @@
       margin-left: 5px;
       margin-bottom: 0;
       margin-top: 0.1em;
-      border: 1px solid #ddd;
+      border: 1px solid @theme-color-background-lowContrast;
       border-radius: 5px;
     }
   }

--- a/plugins/Morpheus/stylesheets/general/_admin.less
+++ b/plugins/Morpheus/stylesheets/general/_admin.less
@@ -1,7 +1,7 @@
 .Menu--admin {
     .Menu-tabList {
         .border-radius(0px);
-        border-color: @color-gray;
+        border-color: @theme-color-background-lowContrast;
         background-image: none;
         padding-left: 0;
         border-top: 0;
@@ -13,8 +13,8 @@
             > span {
                 color: @theme-color-text;
                 .font-default(18px, 26px);
-                border-top: 1px solid @color-gray;
-                border-bottom: 1px solid @color-gray;
+                border-top: 1px solid @theme-color-background-lowContrast;
+                border-bottom: 1px solid @theme-color-background-lowContrast;
                 padding: 12px 15px;
             }
             ul {

--- a/plugins/Morpheus/stylesheets/general/_form.less
+++ b/plugins/Morpheus/stylesheets/general/_form.less
@@ -68,6 +68,14 @@ table.entityTable {
       }
     }
   }
+
+  tr {
+    td {
+      padding-top: 10px;
+      padding-bottom: 10px;
+      padding-left: 10px;
+    }
+  }
 }
 
 .entityTable tr td.first, .entityTable tr th.first {

--- a/plugins/Morpheus/stylesheets/main.less
+++ b/plugins/Morpheus/stylesheets/main.less
@@ -101,8 +101,8 @@ table.entityTable tr td a:hover {
     }
 
     .Menu--dashboard {
-        border-top: 1px solid @color-silver-l80;
-        border-bottom: 1px solid @color-silver-l80;
+        border-top: 1px solid @theme-color-background-lowContrast;
+        border-bottom: 1px solid @theme-color-background-lowContrast;
         > .Menu-tabList {
             margin: 0;
             a {
@@ -113,7 +113,7 @@ table.entityTable tr td a:hover {
                 .border-radius(0px);
                 border: 0;
                 background: none;
-                border-right: 1px solid @color-silver-l80;
+                border-right: 1px solid @theme-color-background-lowContrast;
                 margin-bottom: -1px;
                 border-bottom: 1px solid #ccc;
 
@@ -550,7 +550,7 @@ table.dataTable .dataTableRowActions {
 
 .dataTableFooterIcons {
   padding: 6px 8px 0px;
-  border-top: 1px solid @color-silver-l80;
+  border-top: 1px solid @color-silver-l90;
 }
 
 div.sparkline {

--- a/plugins/Morpheus/stylesheets/main.less
+++ b/plugins/Morpheus/stylesheets/main.less
@@ -169,7 +169,7 @@ table.entityTable tr td a:hover {
         background: @theme-color-menu-contrast-background;
         min-height: 57px;
         .border-radius(0px);
-        border-color: @color-silver-l80 !important;
+        border-color: @theme-color-background-lowContrast !important;
         border-top: 0px !important;
         border-right: 0px !important;
         border-left: 0px !important;

--- a/plugins/Morpheus/stylesheets/theme-advanced.less
+++ b/plugins/Morpheus/stylesheets/theme-advanced.less
@@ -1,6 +1,6 @@
 @theme-color-background-base:          #fff;
 @theme-color-background-tinyContrast:  #f2f2f2;
-@theme-color-background-lowContrast:   @color-silver-l80;
+@theme-color-background-lowContrast:   @color-silver-l85;
 @theme-color-background-contrast:      #5F5A60;
 @theme-color-background-highContrast:  #202020;
 

--- a/plugins/Morpheus/stylesheets/ui/_components.less
+++ b/plugins/Morpheus/stylesheets/ui/_components.less
@@ -207,7 +207,7 @@
 }
 
 #header_message {
-    border: 1px solid @color-silver-l80;
+    border: 1px solid @theme-color-background-lowContrast;
     padding: 8px 10px 8px 10px;
     height: auto;
     background: @theme-color-background-base;

--- a/plugins/Morpheus/stylesheets/uibase/_header.less
+++ b/plugins/Morpheus/stylesheets/uibase/_header.less
@@ -52,7 +52,7 @@
   right: 0px;
   position: absolute;
   padding-left: 110px;
-  color: #9c9c9c;
+  color: #acacac;
   margin: 4px 10px 8px;
   font-size: 13px;
   z-index: 140;


### PR DESCRIPTION
We're using many different border colors and changed the border color of some components like Menu, Site Selector to be a bit lighter (looks nicer IMO) and more consistent with the other border colors. To see the differences you need to checkout the branch or try to see the difference by switching between processed and expected screenshot.
- Flatter menu eg see http://builds-artifacts.piwik.org/ui-tests.flatten_ui/13616.7/Menus_admin_loaded http://builds-artifacts.piwik.org/ui-tests.flatten_ui/13616.7/Menus_mainmenu_loaded
- Date range, Segment filter, Widgets & Dashboard http://builds-artifacts.piwik.org/ui-tests.flatten_ui/13616.7/UIIntegrationTest_dashboard1
- Top menu separator http://builds-artifacts.piwik.org/ui-tests.flatten_ui/13616.7/SimpleUITest_simplePage

I also fixed one issue with spacing see eg http://builds-artifacts.piwik.org/ui-tests.flatten_ui/13616.7/UIIntegrationTest_admin_manage_users . There was a padding-top/bottom missing in entityTables and the text was not aligned correctly (padding-left). I had this change initially while working on #7090 but got lost somehow while making another change...
