### PR TITLE
Remove App-ID setting for mobile apps

### DIFF
--- a/plugins/MobileAppMeasurable/Type.php
+++ b/plugins/MobileAppMeasurable/Type.php
@@ -8,9 +8,6 @@
  */
 namespace Piwik\Plugins\MobileAppMeasurable;
 
-use Piwik\Measurable\MeasurableSetting;
-use Piwik\Measurable\MeasurableSettings;
-
 class Type extends \Piwik\Measurable\Type
 {
     const ID = 'mobileapp';
@@ -19,17 +16,6 @@ class Type extends \Piwik\Measurable\Type
     protected $description = 'MobileAppMeasurable_MobileAppDescription';
     protected $howToSetupUrl = 'http://developer.piwik.org/guides/tracking-api-clients#mobile-sdks';
 
-    public function configureMeasurableSettings(MeasurableSettings $settings)
-    {
-        $appId = new MeasurableSetting('app_id', 'App-ID');
-        $appId->validate = function ($value) {
-            if (strlen($value) > 100) {
-                throw new \Exception('Only 100 characters are allowed');
-            }
-        };
-
-        $settings->addSetting($appId);
-    }
 
 }
 

--- a/plugins/MobileAppMeasurable/config/test.php
+++ b/plugins/MobileAppMeasurable/config/test.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+
+    'Piwik\Plugins\MobileAppMeasurable\Type' => DI\object('Piwik\Plugins\MobileAppMeasurable\tests\Framework\Mock\Type'),
+
+);

--- a/plugins/MobileAppMeasurable/tests/Framework/Mock/Type.php
+++ b/plugins/MobileAppMeasurable/tests/Framework/Mock/Type.php
@@ -1,0 +1,29 @@
+<?php
+/**
+* Piwik - free/libre analytics platform
+*
+* @link http://piwik.org
+* @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+*/
+
+namespace Piwik\Plugins\MobileAppMeasurable\tests\Framework\Mock;
+
+use Piwik\Measurable\MeasurableSetting;
+use Piwik\Measurable\MeasurableSettings;
+use Piwik\Tracker;
+
+class Type extends \Piwik\Plugins\MobileAppMeasurable\Type
+{
+
+    public function configureMeasurableSettings(MeasurableSettings $settings)
+    {
+        $appId = new MeasurableSetting('app_id', 'App-ID');
+        $appId->validate = function ($value) {
+            if (strlen($value) > 100) {
+                throw new \Exception('Only 100 characters are allowed');
+            }
+        };
+
+        $settings->addSetting($appId);
+    }
+}

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\SitesManager\tests\Integration;
 use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Plugins\MobileAppMeasurable;
+use Piwik\Plugins\MobileAppMeasurable\tests\Framework\Mock\Type;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\Plugins\SitesManager\Model;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
@@ -1227,7 +1228,8 @@ class ApiTest extends IntegrationTestCase
     public function provideContainerConfig()
     {
         return array(
-            'Piwik\Access' => new FakeAccess()
+            'Piwik\Access' => new FakeAccess(),
+            'Piwik\Plugins\MobileAppMeasurable\Type' => new Type()
         );
     }
 

--- a/tests/PHPUnit/Integration/Measurable/MeasurableSettingsTest.php
+++ b/tests/PHPUnit/Integration/Measurable/MeasurableSettingsTest.php
@@ -10,6 +10,7 @@ namespace Piwik\Tests\Integration\Measurable;
 
 use Piwik\Db;
 use Piwik\Plugin;
+use Piwik\Plugins\MobileAppMeasurable\tests\Framework\Mock\Type;
 use Piwik\Plugins\MobileAppMeasurable\Type as MobileAppType;
 use Piwik\Measurable\MeasurableSetting;
 use Piwik\Measurable\MeasurableSettings;
@@ -103,7 +104,8 @@ class MeasurableSettingsTest extends IntegrationTestCase
     public function provideContainerConfig()
     {
         return array(
-            'Piwik\Access' => new FakeAccess()
+            'Piwik\Access' => new FakeAccess(),
+            'Piwik\Plugins\MobileAppMeasurable\Type' => new Type()
         );
     }
 }

--- a/tests/PHPUnit/Integration/Measurable/MeasurableTest.php
+++ b/tests/PHPUnit/Integration/Measurable/MeasurableTest.php
@@ -9,6 +9,7 @@
 namespace Piwik\Tests\Integration\Measurable;
 
 use Piwik\Db;
+use Piwik\Plugins\MobileAppMeasurable\tests\Framework\Mock\Type;
 use Piwik\Plugins\MobileAppMeasurable\Type as MobileAppType;
 use Piwik\Plugin;
 use Piwik\Measurable\Measurable;
@@ -84,7 +85,8 @@ class MeasurableTest extends IntegrationTestCase
     public function provideContainerConfig()
     {
         return array(
-            'Piwik\Access' => new FakeAccess()
+            'Piwik\Access' => new FakeAccess(),
+            'Piwik\Plugins\MobileAppMeasurable\Type' => new Type()
         );
     }
 


### PR DESCRIPTION
Was initially done in #8162 but many tests were failing afterwards. 

It's not needed to define an app-id as the app-id can be different for each platform and some might want to track the same app for different platforms under one "Measurable" and use then segmentation.
