### PR TITLE
Ping=1 requests tweaks 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
 
 ### New features 
 * The JavaScript Tracker does now track outlinks and downloads if a user opens the context menu if the `enabled` parameter of the `enableLinkTracking()` method is set to `true`. To use this new feature use `tracker.enableLinkTracking(true)` or `_paq.push(['enableLinkTracking', true]);`. This is not industry standard and is vulnerable to false positives since not every user will select "Open in a new tab" when the context menu is shown. Most users will do though and it will lead to more accurate results in most cases.
-* The JavaScript Tracker now contains the 'heart beat' feature which can be used to obtain more accurate visit lengths by periodically sending 'ping' requests to Piwik. To use this feature use `tracker.setHeartBeatTimer();` or `_paq.push(['enableHeartBeatTimer']);`. By default, a ping request will be sent every 15 seconds. You can specify a custom time by passing an argument, eg, `tracker.enableHeartBeatTimer(10);` or `_paq.push(['enableHeartBeatTimer', 10]);`.
+* The JavaScript Tracker now contains the 'heart beat' feature which can be used to obtain more accurate visit lengths by periodically sending 'ping' requests to Piwik. To use this feature use `tracker.enableHeartBeatTimer();` or `_paq.push(['enableHeartBeatTimer']);`. By default, a ping request will be sent every 15 seconds. You can specify a custom ping delay (in seconds) by passing an argument, eg, `tracker.enableHeartBeatTimer(10);` or `_paq.push(['enableHeartBeatTimer', 10]);`.
 
 ### Library updates
 * Updated pChart library from 2.1.3 to 2.1.4. The files were moved from the directory `libs/pChart2.1.3` to `libs/pChart`

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -170,6 +170,7 @@ class Visit implements VisitInterface
 
         $isNewVisit = $this->isVisitNew($visitor, $action);
 
+
         // Known visit when:
         // ( - the visitor has the Piwik cookie with the idcookie ID used by Piwik to match the visitor
         //   OR
@@ -212,18 +213,18 @@ class Visit implements VisitInterface
             }
         }
 
+        // When a ping request is received more than 30 min after the last request/ping,
+        // we choose not to create a new visit.
+        if ($isNewVisit && $this->isPingRequest()) {
+            Common::printDebug("-> ping=1 request: we do _not_ create a new visit.");
+            return;
+        }
+
         // New visit when:
         // - the visitor has the Piwik cookie but the last action was performed more than 30 min ago @see isLastActionInTheSameVisit()
         // - the visitor doesn't have the Piwik cookie, and couldn't be matched in @see recognizeTheVisitor()
         // - the visitor does have the Piwik cookie but the idcookie and idvisit found in the cookie didn't match to any existing visit in the DB
         if ($isNewVisit) {
-
-            // When a ping request is received more than 30 min after the last request/ping,
-            // we choose not to create a new visit.
-            if ($this->isPingRequest()) {
-                Common::printDebug("-> ping=1 request: we do _not_ create a new visit.");
-                return;
-            }
 
             $this->handleNewVisit($visitor, $action, $visitIsConverted);
             if (!is_null($action)) {

--- a/core/Tracker/Visit/ReferrerSpamFilter.php
+++ b/core/Tracker/Visit/ReferrerSpamFilter.php
@@ -31,7 +31,7 @@ class ReferrerSpamFilter
         $referrerUrl = $request->getParam('urlref');
 
         foreach ($spammers as $spammerHost) {
-            if (strpos($referrerUrl, $spammerHost) !== false) {
+            if (stripos($referrerUrl, $spammerHost) !== false) {
                 Common::printDebug('Referrer URL is a known spam: ' . $spammerHost);
                 return true;
             }

--- a/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_day.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -120,8 +120,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_month.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_month.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -120,8 +120,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/Contents/tests/System/expected/test_Contents_contentInteractionMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_contentInteractionMatch__Live.getLastVisitsDetails_day.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -120,8 +120,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/Contents/tests/System/expected/test_Contents_contentTargetMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_contentTargetMatch__Live.getLastVisitsDetails_day.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -120,8 +120,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/Contents/tests/System/expected/test_ContentscontentNameOrPieceMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_ContentscontentNameOrPieceMatch__Live.getLastVisitsDetails_day.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -120,8 +120,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
+				<timeSpent>270</timeSpent>
+				<timeSpentPretty>4 min 30s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/SegmentEditor/stylesheets/segmentation.less
+++ b/plugins/SegmentEditor/stylesheets/segmentation.less
@@ -519,7 +519,7 @@ div.scrollable {
 }
 
 .segmentEditorPanel.visible .segmentFilterContainer > input[type="text"] {
-    font: 13px Verdana;
+    font-size: 13px;
     width: 100%;
     padding: 0;
     border: 1px solid #ccc;

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -116,7 +116,7 @@ Will pre-process for website id = 1, period = month, date = last%s
 - skipping segment archiving for 'actions>=4'.
 - pre-processing segment 1/1 actions>=2
 Archived website id = 1, period = month, 1 segments, 1 visits in last %s months, 1 visits this month, Time elapsed: %s
-Will pre-process for website id = 1, period = year, date = last%s`
+Will pre-process for website id = 1, period = year, date = last%s
 - pre-processing all visits
 - skipping segment archiving for 'actions>=4'.
 - pre-processing segment 1/1 actions>=2

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -101,22 +101,22 @@ NOTES
 ---------------------------
 START
 Starting Piwik reports archiving...
-Will pre-process for website id = 1, period = day, date = last52
+Will pre-process for website id = 1, period = day, date = last%s
 - pre-processing all visits
 - skipping segment archiving for 'actions>=4'.
 - pre-processing segment 1/1 actions>=2
 Archived website id = 1, period = day, 1 segments, 0 visits in last %s days, 0 visits today, Time elapsed: %s
-Will pre-process for website id = 1, period = week, date = last198
+Will pre-process for website id = 1, period = week, date = last%s
 - pre-processing all visits
 - skipping segment archiving for 'actions>=4'.
 - pre-processing segment 1/1 actions>=2
 Archived website id = 1, period = week, 1 segments, 1 visits in last %s weeks, 1 visits this week, Time elapsed: %s
-Will pre-process for website id = 1, period = month, date = last52
+Will pre-process for website id = 1, period = month, date = last%s
 - pre-processing all visits
 - skipping segment archiving for 'actions>=4'.
 - pre-processing segment 1/1 actions>=2
 Archived website id = 1, period = month, 1 segments, 1 visits in last %s months, 1 visits this month, Time elapsed: %s
-Will pre-process for website id = 1, period = year, date = last7
+Will pre-process for website id = 1, period = year, date = last%s`
 - pre-processing all visits
 - skipping segment archiving for 'actions>=4'.
 - pre-processing segment 1/1 actions>=2

--- a/tests/PHPUnit/Integration/Tracker/PingRequestTest.php
+++ b/tests/PHPUnit/Integration/Tracker/PingRequestTest.php
@@ -77,7 +77,8 @@ class PingRequestTest extends IntegrationTestCase
 
         // send a ping request within 30 minutes
         $pingTime = '2012-01-05 00:20:00';
-        // force trigger a goal
+
+        // force trigger a goal within the ping request
         $tracker->setDebugStringAppend('&idgoal=1');
         $this->doPingRequest($tracker, $pingTime, $setNewDimensionValues = true);
 

--- a/tests/PHPUnit/Integration/Tracker/PingRequestTest.php
+++ b/tests/PHPUnit/Integration/Tracker/PingRequestTest.php
@@ -64,7 +64,7 @@ class PingRequestTest extends IntegrationTestCase
         $this->assertInitialVisitIsExtended($pingTime, self::FIRST_VISIT_TIME, $checkModifiedDimensions = true);
     }
 
-    public function test_PingAfterThirtyMinutes_CreatesNewVisit_AndCreatesNewAction()
+    public function test_PingAfterThirtyMinutes_DoesNotCreateNewVisit()
     {
         $tracker = $this->getTracker();
 
@@ -77,10 +77,10 @@ class PingRequestTest extends IntegrationTestCase
         $pingTime = '2012-01-05 00:40:00';
         $this->doPingRequest($tracker, $pingTime, $setNewDimensionValues = false);
 
-        $this->assertPingCreatedNewVisit(self::FIRST_VISIT_TIME, $pingTime, $checkModifiedDimensions = false);
+        $this->assertPingDidNotCreateNewVisit(self::FIRST_VISIT_TIME, $checkModifiedDimensions = false);
     }
 
-    public function test_PingAfterThirtyMinutes_AndChangedDimensionValues_CreatesNewVisit_AndUsesNewDimensionValues()
+    public function test_PingAfterThirtyMinutes_AndChangedDimensionValues_DoesNotCreateNewVisit()
     {
         $tracker = $this->getTracker();
 
@@ -93,7 +93,7 @@ class PingRequestTest extends IntegrationTestCase
         $pingTime = '2012-01-05 00:40:00';
         $this->doPingRequest($tracker, $pingTime, $setNewDimensionValues = true);
 
-        $this->assertPingCreatedNewVisit(self::FIRST_VISIT_TIME, $pingTime, $checkModifiedDimensions = true);
+        $this->assertPingDidNotCreateNewVisit(self::FIRST_VISIT_TIME, $checkModifiedDimensions = true);
     }
 
     private function getTracker()
@@ -214,28 +214,16 @@ class PingRequestTest extends IntegrationTestCase
         $this->assertEquals(self::CHANGED_REGION, $region);
     }
 
-    private function assertPingCreatedNewVisit($expectedFirstVisitTime, $newVisitTime, $checkPropertiesModified)
+    private function assertPingDidNotCreateNewVisit($expectedFirstVisitTime, $checkPropertiesModified)
     {
-        $this->assertVisitCount(2);
-        $this->assertActionCount(2);
+        $this->assertVisitCount(1);
+        $this->assertActionCount(1);
 
         $firstVisitEndTime = $this->getVisitLastActionTime($idVisit = 1);
         $this->assertEquals($expectedFirstVisitTime, $firstVisitEndTime);
 
         $firstVisitActionTime = $this->getLatestActionTime($idVisit = 1);
         $this->assertEquals($expectedFirstVisitTime, $firstVisitActionTime);
-
-        $secondVisitEndTime = $this->getVisitLastActionTime($idVisit = 2);
-        $this->assertEquals($newVisitTime, $secondVisitEndTime);
-
-        $secondVisitActionTime = $this->getLatestActionTime($idVisit = 2);
-        $this->assertEquals($newVisitTime, $secondVisitActionTime);
-
-        if ($checkPropertiesModified) {
-            $this->assertVisitPropertiesAreChanged($idVisit = 2, $checkUnchangeable = true);
-        } else {
-            $this->assertVisitPropertiesAreUnchanged($idVisit = 2);
-        }
     }
 
     protected static function configureFixture($fixture)

--- a/tests/PHPUnit/System/expected/test_OneVisitor_NoKeywordSpecified__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitor_NoKeywordSpecified__Live.getLastVisitsDetails_day.xml
@@ -116,6 +116,8 @@
 				<pageIdAction>2</pageIdAction>
 				
 				<pageId>1</pageId>
+				<timeSpent>1080</timeSpent>
+				<timeSpentPretty>18 min 0s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__Live.getLastVisitsDetails_month.xml
@@ -154,6 +154,8 @@
 				<pageIdAction>10</pageIdAction>
 				<serverTimePretty>Sat 6 Mar 16:28:33</serverTimePretty>
 				<pageId>9</pageId>
+				<timeSpent>720</timeSpent>
+				<timeSpentPretty>12 min 0s</timeSpentPretty>
 				<icon />
 				<timestamp>1267892913</timestamp>
 			</row>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_LiveEcommerceStatusOrdered__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_LiveEcommerceStatusOrdered__Live.getLastVisitsDetails_day.xml
@@ -229,6 +229,8 @@
 						<customVariablePageValue5>Category TWO LEFT in cart</customVariablePageValue5>
 					</row>
 				</customVariables>
+				<timeSpent>360</timeSpent>
+				<timeSpentPretty>6 min 0s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Live.getLastVisitsDetails_day.xml
@@ -87,6 +87,8 @@
 						<customVariablePageValue5>Category TWO LEFT in cart</customVariablePageValue5>
 					</row>
 				</customVariables>
+				<timeSpent>360</timeSpent>
+				<timeSpentPretty>6 min 0s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -431,6 +433,8 @@
 						<customVariablePageValue5>Category TWO LEFT in cart</customVariablePageValue5>
 					</row>
 				</customVariables>
+				<timeSpent>360</timeSpent>
+				<timeSpentPretty>6 min 0s</timeSpentPretty>
 				<icon />
 				
 			</row>


### PR DESCRIPTION
- do not track any conversion, 
- accurately count time on page for the last action (in Live API),
- case insensitive match for Referrer spammer (wrong branch),
- fix an integration test (unrelated),
- remove a font override (unrelated)

Note: I applied PSR2 in Phpstorm and we can see the downside of applying automatic code reformatter: it screws up some of our git history (in file core/Tracker/Visit.php)

follows up #8069 
