### PR TITLE
Step "Create tables" of new installation appears untranslated

### DIFF
--- a/plugins/LanguagesManager/LanguagesManager.php
+++ b/plugins/LanguagesManager/LanguagesManager.php
@@ -36,6 +36,7 @@ class LanguagesManager extends \Piwik\Plugin
             'AssetManager.getJavaScriptFiles'            => 'getJsFiles',
             'Config.NoConfigurationFile'                 => 'initLanguage',
             'Request.dispatchCoreAndPluginUpdatesScreen' => 'initLanguage',
+            'Request.dispatch'                           => 'initLanguage',
             'Platform.initialized'                       => 'initLanguage',
             'UsersManager.deleteUser'                    => 'deleteUserLanguage',
             'Template.topBar'                            => 'addLanguagesManagerToOtherTopBar',


### PR DESCRIPTION
fixes #7926

This is a simpler fix for #7926 compared to #8022 . I tried to understand what the actual problem is and how to solve it for 2 hours but couldn't figure it out even though I debugged this step 30 times. The setting of language and translation etc is very confusing, maybe needs a refactoring at some point similar to how it used to be. There seems to be a cookie reset when creating the config file which seems to cause it but it should still work. 

It's not really good that we have to init the language that often. As mentioned we might want to refactor it at some point. 
