### PR TITLE
Uninstall dimension only if not defined by another plugin

### DIFF
--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -142,7 +142,7 @@ abstract class Dimension
 
     /**
      * Returns a unique string ID for this dimension. The ID is built using the namespaced class name
-     * of the dimension, but is modified to be more human readable
+     * of the dimension, but is modified to be more human readable.
      *
      * @return string eg, `"Referrers.Keywords"`
      * @throws Exception if the plugin and simple class name of this instance cannot be determined.

--- a/core/Columns/Updater.php
+++ b/core/Columns/Updater.php
@@ -163,15 +163,15 @@ class Updater extends \Piwik\Updates
         $conversionColumns = DbHelper::getTableColumns(Common::prefixTable('log_conversion'));
 
         foreach ($this->visitDimensions as $dimension) {
-            $versions = $this->mixinVersions($updater, $dimension, 'log_visit.', $visitColumns, $versions);
+            $versions = $this->mixinVersions($updater, $dimension, VisitDimension::INSTALLER_PREFIX, $visitColumns, $versions);
         }
 
         foreach ($this->actionDimensions as $dimension) {
-            $versions = $this->mixinVersions($updater, $dimension, 'log_link_visit_action.', $actionColumns, $versions);
+            $versions = $this->mixinVersions($updater, $dimension, ActionDimension::INSTALLER_PREFIX, $actionColumns, $versions);
         }
 
         foreach ($this->conversionDimensions as $dimension) {
-            $versions = $this->mixinVersions($updater, $dimension, 'log_conversion.', $conversionColumns, $versions);
+            $versions = $this->mixinVersions($updater, $dimension, ConversionDimension::INSTALLER_PREFIX, $conversionColumns, $versions);
         }
 
         return $versions;

--- a/core/Plugin/Dimension/ActionDimension.php
+++ b/core/Plugin/Dimension/ActionDimension.php
@@ -36,6 +36,8 @@ use Exception;
  */
 abstract class ActionDimension extends Dimension
 {
+    const INSTALLER_PREFIX = 'log_link_visit_action.';
+
     private $tableName = 'log_link_visit_action';
 
     /**

--- a/core/Plugin/Dimension/ConversionDimension.php
+++ b/core/Plugin/Dimension/ConversionDimension.php
@@ -38,6 +38,8 @@ use Exception;
  */
 abstract class ConversionDimension extends Dimension
 {
+    const INSTALLER_PREFIX = 'log_conversion.';
+
     private $tableName = 'log_conversion';
 
     /**

--- a/core/Plugin/Dimension/VisitDimension.php
+++ b/core/Plugin/Dimension/VisitDimension.php
@@ -37,6 +37,8 @@ use Exception;
  */
 abstract class VisitDimension extends Dimension
 {
+    const INSTALLER_PREFIX = 'log_visit.';
+
     private $tableName = 'log_visit';
 
     /**

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -91,6 +91,21 @@ class Updater
     }
 
     /**
+     * Marks a component as successfully uninstalled. Deletes an option
+     * that looks like `"version_$componentName"`.
+     *
+     * @param string $name The component name. Eg, a plugin name, `'core'` or dimension column name.
+     */
+    public function markComponentSuccessfullyUninstalled($name)
+    {
+        try {
+            Option::delete(self::getNameInOptionTable($name));
+        } catch (\Exception $e) {
+            // case when the option table is not yet created (before 0.2.10)
+        }
+    }
+
+    /**
      * Returns the currently installed version of a Piwik component.
      *
      * @param string $name The component name. Eg, a plugin name, `'core'` or dimension column name.

--- a/tests/PHPUnit/Integration/UpdaterTest.php
+++ b/tests/PHPUnit/Integration/UpdaterTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Integration;
 
+use Piwik\Option;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Updater;
 use Piwik\Tests\Framework\Fixture;
@@ -69,4 +70,31 @@ class UpdaterTest extends IntegrationTestCase
             throw new \Exception("Failed to force update (nothing to update).");
         }
     }
+
+    public function testMarkComponentSuccessfullyUpdated_ShouldCreateAnOptionEntry()
+    {
+        $updater = $this->createUpdater();
+        $updater->markComponentSuccessfullyUpdated('test_entry', '0.5');
+
+        $value = Option::get('version_test_entry');
+        $this->assertEquals('0.5', $value);
+    }
+
+    /**
+     * @depends testMarkComponentSuccessfullyUpdated_ShouldCreateAnOptionEntry
+     */
+    public function testMarkComponentSuccessfullyUninstalled_ShouldCreateAnOptionEntry()
+    {
+        $updater = $this->createUpdater();
+        $updater->markComponentSuccessfullyUninstalled('test_entry');
+
+        $value = Option::get('version_test_entry');
+        $this->assertFalse($value);
+    }
+
+    private function createUpdater()
+    {
+        return new Updater();
+    }
+
 }


### PR DESCRIPTION
refs #8304 
- make sure to not uninstall a dimension if another plugin defines the same
- make sure to correctly mark the dimension as uninstalled so it can be installed again later
