### PR TITLE
Fix bug in notification angular directive, do not use data-binding for noclear attribute...

### DIFF
--- a/plugins/CoreHome/angularjs/notification/notification.directive.js
+++ b/plugins/CoreHome/angularjs/notification/notification.directive.js
@@ -37,7 +37,7 @@
                                               //       HTML of the node that uses the directive.
                 context: '@?',
                 type: '@?',
-                noclear: '=?'
+                noclear: '@?'
             },
             transclude: true,
             templateUrl: 'plugins/CoreHome/angularjs/notification/notification.directive.html?cb=' + piwik.cacheBuster,


### PR DESCRIPTION
…  since it won't be possible to use values (like true/false).
