### PR TITLE
Fixes #8217 regression, make sure temporary metrics are available to UserCountryMap for cities layer

### DIFF
--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -288,11 +288,12 @@ class DataTablePostProcessor
         // after queued filters are run so processed metrics can be removed, too)
         $hideColumns = Common::getRequestVar('hideColumns', '', 'string', $this->request);
         $showColumns = Common::getRequestVar('showColumns', '', 'string', $this->request);
+        $showRawMetrics = Common::getRequestVar('showRawMetrics', 0, 'int', $this->request);
         if (!empty($hideColumns)
             || !empty($showColumns)
         ) {
             $dataTable->filter('ColumnDelete', array($hideColumns, $showColumns));
-        } else {
+        } else if ($showRawMetrics !== 1) {
             $this->removeTemporaryMetrics($dataTable);
         }
 

--- a/plugins/UserCountryMap/javascripts/visitor-map.js
+++ b/plugins/UserCountryMap/javascripts/visitor-map.js
@@ -97,7 +97,8 @@
                     apiAction: action,
                     filter_limit: -1,
                     limit: -1,
-                    format_metrics: 0
+                    format_metrics: 0,
+                    showRawMetrics: 1
                 });
                 if (countryFilter) {
                     $.extend(params, {
@@ -647,7 +648,7 @@
                 $.each(groups, function (g_id, group) {
                     var apv = group.nb_actions / group.nb_visits,
                         ats = group.sum_visit_length / group.nb_visits,
-                        br = group.bounce_rate;
+                        br = group.bounce_count / group.nb_visits;
                     group['nb_actions_per_visit'] = apv;
                     group['avg_time_on_site'] = new Date(0, 0, 0, ats / 3600, ats % 3600 / 60, ats % 60).toLocaleTimeString();
                     group['bounce_rate'] = (br % 1 !== 0 ? br.toFixed(1) : br) + "%";

--- a/tests/PHPUnit/Fixtures/UITestFixture.php
+++ b/tests/PHPUnit/Fixtures/UITestFixture.php
@@ -16,7 +16,9 @@ use Piwik\Db;
 use Piwik\DbHelper;
 use Piwik\FrontController;
 use Piwik\Option;
+use Piwik\Plugins\PrivacyManager\IPAnonymizer;
 use Piwik\Plugins\SegmentEditor\API as APISegmentEditor;
+use Piwik\Plugins\UserCountry\LocationProvider;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
 use Piwik\Tests\Framework\Fixture;
@@ -48,6 +50,10 @@ class UITestFixture extends SqlDump
             array('ts_created' => '2011-01-01'),
             "idsite = 1"
         );
+
+        // for proper geolocation
+        LocationProvider::setCurrentProvider(LocationProvider\GeoIp\Php::ID);
+        IPAnonymizer::deactivate();
 
         $this->addOverlayVisits();
         $this->addNewSitesForSiteSelector();
@@ -107,13 +113,31 @@ class UITestFixture extends SqlDump
             array('page-6.html', 'page-3.html', ''),
         );
 
+        $ips = array( // ip's chosen for geolocation data
+            "20.56.34.67",
+            "24.17.88.121",
+            "24.12.45.67",
+            "24.120.12.5",
+            "24.100.12.5",
+            "24.110.12.5",
+            "24.17.88.122",
+            "24.12.45.68",
+            "24.17.88.123",
+            "24.18.127.34",
+            "18.50.45.71",
+            "24.20.127.34",
+            "24.23.40.34",
+            "18.50.45.70",
+            "24.50.12.5",
+        );
+
         $date = Date::factory('yesterday');
         $t = self::getTracker($idSite = 3, $dateTime = $date->getDatetime(), $defaultInit = true);
         $t->enableBulkTracking();
 
         foreach ($visitProfiles as $visitCount => $visit) {
             $t->setNewVisitorId();
-            $t->setIp("123.234.23.$visitCount");
+            $t->setIp($ips[$visitCount]);
 
             foreach ($visit as $idx => $action) {
                 $t->setForceVisitDateTime($date->addHour($visitCount)->addHour(0.01 * $idx)->getDatetime());

--- a/tests/PHPUnit/Fixtures/UITestFixture.php
+++ b/tests/PHPUnit/Fixtures/UITestFixture.php
@@ -41,6 +41,8 @@ class UITestFixture extends SqlDump
 
     public function setUp()
     {
+        self::downloadGeoIpDbs();
+
         parent::setUp();
 
         self::updateDatabase();

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -744,11 +744,14 @@ class Fixture extends \PHPUnit_Framework_Assert
                 throw new Exception("The file $deflatedOut is empty. Suggestion: delete it and try again.");
             }
 
+            self::copyDownloadedGeoIp($deflatedOut, $filename);
+
             // Valid geoip db found
             return;
         }
 
-        Log::warning("Geoip database $outfileName is not found. Downloading from $url...");
+        echo "Geoip database $outfileName is not found. Downloading from $url...\n";
+
         $dump = fopen($url, 'rb');
         $outfile = fopen($outfileName, 'wb');
         if(!$outfile) {
@@ -768,6 +771,16 @@ class Fixture extends \PHPUnit_Framework_Assert
             Log::info(file_get_contents($outfile));
 
             throw new Exception("gunzip failed($return): " . implode("\n", $output));
+        }
+
+        self::copyDownloadedGeoIp($deflatedOut, $filename);
+    }
+
+    private static function copyDownloadedGeoIp($deflatedOut, $filename)
+    {
+        $realFileOut = PIWIK_INCLUDE_PATH . '/' . LocationProvider\GeoIp::$geoIPDatabaseDir . '/' . $filename;
+        if (!file_exists($realFileOut)) {
+            copy($deflatedOut, $realFileOut);
         }
     }
 

--- a/tests/UI/specs/VisitorMap_spec.js
+++ b/tests/UI/specs/VisitorMap_spec.js
@@ -34,12 +34,9 @@ describe("VisitorMap", function () {
         }, done);
     });
 
-    it("should display the regions layer correctly w/ the bounce rate metric", function (done) {
+    it("should display the regions layer correctly", function (done) {
         expect.screenshot('regions').to.be.capture(function (page) {
             page.load(urlWithCities);
-            page.evaluate(function () {
-                $('.userCountryMapSelectMetrics').val('bounce_rate').trigger('change');
-            });
             page.evaluate(function () {
                 // zoom into USA
                 var path = window.visitorMap.map.getLayer('countries').getPaths({iso: "USA"})[0].svgPath[0];
@@ -53,7 +50,7 @@ describe("VisitorMap", function () {
         }, done);
     });
 
-    it("should display the cities layer correctly w/ the bounce rate metric", function (done) {
+    it("should display the cities layer correctly", function (done) {
         expect.screenshot('cities').to.be.capture(function (page) {
             page.click('.UserCountryMap-btn-city');
         }, done);

--- a/tests/UI/specs/VisitorMap_spec.js
+++ b/tests/UI/specs/VisitorMap_spec.js
@@ -11,7 +11,9 @@ describe("VisitorMap", function () {
     this.timeout(0);
 
     var url = "?module=Widgetize&action=iframe&moduleToWidgetize=UserCountryMap&idSite=1&period=year&date=2012-08-09&"
-        + "actionToWidgetize=visitorMap&viewDataTable=table&filter_limit=5&isFooterExpandedInDashboard=1";
+        + "actionToWidgetize=visitorMap&viewDataTable=table&filter_limit=5&isFooterExpandedInDashboard=1",
+        urlWithCities = "?module=Widgetize&action=iframe&moduleToWidgetize=UserCountryMap&idSite=3&period=week&date=yesterday&"
+            + "actionToWidgetize=visitorMap&viewDataTable=table&filter_limit=5&isFooterExpandedInDashboard=1";
 
     it("should display the bounce rate metric correctly", function (done) {
         expect.screenshot('bounce_rate').to.be.capture(function (page) {
@@ -29,6 +31,31 @@ describe("VisitorMap", function () {
                 $('.userCountryMapSelectMetrics').val('avg_time_on_site').trigger('change');
             });
             page.mouseMove('.UserCountryMap_map.kartograph');
+        }, done);
+    });
+
+    it("should display the regions layer correctly w/ the bounce rate metric", function (done) {
+        expect.screenshot('regions').to.be.capture(function (page) {
+            page.load(urlWithCities);
+            page.evaluate(function () {
+                $('.userCountryMapSelectMetrics').val('bounce_rate').trigger('change');
+            });
+            page.evaluate(function () {
+                // zoom into USA
+                var path = window.visitorMap.map.getLayer('countries').getPaths({iso: "USA"})[0].svgPath[0];
+                $(path).click();
+            });
+            page.evaluate(function () {
+                // go to regions view
+                var path = window.visitorMap.map.getLayer('countries').getPaths({iso: "USA"})[0].svgPath[0];
+                $(path).click();
+            });
+        }, done);
+    });
+
+    it("should display the cities layer correctly w/ the bounce rate metric", function (done) {
+        expect.screenshot('cities').to.be.capture(function (page) {
+            page.click('.UserCountryMap-btn-city');
         }, done);
     });
 });

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -237,6 +237,10 @@ PageRenderer.prototype._downloadLink = function (str, callback) {
 };
 
 PageRenderer.prototype._getPosition = function (selector) {
+    if (selector.x && selector.y) {
+        return selector;
+    }
+
     var pos = this.webpage.evaluate(function (selector) {
         var element = window.jQuery(selector),
             offset = element.offset();


### PR DESCRIPTION
As title, also includes UI tests for cities/regions layer, plus change that allows UI tests to send mouse events to specific coordinates.

In order to get some visits to show up on the city map, I had to set the IPs in UITestFixture visits to IPs that have locations. And force the use of GeoIP there.
