### PR TITLE
Explicitly include UI dialog selector as the dialog is not visible otherwise

### DIFF
--- a/tests/UI/specs/MeasurableManager_spec.js
+++ b/tests/UI/specs/MeasurableManager_spec.js
@@ -21,7 +21,7 @@ describe("MeasurableManager", function () {
 
     function assertScreenshotEquals(screenshotName, done, test)
     {
-        expect.screenshot(screenshotName).to.be.captureSelector('.sitesManagerList,.sitesButtonBar,.sites-manager-header', test, done);
+        expect.screenshot(screenshotName).to.be.captureSelector('.sitesManagerList,.sitesButtonBar,.sites-manager-header,.ui-dialog.ui-widget', test, done);
     }
 
     it("should load correctly and should not use SitesManager wording as another type is enabled", function (done) {


### PR DESCRIPTION
Because of the PHP 5.3 message on PhantomJS
