### PR TITLE
Add OptOutManager

### DIFF
--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -319,7 +319,7 @@ class Controller extends ControllerAdmin
      */
     public function optOut()
     {
-        return $this->optOutManager->createView()->render();
+        return $this->optOutManager->getOptOutView()->render();
     }
 
     public function uploadCustomLogo()

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -40,12 +40,12 @@ class OptOutManager
 
         $this->javascripts = array(
             'inline' => array(),
-            'extern' => array(),
+            'external' => array(),
         );
 
         $this->stylesheets = array(
             'inline' => array(),
-            'extern' => array(),
+            'external' => array(),
         );
     }
 
@@ -55,7 +55,7 @@ class OptOutManager
      */
     public function addJavascript($javascript, $inline = true)
     {
-        $type = $inline ? 'inline' : 'extern';
+        $type = $inline ? 'inline' : 'external';
         $this->javascripts[$type][] = $javascript;
     }
 
@@ -73,7 +73,7 @@ class OptOutManager
      */
     public function addStylesheet($stylesheet, $inline = true)
     {
-        $type = $inline ? 'inline' : 'extern';
+        $type = $inline ? 'inline' : 'external';
         $this->stylesheets[$type][] = $stylesheet;
     }
 

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\CoreAdminHome;
+
+use Piwik\Common;
+use Piwik\Nonce;
+use Piwik\Plugins\LanguagesManager\API as APILanguagesManager;
+use Piwik\Plugins\LanguagesManager\LanguagesManager;
+use Piwik\Plugins\PrivacyManager\DoNotTrackHeaderChecker;
+use Piwik\Tracker\IgnoreCookie;
+use Piwik\Url;
+use Piwik\View;
+
+class OptOutManager
+{
+    /** @var DoNotTrackHeaderChecker */
+    private $doNotTrackHeaderChecker;
+
+    /** @var array */
+    private $javascripts;
+
+    /** @var array */
+    private $stylesheets;
+
+    /** @var string */
+    private $title;
+
+    public function __construct(DoNotTrackHeaderChecker $doNotTrackHeaderChecker = null)
+    {
+        $this->doNotTrackHeaderChecker = $doNotTrackHeaderChecker ?: new DoNotTrackHeaderChecker();
+
+        $this->javascripts = array(
+            'inline' => array(),
+            'extern' => array(),
+        );
+
+        $this->stylesheets = array(
+            'inline' => array(),
+            'extern' => array(),
+        );
+    }
+
+    /**
+     * Add javascript
+     *
+     * @param string $javascript
+     * @param bool $inline
+     */
+    public function addJavascript($javascript, $inline = true)
+    {
+        $type = $inline ? 'inline' : 'extern';
+        $this->javascripts[$type][] = $javascript;
+    }
+
+    /**
+     * Return the javascripts array
+     *
+     * @return array
+     */
+    public function getJavascripts()
+    {
+        return $this->javascripts;
+    }
+
+    /**
+     * Add Stylesheet
+     *
+     * @param string $stylesheet
+     * @param bool $inline
+     */
+    public function addStylesheet($stylesheet, $inline = true)
+    {
+        $type = $inline ? 'inline' : 'extern';
+        $this->stylesheets[$type][] = $stylesheet;
+    }
+
+    /**
+     * Return the stylesheets array
+     *
+     * @return array
+     */
+    public function getStylesheets()
+    {
+        return $this->stylesheets;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    public function createView()
+    {
+        $trackVisits = !IgnoreCookie::isIgnoreCookieFound();
+        $dntFound = $this->getDoNotTrackHeaderChecker()->isDoNotTrackFound();
+
+        $setCookieInNewWindow = Common::getRequestVar('setCookieInNewWindow', false, 'int');
+        if ($setCookieInNewWindow) {
+            $reloadUrl = Url::getCurrentQueryStringWithParametersModified(array(
+                'showConfirmOnly' => 1,
+                'setCookieInNewWindow' => 0,
+            ));
+        } else {
+            $reloadUrl = false;
+
+            $nonce = Common::getRequestVar('nonce', false);
+            if ($nonce !== false && Nonce::verifyNonce('Piwik_OptOut', $nonce)) {
+                Nonce::discardNonce('Piwik_OptOut');
+                IgnoreCookie::setIgnoreCookie();
+                $trackVisits = !$trackVisits;
+            }
+        }
+
+        $language = Common::getRequestVar('language', '');
+        $lang = APILanguagesManager::getInstance()->isLanguageAvailable($language)
+            ? $language
+            : LanguagesManager::getLanguageCodeForCurrentUser();
+
+        $view = new View("@CoreAdminHome/optOut");
+        $view->setXFrameOptions('allow');
+        $view->dntFound = $dntFound;
+        $view->trackVisits = $trackVisits;
+        $view->nonce = Nonce::getNonce('Piwik_OptOut', 3600);
+        $view->language = $lang;
+        $view->isSafari = $this->isUserAgentSafari();
+        $view->showConfirmOnly = Common::getRequestVar('showConfirmOnly', false, 'int');
+        $view->reloadUrl = $reloadUrl;
+
+        return $view;
+    }
+
+    /**
+     * @return DoNotTrackHeaderChecker
+     */
+    protected function getDoNotTrackHeaderChecker()
+    {
+        return $this->doNotTrackHeaderChecker;
+    }
+
+    protected function isUserAgentSafari()
+    {
+        $userAgent = @$_SERVER['HTTP_USER_AGENT'] ?: '';
+        return strpos($userAgent, 'Safari') !== false && strpos($userAgent, 'Chrome') === false;
+    }
+}

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -31,6 +31,9 @@ class OptOutManager
     /** @var string */
     private $title;
 
+    /**
+     * @param DoNotTrackHeaderChecker $doNotTrackHeaderChecker
+     */
     public function __construct(DoNotTrackHeaderChecker $doNotTrackHeaderChecker = null)
     {
         $this->doNotTrackHeaderChecker = $doNotTrackHeaderChecker ?: new DoNotTrackHeaderChecker();
@@ -47,8 +50,6 @@ class OptOutManager
     }
 
     /**
-     * Add javascript
-     *
      * @param string $javascript
      * @param bool $inline
      */
@@ -59,8 +60,6 @@ class OptOutManager
     }
 
     /**
-     * Return the javascripts array
-     *
      * @return array
      */
     public function getJavascripts()
@@ -69,8 +68,6 @@ class OptOutManager
     }
 
     /**
-     * Add Stylesheet
-     *
      * @param string $stylesheet
      * @param bool $inline
      */
@@ -81,8 +78,6 @@ class OptOutManager
     }
 
     /**
-     * Return the stylesheets array
-     *
      * @return array
      */
     public function getStylesheets()
@@ -106,6 +101,10 @@ class OptOutManager
         $this->title = $title;
     }
 
+    /**
+     * @return View
+     * @throws \Exception
+     */
     public function createView()
     {
         $trackVisits = !IgnoreCookie::isIgnoreCookieFound();
@@ -142,6 +141,9 @@ class OptOutManager
         $view->isSafari = $this->isUserAgentSafari();
         $view->showConfirmOnly = Common::getRequestVar('showConfirmOnly', false, 'int');
         $view->reloadUrl = $reloadUrl;
+        $view->javascripts = $this->getJavascripts();
+        $view->stylesheets = $this->getStylesheets();
+        $view->title = $this->getTitle();
 
         return $view;
     }
@@ -154,6 +156,9 @@ class OptOutManager
         return $this->doNotTrackHeaderChecker;
     }
 
+    /**
+     * @return bool
+     */
     protected function isUserAgentSafari()
     {
         $userAgent = @$_SERVER['HTTP_USER_AGENT'] ?: '';

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -31,6 +31,9 @@ class OptOutManager
     /** @var string */
     private $title;
 
+    /** @var View|null */
+    private $view;
+
     /**
      * @param DoNotTrackHeaderChecker $doNotTrackHeaderChecker
      */
@@ -50,6 +53,9 @@ class OptOutManager
     }
 
     /**
+     * Add a javascript file|code into the OptOut View
+     * Note: This method will not escape the inline javascript code!
+     *
      * @param string $javascript
      * @param bool $inline
      */
@@ -68,7 +74,10 @@ class OptOutManager
     }
 
     /**
-     * @param string $stylesheet
+     * Add a stylesheet file|code into the OptOut View
+     * Note: This method will not escape the inline css code!
+     *
+     * @param string $stylesheet Escaped stylesheet
      * @param bool $inline
      */
     public function addStylesheet($stylesheet, $inline = true)
@@ -105,8 +114,12 @@ class OptOutManager
      * @return View
      * @throws \Exception
      */
-    public function createView()
+    public function getOptOutView()
     {
+        if ($this->view) {
+            return $this->view;
+        }
+
         $trackVisits = !IgnoreCookie::isIgnoreCookieFound();
         $dntFound = $this->getDoNotTrackHeaderChecker()->isDoNotTrackFound();
 
@@ -132,20 +145,20 @@ class OptOutManager
             ? $language
             : LanguagesManager::getLanguageCodeForCurrentUser();
 
-        $view = new View("@CoreAdminHome/optOut");
-        $view->setXFrameOptions('allow');
-        $view->dntFound = $dntFound;
-        $view->trackVisits = $trackVisits;
-        $view->nonce = Nonce::getNonce('Piwik_OptOut', 3600);
-        $view->language = $lang;
-        $view->isSafari = $this->isUserAgentSafari();
-        $view->showConfirmOnly = Common::getRequestVar('showConfirmOnly', false, 'int');
-        $view->reloadUrl = $reloadUrl;
-        $view->javascripts = $this->getJavascripts();
-        $view->stylesheets = $this->getStylesheets();
-        $view->title = $this->getTitle();
+        $this->view = new View("@CoreAdminHome/optOut");
+        $this->view->setXFrameOptions('allow');
+        $this->view->dntFound = $dntFound;
+        $this->view->trackVisits = $trackVisits;
+        $this->view->nonce = Nonce::getNonce('Piwik_OptOut', 3600);
+        $this->view->language = $lang;
+        $this->view->isSafari = $this->isUserAgentSafari();
+        $this->view->showConfirmOnly = Common::getRequestVar('showConfirmOnly', false, 'int');
+        $this->view->reloadUrl = $reloadUrl;
+        $this->view->javascripts = $this->getJavascripts();
+        $this->view->stylesheets = $this->getStylesheets();
+        $this->view->title = $this->getTitle();
 
-        return $view;
+        return $this->view;
     }
 
     /**

--- a/plugins/CoreAdminHome/templates/optOut.twig
+++ b/plugins/CoreAdminHome/templates/optOut.twig
@@ -2,9 +2,13 @@
 <html>
 <head>
     <meta charset="utf-8">
+    {% if title %}
+        <title>{{ title }}</title>
+    {% endif %}
     {% if reloadUrl %}
         <meta http-equiv="refresh" content="0; url={{ reloadUrl }}&amp;nonce={{ nonce }}" />
     {% endif %}
+
     <script>
         function submitForm(event, form, loadInNewWindow) {
             event.preventDefault();
@@ -21,6 +25,19 @@
             }
         }
     </script>
+
+    {% if stylesheets.extern|length > 0 %}
+        {% for style in stylesheets.extern %}
+            <link href="{{ style|raw }}" rel="stylesheet" type="text/css">
+        {% endfor %}
+    {% endif %}
+    {% if stylesheets.inline|length > 0 %}
+        <style>
+            {% for style in stylesheets.inline %}
+            {{ style|raw }}
+            {% endfor %}
+        </style>
+    {% endif %}
 </head>
 <body>
 {% if dntFound %}
@@ -68,6 +85,19 @@
         </noscript>
     </form>
     {% endif %}
+{% endif %}
+
+{% if javascripts.extern|length > 0 %}
+    {% for script in javascripts.extern %}
+        <script type="text/javascript" src="{{ script|raw }}"></script>
+    {% endfor %}
+{% endif %}
+{% if javascripts.inline|length > 0 %}
+    <script>
+        {% for script in javascripts.inline %}
+        {{ script|raw }}
+        {% endfor %}
+    </script>
 {% endif %}
 </body>
 </html>

--- a/plugins/CoreAdminHome/templates/optOut.twig
+++ b/plugins/CoreAdminHome/templates/optOut.twig
@@ -26,8 +26,8 @@
         }
     </script>
 
-    {% if stylesheets.extern|length > 0 %}
-        {% for style in stylesheets.extern %}
+    {% if stylesheets.external|length > 0 %}
+        {% for style in stylesheets.external %}
             <link href="{{ style|raw }}" rel="stylesheet" type="text/css">
         {% endfor %}
     {% endif %}
@@ -87,8 +87,8 @@
     {% endif %}
 {% endif %}
 
-{% if javascripts.extern|length > 0 %}
-    {% for script in javascripts.extern %}
+{% if javascripts.external|length > 0 %}
+    {% for script in javascripts.external %}
         <script type="text/javascript" src="{{ script|raw }}"></script>
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
In relation to PR #7979

This OptOut Manager allows plugins to add Javascripts and Stylesheets to the OptOut View.
- [x] Add a new OptOutManager
- [x] Remove opt out logic from CoreAdminHome Controller
- [x] Change OptOut View
