### PR TITLE
Make Access::loadSitesIfNeeded() method protected so UserGroups can override it

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -202,7 +202,7 @@ class Access
         }
     }
 
-    private function loadSitesIfNeeded()
+    protected function loadSitesIfNeeded()
     {
         if ($this->hasSuperUserAccess) {
             if (empty($this->idsitesByAccess['superuser'])) {


### PR DESCRIPTION
In https://github.com/piwik/piwik/pull/7641 site access loading was changed to use lazy loading. This causes the UserGroups plugin to break, since it adds/changes access levels in `reloadAccess()`. To properly change access levels, we have to make the `loadSitesIfNeeded()` protected.

It's possible to modify access levels w/o this, but that requires calling the getSitesIdWith... methods before changing access, then calling the method again. This is, however, not as performant, since the `array_unique/array_merge` methods will be called twice.

CC @tsteur Will merge it now, but feel free to let me know if there's an issue.
