### PR TITLE
Remove one index from log_visit that is actually not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ language: php
 
 php:
   - 5.6
-  - 5.4.0
+  - 5.4
 #  - hhvm
 
 services:
@@ -44,13 +44,13 @@ matrix:
     - php: hhvm
   exclude:
     # Run test suites separately only on PHP 5.6 with PDO
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=SystemTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=IntegrationTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL
     - php: hhvm
       env: TEST_SUITE=SystemTests MYSQL_ADAPTER=PDO_MYSQL
@@ -58,23 +58,23 @@ matrix:
       env: TEST_SUITE=IntegrationTests MYSQL_ADAPTER=PDO_MYSQL
     - php: hhvm
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL
-    # run UI tests on PHP 5.4.0 only
+    # run UI tests on PHP 5.4 only
     - php: 5.6
       env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL
     # run all tests not on PHP 5.6 and run MySQLI tests only on 5.6
     - php: 5.6
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI
     - php: hhvm
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI
     # Javascript tests need to run only on one PHP version
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=JavascriptTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     - php: hhvm
       env: TEST_SUITE=JavascriptTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     # AngularJS tests need to run only on one PHP version
-    - php: 5.4.0
+    - php: 5.4
       env: TEST_SUITE=AngularJSTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     - php: hhvm
       env: TEST_SUITE=AngularJSTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ language: php
 
 php:
   - 5.6
-  - 5.3.3
+  - 5.4.0
 #  - hhvm
 
 services:
@@ -44,13 +44,13 @@ matrix:
     - php: hhvm
   exclude:
     # Run test suites separately only on PHP 5.6 with PDO
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=SystemTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=IntegrationTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL
     - php: hhvm
       env: TEST_SUITE=SystemTests MYSQL_ADAPTER=PDO_MYSQL
@@ -58,23 +58,23 @@ matrix:
       env: TEST_SUITE=IntegrationTests MYSQL_ADAPTER=PDO_MYSQL
     - php: hhvm
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL
-    # run UI tests on PHP 5.3.3 only
+    # run UI tests on PHP 5.4.0 only
     - php: 5.6
       env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL
     # run all tests not on PHP 5.6 and run MySQLI tests only on 5.6
     - php: 5.6
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI
     - php: hhvm
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI
     # Javascript tests need to run only on one PHP version
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=JavascriptTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     - php: hhvm
       env: TEST_SUITE=JavascriptTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     # AngularJS tests need to run only on one PHP version
-    - php: 5.3.3
+    - php: 5.4.0
       env: TEST_SUITE=AngularJSTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
     - php: hhvm
       env: TEST_SUITE=AngularJSTests MYSQL_ADAPTER=PDO_MYSQL SKIP_COMPOSER_INSTALL=1
@@ -83,15 +83,12 @@ sudo: required
 
 script: $PIWIK_ROOT_DIR/tests/travis/travis.sh
 
-before_install:
-  # do not use the Zend allocator on PHP 5.3 since it will randomly segfault after program execution
-  - '[[ "$TRAVIS_PHP_VERSION" == 5.3* ]] && export USE_ZEND_ALLOC=0 || true'
-
 install:
   - git fetch -q
 
-  - export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --core --verbose"
-  - '[[ "$TRAVIS_JOB_NUMBER" != *.1 || "$TRAVIS_PULL_REQUEST" != "false" ]] || ./tests/travis/autoupdate_travis_yml.sh'
+  # Disable it until this is in master, otherwise we have to create a branch for travis submodule
+  #- export GENERATE_TRAVIS_YML_COMMAND="php ./tests/travis/generator/main.php generate:travis-yml --core --verbose"
+  #- '[[ "$TRAVIS_JOB_NUMBER" != *.1 || "$TRAVIS_PULL_REQUEST" != "false" ]] || ./tests/travis/autoupdate_travis_yml.sh'
 
   - '[ ! -f ./tests/travis/install_mysql_5.6.sh ] || ./tests/travis/install_mysql_5.6.sh'
 

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -161,8 +161,7 @@ class Mysql implements SchemaInterface
                               config_id BINARY(8) NOT NULL,
                               location_ip VARBINARY(16) NOT NULL,
                                 PRIMARY KEY(idvisit),
-                                INDEX index_idsite_config_datetime (idsite, config_id, visit_last_action_time),
-                                INDEX index_idsite_datetime (idsite, visit_last_action_time),
+                                INDEX index_idsite_datetime_configid (idsite, visit_last_action_time, config_id),
                                 INDEX index_idsite_idvisitor (idsite, idvisitor)
                               ) ENGINE=$engine DEFAULT CHARSET=utf8
             ",

--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -122,14 +122,11 @@ abstract class ControllerAdmin extends Controller
 
     private static function notifyWhenPhpVersionIsEOL()
     {
-        $notifyPhpIsEOL = Piwik::hasUserSuperUserAccess() && self::isPhpVersion53();
+        $notifyPhpIsEOL = Piwik::hasUserSuperUserAccess() && self::isPhpVersion54();
         if (!$notifyPhpIsEOL) {
             return;
         }
-        $dateDropSupport = Date::factory('2015-05-01')->getLocalized('%longMonth% %longYear%');
-        $message = Piwik::translate('General_WarningPiwikWillStopSupportingPHPVersion', $dateDropSupport)
-            . "\n "
-            . Piwik::translate('General_WarningPhpVersionXIsTooOld', '5.3');
+        $message = Piwik::translate('General_WarningPhpVersionXIsTooOld', '5.4');
 
         $notification = new Notification($message);
         $notification->title = Piwik::translate('General_Warning');
@@ -137,7 +134,7 @@ abstract class ControllerAdmin extends Controller
         $notification->context = Notification::CONTEXT_WARNING;
         $notification->type = Notification::TYPE_TRANSIENT;
         $notification->flags = Notification::FLAG_NO_CLEAR;
-        NotificationManager::notify('PHP53VersionCheck', $notification);
+        NotificationManager::notify('PHP54VersionCheck', $notification);
     }
 
     /**
@@ -214,11 +211,11 @@ abstract class ControllerAdmin extends Controller
     private static function checkPhpVersion($view)
     {
         $view->phpVersion = PHP_VERSION;
-        $view->phpIsNewEnough = version_compare($view->phpVersion, '5.3.0', '>=');
+        $view->phpIsNewEnough = version_compare($view->phpVersion, '5.4.0', '>=');
     }
 
-    private static function isPhpVersion53()
+    private static function isPhpVersion54()
     {
-        return strpos(PHP_VERSION, '5.3') === 0;
+        return strpos(PHP_VERSION, '5.4') === 0;
     }
 }

--- a/core/Updates/3.0.0-b1.php
+++ b/core/Updates/3.0.0-b1.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Common;
+use Piwik\Updater;
+use Piwik\Updates;
+
+/**
+ * Update for version 3.0.0-b1.
+ */
+class Updates_3_0_0_b1 extends Updates
+{
+    /**
+     * Here you can define one or multiple SQL statements that should be executed during the update.
+     * @return array
+     */
+    public function getMigrationQueries(Updater $updater)
+    {
+        $logVisitTable = Common::prefixTable('log_visit');
+
+        return array(
+            'DROP INDEX index_idsite_config_datetime ON `' . $logVisitTable . '`' => 1091,
+            'DROP INDEX index_idsite_datetime ON `' . $logVisitTable . '`' => 1091,
+            'CREATE INDEX index_idsite_datetime_configid ON `' . $logVisitTable . '`(idsite, visit_last_action_time, config_id)' => 1061,
+        );
+    }
+
+    /**
+     * Here you can define any action that should be performed during the update. For instance executing SQL statements,
+     * renaming config entries, updating files, etc.
+     */
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+    }
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Piwik version.
      * @var string
      */
-    const VERSION = '2.14.2';
+    const VERSION = '3.0.0-b1';
 
     public function isStableVersion($version)
     {

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -16,7 +16,7 @@
 $piwik_errorMessage = '';
 
 // Minimum requirement: stream_resolve_include_path, working json_encode in 5.3.3, namespaces in 5.3
-$piwik_minimumPHPVersion = '5.3.3';
+$piwik_minimumPHPVersion = '5.4.0';
 $piwik_currentPHPVersion = PHP_VERSION;
 $minimumPhpInvalid = version_compare($piwik_minimumPHPVersion, $piwik_currentPHPVersion) > 0;
 if ($minimumPhpInvalid) {

--- a/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
+++ b/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
@@ -254,10 +254,6 @@ class ManyVisitsWithGeoIP extends Fixture
         // also fails on other PHP, is it really needed?
         return;
 
-        // this randomly fails on PHP 5.3
-        if(strpos(PHP_VERSION, '5.3') === 0) {
-            return;
-        }
         try {
             LocationProvider::setCurrentProvider('default');
         } catch(Exception $e) {

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -99,6 +99,11 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         return !empty($travis);
     }
 
+    public static function isPhpVersion53()
+    {
+        return strpos(PHP_VERSION, '5.3') === 0;
+    }
+
     public static function isMysqli()
     {
         return getenv('MYSQL_ADAPTER') == 'MYSQLI';

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -99,11 +99,6 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         return !empty($travis);
     }
 
-    public static function isPhpVersion53()
-    {
-        return strpos(PHP_VERSION, '5.3') === 0;
-    }
-
     public static function isMysqli()
     {
         return getenv('MYSQL_ADAPTER') == 'MYSQLI';
@@ -592,13 +587,6 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
     public static function deleteArchiveTables()
     {
         DbHelper::deleteArchiveTables();
-    }
-
-    protected function skipWhenPhp53()
-    {
-        if(self::isPhpVersion53()) {
-            $this->markTestSkipped('Sometimes fail on php 5.3');
-        }
     }
 
     public function assertHttpResponseText($expectedResponseText, $url, $message = '')

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -118,10 +118,6 @@ class Response
 
     private function normalizeEncodingPhp533($apiResponse)
     {
-        if (!SystemTestCase::isPhpVersion53()
-            || strpos($apiResponse, '<result') === false) {
-            return $apiResponse;
-        }
         return str_replace('&amp;#039;', "'", $apiResponse);
     }
 

--- a/tests/PHPUnit/Integration/Plugin/SettingsTest.php
+++ b/tests/PHPUnit/Integration/Plugin/SettingsTest.php
@@ -189,7 +189,6 @@ class SettingsTest extends IntegrationTestCase
 
     public function test_getSettingsForCurrentUser_shouldReturnAllSettingsIfEnoughPermissionsAndSortThemBySettingOrder()
     {
-        $this->skipWhenPhp53();
         $this->setSuperUser();
 
         $this->addSystemSetting('mysystemsetting1', 'mytitle1');

--- a/tests/PHPUnit/System/ArchiveCronTest.php
+++ b/tests/PHPUnit/System/ArchiveCronTest.php
@@ -78,10 +78,6 @@ class ArchiveCronTest extends SystemTestCase
 
     public function testArchivePhpCron()
     {
-        if(self::isPhpVersion53()) {
-            $this->markTestSkipped('Fails on PHP 5.3 once in a blue moon.');
-        }
-
         $this->setLastRunArchiveOptions();
         $output = $this->runArchivePhpCron();
 

--- a/tests/PHPUnit/System/AutoSuggestAPITest.php
+++ b/tests/PHPUnit/System/AutoSuggestAPITest.php
@@ -36,10 +36,6 @@ class AutoSuggestAPITest extends SystemTestCase
         // Refresh cache for CustomVariables\Model
         Cache::clearCacheGeneral();
 
-        if(self::isPhpVersion53() && self::isTravisCI()) {
-            $this->markTestSkipped("Skipping this test as it seg faults on php 5.3 (bug triggered on travis)");
-        }
-
         $this->runApiTests($api, $params);
     }
 

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -82,7 +82,6 @@ class CliMultiTest extends SystemTestCase
 
     public function test_request_shouldRunAsync()
     {
-        $this->skipWhenPhp53();
         $this->assertTrue($this->cliMulti->supportsAsync);
     }
 
@@ -142,7 +141,6 @@ class CliMultiTest extends SystemTestCase
      */
     public function test_request_shouldDetectFinishOfRequest_IfNoParamsAreGiven()
     {
-        $this->skipWhenPhp53();
         $this->cliMulti->runAsSuperUser();
         $response = $this->cliMulti->request(array($this->completeUrl('')));
         $this->assertStringStartsWith('Error in Piwik: Error: no website was found', $response[0]);
@@ -150,7 +148,6 @@ class CliMultiTest extends SystemTestCase
 
     public function test_request_shouldBeAbleToRenderARegularPageInPiwik()
     {
-        $this->skipWhenPhp53();
         Fixture::createWebsite('2014-01-01 00:00:00');
 
         $urls = array($this->completeUrl('/?module=Widgetize&idSite=1&period=day&date=today'));

--- a/tests/PHPUnit/System/ManyVisitorsOneWebsiteTest.php
+++ b/tests/PHPUnit/System/ManyVisitorsOneWebsiteTest.php
@@ -115,54 +115,48 @@ class ManyVisitorsOneWebsiteTest extends SystemTestCase
             )),
         );
 
-        // Randomly fails on 5.3
-        if(!self::isPhpVersion53()) {
+        $apiToTest[] = array('Live.getLastVisitsDetails', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_Live.getLastVisitsDetails_sortDesc',
+            'otherRequestParameters' => array('filter_sort_order' => 'desc', 'filter_limit' => 7)
+        ));
 
-            $apiToTest[] = array('Live.getLastVisitsDetails', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_Live.getLastVisitsDetails_sortDesc',
-                'otherRequestParameters' => array('filter_sort_order' => 'desc', 'filter_limit' => 7)
-            ));
+        // #5950
+        $apiToTest[] = array('Live.getLastVisitsDetails', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_Live.getLastVisitsDetails_sortByIdVisit',
+            'otherRequestParameters' => array('filter_sort_order' => 'desc', 'filter_sort_column' => 'idVisit', 'filter_limit' => 7)
+        ));
 
-            // #5950
-            $apiToTest[] = array('Live.getLastVisitsDetails', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_Live.getLastVisitsDetails_sortByIdVisit',
-                'otherRequestParameters' => array('filter_sort_order' => 'desc', 'filter_sort_column' => 'idVisit', 'filter_limit' => 7)
-            ));
+        // #7458
+        $apiToTest[] = array('Live.getLastVisitsDetails', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_Live.getLastVisitsDetails_offsetAndLimit_1',
+            'otherRequestParameters' => array('filter_offset' => '1', 'filter_limit' => 3)
+        ));
+        $apiToTest[] = array('Live.getLastVisitsDetails', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_Live.getLastVisitsDetails_offsetAndLimit_2',
+            'otherRequestParameters' => array('filter_offset' => '4', 'filter_limit' => 3)
+        ));
 
-            // #7458
-            $apiToTest[] = array('Live.getLastVisitsDetails', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_Live.getLastVisitsDetails_offsetAndLimit_1',
-                'otherRequestParameters' => array('filter_offset' => '1', 'filter_limit' => 3)
-            ));
-            $apiToTest[] = array('Live.getLastVisitsDetails', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_Live.getLastVisitsDetails_offsetAndLimit_2',
-                'otherRequestParameters' => array('filter_offset' => '4', 'filter_limit' => 3)
-            ));
-
-            // #8324
-            // testing filter_excludelowpop and filter_excludelowpop_value
-            $apiToTest[] = array('UserCountry.getCountry', array(
-                'idSite'                 => $idSite,
-                'date'                   => $dateString,
-                'periods'                => 'month',
-                'testSuffix'             => '_getCountry_with_filter_excludelowpop',
-                'otherRequestParameters' => array('filter_excludelowpop' => 'nb_visits', 'filter_excludelowpop_value' => 5)
-            ));
-
-
-        }
+        // #8324
+        // testing filter_excludelowpop and filter_excludelowpop_value
+        $apiToTest[] = array('UserCountry.getCountry', array(
+            'idSite'                 => $idSite,
+            'date'                   => $dateString,
+            'periods'                => 'month',
+            'testSuffix'             => '_getCountry_with_filter_excludelowpop',
+            'otherRequestParameters' => array('filter_excludelowpop' => 'nb_visits', 'filter_excludelowpop_value' => 5)
+        ));
 
         // this also fails on all PHP versions, it seems randomly.
 //            $apiToTest[] = array('Live.getLastVisitsDetails', array(

--- a/tests/PHPUnit/System/PivotByQueryParamTest.php
+++ b/tests/PHPUnit/System/PivotByQueryParamTest.php
@@ -198,10 +198,6 @@ class PivotByQueryParamTest extends SystemTestCase
     }
     public function assertApiResponseEqualsExpected($apiMethod, $queryParams)
     {
-        if(self::isPhpVersion53()) {
-            // 5.3.3 space encoding fail eg. https://travis-ci.org/piwik/piwik/jobs/35920420
-            $this->markTestSkipped();
-        }
         parent::assertApiResponseEqualsExpected($apiMethod, $queryParams);
     }
 }

--- a/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysArchivingDisabledTest.php
+++ b/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysArchivingDisabledTest.php
@@ -26,9 +26,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysArchivingDisabledTest extends SystemTes
      */
     public function testApi($api, $params)
     {
-        if (self::isPhpVersion53() && self::isTravisCI()) {
-            $this->markTestSkipped("Skipping this test as it often fails on travis)");
-        }
         $this->runApiTests($api, $params);
     }
 

--- a/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysConversionsTest.php
+++ b/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysConversionsTest.php
@@ -38,8 +38,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysConversionsTest extends SystemTestCase
      */
     public function testApi($api, $params)
     {
-        $this->markTestSkippedOnPhp53();
-
         $this->runApiTests($api, $params);
     }
 
@@ -126,8 +124,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysConversionsTest extends SystemTestCase
     //       plugins is non-trivial, so not done now.
     public function test_Archive_getNumeric_ReturnsMetricsFromDifferentPlugins_WhenThoseMetricsAreRequested()
     {
-        $this->markTestSkippedOnPhp53();
-
         // Tests that getting a visits summary metric (nb_visits) & a Goal's metric (Goal_revenue)
         // at the same time works.
         $dateTimeRange = '2010-01-03,2010-01-06';
@@ -149,8 +145,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysConversionsTest extends SystemTestCase
     //       plugins is non-trivial, so not done now.
     public function test_Archive_getNumeric_shouldInvalidateRememberedReportsOncePerRequestIfNeeded()
     {
-        $this->markTestSkippedOnPhp53();
-
         // Tests that getting a visits summary metric (nb_visits) & a Goal's metric (Goal_revenue)
         // at the same time works.
         $dateTimeRange = '2010-01-03,2010-01-06';
@@ -218,13 +212,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysConversionsTest extends SystemTestCase
     public static function getOutputPrefix()
     {
         return 'TwoVisitors_twoWebsites_differentDays_Conversions';
-    }
-
-    private function markTestSkippedOnPhp53()
-    {
-        if (self::isPhpVersion53() && self::isTravisCI()) {
-            $this->markTestSkipped("Skipping this test as it often fails on travis)");
-        }
     }
 }
 

--- a/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysTest.php
+++ b/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysTest.php
@@ -37,9 +37,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysTest extends SystemTestCase
      */
     public function testApi($api, $params)
     {
-        if(self::isTravisCI() && self::isPhpVersion53()) {
-            $this->markTestSkipped('This test fails on travis eg. https://travis-ci.org/piwik/piwik/jobs/46944264');
-        }
         $this->runApiTests($api, $params);
     }
 

--- a/tests/PHPUnit/Unit/UrlHelperTest.php
+++ b/tests/PHPUnit/Unit/UrlHelperTest.php
@@ -215,14 +215,6 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('localhost', UrlHelper::getHostFromUrl('localhost/path'));
         $this->assertEquals('sub.localhost', UrlHelper::getHostFromUrl('sub.localhost/path'));
         $this->assertEquals('sub.localhost', UrlHelper::getHostFromUrl('http://sub.localhost/path/?query=test'));
-
-        if(SystemTestCase::isPhpVersion53()) {
-            //parse_url was fixed in 5,4,7
-            //  Fixed host recognition when scheme is omitted and a leading component separator is present.
-            // http://php.net/parse_url
-            return;
-        }
-
         $this->assertEquals('localhost', UrlHelper::getHostFromUrl('//localhost/path'));
         $this->assertEquals('localhost', UrlHelper::getHostFromUrl('//localhost/path?test=test2'));
         $this->assertEquals('example.org', UrlHelper::getHostFromUrl('//example.org/path'));


### PR DESCRIPTION
Original PR was #7271

Noticed the index is quite big for `log_visit` table so had a look and noticed there is one index not needed when we move `config_id` to the end of the existing `index_idsite_datetime` index.

We had a quick look and it seems that we query `config_id` always in combination with `visit_last_action_time` so should be all good. Probably in the past this was not the case and therefore this index was needed.

Should we directly mark the update as `Major`?
