### PR TITLE
Use a card like design in dashboard

### DIFF
--- a/plugins/Dashboard/stylesheets/dashboard.less
+++ b/plugins/Dashboard/stylesheets/dashboard.less
@@ -34,7 +34,7 @@
     padding-left: 7px;
 
     >.sortable {
-      padding: 5px 0;
+      padding: 5px 0 10px 0;
     }
   }
 }

--- a/plugins/Dashboard/stylesheets/widget.less
+++ b/plugins/Dashboard/stylesheets/widget.less
@@ -2,7 +2,6 @@
     .font-default(13px, 18px);
     background: @theme-color-background-base;
     border: 1px solid @color-silver-l85;
-    .border-radius();
     box-shadow: 0 1px 1px rgba(204,204,204,.5);
     overflow: hidden;
     z-index: 1;
@@ -39,7 +38,6 @@
         font-weight: normal;
         padding-bottom: 4px;
         background: @theme-color-widget-title-background;
-        border-bottom: 1px solid @color-silver-l85;
         h3 {
             .font-default(15px, 18px);
             color: @theme-color-widget-title-text;

--- a/plugins/Morpheus/stylesheets/general/_form.less
+++ b/plugins/Morpheus/stylesheets/general/_form.less
@@ -71,9 +71,7 @@ table.entityTable {
 
   tr {
     td {
-      padding-top: 10px;
-      padding-bottom: 10px;
-      padding-left: 10px;
+      padding:10px;
     }
   }
 }

--- a/plugins/Morpheus/stylesheets/general/_form.less
+++ b/plugins/Morpheus/stylesheets/general/_form.less
@@ -45,7 +45,9 @@
 
 /* Add / Edit / List entities */
 .entityContainer {
-  width: 800px;
+  width: 100%;
+  max-width: 850px;
+  min-width: 600px;
   font-size: 14px;
 }
 

--- a/plugins/Morpheus/stylesheets/main.less
+++ b/plugins/Morpheus/stylesheets/main.less
@@ -102,7 +102,7 @@ table.entityTable tr td a:hover {
 
     .Menu--dashboard {
         border-top: 1px solid @theme-color-background-lowContrast;
-        border-bottom: 1px solid @theme-color-background-lowContrast;
+        border-bottom: 0px;
         > .Menu-tabList {
             margin: 0;
             a {
@@ -115,7 +115,7 @@ table.entityTable tr td a:hover {
                 background: none;
                 border-right: 1px solid @theme-color-background-lowContrast;
                 margin-bottom: -1px;
-                border-bottom: 1px solid #ccc;
+                border-bottom: 0px;
 
                 > ul {
                     li {

--- a/plugins/UsersManager/templates/index.twig
+++ b/plugins/UsersManager/templates/index.twig
@@ -38,7 +38,7 @@
             {{ ['UsersManager_AnonymousUserHasViewAccess'|translate("'anonymous'","'view'"), 'UsersManager_AnonymousUserHasViewAccess2'|translate]|join(' ') }}
         </div>
     {% endif %}
-    <table class="entityTable dataTable" id="access" style="display:inline-table;width:500px;">
+    <table class="entityTable dataTable" id="access" style="display:inline-table;width:550px;">
         <thead>
         <tr>
             <th class='first'>{{ 'UsersManager_User'|translate }}</th>


### PR DESCRIPTION
I find the dashboard widgets look a bit old fashioned mainly because of the huge border-radius. Now that we use card design in visitor log and sites manager we could also make the dashboard look a bit like the card design (without the outer shadow as it seems to be too much for now)
