### PR TITLE
#7968 Make sure DI config of plugins is loaded even when the config f…

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -71,6 +71,7 @@ class Manager extends Singleton
         'API',
         'Proxy',
         'LanguagesManager',
+        'Diagnostics',
 
         // default Piwik theme, always enabled
         self::DEFAULT_THEME,
@@ -804,6 +805,7 @@ class Manager extends Singleton
     public function getActivatedPluginsFromConfig()
     {
         $plugins = @Config::getInstance()->Plugins['Plugins'];
+        $plugins = is_array($plugins) ? $plugins : array();
 
         return $this->makePluginsToLoad($plugins);
     }


### PR DESCRIPTION
…ile doesn't exist + force always load the Diagnostics plugin to be able to run the system check any time