### PR TITLE
Run UI tests on PHP 5.4 in Piwik 3.0 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ language: php
 
 php:
   - 5.6
-  - 5.4.0
+  - 5.4
 #  - hhvm
 
 services:
@@ -44,13 +44,13 @@ matrix:
     - php: hhvm
   exclude:
     # Run test suites separately only on PHP 5.6 with PDO
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=SystemTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=IntegrationTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL
     - php: hhvm
       env: TEST_SUITE=SystemTests MYSQL_ADAPTER=PDO_MYSQL
@@ -58,23 +58,23 @@ matrix:
       env: TEST_SUITE=IntegrationTests MYSQL_ADAPTER=PDO_MYSQL
     - php: hhvm
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL
-    # run UI tests on PHP 5.4.0 only
+    # run UI tests on PHP 5.4 only
     - php: 5.6
       env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL
     # run all tests not on PHP 5.6 and run MySQLI tests only on 5.6
     - php: 5.6
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI
     - php: hhvm
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI
     # Javascript tests need to run only on one PHP version
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=JavascriptTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     - php: hhvm
       env: TEST_SUITE=JavascriptTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     # AngularJS tests need to run only on one PHP version
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=AngularJSTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     - php: hhvm
       env: TEST_SUITE=AngularJSTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ language: php
 
 php:
   - 5.6
-  - 5.3.3
+  - 5.4.0
 #  - hhvm
 
 services:
@@ -44,13 +44,13 @@ matrix:
     - php: hhvm
   exclude:
     # Run test suites separately only on PHP 5.6 with PDO
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=SystemTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=IntegrationTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL
     - php: hhvm
       env: TEST_SUITE=SystemTests MYSQL_ADAPTER=PDO_MYSQL
@@ -58,23 +58,23 @@ matrix:
       env: TEST_SUITE=IntegrationTests MYSQL_ADAPTER=PDO_MYSQL
     - php: hhvm
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL
-    # run UI tests on PHP 5.3.3 only
+    # run UI tests on PHP 5.4.0 only
     - php: 5.6
       env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL
     # run all tests not on PHP 5.6 and run MySQLI tests only on 5.6
     - php: 5.6
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI
     - php: hhvm
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI
     # Javascript tests need to run only on one PHP version
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=JavascriptTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     - php: hhvm
       env: TEST_SUITE=JavascriptTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     # AngularJS tests need to run only on one PHP version
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=AngularJSTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     - php: hhvm
       env: TEST_SUITE=AngularJSTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
@@ -83,15 +83,12 @@ sudo: required
 
 script: $PIWIK_ROOT_DIR/tests/travis/travis.sh
 
-before_install:
-  # do not use the Zend allocator on PHP 5.3 since it will randomly segfault after program execution
-  - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && export USE_ZEND_ALLOC=0 || true'
-
 install:
   - git fetch -q
 
-  - export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --core --verbose"
-  - '[[ "$TRAVIS_JOB_NUMBER" != *.1 || "$TRAVIS_PULL_REQUEST" != "false" ]] || ./tests/travis/autoupdate_travis_yml.sh'
+  # Disable it until this is in master, otherwise we have to create a branch for travis submodule
+  #- export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --core --verbose"
+  #- '[[ "$TRAVIS_JOB_NUMBER" != *.1 || "$TRAVIS_PULL_REQUEST" != "false" ]] || ./tests/travis/autoupdate_travis_yml.sh'
 
   - '[ ! -f ./tests/travis/install_mysql_5.6.sh ] || ./tests/travis/install_mysql_5.6.sh'
 

--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -122,14 +122,11 @@ abstract class ControllerAdmin extends Controller
 
     private static function notifyWhenPhpVersionIsEOL()
     {
-        $notifyPhpIsEOL = Piwik::hasUserSuperUserAccess() && self::isPhpVersion53();
+        $notifyPhpIsEOL = Piwik::hasUserSuperUserAccess() && self::isPhpVersion54();
         if (!$notifyPhpIsEOL) {
             return;
         }
-        $dateDropSupport = Date::factory('2015-05-01')->getLocalized('%longMonth% %longYear%');
-        $message = Piwik::translate('General_WarningPiwikWillStopSupportingPHPVersion', $dateDropSupport)
-            . "\n "
-            . Piwik::translate('General_WarningPhpVersionXIsTooOld', '5.3');
+        $message = Piwik::translate('General_WarningPhpVersionXIsTooOld', '5.4');
 
         $notification = new Notification($message);
         $notification->title = Piwik::translate('General_Warning');
@@ -137,7 +134,7 @@ abstract class ControllerAdmin extends Controller
         $notification->context = Notification::CONTEXT_WARNING;
         $notification->type = Notification::TYPE_TRANSIENT;
         $notification->flags = Notification::FLAG_NO_CLEAR;
-        NotificationManager::notify('PHP53VersionCheck', $notification);
+        NotificationManager::notify('PHP54VersionCheck', $notification);
     }
 
     /**
@@ -214,11 +211,11 @@ abstract class ControllerAdmin extends Controller
     private static function checkPhpVersion($view)
     {
         $view->phpVersion = PHP_VERSION;
-        $view->phpIsNewEnough = version_compare($view->phpVersion, '5.3.0', '>=');
+        $view->phpIsNewEnough = version_compare($view->phpVersion, '5.4.0', '>=');
     }
 
-    private static function isPhpVersion53()
+    private static function isPhpVersion54()
     {
-        return strpos(PHP_VERSION, '5.3') === 0;
+        return strpos(PHP_VERSION, '5.4') === 0;
     }
 }

--- a/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
+++ b/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
@@ -254,10 +254,6 @@ class ManyVisitsWithGeoIP extends Fixture
         // also fails on other PHP, is it really needed?
         return;
 
-        // this randomly fails on PHP 5.3
-        if(strpos(PHP_VERSION, '5.3') === 0) {
-            return;
-        }
         try {
             LocationProvider::setCurrentProvider('default');
         } catch(Exception $e) {

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -99,11 +99,6 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         return !empty($travis);
     }
 
-    public static function isPhpVersion53()
-    {
-        return strpos(PHP_VERSION, '5.3') === 0;
-    }
-
     public static function isMysqli()
     {
         return getenv('MYSQL_ADAPTER') == 'MYSQLI';
@@ -592,13 +587,6 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
     public static function deleteArchiveTables()
     {
         DbHelper::deleteArchiveTables();
-    }
-
-    protected function skipWhenPhp53()
-    {
-        if(self::isPhpVersion53()) {
-            $this->markTestSkipped('Sometimes fail on php 5.3');
-        }
     }
 
     public function assertHttpResponseText($expectedResponseText, $url, $message = '')

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -118,10 +118,6 @@ class Response
 
     private function normalizeEncodingPhp533($apiResponse)
     {
-        if (!SystemTestCase::isPhpVersion53()
-            || strpos($apiResponse, '<result') === false) {
-            return $apiResponse;
-        }
         return str_replace('&amp;#039;', "'", $apiResponse);
     }
 

--- a/tests/PHPUnit/Integration/Plugin/SettingsTest.php
+++ b/tests/PHPUnit/Integration/Plugin/SettingsTest.php
@@ -189,7 +189,6 @@ class SettingsTest extends IntegrationTestCase
 
     public function test_getSettingsForCurrentUser_shouldReturnAllSettingsIfEnoughPermissionsAndSortThemBySettingOrder()
     {
-        $this->skipWhenPhp53();
         $this->setSuperUser();
 
         $this->addSystemSetting('mysystemsetting1', 'mytitle1');

--- a/tests/PHPUnit/System/ArchiveCronTest.php
+++ b/tests/PHPUnit/System/ArchiveCronTest.php
@@ -78,10 +78,6 @@ class ArchiveCronTest extends SystemTestCase
 
     public function testArchivePhpCron()
     {
-        if(self::isPhpVersion53()) {
-            $this->markTestSkipped('Fails on PHP 5.3 once in a blue moon.');
-        }
-
         $this->setLastRunArchiveOptions();
         $output = $this->runArchivePhpCron();
 

--- a/tests/PHPUnit/System/AutoSuggestAPITest.php
+++ b/tests/PHPUnit/System/AutoSuggestAPITest.php
@@ -36,10 +36,6 @@ class AutoSuggestAPITest extends SystemTestCase
         // Refresh cache for CustomVariables\Model
         Cache::clearCacheGeneral();
 
-        if(self::isPhpVersion53() && self::isTravisCI()) {
-            $this->markTestSkipped("Skipping this test as it seg faults on php 5.3 (bug triggered on travis)");
-        }
-
         $this->runApiTests($api, $params);
     }
 

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -82,7 +82,6 @@ class CliMultiTest extends SystemTestCase
 
     public function test_request_shouldRunAsync()
     {
-        $this->skipWhenPhp53();
         $this->assertTrue($this->cliMulti->supportsAsync);
     }
 
@@ -142,7 +141,6 @@ class CliMultiTest extends SystemTestCase
      */
     public function test_request_shouldDetectFinishOfRequest_IfNoParamsAreGiven()
     {
-        $this->skipWhenPhp53();
         $this->cliMulti->runAsSuperUser();
         $response = $this->cliMulti->request(array($this->completeUrl('')));
         $this->assertStringStartsWith('Error in Piwik: Error: no website was found', $response[0]);
@@ -150,7 +148,6 @@ class CliMultiTest extends SystemTestCase
 
     public function test_request_shouldBeAbleToRenderARegularPageInPiwik()
     {
-        $this->skipWhenPhp53();
         Fixture::createWebsite('2014-01-01 00:00:00');
 
         $urls = array($this->completeUrl('/?module=Widgetize&idSite=1&period=day&date=today'));

--- a/tests/PHPUnit/System/ManyVisitorsOneWebsiteTest.php
+++ b/tests/PHPUnit/System/ManyVisitorsOneWebsiteTest.php
@@ -115,54 +115,48 @@ class ManyVisitorsOneWebsiteTest extends SystemTestCase
             )),
         );
 
-        // Randomly fails on 5.3
-        if(!self::isPhpVersion53()) {
+        $apiToTest[] = array('Live.getLastVisitsDetails', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_Live.getLastVisitsDetails_sortDesc',
+            'otherRequestParameters' => array('filter_sort_order' => 'desc', 'filter_limit' => 7)
+        ));
 
-            $apiToTest[] = array('Live.getLastVisitsDetails', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_Live.getLastVisitsDetails_sortDesc',
-                'otherRequestParameters' => array('filter_sort_order' => 'desc', 'filter_limit' => 7)
-            ));
+        // #5950
+        $apiToTest[] = array('Live.getLastVisitsDetails', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_Live.getLastVisitsDetails_sortByIdVisit',
+            'otherRequestParameters' => array('filter_sort_order' => 'desc', 'filter_sort_column' => 'idVisit', 'filter_limit' => 7)
+        ));
 
-            // #5950
-            $apiToTest[] = array('Live.getLastVisitsDetails', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_Live.getLastVisitsDetails_sortByIdVisit',
-                'otherRequestParameters' => array('filter_sort_order' => 'desc', 'filter_sort_column' => 'idVisit', 'filter_limit' => 7)
-            ));
+        // #7458
+        $apiToTest[] = array('Live.getLastVisitsDetails', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_Live.getLastVisitsDetails_offsetAndLimit_1',
+            'otherRequestParameters' => array('filter_offset' => '1', 'filter_limit' => 3)
+        ));
+        $apiToTest[] = array('Live.getLastVisitsDetails', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_Live.getLastVisitsDetails_offsetAndLimit_2',
+            'otherRequestParameters' => array('filter_offset' => '4', 'filter_limit' => 3)
+        ));
 
-            // #7458
-            $apiToTest[] = array('Live.getLastVisitsDetails', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_Live.getLastVisitsDetails_offsetAndLimit_1',
-                'otherRequestParameters' => array('filter_offset' => '1', 'filter_limit' => 3)
-            ));
-            $apiToTest[] = array('Live.getLastVisitsDetails', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_Live.getLastVisitsDetails_offsetAndLimit_2',
-                'otherRequestParameters' => array('filter_offset' => '4', 'filter_limit' => 3)
-            ));
-
-            // #8324
-            // testing filter_excludelowpop and filter_excludelowpop_value
-            $apiToTest[] = array('UserCountry.getCountry', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_getCountry_with_filter_excludelowpop',
-                'otherRequestParameters' => array('filter_excludelowpop' => 'nb_visits', 'filter_excludelowpop_value' => 5)
-            ));
-
-
-        }
+        // #8324
+        // testing filter_excludelowpop and filter_excludelowpop_value
+        $apiToTest[] = array('UserCountry.getCountry', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_getCountry_with_filter_excludelowpop',
+            'otherRequestParameters' => array('filter_excludelowpop' => 'nb_visits', 'filter_excludelowpop_value' => 5)
+        ));
 
         // this also fails on all PHP versions, it seems randomly.
 //            $apiToTest[] = array('Live.getLastVisitsDetails', array(

--- a/tests/PHPUnit/System/PivotByQueryParamTest.php
+++ b/tests/PHPUnit/System/PivotByQueryParamTest.php
@@ -198,10 +198,6 @@ class PivotByQueryParamTest extends SystemTestCase
     }
     public function assertApiResponseEqualsExpected($apiMethod, $queryParams)
     {
-        if(self::isPhpVersion53()) {
-            // 5.3.3 space encoding fail eg. https://travis-ci.org/piwik/piwik/jobs/35920420
-            $this->markTestSkipped();
-        }
         parent::assertApiResponseEqualsExpected($apiMethod, $queryParams);
     }
 }

--- a/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysArchivingDisabledTest.php
+++ b/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysArchivingDisabledTest.php
@@ -26,9 +26,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysArchivingDisabledTest extends SystemTes
      */
     public function testApi($api, $params)
     {
-        if (self::isPhpVersion53() && self::isTravisCI()) {
-            $this->markTestSkipped("Skipping this test as it often fails on travis)");
-        }
         $this->runApiTests($api, $params);
     }
 

--- a/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysConversionsTest.php
+++ b/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysConversionsTest.php
@@ -38,8 +38,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysConversionsTest extends SystemTestCase
      */
     public function testApi($api, $params)
     {
-        $this->markTestSkippedOnPhp53();
-
         $this->runApiTests($api, $params);
     }
 
@@ -126,8 +124,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysConversionsTest extends SystemTestCase
     //       plugins is non-trivial, so not done now.
     public function test_Archive_getNumeric_ReturnsMetricsFromDifferentPlugins_WhenThoseMetricsAreRequested()
     {
-        $this->markTestSkippedOnPhp53();
-
         // Tests that getting a visits summary metric (nb_visits) & a Goal's metric (Goal_revenue)
         // at the same time works.
         $dateTimeRange = '2010-01-03,2010-01-06';
@@ -149,8 +145,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysConversionsTest extends SystemTestCase
     //       plugins is non-trivial, so not done now.
     public function test_Archive_getNumeric_shouldInvalidateRememberedReportsOncePerRequestIfNeeded()
     {
-        $this->markTestSkippedOnPhp53();
-
         // Tests that getting a visits summary metric (nb_visits) & a Goal's metric (Goal_revenue)
         // at the same time works.
         $dateTimeRange = '2010-01-03,2010-01-06';
@@ -218,13 +212,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysConversionsTest extends SystemTestCase
     public static function getOutputPrefix()
     {
         return 'TwoVisitors_twoWebsites_differentDays_Conversions';
-    }
-
-    private function markTestSkippedOnPhp53()
-    {
-        if (self::isPhpVersion53() && self::isTravisCI()) {
-            $this->markTestSkipped("Skipping this test as it often fails on travis)");
-        }
     }
 }
 

--- a/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysTest.php
+++ b/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysTest.php
@@ -37,9 +37,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysTest extends SystemTestCase
      */
     public function testApi($api, $params)
     {
-        if(self::isTravisCI() && self::isPhpVersion53()) {
-            $this->markTestSkipped('This test fails on travis eg. https://travis-ci.org/piwik/piwik/jobs/46944264');
-        }
         $this->runApiTests($api, $params);
     }
 

--- a/tests/PHPUnit/Unit/UrlHelperTest.php
+++ b/tests/PHPUnit/Unit/UrlHelperTest.php
@@ -215,14 +215,6 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('localhost', UrlHelper::getHostFromUrl('localhost/path'));
         $this->assertEquals('sub.localhost', UrlHelper::getHostFromUrl('sub.localhost/path'));
         $this->assertEquals('sub.localhost', UrlHelper::getHostFromUrl('http://sub.localhost/path/?query=test'));
-
-        if(SystemTestCase::isPhpVersion53()) {
-            //parse_url was fixed in 5,4,7
-            //  Fixed host recognition when scheme is omitted and a leading component separator is present.
-            // http://php.net/parse_url
-            return;
-        }
-
         $this->assertEquals('localhost', UrlHelper::getHostFromUrl('//localhost/path'));
         $this->assertEquals('localhost', UrlHelper::getHostFromUrl('//localhost/path?test=test2'));
         $this->assertEquals('example.org', UrlHelper::getHostFromUrl('//example.org/path'));


### PR DESCRIPTION
In #7323 we announced to drop support for PHP 5.3 in Piwik 3.0. 

In this PR I changed to run the UI tests to PHP 5.4 as it is needed by PRs like this https://github.com/piwik/piwik/pull/8449 which requires PHP 5.4.

If someone knows what the lowest available PHP 5.4 version on Travis is, let me know. I couldn't find that information. Right now they will run on the latest PHP 5.4

I also removed some code in tests that marked tests as skipped if they run on PHP 5.3. This will be no longer needed. 

If a super user is logged in, we currently show a message PHP 5.3 has reached EOL etc. I changed this to PHP 5.4 as it reaches soon EOL and by the time it will have reached for sure. I removed the message that we will drop support for PHP 5.4 though (as we won't do this for now).
