### PR TITLE
Return all websites my default for API method Sites.getPatternMatchSites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
 
 ### Breaking Changes
 * The method `Dimension::getId()` has been set as `final`. It is not allowed to overwrite this method.
+* We fixed a bug where the API method `Sites.getPatternMatchSites` only returned a very limited number of websites by default. We now return all websites by default unless a limit is specified specifically.
 
 ## Piwik 2.14.0
 

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -21,6 +21,7 @@ use Piwik\Plugins\Goals\Archiver;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Plugins\SitesManager\Model as ModelSitesManager;
 use Piwik\Scheduler\Scheduler;
+use Piwik\SettingsPiwik;
 use Piwik\Site;
 
 /**
@@ -143,6 +144,7 @@ class API extends \Piwik\Plugin\API
             $sites = Request::processRequest('SitesManager.getPatternMatchSites',
                 array('pattern'   => $pattern,
                       // added because caller could overwrite these
+                      'limit'       => SettingsPiwik::getWebsitesCountToDisplay(),
                       'showColumns' => '',
                       'hideColumns' => '',
                       'serialize'   => 0,

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1515,17 +1515,43 @@ class API extends \Piwik\Plugin\API
         return true;
     }
 
-    public function getPatternMatchSites($pattern)
+    /**
+     * Find websites matching the given pattern.
+     *
+     * Any website will be returned that matches the pattern in the name, URL or group.
+     * To limit the number of returned sites you can either specify `filter_limit` as usual or `limit` which is
+     * faster.
+     *
+     * @param string $pattern
+     * @param int|false $limit
+     * @return array
+     */
+    public function getPatternMatchSites($pattern, $limit = false)
     {
         $ids = $this->getSitesIdWithAtLeastViewAccess();
         if (empty($ids)) {
             return array();
         }
 
-        $limit = SettingsPiwik::getWebsitesCountToDisplay();
         $sites = $this->getModel()->getPatternMatchSites($ids, $pattern, $limit);
 
         return $sites;
+    }
+
+    /**
+     * Returns the number of websites to display per page.
+     *
+     * For example this is used in the All Websites Dashboard, in the Website Selector etc. If multiple websites are
+     * shown somewhere, one should request this method to detect how many websites should be shown per page when
+     * using paging. To use paging is always recommended since some installations have thousands of websites.
+     *
+     * @return int
+     */
+    public function getNumWebsitesToDisplayPerPage()
+    {
+        Piwik::checkUserHasSomeViewAccess();
+
+        return SettingsPiwik::getWebsitesCountToDisplay();
     }
 
     /**

--- a/plugins/SitesManager/tests/System/ApiTest.php
+++ b/plugins/SitesManager/tests/System/ApiTest.php
@@ -9,7 +9,6 @@
 namespace Piwik\Plugins\SitesManager\tests\System;
 
 use Piwik\Plugins\SitesManager\tests\Fixtures\ManySites;
-use Piwik\Plugins\SitesManager\tests\Fixtures\SimpleFixtureTrackFewVisits;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
 /**
@@ -34,12 +33,25 @@ class ApiTest extends SystemTestCase
 
     public function getApiForTesting()
     {
-        $api = array(
-            'SitesManager.getPatternMatchSites',
-        );
-
         $apiToTest   = array();
-        $apiToTest[] = array($api,
+        $apiToTest[] = array(array('SitesManager.getPatternMatchSites'),
+            array(
+                'idSite'     => 1,
+                'date'       => self::$fixture->dateTime,
+                'periods'    => array('day'),
+                'otherRequestParameters' => array('pattern' => 'SiteTest1')
+            )
+        );
+        $apiToTest[] = array(array('SitesManager.getPatternMatchSites'),
+            array(
+                'idSite'     => 1,
+                'date'       => self::$fixture->dateTime,
+                'periods'    => array('day'),
+                'otherRequestParameters' => array('pattern' => 'SiteTest1', 'limit' => 2),
+                'testSuffix' => 'withLimit'
+            )
+        );
+        $apiToTest[] = array(array('SitesManager.getNumWebsitesToDisplayPerPage'),
             array(
                 'idSite'     => 1,
                 'date'       => self::$fixture->dateTime,

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getNumWebsitesToDisplayPerPage.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getNumWebsitesToDisplayPerPage.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>15</result>

--- a/plugins/SitesManager/tests/System/expected/test_SitesManagerwithLimit__SitesManager.getPatternMatchSites.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManagerwithLimit__SitesManager.getPatternMatchSites.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<idsite>1</idsite>
+		<name>SiteTest1</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+	<row>
+		<idsite>10</idsite>
+		<name>SiteTest10</name>
+		<main_url>http://piwik.net</main_url>
+		<ts_created>2010-01-02 11:22:33</ts_created>
+		<ecommerce>0</ecommerce>
+		<sitesearch>1</sitesearch>
+		<sitesearch_keyword_parameters />
+		<sitesearch_category_parameters />
+		<timezone>UTC</timezone>
+		<currency>USD</currency>
+		<excluded_ips />
+		<excluded_parameters />
+		<excluded_user_agents />
+		<group />
+		<type>website</type>
+		<keep_url_fragment>0</keep_url_fragment>
+	</row>
+</result>


### PR DESCRIPTION
fixes #7700 

There's still a `$limit` URL parameter to make sure the All Websites Dashboard stays fast when having 30.000 websites or more. `$limit` directly limits the number of websites in the MySQL query whereas `$filter_limit` returns all sites and then removes the not needed sites in the response builder.
