### PR TITLE
Refactor tracker code for clarity, modularity and so plugins can have more granular control over tracking

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -777,6 +777,7 @@ Plugins[] = TestRunner
 Plugins[] = BulkTracking
 Plugins[] = Resolution
 Plugins[] = DevicePlugins
+Plugins[] = Heartbeat
 Plugins[] = Intl
 
 [PluginsInstalled]

--- a/config/global.php
+++ b/config/global.php
@@ -80,4 +80,8 @@ return array(
         ->constructorParameter('visitStandardLength', DI\get('ini.Tracker.visit_standard_length'))
         ->constructorParameter('lookbackNSecondsCustom', DI\get('ini.Tracker.window_look_back_for_visitor'))
         ->constructorParameter('trackerAlwaysNewVisitor', DI\get('ini.Debug.tracker_always_new_visitor')),
+
+    'Piwik\Tracker\Settings' => DI\object()
+        ->constructorParameter('isSameFingerprintsAcrossWebsites', DI\get('ini.Tracker.enable_fingerprinting_across_websites')),
+
 );

--- a/config/global.php
+++ b/config/global.php
@@ -73,6 +73,7 @@ return array(
             ))));
     },
 
+    // contains RequestProcessor instances, currently used by Piwik\Tracker\Visit
     'tracker.request.processors' => array(),
 
     'Piwik\Tracker\VisitorRecognizer' => DI\object()

--- a/config/global.php
+++ b/config/global.php
@@ -75,4 +75,9 @@ return array(
 
     'tracker.request.processors' => array(),
 
+    'Piwik\Tracker\VisitorRecognizer' => DI\object()
+        ->constructorParameter('trustCookiesOnly', DI\get('ini.Tracker.trust_visitors_cookies'))
+        ->constructorParameter('visitStandardLength', DI\get('ini.Tracker.visit_standard_length'))
+        ->constructorParameter('lookbackNSecondsCustom', DI\get('ini.Tracker.window_look_back_for_visitor'))
+        ->constructorParameter('trackerAlwaysNewVisitor', DI\get('ini.Debug.tracker_always_new_visitor')),
 );

--- a/config/global.php
+++ b/config/global.php
@@ -72,4 +72,7 @@ return array(
                 'tld' => false,
             ))));
     },
+
+    'tracker.request.processors' => array(),
+
 );

--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -290,6 +290,7 @@ class DocumentationGenerator
         $aParameters['pivotByColumnLimit'] = false;
         $aParameters['disable_queued_filters'] = false;
         $aParameters['disable_generic_filters'] = false;
+        $aParameters['expanded'] = false;
 
         $moduleName = Proxy::getInstance()->getModuleNameFromClassName($class);
         $aParameters = array_merge(array('module' => 'API', 'method' => $moduleName . '.' . $methodName), $aParameters);

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -451,6 +451,19 @@ class Plugin
     }
 
     /**
+     * Override this method in your plugin class if you want your plugin to be loaded during tracking.
+     *
+     * Note: If you define your own dimension or handle a tracker event, your plugin will automatically
+     * be detected as a tracker plugin.
+     *
+     * @return bool
+     */
+    public function isTrackerPlugin()
+    {
+        return false;
+    }
+
+    /**
      * @param $directoryWithinPlugin
      * @param $expectedSubclass
      * @return array

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -457,6 +457,7 @@ class Plugin
      * be detected as a tracker plugin.
      *
      * @return bool
+     * @internal
      */
     public function isTrackerPlugin()
     {

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1102,6 +1102,10 @@ class Manager
             return true;
         }
 
+        if ($plugin->isTrackerPlugin()) {
+            return true;
+        }
+
         return false;
     }
 

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -205,7 +205,7 @@ class GoalManager
      */
     public function recordGoals(VisitProperties $visitProperties, Request $request)
     {
-        $visitorInformation = $visitProperties->visitorInfo;
+        $visitorInformation = $visitProperties->getProperties();
         $visitCustomVariables = $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables');
 
         /** @var Action $action */
@@ -315,9 +315,10 @@ class GoalManager
         $conversion['items'] = $itemsCount;
 
         if ($isThereExistingCartInVisit) {
-            $recorded = $this->getModel()->updateConversion($visitProperties->visitorInfo['idvisit'], self::IDGOAL_CART, $conversion);
+            $recorded = $this->getModel()->updateConversion(
+                $visitProperties->getProperty('idvisit'), self::IDGOAL_CART, $conversion);
         } else {
-            $recorded = $this->insertNewConversion($conversion, $visitProperties->visitorInfo, $request);
+            $recorded = $this->insertNewConversion($conversion, $visitProperties->getProperties(), $request);
         }
 
         if ($recorded) {
@@ -335,7 +336,7 @@ class GoalManager
          * @param array $visitInformation The visit entity that we are tracking a conversion for. See what
          *                                information it contains [here](/guides/persistence-and-the-mysql-backend#visits).
          */
-        Piwik::postEvent('Tracker.recordEcommerceGoal', array($conversion, $visitProperties->visitorInfo));
+        Piwik::postEvent('Tracker.recordEcommerceGoal', array($conversion, $visitProperties->getProperties()));
     }
 
     /**
@@ -665,12 +666,12 @@ class GoalManager
             // If multiple Goal conversions per visit, set a cache buster
             $conversion['buster'] = $convertedGoal['allow_multiple'] == 0
                 ? '0'
-                : $visitProperties->visitorInfo['visit_last_action_time'];
+                : $visitProperties->getProperty('visit_last_action_time');
 
             $conversionDimensions = ConversionDimension::getAllDimensions();
             $conversion = $this->triggerHookOnDimensions($request, $conversionDimensions, 'onGoalConversion', $visitor, $action, $conversion);
 
-            $this->insertNewConversion($conversion, $visitProperties->visitorInfo, $request);
+            $this->insertNewConversion($conversion, $visitProperties->getProperties(), $request);
 
             /**
              * Triggered after successfully recording a non-ecommerce conversion.
@@ -791,9 +792,9 @@ class GoalManager
     private function getGoalFromVisitor(VisitProperties $visitProperties, Request $request, $action)
     {
         $goal = array(
-            'idvisit'     => $visitProperties->visitorInfo['idvisit'],
-            'idvisitor'   => $visitProperties->visitorInfo['idvisitor'],
-            'server_time' => Date::getDatetimeFromTimestamp($visitProperties->visitorInfo['visit_last_action_time'])
+            'idvisit'     => $visitProperties->getProperty('idvisit'),
+            'idvisitor'   => $visitProperties->getProperty('idvisitor'),
+            'server_time' => Date::getDatetimeFromTimestamp($visitProperties->getProperty('visit_last_action_time')),
         );
 
         $visitDimensions = VisitDimension::getAllDimensions();

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -55,54 +55,24 @@ class GoalManager
     const INTERNAL_ITEM_PRICE = 7;
     const INTERNAL_ITEM_QUANTITY = 8;
 
-    public $idGoal;
-    public $requestIsEcommerce;
-    private $isGoalAnOrder;
-
     /**
-     * @var Action
+     * TODO: should remove this, but it is used by getGoalColumn which is used by dimensions. should replace w/ value object.
+     *
+     * @var array
      */
-    protected $action = null;
-    protected $convertedGoals = array();
-
     private $currentGoal = array();
-
-    /**
-     * @var Request
-     */
-    protected $request;
-    protected $orderId;
-
-    protected $isThereExistingCartInVisit = false;
-
-    /**
-     * Constructor
-     * @param Request $request
-     */
-    public function __construct(Request $request)
-    {
-        $this->request = $request;
-        $this->orderId = $request->getParam('ec_id');
-        $this->idGoal  = $request->getParam('idgoal');
-
-        $this->isGoalAnOrder = !empty($this->orderId);
-        $this->requestIsEcommerce = (0 == $this->idGoal);
-    }
-
-    public function isGoalAnOrder()
-    {
-        return $this->isGoalAnOrder;
-    }
 
     public function detectIsThereExistingCartInVisit($visitInformation)
     {
-        if (!empty($visitInformation['visit_goal_buyer'])) {
-            $goalBuyer = $visitInformation['visit_goal_buyer'];
-            $types     = array(GoalManager::TYPE_BUYER_OPEN_CART, GoalManager::TYPE_BUYER_ORDERED_AND_OPEN_CART);
-
-            // Was there a Cart for this visit prior to the order?
-            $this->isThereExistingCartInVisit = in_array($goalBuyer, $types);
+        if (empty($visitInformation['visit_goal_buyer'])) {
+            return false;
         }
+
+        $goalBuyer = $visitInformation['visit_goal_buyer'];
+        $types     = array(GoalManager::TYPE_BUYER_OPEN_CART, GoalManager::TYPE_BUYER_ORDERED_AND_OPEN_CART);
+
+        // Was there a Cart for this visit prior to the order?
+        return in_array($goalBuyer, $types);
     }
 
     public static function getGoalDefinitions($idSite)
@@ -147,17 +117,18 @@ class GoalManager
      * @param int $idSite
      * @param Action $action
      * @throws Exception
-     * @return int Number of goals matched
+     * @return array[] Goals matched
      */
     public function detectGoalsMatchingUrl($idSite, $action)
     {
         if (!Common::isGoalPluginEnabled()) {
-            return false;
+            return array();
         }
 
         $actionType = $action->getActionType();
         $goals = $this->getGoalDefinitions($idSite);
 
+        $convertedGoals = array();
         foreach ($goals as $goal) {
             $attribute = $goal['match_attribute'];
             // if the attribute to match is not the type of the current action
@@ -196,37 +167,32 @@ class GoalManager
             $match = $this->isUrlMatchingGoal($goal, $pattern_type, $url);
             if ($match) {
                 $goal['url'] = $action->getActionUrl();
-                $this->convertedGoals[] = $goal;
+                $convertedGoals[] = $goal;
             }
         }
 
-        return count($this->convertedGoals) > 0;
+        return $convertedGoals;
     }
 
-    public function isManualGoalConversion()
-    {
-        return $this->idGoal > 0;
-    }
-
-    public function detectGoalId($idSite)
+    public function detectGoalId($idSite, Request $request)
     {
         if (!Common::isGoalPluginEnabled()) {
-            return false;
+            return null;
         }
+
+        $idGoal = $request->getParam('idgoal');
 
         $goals = $this->getGoalDefinitions($idSite);
 
-        if (!isset($goals[$this->idGoal])) {
-            return false;
+        if (!isset($goals[$idGoal])) {
+            return null;
         }
 
-        $goal = $goals[$this->idGoal];
+        $goal = $goals[$idGoal];
 
-        $url         = $this->request->getParam('url');
+        $url         = $request->getParam('url');
         $goal['url'] = PageUrl::excludeQueryParametersFromUrl($url, $idSite);
-        $this->convertedGoals[] = $goal;
-
-        return true;
+        return $goal;
     }
 
     /**
@@ -237,7 +203,7 @@ class GoalManager
      * @param array $visitCustomVariables
      * @param Action $action
      */
-    public function recordGoals(VisitProperties $visitProperties)
+    public function recordGoals(VisitProperties $visitProperties, Request $request)
     {
         $visitorInformation = $visitProperties->visitorInfo;
         $visitCustomVariables = $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables');
@@ -245,7 +211,7 @@ class GoalManager
         /** @var Action $action */
         $action = $visitProperties->getRequestMetadata('Actions', 'action');
 
-        $goal = $this->getGoalFromVisitor($visitProperties, $action);
+        $goal = $this->getGoalFromVisitor($visitProperties, $request, $action);
 
         // Copy Custom Variables from Visit row to the Goal conversion
         // Otherwise, set the Custom Variables found in the cookie sent with this request
@@ -266,10 +232,11 @@ class GoalManager
         }
 
         // some goals are converted, so must be ecommerce Order or Cart Update
-        if ($this->requestIsEcommerce) {
-            $this->recordEcommerceGoal($visitProperties, $goal, $action);
+        $isRequestEcommerce = $visitProperties->getRequestMetadata('Ecommerce', 'isRequestEcommerce');
+        if ($isRequestEcommerce) {
+            $this->recordEcommerceGoal($visitProperties, $request, $goal, $action);
         } else {
-            $this->recordStandardGoals($visitProperties, $goal, $action);
+            $this->recordStandardGoals($visitProperties, $request, $goal, $action);
         }
     }
 
@@ -299,23 +266,27 @@ class GoalManager
      * @param Action $action
      * @param array $visitInformation
      */
-    protected function recordEcommerceGoal(VisitProperties $visitProperties, $conversion, $action)
+    protected function recordEcommerceGoal(VisitProperties $visitProperties, Request $request, $conversion, $action)
     {
-        if ($this->isThereExistingCartInVisit) {
+        $isThereExistingCartInVisit = $visitProperties->getRequestMetadata('Goals', 'isThereExistingCartInVisit');
+        if ($isThereExistingCartInVisit) {
             Common::printDebug("There is an existing cart for this visit");
         }
 
         $visitor = Visitor::makeFromVisitProperties($visitProperties);
 
-        if ($this->isGoalAnOrder) {
+        $isGoalAnOrder = $visitProperties->getRequestMetadata('Ecommerce', 'isGoalAnOrder');
+        if ($isGoalAnOrder) {
             $debugMessage = 'The conversion is an Ecommerce order';
 
-            $conversion['idorder'] = $this->orderId;
+            $orderId = $request->getParam('ec_id');
+
+            $conversion['idorder'] = $orderId;
             $conversion['idgoal']  = self::IDGOAL_ORDER;
-            $conversion['buster']  = Common::hashStringToInt($this->orderId);
+            $conversion['buster']  = Common::hashStringToInt($orderId);
 
             $conversionDimensions = ConversionDimension::getAllDimensions();
-            $conversion = $this->triggerHookOnDimensions($conversionDimensions, 'onEcommerceOrderConversion', $visitor, $action, $conversion);
+            $conversion = $this->triggerHookOnDimensions($request, $conversionDimensions, 'onEcommerceOrderConversion', $visitor, $action, $conversion);
         } // If Cart update, select current items in the previous Cart
         else {
             $debugMessage = 'The conversion is an Ecommerce Cart Update';
@@ -324,13 +295,13 @@ class GoalManager
             $conversion['idgoal'] = self::IDGOAL_CART;
 
             $conversionDimensions = ConversionDimension::getAllDimensions();
-            $conversion = $this->triggerHookOnDimensions($conversionDimensions, 'onEcommerceCartUpdateConversion', $visitor, $action, $conversion);
+            $conversion = $this->triggerHookOnDimensions($request, $conversionDimensions, 'onEcommerceCartUpdateConversion', $visitor, $action, $conversion);
         }
 
         Common::printDebug($debugMessage . ':' . var_export($conversion, true));
 
         // INSERT or Sync items in the Cart / Order for this visit & order
-        $items = $this->getEcommerceItemsFromRequest();
+        $items = $this->getEcommerceItemsFromRequest($request);
 
         if (false === $items) {
             return;
@@ -343,10 +314,10 @@ class GoalManager
 
         $conversion['items'] = $itemsCount;
 
-        if ($this->isThereExistingCartInVisit) {
+        if ($isThereExistingCartInVisit) {
             $recorded = $this->getModel()->updateConversion($visitProperties->visitorInfo['idvisit'], self::IDGOAL_CART, $conversion);
         } else {
-            $recorded = $this->insertNewConversion($conversion, $visitProperties->visitorInfo);
+            $recorded = $this->insertNewConversion($conversion, $visitProperties->visitorInfo, $request);
         }
 
         if ($recorded) {
@@ -371,9 +342,9 @@ class GoalManager
      * Returns Items read from the request string
      * @return array|bool
      */
-    private function getEcommerceItemsFromRequest()
+    private function getEcommerceItemsFromRequest(Request $request)
     {
-        $items = $this->request->getParam('ec_items');
+        $items = $request->getParam('ec_items');
 
         if (empty($items)) {
             Common::printDebug("There are no Ecommerce items in the request");
@@ -674,11 +645,12 @@ class GoalManager
      * @param Action $action
      * @param $visitorInformation
      */
-    protected function recordStandardGoals(VisitProperties $visitProperties, $goal, $action)
+    protected function recordStandardGoals(VisitProperties $visitProperties, Request $request, $goal, $action)
     {
         $visitor = Visitor::makeFromVisitProperties($visitProperties);
 
-        foreach ($this->convertedGoals as $convertedGoal) {
+        $convertedGoals = $visitProperties->getRequestMetadata('Goals', 'goalsConverted') ?: array();
+        foreach ($convertedGoals as $convertedGoal) {
             $this->currentGoal = $convertedGoal;
             Common::printDebug("- Goal " . $convertedGoal['idgoal'] . " matched. Recording...");
             $conversion = $goal;
@@ -696,9 +668,9 @@ class GoalManager
                 : $visitProperties->visitorInfo['visit_last_action_time'];
 
             $conversionDimensions = ConversionDimension::getAllDimensions();
-            $conversion = $this->triggerHookOnDimensions($conversionDimensions, 'onGoalConversion', $visitor, $action, $conversion);
+            $conversion = $this->triggerHookOnDimensions($request, $conversionDimensions, 'onGoalConversion', $visitor, $action, $conversion);
 
-            $this->insertNewConversion($conversion, $visitProperties->visitorInfo);
+            $this->insertNewConversion($conversion, $visitProperties->visitorInfo, $request);
 
             /**
              * Triggered after successfully recording a non-ecommerce conversion.
@@ -720,7 +692,7 @@ class GoalManager
      * @param array $visitInformation
      * @return bool
      */
-    protected function insertNewConversion($conversion, $visitInformation)
+    protected function insertNewConversion($conversion, $visitInformation, Request $request)
     {
         /**
          * Triggered before persisting a new [conversion entity](/guides/persistence-and-the-mysql-backend#conversions).
@@ -733,7 +705,7 @@ class GoalManager
          *                                information it contains [here](/guides/persistence-and-the-mysql-backend#visits).
          * @param \Piwik\Tracker\Request $request An object describing the tracking request being processed.
          */
-        Piwik::postEvent('Tracker.newConversionInformation', array(&$conversion, $visitInformation, $this->request));
+        Piwik::postEvent('Tracker.newConversionInformation', array(&$conversion, $visitInformation, $request));
 
         $newGoalDebug = $conversion;
         $newGoalDebug['idvisitor'] = bin2hex($newGoalDebug['idvisitor']);
@@ -796,10 +768,10 @@ class GoalManager
      *
      * @return array|null The updated $valuesToUpdate or null if no $valuesToUpdate given
      */
-    private function triggerHookOnDimensions($dimensions, $hook, $visitor, $action, $valuesToUpdate)
+    private function triggerHookOnDimensions(Request $request, $dimensions, $hook, $visitor, $action, $valuesToUpdate)
     {
         foreach ($dimensions as $dimension) {
-            $value = $dimension->$hook($this->request, $visitor, $action, $this);
+            $value = $dimension->$hook($request, $visitor, $action, $this);
 
             if (false !== $value) {
                 if (is_float($value)) {
@@ -816,7 +788,7 @@ class GoalManager
         return $valuesToUpdate;
     }
 
-    private function getGoalFromVisitor(VisitProperties $visitProperties, $action)
+    private function getGoalFromVisitor(VisitProperties $visitProperties, Request $request, $action)
     {
         $goal = array(
             'idvisit'     => $visitProperties->visitorInfo['idvisit'],
@@ -828,7 +800,7 @@ class GoalManager
 
         $visit = Visitor::makeFromVisitProperties($visitProperties);
         foreach ($visitDimensions as $dimension) {
-            $value = $dimension->onAnyGoalConversion($this->request, $visit, $action);
+            $value = $dimension->onAnyGoalConversion($request, $visit, $action);
             if (false !== $value) {
                 $goal[$dimension->getColumnName()] = $value;
             }

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -237,7 +237,7 @@ class GoalManager
      * @param array $visitCustomVariables
      * @param Action $action
      */
-    public function recordGoals(VisitProperties $visitProperties, Request $request)
+    public function recordGoals(VisitProperties $visitProperties)
     {
         $visitorInformation = $visitProperties->visitorInfo;
         $visitCustomVariables = $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables');
@@ -245,7 +245,7 @@ class GoalManager
         /** @var Action $action */
         $action = $visitProperties->getRequestMetadata('Actions', 'action');
 
-        $goal = $this->getGoalFromVisitor($visitProperties, $request, $action);
+        $goal = $this->getGoalFromVisitor($visitProperties, $action);
 
         // Copy Custom Variables from Visit row to the Goal conversion
         // Otherwise, set the Custom Variables found in the cookie sent with this request
@@ -267,9 +267,9 @@ class GoalManager
 
         // some goals are converted, so must be ecommerce Order or Cart Update
         if ($this->requestIsEcommerce) {
-            $this->recordEcommerceGoal($visitProperties, $request, $goal, $action);
+            $this->recordEcommerceGoal($visitProperties, $goal, $action);
         } else {
-            $this->recordStandardGoals($visitProperties, $request, $goal, $action);
+            $this->recordStandardGoals($visitProperties, $goal, $action);
         }
     }
 
@@ -299,13 +299,13 @@ class GoalManager
      * @param Action $action
      * @param array $visitInformation
      */
-    protected function recordEcommerceGoal(VisitProperties $visitProperties, Request $request, $conversion, $action)
+    protected function recordEcommerceGoal(VisitProperties $visitProperties, $conversion, $action)
     {
         if ($this->isThereExistingCartInVisit) {
             Common::printDebug("There is an existing cart for this visit");
         }
 
-        $visitor = Visitor::makeFromVisitProperties($visitProperties, $request);
+        $visitor = Visitor::makeFromVisitProperties($visitProperties);
 
         if ($this->isGoalAnOrder) {
             $debugMessage = 'The conversion is an Ecommerce order';
@@ -674,9 +674,9 @@ class GoalManager
      * @param Action $action
      * @param $visitorInformation
      */
-    protected function recordStandardGoals(VisitProperties $visitProperties, Request $request, $goal, $action)
+    protected function recordStandardGoals(VisitProperties $visitProperties, $goal, $action)
     {
-        $visitor = Visitor::makeFromVisitProperties($visitProperties, $request);
+        $visitor = Visitor::makeFromVisitProperties($visitProperties);
 
         foreach ($this->convertedGoals as $convertedGoal) {
             $this->currentGoal = $convertedGoal;
@@ -816,7 +816,7 @@ class GoalManager
         return $valuesToUpdate;
     }
 
-    private function getGoalFromVisitor(VisitProperties $visitProperties, Request $request, $action)
+    private function getGoalFromVisitor(VisitProperties $visitProperties, $action)
     {
         $goal = array(
             'idvisit'     => $visitProperties->visitorInfo['idvisit'],
@@ -826,7 +826,7 @@ class GoalManager
 
         $visitDimensions = VisitDimension::getAllDimensions();
 
-        $visit = Visitor::makeFromVisitProperties($visitProperties, $request);
+        $visit = Visitor::makeFromVisitProperties($visitProperties);
         foreach ($visitDimensions as $dimension) {
             $value = $dimension->onAnyGoalConversion($this->request, $visit, $action);
             if (false !== $value) {

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -206,10 +206,10 @@ class GoalManager
     public function recordGoals(VisitProperties $visitProperties, Request $request)
     {
         $visitorInformation = $visitProperties->getProperties();
-        $visitCustomVariables = $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables');
+        $visitCustomVariables = $request->getMetadata('CustomVariables', 'visitCustomVariables');
 
         /** @var Action $action */
-        $action = $visitProperties->getRequestMetadata('Actions', 'action');
+        $action = $request->getMetadata('Actions', 'action');
 
         $goal = $this->getGoalFromVisitor($visitProperties, $request, $action);
 
@@ -232,7 +232,7 @@ class GoalManager
         }
 
         // some goals are converted, so must be ecommerce Order or Cart Update
-        $isRequestEcommerce = $visitProperties->getRequestMetadata('Ecommerce', 'isRequestEcommerce');
+        $isRequestEcommerce = $request->getMetadata('Ecommerce', 'isRequestEcommerce');
         if ($isRequestEcommerce) {
             $this->recordEcommerceGoal($visitProperties, $request, $goal, $action);
         } else {
@@ -268,14 +268,14 @@ class GoalManager
      */
     protected function recordEcommerceGoal(VisitProperties $visitProperties, Request $request, $conversion, $action)
     {
-        $isThereExistingCartInVisit = $visitProperties->getRequestMetadata('Goals', 'isThereExistingCartInVisit');
+        $isThereExistingCartInVisit = $request->getMetadata('Goals', 'isThereExistingCartInVisit');
         if ($isThereExistingCartInVisit) {
             Common::printDebug("There is an existing cart for this visit");
         }
 
-        $visitor = Visitor::makeFromVisitProperties($visitProperties);
+        $visitor = Visitor::makeFromVisitProperties($visitProperties, $request);
 
-        $isGoalAnOrder = $visitProperties->getRequestMetadata('Ecommerce', 'isGoalAnOrder');
+        $isGoalAnOrder = $request->getMetadata('Ecommerce', 'isGoalAnOrder');
         if ($isGoalAnOrder) {
             $debugMessage = 'The conversion is an Ecommerce order';
 
@@ -648,9 +648,9 @@ class GoalManager
      */
     protected function recordStandardGoals(VisitProperties $visitProperties, Request $request, $goal, $action)
     {
-        $visitor = Visitor::makeFromVisitProperties($visitProperties);
+        $visitor = Visitor::makeFromVisitProperties($visitProperties, $request);
 
-        $convertedGoals = $visitProperties->getRequestMetadata('Goals', 'goalsConverted') ?: array();
+        $convertedGoals = $request->getMetadata('Goals', 'goalsConverted') ?: array();
         foreach ($convertedGoals as $convertedGoal) {
             $this->currentGoal = $convertedGoal;
             Common::printDebug("- Goal " . $convertedGoal['idgoal'] . " matched. Recording...");
@@ -799,7 +799,7 @@ class GoalManager
 
         $visitDimensions = VisitDimension::getAllDimensions();
 
-        $visit = Visitor::makeFromVisitProperties($visitProperties);
+        $visit = Visitor::makeFromVisitProperties($visitProperties, $request);
         foreach ($visitDimensions as $dimension) {
             $value = $dimension->onAnyGoalConversion($request, $visit, $action);
             if (false !== $value) {

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -302,15 +302,9 @@ class Model
         return $wasInserted;
     }
 
-    public function findVisitor($idSite, $configId, $idVisitor, $fieldsToRead, $numCustomVarsToRead, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead)
+    public function findVisitor($idSite, $configId, $idVisitor, $fieldsToRead, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead)
     {
         $selectCustomVariables = '';
-
-        if ($numCustomVarsToRead) {
-            for ($index = 1; $index <= $numCustomVarsToRead; $index++) {
-                $selectCustomVariables .= ', custom_var_k' . $index . ', custom_var_v' . $index;
-            }
-        }
 
         $selectFields = implode(', ', $fieldsToRead);
 

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -43,6 +43,15 @@ class Request
 
     protected $tokenAuth;
 
+    /**
+     * Stores plugin specific tracking request metadata. RequestProcessors can store
+     * whatever they want in this array, and other RequestProcessors can modify these
+     * values to change tracker behavior.
+     *
+     * @var string[][]
+     */
+    private $requestMetadata = array();
+
     const UNKNOWN_RESOLUTION = 'unknown';
 
     const CUSTOM_TIMESTAMP_DOES_NOT_REQUIRE_TOKENAUTH_WHEN_NEWER_THAN = 14400; // 4 hours
@@ -761,5 +770,29 @@ class Request
         }
 
         return $cip;
+    }
+
+    /**
+     * Set a request metadata value.
+     *
+     * @param string $pluginName eg, `'Actions'`, `'Goals'`, `'YourPlugin'`
+     * @param string $key
+     * @param mixed $value
+     */
+    public function setMetadata($pluginName, $key, $value)
+    {
+        $this->requestMetadata[$pluginName][$key] = $value;
+    }
+
+    /**
+     * Get a request metadata value. Returns `null` if none exists.
+     *
+     * @param string $pluginName eg, `'Actions'`, `'Goals'`, `'YourPlugin'`
+     * @param string $key
+     * @return mixed
+     */
+    public function getMetadata($pluginName, $key)
+    {
+        return isset($this->requestMetadata[$pluginName][$key]) ? $this->requestMetadata[$pluginName][$key] : null;
     }
 }

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tracker;
+
+use Piwik\Tracker\Visit\VisitProperties;
+
+/**
+ * TODO
+ */
+abstract class RequestProcessor
+{
+    /**
+     * TODO
+     */
+    public function processRequestParams(VisitProperties $visitProperties, Request $request)
+    {
+        return false;
+    }
+
+    /**
+     * TODO
+     */
+    public function manipulateVisitProperties(VisitProperties $visitProperties)
+    {
+        return false;
+    }
+
+    /**
+     * TODO
+     */
+    public function processRequest(VisitProperties $visitProperties)
+    {
+        // empty
+    }
+}

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -156,8 +156,9 @@ abstract class RequestProcessor
      * other words, the values in the array were persisted to the DB before this method was called).
      *
      * @param VisitProperties $visitProperties
+     * @param Request $request
      */
-    public function recordLogs(VisitProperties $visitProperties)
+    public function recordLogs(VisitProperties $visitProperties, Request $request)
     {
         // empty
     }

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -12,6 +12,8 @@ use Piwik\Tracker\Visit\VisitProperties;
 
 /**
  * TODO
+ *
+ * TODO: maybe we should rename manipulateVisitProperties to afterRequestProcessed and rename processRequest to handleRequest or recordLogs
  */
 abstract class RequestProcessor
 {
@@ -26,7 +28,7 @@ abstract class RequestProcessor
     /**
      * TODO
      */
-    public function manipulateVisitProperties(VisitProperties $visitProperties)
+    public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
     {
         return false;
     }

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -52,7 +52,7 @@ abstract class RequestProcessor
     /**
      * TODO
      */
-    public function processRequest(VisitProperties $visitProperties)
+    public function processRequest(Visitor $visitor, VisitProperties $visitProperties)
     {
         // empty
     }

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -85,7 +85,9 @@ abstract class RequestProcessor
      *
      * Derived classes should use this method to set request metadata based on the tracking
      * request alone. They should not try to access request metadata from other plugins,
-     * since they may not be set yet.@deprecated
+     * since they may not be set yet.
+     *
+     * When this method is called, `$visitProperties->visitorInfo` will be empty.
      *
      * @param VisitProperties $visitProperties
      * @param Request $request
@@ -104,7 +106,8 @@ abstract class RequestProcessor
      * tracking behavior.
      *
      * When this method is called, you can assume all available request metadata from all plugins
-     * will be initialized (but not at their final value).
+     * will be initialized (but not at their final value). Also, `$visitProperties->visitorInfo`
+     * will contain the values of the visitor's last known visit (if any).
      *
      * @param VisitProperties $visitProperties
      * @param Request $request
@@ -135,6 +138,7 @@ abstract class RequestProcessor
      *
      * Only implement this method if you cannot use a Dimension for the same thing.
      *
+     * @param array &$valuesToUpdate
      * @param VisitProperties $visitProperties
      * @param Request $request
      */
@@ -147,7 +151,9 @@ abstract class RequestProcessor
      * This method is called last. Derived classes should use this method to insert log data. They
      * should also only read request metadata, and not set it.
      *
-     * When this method is called, you can assume all request metadata have their final values.
+     * When this method is called, you can assume all request metadata have their final values. Also,
+     * `$visitProperties->visitorInfo` will contain the properties of the visitor's current visit (in
+     * other words, the values in the array were persisted to the DB before this method was called).
      *
      * @param VisitProperties $visitProperties
      */

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -12,8 +12,6 @@ use Piwik\Tracker\Visit\VisitProperties;
 
 /**
  * TODO
- *
- * TODO: maybe we should rename manipulateVisitProperties to afterRequestProcessed and rename processRequest to handleRequest or recordLogs
  */
 abstract class RequestProcessor
 {
@@ -28,7 +26,7 @@ abstract class RequestProcessor
     /**
      * TODO
      */
-    public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
+    public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
     {
         return false;
     }
@@ -52,7 +50,7 @@ abstract class RequestProcessor
     /**
      * TODO
      */
-    public function processRequest(VisitProperties $visitProperties, Request $request)
+    public function recordLogs(VisitProperties $visitProperties )
     {
         // empty
     }

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -36,6 +36,22 @@ abstract class RequestProcessor
     /**
      * TODO
      */
+    public function onNewVisit(VisitProperties $visitProperties, Request $request)
+    {
+        // empty
+    }
+
+    /**
+     * TODO
+     */
+    public function onExistingVisit(&$valuesToUpdate, VisitProperties $visitProperties, Request $request)
+    {
+        // empty
+    }
+
+    /**
+     * TODO
+     */
     public function processRequest(VisitProperties $visitProperties)
     {
         // empty

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -11,12 +11,85 @@ namespace Piwik\Tracker;
 use Piwik\Tracker\Visit\VisitProperties;
 
 /**
- * TODO
+ * Base class for all tracker RequestProcessors. RequestProcessors handle and respond to tracking
+ * requests.
+ *
+ * ## Concept: Request Metadata
+ *
+ * RequestProcessors take a Tracker\Request object and based on its information, set request metadata.
+ *
+ * Request metadata is information about the current tracking request, for example, whether
+ * the request is for an existing visit or new visit, or whether the current visitor is a known
+ * visitor, etc. It is used to control tracking behavior.
+ *
+ * Request metadata is shared between RequestProcessors, so RequestProcessors can tweak each others
+ * behavior, and thus, the behavior of the Tracker. Request metadata can be set and get using the
+ * {@link VisitProperties::setRequestMetadata()} and {@link VisitProperties::getRequestMetadata()}
+ * methods.
+ *
+ * Each RequestProcessor lists the request metadata it computes and exposes in its class
+ * documentation.
+ *
+ * ## The Tracking Process
+ *
+ * When Piwik handles a single tracking request, it gathers all available RequestProcessors and
+ * invokes their methods in sequence.
+ *
+ * The first method called is {@link self::processRequestParams()}. RequestProcessors should use
+ * this method to compute request metadata and set visit properties using the tracking request.
+ * An example includes the ActionRequestProcessor, which uses this method to determine the action
+ * being tracked.
+ *
+ * The second method called is {@link self::afterRequestProcessed()}. RequestProcessors should
+ * use this method to either compute request metadata/visit properties using other plugins'
+ * request metadata, OR override other plugins' request metadata to tweak tracker behavior.
+ * An example of the former can be seen in the GoalsRequestProcessor which uses the action
+ * detected by the ActionsRequestProcessor to see if there are any action-matching goal
+ * conversions. An example of the latter can be seen in the PingRequestProcessor, which on
+ * ping requests, aborts conversion recording and new visit recording.
+ *
+ * After these two methods are called, either {@link self::onNewVisit()} or {@link self::onExistingVisit()}
+ * is called. Generally, plugins should favor defining Dimension classes instead of using these methods,
+ * however sometimes it is not possible (as is the case with the CustomVariables plugin).
+ *
+ * Finally, the {@link self::recordLogs()} method is called. In this method, RequestProcessors
+ * should use the request metadata that was set (and maybe overridden) to insert whatever log data
+ * they want.
+ *
+ * ## Extending The Piwik Tracker
+ *
+ * Plugins that want to change the tracking process in order to track new data or change how
+ * existing data is tracked can create RequestProcessors to accomplish.
+ *
+ * _Note: If you only want to add tracked data to visits, actions or conversions, you should create
+ * a {@link Dimension} class._
+ *
+ * To create a new RequestProcessor, create a new class that derives from this one, and implement the
+ * methods you need. Then in your plugin's DI config file (located at
+ * `/path/to/piwik/plugins/YourPlugin/config/config.php`), add the following to the array:
+ *
+ * ```
+ *     'tracker.request.processors' => DI\add(array(
+ *         DI\get('Piwik\Plugins\Goals\Tracker\GoalsRequestProcessor'),
+ *     )),
+ * ```
+ *
+ * Final note: RequestProcessors are shared between tracking requests, and so, should ideally be
+ * stateless. They are stored in DI, so they can contain references to other objects in DI, but
+ * they shouldn't contain data that might change between tracking requests.
  */
 abstract class RequestProcessor
 {
     /**
-     * TODO
+     * This is the first method called when processing a tracker request.
+     *
+     * Derived classes should use this method to set request metadata based on the tracking
+     * request alone. They should not try to access request metadata from other plugins,
+     * since they may not be set yet.@deprecated
+     *
+     * @param VisitProperties $visitProperties
+     * @param Request $request
+     * @return bool If `true` the tracking request will be aborted.
      */
     public function processRequestParams(VisitProperties $visitProperties, Request $request)
     {
@@ -24,7 +97,18 @@ abstract class RequestProcessor
     }
 
     /**
-     * TODO
+     * This is the second method called when processing a tracker request.
+     *
+     * Derived classes should use this method to set request metadata that needs request metadata
+     * from other plugins, or to override request metadata from other plugins to change
+     * tracking behavior.
+     *
+     * When this method is called, you can assume all available request metadata from all plugins
+     * will be initialized (but not at their final value).
+     *
+     * @param VisitProperties $visitProperties
+     * @param Request $request
+     * @return bool If `true` the tracking request will be aborted.
      */
     public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
     {
@@ -32,7 +116,13 @@ abstract class RequestProcessor
     }
 
     /**
-     * TODO
+     * This method is called before recording a new visit. You can set/change visit information here
+     * to change what gets inserted into `log_visit`.
+     *
+     * Only implement this method if you cannot use a Dimension for the same thing.
+     *
+     * @param VisitProperties $visitProperties
+     * @param Request $request
      */
     public function onNewVisit(VisitProperties $visitProperties, Request $request)
     {
@@ -40,7 +130,13 @@ abstract class RequestProcessor
     }
 
     /**
-     * TODO
+     * This method is called before updating an existing visit. You can set/change visit information
+     * here to change what gets recorded in `log_visit`.
+     *
+     * Only implement this method if you cannot use a Dimension for the same thing.
+     *
+     * @param VisitProperties $visitProperties
+     * @param Request $request
      */
     public function onExistingVisit(&$valuesToUpdate, VisitProperties $visitProperties, Request $request)
     {
@@ -48,9 +144,14 @@ abstract class RequestProcessor
     }
 
     /**
-     * TODO
+     * This method is called last. Derived classes should use this method to insert log data. They
+     * should also only read request metadata, and not set it.
+     *
+     * When this method is called, you can assume all request metadata have their final values.
+     *
+     * @param VisitProperties $visitProperties
      */
-    public function recordLogs(VisitProperties $visitProperties )
+    public function recordLogs(VisitProperties $visitProperties)
     {
         // empty
     }

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -24,7 +24,7 @@ use Piwik\Tracker\Visit\VisitProperties;
  *
  * Request metadata is shared between RequestProcessors, so RequestProcessors can tweak each others
  * behavior, and thus, the behavior of the Tracker. Request metadata can be set and get using the
- * {@link VisitProperties::setRequestMetadata()} and {@link VisitProperties::getRequestMetadata()}
+ * {@link Request::setMetadata()} and {@link Request::getMetadata()}
  * methods.
  *
  * Each RequestProcessor lists the request metadata it computes and exposes in its class

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -52,7 +52,7 @@ abstract class RequestProcessor
     /**
      * TODO
      */
-    public function processRequest(Visitor $visitor, VisitProperties $visitProperties)
+    public function processRequest(VisitProperties $visitProperties, Request $request)
     {
         // empty
     }

--- a/core/Tracker/Settings.php
+++ b/core/Tracker/Settings.php
@@ -13,7 +13,7 @@ use Piwik\Tracker;
 use Piwik\DeviceDetectorFactory;
 use Piwik\SettingsPiwik;
 
-class Settings
+class Settings // TODO: merge w/ visitor recognizer
 {
     const OS_BOT = 'BOT';
 

--- a/core/Tracker/Settings.php
+++ b/core/Tracker/Settings.php
@@ -18,7 +18,8 @@ class Settings // TODO: merge w/ visitor recognizer or make it it's own service.
     const OS_BOT = 'BOT';
 
     /**
-     * TODO
+     * If `true`, the config ID for a visitor will be the same no matter what site is being tracked.
+     * If `false, the config ID will be different.
      *
      * @var bool
      */

--- a/core/Tracker/Settings.php
+++ b/core/Tracker/Settings.php
@@ -13,33 +13,28 @@ use Piwik\Tracker;
 use Piwik\DeviceDetectorFactory;
 use Piwik\SettingsPiwik;
 
-class Settings // TODO: merge w/ visitor recognizer
+class Settings // TODO: merge w/ visitor recognizer or make it it's own service. the class name is required for BC.
 {
     const OS_BOT = 'BOT';
 
-    public function __construct(Request $request, $ip, $isSameFingerprintsAcrossWebsites)
+    /**
+     * TODO
+     *
+     * @var bool
+     */
+    private $isSameFingerprintsAcrossWebsites;
+
+    public function __construct($isSameFingerprintsAcrossWebsites)
     {
-        $this->request   = $request;
-        $this->ipAddress = $ip;
         $this->isSameFingerprintsAcrossWebsites = $isSameFingerprintsAcrossWebsites;
-        $this->configId  = null;
     }
 
-    public function getConfigId()
-    {
-        if (empty($this->configId)) {
-            $this->loadInfo();
-        }
-
-        return $this->configId;
-    }
-
-    protected function loadInfo()
+    public function getConfigId(Request $request, $ipAddress)
     {
         list($plugin_Flash, $plugin_Java, $plugin_Director, $plugin_Quicktime, $plugin_RealPlayer, $plugin_PDF,
-            $plugin_WindowsMedia, $plugin_Gears, $plugin_Silverlight, $plugin_Cookie) = $this->request->getPlugins();
+            $plugin_WindowsMedia, $plugin_Gears, $plugin_Silverlight, $plugin_Cookie) = $request->getPlugins();
 
-        $userAgent = $this->request->getUserAgent();
+        $userAgent = $request->getUserAgent();
 
         $deviceDetector = DeviceDetectorFactory::getInstance($userAgent);
         $aBrowserInfo   = $deviceDetector->getClient();
@@ -59,9 +54,10 @@ class Settings // TODO: merge w/ visitor recognizer
             $os = empty($os['short_name']) ? 'UNK' : $os['short_name'];
         }
 
-        $browserLang = substr($this->request->getBrowserLanguage(), 0, 20); // limit the length of this string to match db
+        $browserLang = substr($request->getBrowserLanguage(), 0, 20); // limit the length of this string to match db
 
-        $this->configId = $this->getConfigHash(
+        return $this->getConfigHash(
+            $request,
             $os,
             $browserName,
             $browserVersion,
@@ -75,7 +71,7 @@ class Settings // TODO: merge w/ visitor recognizer
             $plugin_Gears,
             $plugin_Silverlight,
             $plugin_Cookie,
-            $this->ipAddress,
+            $ipAddress,
             $browserLang);
     }
 
@@ -100,7 +96,10 @@ class Settings // TODO: merge w/ visitor recognizer
      * @param $browserLang
      * @return string
      */
-    protected function getConfigHash($os, $browserName, $browserVersion, $plugin_Flash, $plugin_Java, $plugin_Director, $plugin_Quicktime, $plugin_RealPlayer, $plugin_PDF, $plugin_WindowsMedia, $plugin_Gears, $plugin_Silverlight, $plugin_Cookie, $ip, $browserLang)
+    protected function getConfigHash(Request $request, $os, $browserName, $browserVersion, $plugin_Flash, $plugin_Java,
+                                     $plugin_Director, $plugin_Quicktime, $plugin_RealPlayer, $plugin_PDF,
+                                     $plugin_WindowsMedia, $plugin_Gears, $plugin_Silverlight, $plugin_Cookie, $ip,
+                                     $browserLang)
     {
         // prevent the config hash from being the same, across different Piwik instances
         // (limits ability of different Piwik instances to cross-match users)
@@ -109,13 +108,14 @@ class Settings // TODO: merge w/ visitor recognizer
         $configString =
               $os
             . $browserName . $browserVersion
-            . $plugin_Flash . $plugin_Java . $plugin_Director . $plugin_Quicktime . $plugin_RealPlayer . $plugin_PDF . $plugin_WindowsMedia . $plugin_Gears . $plugin_Silverlight . $plugin_Cookie
+            . $plugin_Flash . $plugin_Java . $plugin_Director . $plugin_Quicktime . $plugin_RealPlayer . $plugin_PDF
+            . $plugin_WindowsMedia . $plugin_Gears . $plugin_Silverlight . $plugin_Cookie
             . $ip
             . $browserLang
             . $salt;
 
         if (!$this->isSameFingerprintsAcrossWebsites) {
-            $configString .= $this->request->getIdSite();
+            $configString .= $request->getIdSite();
         }
 
         $hash = md5($configString, $raw_output = true);

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -131,8 +131,6 @@ class Visit implements VisitInterface
             }
         }
 
-        $goalManager = GoalsRequestProcessor::$goalManager;
-
         /** @var Action $action */
         $action = $this->visitProperties->getRequestMetadata('Actions', 'action');
 
@@ -144,19 +142,8 @@ class Visit implements VisitInterface
         // AND
         // - the last page view for this visitor was less than 30 minutes ago @see isLastActionInTheSameVisit()
         if (!$isNewVisit) {
-            $idReferrerActionUrl = $this->visitProperties->visitorInfo['visit_exit_idaction_url'];
-            $idReferrerActionName = $this->visitProperties->visitorInfo['visit_exit_idaction_name'];
-
             try {
-                if($goalManager) {
-                    $goalManager->detectIsThereExistingCartInVisit($this->visitProperties->visitorInfo);
-                }
-
                 $this->handleExistingVisit($this->visitProperties->getRequestMetadata('Goals', 'visitIsConverted'));
-
-                if (!is_null($action)) {
-                    $action->record($this->makeVisitorFacade(), $idReferrerActionUrl, $idReferrerActionName); // TODO
-                }
             } catch (VisitorNotFoundInDb $e) {
                 $this->visitProperties->setRequestMetadata('CoreHome', 'visitorNotFoundInDb', true);
             }
@@ -174,11 +161,7 @@ class Visit implements VisitInterface
         // - the visitor doesn't have the Piwik cookie, and couldn't be matched in @see recognizeTheVisitor()
         // - the visitor does have the Piwik cookie but the idcookie and idvisit found in the cookie didn't match to any existing visit in the DB
         if ($isNewVisit) {
-
             $this->handleNewVisit($this->visitProperties->getRequestMetadata('Goals', 'visitIsConverted'));
-            if (!is_null($action)) {
-                $action->record($this->makeVisitorFacade(), 0, 0);
-            }
         }
 
         // update the cookie with the new visit information

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -122,6 +122,9 @@ class Visit implements VisitInterface
             // on a ping request that is received before the standard visit length, we just update the visit time w/o adding a new action
             Common::printDebug("-> ping=1 request: we do not track a new action nor a new visit nor any goal.");
 
+            $action = null;
+            $this->visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);
+            $this->visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
         } else {
 
             $goalManager = new GoalManager($this->request);

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -160,7 +160,7 @@ class Visit implements VisitInterface
         $this->request->setThirdPartyCookie($this->visitProperties->visitorInfo['idvisitor']);
 
         foreach ($this->requestProcessors as $processor) {
-            $processor->processRequest($this->makeVisitorFacade(), $this->visitProperties);
+            $processor->processRequest($this->visitProperties, $this->request);
         }
 
         $this->markArchivedReportsAsInvalidIfArchiveAlreadyFinished();
@@ -568,7 +568,6 @@ class Visit implements VisitInterface
 
     private function makeVisitorFacade()
     {
-        $isKnown = $this->visitProperties->getRequestMetadata('CoreHome', 'isVisitorKnown');
-        return new Visitor($this->request, $this->visitProperties, $isKnown);
+        return Visitor::makeFromVisitProperties($this->visitProperties, $this->request);
     }
 }

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -119,10 +119,10 @@ class Visit implements VisitInterface
             }
         }
 
-        $isNewVisit = $this->visitProperties->getRequestMetadata('CoreHome', 'isNewVisit');
+        $isNewVisit = $this->request->getMetadata('CoreHome', 'isNewVisit');
         if (!$isNewVisit) {
             $isNewVisit = $this->triggerPredicateHookOnDimensions($this->getAllVisitDimensions(), 'shouldForceNewVisit');
-            $this->visitProperties->setRequestMetadata('CoreHome', 'isNewVisit', $isNewVisit);
+            $this->request->setMetadata('CoreHome', 'isNewVisit', $isNewVisit);
         }
 
         foreach ($this->requestProcessors as $processor) {
@@ -135,7 +135,7 @@ class Visit implements VisitInterface
             }
         }
 
-        $isNewVisit = $this->visitProperties->getRequestMetadata('CoreHome', 'isNewVisit');
+        $isNewVisit = $this->request->getMetadata('CoreHome', 'isNewVisit');
 
         // Known visit when:
         // ( - the visitor has the Piwik cookie with the idcookie ID used by Piwik to match the visitor
@@ -146,9 +146,9 @@ class Visit implements VisitInterface
         // - the last page view for this visitor was less than 30 minutes ago @see isLastActionInTheSameVisit()
         if (!$isNewVisit) {
             try {
-                $this->handleExistingVisit($this->visitProperties->getRequestMetadata('Goals', 'visitIsConverted'));
+                $this->handleExistingVisit($this->request->getMetadata('Goals', 'visitIsConverted'));
             } catch (VisitorNotFoundInDb $e) {
-                $this->visitProperties->setRequestMetadata('CoreHome', 'visitorNotFoundInDb', true); // TODO: perhaps we should just abort here?
+                $this->request->setMetadata('CoreHome', 'visitorNotFoundInDb', true); // TODO: perhaps we should just abort here?
             }
         }
 
@@ -157,7 +157,7 @@ class Visit implements VisitInterface
         // - the visitor doesn't have the Piwik cookie, and couldn't be matched in @see recognizeTheVisitor()
         // - the visitor does have the Piwik cookie but the idcookie and idvisit found in the cookie didn't match to any existing visit in the DB
         if ($isNewVisit) {
-            $this->handleNewVisit($this->visitProperties->getRequestMetadata('Goals', 'visitIsConverted'));
+            $this->handleNewVisit($this->request->getMetadata('Goals', 'visitIsConverted'));
         }
 
         // update the cookie with the new visit information
@@ -298,7 +298,7 @@ class Visit implements VisitInterface
      */
     protected function getVisitorIdcookie()
     {
-        $isKnown = $this->visitProperties->getRequestMetadata('CoreHome', 'isVisitorKnown');
+        $isKnown = $this->request->getMetadata('CoreHome', 'isVisitorKnown');
         if ($isKnown) {
             return $this->visitProperties->getProperty('idvisitor');
         }
@@ -407,7 +407,7 @@ class Visit implements VisitInterface
     {
         $idVisitor = $this->getVisitorIdcookie();
         $visitorIp = $this->getVisitorIp();
-        $configId = $this->visitProperties->getRequestMetadata('CoreHome', 'visitorId');
+        $configId = $this->request->getMetadata('CoreHome', 'visitorId');
 
         $this->visitProperties->clearProperties();
 
@@ -453,7 +453,7 @@ class Visit implements VisitInterface
         $visitor = $this->makeVisitorFacade();
 
         /** @var Action $action */
-        $action = $this->visitProperties->getRequestMetadata('Actions', 'action');
+        $action = $this->request->getMetadata('Actions', 'action');
 
         foreach ($dimensions as $dimension) {
             $value = $dimension->$hook($this->request, $visitor, $action);
@@ -482,7 +482,7 @@ class Visit implements VisitInterface
         $visitor = $this->makeVisitorFacade();
 
         /** @var Action $action */
-        $action = $this->visitProperties->getRequestMetadata('Actions', 'action');
+        $action = $this->request->getMetadata('Actions', 'action');
 
         foreach ($dimensions as $dimension) {
             if ($dimension->$hook($this->request, $visitor, $action)) {
@@ -577,6 +577,6 @@ class Visit implements VisitInterface
 
     private function makeVisitorFacade()
     {
-        return Visitor::makeFromVisitProperties($this->visitProperties);
+        return Visitor::makeFromVisitProperties($this->visitProperties, $this->request);
     }
 }

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -166,7 +166,7 @@ class Visit implements VisitInterface
         foreach ($this->requestProcessors as $processor) {
             Common::printDebug("Executing " . get_class($processor) . "::recordLogs()...");
 
-            $processor->recordLogs($this->visitProperties);
+            $processor->recordLogs($this->visitProperties, $this->request);
         }
 
         $this->markArchivedReportsAsInvalidIfArchiveAlreadyFinished();

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -129,15 +129,7 @@ class Visit implements VisitInterface
             $isManualGoalConversion = $goalManager->isManualGoalConversion();
             $requestIsEcommerce = $goalManager->requestIsEcommerce;
 
-            if ($requestIsEcommerce) {
-                $this->visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', true);
-
-                // Mark the visit as Converted only if it is an order (not for a Cart update)
-                if ($goalManager->isGoalAnOrder()) {
-                    $this->visitProperties->setRequestMetadata('Goals', 'visitIsConverted', true);
-                }
-            } else if ($isManualGoalConversion) {
-            } else {
+            if (!$requestIsEcommerce && !$isManualGoalConversion) {
                 // normal page view, potentially triggering a URL matching goal
                 $action = Action::factory($this->request);
 

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -173,10 +173,6 @@ class Visit implements VisitInterface
                 ) {
                     $this->visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);
                     $this->visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
-                } // When the row wasn't found in the logs, and this is a pageview or
-                // goal matching URL, we force a new visitor
-                else {
-                    $visitor->setIsVisitorKnown(false);
                 }
             }
         }

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -111,19 +111,6 @@ class Visit implements VisitInterface
             }
         }
 
-        foreach ($this->requestProcessors as $processor) {
-            $abort = $processor->manipulateVisitProperties($this->visitProperties);
-            if ($abort) {
-                return;
-            }
-        }
-
-        $this->visitorCustomVariables = $this->request->getCustomVariables($scope = 'visit');
-        if (!empty($this->visitorCustomVariables)) {
-            Common::printDebug("Visit level Custom Variables: ");
-            Common::printDebug($this->visitorCustomVariables);
-        }
-
         /**
          * Goals & Ecommerce conversions
          */
@@ -177,13 +164,25 @@ class Visit implements VisitInterface
          * Visitor recognition
          */
         $visitorId = $this->getSettingsObject()->getConfigId();
-        $visitor = new Visitor($this->request, $visitorId, $this->visitProperties->visitorInfo, $this->visitorCustomVariables);
+        $visitor = new Visitor($this->request, $visitorId, $this->visitProperties->visitorInfo);
         $visitor->recognize();
 
         $this->visitProperties->visitorInfo = $visitor->getVisitorInfo();
 
         $isNewVisit = $this->isVisitNew($visitor, $action);
 
+        $this->visitorCustomVariables = $this->request->getCustomVariables($scope = 'visit');
+        if (!empty($this->visitorCustomVariables)) {
+            Common::printDebug("Visit level Custom Variables: ");
+            Common::printDebug($this->visitorCustomVariables);
+        }
+
+        foreach ($this->requestProcessors as $processor) {
+            $abort = $processor->manipulateVisitProperties($this->visitProperties);
+            if ($abort) {
+                return;
+            }
+        }
 
         // Known visit when:
         // ( - the visitor has the Piwik cookie with the idcookie ID used by Piwik to match the visitor
@@ -577,6 +576,7 @@ class Visit implements VisitInterface
         }
 
         // Custom Variables overwrite previous values on each page view
+        //return $valuesToUpdate;
         return array_merge($valuesToUpdate, $this->visitorCustomVariables);
     }
 

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -114,29 +114,16 @@ class Visit implements VisitInterface
         /**
          * Goals & Ecommerce conversions
          */
-        $isManualGoalConversion = $requestIsEcommerce = false;
-        $action = null;
-        $goalManager = null;
+        /** @var Action $action */
+        $action = $this->visitProperties->getRequestMetadata('Actions', 'action');
 
-        if($this->isPingRequest()) {
-            // on a ping request that is received before the standard visit length, we just update the visit time w/o adding a new action
-            Common::printDebug("-> ping=1 request: we do not track a new action nor a new visit nor any goal.");
+        $goalManager = new GoalManager($this->request);
+        $isManualGoalConversion = $goalManager->isManualGoalConversion();
+        $requestIsEcommerce = $goalManager->requestIsEcommerce;
 
-            $action = null;
-            $this->visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);
-            $this->visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
-        } else {
-
-            $goalManager = new GoalManager($this->request);
-
-            $isManualGoalConversion = $goalManager->isManualGoalConversion();
-            $requestIsEcommerce = $goalManager->requestIsEcommerce;
+        if (!empty($action)) {
 
             if (!$requestIsEcommerce && !$isManualGoalConversion) {
-                // normal page view, potentially triggering a URL matching goal
-                $action = Action::factory($this->request);
-
-                $action->writeDebugInfo();
 
                 $someGoalsConverted = $goalManager->detectGoalsMatchingUrl($this->request->getIdSite(), $action);
                 $this->visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', $someGoalsConverted);

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -18,7 +18,6 @@ use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Network\IPUtils;
 use Piwik\Piwik;
 use Piwik\Plugin\Dimension\VisitDimension;
-use Piwik\Plugins\Goals\Tracker\GoalsRequestProcessor;
 use Piwik\Tracker;
 use Piwik\Tracker\Visit\VisitProperties;
 

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -125,7 +125,7 @@ class Visit implements VisitInterface
         }
 
         foreach ($this->requestProcessors as $processor) {
-            $abort = $processor->manipulateVisitProperties($this->visitProperties, $this->request);
+            $abort = $processor->afterRequestProcessed($this->visitProperties, $this->request);
             if ($abort) {
                 return;
             }
@@ -160,7 +160,7 @@ class Visit implements VisitInterface
         $this->request->setThirdPartyCookie($this->visitProperties->visitorInfo['idvisitor']);
 
         foreach ($this->requestProcessors as $processor) {
-            $processor->processRequest($this->visitProperties, $this->request);
+            $processor->recordLogs($this->visitProperties, $this->request);
         }
 
         $this->markArchivedReportsAsInvalidIfArchiveAlreadyFinished();
@@ -568,6 +568,6 @@ class Visit implements VisitInterface
 
     private function makeVisitorFacade()
     {
-        return Visitor::makeFromVisitProperties($this->visitProperties, $this->request);
+        return Visitor::makeFromVisitProperties($this->visitProperties);
     }
 }

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -148,7 +148,7 @@ class Visit implements VisitInterface
             try {
                 $this->handleExistingVisit($this->visitProperties->getRequestMetadata('Goals', 'visitIsConverted'));
             } catch (VisitorNotFoundInDb $e) {
-                $this->visitProperties->setRequestMetadata('CoreHome', 'visitorNotFoundInDb', true);
+                $this->visitProperties->setRequestMetadata('CoreHome', 'visitorNotFoundInDb', true); // TODO: perhaps we should just abort here?
             }
         }
 

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -120,8 +120,6 @@ class Visit implements VisitInterface
         $visitor = new Visitor($this->request, $visitorId, $this->visitProperties);
         $visitor->recognize();
 
-        $this->visitProperties->visitorInfo = $visitor->getVisitorInfo();
-
         /** @var Action $action */
         $action = $this->visitProperties->getRequestMetadata('Actions', 'action');
 

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -47,7 +47,6 @@ class Visit implements VisitInterface
      */
     protected $request;
 
-    // TODO: removed $visitorInfo, this is a BC break for those overriding VisitInterface
     /**
      * @var Settings
      */
@@ -110,10 +109,12 @@ class Visit implements VisitInterface
     {
         $this->visitProperties = new VisitProperties();
 
-        // TODO: add debug logging
         foreach ($this->requestProcessors as $processor) {
+            Common::printDebug("Executing " . get_class($processor) . "::processRequestParams()...");
+
             $abort = $processor->processRequestParams($this->visitProperties, $this->request);
             if ($abort) {
+                Common::printDebug("-> aborting due to processRequestParams method");
                 return;
             }
         }
@@ -125,8 +126,11 @@ class Visit implements VisitInterface
         }
 
         foreach ($this->requestProcessors as $processor) {
+            Common::printDebug("Executing " . get_class($processor) . "::afterRequestProcessed()...");
+
             $abort = $processor->afterRequestProcessed($this->visitProperties, $this->request);
             if ($abort) {
+                Common::printDebug("-> aborting due to afterRequestProcessed method");
                 return;
             }
         }
@@ -160,7 +164,9 @@ class Visit implements VisitInterface
         $this->request->setThirdPartyCookie($this->visitProperties->visitorInfo['idvisitor']);
 
         foreach ($this->requestProcessors as $processor) {
-            $processor->recordLogs($this->visitProperties, $this->request);
+            Common::printDebug("Executing " . get_class($processor) . "::recordLogs()...");
+
+            $processor->recordLogs($this->visitProperties);
         }
 
         $this->markArchivedReportsAsInvalidIfArchiveAlreadyFinished();

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -185,17 +185,7 @@ class Visit implements VisitInterface
         $this->request->setThirdPartyCookie($this->visitProperties->visitorInfo['idvisitor']);
 
         foreach ($this->requestProcessors as $processor) {
-            $processor->processRequest($this->visitProperties);
-        }
-
-        // record the goals if applicable
-        if ($this->visitProperties->getRequestMetadata('Goals', 'someGoalsConverted')) {
-            $goalManager->recordGoals(
-                $visitor,
-                $this->visitProperties->visitorInfo,
-                $this->visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables'),
-                $action
-            );
+            $processor->processRequest($visitor, $this->visitProperties);
         }
 
         unset($action);

--- a/core/Tracker/Visit/VisitProperties.php
+++ b/core/Tracker/Visit/VisitProperties.php
@@ -10,8 +10,6 @@ namespace Piwik\Tracker\Visit;
 
 /**
  * Holds temporary data for tracking requests.
- *
- * RequestProcessors
  */
 class VisitProperties
 {
@@ -21,7 +19,7 @@ class VisitProperties
      *
      * @var array
      */
-    public $visitorInfo = array();
+    private $visitInfo = array();
 
     /**
      * Stores plugin specific tracking request metadata. RequestProcessors can store
@@ -54,5 +52,55 @@ class VisitProperties
     public function getRequestMetadata($pluginName, $key)
     {
         return @$this->requestMetadata[$pluginName][$key];
+    }
+
+    /**
+     * Returns a visit property, or `null` if none is set.
+     *
+     * @param string $name The property name.
+     * @return mixed
+     */
+    public function getProperty($name)
+    {
+        return isset($this->visitInfo[$name]) ? $this->visitInfo[$name] : null;
+    }
+
+    /**
+     * Returns all visit properties by reference.
+     *
+     * @return array
+     */
+    public function &getProperties()
+    {
+        return $this->visitInfo;
+    }
+
+    /**
+     * Sets a visit property.
+     *
+     * @param string $name The property name.
+     * @param mixed $value The property value.
+     */
+    public function setProperty($name, $value)
+    {
+        $this->visitInfo[$name] = $value;
+    }
+
+    /**
+     * Unsets all visit properties.
+     */
+    public function clearProperties()
+    {
+        $this->visitInfo = array();
+    }
+
+    /**
+     * Sets all visit properties.
+     *
+     * @param array $properties
+     */
+    public function setProperties($properties)
+    {
+        $this->visitInfo = $properties;
     }
 }

--- a/core/Tracker/Visit/VisitProperties.php
+++ b/core/Tracker/Visit/VisitProperties.php
@@ -8,14 +8,16 @@
 
 namespace Piwik\Tracker\Visit;
 
-
 /**
- * TODO
+ * Holds temporary data for tracking requests.
+ *
+ * RequestProcessors
  */
 class VisitProperties
 {
     /**
-     * TODO
+     * Information about the current visit. This array holds the column values that will be inserted or updated
+     * in the `log_visit` table, or the values for the last known visit of the current visitor.
      *
      * @var array
      */
@@ -30,11 +32,25 @@ class VisitProperties
      */
     private $requestMetadata = array();
 
+    /**
+     * Set a request metadata value.
+     *
+     * @param string $pluginName eg, `'Actions'`, `'Goals'`, `'YourPlugin'`
+     * @param string $key
+     * @param mixed $value
+     */
     public function setRequestMetadata($pluginName, $key, $value)
     {
         $this->requestMetadata[$pluginName][$key] = $value;
     }
 
+    /**
+     * Get a request metadata value. Returns `null` if none exists.
+     *
+     * @param string $pluginName eg, `'Actions'`, `'Goals'`, `'YourPlugin'`
+     * @param string $key
+     * @return mixed
+     */
     public function getRequestMetadata($pluginName, $key)
     {
         return @$this->requestMetadata[$pluginName][$key];

--- a/core/Tracker/Visit/VisitProperties.php
+++ b/core/Tracker/Visit/VisitProperties.php
@@ -16,6 +16,8 @@ class VisitProperties
 {
     /**
      * TODO
+     *
+     * @var array
      */
     public $visitorInfo = array();
 

--- a/core/Tracker/Visit/VisitProperties.php
+++ b/core/Tracker/Visit/VisitProperties.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tracker\Visit;
+
+
+/**
+ * TODO
+ */
+class VisitProperties
+{
+    /**
+     * TODO
+     */
+    public $visitorInfo = array();
+
+    // TODO
+}

--- a/core/Tracker/Visit/VisitProperties.php
+++ b/core/Tracker/Visit/VisitProperties.php
@@ -22,39 +22,6 @@ class VisitProperties
     private $visitInfo = array();
 
     /**
-     * Stores plugin specific tracking request metadata. RequestProcessors can store
-     * whatever they want in this array, and other RequestProcessors can modify these
-     * values to change tracker behavior.
-     *
-     * @var string[][]
-     */
-    private $requestMetadata = array();
-
-    /**
-     * Set a request metadata value.
-     *
-     * @param string $pluginName eg, `'Actions'`, `'Goals'`, `'YourPlugin'`
-     * @param string $key
-     * @param mixed $value
-     */
-    public function setRequestMetadata($pluginName, $key, $value)
-    {
-        $this->requestMetadata[$pluginName][$key] = $value;
-    }
-
-    /**
-     * Get a request metadata value. Returns `null` if none exists.
-     *
-     * @param string $pluginName eg, `'Actions'`, `'Goals'`, `'YourPlugin'`
-     * @param string $key
-     * @return mixed
-     */
-    public function getRequestMetadata($pluginName, $key)
-    {
-        return @$this->requestMetadata[$pluginName][$key];
-    }
-
-    /**
      * Returns a visit property, or `null` if none is set.
      *
      * @param string $name The property name.

--- a/core/Tracker/Visit/VisitProperties.php
+++ b/core/Tracker/Visit/VisitProperties.php
@@ -19,5 +19,22 @@ class VisitProperties
      */
     public $visitorInfo = array();
 
-    // TODO
+    /**
+     * Stores plugin specific tracking request metadata. RequestProcessors can store
+     * whatever they want in this array, and other RequestProcessors can modify these
+     * values to change tracker behavior.
+     *
+     * @var string[][]
+     */
+    private $requestMetadata = array();
+
+    public function setRequestMetadata($pluginName, $key, $value)
+    {
+        $this->requestMetadata[$pluginName][$key] = $value;
+    }
+
+    public function getRequestMetadata($pluginName, $key)
+    {
+        return @$this->requestMetadata[$pluginName][$key];
+    }
 }

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -14,19 +14,20 @@ use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\CustomVariables\CustomVariables;
 use Piwik\Piwik;
 use Piwik\Tracker;
+use Piwik\Tracker\Visit\VisitProperties;
 
 class Visitor
 {
     private $visitorKnown = false;
     private $request;
-    private $visitorInfo;
+    private $visitProperties;
     private $configId;
 
-    public function __construct(Request $request, $configId, $visitorInfo = array())
+    public function __construct(Request $request, $configId, VisitProperties $visitProperties)
     {
         $this->request = $request;
         $this->configId = $configId;
-        $this->visitorInfo = $visitorInfo;
+        $this->visitProperties = $visitProperties;
     }
 
     /**
@@ -47,7 +48,7 @@ class Visitor
         $isVisitorIdToLookup = !empty($idVisitor);
 
         if ($isVisitorIdToLookup) {
-            $this->visitorInfo['idvisitor'] = $idVisitor;
+            $this->visitProperties->visitorInfo['idvisitor'] = $idVisitor;
             Common::printDebug("Matching visitors with: visitorId=" . bin2hex($idVisitor) . " OR configId=" . bin2hex($configId));
         } else {
             Common::printDebug("Visitor doesn't have the piwik cookie...");
@@ -72,11 +73,11 @@ class Visitor
 
             // These values will be used throughout the request
             foreach ($persistedVisitAttributes as $field) {
-                $this->visitorInfo[$field] = $visitRow[$field];
+                $this->visitProperties->visitorInfo[$field] = $visitRow[$field];
             }
 
-            $this->visitorInfo['visit_last_action_time']  = strtotime($visitRow['visit_last_action_time']);
-            $this->visitorInfo['visit_first_action_time'] = strtotime($visitRow['visit_first_action_time']);
+            $this->visitProperties->visitorInfo['visit_last_action_time']  = strtotime($visitRow['visit_last_action_time']);
+            $this->visitProperties->visitorInfo['visit_first_action_time'] = strtotime($visitRow['visit_first_action_time']);
 
             // Custom Variables copied from Visit in potential later conversion
             if (!empty($numCustomVarsToRead)) {
@@ -84,23 +85,23 @@ class Visitor
                     if (isset($visitRow['custom_var_k' . $i])
                         && strlen($visitRow['custom_var_k' . $i])
                     ) {
-                        $this->visitorInfo['custom_var_k' . $i] = $visitRow['custom_var_k' . $i];
+                        $this->visitProperties->visitorInfo['custom_var_k' . $i] = $visitRow['custom_var_k' . $i];
                     }
                     if (isset($visitRow['custom_var_v' . $i])
                         && strlen($visitRow['custom_var_v' . $i])
                     ) {
-                        $this->visitorInfo['custom_var_v' . $i] = $visitRow['custom_var_v' . $i];
+                        $this->visitProperties->visitorInfo['custom_var_v' . $i] = $visitRow['custom_var_v' . $i];
                     }
                 }
             }
 
             $this->setIsVisitorKnown(true);
-            Common::printDebug("The visitor is known (idvisitor = " . bin2hex($this->visitorInfo['idvisitor']) . ",
+            Common::printDebug("The visitor is known (idvisitor = " . bin2hex($this->visitProperties->visitorInfo['idvisitor']) . ",
                     config_id = " . bin2hex($configId) . ",
-                    idvisit = {$this->visitorInfo['idvisit']},
-                    last action = " . date("r", $this->visitorInfo['visit_last_action_time']) . ",
-                    first action = " . date("r", $this->visitorInfo['visit_first_action_time']) . ",
-                    visit_goal_buyer' = " . $this->visitorInfo['visit_goal_buyer'] . ")");
+                    idvisit = {$this->visitProperties->visitorInfo['idvisit']},
+                    last action = " . date("r", $this->visitProperties->visitorInfo['visit_last_action_time']) . ",
+                    first action = " . date("r", $this->visitProperties->visitorInfo['visit_first_action_time']) . ",
+                    visit_goal_buyer' = " . $this->visitProperties->visitorInfo['visit_goal_buyer'] . ")");
         } else {
             Common::printDebug("The visitor was not matched with an existing visitor...");
         }
@@ -231,23 +232,23 @@ class Visitor
 
     public function getVisitorInfo()
     {
-        return $this->visitorInfo;
+        return $this->visitProperties->visitorInfo;
     }
 
     public function clearVisitorInfo()
     {
-        $this->visitorInfo = array();
+        $this->visitProperties->visitorInfo = array();
     }
 
     public function setVisitorColumn($column, $value)
     {
-        $this->visitorInfo[$column] = $value;
+        $this->visitProperties->visitorInfo[$column] = $value;
     }
 
     public function getVisitorColumn($column)
     {
-        if (array_key_exists($column, $this->visitorInfo)) {
-            return $this->visitorInfo[$column];
+        if (array_key_exists($column, $this->visitProperties->visitorInfo)) {
+            return $this->visitProperties->visitorInfo[$column];
         }
 
         return false;

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -19,12 +19,10 @@ class Visitor
     private $visitorKnown = false;
     private $request;
     private $visitProperties;
-    private $configId;
 
-    public function __construct(Request $request, $configId, VisitProperties $visitProperties, $isVisitorKnown = false)
+    public function __construct(Request $request, VisitProperties $visitProperties, $isVisitorKnown = false)
     {
         $this->request = $request;
-        $this->configId = $configId;
         $this->visitProperties = $visitProperties;
         $this->setIsVisitorKnown($isVisitorKnown);
     }

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -24,9 +24,9 @@ class Visitor
         $this->setIsVisitorKnown($isVisitorKnown);
     }
 
-    public static function makeFromVisitProperties(VisitProperties $visitProperties)
+    public static function makeFromVisitProperties(VisitProperties $visitProperties, Request $request)
     {
-        $isKnown = $visitProperties->getRequestMetadata('CoreHome', 'isVisitorKnown');
+        $isKnown = $request->getMetadata('CoreHome', 'isVisitorKnown');
         return new Visitor($visitProperties, $isKnown);
     }
 

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -27,6 +27,12 @@ class Visitor
         $this->setIsVisitorKnown($isVisitorKnown);
     }
 
+    public static function makeFromVisitProperties(VisitProperties $visitProperties, Request $request)
+    {
+        $isKnown = $visitProperties->getRequestMetadata('CoreHome', 'isVisitorKnown');
+        return new Visitor($request, $visitProperties, $isKnown);
+    }
+
     public function setVisitorColumn($column, $value) // TODO: remove this eventually
     {
         $this->visitProperties->visitorInfo[$column] = $value;

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -21,33 +21,12 @@ class Visitor
     private $visitProperties;
     private $configId;
 
-    /**
-     * @var VisitorRecognizer
-     */
-    private $visitorRecognizer;
-
     public function __construct(Request $request, $configId, VisitProperties $visitProperties, $isVisitorKnown = false)
     {
         $this->request = $request;
         $this->configId = $configId;
         $this->visitProperties = $visitProperties;
-        $this->visitorRecognizer = StaticContainer::get('Piwik\Tracker\VisitorRecognizer');
         $this->setIsVisitorKnown($isVisitorKnown);
-    }
-
-    /**
-     * This methods tries to see if the visitor has visited the website before.
-     *
-     * We have to split the visitor into one of the category
-     * - Known visitor
-     * - New visitor
-     */
-    public function recognize()
-    {
-        $this->setIsVisitorKnown(false);
-
-        $isKnown = $this->visitorRecognizer->findKnownVisitor($this->configId, $this->visitProperties, $this->request);
-        $this->setIsVisitorKnown($isKnown);
     }
 
     public function setVisitorColumn($column, $value) // TODO: remove this eventually

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -32,13 +32,13 @@ class Visitor
 
     public function setVisitorColumn($column, $value)
     {
-        $this->visitProperties->visitorInfo[$column] = $value;
+        $this->visitProperties->setProperty($column, $value);
     }
 
     public function getVisitorColumn($column)
     {
-        if (array_key_exists($column, $this->visitProperties->visitorInfo)) {
-            return $this->visitProperties->visitorInfo[$column];
+        if (array_key_exists($column, $this->visitProperties->getProperties())) {
+            return $this->visitProperties->getProperty($column);
         }
 
         return false;

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -30,7 +30,7 @@ class Visitor
         return new Visitor($visitProperties, $isKnown);
     }
 
-    public function setVisitorColumn($column, $value) // TODO: remove this eventually
+    public function setVisitorColumn($column, $value)
     {
         $this->visitProperties->visitorInfo[$column] = $value;
     }

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -16,7 +16,7 @@ use Piwik\Tracker\Visit\VisitProperties;
 class Visitor
 {
     private $visitorKnown = false;
-    private $visitProperties;
+    public $visitProperties;
 
     public function __construct(VisitProperties $visitProperties, $isVisitorKnown = false)
     {

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -8,11 +8,9 @@
  */
 namespace Piwik\Tracker;
 
-use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\Plugin\Dimension\VisitDimension;
-use Piwik\Plugins\CustomVariables\CustomVariables;
-use Piwik\Piwik;
 use Piwik\Tracker;
 use Piwik\Tracker\Visit\VisitProperties;
 
@@ -23,11 +21,18 @@ class Visitor
     private $visitProperties;
     private $configId;
 
-    public function __construct(Request $request, $configId, VisitProperties $visitProperties)
+    /**
+     * @var VisitorRecognizer
+     */
+    private $visitorRecognizer;
+
+    public function __construct(Request $request, $configId, VisitProperties $visitProperties, $isVisitorKnown = false)
     {
         $this->request = $request;
         $this->configId = $configId;
         $this->visitProperties = $visitProperties;
+        $this->visitorRecognizer = StaticContainer::get('Piwik\Tracker\VisitorRecognizer');
+        $this->setIsVisitorKnown($isVisitorKnown);
     }
 
     /**
@@ -41,206 +46,11 @@ class Visitor
     {
         $this->setIsVisitorKnown(false);
 
-        $configId  = $this->configId;
-        $idSite    = $this->request->getIdSite();
-        $idVisitor = $this->request->getVisitorId();
-
-        $isVisitorIdToLookup = !empty($idVisitor);
-
-        if ($isVisitorIdToLookup) {
-            $this->visitProperties->visitorInfo['idvisitor'] = $idVisitor;
-            Common::printDebug("Matching visitors with: visitorId=" . bin2hex($idVisitor) . " OR configId=" . bin2hex($configId));
-        } else {
-            Common::printDebug("Visitor doesn't have the piwik cookie...");
-        }
-
-        $persistedVisitAttributes = $this->getVisitFieldsPersist();
-
-        $shouldMatchOneFieldOnly  = $this->shouldLookupOneVisitorFieldOnly($isVisitorIdToLookup);
-        list($timeLookBack, $timeLookAhead) = $this->getWindowLookupThisVisit();
-
-        $model    = $this->getModel();
-        $visitRow = $model->findVisitor($idSite, $configId, $idVisitor, $persistedVisitAttributes, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead);
-
-        $isNewVisitForced = $this->request->getParam('new_visit');
-        $isNewVisitForced = !empty($isNewVisitForced);
-        $enforceNewVisit  = $isNewVisitForced || Config::getInstance()->Debug['tracker_always_new_visitor'];
-
-        if (!$enforceNewVisit
-            && $visitRow
-            && count($visitRow) > 0
-        ) {
-
-            // These values will be used throughout the request
-            foreach ($persistedVisitAttributes as $field) {
-                $this->visitProperties->visitorInfo[$field] = $visitRow[$field];
-            }
-
-            $this->visitProperties->visitorInfo['visit_last_action_time']  = strtotime($visitRow['visit_last_action_time']);
-            $this->visitProperties->visitorInfo['visit_first_action_time'] = strtotime($visitRow['visit_first_action_time']);
-
-            // Custom Variables copied from Visit in potential later conversion
-            if (!empty($numCustomVarsToRead)) {
-                for ($i = 1; $i <= $numCustomVarsToRead; $i++) {
-                    if (isset($visitRow['custom_var_k' . $i])
-                        && strlen($visitRow['custom_var_k' . $i])
-                    ) {
-                        $this->visitProperties->visitorInfo['custom_var_k' . $i] = $visitRow['custom_var_k' . $i];
-                    }
-                    if (isset($visitRow['custom_var_v' . $i])
-                        && strlen($visitRow['custom_var_v' . $i])
-                    ) {
-                        $this->visitProperties->visitorInfo['custom_var_v' . $i] = $visitRow['custom_var_v' . $i];
-                    }
-                }
-            }
-
-            $this->setIsVisitorKnown(true);
-            Common::printDebug("The visitor is known (idvisitor = " . bin2hex($this->visitProperties->visitorInfo['idvisitor']) . ",
-                    config_id = " . bin2hex($configId) . ",
-                    idvisit = {$this->visitProperties->visitorInfo['idvisit']},
-                    last action = " . date("r", $this->visitProperties->visitorInfo['visit_last_action_time']) . ",
-                    first action = " . date("r", $this->visitProperties->visitorInfo['visit_first_action_time']) . ",
-                    visit_goal_buyer' = " . $this->visitProperties->visitorInfo['visit_goal_buyer'] . ")");
-        } else {
-            Common::printDebug("The visitor was not matched with an existing visitor...");
-        }
+        $isKnown = $this->visitorRecognizer->findKnownVisitor($this->configId, $this->visitProperties, $this->request);
+        $this->setIsVisitorKnown($isKnown);
     }
 
-    /**
-     * By default, we look back 30 minutes to find a previous visitor (for performance reasons).
-     * In some cases, it is useful to look back and count unique visitors more accurately. You can set custom lookback window in
-     * [Tracker] window_look_back_for_visitor
-     *
-     * The returned value is the window range (Min, max) that the matched visitor should fall within
-     *
-     * @return array( datetimeMin, datetimeMax )
-     */
-    protected function getWindowLookupThisVisit()
-    {
-        $visitStandardLength    = Config::getInstance()->Tracker['visit_standard_length'];
-        $lookBackNSecondsCustom = Config::getInstance()->Tracker['window_look_back_for_visitor'];
-
-        $lookAheadNSeconds = $visitStandardLength;
-        $lookBackNSeconds  = $visitStandardLength;
-        if ($lookBackNSecondsCustom > $lookBackNSeconds) {
-            $lookBackNSeconds = $lookBackNSecondsCustom;
-        }
-
-        $timeLookBack  = date('Y-m-d H:i:s', $this->request->getCurrentTimestamp() - $lookBackNSeconds);
-        $timeLookAhead = date('Y-m-d H:i:s', $this->request->getCurrentTimestamp() + $lookAheadNSeconds);
-
-        return array($timeLookBack, $timeLookAhead);
-    }
-
-    protected function shouldLookupOneVisitorFieldOnly($isVisitorIdToLookup)
-    {
-        $isForcedUserIdMustMatch = (false !== $this->request->getForcedUserId());
-
-        if ($isForcedUserIdMustMatch) {
-            // if &iud was set, we must try and match both idvisitor and config_id
-            return false;
-        }
-
-        // This setting would be enabled for Intranet websites, to ensure that visitors using all the same computer config, same IP
-        // are not counted as 1 visitor. In this case, we want to enforce and trust the visitor ID from the cookie.
-        $trustCookiesOnly = Config::getInstance()->Tracker['trust_visitors_cookies'];
-        if ($isVisitorIdToLookup && $trustCookiesOnly) {
-            return true;
-        }
-
-        // If a &cid= was set, we force to select this visitor (or create a new one)
-        $isForcedVisitorIdMustMatch = ($this->request->getForcedVisitorId() != null);
-
-        if ($isForcedVisitorIdMustMatch) {
-            return true;
-        }
-
-        if (!$isVisitorIdToLookup) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @return array
-     */
-    private function getVisitFieldsPersist()
-    {
-        static $fields;
-
-        if (is_null($fields)) {
-            $fields = array(
-                'idvisitor',
-                'idvisit',
-                'user_id',
-
-                'visit_exit_idaction_url',
-                'visit_exit_idaction_name',
-                'visitor_returning',
-                'visitor_days_since_first',
-                'visitor_days_since_order',
-                'visitor_count_visits',
-                'visit_goal_buyer',
-
-                'location_country',
-                'location_region',
-                'location_city',
-                'location_latitude',
-                'location_longitude',
-
-                'referer_name',
-                'referer_keyword',
-                'referer_type',
-            );
-
-            $dimensions = VisitDimension::getAllDimensions();
-
-            foreach ($dimensions as $dimension) {
-                if ($dimension->hasImplementedEvent('onExistingVisit')) {
-                    $fields[] = $dimension->getColumnName();
-                }
-
-                foreach ($dimension->getRequiredVisitFields() as $field) {
-                    $fields[] = $field;
-                }
-            }
-
-            /**
-             * This event collects a list of [visit entity](/guides/persistence-and-the-mysql-backend#visits) properties that should be loaded when reading
-             * the existing visit. Properties that appear in this list will be available in other tracking
-             * events such as 'onExistingVisit'.
-             *
-             * Plugins can use this event to load additional visit entity properties for later use during tracking.
-             */
-            Piwik::postEvent('Tracker.getVisitFieldsToPersist', array(&$fields));
-
-            array_unshift($fields, 'visit_first_action_time');
-            array_unshift($fields, 'visit_last_action_time');
-
-            for ($index = 1; $index <= CustomVariables::getMaxCustomVariables(); $index++) {
-                $fields[] = 'custom_var_k' . $index;
-                $fields[] = 'custom_var_v' . $index;
-            }
-
-            $fields = array_unique($fields);
-        }
-
-        return $fields;
-    }
-
-    public function getVisitorInfo()
-    {
-        return $this->visitProperties->visitorInfo;
-    }
-
-    public function clearVisitorInfo()
-    {
-        $this->visitProperties->visitorInfo = array();
-    }
-
-    public function setVisitorColumn($column, $value)
+    public function setVisitorColumn($column, $value) // TODO: remove this eventually
     {
         $this->visitProperties->visitorInfo[$column] = $value;
     }
@@ -259,13 +69,8 @@ class Visitor
         return $this->visitorKnown === true;
     }
 
-    public function setIsVisitorKnown($isVisitorKnown)
+    private function setIsVisitorKnown($isVisitorKnown)
     {
         return $this->visitorKnown = $isVisitorKnown;
-    }
-
-    private function getModel()
-    {
-        return new Model();
     }
 }

--- a/core/Tracker/Visitor.php
+++ b/core/Tracker/Visitor.php
@@ -9,7 +9,6 @@
 namespace Piwik\Tracker;
 
 use Piwik\Config;
-use Piwik\Container\StaticContainer;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Tracker;
 use Piwik\Tracker\Visit\VisitProperties;
@@ -17,20 +16,18 @@ use Piwik\Tracker\Visit\VisitProperties;
 class Visitor
 {
     private $visitorKnown = false;
-    private $request;
     private $visitProperties;
 
-    public function __construct(Request $request, VisitProperties $visitProperties, $isVisitorKnown = false)
+    public function __construct(VisitProperties $visitProperties, $isVisitorKnown = false)
     {
-        $this->request = $request;
         $this->visitProperties = $visitProperties;
         $this->setIsVisitorKnown($isVisitorKnown);
     }
 
-    public static function makeFromVisitProperties(VisitProperties $visitProperties, Request $request)
+    public static function makeFromVisitProperties(VisitProperties $visitProperties)
     {
         $isKnown = $visitProperties->getRequestMetadata('CoreHome', 'isVisitorKnown');
-        return new Visitor($request, $visitProperties, $isKnown);
+        return new Visitor($visitProperties, $isKnown);
     }
 
     public function setVisitorColumn($column, $value) // TODO: remove this eventually

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -15,55 +15,52 @@ use Piwik\Plugins\CustomVariables\CustomVariables;
 use Piwik\Tracker\Visit\VisitProperties;
 
 /**
- * TODO
+ * Tracker service that finds the last known visit for the visitor being tracked.
  */
 class VisitorRecognizer
 {
     /**
-     * TODO
+     * Local variable cache for the getVisitFieldsPersist() method.
      *
      * @var array
      */
     private $visitFieldsToSelect;
 
     /**
-     * TODO
+     * See http://piwik.org/faq/how-to/faq_175/.
      *
      * @var bool
      */
     private $trustCookiesOnly;
 
     /**
-     * TODO
+     * Length of a visit in seconds.
      *
      * @var int
      */
     private $visitStandardLength;
 
     /**
-     * TODO
+     * Number of seconds that have to pass after an action before a new action from the same visitor is
+     * considered a new visit. Defaults to $visitStandardLength.
      *
      * @var int
      */
     private $lookBackNSecondsCustom;
 
     /**
-     * TODO
+     * Forces all requests to result in new visits. For debugging only.
      *
      * @var int
      */
     private $trackerAlwaysNewVisitor;
 
     /**
-     * TODO
-     *
      * @var Model
      */
     private $model;
 
     /**
-     * TODO
-     *
      * @var EventDispatcher
      */
     private $eventDispatcher;
@@ -80,15 +77,6 @@ class VisitorRecognizer
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    /**
-     * This methods tries to see if the visitor has visited the website before.
-     *
-     * We have to split the visitor into one of the category
-     * - Known visitor
-     * - New visitor
-     *
-     * TODO: move docs to class docs
-     */
     public function findKnownVisitor($configId, VisitProperties $visitProperties, Request $request)
     {
         $idSite    = $request->getIdSite();

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tracker;
+
+use Piwik\Common;
+use Piwik\EventDispatcher;
+use Piwik\Plugin\Dimension\VisitDimension;
+use Piwik\Plugins\CustomVariables\CustomVariables;
+use Piwik\Tracker\Visit\VisitProperties;
+
+/**
+ * TODO
+ */
+class VisitorRecognizer
+{
+    /**
+     * TODO
+     *
+     * @var array
+     */
+    private $visitFieldsToSelect;
+
+    /**
+     * TODO
+     *
+     * @var bool
+     */
+    private $trustCookiesOnly;
+
+    /**
+     * TODO
+     *
+     * @var int
+     */
+    private $visitStandardLength;
+
+    /**
+     * TODO
+     *
+     * @var int
+     */
+    private $lookBackNSecondsCustom;
+
+    /**
+     * TODO
+     *
+     * @var int
+     */
+    private $trackerAlwaysNewVisitor;
+
+    /**
+     * TODO
+     *
+     * @var Model
+     */
+    private $model;
+
+    /**
+     * TODO
+     *
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+
+    public function __construct($trustCookiesOnly, $visitStandardLength, $lookbackNSecondsCustom, $trackerAlwaysNewVisitor,
+                                Model $model, EventDispatcher $eventDispatcher)
+    {
+        $this->trustCookiesOnly = $trustCookiesOnly;
+        $this->visitStandardLength = $visitStandardLength;
+        $this->lookBackNSecondsCustom = $lookbackNSecondsCustom;
+        $this->trackerAlwaysNewVisitor = $trackerAlwaysNewVisitor;
+
+        $this->model = $model;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * This methods tries to see if the visitor has visited the website before.
+     *
+     * We have to split the visitor into one of the category
+     * - Known visitor
+     * - New visitor
+     *
+     * TODO: move docs to class docs
+     */
+    public function findKnownVisitor($configId, VisitProperties $visitProperties, Request $request)
+    {
+        $idSite    = $request->getIdSite();
+        $idVisitor = $request->getVisitorId();
+
+        $isVisitorIdToLookup = !empty($idVisitor);
+
+        if ($isVisitorIdToLookup) {
+            $visitProperties->visitorInfo['idvisitor'] = $idVisitor;
+            Common::printDebug("Matching visitors with: visitorId=" . bin2hex($idVisitor) . " OR configId=" . bin2hex($configId));
+        } else {
+            Common::printDebug("Visitor doesn't have the piwik cookie...");
+        }
+
+        $persistedVisitAttributes = $this->getVisitFieldsPersist();
+
+        $shouldMatchOneFieldOnly  = $this->shouldLookupOneVisitorFieldOnly($isVisitorIdToLookup, $request);
+        list($timeLookBack, $timeLookAhead) = $this->getWindowLookupThisVisit($request);
+
+        $visitRow = $this->model->findVisitor($idSite, $configId, $idVisitor, $persistedVisitAttributes, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead);
+
+        $isNewVisitForced = $request->getParam('new_visit');
+        $isNewVisitForced = !empty($isNewVisitForced);
+        $enforceNewVisit  = $isNewVisitForced || $this->trackerAlwaysNewVisitor;
+
+        if (!$enforceNewVisit
+            && $visitRow
+            && count($visitRow) > 0
+        ) {
+
+            // These values will be used throughout the request
+            foreach ($persistedVisitAttributes as $field) {
+                $visitProperties->visitorInfo[$field] = $visitRow[$field];
+            }
+
+            $visitProperties->visitorInfo['visit_last_action_time']  = strtotime($visitRow['visit_last_action_time']);
+            $visitProperties->visitorInfo['visit_first_action_time'] = strtotime($visitRow['visit_first_action_time']);
+
+            // Custom Variables copied from Visit in potential later conversion
+            if (!empty($numCustomVarsToRead)) {
+                for ($i = 1; $i <= $numCustomVarsToRead; $i++) {
+                    if (isset($visitRow['custom_var_k' . $i])
+                        && strlen($visitRow['custom_var_k' . $i])
+                    ) {
+                        $visitProperties->visitorInfo['custom_var_k' . $i] = $visitRow['custom_var_k' . $i];
+                    }
+                    if (isset($visitRow['custom_var_v' . $i])
+                        && strlen($visitRow['custom_var_v' . $i])
+                    ) {
+                        $visitProperties->visitorInfo['custom_var_v' . $i] = $visitRow['custom_var_v' . $i];
+                    }
+                }
+            }
+
+            Common::printDebug("The visitor is known (idvisitor = " . bin2hex($visitProperties->visitorInfo['idvisitor']) . ",
+                    config_id = " . bin2hex($configId) . ",
+                    idvisit = {$visitProperties->visitorInfo['idvisit']},
+                    last action = " . date("r", $visitProperties->visitorInfo['visit_last_action_time']) . ",
+                    first action = " . date("r", $visitProperties->visitorInfo['visit_first_action_time']) . ",
+                    visit_goal_buyer' = " . $visitProperties->visitorInfo['visit_goal_buyer'] . ")");
+
+            return true;
+        } else {
+            Common::printDebug("The visitor was not matched with an existing visitor...");
+
+            return false;
+        }
+    }
+
+    protected function shouldLookupOneVisitorFieldOnly($isVisitorIdToLookup, Request $request)
+    {
+        $isForcedUserIdMustMatch = (false !== $request->getForcedUserId());
+
+        if ($isForcedUserIdMustMatch) {
+            // if &iud was set, we must try and match both idvisitor and config_id
+            return false;
+        }
+
+        // This setting would be enabled for Intranet websites, to ensure that visitors using all the same computer config, same IP
+        // are not counted as 1 visitor. In this case, we want to enforce and trust the visitor ID from the cookie.
+        if ($isVisitorIdToLookup && $this->trustCookiesOnly) {
+            return true;
+        }
+
+        // If a &cid= was set, we force to select this visitor (or create a new one)
+        $isForcedVisitorIdMustMatch = ($request->getForcedVisitorId() != null);
+
+        if ($isForcedVisitorIdMustMatch) {
+            return true;
+        }
+
+        if (!$isVisitorIdToLookup) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * By default, we look back 30 minutes to find a previous visitor (for performance reasons).
+     * In some cases, it is useful to look back and count unique visitors more accurately. You can set custom lookback window in
+     * [Tracker] window_look_back_for_visitor
+     *
+     * The returned value is the window range (Min, max) that the matched visitor should fall within
+     *
+     * @return array( datetimeMin, datetimeMax )
+     */
+    protected function getWindowLookupThisVisit(Request $request)
+    {
+        $lookAheadNSeconds = $this->visitStandardLength;
+        $lookBackNSeconds  = $this->visitStandardLength;
+        if ($this->lookBackNSecondsCustom > $lookBackNSeconds) {
+            $lookBackNSeconds = $lookBackNSecondsCustom;
+        }
+
+        $timeLookBack  = date('Y-m-d H:i:s', $request->getCurrentTimestamp() - $lookBackNSeconds);
+        $timeLookAhead = date('Y-m-d H:i:s', $request->getCurrentTimestamp() + $lookAheadNSeconds);
+
+        return array($timeLookBack, $timeLookAhead);
+    }
+
+    /**
+     * @return array
+     */
+    private function getVisitFieldsPersist()
+    {
+        if (is_null($this->visitFieldsToSelect)) {
+            $fields = array(
+                'idvisitor',
+                'idvisit',
+                'user_id',
+
+                'visit_exit_idaction_url',
+                'visit_exit_idaction_name',
+                'visitor_returning',
+                'visitor_days_since_first',
+                'visitor_days_since_order',
+                'visitor_count_visits',
+                'visit_goal_buyer',
+
+                'location_country',
+                'location_region',
+                'location_city',
+                'location_latitude',
+                'location_longitude',
+
+                'referer_name',
+                'referer_keyword',
+                'referer_type',
+            );
+
+            $dimensions = VisitDimension::getAllDimensions();
+
+            foreach ($dimensions as $dimension) {
+                if ($dimension->hasImplementedEvent('onExistingVisit')) {
+                    $fields[] = $dimension->getColumnName();
+                }
+
+                foreach ($dimension->getRequiredVisitFields() as $field) {
+                    $fields[] = $field;
+                }
+            }
+
+            /**
+             * This event collects a list of [visit entity](/guides/persistence-and-the-mysql-backend#visits) properties that should be loaded when reading
+             * the existing visit. Properties that appear in this list will be available in other tracking
+             * events such as 'onExistingVisit'.
+             *
+             * Plugins can use this event to load additional visit entity properties for later use during tracking.
+             */
+            $this->eventDispatcher->postEvent('Tracker.getVisitFieldsToPersist', array(&$fields));
+
+            array_unshift($fields, 'visit_first_action_time');
+            array_unshift($fields, 'visit_last_action_time');
+
+            for ($index = 1; $index <= CustomVariables::getMaxCustomVariables(); $index++) {
+                $fields[] = 'custom_var_k' . $index;
+                $fields[] = 'custom_var_v' . $index;
+            }
+
+            $this->visitFieldsToSelect = array_unique($fields);
+        }
+
+        return $this->visitFieldsToSelect;
+    }
+}

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -201,7 +201,7 @@ class VisitorRecognizer
         $lookAheadNSeconds = $this->visitStandardLength;
         $lookBackNSeconds  = $this->visitStandardLength;
         if ($this->lookBackNSecondsCustom > $lookBackNSeconds) {
-            $lookBackNSeconds = $lookBackNSecondsCustom;
+            $lookBackNSeconds = $this->lookBackNSecondsCustom;
         }
 
         $timeLookBack  = date('Y-m-d H:i:s', $request->getCurrentTimestamp() - $lookBackNSeconds);

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -85,7 +85,7 @@ class VisitorRecognizer
         $isVisitorIdToLookup = !empty($idVisitor);
 
         if ($isVisitorIdToLookup) {
-            $visitProperties->visitorInfo['idvisitor'] = $idVisitor;
+            $visitProperties->setProperty('idvisitor', $idVisitor);
             Common::printDebug("Matching visitors with: visitorId=" . bin2hex($idVisitor) . " OR configId=" . bin2hex($configId));
         } else {
             Common::printDebug("Visitor doesn't have the piwik cookie...");
@@ -109,11 +109,11 @@ class VisitorRecognizer
 
             // These values will be used throughout the request
             foreach ($persistedVisitAttributes as $field) {
-                $visitProperties->visitorInfo[$field] = $visitRow[$field];
+                $visitProperties->setProperty($field, $visitRow[$field]);
             }
 
-            $visitProperties->visitorInfo['visit_last_action_time']  = strtotime($visitRow['visit_last_action_time']);
-            $visitProperties->visitorInfo['visit_first_action_time'] = strtotime($visitRow['visit_first_action_time']);
+            $visitProperties->setProperty('visit_last_action_time', strtotime($visitRow['visit_last_action_time']));
+            $visitProperties->setProperty('visit_first_action_time', strtotime($visitRow['visit_first_action_time']));
 
             // Custom Variables copied from Visit in potential later conversion
             if (!empty($numCustomVarsToRead)) {
@@ -121,22 +121,22 @@ class VisitorRecognizer
                     if (isset($visitRow['custom_var_k' . $i])
                         && strlen($visitRow['custom_var_k' . $i])
                     ) {
-                        $visitProperties->visitorInfo['custom_var_k' . $i] = $visitRow['custom_var_k' . $i];
+                        $visitProperties->setProperty('custom_var_k' . $i, $visitRow['custom_var_k' . $i]);
                     }
                     if (isset($visitRow['custom_var_v' . $i])
                         && strlen($visitRow['custom_var_v' . $i])
                     ) {
-                        $visitProperties->visitorInfo['custom_var_v' . $i] = $visitRow['custom_var_v' . $i];
+                        $visitProperties->setProperty('custom_var_v' . $i, $visitRow['custom_var_v' . $i]);
                     }
                 }
             }
 
-            Common::printDebug("The visitor is known (idvisitor = " . bin2hex($visitProperties->visitorInfo['idvisitor']) . ",
+            Common::printDebug("The visitor is known (idvisitor = " . bin2hex($visitProperties->getProperty('idvisitor')) . ",
                     config_id = " . bin2hex($configId) . ",
-                    idvisit = {$visitProperties->visitorInfo['idvisit']},
-                    last action = " . date("r", $visitProperties->visitorInfo['visit_last_action_time']) . ",
-                    first action = " . date("r", $visitProperties->visitorInfo['visit_first_action_time']) . ",
-                    visit_goal_buyer' = " . $visitProperties->visitorInfo['visit_goal_buyer'] . ")");
+                    idvisit = {$visitProperties->getProperty('idvisit')},
+                    last action = " . date("r", $visitProperties->getProperty('visit_last_action_time')) . ",
+                    first action = " . date("r", $visitProperties->getProperty('visit_first_action_time')) . ",
+                    visit_goal_buyer' = " . $visitProperties->getProperty('visit_goal_buyer') . ")");
 
             return true;
         } else {

--- a/core/Updates/2.15.0.php
+++ b/core/Updates/2.15.0.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Updater;
+use Piwik\Updates;
+
+class Updates_2_15_0 extends Updates
+{
+    public function doUpdate(Updater $updater)
+    {
+        $pluginManager = \Piwik\Plugin\Manager::getInstance();
+
+        try {
+            $pluginManager->activatePlugin('Heartbeat');
+        } catch (\Exception $e) {
+        }
+    }
+}

--- a/plugins/Actions/Tracker/ActionsRequestProcessor.php
+++ b/plugins/Actions/Tracker/ActionsRequestProcessor.php
@@ -45,7 +45,7 @@ class ActionsRequestProcessor extends RequestProcessor
         $visitProperties->setRequestMetadata('Actions', 'idReferrerActionName', @$visitProperties->visitorInfo['visit_exit_idaction_name']);
     }
 
-    public function processRequest(Visitor $visitor, VisitProperties $visitProperties)
+    public function processRequest(VisitProperties $visitProperties, Request $request)
     {
         /** @var Action $action */
         $action = $visitProperties->getRequestMetadata('Actions', 'action');
@@ -61,6 +61,7 @@ class ActionsRequestProcessor extends RequestProcessor
                 $idReferrerActionName = $visitProperties->getRequestMetadata('Actions', 'idReferrerActionName');
             }
 
+            $visitor = Visitor::makeFromVisitProperties($visitProperties, $request);
             $action->record($visitor, $idReferrerActionUrl, $idReferrerActionName);
         }
     }

--- a/plugins/Actions/Tracker/ActionsRequestProcessor.php
+++ b/plugins/Actions/Tracker/ActionsRequestProcessor.php
@@ -51,20 +51,20 @@ class ActionsRequestProcessor extends RequestProcessor
         $action = Action::factory($request);
         $action->writeDebugInfo();
 
-        $visitProperties->setRequestMetadata('Actions', 'action', $action);
+        $request->setMetadata('Actions', 'action', $action);
 
         // save the exit actions of the last action in this visit as the referrer actions for the action being tracked.
         // when the visit is updated, these columns will be changed, so we have to do this before recordLogs
-        $visitProperties->setRequestMetadata('Actions', 'idReferrerActionUrl',
+        $request->setMetadata('Actions', 'idReferrerActionUrl',
             $visitProperties->getProperty('visit_exit_idaction_url'));
-        $visitProperties->setRequestMetadata('Actions', 'idReferrerActionName',
+        $request->setMetadata('Actions', 'idReferrerActionName',
             $visitProperties->getProperty('visit_exit_idaction_name'));
     }
 
     public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
     {
         /** @var Action $action */
-        $action = $visitProperties->getRequestMetadata('Actions', 'action');
+        $action = $request->getMetadata('Actions', 'action');
 
         if (!empty($action)) { // other plugins can unset the action if they want
             $action->loadIdsFromLogActionTable();
@@ -74,20 +74,20 @@ class ActionsRequestProcessor extends RequestProcessor
     public function recordLogs(VisitProperties $visitProperties, Request $request)
     {
         /** @var Action $action */
-        $action = $visitProperties->getRequestMetadata('Actions', 'action');
+        $action = $request->getMetadata('Actions', 'action');
 
         if ($action !== null
-            && !$visitProperties->getRequestMetadata('CoreHome', 'visitorNotFoundInDb')
+            && !$request->getMetadata('CoreHome', 'visitorNotFoundInDb')
         ) {
             $idReferrerActionUrl = 0;
             $idReferrerActionName = 0;
 
-            if (!$visitProperties->getRequestMetadata('CoreHome', 'isNewVisit')) {
-                $idReferrerActionUrl = $visitProperties->getRequestMetadata('Actions', 'idReferrerActionUrl');
-                $idReferrerActionName = $visitProperties->getRequestMetadata('Actions', 'idReferrerActionName');
+            if (!$request->getMetadata('CoreHome', 'isNewVisit')) {
+                $idReferrerActionUrl = $request->getMetadata('Actions', 'idReferrerActionUrl');
+                $idReferrerActionName = $request->getMetadata('Actions', 'idReferrerActionName');
             }
 
-            $visitor = Visitor::makeFromVisitProperties($visitProperties);
+            $visitor = Visitor::makeFromVisitProperties($visitProperties, $request);
             $action->record($visitor, $idReferrerActionUrl, $idReferrerActionName);
         }
     }

--- a/plugins/Actions/Tracker/ActionsRequestProcessor.php
+++ b/plugins/Actions/Tracker/ActionsRequestProcessor.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Actions\Tracker;
+
+use Piwik\Tracker\Action;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\RequestProcessor;
+use Piwik\Tracker\Visit\VisitProperties;
+
+/**
+ * TODO
+ *
+ * TODO: document request metadata here (ie, 'actions')
+ */
+class ActionsRequestProcessor extends RequestProcessor
+{
+    public function processRequestParams(VisitProperties $visitProperties, Request $request)
+    {
+        // normal page view, potentially triggering a URL matching goal
+        $action = Action::factory($request);
+        $action->writeDebugInfo();
+
+        $visitProperties->setRequestMetadata('Actions', 'action', $action);
+    }
+}

--- a/plugins/Actions/Tracker/ActionsRequestProcessor.php
+++ b/plugins/Actions/Tracker/ActionsRequestProcessor.php
@@ -69,7 +69,7 @@ class ActionsRequestProcessor extends RequestProcessor
         }
     }
 
-    public function recordLogs(VisitProperties $visitProperties)
+    public function recordLogs(VisitProperties $visitProperties, Request $request)
     {
         /** @var Action $action */
         $action = $visitProperties->getRequestMetadata('Actions', 'action');

--- a/plugins/Actions/Tracker/ActionsRequestProcessor.php
+++ b/plugins/Actions/Tracker/ActionsRequestProcessor.php
@@ -55,8 +55,10 @@ class ActionsRequestProcessor extends RequestProcessor
 
         // save the exit actions of the last action in this visit as the referrer actions for the action being tracked.
         // when the visit is updated, these columns will be changed, so we have to do this before recordLogs
-        $visitProperties->setRequestMetadata('Actions', 'idReferrerActionUrl', @$visitProperties->visitorInfo['visit_exit_idaction_url']);
-        $visitProperties->setRequestMetadata('Actions', 'idReferrerActionName', @$visitProperties->visitorInfo['visit_exit_idaction_name']);
+        $visitProperties->setRequestMetadata('Actions', 'idReferrerActionUrl',
+            $visitProperties->getProperty('visit_exit_idaction_url'));
+        $visitProperties->setRequestMetadata('Actions', 'idReferrerActionName',
+            $visitProperties->getProperty('visit_exit_idaction_name'));
     }
 
     public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)

--- a/plugins/Actions/Tracker/ActionsRequestProcessor.php
+++ b/plugins/Actions/Tracker/ActionsRequestProcessor.php
@@ -28,4 +28,14 @@ class ActionsRequestProcessor extends RequestProcessor
 
         $visitProperties->setRequestMetadata('Actions', 'action', $action);
     }
+
+    public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
+    {
+        /** @var Action $action */
+        $action = $visitProperties->getRequestMetadata('Actions', 'action');
+
+        if (!empty($action)) { // other plugins can unset the action if they want
+            $action->loadIdsFromLogActionTable();
+        }
+    }
 }

--- a/plugins/Actions/Tracker/ActionsRequestProcessor.php
+++ b/plugins/Actions/Tracker/ActionsRequestProcessor.php
@@ -30,7 +30,7 @@ class ActionsRequestProcessor extends RequestProcessor
         $visitProperties->setRequestMetadata('Actions', 'action', $action);
     }
 
-    public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
+    public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
     {
         /** @var Action $action */
         $action = $visitProperties->getRequestMetadata('Actions', 'action');
@@ -45,7 +45,7 @@ class ActionsRequestProcessor extends RequestProcessor
         $visitProperties->setRequestMetadata('Actions', 'idReferrerActionName', @$visitProperties->visitorInfo['visit_exit_idaction_name']);
     }
 
-    public function processRequest(VisitProperties $visitProperties, Request $request)
+    public function recordLogs(VisitProperties $visitProperties)
     {
         /** @var Action $action */
         $action = $visitProperties->getRequestMetadata('Actions', 'action');
@@ -61,7 +61,7 @@ class ActionsRequestProcessor extends RequestProcessor
                 $idReferrerActionName = $visitProperties->getRequestMetadata('Actions', 'idReferrerActionName');
             }
 
-            $visitor = Visitor::makeFromVisitProperties($visitProperties, $request);
+            $visitor = Visitor::makeFromVisitProperties($visitProperties);
             $action->record($visitor, $idReferrerActionUrl, $idReferrerActionName);
         }
     }

--- a/plugins/Actions/config/config.php
+++ b/plugins/Actions/config/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+
+    'tracker.request.processors' => DI\add(array(
+        DI\get('Piwik\Plugins\Actions\Tracker\ActionsRequestProcessor'),
+    )),
+
+);

--- a/plugins/CoreHome/Columns/VisitGoalBuyer.php
+++ b/plugins/CoreHome/Columns/VisitGoalBuyer.php
@@ -56,7 +56,7 @@ class VisitGoalBuyer extends VisitDimension
      */
     public function onNewVisit(Request $request, Visitor $visitor, $action)
     {
-        return $this->getBuyerType($request);
+        return $this->getBuyerType($visitor);
     }
 
     /**
@@ -70,7 +70,7 @@ class VisitGoalBuyer extends VisitDimension
         $goalBuyer = $visitor->getVisitorColumn($this->columnName);
 
         // Ecommerce buyer status
-        $visitEcommerceStatus = $this->getBuyerType($request, $goalBuyer);
+        $visitEcommerceStatus = $this->getBuyerType($visitor, $goalBuyer);
 
         if ($visitEcommerceStatus != self::TYPE_BUYER_NONE
             // only update if the value has changed (prevents overwriting the value in case a request has
@@ -106,15 +106,15 @@ class VisitGoalBuyer extends VisitDimension
         return self::$visitEcommerceStatus[$id];
     }
 
-    private function getBuyerType(Request $request, $existingType = self::TYPE_BUYER_NONE)
+    private function getBuyerType(Visitor $visitor, $existingType = self::TYPE_BUYER_NONE)
     {
-        $goalManager = new GoalManager($request);
-
-        if (!$goalManager->requestIsEcommerce) {
+        $isRequestEcommerce = $visitor->visitProperties->getRequestMetadata('Ecommerce', 'isRequestEcommerce');
+        if (!$isRequestEcommerce) {
             return $existingType;
         }
 
-        if ($goalManager->isGoalAnOrder()) {
+        $isGoalAnOrder = $visitor->visitProperties->getRequestMetadata('Ecommerce', 'isGoalAnOrder');
+        if ($isGoalAnOrder) {
             return self::TYPE_BUYER_ORDERED;
         }
 

--- a/plugins/CoreHome/Columns/VisitGoalBuyer.php
+++ b/plugins/CoreHome/Columns/VisitGoalBuyer.php
@@ -56,7 +56,7 @@ class VisitGoalBuyer extends VisitDimension
      */
     public function onNewVisit(Request $request, Visitor $visitor, $action)
     {
-        return $this->getBuyerType($visitor);
+        return $this->getBuyerType($request);
     }
 
     /**
@@ -70,7 +70,7 @@ class VisitGoalBuyer extends VisitDimension
         $goalBuyer = $visitor->getVisitorColumn($this->columnName);
 
         // Ecommerce buyer status
-        $visitEcommerceStatus = $this->getBuyerType($visitor, $goalBuyer);
+        $visitEcommerceStatus = $this->getBuyerType($request, $goalBuyer);
 
         if ($visitEcommerceStatus != self::TYPE_BUYER_NONE
             // only update if the value has changed (prevents overwriting the value in case a request has
@@ -106,14 +106,14 @@ class VisitGoalBuyer extends VisitDimension
         return self::$visitEcommerceStatus[$id];
     }
 
-    private function getBuyerType(Visitor $visitor, $existingType = self::TYPE_BUYER_NONE)
+    private function getBuyerType(Request $request, $existingType = self::TYPE_BUYER_NONE)
     {
-        $isRequestEcommerce = $visitor->visitProperties->getRequestMetadata('Ecommerce', 'isRequestEcommerce');
+        $isRequestEcommerce = $request->getMetadata('Ecommerce', 'isRequestEcommerce');
         if (!$isRequestEcommerce) {
             return $existingType;
         }
 
-        $isGoalAnOrder = $visitor->visitProperties->getRequestMetadata('Ecommerce', 'isGoalAnOrder');
+        $isGoalAnOrder = $request->getMetadata('Ecommerce', 'isGoalAnOrder');
         if ($isGoalAnOrder) {
             return self::TYPE_BUYER_ORDERED;
         }

--- a/plugins/CoreHome/Columns/VisitTotalTime.php
+++ b/plugins/CoreHome/Columns/VisitTotalTime.php
@@ -72,14 +72,12 @@ class VisitTotalTime extends VisitDimension
             return false;
         }
 
-        $goalManager = new GoalManager($request);
-
         $totalTime = $visitor->getVisitorColumn('visit_total_time');
 
         // If a pageview and goal conversion in the same second, with previously a goal conversion recorded
         // the request would not "update" the row since all values are the same as previous
         // therefore the request below throws exception, instead we make sure the UPDATE will affect the row
-        $totalTime = $totalTime + $goalManager->idGoal;
+        $totalTime = $totalTime + $request->getParam('idgoal');
         // +2 to offset idgoal=-1 and idgoal=0
         $totalTime = $totalTime + 2;
 

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -43,7 +43,7 @@ class VisitRequestProcessor extends RequestProcessor
         return false;
     }
 
-    public function manipulateVisitProperties(VisitProperties $visitProperties)
+    public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
     {
         /**
          * Triggered after visits are tested for exclusion so plugins can modify the IP address

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreHome\Tracker;
+
+use Piwik\EventDispatcher;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\RequestProcessor;
+use Piwik\Tracker\Visit\VisitProperties;
+use Piwik\Tracker\VisitExcluded;
+
+/**
+ * Encapsulates core tracking logic related to visits.
+ */
+class VisitRequestProcessor extends RequestProcessor
+{
+    /**
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcher $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function processRequestParams(VisitProperties $visitProperties, Request $request)
+    {
+        // the IP is needed by isExcluded() and GoalManager->recordGoals()
+        $visitProperties->visitorInfo['location_ip'] = $request->getIp();
+
+        // TODO: move VisitExcluded logic to here (or break into other request processors)
+        $excluded = new VisitExcluded($request, $visitProperties->visitorInfo['location_ip']);
+        if ($excluded->isExcluded()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function manipulateVisitProperties(VisitProperties $visitProperties)
+    {
+        /**
+         * Triggered after visits are tested for exclusion so plugins can modify the IP address
+         * persisted with a visit.
+         *
+         * This event is primarily used by the **PrivacyManager** plugin to anonymize IP addresses.
+         *
+         * @param string &$ip The visitor's IP address.
+         */
+        $this->eventDispatcher->postEvent('Tracker.setVisitorIp', array(&$visitProperties->visitorInfo['location_ip']));
+    }
+}

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -22,6 +22,8 @@ use Piwik\Tracker\VisitorRecognizer;
 
 /**
  * Encapsulates core tracking logic related to visits.
+ *
+ * TODO: much of the logic in this class should be moved to new service class
  */
 class VisitRequestProcessor extends RequestProcessor
 {

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -23,10 +23,34 @@ use Piwik\Tracker\VisitorRecognizer;
 /**
  * Encapsulates core tracking logic related to visits.
  *
- * TODO: much of the logic in this class should be moved to new service class
+ * ## Request Metadata
+ *
+ * This RequestProcessor exposes the following metadata for the **CoreHome** plugin:
+ *
+ * * **visitorId**: A hash that identifies the current visitor being tracked. This value is
+ *                  calculated using the Piwik\Tracker\Settings;:getConfigId() method.
+ *
+ *                  Set in `processRequestParams()`.
+ *
+ * * **isVisitorKnown**: True if the current visitor has visited the site before. False if
+ *                       otherwise.
+ *
+ *                       Set in `processRequestParams()`.
+ *
+ * * **isNewVisit**: True if the current action is the start of a new visit, false if it
+ *                   is part of an ongoing visit.
+ *
+ *                   Set in `processRequestParams()`. Other RequestProcessors can override
+ *                   this value to force a new visit or stop a new visit.
+ *
+ * * **visitorNotFoundInDb**: True if the current visit could not be updated.
+ *
+ *                            Set by the Visit object.
  */
 class VisitRequestProcessor extends RequestProcessor
 {
+    // TODO: much of the logic in this class should be moved to new service class
+
     /**
      * @var EventDispatcher
      */

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -61,7 +61,7 @@ class VisitRequestProcessor extends RequestProcessor
         // the IP is needed by isExcluded() and GoalManager->recordGoals()
         $visitProperties->visitorInfo['location_ip'] = $request->getIp();
 
-        // TODO: move VisitExcluded logic to here (or break into other request processors)
+        // TODO: move VisitExcluded logic to here (or move to service class stored in DI)
         $excluded = new VisitExcluded($request, $visitProperties->visitorInfo['location_ip']);
         if ($excluded->isExcluded()) {
             return true;
@@ -80,7 +80,7 @@ class VisitRequestProcessor extends RequestProcessor
         return false;
     }
 
-    public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
+    public function afterRequestProcessed(VisitProperties $visitProperties)
     {
         /**
          * Triggered after visits are tested for exclusion so plugins can modify the IP address
@@ -135,7 +135,7 @@ class VisitRequestProcessor extends RequestProcessor
 
         return isset($lastActionTime)
             && false !== $lastActionTime
-            && ($lastActionTime > ($request->getCurrentTimestamp() - $this->visitStandardLength)); // TODO: move to DI
+            && ($lastActionTime > ($request->getCurrentTimestamp() - $this->visitStandardLength));
     }
 
     /**

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -40,11 +40,18 @@ class VisitRequestProcessor extends RequestProcessor
      */
     private $userSettings;
 
-    public function __construct(EventDispatcher $eventDispatcher, VisitorRecognizer $visitorRecognizer, Settings $userSettings)
+    /**
+     * @var int
+     */
+    private $visitStandardLength;
+
+    public function __construct(EventDispatcher $eventDispatcher, VisitorRecognizer $visitorRecognizer, Settings $userSettings,
+                                $visitStandardLength)
     {
         $this->eventDispatcher = $eventDispatcher;
         $this->visitorRecognizer = $visitorRecognizer;
         $this->userSettings = $userSettings;
+        $this->visitStandardLength = $visitStandardLength;
     }
 
     public function processRequestParams(VisitProperties $visitProperties, Request $request)
@@ -126,7 +133,7 @@ class VisitRequestProcessor extends RequestProcessor
 
         return isset($lastActionTime)
             && false !== $lastActionTime
-            && ($lastActionTime > ($request->getCurrentTimestamp() - \Piwik\Config::getInstance()->Tracker['visit_standard_length'])); // TODO: move to DI
+            && ($lastActionTime > ($request->getCurrentTimestamp() - $this->visitStandardLength)); // TODO: move to DI
     }
 
     /**

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -8,11 +8,17 @@
 
 namespace Piwik\Plugins\CoreHome\Tracker;
 
+use Piwik\Common;
+use Piwik\Date;
 use Piwik\EventDispatcher;
+use Piwik\Exception\UnexpectedWebsiteFoundException;
+use Piwik\Tracker\Cache;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\RequestProcessor;
+use Piwik\Tracker\Settings;
 use Piwik\Tracker\Visit\VisitProperties;
 use Piwik\Tracker\VisitExcluded;
+use Piwik\Tracker\VisitorRecognizer;
 
 /**
  * Encapsulates core tracking logic related to visits.
@@ -24,9 +30,21 @@ class VisitRequestProcessor extends RequestProcessor
      */
     private $eventDispatcher;
 
-    public function __construct(EventDispatcher $eventDispatcher)
+    /**
+     * @var VisitorRecognizer
+     */
+    private $visitorRecognizer;
+
+    /**
+     * @var Settings
+     */
+    private $userSettings;
+
+    public function __construct(EventDispatcher $eventDispatcher, VisitorRecognizer $visitorRecognizer, Settings $userSettings)
     {
         $this->eventDispatcher = $eventDispatcher;
+        $this->visitorRecognizer = $visitorRecognizer;
+        $this->userSettings = $userSettings;
     }
 
     public function processRequestParams(VisitProperties $visitProperties, Request $request)
@@ -39,6 +57,16 @@ class VisitRequestProcessor extends RequestProcessor
         if ($excluded->isExcluded()) {
             return true;
         }
+
+        // visitor recognition
+        $visitorId = $this->userSettings->getConfigId($request, $visitProperties->visitorInfo['location_ip']);
+        $visitProperties->setRequestMetadata('CoreHome', 'visitorId', $visitorId);
+
+        $isKnown = $this->visitorRecognizer->findKnownVisitor($visitorId, $visitProperties, $request);
+        $visitProperties->setRequestMetadata('CoreHome', 'isVisitorKnown', $isKnown);
+
+        $isNewVisit = $this->isVisitNew($visitProperties, $request);
+        $visitProperties->setRequestMetadata('CoreHome', 'isNewVisit', $isNewVisit);
 
         return false;
     }
@@ -54,5 +82,92 @@ class VisitRequestProcessor extends RequestProcessor
          * @param string &$ip The visitor's IP address.
          */
         $this->eventDispatcher->postEvent('Tracker.setVisitorIp', array(&$visitProperties->visitorInfo['location_ip']));
+    }
+
+    /**
+     * Determines if the tracker if the current action should be treated as the start of a new visit or
+     * an action in an existing visit.
+     *
+     * @param VisitProperties $visitProperties The current visit/visitor information.
+     * @param Request $request
+     * @return bool
+     */
+    private function isVisitNew(VisitProperties $visitProperties, Request $request)
+    {
+        $isKnown = $visitProperties->getRequestMetadata('CoreHome', 'isVisitorKnown');
+        if (!$isKnown) {
+            return true;
+        }
+
+        $isLastActionInTheSameVisit = $this->isLastActionInTheSameVisit($visitProperties, $request);
+        if (!$isLastActionInTheSameVisit) {
+            Common::printDebug("Visitor detected, but last action was more than 30 minutes ago...");
+
+            return true;
+        }
+
+        $wasLastActionYesterday = $this->wasLastActionNotToday($visitProperties, $request);
+        if ($wasLastActionYesterday) {
+            Common::printDebug("Visitor detected, but last action was yesterday...");
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the last action was done during the last 30 minutes
+     * @return bool
+     */
+    protected function isLastActionInTheSameVisit(VisitProperties $visitProperties, Request $request)
+    {
+        $lastActionTime = $visitProperties->visitorInfo['visit_last_action_time'];
+
+        return isset($lastActionTime)
+            && false !== $lastActionTime
+            && ($lastActionTime > ($request->getCurrentTimestamp() - \Piwik\Config::getInstance()->Tracker['visit_standard_length'])); // TODO: move to DI
+    }
+
+    /**
+     * Returns true if the last action was not today.
+     * @param VisitProperties $visitor
+     * @return bool
+     */
+    private function wasLastActionNotToday(VisitProperties $visitProperties, Request $request)
+    {
+        $lastActionTime = $visitProperties->visitorInfo['visit_last_action_time'];
+
+        if (empty($lastActionTime)) {
+            return false;
+        }
+
+        $idSite = $request->getIdSite();
+        $timezone = $this->getTimezoneForSite($idSite);
+
+        if (empty($timezone)) {
+            throw new UnexpectedWebsiteFoundException('An unexpected website was found, check idSite in the request');
+        }
+
+        $date = Date::factory((int)$lastActionTime, $timezone);
+        $now = $request->getCurrentTimestamp();
+        $now = Date::factory((int)$now, $timezone);
+
+        return $date->toString() !== $now->toString();
+    }
+
+    private function getTimezoneForSite($idSite) // TODO: duplicate function in Visit
+    {
+        try {
+            $site = Cache::getCacheWebsiteAttributes($idSite);
+        } catch (UnexpectedWebsiteFoundException $e) {
+            return null;
+        }
+
+        if (!empty($site['timezone'])) {
+            return $site['timezone'];
+        }
+
+        return null;
     }
 }

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -104,7 +104,7 @@ class VisitRequestProcessor extends RequestProcessor
         return false;
     }
 
-    public function afterRequestProcessed(VisitProperties $visitProperties)
+    public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
     {
         /**
          * Triggered after visits are tested for exclusion so plugins can modify the IP address
@@ -121,11 +121,13 @@ class VisitRequestProcessor extends RequestProcessor
      * Determines if the tracker if the current action should be treated as the start of a new visit or
      * an action in an existing visit.
      *
+     * Note: public only for tests.
+     *
      * @param VisitProperties $visitProperties The current visit/visitor information.
      * @param Request $request
      * @return bool
      */
-    private function isVisitNew(VisitProperties $visitProperties, Request $request)
+    public function isVisitNew(VisitProperties $visitProperties, Request $request)
     {
         $isKnown = $visitProperties->getRequestMetadata('CoreHome', 'isVisitorKnown');
         if (!$isKnown) {

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -93,13 +93,13 @@ class VisitRequestProcessor extends RequestProcessor
 
         // visitor recognition
         $visitorId = $this->userSettings->getConfigId($request, $visitProperties->getProperty('location_ip'));
-        $visitProperties->setRequestMetadata('CoreHome', 'visitorId', $visitorId);
+        $request->setMetadata('CoreHome', 'visitorId', $visitorId);
 
         $isKnown = $this->visitorRecognizer->findKnownVisitor($visitorId, $visitProperties, $request);
-        $visitProperties->setRequestMetadata('CoreHome', 'isVisitorKnown', $isKnown);
+        $request->setMetadata('CoreHome', 'isVisitorKnown', $isKnown);
 
         $isNewVisit = $this->isVisitNew($visitProperties, $request);
-        $visitProperties->setRequestMetadata('CoreHome', 'isNewVisit', $isNewVisit);
+        $request->setMetadata('CoreHome', 'isNewVisit', $isNewVisit);
 
         return false;
     }
@@ -133,7 +133,7 @@ class VisitRequestProcessor extends RequestProcessor
      */
     public function isVisitNew(VisitProperties $visitProperties, Request $request)
     {
-        $isKnown = $visitProperties->getRequestMetadata('CoreHome', 'isVisitorKnown');
+        $isKnown = $request->getMetadata('CoreHome', 'isVisitorKnown');
         if (!$isKnown) {
             return true;
         }

--- a/plugins/CoreHome/config/config.php
+++ b/plugins/CoreHome/config/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+
+    'tracker.request.processors' => DI\add(array(
+        DI\get('Piwik\Plugins\CoreHome\Tracker\VisitRequestProcessor'),
+    )),
+
+);

--- a/plugins/CoreHome/config/config.php
+++ b/plugins/CoreHome/config/config.php
@@ -2,6 +2,9 @@
 
 return array(
 
+    'Piwik\Plugins\CoreHome\Tracker\VisitRequestProcessor' => DI\object()
+        ->constructorParameter('visitStandardLength', DI\get('ini.Tracker.visit_standard_length')),
+
     'tracker.request.processors' => DI\add(array(
         DI\get('Piwik\Plugins\CoreHome\Tracker\VisitRequestProcessor'),
     )),

--- a/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
+++ b/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
@@ -96,11 +96,12 @@ class VisitRequestProcessorTest extends IntegrationTestCase
     {
         $idsite = API::getInstance()->addSite("name", "http://piwik.net/");
 
+        /** @var Request $request */
         list($visit, $request) = $this->prepareVisitWithRequest(array('idsite' => $idsite), $currentActionTime);
 
         $visitProperties = new VisitProperties();
         $visitProperties->setProperty('visit_last_action_time', Date::factory($lastActionTimestamp)->getTimestamp());
-        $visitProperties->setRequestMetadata('CoreHome', 'isVisitorKnown', $isVisitorKnown);
+        $request->setMetadata('CoreHome', 'isVisitorKnown', $isVisitorKnown);
 
         return array($visit, $visitProperties, $request);
     }

--- a/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
+++ b/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreHome\tests\Integration\Tracker;
+
+use Piwik\Cache;
+use Piwik\CacheId;
+use Piwik\Date;
+use Piwik\Plugins\CoreHome\Tracker\VisitRequestProcessor;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Plugins\SitesManager\API;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\Visit;
+use Piwik\Tracker\Visit\VisitProperties;
+
+/**
+ * @group CoreHome
+ * @group CoreHome_Integration
+ */
+class VisitRequestProcessorTest extends IntegrationTestCase
+{
+    public function test_isVisitNew_ReturnsFalse_IfLastActionTimestampIsWithinVisitTimeLength_AndNoDimensionForcesVisit_AndVisitorKnown()
+    {
+        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+
+        /** @var VisitRequestProcessor $visit */
+        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+            $lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 08:12:45', $isVisitorKnown = true);
+
+        $result = $visit->isVisitNew($visitProperties, $request);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_isVisitNew_ReturnsTrue_IfLastActionTimestampWasYesterday()
+    {
+        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+
+        // test same day
+        /** @var VisitRequestProcessor $visit */
+        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+            $lastActionTime = '2012-01-01 23:59:58', $thisActionTime = '2012-01-01 23:59:59', $isVisitorKnown = true);
+        $result = $visit->isVisitNew($visitProperties, $request);
+        $this->assertFalse($result);
+
+        // test different day
+        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction(
+            $lastActionTime = '2012-01-01 23:59:58', $thisActionTime = '2012-01-02 00:00:01', $isVisitorKnown = true);
+        $result = $visit->isVisitNew($visitProperties, $request);
+        $this->assertTrue($result);
+    }
+
+
+    public function test_isVisitNew_ReturnsTrue_IfLastActionTimestampIsNotWithinVisitTimeLength_AndNoDimensionForcesVisit_AndVisitorNotKnown()
+    {
+        $this->setDimensionsWithOnNewVisit(array(false, false, false));
+
+        /** @var VisitRequestProcessor $visit */
+        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction($lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 09:12:45');
+
+        $result = $visit->isVisitNew($visitProperties, $request);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_isVisitNew_ReturnsTrue_IfLastActionTimestampIsWithinVisitTimeLength_AndDimensionForcesVisit()
+    {
+        $this->setDimensionsWithOnNewVisit(array(false, false, true));
+
+        /** @var VisitRequestProcessor $visit */
+        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction($lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 08:12:45');
+
+        $result = $visit->isVisitNew($visitProperties, $request);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_isVisitNew_ReturnsTrue_IfDimensionForcesVisit_AndVisitorKnown()
+    {
+        $this->setDimensionsWithOnNewVisit(array(false, false, true));
+
+        /** @var VisitRequestProcessor $visit */
+        list($visit, $visitProperties, $request) = $this->makeVisitorAndAction($lastActionTime = '2012-01-02 08:08:34', $thisActionTime = '2012-01-02 08:12:45');
+
+        $result = $visit->isVisitNew($visitProperties, $request);
+
+        $this->assertTrue($result);
+    }
+
+    private function makeVisitorAndAction($lastActionTimestamp, $currentActionTime, $isVisitorKnown = false)
+    {
+        $idsite = API::getInstance()->addSite("name", "http://piwik.net/");
+
+        list($visit, $request) = $this->prepareVisitWithRequest(array('idsite' => $idsite), $currentActionTime);
+
+        $visitProperties = new VisitProperties();
+        $visitProperties->visitorInfo = array('visit_last_action_time' => Date::factory($lastActionTimestamp)->getTimestamp());
+        $visitProperties->setRequestMetadata('CoreHome', 'isVisitorKnown', $isVisitorKnown);
+
+        return array($visit, $visitProperties, $request);
+    }
+
+    private function setDimensionsWithOnNewVisit($dimensionOnNewVisitResults)
+    {
+        $dimensions = array();
+        foreach ($dimensionOnNewVisitResults as $onNewVisitResult) {
+            $dim = $this->getMock('Piwik\\Plugin\\Dimension', array('shouldForceNewVisit', 'getColumnName'));
+            $dim->expects($this->any())->method('shouldForceNewVisit')->will($this->returnValue($onNewVisitResult));
+            $dimensions[] = $dim;
+        }
+
+        $cache = Cache::getTransientCache();
+        $cache->save(CacheId::pluginAware('VisitDimensions'), $dimensions);
+        Visit::$dimensions = null;
+    }
+
+    private function prepareVisitWithRequest($requestParams, $requestDate)
+    {
+        $request = new Request($requestParams);
+        $request->setCurrentTimestamp(Date::factory($requestDate)->getTimestamp());
+
+        $visit = self::$fixture->piwikEnvironment->getContainer()->get('Piwik\Plugins\CoreHome\Tracker\VisitRequestProcessor');
+
+        return array($visit, $request);
+    }
+}

--- a/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
+++ b/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
@@ -99,7 +99,7 @@ class VisitRequestProcessorTest extends IntegrationTestCase
         list($visit, $request) = $this->prepareVisitWithRequest(array('idsite' => $idsite), $currentActionTime);
 
         $visitProperties = new VisitProperties();
-        $visitProperties->visitorInfo = array('visit_last_action_time' => Date::factory($lastActionTimestamp)->getTimestamp());
+        $visitProperties->setProperty('visit_last_action_time', Date::factory($lastActionTimestamp)->getTimestamp());
         $visitProperties->setRequestMetadata('CoreHome', 'isVisitorKnown', $isVisitorKnown);
 
         return array($visit, $visitProperties, $request);

--- a/plugins/CustomVariables/Tracker/CustomVariablesRequestProcessor.php
+++ b/plugins/CustomVariables/Tracker/CustomVariablesRequestProcessor.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CustomVariables\Tracker;
+
+use Piwik\Common;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\RequestProcessor;
+use Piwik\Tracker\Visit\VisitProperties;
+
+/**
+ * TODO
+ *
+ * TODO: document request metadata
+ */
+class CustomVariablesRequestProcessor extends RequestProcessor
+{
+    public function processRequestParams(VisitProperties $visitProperties, Request $request)
+    {
+        // TODO: re-add optimization where if custom variables exist in request, don't bother selecting them in Visitor
+        $visitorCustomVariables = $request->getCustomVariables($scope = 'visit');
+        if (!empty($visitorCustomVariables)) {
+            Common::printDebug("Visit level Custom Variables: ");
+            Common::printDebug($visitorCustomVariables);
+        }
+
+        $visitProperties->setRequestMetadata('CustomVariables', 'visitCustomVariables', $visitorCustomVariables);
+    }
+
+    public function onNewVisit(VisitProperties $visitProperties, Request $request)
+    {
+        $visitCustomVariables = $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables');
+
+        if (!empty($visitCustomVariables)) {
+            $visitProperties->visitorInfo = array_merge($visitProperties->visitorInfo, $visitCustomVariables);
+        }
+    }
+
+    public function onExistingVisit(&$valuesToUpdate, VisitProperties $visitProperties, Request $request)
+    {
+        $visitCustomVariables = $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables');
+
+        if (!empty($visitCustomVariables)) {
+            $valuesToUpdate = array_merge($valuesToUpdate, $visitCustomVariables);
+        }
+    }
+
+
+}

--- a/plugins/CustomVariables/Tracker/CustomVariablesRequestProcessor.php
+++ b/plugins/CustomVariables/Tracker/CustomVariablesRequestProcessor.php
@@ -50,7 +50,7 @@ class CustomVariablesRequestProcessor extends RequestProcessor
         $visitCustomVariables = $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables');
 
         if (!empty($visitCustomVariables)) {
-            $visitProperties->visitorInfo = array_merge($visitProperties->visitorInfo, $visitCustomVariables);
+            $visitProperties->setProperties(array_merge($visitProperties->getProperties(), $visitCustomVariables));
         }
     }
 

--- a/plugins/CustomVariables/Tracker/CustomVariablesRequestProcessor.php
+++ b/plugins/CustomVariables/Tracker/CustomVariablesRequestProcessor.php
@@ -42,12 +42,12 @@ class CustomVariablesRequestProcessor extends RequestProcessor
             Common::printDebug($visitorCustomVariables);
         }
 
-        $visitProperties->setRequestMetadata('CustomVariables', 'visitCustomVariables', $visitorCustomVariables);
+        $request->setMetadata('CustomVariables', 'visitCustomVariables', $visitorCustomVariables);
     }
 
     public function onNewVisit(VisitProperties $visitProperties, Request $request)
     {
-        $visitCustomVariables = $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables');
+        $visitCustomVariables = $request->getMetadata('CustomVariables', 'visitCustomVariables');
 
         if (!empty($visitCustomVariables)) {
             $visitProperties->setProperties(array_merge($visitProperties->getProperties(), $visitCustomVariables));
@@ -56,7 +56,7 @@ class CustomVariablesRequestProcessor extends RequestProcessor
 
     public function onExistingVisit(&$valuesToUpdate, VisitProperties $visitProperties, Request $request)
     {
-        $visitCustomVariables = $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables');
+        $visitCustomVariables = $request->getMetadata('CustomVariables', 'visitCustomVariables');
 
         if (!empty($visitCustomVariables)) {
             $valuesToUpdate = array_merge($valuesToUpdate, $visitCustomVariables);

--- a/plugins/CustomVariables/Tracker/CustomVariablesRequestProcessor.php
+++ b/plugins/CustomVariables/Tracker/CustomVariablesRequestProcessor.php
@@ -14,9 +14,22 @@ use Piwik\Tracker\RequestProcessor;
 use Piwik\Tracker\Visit\VisitProperties;
 
 /**
- * TODO
+ * Handles tracking of visit level custom variables.
  *
- * TODO: document request metadata
+ * ### Request Metadata
+ *
+ * Defines the following request metadata for the **CustomVariables** plugin:
+ *
+ * * **visitCustomVariables**: An array of custom variable names & values. The data is stored
+ *                             as log_visit column name/value pairs, eg,
+ *
+ *                             ```
+ *                             array(
+ *                                 'custom_var_k1' => 'the name',
+ *                                 'custom_var_v1' => 'the value',
+ *                                 ...
+ *                             )
+ *                             ```
  */
 class CustomVariablesRequestProcessor extends RequestProcessor
 {
@@ -49,6 +62,4 @@ class CustomVariablesRequestProcessor extends RequestProcessor
             $valuesToUpdate = array_merge($valuesToUpdate, $visitCustomVariables);
         }
     }
-
-
 }

--- a/plugins/CustomVariables/config/config.php
+++ b/plugins/CustomVariables/config/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+
+    'tracker.request.processors' => DI\add(array(
+        DI\get('Piwik\Plugins\CustomVariables\Tracker\CustomVariablesRequestProcessor'),
+    )),
+
+);

--- a/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
+++ b/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
@@ -67,7 +67,8 @@ class EcommerceRequestProcessor extends RequestProcessor
     {
         $goalsConverted = $visitProperties->getRequestMetadata('Goals', 'goalsConverted');
         if (!empty($goalsConverted)) {
-            $isThereExistingCartInVisit = $this->goalManager->detectIsThereExistingCartInVisit($visitProperties->visitorInfo);
+            $isThereExistingCartInVisit = $this->goalManager->detectIsThereExistingCartInVisit(
+                $visitProperties->getProperties());
             $visitProperties->setRequestMetadata('Goals', 'isThereExistingCartInVisit', $isThereExistingCartInVisit);
         }
     }

--- a/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
+++ b/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
@@ -29,6 +29,8 @@ class EcommerceRequestProcessor extends RequestProcessor
             if ($goalManager->isGoalAnOrder()) {
                 $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', true);
             }
+
+            $visitProperties->setRequestMetadata('Actions', 'action', null); // don't track actions when tracking ecommerce orders
         }
     }
 }

--- a/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
+++ b/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Ecommerce\Tracker;
+
+use Piwik\Tracker\GoalManager;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\RequestProcessor;
+use Piwik\Tracker\Visit\VisitProperties;
+
+/**
+ * TODO
+ */
+class EcommerceRequestProcessor extends RequestProcessor
+{
+    public function processRequestParams(VisitProperties $visitProperties, Request $request)
+    {
+        $goalManager = new GoalManager($request); // TODO: GoalManager should be stateless and stored in DI.
+
+        if ($goalManager->requestIsEcommerce) {
+            $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', true);
+
+            // Mark the visit as Converted only if it is an order (not for a Cart update)
+            if ($goalManager->isGoalAnOrder()) {
+                $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', true);
+            }
+        }
+    }
+}

--- a/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
+++ b/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
@@ -14,7 +14,9 @@ use Piwik\Tracker\RequestProcessor;
 use Piwik\Tracker\Visit\VisitProperties;
 
 /**
- * TODO
+ * Handles ecommerce tracking requests.
+ *
+ * Defines no new request metadata.
  */
 class EcommerceRequestProcessor extends RequestProcessor
 {

--- a/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
+++ b/plugins/Ecommerce/Tracker/EcommerceRequestProcessor.php
@@ -44,32 +44,32 @@ class EcommerceRequestProcessor extends RequestProcessor
     public function processRequestParams(VisitProperties $visitProperties, Request $request)
     {
         $isGoalAnOrder = $this->isRequestForAnOrder($request);
-        $visitProperties->setRequestMetadata('Ecommerce', 'isGoalAnOrder', $isGoalAnOrder);
+        $request->setMetadata('Ecommerce', 'isGoalAnOrder', $isGoalAnOrder);
 
         $isRequestEcommerce = $this->isRequestEcommerce($request);
-        $visitProperties->setRequestMetadata('Ecommerce', 'isRequestEcommerce', $isRequestEcommerce);
+        $request->setMetadata('Ecommerce', 'isRequestEcommerce', $isRequestEcommerce);
 
         if ($isRequestEcommerce) {
             // Mark the visit as Converted only if it is an order (not for a Cart update)
             $idGoal = GoalManager::IDGOAL_CART;
             if ($isGoalAnOrder) {
                 $idGoal = GoalManager::IDGOAL_ORDER;
-                $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', true);
+                $request->setMetadata('Goals', 'visitIsConverted', true);
             }
 
-            $visitProperties->setRequestMetadata('Goals', 'goalsConverted', array(array('idgoal' => $idGoal)));
+            $request->setMetadata('Goals', 'goalsConverted', array(array('idgoal' => $idGoal)));
 
-            $visitProperties->setRequestMetadata('Actions', 'action', null); // don't track actions when tracking ecommerce orders
+            $request->setMetadata('Actions', 'action', null); // don't track actions when tracking ecommerce orders
         }
     }
 
     public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
     {
-        $goalsConverted = $visitProperties->getRequestMetadata('Goals', 'goalsConverted');
+        $goalsConverted = $request->getMetadata('Goals', 'goalsConverted');
         if (!empty($goalsConverted)) {
             $isThereExistingCartInVisit = $this->goalManager->detectIsThereExistingCartInVisit(
                 $visitProperties->getProperties());
-            $visitProperties->setRequestMetadata('Goals', 'isThereExistingCartInVisit', $isThereExistingCartInVisit);
+            $request->setMetadata('Goals', 'isThereExistingCartInVisit', $isThereExistingCartInVisit);
         }
     }
 

--- a/plugins/Ecommerce/config/config.php
+++ b/plugins/Ecommerce/config/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+
+    'tracker.request.processors' => DI\add(array(
+        DI\get('Piwik\Plugins\Ecommerce\Tracker\EcommerceRequestProcessor'),
+    )),
+
+);

--- a/plugins/Goals/Tracker/GoalsRequestProcessor.php
+++ b/plugins/Goals/Tracker/GoalsRequestProcessor.php
@@ -94,7 +94,9 @@ class GoalsRequestProcessor extends RequestProcessor
             $existingGoalsConverted = $visitProperties->getRequestMetadata('Goals', 'goalsConverted') ?: array();
             $visitProperties->setRequestMetadata('Goals', 'goalsConverted', array_merge($existingGoalsConverted, $goalsConverted));
 
-            $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', !empty($goalsConverted));
+            if (!empty($goalsConverted)) {
+                $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', true);
+            }
         }
 
         // There is an edge case when:

--- a/plugins/Goals/Tracker/GoalsRequestProcessor.php
+++ b/plugins/Goals/Tracker/GoalsRequestProcessor.php
@@ -32,6 +32,8 @@ class GoalsRequestProcessor extends RequestProcessor
             $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', $someGoalsConverted);
             $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', $someGoalsConverted);
 
+            $visitProperties->setRequestMetadata('Actions', 'action', null); // don't track actions when doing manual goal conversions
+
             // if we find a idgoal in the URL, but then the goal is not valid, this is most likely a fake request
             if (!$someGoalsConverted) {
                 Common::printDebug('Invalid goal tracking request for goal id = ' . $goalManager->idGoal);

--- a/plugins/Goals/Tracker/GoalsRequestProcessor.php
+++ b/plugins/Goals/Tracker/GoalsRequestProcessor.php
@@ -77,7 +77,7 @@ class GoalsRequestProcessor extends RequestProcessor
         }
     }
 
-    public function processRequest(Visitor $visitor, VisitProperties $visitProperties)
+    public function processRequest(VisitProperties $visitProperties, Request $request)
     {
         $isManualGoalConversion = self::$goalManager->isManualGoalConversion();
         $requestIsEcommerce = self::$goalManager->requestIsEcommerce;
@@ -100,15 +100,7 @@ class GoalsRequestProcessor extends RequestProcessor
 
         // record the goals if there were conversions in this request (even if the visit itself was not converted)
         if ($visitProperties->getRequestMetadata('Goals', 'someGoalsConverted')) {
-            /** @var Action $action */
-            $action = $visitProperties->getRequestMetadata('Actions', 'action');
-
-            self::$goalManager->recordGoals(
-                $visitor,
-                $visitProperties->visitorInfo,
-                $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables'),
-                $action
-            );
+            self::$goalManager->recordGoals($visitProperties, $request);
         }
     }
 }

--- a/plugins/Goals/Tracker/GoalsRequestProcessor.php
+++ b/plugins/Goals/Tracker/GoalsRequestProcessor.php
@@ -55,7 +55,7 @@ class GoalsRequestProcessor extends RequestProcessor
 
     public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
     {
-        $visitsConverted = $visitProperties->getRequestMetadata('Goals', 'visitIsConverted');
+        $visitsConverted = $visitProperties->getRequestMetadata('Goals', 'visitIsConverted'); // TODO: double check, should this be visitIsConverted or someGoalsConverted?
 
         /** @var Action $action */
         $action = $visitProperties->getRequestMetadata('Actions', 'action');
@@ -69,6 +69,11 @@ class GoalsRequestProcessor extends RequestProcessor
 
             $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', $someGoalsConverted);
             $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', $someGoalsConverted);
+        }
+
+        $someGoalsConverted = $visitProperties->getRequestMetadata('Goals', 'someGoalsConverted');
+        if ($someGoalsConverted) {
+            self::$goalManager->detectIsThereExistingCartInVisit($visitProperties->visitorInfo);
         }
     }
 
@@ -95,6 +100,7 @@ class GoalsRequestProcessor extends RequestProcessor
 
         // record the goals if there were conversions in this request (even if the visit itself was not converted)
         if ($visitProperties->getRequestMetadata('Goals', 'someGoalsConverted')) {
+            /** @var Action $action */
             $action = $visitProperties->getRequestMetadata('Actions', 'action');
 
             self::$goalManager->recordGoals(

--- a/plugins/Goals/Tracker/GoalsRequestProcessor.php
+++ b/plugins/Goals/Tracker/GoalsRequestProcessor.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Goals\Tracker;
+
+use Piwik\Common;
+use Piwik\Tracker\GoalManager;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\RequestProcessor;
+use Piwik\Tracker\Visit\VisitProperties;
+
+/**
+ * TODO
+ *
+ * TODO: document request metadata here
+ */
+class GoalsRequestProcessor extends RequestProcessor
+{
+    public function processRequestParams(VisitProperties $visitProperties, Request $request)
+    {
+        $goalManager = new GoalManager($request); // TODO: GoalManager should be stateless and stored in DI.
+
+        if ($goalManager->isManualGoalConversion()) {
+            // this request is from the JS call to piwikTracker.trackGoal()
+            $someGoalsConverted = $goalManager->detectGoalId($request->getIdSite());
+
+            $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', $someGoalsConverted);
+            $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', $someGoalsConverted);
+
+            // if we find a idgoal in the URL, but then the goal is not valid, this is most likely a fake request
+            if (!$someGoalsConverted) {
+                Common::printDebug('Invalid goal tracking request for goal id = ' . $goalManager->idGoal);
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/plugins/Goals/Tracker/GoalsRequestProcessor.php
+++ b/plugins/Goals/Tracker/GoalsRequestProcessor.php
@@ -14,6 +14,7 @@ use Piwik\Tracker\GoalManager;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\RequestProcessor;
 use Piwik\Tracker\Visit\VisitProperties;
+use Piwik\Tracker\Visitor;
 
 /**
  * TODO
@@ -71,7 +72,7 @@ class GoalsRequestProcessor extends RequestProcessor
         }
     }
 
-    public function processRequest(VisitProperties $visitProperties)
+    public function processRequest(Visitor $visitor, VisitProperties $visitProperties)
     {
         $isManualGoalConversion = self::$goalManager->isManualGoalConversion();
         $requestIsEcommerce = self::$goalManager->requestIsEcommerce;
@@ -90,6 +91,18 @@ class GoalsRequestProcessor extends RequestProcessor
         ) {
             $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);
             $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
+        }
+
+        // record the goals if there were conversions in this request (even if the visit itself was not converted)
+        if ($visitProperties->getRequestMetadata('Goals', 'someGoalsConverted')) {
+            $action = $visitProperties->getRequestMetadata('Actions', 'action');
+
+            self::$goalManager->recordGoals(
+                $visitor,
+                $visitProperties->visitorInfo,
+                $visitProperties->getRequestMetadata('CustomVariables', 'visitCustomVariables'),
+                $action
+            );
         }
     }
 }

--- a/plugins/Goals/Tracker/GoalsRequestProcessor.php
+++ b/plugins/Goals/Tracker/GoalsRequestProcessor.php
@@ -14,7 +14,6 @@ use Piwik\Tracker\GoalManager;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\RequestProcessor;
 use Piwik\Tracker\Visit\VisitProperties;
-use Piwik\Tracker\Visitor;
 
 /**
  * TODO
@@ -53,7 +52,7 @@ class GoalsRequestProcessor extends RequestProcessor
         return false;
     }
 
-    public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
+    public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
     {
         $visitsConverted = $visitProperties->getRequestMetadata('Goals', 'visitIsConverted'); // TODO: double check, should this be visitIsConverted or someGoalsConverted?
 
@@ -77,7 +76,7 @@ class GoalsRequestProcessor extends RequestProcessor
         }
     }
 
-    public function processRequest(VisitProperties $visitProperties, Request $request)
+    public function recordLogs(VisitProperties $visitProperties)
     {
         $isManualGoalConversion = self::$goalManager->isManualGoalConversion();
         $requestIsEcommerce = self::$goalManager->requestIsEcommerce;
@@ -100,7 +99,7 @@ class GoalsRequestProcessor extends RequestProcessor
 
         // record the goals if there were conversions in this request (even if the visit itself was not converted)
         if ($visitProperties->getRequestMetadata('Goals', 'someGoalsConverted')) {
-            self::$goalManager->recordGoals($visitProperties, $request);
+            self::$goalManager->recordGoals($visitProperties);
         }
     }
 }

--- a/plugins/Goals/config/config.php
+++ b/plugins/Goals/config/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+
+    'tracker.request.processors' => DI\add(array(
+        DI\get('Piwik\Plugins\Goals\Tracker\GoalsRequestProcessor'),
+    )),
+
+);

--- a/plugins/Heartbeat/Heartbeat.php
+++ b/plugins/Heartbeat/Heartbeat.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Heartbeat;
+
+use Piwik\Plugin;
+
+class Heartbeat extends Plugin
+{
+    public function isTrackerPlugin()
+    {
+        return true;
+    }
+}

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -24,7 +24,12 @@ class PingRequestProcessor extends RequestProcessor
             Common::printDebug("-> ping=1 request: we do not track a new action nor a new visit nor any goal.");
 
             $visitProperties->setRequestMetadata('Actions', 'action', null);
+        }
+    }
 
+    public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
+    {
+        if ($this->isPingRequest($request)) {
             $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);
             $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
         }

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -32,7 +32,17 @@ class PingRequestProcessor extends RequestProcessor
         if ($this->isPingRequest($request)) {
             $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);
             $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
+            // TODO: double check: can this be merged w/ setting action to null?
+
+            // When a ping request is received more than 30 min after the last request/ping,
+            // we choose not to create a new visit.
+            if ($visitProperties->getRequestMetadata('CoreHome', 'isNewVisit')) {
+                Common::printDebug("-> ping=1 request: we do _not_ create a new visit.");
+                return true; // abort request
+            }
         }
+
+        return false;
     }
 
     private function isPingRequest(Request $request)

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -19,22 +19,14 @@ use Piwik\Tracker\Visit\VisitProperties;
  */
 class PingRequestProcessor extends RequestProcessor
 {
-    public function processRequestParams(VisitProperties $visitProperties, Request $request)
+    public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
     {
         if ($this->isPingRequest($request)) {
             // on a ping request that is received before the standard visit length, we just update the visit time w/o adding a new action
             Common::printDebug("-> ping=1 request: we do not track a new action nor a new visit nor any goal.");
-
             $visitProperties->setRequestMetadata('Actions', 'action', null);
-        }
-    }
-
-    public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
-    {
-        if ($this->isPingRequest($request)) {
             $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);
             $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
-            // TODO: double check: can this be merged w/ setting action to null?
 
             // When a ping request is received more than 30 min after the last request/ping,
             // we choose not to create a new visit.

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -13,7 +13,9 @@ use Piwik\Tracker\RequestProcessor;
 use Piwik\Tracker\Visit\VisitProperties;
 
 /**
- * TODO
+ * Handles ping tracker requests.
+ *
+ * Defines no request metadata.
  */
 class PingRequestProcessor extends RequestProcessor
 {

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -27,7 +27,7 @@ class PingRequestProcessor extends RequestProcessor
         }
     }
 
-    public function manipulateVisitProperties(VisitProperties $visitProperties, Request $request)
+    public function afterRequestProcessed(VisitProperties $visitProperties, Request $request)
     {
         if ($this->isPingRequest($request)) {
             $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -25,7 +25,7 @@ class PingRequestProcessor extends RequestProcessor
             // on a ping request that is received before the standard visit length, we just update the visit time w/o adding a new action
             Common::printDebug("-> ping=1 request: we do not track a new action nor a new visit nor any goal.");
             $visitProperties->setRequestMetadata('Actions', 'action', null);
-            $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);
+            $visitProperties->setRequestMetadata('Goals', 'goalsConverted', array());
             $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
 
             // When a ping request is received more than 30 min after the last request/ping,

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Plugins\Heartbeat\Tracker;
+
+use Piwik\Common;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\RequestProcessor;
+use Piwik\Tracker\Visit\VisitProperties;
+
+/**
+ * TODO
+ */
+class PingRequestProcessor extends RequestProcessor
+{
+    public function processRequestParams(VisitProperties $visitProperties, Request $request)
+    {
+        if ($this->isPingRequest($request)) {
+            // on a ping request that is received before the standard visit length, we just update the visit time w/o adding a new action
+            Common::printDebug("-> ping=1 request: we do not track a new action nor a new visit nor any goal.");
+
+            $visitProperties->setRequestMetadata('Actions', 'action', null);
+
+            $visitProperties->setRequestMetadata('Goals', 'someGoalsConverted', false);
+            $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
+        }
+    }
+
+    private function isPingRequest(Request $request)
+    {
+        return $request->getParam('ping') == 1;
+    }
+}

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -24,13 +24,13 @@ class PingRequestProcessor extends RequestProcessor
         if ($this->isPingRequest($request)) {
             // on a ping request that is received before the standard visit length, we just update the visit time w/o adding a new action
             Common::printDebug("-> ping=1 request: we do not track a new action nor a new visit nor any goal.");
-            $visitProperties->setRequestMetadata('Actions', 'action', null);
-            $visitProperties->setRequestMetadata('Goals', 'goalsConverted', array());
-            $visitProperties->setRequestMetadata('Goals', 'visitIsConverted', false);
+            $request->setMetadata('Actions', 'action', null);
+            $request->setMetadata('Goals', 'goalsConverted', array());
+            $request->setMetadata('Goals', 'visitIsConverted', false);
 
             // When a ping request is received more than 30 min after the last request/ping,
             // we choose not to create a new visit.
-            if ($visitProperties->getRequestMetadata('CoreHome', 'isNewVisit')) {
+            if ($request->getMetadata('CoreHome', 'isNewVisit')) {
                 Common::printDebug("-> ping=1 request: we do _not_ create a new visit.");
                 return true; // abort request
             }

--- a/plugins/Heartbeat/config/config.php
+++ b/plugins/Heartbeat/config/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+
+    'tracker.request.processors' => DI\add(array(
+        DI\get('Piwik\Plugins\Heartbeat\Tracker\PingRequestProcessor'),
+    )),
+
+);

--- a/plugins/Heartbeat/plugin.json
+++ b/plugins/Heartbeat/plugin.json
@@ -1,0 +1,3 @@
+{
+  "description": "Handles ping tracker requests."
+}

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -88,6 +88,8 @@ class Response
 
     private function normalizeApiResponse($apiResponse)
     {
+        $apiResponse = $this->removeSubtableIdsFromXml($apiResponse);
+
         if ($this->shouldDeleteLiveIds()) {
             $apiResponse = $this->removeAllIdsFromXml($apiResponse);
         }
@@ -254,5 +256,10 @@ class Response
         }
 
         return $apiResponse;
+    }
+
+    private function removeSubtableIdsFromXml($apiResponse)
+    {
+        return $this->removeXmlFields($apiResponse, array('idsubdatatable_in_db'));
     }
 }

--- a/tests/PHPUnit/Integration/Tracker/SettingsTest.php
+++ b/tests/PHPUnit/Integration/Tracker/SettingsTest.php
@@ -39,10 +39,13 @@ class SettingsTest extends IntegrationTestCase
 
     public function test_getConfigId_isSame()
     {
-        $settings1 = $this->makeSettings(array('idsite' => 1));
-        $settings2 = $this->makeSettings(array('idsite' => 1));
+        $request1 = $this->makeRequest(array('idsite' => 1));
+        $settings1 = $this->makeSettings();
 
-        $this->assertEquals($settings1->getConfigId(), $settings2->getConfigId());
+        $request2 = $this->makeRequest(array('idsite' => 1));
+        $settings2 = $this->makeSettings();
+
+        $this->assertEquals($settings1->getConfigId($request1, $this->ip), $settings2->getConfigId($request2, $this->ip));
     }
 
 
@@ -50,44 +53,59 @@ class SettingsTest extends IntegrationTestCase
     {
         $isSameFingerprintAcrossWebsites = true;
 
-        $settingsSite1 = $this->makeSettings(array('idsite' => 1), $isSameFingerprintAcrossWebsites);
-        $settingsSite2 = $this->makeSettings(array('idsite' => 2), $isSameFingerprintAcrossWebsites);
+        $request1 = $this->makeRequest(array('idsite' => 1));
+        $settingsSite1 = $this->makeSettings($isSameFingerprintAcrossWebsites);
 
-        $this->assertEquals($settingsSite1->getConfigId(), $settingsSite2->getConfigId());
+        $request2 = $this->makeRequest(array('idsite' => 2));
+        $settingsSite2 = $this->makeSettings($isSameFingerprintAcrossWebsites);
+
+        $this->assertEquals($settingsSite1->getConfigId($request1, $this->ip), $settingsSite2->getConfigId($request2, $this->ip));
     }
 
     public function test_getConfigId_isDifferent_whenConfiguredUserHasDifferentFingerprintAcrossWebsites()
     {
         $isSameFingerprintAcrossWebsites = false;
 
-        $settingsSite1 = $this->makeSettings(array('idsite' => 1), $isSameFingerprintAcrossWebsites);
-        $settingsSite2 = $this->makeSettings(array('idsite' => 2), $isSameFingerprintAcrossWebsites);
+        $request1 = $this->makeRequest(array('idsite' => 1));
+        $settingsSite1 = $this->makeSettings($isSameFingerprintAcrossWebsites);
 
-        $this->assertNotSame($settingsSite1->getConfigId(), $settingsSite2->getConfigId());
+        $request2 = $this->makeRequest(array('idsite' => 2));
+        $settingsSite2 = $this->makeSettings($isSameFingerprintAcrossWebsites);
+
+        $this->assertNotSame($settingsSite1->getConfigId($request1, $this->ip), $settingsSite2->getConfigId($request2, $this->ip));
     }
 
     public function test_getConfigId_isSame_whenBrowserSamebutDifferentUserAgent()
     {
-        $settingsFirefox = $this->makeSettings(array('ua' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0'));
-        $settingsSlightlyDifferentUserAgent = $this->makeSettings(array('ua' => 'Mozilla/5.0 (Macintosh; Extra; string; here; Hello; world; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0'));
+        $request1 = $this->makeRequest(array('ua' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0'));
+        $settingsFirefox = $this->makeSettings();
 
-        $this->assertSame($settingsSlightlyDifferentUserAgent->getConfigId(), $settingsFirefox->getConfigId());
+        $request2 = $this->makeRequest(array('ua' => 'Mozilla/5.0 (Macintosh; Extra; string; here; Hello; world; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0'));
+        $settingsSlightlyDifferentUserAgent = $this->makeSettings();
+
+        $this->assertSame($settingsSlightlyDifferentUserAgent->getConfigId($request1, $this->ip), $settingsFirefox->getConfigId($request2, $this->ip));
     }
 
     public function test_getConfigId_isDifferent_whenBrowserChanges()
     {
-        $settingsFirefox = $this->makeSettings(array('ua' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0'));
-        $settingsChrome = $this->makeSettings(array('ua' => 'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19 '));
+        $request1 = $this->makeRequest(array('ua' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0'));
+        $settingsFirefox = $this->makeSettings();
 
-        $this->assertNotSame($settingsChrome->getConfigId(), $settingsFirefox->getConfigId());
+        $request2 = $this->makeRequest(array('ua' => 'Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19 '));
+        $settingsChrome = $this->makeSettings();
+
+        $this->assertNotSame($settingsChrome->getConfigId($request1, $this->ip), $settingsFirefox->getConfigId($request2, $this->ip));
     }
 
     public function test_getConfigId_isDifferent_whenOSChanges()
     {
-        $settingsFirefoxMac = $this->makeSettings(array('ua' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0'));
-        $settingsFirefoxLinux = $this->makeSettings(array('ua' => 'Mozilla/5.0 (Linux; rv:33.0) Gecko/20100101 Firefox/33.0'));
+        $request1 = $this->makeRequest(array('ua' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0'));
+        $settingsFirefoxMac = $this->makeSettings();
 
-        $this->assertNotSame($settingsFirefoxLinux->getConfigId(), $settingsFirefoxMac->getConfigId());
+        $request2 = $this->makeRequest(array('ua' => 'Mozilla/5.0 (Linux; rv:33.0) Gecko/20100101 Firefox/33.0'));
+        $settingsFirefoxLinux = $this->makeSettings();
+
+        $this->assertNotSame($settingsFirefoxLinux->getConfigId($request1, $this->ip), $settingsFirefoxMac->getConfigId($request2, $this->ip));
     }
 
     public function test_getConfigId_isDifferent_whenPluginChanges()
@@ -98,50 +116,52 @@ class SettingsTest extends IntegrationTestCase
             'fla' => 0,
             'idsite' => 1,
         );
-        $settingsWithoutFlash = $this->makeSettings($params);
+        $request1 = $this->makeRequest($params);
+        $settingsWithoutFlash = $this->makeSettings();
 
         // activate flash
         $params['fla'] = 1;
+        $request2 = $this->makeRequest($params);
         $settingsWithFlash = $this->makeSettings($params);
 
-        $this->assertNotSame($settingsWithoutFlash->getConfigId(), $settingsWithFlash->getConfigId());
+        $this->assertNotSame($settingsWithoutFlash->getConfigId($request1, $this->ip), $settingsWithFlash->getConfigId($request2, $this->ip));
     }
 
     public function test_getConfigId_isDifferent_whenIPIsAnonimised()
     {
-        $settingsIpIsNotAnon = $this->makeSettings(array(), true, '125.1.55.55');
-        $settingsIpIsAnon = $this->makeSettings(array(), true, '125.1.0.0');
+        $request1 = $this->makeRequest(array());
+        $settingsIpIsNotAnon = $this->makeSettings(true);
 
-        $this->assertNotSame($settingsIpIsNotAnon->getConfigId(), $settingsIpIsAnon->getConfigId());
+        $request2 = $this->makeRequest(array());
+        $settingsIpIsAnon = $this->makeSettings(true);
+
+        $this->assertNotSame($settingsIpIsNotAnon->getConfigId($request1, '125.1.55.55'), $settingsIpIsAnon->getConfigId($request2, '125.1.0.0'));
     }
 
     public function test_getConfigId_isSame_whenIPIsAnonimisedAndBothSame()
     {
-        $settingsIpIsAnon = $this->makeSettings(array(), true, '125.2.0.0');
-        $settingsIpIsAnonBis = $this->makeSettings(array(), true, '125.2.0.0');
+        $request1 = $this->makeRequest(array());
+        $settingsIpIsAnon = $this->makeSettings(true);
 
-        $this->assertSame($settingsIpIsAnonBis->getConfigId(), $settingsIpIsAnon->getConfigId());
+        $request2 = $this->makeRequest(array());
+        $settingsIpIsAnonBis = $this->makeSettings(true);
+
+        $this->assertSame($settingsIpIsAnonBis->getConfigId($request1, '125.2.0.0'), $settingsIpIsAnon->getConfigId($request2, '125.2.0.0'));
     }
 
     /**
-     * @param $params array
      * @param $isSameFingerprintAcrossWebsites
-     * @param $ip
      * @return Settings
      */
-    protected function makeSettings($params, $isSameFingerprintAcrossWebsites = false, $ip = null)
+    protected function makeSettings($isSameFingerprintAcrossWebsites = false)
     {
-        if(is_null($ip)) {
-            $ip = $this->ip;
-        }
-        $requestSite1 = $this->makeRequest($params);
-        $settingsSite1 = new Settings($requestSite1, $ip, $isSameFingerprintAcrossWebsites);
+        $settingsSite1 = new Settings($isSameFingerprintAcrossWebsites);
         return $settingsSite1;
     }
 
     /**
      * @param $extraParams array
-     * @return array
+     * @return Request
      */
     private function makeRequest($extraParams)
     {

--- a/tests/PHPUnit/Integration/Tracker/Visit2Test.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit2Test.php
@@ -95,8 +95,8 @@ class FakeTrackerVisit extends Visit
     public function __construct($request)
     {
         $this->request = $request;
-        $this->visitorInfo['location_ip'] = $request->getIp();
-        $this->visitorInfo['idvisitor']   = 1;
+        $this->visitProperties->visitorInfo['location_ip'] = $request->getIp();
+        $this->visitProperties->visitorInfo['idvisitor']   = 1;
     }
 
     public function handleExistingVisit($visitor, $action, $visitIsConverted)
@@ -121,7 +121,7 @@ class FakeTrackerVisit extends Visit
 
     public function getVisitorInfo()
     {
-        return $this->visitorInfo;
+        return $this->visitProperties->visitorInfo;
     }
 
     protected function insertNewVisit($visit)

--- a/tests/PHPUnit/Integration/Tracker/Visit2Test.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit2Test.php
@@ -94,7 +94,10 @@ class FakeTrackerVisit extends Visit
 {
     public function __construct($request)
     {
+        parent::__construct();
+
         $this->request = $request;
+        $this->visitProperties = new Visit\VisitProperties();
         $this->visitProperties->visitorInfo['location_ip'] = $request->getIp();
         $this->visitProperties->visitorInfo['idvisitor']   = 1;
     }
@@ -151,7 +154,7 @@ class Visit2Test extends IntegrationTestCase
     public function test_handleNewVisitWithoutConversion_shouldTriggerDimensions()
     {
         $request = new Request(array());
-        $visitor = new Visitor($request, '');
+        $visitor = new Visitor($request, '', new Visit\VisitProperties());
 
         $visit = new FakeTrackerVisit($request);
         $visit->handleNewVisit($visitor, null, false);
@@ -173,7 +176,7 @@ class Visit2Test extends IntegrationTestCase
     public function test_handleNewVisitWithConversion_shouldTriggerDimensions()
     {
         $request = new Request(array());
-        $visitor = new Visitor($request, '');
+        $visitor = new Visitor($request, '', new Visit\VisitProperties());
 
         $visit = new FakeTrackerVisit($request);
         $visit->handleNewVisit($visitor, null, true);
@@ -191,7 +194,7 @@ class Visit2Test extends IntegrationTestCase
     public function test_handleExistingVisitWithoutConversion_shouldTriggerDimensions()
     {
         $request = new Request(array());
-        $visitor = new Visitor($request, '');
+        $visitor = new Visitor($request, '', new Visit\VisitProperties());
 
         $visit = new FakeTrackerVisit($request);
         $visit->handleNewVisit($visitor, null, false);
@@ -214,7 +217,7 @@ class Visit2Test extends IntegrationTestCase
     public function test_handleExistingVisitWithConversion_shouldTriggerDimensions()
     {
         $request = new Request(array());
-        $visitor = new Visitor($request, '');
+        $visitor = new Visitor($request, '', new Visit\VisitProperties());
 
         $visit = new FakeTrackerVisit($request);
         $visit->handleNewVisit($visitor, null, false);

--- a/tests/PHPUnit/Integration/Tracker/Visit2Test.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit2Test.php
@@ -97,8 +97,8 @@ class FakeTrackerVisit extends Visit
 
         $this->request = $request;
         $this->visitProperties = $visitProperties;
-        $this->visitProperties->visitorInfo['location_ip'] = $request->getIp();
-        $this->visitProperties->visitorInfo['idvisitor']   = 1;
+        $this->visitProperties->setProperty('location_ip', $request->getIp());
+        $this->visitProperties->setProperty('idvisitor', 1);
     }
 
     public function handleExistingVisit($visitIsConverted)
@@ -123,7 +123,7 @@ class FakeTrackerVisit extends Visit
 
     public function getVisitorInfo()
     {
-        return $this->visitProperties->visitorInfo;
+        return $this->visitProperties->getProperties();
     }
 
     protected function insertNewVisit($visit)

--- a/tests/PHPUnit/Integration/Tracker/Visit2Test.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit2Test.php
@@ -154,7 +154,7 @@ class Visit2Test extends IntegrationTestCase
     {
         $request = new Request(array());
         $visitProperties = new Visit\VisitProperties();
-        $visitor = new Visitor($request, $visitProperties);
+        $visitor = new Visitor($visitProperties);
 
         $visit = new FakeTrackerVisit($request, $visitProperties);
         $visit->handleNewVisit(false);
@@ -177,7 +177,7 @@ class Visit2Test extends IntegrationTestCase
     {
         $request = new Request(array());
         $visitProperties = new Visit\VisitProperties();
-        $visitor = new Visitor($request, $visitProperties);
+        $visitor = new Visitor($visitProperties);
 
         $visit = new FakeTrackerVisit($request, $visitProperties);
         $visit->handleNewVisit(true);
@@ -196,7 +196,7 @@ class Visit2Test extends IntegrationTestCase
     {
         $request = new Request(array());
         $visitProperties = new Visit\VisitProperties();
-        $visitor = new Visitor($request, $visitProperties);
+        $visitor = new Visitor($visitProperties);
 
         $visit = new FakeTrackerVisit($request, $visitProperties);
         $visit->handleNewVisit(false);
@@ -220,7 +220,7 @@ class Visit2Test extends IntegrationTestCase
     {
         $request = new Request(array());
         $visitProperties = new Visit\VisitProperties();
-        $visitor = new Visitor($request, $visitProperties);
+        $visitor = new Visitor($visitProperties);
 
         $visit = new FakeTrackerVisit($request, $visitProperties);
         $visit->handleNewVisit(false);

--- a/tests/PHPUnit/Integration/Tracker/Visit2Test.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit2Test.php
@@ -15,7 +15,6 @@ use Piwik\Tracker\Request;
 use Piwik\Tracker\Visit;
 use Piwik\Tracker\Visitor;
 use Piwik\Piwik;
-use Piwik\EventDispatcher;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -92,24 +91,24 @@ class FakeTrackerVisitDimension4 extends VisitDimension
 
 class FakeTrackerVisit extends Visit
 {
-    public function __construct($request)
+    public function __construct($request, Visit\VisitProperties $visitProperties)
     {
         parent::__construct();
 
         $this->request = $request;
-        $this->visitProperties = new Visit\VisitProperties();
+        $this->visitProperties = $visitProperties;
         $this->visitProperties->visitorInfo['location_ip'] = $request->getIp();
         $this->visitProperties->visitorInfo['idvisitor']   = 1;
     }
 
-    public function handleExistingVisit($visitor, $action, $visitIsConverted)
+    public function handleExistingVisit($visitIsConverted)
     {
-        parent::handleExistingVisit($visitor, $action, $visitIsConverted);
+        parent::handleExistingVisit($visitIsConverted);
     }
 
-    public function handleNewVisit($visitor, $action, $visitIsConverted)
+    public function handleNewVisit($visitIsConverted)
     {
-        parent::handleNewVisit($visitor, $action, $visitIsConverted);
+        parent::handleNewVisit($visitIsConverted);
     }
 
     public function getAllVisitDimensions()
@@ -154,10 +153,11 @@ class Visit2Test extends IntegrationTestCase
     public function test_handleNewVisitWithoutConversion_shouldTriggerDimensions()
     {
         $request = new Request(array());
-        $visitor = new Visitor($request, '', new Visit\VisitProperties());
+        $visitProperties = new Visit\VisitProperties();
+        $visitor = new Visitor($request, $visitProperties);
 
-        $visit = new FakeTrackerVisit($request);
-        $visit->handleNewVisit($visitor, null, false);
+        $visit = new FakeTrackerVisit($request, $visitProperties);
+        $visit->handleNewVisit(false);
 
         $info = $visit->getVisitorInfo();
 
@@ -176,10 +176,11 @@ class Visit2Test extends IntegrationTestCase
     public function test_handleNewVisitWithConversion_shouldTriggerDimensions()
     {
         $request = new Request(array());
-        $visitor = new Visitor($request, '', new Visit\VisitProperties());
+        $visitProperties = new Visit\VisitProperties();
+        $visitor = new Visitor($request, $visitProperties);
 
-        $visit = new FakeTrackerVisit($request);
-        $visit->handleNewVisit($visitor, null, true);
+        $visit = new FakeTrackerVisit($request, $visitProperties);
+        $visit->handleNewVisit(true);
 
         $info = $visit->getVisitorInfo();
 
@@ -194,11 +195,12 @@ class Visit2Test extends IntegrationTestCase
     public function test_handleExistingVisitWithoutConversion_shouldTriggerDimensions()
     {
         $request = new Request(array());
-        $visitor = new Visitor($request, '', new Visit\VisitProperties());
+        $visitProperties = new Visit\VisitProperties();
+        $visitor = new Visitor($request, $visitProperties);
 
-        $visit = new FakeTrackerVisit($request);
-        $visit->handleNewVisit($visitor, null, false);
-        $visit->handleExistingVisit($visitor, null, false);
+        $visit = new FakeTrackerVisit($request, $visitProperties);
+        $visit->handleNewVisit(false);
+        $visit->handleExistingVisit(false);
 
         $info = $visit->getVisitorInfo();
 
@@ -217,11 +219,12 @@ class Visit2Test extends IntegrationTestCase
     public function test_handleExistingVisitWithConversion_shouldTriggerDimensions()
     {
         $request = new Request(array());
-        $visitor = new Visitor($request, '', new Visit\VisitProperties());
+        $visitProperties = new Visit\VisitProperties();
+        $visitor = new Visitor($request, $visitProperties);
 
-        $visit = new FakeTrackerVisit($request);
-        $visit->handleNewVisit($visitor, null, false);
-        $visit->handleExistingVisit($visitor, null, true);
+        $visit = new FakeTrackerVisit($request, $visitProperties);
+        $visit->handleNewVisit(false);
+        $visit->handleExistingVisit(true);
 
         $info = $visit->getVisitorInfo();
 

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -26,6 +26,8 @@ use Piwik\Tracker\Visitor;
 
 /**
  * @group Core
+ *
+ * TODO: move isVisitNew tests to CoreHome plugin
  */
 class VisitTest extends IntegrationTestCase
 {

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -432,8 +432,7 @@ class VisitTest extends IntegrationTestCase
         $visitProperties = new Visit\VisitProperties();
         $visitProperties->visitorInfo = array('visit_last_action_time' => Date::factory($lastActionTimestamp)->getTimestamp());
 
-        $visitor = new Visitor($request, 'configid', $visitProperties);
-        $visitor->setIsVisitorKnown($isVisitorKnown);
+        $visitor = new Visitor($request, 'configid', $visitProperties, $isVisitorKnown);
 
         $action = new ActionPageview($request);
 

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -23,8 +23,6 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
  * @group Core
- *
- * TODO: move isVisitNew tests to CoreHome plugin
  */
 class VisitTest extends IntegrationTestCase
 {

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -429,7 +429,10 @@ class VisitTest extends IntegrationTestCase
 
         list($visit, $request) = $this->prepareVisitWithRequest(array('idsite' => $idsite), $currentActionTime);
 
-        $visitor = new Visitor($request, 'configid', array('visit_last_action_time' => Date::factory($lastActionTimestamp)->getTimestamp()));
+        $visitProperties = new Visit\VisitProperties();
+        $visitProperties->visitorInfo = array('visit_last_action_time' => Date::factory($lastActionTimestamp)->getTimestamp());
+
+        $visitor = new Visitor($request, 'configid', $visitProperties);
         $visitor->setIsVisitorKnown($isVisitorKnown);
 
         $action = new ActionPageview($request);

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
@@ -161,48 +161,59 @@
 	<reportMetadata>
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
+				
 				<segment>eventAction==playTrailer</segment>
-				<idsubdatatable>8</idsubdatatable>
+				<idsubdatatable>815</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==Search</segment>
-				<idsubdatatable>1</idsubdatatable>
+				<idsubdatatable>808</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==play25%25</segment>
-				<idsubdatatable>3</idsubdatatable>
+				<idsubdatatable>810</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==play50%25</segment>
-				<idsubdatatable>4</idsubdatatable>
+				<idsubdatatable>811</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==play75%25</segment>
-				<idsubdatatable>5</idsubdatatable>
+				<idsubdatatable>812</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==playEnd</segment>
-				<idsubdatatable>6</idsubdatatable>
+				<idsubdatatable>813</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==rating</segment>
-				<idsubdatatable>7</idsubdatatable>
+				<idsubdatatable>814</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==clickBuyNow</segment>
-				<idsubdatatable>9</idsubdatatable>
+				<idsubdatatable>816</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==event+action+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+---%26gt%3B+SHOULD+APPEAR+IN+TEST+OUTPUT+NOT+TRUNCATED+%26lt%3B---</segment>
-				<idsubdatatable>11</idsubdatatable>
+				<idsubdatatable>818</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==play</segment>
-				<idsubdatatable>2</idsubdatatable>
+				<idsubdatatable>809</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventAction==playStart</segment>
-				<idsubdatatable>10</idsubdatatable>
+				<idsubdatatable>817</idsubdatatable>
 			</row>
 			<row>
 				<segment>eventAction==Purchase</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
@@ -80,16 +80,19 @@
 	<reportMetadata>
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
+				
 				<segment>eventCategory==Movie</segment>
-				<idsubdatatable>1</idsubdatatable>
+				<idsubdatatable>753</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventCategory==Music</segment>
-				<idsubdatatable>2</idsubdatatable>
+				<idsubdatatable>754</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventCategory==event+category+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+---%26gt%3B+SHOULD+APPEAR+IN+TEST+OUTPUT+NOT+TRUNCATED+%26lt%3B---</segment>
-				<idsubdatatable>3</idsubdatatable>
+				<idsubdatatable>755</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010" />

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
@@ -116,31 +116,38 @@
 	<reportMetadata>
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
+				
 				<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
-				<idsubdatatable>3</idsubdatatable>
+				<idsubdatatable>881</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
-				<idsubdatatable>2</idsubdatatable>
+				<idsubdatatable>880</idsubdatatable>
 			</row>
 			<row>
-				<idsubdatatable>1</idsubdatatable>
+				
+				<idsubdatatable>879</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventName==event+name+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+Extremely+long+---%26gt%3B+SHOULD+APPEAR+IN+TEST+OUTPUT+NOT+TRUNCATED+%26lt%3B---</segment>
-				<idsubdatatable>7</idsubdatatable>
+				<idsubdatatable>885</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventName==Ponyo+%28%E5%B4%96%E3%81%AE%E4%B8%8A%E3%81%AE%E3%83%9D%E3%83%8B%E3%83%A7%29</segment>
-				<idsubdatatable>5</idsubdatatable>
+				<idsubdatatable>883</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventName==Princess+Mononoke+%28%E3%82%82%E3%81%AE%E3%81%AE%E3%81%91%E5%A7%AB%29</segment>
-				<idsubdatatable>4</idsubdatatable>
+				<idsubdatatable>882</idsubdatatable>
 			</row>
 			<row>
+				
 				<segment>eventName==Search+query+here</segment>
-				<idsubdatatable>6</idsubdatatable>
+				<idsubdatatable>884</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010" />

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric__API.getProcessedReport_day.xml
@@ -59,10 +59,12 @@
 	</reportData>
 	<reportMetadata>
 		<row>
-			<idsubdatatable>1</idsubdatatable>
+			
+			<idsubdatatable>2721</idsubdatatable>
 		</row>
 		<row>
-			<idsubdatatable>2</idsubdatatable>
+			
+			<idsubdatatable>2722</idsubdatatable>
 		</row>
 	</reportMetadata>
 	<reportTotal>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
@@ -44,7 +44,8 @@
 	</reportData>
 	<reportMetadata>
 		<row>
-			<idsubdatatable>1</idsubdatatable>
+			
+			<idsubdatatable>2095</idsubdatatable>
 		</row>
 	</reportMetadata>
 	<reportTotal>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumns___API.getProcessedReport_day.xml
@@ -53,7 +53,8 @@
 	</reportData>
 	<reportMetadata>
 		<row>
-			<idsubdatatable>1</idsubdatatable>
+			
+			<idsubdatatable>2099</idsubdatatable>
 		</row>
 	</reportMetadata>
 	<reportTotal>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_day.xml
@@ -111,18 +111,22 @@
 	<reportMetadata>
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
-				<idsubdatatable>2</idsubdatatable>
+				
+				<idsubdatatable>3205</idsubdatatable>
 			</row>
 			<row>
-				<idsubdatatable>1</idsubdatatable>
+				
+				<idsubdatatable>3204</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010">
 			<row>
-				<idsubdatatable>2</idsubdatatable>
+				
+				<idsubdatatable>3208</idsubdatatable>
 			</row>
 			<row>
-				<idsubdatatable>1</idsubdatatable>
+				
+				<idsubdatatable>3207</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Tuesday 5 January 2010" />

--- a/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_month.xml
@@ -80,10 +80,12 @@
 	<reportMetadata>
 		<result prettyDate="2010, January">
 			<row>
-				<idsubdatatable>2</idsubdatatable>
+				
+				<idsubdatatable>3230</idsubdatatable>
 			</row>
 			<row>
-				<idsubdatatable>1</idsubdatatable>
+				
+				<idsubdatatable>3229</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="2010, February" />

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
@@ -170,42 +170,52 @@
 		<result prettyDate="Monday 4 January 2010" />
 		<result prettyDate="Tuesday 5 January 2010">
 			<row>
-				<idsubdatatable>2</idsubdatatable>
+				
+				<idsubdatatable>17084</idsubdatatable>
 			</row>
 			<row>
-				<idsubdatatable>1</idsubdatatable>
+				
+				<idsubdatatable>17083</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Wednesday 6 January 2010">
 			<row>
-				<idsubdatatable>2</idsubdatatable>
+				
+				<idsubdatatable>17088</idsubdatatable>
 			</row>
 			<row>
-				<idsubdatatable>1</idsubdatatable>
+				
+				<idsubdatatable>17087</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Thursday 7 January 2010">
 			<row>
-				<idsubdatatable>2</idsubdatatable>
+				
+				<idsubdatatable>17092</idsubdatatable>
 			</row>
 			<row>
-				<idsubdatatable>1</idsubdatatable>
+				
+				<idsubdatatable>17091</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Friday 8 January 2010">
 			<row>
-				<idsubdatatable>2</idsubdatatable>
+				
+				<idsubdatatable>17096</idsubdatatable>
 			</row>
 			<row>
-				<idsubdatatable>1</idsubdatatable>
+				
+				<idsubdatatable>17095</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Saturday 9 January 2010">
 			<row>
-				<idsubdatatable>2</idsubdatatable>
+				
+				<idsubdatatable>17100</idsubdatatable>
 			</row>
 			<row>
-				<idsubdatatable>1</idsubdatatable>
+				
+				<idsubdatatable>17099</idsubdatatable>
 			</row>
 		</result>
 	</reportMetadata>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Referrers.getWebsites_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Referrers.getWebsites_firstSite_lastN__API.getProcessedReport_day.xml
@@ -113,14 +113,16 @@
 	<reportMetadata>
 		<result prettyDate="Sunday 3 January 2010">
 			<row>
+				
 				<segment>referrerName==referrer.com</segment>
-				<idsubdatatable>1</idsubdatatable>
+				<idsubdatatable>17035</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Monday 4 January 2010">
 			<row>
+				
 				<segment>referrerName==referrer.com</segment>
-				<idsubdatatable>1</idsubdatatable>
+				<idsubdatatable>17037</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Tuesday 5 January 2010" />
@@ -128,14 +130,16 @@
 		<result prettyDate="Thursday 7 January 2010" />
 		<result prettyDate="Friday 8 January 2010">
 			<row>
+				
 				<segment>referrerName==referrer.com</segment>
-				<idsubdatatable>1</idsubdatatable>
+				<idsubdatatable>17042</idsubdatatable>
 			</row>
 		</result>
 		<result prettyDate="Saturday 9 January 2010">
 			<row>
+				
 				<segment>referrerName==referrer.com</segment>
-				<idsubdatatable>1</idsubdatatable>
+				<idsubdatatable>17044</idsubdatatable>
 			</row>
 		</result>
 	</reportMetadata>


### PR DESCRIPTION
This PR heavily refactors the tracking code to make it easy for plugins to tweak, change and extend tracking behavior. It moves a big chunk of the code currently in Visit::handle() to other plugins, like Goals, Actions, CustomVariables, etc.

**Note: Though this PR implements enough changes for the plugin I'm working on, it doesn't completely close #8071, there's still more logic that can be moved out of core.**
# Concepts

This PR introduces the concept of the RequestProcessor. RequestProcessors handle and tweak tracker behavior. To learn more, read the class docs for the RequestProcessor class.
# Changes
- Added the RequestProcessor base class and added a new collection to DI, `tracker.request.processors`.
- Made Tracker\Settings a stateless service and moved it to DI.
- Gutted the Tracker\Visitor class. All the real logic was moved to a new stateless service, VisitorRecognizer. Visitor still exists because it is used in Dimension hooks, but it is at best a facade now.
- Created a new Heartbeat plugin to hold the ping tracker behavior.
- Moved action related tracking code in Visit::handle() to the Actions plugin, moved custom variables related tracking code to CustomVariables, moved goals related code to Goals, moved Ecommerce related code to Ecommerce and moved some core Visit handling code to CoreHome.
- Added a method to the Plugin class, `isTrackerPlugin()`. Plugins that don't implement dimensions or use tracker events can override this method to make sure they are loaded during tracking (if they need it).
# Future TODO

This TODO list can be added to #8071 or to a new issue:
- [x] Make GoalManager a stateless service and store in DI.
- [ ] Move Action class & related code to Actions plugin. Move GoalManager to Goals plugin. Move other plugin related code to plugins from core.
- [ ] Move current code to insert/update visit data in core to CoreHome. To do this correctly, would need a new service (eg, VisitRecorder), so VisitRequestProcessor does not get bloated (or more bloated).
- [ ] Remove lots of tracking events, I think many (if not most) are no longer needed.
- [ ] Create a new method in RequestProcessor specifically for manipulating request metadata. Right now, `afterRequestProcessed()` is used for both defining metadata that depends on other plugins' metadata and for manipulating other plugins' metadata. This means metadata that uses other plugins' metadata, can't be manipulated. Order of plugins will be come a problem eventually if many plugins get involved together...
- [ ] Refactor the system again for clarity and ease of use. This makes it possible to split up the code and correctly scope classes, but the code is still verbose and the tracking logic is still not obvious. Before the system is made `@api` it should be made as easy to use as possible.
- [ ] After it is possible to inject "component" types, RequestProcessors should use the "component" scheme.
- [ ] Decouple VisitorRecognizer from Tracker classes and add integration test for it.
- [ ] Do not use multi-dimensional array of properties for request metadata, instead use array of classes defined by plugins, so:
  
  ```
  /** @var $data MyPluginRequestMetadata */
  $data = $request->getMetadata('MyPlugin');
  ```

Refs #8071 
