### PR TITLE
Auto-update the referrer spammer blacklist

### DIFF
--- a/core/Tracker/Visit/ReferrerSpamFilter.php
+++ b/core/Tracker/Visit/ReferrerSpamFilter.php
@@ -3,6 +3,7 @@
 namespace Piwik\Tracker\Visit;
 
 use Piwik\Common;
+use Piwik\Option;
 use Piwik\Tracker\Request;
 
 /**
@@ -10,6 +11,7 @@ use Piwik\Tracker\Request;
  */
 class ReferrerSpamFilter
 {
+    const OPTION_STORAGE_NAME = 'referrer_spam_blacklist';
     /**
      * @var string[]
      */
@@ -43,8 +45,16 @@ class ReferrerSpamFilter
             return $this->spammerList;
         }
 
-        $file = PIWIK_INCLUDE_PATH . '/vendor/piwik/referrer-spam-blacklist/spammers.txt';
-        $this->spammerList = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        // Read first from the auto-updated list in database
+        $list = Option::get(self::OPTION_STORAGE_NAME);
+
+        if ($list) {
+            $this->spammerList = unserialize($list);
+        } else {
+            // Fallback to reading the bundled list
+            $file = PIWIK_INCLUDE_PATH . '/vendor/piwik/referrer-spam-blacklist/spammers.txt';
+            $this->spammerList = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        }
 
         return $this->spammerList;
     }

--- a/core/Tracker/Visit/ReferrerSpamFilter.php
+++ b/core/Tracker/Visit/ReferrerSpamFilter.php
@@ -45,9 +45,9 @@ class ReferrerSpamFilter
         $cache = Cache::getEagerCache();
         $cacheId = 'ReferrerSpamFilter-' . self::OPTION_STORAGE_NAME;
 
-        $list = $cache->fetch($cacheId);
-
-        if (! is_array($list)) {
+        if ($cache->contains($cacheId)) {
+            $list = $cache->fetch($cacheId);
+        } else {
             $list = $this->loadSpammerList();
             $cache->save($cacheId, $list);
         }

--- a/core/Tracker/Visit/ReferrerSpamFilter.php
+++ b/core/Tracker/Visit/ReferrerSpamFilter.php
@@ -43,7 +43,7 @@ class ReferrerSpamFilter
     private function getSpammerListFromCache()
     {
         $cache = Cache::getLazyCache();
-        $cacheId = __CLASS__ . '-' . self::OPTION_STORAGE_NAME;
+        $cacheId = 'ReferrerSpamFilter-' . self::OPTION_STORAGE_NAME;
 
         $list = $cache->fetch($cacheId);
 

--- a/core/Tracker/Visit/ReferrerSpamFilter.php
+++ b/core/Tracker/Visit/ReferrerSpamFilter.php
@@ -42,7 +42,7 @@ class ReferrerSpamFilter
 
     private function getSpammerListFromCache()
     {
-        $cache = Cache::getLazyCache();
+        $cache = Cache::getEagerCache();
         $cacheId = 'ReferrerSpamFilter-' . self::OPTION_STORAGE_NAME;
 
         $list = $cache->fetch($cacheId);

--- a/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
+++ b/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
@@ -9,9 +9,11 @@
 
 namespace Piwik\Plugins\CoreAdminHome\Commands;
 
+use Piwik\Container\StaticContainer;
 use Piwik\FrontController;
 use Piwik\Plugin\ConsoleCommand;
-use Piwik\Plugins\CoreAdminHome\API;
+use Piwik\Scheduler\Scheduler;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -20,9 +22,10 @@ class RunScheduledTasks extends ConsoleCommand
 {
     protected function configure()
     {
-        $this->setName('core:run-scheduled-tasks');
-        $this->setAliases(array('scheduled-tasks:run'));
+        $this->setName('scheduled-tasks:run');
+        $this->setAliases(array('core:run-scheduled-tasks'));
         $this->setDescription('Will run all scheduled tasks due to run at this time.');
+        $this->addArgument('task', InputArgument::OPTIONAL, 'Optionally pass the name of a task to run (will run even if not scheduled to run now)');
         $this->addOption('force', null, InputOption::VALUE_NONE, 'If set, it will execute all tasks even the ones not due to run at this time.');
     }
 
@@ -34,7 +37,18 @@ class RunScheduledTasks extends ConsoleCommand
         $this->forceRunAllTasksIfRequested($input);
 
         FrontController::getInstance()->init();
-        API::getInstance()->runScheduledTasks();
+
+        // TODO use dependency injection
+        /** @var Scheduler $scheduler */
+        $scheduler = StaticContainer::get('Piwik\Scheduler\Scheduler');
+
+        $task = $input->getArgument('task');
+
+        if ($task) {
+            $this->runSingleTask($scheduler, $task);
+        } else {
+            $scheduler->run();
+        }
 
         $this->writeSuccessMessage($output, array('Scheduled Tasks executed'));
     }
@@ -45,6 +59,19 @@ class RunScheduledTasks extends ConsoleCommand
 
         if ($force && !defined('DEBUG_FORCE_SCHEDULED_TASKS')) {
             define('DEBUG_FORCE_SCHEDULED_TASKS', true);
+        }
+    }
+
+    private function runSingleTask(Scheduler $scheduler, $task)
+    {
+        try {
+            $scheduler->runTaskNow($task);
+        } catch (\InvalidArgumentException $e) {
+            $message = $e->getMessage() . PHP_EOL
+                . 'Available tasks:' . PHP_EOL
+                . implode(PHP_EOL, $scheduler->getTaskList());
+
+            throw new \Exception($message);
         }
     }
 }

--- a/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
+++ b/plugins/CoreAdminHome/Commands/RunScheduledTasks.php
@@ -45,7 +45,7 @@ class RunScheduledTasks extends ConsoleCommand
         $task = $input->getArgument('task');
 
         if ($task) {
-            $this->runSingleTask($scheduler, $task);
+            $this->runSingleTask($scheduler, $task, $output);
         } else {
             $scheduler->run();
         }
@@ -62,10 +62,10 @@ class RunScheduledTasks extends ConsoleCommand
         }
     }
 
-    private function runSingleTask(Scheduler $scheduler, $task)
+    private function runSingleTask(Scheduler $scheduler, $task, OutputInterface $output)
     {
         try {
-            $scheduler->runTaskNow($task);
+            $message = $scheduler->runTaskNow($task);
         } catch (\InvalidArgumentException $e) {
             $message = $e->getMessage() . PHP_EOL
                 . 'Available tasks:' . PHP_EOL
@@ -73,5 +73,7 @@ class RunScheduledTasks extends ConsoleCommand
 
             throw new \Exception($message);
         }
+
+        $output->writeln($message);
     }
 }

--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -112,7 +112,7 @@ class Tasks extends \Piwik\Plugin\Tasks
     public function updateSpammerBlacklist()
     {
         $url = 'https://raw.githubusercontent.com/piwik/referrer-spam-blacklist/master/spammers.txt';
-        $list = Http::sendHttpRequest($url, 10);
+        $list = Http::sendHttpRequest($url, 30);
         $list = preg_split("/\r\n|\n|\r/", $list);
         Option::set(ReferrerSpamFilter::OPTION_STORAGE_NAME, serialize($list));
     }

--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -114,6 +114,13 @@ class Tasks extends \Piwik\Plugin\Tasks
         $url = 'https://raw.githubusercontent.com/piwik/referrer-spam-blacklist/master/spammers.txt';
         $list = Http::sendHttpRequest($url, 30);
         $list = preg_split("/\r\n|\n|\r/", $list);
+        if (count($list) < 10) {
+            throw new \Exception(sprintf(
+                'The spammers list downloaded from %s contains less than 10 entries, considering it a fail',
+                $url
+            ));
+        }
+
         Option::set(ReferrerSpamFilter::OPTION_STORAGE_NAME, serialize($list));
     }
 

--- a/tests/PHPUnit/Integration/Tracker/Visit/ReferrerSpamFilterTest.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit/ReferrerSpamFilterTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Integration\Tracker\Visit;
 
+use Piwik\Cache;
 use Piwik\Option;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Tracker\Request;
@@ -27,7 +28,16 @@ class ReferrerSpamFilterTest extends IntegrationTestCase
     public function setUp()
     {
         parent::setUp();
+
+        Cache::flushAll();
         $this->filter = new ReferrerSpamFilter;
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Cache::flushAll();
     }
 
     /**

--- a/tests/PHPUnit/Integration/Tracker/Visit/ReferrerSpamFilterTest.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit/ReferrerSpamFilterTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Tracker\Visit;
+
+use Piwik\Option;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\Visit\ReferrerSpamFilter;
+
+/**
+ * @group Tracker
+ * @group Visit
+ */
+class ReferrerSpamFilterTest extends IntegrationTestCase
+{
+    /**
+     * @var ReferrerSpamFilter
+     */
+    private $filter;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->filter = new ReferrerSpamFilter;
+    }
+
+    /**
+     * @test
+     */
+    public function should_detect_spam()
+    {
+        $request = new Request(array(
+            'urlref' => 'semalt.com',
+        ));
+
+        $this->assertTrue($this->filter->isSpam($request));
+    }
+
+    /**
+     * @test
+     */
+    public function should_ignore_valid_referrers()
+    {
+        $request = new Request(array(
+            'urlref' => 'google.com',
+        ));
+
+        $this->assertFalse($this->filter->isSpam($request));
+    }
+
+    /**
+     * @test
+     */
+    public function should_ignore_requests_with_empty_referrers()
+    {
+        $request = new Request(array());
+
+        $this->assertFalse($this->filter->isSpam($request));
+    }
+
+    /**
+     * @test
+     */
+    public function should_load_spammer_list_from_options_if_exists()
+    {
+        // We store google.com in the spammer blacklist
+        $list = serialize(array(
+            'google.com',
+        ));
+        Option::set(ReferrerSpamFilter::OPTION_STORAGE_NAME, $list);
+
+        $request = new Request(array(
+            'urlref' => 'semalt.com',
+        ));
+        $this->assertFalse($this->filter->isSpam($request));
+
+        // Now Google is blacklisted
+        $request = new Request(array(
+            'urlref' => 'google.com',
+        ));
+        $this->assertTrue($this->filter->isSpam($request));
+
+        Option::delete(ReferrerSpamFilter::OPTION_STORAGE_NAME);
+    }
+}


### PR DESCRIPTION
Fixes #7674

Auto-update the list from [piwik/referrer-spam-blacklist](https://github.com/piwik/referrer-spam-blacklist) (full URL is https://raw.githubusercontent.com/piwik/referrer-spam-blacklist/master/spammers.txt).

The up-to-date list is stored serialized in the `option` table. If it doesn't exist, the one in `vendor/` is used.

I also added the possibility to run a specific scheduled task, which is pretty useful to test it:

``` bash
./console scheduled-tasks:run "Piwik\Plugins\CoreAdminHome\Tasks.updateSpammerBlacklist"
```
