### PR TITLE
Fix exclude by User-Agent with special characters

### DIFF
--- a/core/Tracker/VisitExcluded.php
+++ b/core/Tracker/VisitExcluded.php
@@ -271,9 +271,11 @@ class VisitExcluded
         $websiteAttributes = Cache::getCacheWebsiteAttributes($this->idSite);
 
         if (!empty($websiteAttributes['excluded_user_agents'])) {
-            foreach ($websiteAttributes['excluded_user_agents'] as $excludedUserAgent) {
-                // if the excluded user agent string part is in this visit's user agent, this visit should be excluded
-                if (stripos($this->userAgent, $excludedUserAgent) !== false) {
+            $requestUserAgentWords = array_filter(preg_split('/\W+/', strtolower($this->userAgent)), 'strlen');
+            foreach ($websiteAttributes['excluded_user_agents'] as $excludedUserAgentWords) {
+                $excludedUserAgentWords = array_filter(preg_split('/\W+/', strtolower($excludedUserAgentWords)), 'strlen');
+                // if all \w+ sub-strings of $excludedUserAgent present in $requestUserAgent
+                if (!array_diff($excludedUserAgentWords, $requestUserAgentWords)) {
                     return true;
                 }
             }

--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
@@ -104,7 +104,7 @@
                 ecommerce: $scope.site.ecommerce,
                 excludedIps: $scope.site.excluded_ips.join(','),
                 excludedQueryParameters: $scope.site.excluded_parameters.join(','),
-                excludedUserAgents: $scope.site.excluded_user_agents.join(','),
+                excludedUserAgents: $scope.site.excluded_user_agents.replace(/,/g, ';').join(','),
                 keepURLFragments: $scope.site.keep_url_fragment,
                 siteSearch: $scope.site.sitesearch,
                 type: $scope.site.type,

--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
@@ -237,7 +237,7 @@
                 currency: $scope.globalSettings.defaultCurrency,
                 excludedIps: $scope.globalSettings.excludedIpsGlobal.join(','),
                 excludedQueryParameters: $scope.globalSettings.excludedQueryParametersGlobal.join(','),
-                excludedUserAgents: $scope.globalSettings.excludedUserAgentsGlobal.join(','),
+                excludedUserAgents: $scope.globalSettings.excludedUserAgentsGlobal.replace(/,/g, ';').join(','),
                 keepURLFragments: $scope.globalSettings.keepURLFragmentsGlobal ? 1 : 0,
                 enableSiteUserAgentExclude: $scope.globalSettings.siteSpecificUserAgentExcludeEnabled ? 1 : 0,
                 searchKeywordParameters: $scope.globalSettings.searchKeywordParametersGlobal.join(','),

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -113,16 +113,24 @@ class VisitTest extends IntegrationTestCase
                 ''                => false,
                 'nlksdjfsldkjfsa' => false,
             )),
-            array('mozilla', array(
-                'this has mozilla in it' => true,
-                'this doesn\'t'          => false,
-                'partial presence: mozi' => false,
+            array('chrome mozilla ', array(
+                'Google ChromE and Mozilla' => true,
+                'Mozilla and chrome' => true,
+                'chromemozilla' => false,
+                'chrome' => false,
+                'xchrome xmozilla' => false,
+                '' => false
             )),
-            array('cHrOmE,notinthere,&^%', array(
-                'chrome is here' => true,
-                'CHROME is here' => true,
-                '12&^%345'       => true,
-                'sfasdf'         => false,
+            array('Mozilla 5.0', array(
+                'mozilla bla bla bla (5.0.23)' => true,
+                '"mozilla 5.0.23"' => true,
+                'mozilla 5.1.23' => false,
+                'opera 5.0' => false,
+            )),
+            array('a,b', array(
+                'a' => true,
+                'b' => true,
+                'c' => false,
             )),
         );
     }


### PR DESCRIPTION
User-Agent matching rule changed from equal substring matching, to all words(\w+) presenting validation. So now special characters and words(\w+) order does not matter.

Also, `,` character in User-Agent pattern will be automatically replaced to `;` before sending to server. It will fix the conflict when `,` present in User-Agent pattern and in the same way is used to separate patterns in DB store field.

Closes #7978
