### PR TITLE
 visitor log+profile: show campaign details in same depth & format

### DIFF
--- a/plugins/Live/VisitorProfile.php
+++ b/plugins/Live/VisitorProfile.php
@@ -133,7 +133,14 @@ class VisitorProfile
         }
 
         if ($referrerType == 'campaign') {
-            return Piwik::translate('Referrers_ColumnCampaign') . ' (' . $visit->getColumn('referrerName') . ')';
+
+            $summary = Piwik::translate('Referrers_ColumnCampaign') . ': ' . $visit->getColumn('referrerName');
+            $keyword = $visit->getColumn('referrerKeyword');
+            if (!empty($keyword)) {
+                $summary .= ' - ' . $keyword;
+            }
+
+            return $summary;
         }
 
         return $visit->getColumn('referrerName');


### PR DESCRIPTION
fixes #8140

FYI: I tried to fix it properly by extracting logic from visitor log into a macro (https://github.com/piwik/piwik/blob/2.14.3-b1/plugins/Live/templates/_dataTableViz_visitorLog.twig#L69-L105) and reuse it in visitor profile but it wasn't really possible as visitor profile returns a completely different format that is not a datatable but a custom array and it doesn't contain all visitor information. 

A workaround would be to fetch `Live.getVisitorProfile` (as usual) and `Live.getLastVisitDetails` (on top, just for referrer information) in controller but then we have to be careful to fetch `Live.getLastVisitDetails` the same way as `Live.getLastVisitorProfile` does, otherwise it would show wrong first/last visit information.

Another way I tried was to reuse the method from visitor profile (https://github.com/piwik/piwik/blob/2.14.3-b1/plugins/Live/VisitorProfile.php#L114-L140) in the visitor log but then it gets very complicated since visitor log needs HTML and links whereas this method is used in API output where HTML is not wanted. 

That's why I decided to go with the simple solution. The API method  `Live.getVisitorProfile` does many things that should be in controller but are done in the API. This is a problem and needs to be changed but I do not want to break in the API  
