### PR TITLE
Add Vagrant config to run Piwik on Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,5 @@ php_errors.log
 /tests/PHPUnit/proxy/plugins
 /tests/PHPUnit/proxy/tests
 /config/*.config.ini.php
-/Vagrantfile
-/misc/vagrant
 /.vagrant
 /plugins/.gitignore

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.hostname = "piwik"
+  config.vm.box = "trusty64"
+
+  config.vm.synced_folder ".", "/vagrant", type: "nfs"
+
+  config.ssh.forward_agent = true
+
+  config.vm.network :private_network, ip: "192.168.33.10"
+
+  config.vm.provision :shell, path: "misc/vagrant/bootstrap.sh"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+  end
+
+end

--- a/misc/vagrant/.zshrc
+++ b/misc/vagrant/.zshrc
@@ -1,0 +1,15 @@
+export ZSH=$HOME/.oh-my-zsh
+
+ZSH_THEME="evan"
+
+# Aliases
+alias grep="grep --color"
+
+DISABLE_AUTO_UPDATE="true"
+DISABLE_CORRECTION="true"
+
+plugins=(git git-extras composer)
+
+source $ZSH/oh-my-zsh.sh
+
+export PATH=/usr/local/bin:/usr/local/sbin:$PATH

--- a/misc/vagrant/apache/sites/apache.piwik.conf
+++ b/misc/vagrant/apache/sites/apache.piwik.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+
+    ServerName apache.piwik
+
+    DocumentRoot /vagrant
+
+    <Directory "/vagrant">
+        Options Indexes FollowSymLinks MultiViews
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+</VirtualHost>

--- a/misc/vagrant/apache/sites/phpmyadmin.piwik.conf
+++ b/misc/vagrant/apache/sites/phpmyadmin.piwik.conf
@@ -1,0 +1,45 @@
+<VirtualHost *:80>
+
+    ServerName phpmyadmin.piwik
+
+    DocumentRoot /usr/share/phpmyadmin
+
+    <Directory "/usr/share/phpmyadmin">
+        Options FollowSymLinks
+        DirectoryIndex index.php
+        AllowOverride All
+        Require all granted
+
+        <IfModule mod_php5.c>
+                AddType application/x-httpd-php .php
+                php_flag magic_quotes_gpc Off
+                php_flag track_vars On
+                php_flag register_globals Off
+                php_admin_flag allow_url_fopen Off
+                php_value include_path .
+                php_admin_value upload_tmp_dir /var/lib/phpmyadmin/tmp
+                php_admin_value open_basedir /usr/share/phpmyadmin/:/etc/phpmyadmin/:/var/lib/phpmyadmin/:/usr/share/php/php-gettext/:/usr/share/javascript/
+        </IfModule>
+    </Directory>
+
+    # Authorize for setup
+    <Directory /usr/share/phpmyadmin/setup>
+        <IfModule mod_authn_file.c>
+        AuthType Basic
+        AuthName "phpMyAdmin Setup"
+        AuthUserFile /etc/phpmyadmin/htpasswd.setup
+        </IfModule>
+        Require valid-user
+    </Directory>
+
+    # Disallow web access to directories that don't need it
+    <Directory /usr/share/phpmyadmin/libraries>
+        Order Deny,Allow
+        Deny from All
+    </Directory>
+    <Directory /usr/share/phpmyadmin/setup/lib>
+        Order Deny,Allow
+        Deny from All
+    </Directory>
+
+</VirtualHost>

--- a/misc/vagrant/apache/user.conf
+++ b/misc/vagrant/apache/user.conf
@@ -1,0 +1,2 @@
+User vagrant
+Group vagrant

--- a/misc/vagrant/bootstrap.sh
+++ b/misc/vagrant/bootstrap.sh
@@ -1,0 +1,53 @@
+ #!/bin/bash
+
+# fonts + phantomjs 1.9.8, tests do not work with the PhantomJS version provided by Ubuntu
+add-apt-repository "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ trusty multiverse"
+add-apt-repository "deb http://us-east-1.ec2.archive.ubuntu.com/ubuntu/ trusty-updates multiverse"
+echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+
+# Blackfire
+curl -s https://packagecloud.io/gpg.key | apt-key add -
+echo "deb http://packages.blackfire.io/debian any main" > /etc/apt/sources.list.d/blackfire.list
+
+apt-get update -qq
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y --quiet git zsh curl apache2 php5 php5-curl php5-gd php5-mcrypt php5-mysql php5-redis mysql-server-5.5 redis-server phantomjs ttf-mscorefonts-installer imagemagick imagemagick-doc blackfire-agent blackfire-php
+
+# Apache
+rm /etc/apache2/sites-enabled/000-default.conf
+cp /vagrant/misc/vagrant/apache/sites/* /etc/apache2/sites-enabled/
+cp /vagrant/misc/vagrant/apache/user.conf /etc/apache2/conf-enabled/
+chmod -R 777 /var/log/apache2/
+
+# PHP
+cp /vagrant/misc/vagrant/php/custom.ini /etc/php5/apache2/conf.d/
+cp /vagrant/misc/vagrant/php/custom.ini /etc/php5/cli/conf.d/
+
+service apache2 restart
+
+# MySQL
+mysql -e "CREATE DATABASE piwik"
+
+# phpMyAdmin
+export DEBIAN_FRONTEND=noninteractive
+echo 'phpmyadmin phpmyadmin/dbconfig-install boolean true' | debconf-set-selections
+echo 'phpmyadmin phpmyadmin/app-password-confirm password ' | debconf-set-selections
+echo 'phpmyadmin phpmyadmin/mysql/admin-pass password ' | debconf-set-selections
+echo 'phpmyadmin phpmyadmin/mysql/app-pass password ' | debconf-set-selections
+echo 'phpmyadmin phpmyadmin/reconfigure-webserver multiselect apache2' | debconf-set-selections
+apt-get install -q -y phpmyadmin
+cp /vagrant/misc/vagrant/phpmyadmin/phpmyadmin-config.inc.php /etc/phpmyadmin/config.inc.php
+chmod 755 /etc/phpmyadmin/*
+
+# Composer
+curl -sS https://getcomposer.org/installer | php
+mv composer.phar /usr/local/bin/composer
+
+# Zsh
+chsh -s /bin/zsh vagrant
+git clone git://github.com/robbyrussell/oh-my-zsh.git /home/vagrant/.oh-my-zsh
+cp /vagrant/misc/vagrant/.zshrc /home/vagrant/.zshrc
+
+# This locale is used in tests
+locale-gen de_DE

--- a/misc/vagrant/nginx-sites/default
+++ b/misc/vagrant/nginx-sites/default
@@ -1,0 +1,12 @@
+server {
+	listen  80;
+	root    /vagrant;
+	index   index.php index.html;
+
+	location ~ \.php(/|$) {
+		include	fastcgi_params;
+		fastcgi_pass unix:/var/run/php5-fpm.sock;
+		fastcgi_read_timeout 300s;
+		fastcgi_split_path_info ^(.+\.php)(/.*)$;
+	}
+}

--- a/misc/vagrant/php/custom.php.ini
+++ b/misc/vagrant/php/custom.php.ini
@@ -1,0 +1,11 @@
+xhprof.output_dir=/tmp
+
+date.timezone = "UTC"
+
+display_errors = STDOUT
+display_startup_errors = On
+error_reporting = E_ALL
+
+always_populate_raw_post_data=-1
+
+memory_limit = 1024M

--- a/misc/vagrant/phpmyadmin/phpmyadmin-config.inc.php
+++ b/misc/vagrant/phpmyadmin/phpmyadmin-config.inc.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Debian local configuration file
+ *
+ * This file overrides the settings made by phpMyAdmin interactive setup
+ * utility.
+ *
+ * For example configuration see
+ *   /usr/share/doc/phpmyadmin/examples/config.sample.inc.php
+ * or
+ *   /usr/share/doc/phpmyadmin/examples/config.manyhosts.inc.php
+ *
+ * NOTE: do not add security sensitive data to this file (like passwords)
+ * unless you really know what you're doing. If you do, any user that can
+ * run PHP or CGI on your webserver will be able to read them. If you still
+ * want to do this, make sure to properly secure the access to this file
+ * (also on the filesystem level).
+ */
+
+// Load secret generated on postinst
+include('/var/lib/phpmyadmin/blowfish_secret.inc.php');
+
+// Load autoconf local config
+include('/var/lib/phpmyadmin/config.inc.php');
+
+/**
+ * Server(s) configuration
+ */
+$i = 0;
+// The $cfg['Servers'] array starts with $cfg['Servers'][1].  Do not use $cfg['Servers'][0].
+// You can disable a server config entry by setting host to ''.
+$i++;
+
+/**
+ * Read configuration from dbconfig-common
+ * You can regenerate it using: dpkg-reconfigure -plow phpmyadmin
+ */
+if (is_readable('/etc/phpmyadmin/config-db.php')) {
+    require('/etc/phpmyadmin/config-db.php');
+} else {
+    error_log('phpmyadmin: Failed to load /etc/phpmyadmin/config-db.php.'
+        . ' Check group www-data has read access.');
+}
+
+/* Configure according to dbconfig-common if enabled */
+if (!empty($dbname)) {
+    /* Authentication type */
+    $cfg['Servers'][$i]['auth_type'] = 'cookie';
+    /* Server parameters */
+    if (empty($dbserver)) $dbserver = 'localhost';
+    $cfg['Servers'][$i]['host'] = $dbserver;
+
+    if (!empty($dbport) || $dbserver != 'localhost') {
+        $cfg['Servers'][$i]['connect_type'] = 'tcp';
+        $cfg['Servers'][$i]['port'] = $dbport;
+    }
+    //$cfg['Servers'][$i]['compress'] = false;
+    /* Select mysqli if your server has it */
+    $cfg['Servers'][$i]['extension'] = 'mysqli';
+    /* Optional: User for advanced features */
+    $cfg['Servers'][$i]['controluser'] = $dbuser;
+    $cfg['Servers'][$i]['controlpass'] = $dbpass;
+    /* Optional: Advanced phpMyAdmin features */
+    $cfg['Servers'][$i]['pmadb'] = $dbname;
+    $cfg['Servers'][$i]['bookmarktable'] = 'pma_bookmark';
+    $cfg['Servers'][$i]['relation'] = 'pma_relation';
+    $cfg['Servers'][$i]['table_info'] = 'pma_table_info';
+    $cfg['Servers'][$i]['table_coords'] = 'pma_table_coords';
+    $cfg['Servers'][$i]['pdf_pages'] = 'pma_pdf_pages';
+    $cfg['Servers'][$i]['column_info'] = 'pma_column_info';
+    $cfg['Servers'][$i]['history'] = 'pma_history';
+    $cfg['Servers'][$i]['designer_coords'] = 'pma_designer_coords';
+    $cfg['Servers'][$i]['tracking'] = 'pma_tracking';
+    $cfg['Servers'][$i]['userconfig'] = 'pma_userconfig';
+
+    /* Uncomment the following to enable logging in to passwordless accounts,
+     * after taking note of the associated security risks. */
+    $cfg['Servers'][$i]['AllowNoPassword'] = TRUE;
+
+    /* Advance to next server for rest of config */
+    $i++;
+}
+
+/* Authentication type */
+//$cfg['Servers'][$i]['auth_type'] = 'cookie';
+/* Server parameters */
+//$cfg['Servers'][$i]['host'] = 'localhost';
+//$cfg['Servers'][$i]['connect_type'] = 'tcp';
+//$cfg['Servers'][$i]['compress'] = false;
+/* Select mysqli if your server has it */
+//$cfg['Servers'][$i]['extension'] = 'mysql';
+/* Optional: User for advanced features */
+// $cfg['Servers'][$i]['controluser'] = 'pma';
+// $cfg['Servers'][$i]['controlpass'] = 'pmapass';
+/* Optional: Advanced phpMyAdmin features */
+// $cfg['Servers'][$i]['pmadb'] = 'phpmyadmin';
+// $cfg['Servers'][$i]['bookmarktable'] = 'pma_bookmark';
+// $cfg['Servers'][$i]['relation'] = 'pma_relation';
+// $cfg['Servers'][$i]['table_info'] = 'pma_table_info';
+// $cfg['Servers'][$i]['table_coords'] = 'pma_table_coords';
+// $cfg['Servers'][$i]['pdf_pages'] = 'pma_pdf_pages';
+// $cfg['Servers'][$i]['column_info'] = 'pma_column_info';
+// $cfg['Servers'][$i]['history'] = 'pma_history';
+// $cfg['Servers'][$i]['designer_coords'] = 'pma_designer_coords';
+/* Uncomment the following to enable logging in to passwordless accounts,
+ * after taking note of the associated security risks. */
+// $cfg['Servers'][$i]['AllowNoPassword'] = TRUE;
+
+/*
+ * End of servers configuration
+ */
+
+/*
+ * Directories for saving/loading files from server
+ */
+$cfg['UploadDir'] = '';
+$cfg['SaveDir'] = '';
+
+


### PR DESCRIPTION
The [piwik-dev-environment](https://github.com/piwik/piwik-dev-environment) project is [not maintained](https://github.com/piwik/piwik-dev-environment). Additionally it doesn't work with an existing Piwik install (https://github.com/piwik/piwik-dev-environment/issues/2) so I don't think it's worth fixing anyway.

I'm committing the Vagrant config I've been using (cleaned up of custom things). Using it is very simple:
- set up the following aliases in `/etc/hosts`
  
  ```
  192.168.33.10   apache.piwik
  192.168.33.10   nginx.piwik
  192.168.33.10   phpmyadmin.piwik
  ```
- run `vagrant up`
- if Piwik is already installed, add `apache.piwik` to the trusted hosts: `trusted_hosts[] = "apache.piwik"`

That's it, Piwik is accessible at http://apache.piwik or http://nginx.piwik.

To run e.g. UI tests:

```
vagrant ssh
cd /vagrant
./console tests:run-ui
```

As you can see, the Piwik directory is synced in `/vagrant` (just like any other Vagrant setup, it's standard). The VM mounts the folder using NFS, which is much faster than the default vboxfs filesystem, however on OS X vagrant will ask for the root password to edit the NFS config (that's automatic, just type the root password when it tries to do something with sudo).

Feel free to merge it or not.
