### PR TITLE
Update look of boxes for consistency (ErrorHandler, Updater, ...)

### DIFF
--- a/plugins/Morpheus/stylesheets/simple_structure.css
+++ b/plugins/Morpheus/stylesheets/simple_structure.css
@@ -21,8 +21,6 @@ body#simple  {
     max-width: 780px;
     margin: 30px auto 60px auto;
     overflow: hidden;
-    -webkit-box-shadow: 0 1px 6px 0 #ccc;
-    -moz-box-shadow: 0 1px 6px 0 #ccc;
     box-shadow: 0 1px 6px 0 #ccc;
 }
 

--- a/plugins/Morpheus/stylesheets/simple_structure.css
+++ b/plugins/Morpheus/stylesheets/simple_structure.css
@@ -16,7 +16,6 @@ body#simple  {
 	text-decoration: none;
 }
 #simple .box {
-    border-radius: 12px;
     border: solid 1px #ccc;
     max-width: 780px;
     margin: 30px auto 60px auto;

--- a/plugins/Morpheus/stylesheets/simple_structure.css
+++ b/plugins/Morpheus/stylesheets/simple_structure.css
@@ -16,16 +16,18 @@ body#simple  {
 	text-decoration: none;
 }
 #simple .box {
+    border-radius: 2px;	
     border: solid 1px #ccc;
     max-width: 780px;
     margin: 30px auto 60px auto;
     overflow: hidden;
-    box-shadow: 0 1px 2px 0 #ccc;
+    -webkit-box-shadow: 0 1px 6px 0 #ccc;
+    -moz-box-shadow: 0 1px 6px 0 #ccc;
+    box-shadow: 0 1px 6px 0 #ccc;
 }
 
 #simple .box .header {
     background-color: #f0f0f0;
-    border-bottom: solid 1px #ccc;
 	padding: 40px 80px;
     text-align: center;
 }
@@ -78,7 +80,6 @@ body#simple  {
 
 #simple .box .footer {
     background-color: #f0f0f0;
-    border-top: solid 1px #ccc;
     padding: 15px;
     text-align: center;
 }


### PR DESCRIPTION
We removed the border-radius and another border from the widgets in dashboard and also started using the card design in some places so thought might be consistent to use no border there as well

UI tests: http://builds-artifacts.piwik.org/ui-tests.no_border_radius_in_boxes/13715.7/

eg

http://builds-artifacts.piwik.org/ui-tests.no_border_radius_in_boxes/13715.7/CoreUpdaterDb_updated
http://builds-artifacts.piwik.org/ui-tests.no_border_radius_in_boxes/13715.7/UIIntegrationTest_db_connect_error
http://builds-artifacts.piwik.org/ui-tests.no_border_radius_in_boxes/13715.7/UIIntegrationTest_widgetize_apidisallowed

FYI: I noticed there is the background-color #f0f0f0 used but in Piwik itself we often use #f2f2f2. I didn't change it as I thought this color might be used in the future instead
