### PR TITLE
Replaced inline style with stylesheet in add email report form

### DIFF
--- a/plugins/ScheduledReports/stylesheets/scheduledreports.less
+++ b/plugins/ScheduledReports/stylesheets/scheduledreports.less
@@ -3,3 +3,9 @@
     padding-top: 16px;
   }
 }
+
+#report_hour {
+  height: 0.9em;
+  padding: 0 0 0 5px;
+  width: 35px;
+}

--- a/plugins/ScheduledReports/templates/_addReport.twig
+++ b/plugins/ScheduledReports/templates/_addReport.twig
@@ -60,7 +60,7 @@
                         {{ 'ScheduledReports_MonthlyScheduleHelp'|translate }}
                         <br/>
                         {{ 'ScheduledReports_ReportHour'|translate }}
-                        <input type="text" style="height: 0.9em;padding-left: 5px;width: 35px;padding-top:0px;padding-bottom:0px;" id="report_hour" class="inp" size="2">
+                        <input type="text" id="report_hour" class="inp" size="2">
                         {{ 'ScheduledReports_OClock'|translate }}
                     </div>
                 </td>


### PR DESCRIPTION
Why using inline style when we have an id anyway?
I removed the style attribute and moved the content to the scheduledreports.less.
