### PR TITLE
Allow developers to disable iCheck on specific inputs using special CSS class

### DIFF
--- a/plugins/Morpheus/javascripts/morpheus.js
+++ b/plugins/Morpheus/javascripts/morpheus.js
@@ -7,7 +7,8 @@ $(document).ready(function () {
     function initICheck()
     {
         $('input').filter(function () {
-            return !$(this).parent().is('.form-radio');
+            return !$(this).parent().is('.form-radio')
+                && !$(this).hasClass('no-icheck');
         }).iCheck({
             checkboxClass: 'form-checkbox',
             radioClass: 'form-radio',


### PR DESCRIPTION
Add check to morpheus icheck application so inputs can avoid using icheck if needed (works around angularjs icheck issue).
