### PR TITLE
Make it possible to remote debug / profile UI tests

### DIFF
--- a/tests/lib/screenshot-testing/run-tests.js
+++ b/tests/lib/screenshot-testing/run-tests.js
@@ -8,7 +8,7 @@
  */
 
 // required modules
-var config = require("./../../UI/config.dist");
+config = require("./../../UI/config.dist");
 try {
     var localConfig = require("./../../UI/config");
 } catch (e) {


### PR DESCRIPTION
Removing the var was needed to make it possible to remote debug otherwise the variable was not available in other scripts and caused errors.

Afterwards it should be possible to start remote debugging via `phantomjs  --remote-debugger-port=9000 run-tests.js`
