### PR TITLE
Fixes duplication `onchange` event for `radio` elements

### DIFF
--- a/plugins/Morpheus/javascripts/morpheus.js
+++ b/plugins/Morpheus/javascripts/morpheus.js
@@ -25,6 +25,8 @@ $(document).ready(function () {
     $('body').on('ifClicked', 'input', function () {
         $(this).trigger('click');
     }).on('ifChanged', 'input', function () {
-        $(this).trigger('change');
+        if(this.type != 'radio' || this.checked) {
+            $(this).trigger('change');
+        }
     });
 });


### PR DESCRIPTION
The problem was in `change` event that was triggered twice: 1) when one radio is unchecked 2) when another radio becomes checked. I've made patch ignoring 1) event, because in that case `$('input:checked').val()` is `undefined`.

Fixes #8245 
