### PR TITLE
Use improved tooltips for all tooltips in the visitor log

### DIFF
--- a/plugins/Live/javascripts/visitorLog.js
+++ b/plugins/Live/javascripts/visitorLog.js
@@ -57,6 +57,21 @@
                 });
             });
 
+            $('.visitorLogTooltip').each(function () {
+                $(this).tooltip({
+                    track: true,
+                    show: false,
+                    hide: false,
+                    tooltipClass: 'small',
+                    open: function () {
+                        tooltipIsOpened = true;
+                    },
+                    close: function () {
+                        tooltipIsOpened = false;
+                    }
+                });
+            });
+
             // Replace duplicated page views by a NX count instead of using too much vertical space
             $("ol.visitorLog").each(function () {
                 var prevelement;

--- a/plugins/Live/templates/_dataTableViz_visitorLog.twig
+++ b/plugins/Live/templates/_dataTableViz_visitorLog.twig
@@ -119,14 +119,12 @@
 
         {% set cycleIndex=cycleIndex+1 %}
             <div class="col-md-{% if displayVisitorsInOwnColumn %}3{% else %}4{% endif %}">
-                <span class="visitorLogIconWithDetails">
-                    <strong title="{% if visitor.getColumn('visitorType')=='new' %}{{ 'General_NewVisitor'|translate }}{% else %}{{ 'Live_VisitorsLastVisit'|translate(visitor.getColumn('daysSinceLastVisit')) }}{% endif %}">
-                        {{ visitor.getColumn('serverDatePrettyFirstAction') }}
-                        {% if isWidget %}<br/>{% else %}-{% endif %} {{ visitor.getColumn('serverTimePrettyFirstAction') }}</strong>
-                </span>
+                <strong class="visitorLogTooltip" title="{% if visitor.getColumn('visitorType')=='new' %}{{ 'General_NewVisitor'|translate }}{% else %}{{ 'Live_VisitorsLastVisit'|translate(visitor.getColumn('daysSinceLastVisit')) }}{% endif %}">
+                    {{ visitor.getColumn('serverDatePrettyFirstAction') }}
+                    {% if isWidget %}<br/>{% else %}-{% endif %} {{ visitor.getColumn('serverTimePrettyFirstAction') }}</strong>
                 {% if visitor.getColumn('visitIp') is not empty %}
                     <br/>
-                <span title="{% if visitor.getColumn('userId') is not empty %}{{ 'General_UserId'|translate }}: {{ visitor.getColumn('userId')|raw }}{% endif %}
+                <span class="visitorLogTooltip" title="{% if visitor.getColumn('userId') is not empty %}{{ 'General_UserId'|translate }}: {{ visitor.getColumn('userId')|raw }}{% endif %}
 
 {% if visitor.getColumn('visitorId') is not empty %}{{ 'General_VisitorID'|translate }}: {{ visitor.getColumn('visitorId') }}{% endif -%}
 {%- if visitor.getColumn('latitude') or visitor.getColumn('longitude') %}
@@ -172,7 +170,7 @@ GPS (lat/long): {{ visitor.getColumn('latitude') }},{{ visitor.getColumn('longit
                         {% set name='customVariableName' ~ id %}
                         {% set value='customVariableValue' ~ id %}
                         <br/>
-                        <acronym title="{{ 'CustomVariables_CustomVariables'|translate }} (index {{ id }})">
+                        <acronym class="visitorLogTooltip" title="{{ 'CustomVariables_CustomVariables'|translate }} (index {{ id }})">
                             {{ customVariable[name]|truncate(30) }}
                         </acronym>
                     {% if customVariable[value]|length > 0 %}: {{ customVariable[value]|truncate(50) }}{% endif %}

--- a/plugins/Live/templates/_dataTableViz_visitorLog.twig
+++ b/plugins/Live/templates/_dataTableViz_visitorLog.twig
@@ -15,11 +15,14 @@
                 <ul class="details">
                     <li>{{ 'DevicesDetection_ColumnBrowser'|translate }}: {{ visitor.getColumn('browser') }}</li>
                     <li>{{ 'DevicesDetection_BrowserEngine'|translate }}: {{ visitor.getColumn('browserFamily') }}</li>
-                    {% if visitor.getColumn('pluginsIcons')|length > 0 %}<li>{{ 'General_Plugins'|translate }}:
-                        {% for pluginIcon in visitor.getColumn('pluginsIcons') %}
-                            <img src="{{ pluginIcon.pluginIcon }}" title="{{ pluginIcon.pluginName|capitalize(true) }}" alt="{{ pluginIcon.pluginName|capitalize(true) }}"/>
-                        {% endfor %}
-                    </li>{% endif %}
+                    {% if visitor.getColumn('pluginsIcons')|length > 0 %}
+                        <li>
+                            {{ 'General_Plugins'|translate }}:
+                            {% for pluginIcon in visitor.getColumn('pluginsIcons') %}
+                                <img src="{{ pluginIcon.pluginIcon }}" alt="{{ pluginIcon.pluginName|capitalize(true) }}"/>
+                            {% endfor %}
+                        </li>
+                    {% endif %}
                 </ul>
             </span>
         {% endif %}
@@ -45,21 +48,21 @@
         </span>
 
         <span class="visitorType">
-        {# Goals, and/or Ecommerce activity #}
+            {# Goals, and/or Ecommerce activity #}
             {% if visitor.getColumn('visitConverted') %}
-                <span title="{{ 'General_VisitConvertedNGoals'|translate(visitor.getColumn('goalConversions')) }}" class='visitorRank'
+                <span title="{{ 'General_VisitConvertedNGoals'|translate(visitor.getColumn('goalConversions')) }}" class='visitorRank visitorLogTooltip'
                       {% if not displayVisitorsInOwnColumn or breakBeforeVisitorRank %}style="margin-left:0;"{% endif %}>
-                <img src="{{ visitor.getColumn('visitConvertedIcon') }}"/>
-                <span class='hash'>#</span>
+                    <img src="{{ visitor.getColumn('visitConvertedIcon') }}"/>
+                    <span class='hash'>#</span>
                     {{ visitor.getColumn('goalConversions') }}
                     {% if visitHasEcommerceActivity %}
                         &nbsp;
                         <img src="{{ visitor.getColumn('visitEcommerceStatusIcon') }}" title="{{ visitor.getColumn('visitEcommerceStatus') }}"/>
                     {% endif %}
-            </span>
-        {# Ecommerce activity only (no goal) #}
-        {% elseif visitHasEcommerceActivity %}
-                <span><img src="{{ visitor.getColumn('visitEcommerceStatusIcon') }}" title="{{ visitor.getColumn('visitEcommerceStatus') }}"/></span>
+                </span>
+            {# Ecommerce activity only (no goal) #}
+            {% elseif visitHasEcommerceActivity %}
+                <img class="visitorLogTooltip" src="{{ visitor.getColumn('visitEcommerceStatusIcon') }}" title="{{ visitor.getColumn('visitEcommerceStatus') }}"/>
             {% endif %}
         </span>
     </span>
@@ -70,7 +73,7 @@
     <div class="visitorReferrer">
         {% if visitor.getColumn('referrerType') == 'website' %}
             {{ 'Referrers_ColumnWebsite'|translate }}:
-            <a href="{{ visitor.getColumn('referrerUrl') }}" rel="noreferrer" target="_blank" title="{{ visitor.getColumn('referrerUrl') }}"
+            <a href="{{ visitor.getColumn('referrerUrl') }}" rel="noreferrer" target="_blank" class="visitorLogTooltip" title="{{ visitor.getColumn('referrerUrl') }}"
                style="text-decoration:underline;">
                 {{ visitor.getColumn('referrerName') }}
             </a>
@@ -116,9 +119,11 @@
 
         {% set cycleIndex=cycleIndex+1 %}
             <div class="col-md-{% if displayVisitorsInOwnColumn %}3{% else %}4{% endif %}">
-                <strong title="{% if visitor.getColumn('visitorType')=='new' %}{{ 'General_NewVisitor'|translate }}{% else %}{{ 'Live_VisitorsLastVisit'|translate(visitor.getColumn('daysSinceLastVisit')) }}{% endif %}">
-                    {{ visitor.getColumn('serverDatePrettyFirstAction') }}
-                    {% if isWidget %}<br/>{% else %}-{% endif %} {{ visitor.getColumn('serverTimePrettyFirstAction') }}</strong>
+                <span class="visitorLogIconWithDetails">
+                    <strong title="{% if visitor.getColumn('visitorType')=='new' %}{{ 'General_NewVisitor'|translate }}{% else %}{{ 'Live_VisitorsLastVisit'|translate(visitor.getColumn('daysSinceLastVisit')) }}{% endif %}">
+                        {{ visitor.getColumn('serverDatePrettyFirstAction') }}
+                        {% if isWidget %}<br/>{% else %}-{% endif %} {{ visitor.getColumn('serverTimePrettyFirstAction') }}</strong>
+                </span>
                 {% if visitor.getColumn('visitIp') is not empty %}
                     <br/>
                 <span title="{% if visitor.getColumn('userId') is not empty %}{{ 'General_UserId'|translate }}: {{ visitor.getColumn('userId')|raw }}{% endif %}
@@ -137,15 +142,19 @@ GPS (lat/long): {{ visitor.getColumn('latitude') }},{{ visitor.getColumn('longit
                 {% if visitor.getColumn('provider') %}
                     <br/>
                     {{ 'Provider_ColumnProvider'|translate }}:
-                    <a href="{{ visitor.getColumn('providerUrl') }}" rel="noreferrer" target="_blank" title="{{ visitor.getColumn('providerName') }} {{ visitor.getColumn('providerUrl') }}" style="text-decoration:underline;">
+                    <a href="{{ visitor.getColumn('providerUrl') }}" rel="noreferrer" target="_blank" class="visitorLogTooltip" title="{{ visitor.getColumn('providerName') }} {{ visitor.getColumn('providerUrl') }}" style="text-decoration:underline;">
                         {{ visitor.getColumn('providerName') }}</a>
                 {% endif %}
                 {% if visitor.getColumn('visitorTypeIcon') or visitor.getColumn('countryFlag') %}
                     <br/>
                 {% endif %}
                 {% if visitor.getColumn('visitorTypeIcon') %}
-                    <img src="{{ visitor.getColumn('visitorTypeIcon') }}"
-                         title="{{ 'General_ReturningVisitor'|translate }} - {{ 'General_NVisits'|translate(visitor.getColumn('visitCount')) }}"/>
+                    <span class="visitorLogIconWithDetails">
+                        <img src="{{ visitor.getColumn('visitorTypeIcon') }}"/>
+                        <ul class="details">
+                            <li>{{ 'General_ReturningVisitor'|translate }} - {{ 'General_NVisits'|translate(visitor.getColumn('visitCount')) }}</li>
+                        </ul>
+                    </span>
                 {% endif %}
                 {% if visitor.getColumn('countryFlag') %}
                     <span class="visitorLogIconWithDetails">


### PR DESCRIPTION
Fixes #8356

Example (not limited to this tooltip):

<img width="263" alt="capture d ecran 2015-08-11 a 13 20 30" src="https://cloud.githubusercontent.com/assets/720328/9196444/c38fdff2-402b-11e5-91db-928cb0fce1c2.png">
