### PR TITLE
Visitorlog: show always full url instead of "(url)"

### DIFF
--- a/plugins/Live/templates/_actionsList.twig
+++ b/plugins/Live/templates/_actionsList.twig
@@ -103,11 +103,7 @@
                 {% else %}
                     <a href="{{ action.url }}" rel="noreferrer" target="_blank" class="{% if action.eventCategory|default(false) is empty %}action-list-url{# don't put URL on new line for events #}{% endif %} truncated-text-line"
                        {% if overrideLinkStyle is not defined or overrideLinkStyle %}style="text-decoration:underline;"{% endif %}>
-                       {% if action.eventCategory|default(false) is not empty %}
-                           (url)
-                       {% else %}
-                           {{ action.url }}
-                       {% endif %}
+                       {{ action.url }}
                     </a>
                 {% endif %}
                 {% if action.type == 'action' and action.pageTitle|default(false) is not empty %}</p>{% endif %}


### PR DESCRIPTION
fixes #8202
