### PR TITLE
Piwik logo on IE9 is misplaced

### DIFF
--- a/plugins/Morpheus/stylesheets/uibase/_header.less
+++ b/plugins/Morpheus/stylesheets/uibase/_header.less
@@ -29,8 +29,14 @@
   #logo > a {
     text-decoration: none;
   }
+  
+  #logo {
+    // IE 9 only
+    width: 200px\9\0;
+  }
 }
 
+// IE 10+
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   #root #logo {
     width: 80px;


### PR DESCRIPTION
fixes #8190 

Tested IE8 + 9 + 10 with default logo and custom logo. Seems to work.
