### PR TITLE
Removed unused test files

### DIFF
--- a/tests/PHPUnit/Integration/expected/test_ImportLogs__WhiteLabel.getSampleReport_month.xml
+++ b/tests/PHPUnit/Integration/expected/test_ImportLogs__WhiteLabel.getSampleReport_month.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<result>
-	<error message="The plugin WhiteLabel is not enabled. You can activate the plugin on Settings &gt; Plugins page in Piwik.
- 
- --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
-</result>

--- a/tests/PHPUnit/Integration/expected/test_noVisit_PeriodIsLast__WhiteLabel.getSampleReport_day.xml
+++ b/tests/PHPUnit/Integration/expected/test_noVisit_PeriodIsLast__WhiteLabel.getSampleReport_day.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<result>
-	<error message="The plugin WhiteLabel is not enabled. You can activate the plugin on Settings &gt; Plugins page in Piwik.
- 
- --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
-</result>

--- a/tests/PHPUnit/Integration/expected/test_noVisit_PeriodIsLast__WhiteLabel.getSampleReport_week.xml
+++ b/tests/PHPUnit/Integration/expected/test_noVisit_PeriodIsLast__WhiteLabel.getSampleReport_week.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<result>
-	<error message="The plugin WhiteLabel is not enabled. You can activate the plugin on Settings &gt; Plugins page in Piwik.
- 
- --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
-</result>

--- a/tests/PHPUnit/Integration/expected/test_noVisit__WhiteLabel.getSampleReport_day.xml
+++ b/tests/PHPUnit/Integration/expected/test_noVisit__WhiteLabel.getSampleReport_day.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<result>
-	<error message="The plugin WhiteLabel is not enabled. You can activate the plugin on Settings &gt; Plugins page in Piwik.
- 
- --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
-</result>


### PR DESCRIPTION
I've removed some unused test files.
They seem to be related to the WhiteLabel Plugin, which is not contained in core

@mattab you had added those files back in Oct. 2014. Guess that was not on purpose.
