### PR TITLE
Fix Travis fonts issues by embedding the fonts in the repository

### DIFF
--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -73,7 +73,7 @@ class Piwik
         Common::sendHeader('Content-Type: text/html; charset=utf-8');
 
         $output = "<style>a{color:red;}</style>\n" .
-            "<div style='color:red;font-family:Georgia;font-size:120%'>" .
+            "<div style='color:red;font-size:120%'>" .
             "<p><img src='plugins/Morpheus/images/error_medium.png' style='vertical-align:middle; float:left;padding:20px' />" .
             $message .
             "</p></div>";

--- a/plugins/Login/stylesheets/login.less
+++ b/plugins/Login/stylesheets/login.less
@@ -41,14 +41,6 @@
         margin-right: 20px;
     }
 
-    #logo .h1 {
-        font-family: Georgia, "Times New Roman", Times, serif;
-        font-weight: normal;
-        color: #136F8B;
-        font-size: 45pt;
-        text-transform: none;
-    }
-
     /* LAYOUT
     ***********************/
     #loginPage a {


### PR DESCRIPTION
We see more and more issues on Travis where the font used in UI tests is not correct. This happens also locally (in VMs/containers), and it seems to be because the fonts are not installed correctly. I've seen the `ttf-mscorefonts-installer` fail to download the fonts (from the Microsoft servers) yet no error is thrown (and the fonts are then missing).

To fix that, I'm embedding the fonts we use in the "tests/travis" repository.

Waiting for the build to be green before merging.
