### PR TITLE
Fixes #8316, re-add core:archive URL override functionality for usersthat do not use systems that support CLI archiving.

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -49,6 +49,13 @@ class CliMulti
      */
     private $runAsSuperUser = false;
 
+    /**
+     * Only used when doing synchronous curl requests.
+     *
+     * @var string
+     */
+    private $urlToPiwik = null;
+
     public function __construct()
     {
         $this->supportsAsync = $this->supportsAsync();
@@ -263,7 +270,7 @@ class CliMulti
 
     private function executeNotAsyncHttp($url, Output $output)
     {
-        $piwikUrl = SettingsPiwik::getPiwikUrl();
+        $piwikUrl = $this->urlToPiwik ?: SettingsPiwik::getPiwikUrl();
         if (empty($piwikUrl)) {
             $piwikUrl = 'http://' . Url::getHost() . '/';
         }
@@ -350,5 +357,10 @@ class CliMulti
         Piwik::postEvent('CronArchive.getTokenAuth', array(&$tokens));
 
         return $tokens;
+    }
+
+    public function setUrlToPiwik($urlToPiwik)
+    {
+        $this->urlToPiwik = $urlToPiwik;
     }
 }

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -223,6 +223,13 @@ class CronArchive
     private $logger;
 
     /**
+     * Only used when archiving using HTTP requests.
+     *
+     * @var string
+     */
+    private $urlToPiwik = null;
+
+    /**
      * Returns the option name of the option that stores the time core:archive was last executed.
      *
      * @param int $idSite
@@ -1544,6 +1551,13 @@ class CronArchive
      */
     private function makeCliMulti()
     {
-        return StaticContainer::get('Piwik\CliMulti');
+        $cliMulti = StaticContainer::get('Piwik\CliMulti');
+        $cliMulti->setUrlToPiwik($this->urlToPiwik);
+        return $cliMulti;
+    }
+
+    public function setUrlToPiwik($url)
+    {
+        $this->urlToPiwik = $url;
     }
 }

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -23,12 +23,12 @@ class CoreArchiver extends ConsoleCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $archiver = self::makeArchiver("", $input);
+        $archiver = self::makeArchiver($input->getOption('url'), $input);
         $archiver->main();
     }
 
     // also used by another console command
-    public static function makeArchiver($url, InputInterface $input) // TODO: remove url from this function
+    public static function makeArchiver($url, InputInterface $input)
     {
         $archiver = new CronArchive();
 
@@ -56,6 +56,8 @@ class CoreArchiver extends ConsoleCommand
         $segmentIds = array_map('trim', $segmentIds);
         $archiver->setSegmentsToForceFromSegmentIds($segmentIds);
 
+        $archiver->setUrlToPiwik($url);
+
         return $archiver;
     }
 
@@ -75,7 +77,10 @@ class CoreArchiver extends ConsoleCommand
   but it is recommended to run it via command line/CLI instead.
 * If you have any suggestion about this script, please let the team know at feedback@piwik.org
 * Enjoy!");
-        $command->addOption('url', null, InputOption::VALUE_REQUIRED, "Deprecated.");
+        $command->addOption('url', null, InputOption::VALUE_REQUIRED,
+            "Deprecated. Forces the value of this option to be used as the URL to Piwik. If your system does not support"
+            . " archiving with CLI processes, you may need to set this in order for the archiving HTTP requests to use"
+            . " the desired URLs.");
         $command->addOption('force-all-websites', null, InputOption::VALUE_NONE,
             "If specified, the script will trigger archiving on all websites.\nUse with --force-all-periods=[seconds] "
             . "to also process those websites that had visits in the last [seconds] seconds.\nLaunching several processes"

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -78,7 +78,7 @@ class CoreArchiver extends ConsoleCommand
 * If you have any suggestion about this script, please let the team know at feedback@piwik.org
 * Enjoy!");
         $command->addOption('url', null, InputOption::VALUE_REQUIRED,
-            "Deprecated. Forces the value of this option to be used as the URL to Piwik. If your system does not support"
+            "Forces the value of this option to be used as the URL to Piwik. \nIf your system does not support"
             . " archiving with CLI processes, you may need to set this in order for the archiving HTTP requests to use"
             . " the desired URLs.");
         $command->addOption('force-all-websites', null, InputOption::VALUE_NONE,


### PR DESCRIPTION
As title, straightforward changes.

Fixes #8316
