### PR TITLE
Fixes #7969 escape goal names and patterns on output in goals controller

### DIFF
--- a/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
+++ b/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
@@ -135,12 +135,14 @@
                     for (var d = 0; d < self.data.length; d++) {
                         var value = self.formatY(self.data[d][tick], d);
                         var series = self.jqplotParams.series[d].label;
-                        text.push('<strong>' + value + '</strong> ' + series);
+                        text.push('<strong>' + value + '</strong> ' + piwikHelper.htmlEntities(series));
                     }
+                    var content = '<h3>'+piwikHelper.htmlEntities(label)+'</h3>'+text.join('<br />');
+
                     $(this).tooltip({
                         track:   true,
                         items:   'div',
-                        content: '<h3>'+label+'</h3>'+text.join('<br />'),
+                        content: content,
                         show: false,
                         hide: false
                     }).trigger('mouseover');

--- a/plugins/Goals/Controller.php
+++ b/plugins/Goals/Controller.php
@@ -79,12 +79,6 @@ class Controller extends \Piwik\Plugin\Controller
 
         $this->idSite = Common::getRequestVar('idSite', null, 'int');
         $this->goals = API::getInstance()->getGoals($this->idSite);
-        foreach ($this->goals as &$goal) {
-            $goal['name'] = Common::sanitizeInputValue($goal['name']);
-            if (isset($goal['pattern'])) {
-                $goal['pattern'] = Common::sanitizeInputValue($goal['pattern']);
-            }
-        }
     }
 
     public function widgetGoalReport()
@@ -152,12 +146,6 @@ class Controller extends \Piwik\Plugin\Controller
         // unsanitize goal names and other text data (not done in API so as not to break
         // any other code/cause security issues)
         $goals = $this->goals;
-        foreach ($goals as &$goal) {
-            $goal['name'] = Common::unsanitizeInputValue($goal['name']);
-            if (isset($goal['pattern'])) {
-                $goal['pattern'] = Common::unsanitizeInputValue($goal['pattern']);
-            }
-        }
         $view->goalsJSON = json_encode($goals);
 
         $view->ecommerceEnabled = $this->site->isEcommerceEnabled();

--- a/plugins/Goals/templates/_listGoalEdit.twig
+++ b/plugins/Goals/templates/_listGoalEdit.twig
@@ -22,11 +22,11 @@
             {% for goal in goals %}
                 <tr>
                     <td class="first">{{ goal.idgoal }}</td>
-                    <td>{{ goal.name|raw }}</td>{# NOTE: goal names are escaped in the DB #}
+                    <td>{{ goal.name }}</td>
                     <td><span class='matchAttribute'>{{ goal.match_attribute }}</span>
                         {% if goal.pattern_type is defined %}
                             <br/>
-                            {{ 'Goals_Pattern'|translate }} {{ goal.pattern_type }}: {{ goal.pattern|raw }}
+                            {{ 'Goals_Pattern'|translate }} {{ goal.pattern_type }}: {{ goal.pattern }}
                         {% endif %}
                     </td>
                     <td>{% if goal.revenue==0 %}-{% else %}{{ goal.revenue|money(idSite)|raw }}{% endif %}</td>

--- a/plugins/Goals/templates/_titleAndEvolutionGraph.twig
+++ b/plugins/Goals/templates/_titleAndEvolutionGraph.twig
@@ -6,7 +6,7 @@
             edit-url="{{ linkTo({'module': 'Goals', 'action': 'manage', 'idGoal': idGoal})|e('html_attr') }}"
             feature-name="{{ 'Goals_Details'|translate|e('html_attr') }}"
         {% endif %}
-       >{% if headline is defined %}{{ headline }}{% elseif goalName is defined %}{{ 'Goals_GoalX'|translate(goalName)|raw }}{% else %}{{ 'General_EvolutionOverPeriod'|translate }}{% endif %}</h2>
+       >{% if headline is defined %}{{ headline }}{% elseif goalName is defined %}{{ 'Goals_GoalX'|translate(goalName) }}{% else %}{{ 'General_EvolutionOverPeriod'|translate }}{% endif %}</h2>
 {% endif %}
 {{ graphEvolution|raw }}
 

--- a/plugins/Goals/templates/getGoalReportView.twig
+++ b/plugins/Goals/templates/getGoalReportView.twig
@@ -56,7 +56,7 @@
     {% if nb_conversions > 0 or cart_nb_conversions is defined %}
         <h2 id='titleGoalsByDimension'>
             {% if idGoal is defined %}
-                {{ 'Goals_GoalConversionsBy'|translate(goalName)|raw }}
+                {{ 'Goals_GoalConversionsBy'|translate(goalName) }}
             {% else %}
                 {{ 'Goals_ConversionsOverviewBy'|translate }}
             {% endif %}

--- a/plugins/Goals/templates/getOverviewView.twig
+++ b/plugins/Goals/templates/getOverviewView.twig
@@ -11,7 +11,7 @@
     <div class="goalEntry" style="clear:both">
         <h2>
             <a href="javascript:broadcast.propagateAjax('module=Goals&action=goalReport&idGoal={{ goal.id }}')">
-                {{ 'Goals_GoalX'|translate("'"~name~"'")|raw }}
+                {{ 'Goals_GoalX'|translate("'"~name~"'") }}
             </a>
         </h2>
 
@@ -48,7 +48,7 @@
     {% if sum_nb_conversions != 0 %}
     <h2 id='titleGoalsByDimension'>
         {% if idGoal is defined %}
-            {{ 'Goals_GoalConversionsBy'|translate(goalName)|raw }}
+            {{ 'Goals_GoalConversionsBy'|translate(goalName) }}
         {% else %}
             {{ 'Goals_ConversionsOverviewBy'|translate }}
         {% endif %}


### PR DESCRIPTION
As title. Previously, goal names and patterns were escaped in the Goals controller by calling the `Common::sanitizeInputValue()` method, and then outputted w/ `|raw` in twig. This PR removes the manual escaping in the Goals controller and removes the `|raw` filters in related twig files. It also makes sure jqplot evolution graphs escape series and metric names before displaying tooltips.

This fixes #7969, because goal data is used in the JSON jqplot graph data, and since it was escaped in the PHP, it ended up escaped in the JSON. Then jqplot escaped it again.

Fixes #7969
