### PR TITLE
add constant PIWIK_VENDOR_PATH

### DIFF
--- a/core/Tracker/Visit/ReferrerSpamFilter.php
+++ b/core/Tracker/Visit/ReferrerSpamFilter.php
@@ -68,11 +68,7 @@ class ReferrerSpamFilter
             $this->spammerList = unserialize($list);
         } else {
             // Fallback to reading the bundled list
-            if (file_exists(PIWIK_INCLUDE_PATH . '/vendor/piwik/referrer-spam-blacklist/spammers.txt')) {
-                $file = PIWIK_INCLUDE_PATH . '/vendor/piwik/referrer-spam-blacklist/spammers.txt'; // Piwik is the main project
-            } else {
-                $file = PIWIK_INCLUDE_PATH . '/../../piwik/referrer-spam-blacklist/spammers.txt'; // Piwik is installed as a dependency
-            }
+            $file = PIWIK_VENDOR_PATH . '/piwik/referrer-spam-blacklist/spammers.txt';
             $this->spammerList = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         }
 

--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -14,6 +14,14 @@ error_reporting(E_ALL | E_NOTICE);
 @ini_set('xdebug.show_exception_trace', 0);
 @ini_set('magic_quotes_runtime', 0);
 
+if (!defined('PIWIK_VENDOR_PATH')) {
+	if (is_dir(PIWIK_INCLUDE_PATH . '/vendor')) {
+		define('PIWIK_VENDOR_PATH', PIWIK_INCLUDE_PATH . '/vendor'); // Piwik is the main project
+	} else {
+		define('PIWIK_VENDOR_PATH', PIWIK_INCLUDE_PATH . '/../..'); // Piwik is installed as a Composer dependency
+	}
+}
+
 // NOTE: the code above must be PHP 4 compatible
 require_once PIWIK_INCLUDE_PATH . '/core/testMinimumPhpVersion.php';
 
@@ -25,12 +33,7 @@ disableEaccelerator();
 require_once PIWIK_INCLUDE_PATH . '/libs/upgradephp/upgrade.php';
 
 // Composer autoloader
-if (file_exists(PIWIK_INCLUDE_PATH . '/vendor/autoload.php')) {
-    $path = PIWIK_INCLUDE_PATH . '/vendor/autoload.php'; // Piwik is the main project
-} else {
-    $path = PIWIK_INCLUDE_PATH . '/../../autoload.php'; // Piwik is installed as a dependency
-}
-require_once $path;
+require_once PIWIK_VENDOR_PATH . '/autoload.php';
 
 /**
  * Eaccelerator does not support closures and is known to be not comptabile with Piwik. Therefore we are disabling

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -50,8 +50,7 @@ if ($minimumPhpInvalid) {
 					To use Piwik, please ask your web host to install php5-json or install it yourself, for example on debian system: <code>sudo apt-get install php5-json</code>. <br/>Then restart your webserver and refresh this page.</p>";
     }
 
-    if (!file_exists(PIWIK_INCLUDE_PATH . '/vendor/autoload.php')
-        && !file_exists(PIWIK_INCLUDE_PATH . '/../../autoload.php')) {
+    if (!file_exists(PIWIK_VENDOR_PATH . '/autoload.php')) {
         $composerInstall = "In the piwik directory, run in the command line the following (eg. via ssh): \n\n"
             . "<pre> curl -sS https://getcomposer.org/installer | php \n\n php composer.phar install\n\n</pre> ";
         if (DIRECTORY_SEPARATOR === '\\' /* ::isWindows() */) {

--- a/js/tracker.php
+++ b/js/tracker.php
@@ -28,13 +28,14 @@ define('PIWIK_USER_PATH', '..');
 
 require_once PIWIK_INCLUDE_PATH . '/libs/upgradephp/upgrade.php';
 
-// Composer autoloader
-if (file_exists(PIWIK_INCLUDE_PATH . '/vendor/autoload.php')) {
-    $path = PIWIK_INCLUDE_PATH . '/vendor/autoload.php'; // Piwik is the main project
+if (is_dir(PIWIK_INCLUDE_PATH . '/vendor')) {
+    define('PIWIK_VENDOR_PATH', PIWIK_INCLUDE_PATH . '/vendor'); // Piwik is the main project
 } else {
-    $path = PIWIK_INCLUDE_PATH . '/../../autoload.php'; // Piwik is installed as a dependency
+    define('PIWIK_VENDOR_PATH', PIWIK_INCLUDE_PATH . '/../..'); // Piwik is installed as a Composer dependency
 }
-require $path;
+
+// Composer autoloader
+require PIWIK_VENDOR_PATH . '/autoload.php';
 
 $file = '../piwik.js';
 

--- a/plugins/ScheduledReports/config/tcpdf_config.php
+++ b/plugins/ScheduledReports/config/tcpdf_config.php
@@ -13,7 +13,7 @@ use Piwik\Container\StaticContainer;
  *
  */
 
-define('K_PATH_MAIN', PIWIK_INCLUDE_PATH . '/vendor/tecnick.com/tcpdf/');
+define('K_PATH_MAIN', PIWIK_VENDOR_PATH . '/tecnick.com/tcpdf/');
 
 $pathTmpTCPDF = StaticContainer::get('path.tmp') . '/tcpdf/';
 

--- a/plugins/TestRunner/Commands/TestsRun.php
+++ b/plugins/TestRunner/Commands/TestsRun.php
@@ -44,7 +44,7 @@ class TestsRun extends ConsoleCommand
 
         $groups = $this->getGroupsFromString($groups);
 
-        $command = '../../vendor/phpunit/phpunit/phpunit';
+        $command = PIWIK_VENDOR_PATH . '/phpunit/phpunit/phpunit';
 
         if (version_compare(PHP_VERSION, '5.4.0', '<')) {
             $command = 'php -dzend.enable_gc=0 ' . $command;


### PR DESCRIPTION
Instead of `PIWIK_INCLUDE_PATH . '/vendor/...'`, now `PIWIK_VENDOR_PATH . '/...'` should be used. The new constant `PIWIK_VENDOR_PATH` points directly to the `vendor` dir.

This is an approach to avoid (future) issues with files not being found when Piwik is installed as a Composer dependency. See #173 and #8226.

I just searched the repo for `vendor` and tried to replace it when possible, although there's some code I decided to leave untouched for now to avoid accidentally breaking it. E.g. in `core/Profiler.php` there's [one line](https://github.com/piwik/piwik/blob/da4f5e542d4225774916e432a0c976792ba6abc9/core/Profiler.php#L212) which could be changed easily but also [one line](https://github.com/piwik/piwik/blob/da4f5e542d4225774916e432a0c976792ba6abc9/core/Profiler.php#L270) creating a URL based on the path. So please review the changes carefully and let me know if there's something wrong or missing.
