### PR TITLE
Update to fix some dimensions were not marked as successfully uninstalled

### DIFF
--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -142,7 +142,7 @@ abstract class Dimension
 
     /**
      * Returns a unique string ID for this dimension. The ID is built using the namespaced class name
-     * of the dimension, but is modified to be more human readable
+     * of the dimension, but is modified to be more human readable.
      *
      * @return string eg, `"Referrers.Keywords"`
      * @throws Exception if the plugin and simple class name of this instance cannot be determined.

--- a/core/Columns/Updater.php
+++ b/core/Columns/Updater.php
@@ -163,15 +163,15 @@ class Updater extends \Piwik\Updates
         $conversionColumns = DbHelper::getTableColumns(Common::prefixTable('log_conversion'));
 
         foreach ($this->visitDimensions as $dimension) {
-            $versions = $this->mixinVersions($updater, $dimension, 'log_visit.', $visitColumns, $versions);
+            $versions = $this->mixinVersions($updater, $dimension, VisitDimension::INSTALLER_PREFIX, $visitColumns, $versions);
         }
 
         foreach ($this->actionDimensions as $dimension) {
-            $versions = $this->mixinVersions($updater, $dimension, 'log_link_visit_action.', $actionColumns, $versions);
+            $versions = $this->mixinVersions($updater, $dimension, ActionDimension::INSTALLER_PREFIX, $actionColumns, $versions);
         }
 
         foreach ($this->conversionDimensions as $dimension) {
-            $versions = $this->mixinVersions($updater, $dimension, 'log_conversion.', $conversionColumns, $versions);
+            $versions = $this->mixinVersions($updater, $dimension, ConversionDimension::INSTALLER_PREFIX, $conversionColumns, $versions);
         }
 
         return $versions;

--- a/core/Plugin/Dimension/ActionDimension.php
+++ b/core/Plugin/Dimension/ActionDimension.php
@@ -36,6 +36,8 @@ use Exception;
  */
 abstract class ActionDimension extends Dimension
 {
+    const INSTALLER_PREFIX = 'log_link_visit_action.';
+
     private $tableName = 'log_link_visit_action';
 
     /**

--- a/core/Plugin/Dimension/ConversionDimension.php
+++ b/core/Plugin/Dimension/ConversionDimension.php
@@ -38,6 +38,8 @@ use Exception;
  */
 abstract class ConversionDimension extends Dimension
 {
+    const INSTALLER_PREFIX = 'log_conversion.';
+
     private $tableName = 'log_conversion';
 
     /**

--- a/core/Plugin/Dimension/VisitDimension.php
+++ b/core/Plugin/Dimension/VisitDimension.php
@@ -37,6 +37,8 @@ use Exception;
  */
 abstract class VisitDimension extends Dimension
 {
+    const INSTALLER_PREFIX = 'log_visit.';
+
     private $tableName = 'log_visit';
 
     /**

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -91,6 +91,21 @@ class Updater
     }
 
     /**
+     * Marks a component as successfully uninstalled. Deletes an option
+     * that looks like `"version_$componentName"`.
+     *
+     * @param string $name The component name. Eg, a plugin name, `'core'` or dimension column name.
+     */
+    public function markComponentSuccessfullyUninstalled($name)
+    {
+        try {
+            Option::delete(self::getNameInOptionTable($name));
+        } catch (\Exception $e) {
+            // case when the option table is not yet created (before 0.2.10)
+        }
+    }
+
+    /**
      * Returns the currently installed version of a Piwik component.
      *
      * @param string $name The component name. Eg, a plugin name, `'core'` or dimension column name.

--- a/core/Updates/2.14.2.php
+++ b/core/Updates/2.14.2.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Common;
+use Piwik\DbHelper;
+use Piwik\Option;
+use Piwik\Plugin\Dimension\ActionDimension;
+use Piwik\Plugin\Dimension\ConversionDimension;
+use Piwik\Plugin\Dimension\VisitDimension;
+use Piwik\Tracker\Visit;
+use Piwik\Updater;
+use Piwik\Updates;
+
+/**
+ * Update for version 2.14.2.
+ */
+class Updates_2_14_2 extends Updates
+{
+    /**
+     * Removes option entries for columns that are marked as installed but are actually no longer installed due to
+     * a bug in previous versions where the option entries were not correctly removed.
+     *
+     * @param Updater $updater
+     * @return array
+     */
+    public function getMigrationQueries(Updater $updater)
+    {
+        $visitSqls = self::getSqlsThatRemoveOptionEntriesOfNotActuallyInstalledColumns(VisitDimension::INSTALLER_PREFIX, 'log_visit');
+        $actionSqls = self::getSqlsThatRemoveOptionEntriesOfNotActuallyInstalledColumns(ActionDimension::INSTALLER_PREFIX, 'log_link_visit_action');
+        $conversionSqls = self::getSqlsThatRemoveOptionEntriesOfNotActuallyInstalledColumns(ConversionDimension::INSTALLER_PREFIX, 'log_conversion');
+
+        $sqls = array();
+
+        foreach ($visitSqls as $sql) {
+            $sqls[$sql] = false;
+        }
+
+        foreach ($actionSqls as $sql) {
+            $sqls[$sql] = false;
+        }
+
+        foreach ($conversionSqls as $sql) {
+            $sqls[$sql] = false;
+        }
+
+        return $sqls;
+    }
+
+    private static function getSqlsThatRemoveOptionEntriesOfNotActuallyInstalledColumns($dimensionPrefix, $tableName)
+    {
+        $componentPrefix = 'version_' . $dimensionPrefix;
+
+        $notActuallyInstalledColumns = self::getNotActuallyInstalledColumnNames($componentPrefix, $tableName);
+
+        $sqls = array();
+        foreach ($notActuallyInstalledColumns as $column) {
+            $sqls[] = self::buildRemoveOptionEntrySql($componentPrefix . $column);
+        }
+
+        return $sqls;
+    }
+
+    private static function buildRemoveOptionEntrySql($optionName)
+    {
+        $tableName = Common::prefixTable('option');
+
+        return sprintf("DELETE FROM `%s` WHERE `option_name` = '%s'", $tableName, $optionName);
+    }
+
+    /**
+     * @param string $componentPrefix
+     * @param string $tableName
+     * @return array An array of columns that are marked as installed but are actually removed. There was a bug
+     *               where option entries were not correctly removed. eg array('idvist', 'server_time', ...)
+     */
+    private static function getNotActuallyInstalledColumnNames($componentPrefix, $tableName)
+    {
+        $installedVisitColumns = self::getMarkedAsInstalledColumns($componentPrefix);
+        $existingVisitColumns  = self::getActuallyExistingColumns($tableName);
+
+        return array_diff($installedVisitColumns, $existingVisitColumns);
+    }
+
+    /**
+     * @param  string $componentPrefix eg 'version_log_visit.'
+     * @return array An array of column names that are marked as installed. eg array('idvist', 'server_time', ...)
+     */
+    private static function getMarkedAsInstalledColumns($componentPrefix)
+    {
+        $installedVisitColumns = Option::getLike($componentPrefix . '%');
+        $installedVisitColumns = array_keys($installedVisitColumns);
+        $installedVisitColumns = array_map(function ($entry) use ($componentPrefix) {
+            return str_replace($componentPrefix, '', $entry);
+        }, $installedVisitColumns);
+
+        return $installedVisitColumns;
+    }
+
+    /**
+     * @param string $tableName
+     * @return array  An array of actually existing column names in the given table. eg array('idvist', 'server_time', ...)
+     */
+    private static function getActuallyExistingColumns($tableName)
+    {
+        $tableName = Common::prefixTable($tableName);
+        return array_keys(DbHelper::getTableColumns($tableName));
+    }
+
+    /**
+     * @param Updater $updater
+     */
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+    }
+}

--- a/tests/PHPUnit/Integration/UpdaterTest.php
+++ b/tests/PHPUnit/Integration/UpdaterTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Integration;
 
+use Piwik\Option;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Updater;
 use Piwik\Tests\Framework\Fixture;
@@ -69,4 +70,31 @@ class UpdaterTest extends IntegrationTestCase
             throw new \Exception("Failed to force update (nothing to update).");
         }
     }
+
+    public function testMarkComponentSuccessfullyUpdated_ShouldCreateAnOptionEntry()
+    {
+        $updater = $this->createUpdater();
+        $updater->markComponentSuccessfullyUpdated('test_entry', '0.5');
+
+        $value = Option::get('version_test_entry');
+        $this->assertEquals('0.5', $value);
+    }
+
+    /**
+     * @depends testMarkComponentSuccessfullyUpdated_ShouldCreateAnOptionEntry
+     */
+    public function testMarkComponentSuccessfullyUninstalled_ShouldCreateAnOptionEntry()
+    {
+        $updater = $this->createUpdater();
+        $updater->markComponentSuccessfullyUninstalled('test_entry');
+
+        $value = Option::get('version_test_entry');
+        $this->assertFalse($value);
+    }
+
+    private function createUpdater()
+    {
+        return new Updater();
+    }
+
 }


### PR DESCRIPTION
refs #8304 

This PR requires #8388 to be merged first. Only `core/Updates/2.14.2.php` belongs to this PR.

While working on #8304 I noticed dimensions are not correctly marked as uninstalled. This is fixed in #8388. This PR provides an update that removes option entries of actually no longer installed dimensions.

Background:
When installing a dimension we create an entry in the `option` table eg `name=version_log_visit.server_time`. This way we know the dimension was installed and which version of that dimension is installed. When uninstalling a dimension this option entry is supposed to be removed but it did not work. This prevented eg that the same dimension will be installed later again which is a bug. 

In this update we compare the option entries (columns marked as installed) with the actually existing columns (by fetching the actual column names from the DB table) and remove the option entries that are marked as installed but no longer exist.
