### PR TITLE
Fix checkboxes in Manage Websites form

### DIFF
--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
@@ -105,7 +105,6 @@
                         $scope.totalNumberOfSites = siteIds.length;
                     }
                 });
-                $(piwik.broadcast).trigger('updateICheck', {});
             });
         };
 


### PR DESCRIPTION
There is a popular conflict between Angular and iCheck. I tried different solutions, like using custom derective for iCheck https://github.com/fronteed/iCheck/issues/62, but it does not helps. 

I think for now we can just disable iCheck for that Angular form.

Closes #8247
