### PR TITLE
Set method Dimension::getId as final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is a changelog for Piwik platform developers. All changes for our HTTP API's, Plugins, Themes, etc will be listed here.
 
+## Piwik 2.15.0
+
+### Breaking Changes
+* We marked the method `Dimension::getId()` as final.
+
 ## Piwik 2.14.0
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
 ## Piwik 2.15.0
 
 ### Breaking Changes
-* We marked the method `Dimension::getId()` as final.
+* The method `Dimension::getId()` has been set as `final`. It is not allowed to overwrite this method.
 
 ## Piwik 2.14.0
 

--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -149,7 +149,7 @@ abstract class Dimension
      *                   This would only happen if the dimension is located in the wrong directory.
      * @api
      */
-    public function getId()
+    final public function getId()
     {
         $className = get_class($this);
 


### PR DESCRIPTION
While working on #8304 I noticed this method was added and marked as API. If someone overwrites it, the method `getModule()` can break. We should only allow to call this method but not to overwrite it as otherwise other features can break. I did not include it in #8304 as I did not want to have a breaking change in 2.14.2 even though `Dimension` won't be in use by plugins anyway.
