### PR TITLE
Visualization: better error message 

### DIFF
--- a/core/Plugin/ViewDataTable.php
+++ b/core/Plugin/ViewDataTable.php
@@ -514,4 +514,46 @@ abstract class ViewDataTable implements ViewInterface
             }
         }
     }
+
+    /**
+     * Display a meaningful error message when any invalid parameter is being set.
+     *
+     * @param $overrideParams
+     * @throws
+     */
+    public function throwWhenSettingNonOverridableParameter($overrideParams)
+    {
+        $nonOverridableParams = $this->getNonOverridableParams($overrideParams);
+        if(count($nonOverridableParams) > 0) {
+            throw new \Exception(sprintf(
+                "Setting parameters %s is not allowed. Please report this bug to the Piwik team.",
+                implode(" and ", $nonOverridableParams)
+            ));
+        }
+    }
+
+    /**
+     * @param $overrideParams
+     * @return array
+     */
+    public function getNonOverridableParams($overrideParams)
+    {
+        $paramsCannotBeOverridden = array();
+        foreach ($overrideParams as $paramName => $paramValue) {
+            if (property_exists($this->requestConfig, $paramName)) {
+                $allowedParams = $this->requestConfig->overridableProperties;
+            } elseif (property_exists($this->config, $paramName)) {
+                $allowedParams = $this->config->overridableProperties;
+            } else {
+                // setting Config.custom_parameters is always allowed
+                continue;
+            }
+
+            if (!in_array($paramName, $allowedParams)) {
+                $paramsCannotBeOverridden[] = $paramName;
+            }
+        }
+        return $paramsCannotBeOverridden;
+    }
+
 }

--- a/core/ViewDataTable/Factory.php
+++ b/core/ViewDataTable/Factory.php
@@ -244,6 +244,10 @@ class Factory
             $params = array();
         }
 
+        if(!is_subclass_of($klass, 'Piwik\View\ViewInterface')) {
+            throw new \Exception("viewDataTable $klass must implement Piwik\View\ViewInterface interface.");
+        }
+
         return new $klass($controllerAction, $apiAction, $params);
     }
 }

--- a/core/ViewDataTable/Factory.php
+++ b/core/ViewDataTable/Factory.php
@@ -86,10 +86,12 @@ class Factory
      *                                       Defaulted to `$apiAction` if `false` is supplied.
      * @param bool $forceDefault If true, then the visualization type that was configured for the report will be
      *                           ignored and `$defaultType` will be used as the default.
+     * @param bool $loadViewDataTableParametersForUser Whether the per-user parameters for this user, this ViewDataTable and this Api action
+     *                                          should be loaded from the user preferences and override the default params values.
      * @throws \Exception
      * @return \Piwik\Plugin\ViewDataTable
      */
-    public static function build($defaultType = null, $apiAction = false, $controllerAction = false, $forceDefault = false)
+    public static function build($defaultType = null, $apiAction = false, $controllerAction = false, $forceDefault = false, $loadViewDataTableParametersForUser = null)
     {
         if (false === $controllerAction) {
             $controllerAction = $apiAction;
@@ -99,11 +101,12 @@ class Factory
 
         $defaultViewType = self::getDefaultViewTypeForReport($report, $apiAction);
 
-        $isWidget = Common::getRequestVar('widget', '0', 'string');
+        $params = array();
 
-        if (!empty($isWidget)) {
-            $params = array();
-        } else {
+        if(is_null($loadViewDataTableParametersForUser)) {
+            $loadViewDataTableParametersForUser = ('0' == Common::getRequestVar('widget', '0', 'string'));
+        }
+        if ($loadViewDataTableParametersForUser) {
             $login  = Piwik::getCurrentUserLogin();
             $params = Manager::getViewDataTableParameters($login, $controllerAction);
         }

--- a/core/ViewDataTable/Manager.php
+++ b/core/ViewDataTable/Manager.php
@@ -345,7 +345,8 @@ class Manager
         $viewDataTableType = isset($params['viewDataTable']) ? $params['viewDataTable'] : $report->getDefaultTypeViewDataTable();
 
         $apiAction = $controllerAction;
-        $viewDataTable = Factory::build($viewDataTableType, $apiAction, $controllerAction);
+        $loadViewDataTableParametersForUser = false;
+        $viewDataTable = Factory::build($viewDataTableType, $apiAction, $controllerAction, $forceDefault = false, $loadViewDataTableParametersForUser);
         return $viewDataTable;
     }
 

--- a/plugins/CoreHome/Controller.php
+++ b/plugins/CoreHome/Controller.php
@@ -111,6 +111,9 @@ class Controller extends \Piwik\Plugin\Controller
         $controllerName = Common::getRequestVar('moduleToLoad');
         $actionName     = Common::getRequestVar('actionToLoad', 'index');
 
+        if($controllerName == 'API') {
+            throw new Exception("Showing API requests in context is not supported for security reasons. Please change query parameter 'moduleToLoad'.");
+        }
         if ($actionName == 'showInContext') {
             throw new Exception("Preventing infinite recursion...");
         }

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -121,7 +121,8 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
         if (!self.isDashboard()) {
             self.notifyWidgetParametersChange(domElem, {
-                filter_sort_column: newColumnToSort
+                filter_sort_column: newColumnToSort,
+                filter_sort_order: self.param.filter_sort_order
             });
         }
 

--- a/tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php
+++ b/tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Integration\ViewDataTable;
 
+use Piwik\Option;
 use Piwik\ViewDataTable\Manager as ViewDataTableManager;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -38,6 +39,84 @@ class ManagerTest extends IntegrationTestCase
 
         $storedParams = ViewDataTableManager::getViewDataTableParameters($params['login'], $params['method']);
         $this->assertEquals($params['params'], $storedParams);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Setting parameters translations is not allowed. Please report this bug to the Piwik team.
+     */
+    public function test_setViewDataTableParameters_inConfigProperty_shouldOnlyAllowOverridableParams()
+    {
+        $login  = 'mylogin';
+        $method = 'API.get';
+        $params = array(
+            'flat' => '0',
+            'translations' => 'this is not overridable param and should fail',
+            'viewDataTable' => 'tableAllColumns'
+        );
+
+        ViewDataTableManager::saveViewDataTableParameters($login, $method, $params);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Setting parameters filters is not allowed. Please report this bug to the Piwik team.
+     */
+    public function test_setViewDataTableParameters_inConfigProperty_shouldOnlyAllowOverridableParams_bis()
+    {
+        $login  = 'mylogin';
+        $method = 'API.get';
+        $params = array(
+            'flat' => '0',
+            'filters' => 'this is not overridable param and should fail',
+            'viewDataTable' => 'tableAllColumns'
+        );
+
+        ViewDataTableManager::saveViewDataTableParameters($login, $method, $params);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Setting parameters apiMethodToRequestDataTable is not allowed. Please report this bug to the Piwik team.
+     */
+    public function test_setViewDataTableParameters_inRequestConfigProperty_shouldOnlyAllowOverridableParams()
+    {
+        $login  = 'mylogin';
+        $method = 'API.get';
+        $params = array(
+            'flat' => '0',
+            'apiMethodToRequestDataTable' => 'this is not overridable in RequestConfig param and should fail',
+            'viewDataTable' => 'tableAllColumns'
+        );
+
+        ViewDataTableManager::saveViewDataTableParameters($login, $method, $params);
+    }
+
+    public function test_getViewDataTableParameters_removesNonOverridableParameter()
+    {
+        $params = array(
+            'flat' => '0',
+            'filters' => 'this is not overridable param and should fail',
+            'viewDataTable' => 'tableAllColumns'
+        );
+
+        // 'filters' was removed
+        $paramsExpectedWhenFetched = array(
+            'flat' => '0',
+            'viewDataTable' => 'tableAllColumns'
+        );
+
+        $login  = 'mylogin';
+        $controllerAction = 'API.get';
+
+        // simulate an invalid list of parameters (contains 'filters')
+        $paramsKey = sprintf('viewDataTableParameters_%s_%s', $login, $controllerAction);
+        Option::set($paramsKey, json_encode($params));
+
+        // check the invalid list is fetched without the overridable parameter
+        $processed = ViewDataTableManager::getViewDataTableParameters($login, $controllerAction);
+        $this->assertEquals($paramsExpectedWhenFetched, $processed);
+
     }
 
     public function test_clearAllViewDataTableParameters_shouldRemoveAllPersistedParameters()


### PR DESCRIPTION
-   Remember and restore sort order as well as sort column  
- Display a meaningful & useful error message when setting viewDataTable parameters, rather than silently fail
