### PR TITLE
PHP7 compatibility: rename sparkline constructors to __construct

### DIFF
--- a/libs/sparkline/lib/Object.php
+++ b/libs/sparkline/lib/Object.php
@@ -81,7 +81,7 @@ class Object {
   ////////////////////////////////////////////////////////////////////////////
   // constructor
   //
-  function Object($catch_errors = true) {
+  function __construct($catch_errors = true) {
     $this->isError         = false;
     $this->logFile         = null;
     $this->logDate         = '';

--- a/libs/sparkline/lib/Sparkline.php
+++ b/libs/sparkline/lib/Sparkline.php
@@ -38,8 +38,8 @@ class Sparkline extends Object {
   ////////////////////////////////////////////////////////////////////////////
   // constructor
   //
-  function Sparkline($catch_errors = true) {
-    parent::Object($catch_errors);
+  function __construct($catch_errors = true) {
+    parent::__construct($catch_errors);
 
     $this->colorList       = array();
     $this->colorBackground = 'white';

--- a/libs/sparkline/lib/Sparkline_Bar.php
+++ b/libs/sparkline/lib/Sparkline_Bar.php
@@ -28,8 +28,8 @@ class Sparkline_Bar extends Sparkline {
   ////////////////////////////////////////////////////////////////////////////
   // constructor
   //
-  function Sparkline_Bar($catch_errors = true) {
-    parent::Sparkline($catch_errors);
+  function __construct($catch_errors = true) {
+    parent::__construct($catch_errors);
 
     $this->dataSeries                = array();
     $this->dataSeriesStats           = array();

--- a/libs/sparkline/lib/Sparkline_Line.php
+++ b/libs/sparkline/lib/Sparkline_Line.php
@@ -25,8 +25,8 @@ class Sparkline_Line extends Sparkline {
   ////////////////////////////////////////////////////////////////////////////
   // constructor
   //
-  function Sparkline_Line($catch_errors = true) {
-    parent::Sparkline($catch_errors);
+  function __construct($catch_errors = true) {
+    parent::__construct($catch_errors);
 
     $this->dataSeries          = array();
     $this->dataSeriesStats     = array();


### PR DESCRIPTION
Old naming method for constructors (same name as class) is deprecated as
of PHP7
