### PR TITLE
Ajax  angular HTTP request are not aborted as expected

### DIFF
--- a/plugins/CoreHome/angularjs/common/services/piwik-api.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik-api.js
@@ -76,7 +76,7 @@
             {
                 response = response.data;
 
-                if (!angular.isDefined(response) || response.data === null) {
+                if (!angular.isDefined(response) || response === null) {
                     return $q.reject(null);
 
                 } else if (isErrorResponse(response)) {
@@ -92,8 +92,8 @@
             function onError(response)
             {
                 var message = 'Something went wrong';
-                if (response && response.status === 0) {
-                    message = 'Request was most likely aborted';
+                if (response && (response.status === 0 || response.status === -1)) {
+                    message = 'Request was possibly aborted';
                 }
 
                 return $q.reject(message);

--- a/plugins/CoreHome/angularjs/common/services/piwik-api.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik-api.js
@@ -72,22 +72,35 @@
                 options.createErrorNotification = true;
             }
 
-            var deferred = $q.defer(),
-                requestPromise = deferred.promise;
+            function onSuccess(response)
+            {
+                response = response.data;
 
-            var onError = function (message) {
-                deferred.reject(message);
-            };
+                if (!angular.isDefined(response) || response.data === null) {
+                    return $q.reject(null);
 
-            var onSuccess = function (response) {
-                if (isErrorResponse(response)) {
-                    onError(response.message || null);
+                } else if (isErrorResponse(response)) {
 
                     createResponseErrorNotification(response, options);
+
+                    return $q.reject(response.message || null);
                 } else {
-                    deferred.resolve(response);
+                    return response;
                 }
-            };
+            }
+
+            function onError(response)
+            {
+                var message = 'Something went wrong';
+                if (response && response.status === 0) {
+                    message = 'Request was most likely aborted';
+                }
+
+                return $q.reject(message);
+            }
+
+            var deferred = $q.defer(),
+                requestPromise = deferred.promise;
 
             var headers = {
                 'Content-Type': 'application/x-www-form-urlencoded',
@@ -105,32 +118,32 @@
                 headers: headers
             };
 
-            $http(ajaxCall).success(onSuccess).error(onError);
+            var promise = $http(ajaxCall).then(onSuccess, onError);
 
             // we can't modify requestPromise directly and add an abort method since for some reason it gets
             // removed after then/finally/catch is called.
-            var addAbortMethod = function (to) {
+            var addAbortMethod = function (to, deferred) {
                 return {
                     then: function () {
-                        return addAbortMethod(to.then.apply(to, arguments));
+                        return addAbortMethod(to.then.apply(to, arguments), deferred);
                     },
 
                     'finally': function () {
-                        return addAbortMethod(to['finally'].apply(to, arguments));
+                        return addAbortMethod(to['finally'].apply(to, arguments), deferred);
                     },
 
                     'catch': function () {
-                        return addAbortMethod(to['catch'].apply(to, arguments));
+                        return addAbortMethod(to['catch'].apply(to, arguments), deferred);
                     },
 
                     abort: function () {
-                        deferred.reject();
+                        deferred.resolve();
                         return this;
                     }
                 };
             };
 
-            var request = addAbortMethod(requestPromise);
+            var request = addAbortMethod(promise, deferred);
 
             allRequests.push(request);
 

--- a/plugins/CoreHome/angularjs/common/services/piwik-api.spec.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik-api.spec.js
@@ -86,13 +86,13 @@
             $httpBackend.flush();
         });
 
-        it("should not fail when multiple aborts are issued", function (done) {
+        it("should fail when multiple aborts are issued", function (done) {
             var request = piwikApi.fetch({
                 method: "SomePlugin.action"
             }).then(function (response) {
-                done(new Error("Aborted request succeeded!"));
+                done(new Error("Aborted request succeeded but should fail!"));
             }).catch(function (ex) {
-                done(ex);
+                done();
             });
 
             request.abort();
@@ -153,8 +153,6 @@
             }).then(function (response) {
                 done(new Error("Aborted request finished!"));
             }).catch(function (ex) {
-                done(ex);
-            }).finally(function () {
                 request1Done = true;
                 finishIfBothDone();
             });
@@ -190,8 +188,6 @@
             }).then(function (response) {
                 done(new Error("Aborted request finished (request 1)!"));
             }).catch(function (ex) {
-                done(ex);
-            }).finally(function () {
                 request1Done = true;
                 finishIfBothDone();
             });
@@ -201,8 +197,6 @@
             }).then(function (response) {
                 done(new Error("Aborted request finished (request 2)!"));
             }).catch(function (ex) {
-                done(ex);
-            }).finally(function () {
                 request2Done = true;
                 finishIfBothDone();
             });


### PR DESCRIPTION
While working for a fix of #7692 in #8467 I noticed that Piwik API requests made via angularjs were never really aborted. You can reproduce this by opening the website selector, then type many letters quickly. You will notice in the network tab of developer tools that the requests are not aborted. They are all finished and it slows down all the requests.

The only way the aborting of requests worked was to call `deferred.resolve()` instead of `deferred.reject()`. I presume this is because the `$http timeout` config that is used to cancel a request only listens to the success callback here: https://github.com/angular/angular.js/blob/v1.2.28/src/ng/httpBackend.js#L136 . When calling `reject()` it won't trigger the success callback and won't abort the HTTP request.

It used to work via `resolve()` but was changed to `reject()` here: https://github.com/piwik/piwik/commit/2b72250738ba66a3f98d492d388016c984fe129f
