### PR TITLE
Use translated plugin description if available

### DIFF
--- a/core/Plugin/MetadataLoader.php
+++ b/core/Plugin/MetadataLoader.php
@@ -49,9 +49,17 @@ class MetadataLoader
      */
     public function load()
     {
+        $defaults = $this->getDefaultPluginInformation();
+        $plugin   = $this->loadPluginInfoJson();
+
+        // use translated plugin description if available
+        if ($defaults['description'] != Piwik::translate($defaults['description'])) {
+            unset($plugin['description']);
+        }
+
         return array_merge(
-            $this->getDefaultPluginInformation(),
-            $this->loadPluginInfoJson()
+            $defaults,
+            $plugin
         );
     }
 


### PR DESCRIPTION
Currently the plugin description will always be taken from plugin.json even if a translated description is available in the plugin translation files.

This small change allows to "overwrite" the description defined in plugin.json within the translation file.
