### PR TITLE
escape trusted hosts before calling preg_match to prevent PHP warning

### DIFF
--- a/core/Url.php
+++ b/core/Url.php
@@ -240,9 +240,12 @@ class Url
             return true;
         }
 
+        // Escape trusted hosts for preg_match call below
         foreach ($trustedHosts as &$trustedHost) {
             $trustedHost = preg_quote($trustedHost);
         }
+        $trustedHosts = str_replace("/", "\\/", $trustedHosts);
+
         $untrustedHost = Common::mb_strtolower($host);
         $untrustedHost = rtrim($untrustedHost, '.');
 

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -231,6 +231,8 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             array(false, 'www.example.com:8080', array('example.com'), 'host:port is valid'),
             array(true, 'www.example.com:8080', array('example.com:8080'), 'host:port is valid'),
             array(false, 'www.whatever.com', array('*.whatever.com'), 'regex char is escaped'),
+            array(false, 'www.whatever.com', array('www.whatever.com/abc'), 'with path starting with /a does not throw error'),
+            array(false, 'www.whatever.com', array('www.whatever.com/path/here'), 'with path starting with /p does not throw error'),
         );
     }
 


### PR DESCRIPTION
Fixes #8290 
