### PR TITLE
Set database charset utf-8 by default

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -21,11 +21,10 @@ port = 3306
 adapter = PDO\MYSQL
 type = InnoDB
 schema = Mysql
-
 ; if charset is set to utf8, Piwik will ensure that it is storing its data using UTF8 charset.
 ; it will add a sql query SET at each page view.
-; Piwik should work correctly without this setting.
-;charset = utf8
+; Piwik should work correctly without this setting but we recommend to have a charset set.
+charset = utf8
 
 [database_tests]
 host = localhost

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -47,9 +47,14 @@ class Mysql extends Db
         } else {
             $this->dsn = $driverName . ':dbname=' . $dbInfo['dbname'] . ';host=' . $dbInfo['host'] . ';port=' . $dbInfo['port'];
         }
+
         $this->username = $dbInfo['username'];
         $this->password = $dbInfo['password'];
-        $this->charset = isset($dbInfo['charset']) ? $dbInfo['charset'] : null;
+
+        if (isset($dbInfo['charset'])) {
+            $this->charset = $dbInfo['charset'];
+            $this->dsn .= ';charset=' . $this->charset;
+        }
     }
 
     public function __destruct()


### PR DESCRIPTION
fixes #6497 

Made sure to have the charset set in DSN as well. It is done by Zend as well, meaning in the normal DB handler.
