### PR TITLE
Do not show encoded HTML tags in updater view

### DIFF
--- a/plugins/CoreUpdater/templates/runUpdaterAndExit_done.twig
+++ b/plugins/CoreUpdater/templates/runUpdaterAndExit_done.twig
@@ -13,7 +13,7 @@
         <div class="alert alert-danger">
             {{ 'CoreUpdater_CriticalErrorDuringTheUpgradeProcess'|translate }}
             {% for message in errorMessages %}
-                <br/><strong>{{ message }}</strong>
+                <br/><strong>{{ message|striptags }}</strong>
             {% endfor %}
         </div>
         <p>{{ 'CoreUpdater_HelpMessageIntroductionWhenError'|translate }}</p>
@@ -43,7 +43,7 @@
             <div class="alert alert-warning">
                 <p>{{ 'CoreUpdater_WarningMessages'|translate }}</p>
                 {% for message in warningMessages %}
-                    <br/><strong>{{ message }}</strong>
+                    <br/><strong>{{ message|striptags }}</strong>
                 {% endfor %}
             </div>
         {% endif %}
@@ -52,7 +52,7 @@
             <div class="alert alert-warning">
                 <p>{{ 'CoreUpdater_ErrorDuringPluginsUpdates'|translate }}</p>
                 {% for message in errorMessages %}
-                    <br/><strong>{{ message }}</strong>
+                    <br/><strong>{{ message|striptags }}</strong>
                 {% endfor %}
             </div>
             {% if deactivatedPlugins is defined and deactivatedPlugins|length > 0 %}


### PR DESCRIPTION
fixes #8366 

For now I decided to strip tags as it was done in https://github.com/piwik/piwik/commit/4f9f30e653ff22e253e90b0d3797a5831fb259d0#diff-d3148e3bddcfc2a08ca93436357a0a0cR161

What I should mention is that the welcome updater screen uses the `raw` filter for `coreMessage`. I presume it could make sense to use the same for both: https://github.com/piwik/piwik/blob/2.14.3/plugins/CoreUpdater/templates/runUpdaterAndExit_welcome.twig#L21

 but I'm scared of introducing an XSS or so as I'm not sure what kind of errors there could be. Stripping tags should be the most secure for sure and I'm not sure if formatted output is really needed. The `code` element could be still quite useful but otherwise it is displayed bold anyway (I could allow `code` in `striptags`).
