### PR TITLE
Display total number of actions across all websites

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -353,7 +353,7 @@
         "Total": "Total",
         "TotalRatioTooltip": "This is %1$s of all %2$s %3$s.",
         "TotalRevenue": "Total Revenue",
-        "TotalVisitsPageviewsRevenue": "(Total: %s visits, %s pageviews, %s revenue)",
+        "TotalVisitsPageviewsActionsRevenue": "(Total: %s visits, %s pageviews, %s actions, %s revenue)",
         "TransitionsRowActionTooltip": "See what visitors did before and after viewing this page",
         "TransitionsRowActionTooltipTitle": "Open Transitions",
         "TranslatorEmail": "hello@piwik.org",

--- a/plugins/MultiSites/Dashboard.php
+++ b/plugins/MultiSites/Dashboard.php
@@ -44,7 +44,7 @@ class Dashboard
     {
         $sites = API::getInstance()->getAll($period, $date, $segment, $_restrictSitesToLogin = false,
                                             $enhanced = true, $searchTerm = false,
-                                            $showColumns = array('nb_visits', 'nb_pageviews', 'revenue'));
+                                            $showColumns = array('nb_visits', 'nb_pageviews', 'nb_actions', 'revenue'));
         $sites->deleteRow(DataTable::ID_SUMMARY_ROW);
 
         /** @var DataTable $pastData */
@@ -101,6 +101,7 @@ class Dashboard
         return array(
             'nb_pageviews'       => $this->sitesByGroup->getMetadata('total_nb_pageviews'),
             'nb_visits'          => $this->sitesByGroup->getMetadata('total_nb_visits'),
+            'nb_actions'         => $this->sitesByGroup->getMetadata('total_nb_actions'),
             'revenue'            => $this->sitesByGroup->getMetadata('total_revenue'),
             'nb_visits_lastdate' => $this->sitesByGroup->getMetadata('total_nb_visits_lastdate') ? : 0,
         );

--- a/plugins/MultiSites/MultiSites.php
+++ b/plugins/MultiSites/MultiSites.php
@@ -46,8 +46,9 @@ class MultiSites extends \Piwik\Plugin
         $translations[] = 'General_Website';
         $translations[] = 'General_ColumnNbVisits';
         $translations[] = 'General_ColumnPageviews';
+        $translations[] = 'General_Actions';
         $translations[] = 'General_ColumnRevenue';
-        $translations[] = 'General_TotalVisitsPageviewsRevenue';
+        $translations[] = 'General_TotalVisitsPageviewsActionsRevenue';
         $translations[] = 'General_EvolutionSummaryGeneric';
         $translations[] = 'General_AllWebsitesDashboard';
         $translations[] = 'General_NVisits';

--- a/plugins/MultiSites/MultiSites.php
+++ b/plugins/MultiSites/MultiSites.php
@@ -46,7 +46,6 @@ class MultiSites extends \Piwik\Plugin
         $translations[] = 'General_Website';
         $translations[] = 'General_ColumnNbVisits';
         $translations[] = 'General_ColumnPageviews';
-        $translations[] = 'General_Actions';
         $translations[] = 'General_ColumnRevenue';
         $translations[] = 'General_TotalVisitsPageviewsActionsRevenue';
         $translations[] = 'General_EvolutionSummaryGeneric';

--- a/plugins/MultiSites/angularjs/dashboard/dashboard-model.service.js
+++ b/plugins/MultiSites/angularjs/dashboard/dashboard-model.service.js
@@ -17,6 +17,7 @@
             pageSize     : 25,
             currentPage  : 0,
             totalVisits  : '?',
+            totalPageviews : '?',
             totalActions : '?',
             totalRevenue : '?',
             searchTerm   : '',
@@ -66,8 +67,9 @@
                 site.revenue_evolution   = parseInt(site.revenue_evolution, 10);
             });
 
-            model.totalActions  = report.totals.nb_pageviews;
             model.totalVisits   = report.totals.nb_visits;
+            model.totalPageviews  = report.totals.nb_pageviews;
+            model.totalActions  = report.totals.nb_actions;
             model.totalRevenue  = report.totals.revenue;
             model.lastVisits    = report.totals.nb_visits_lastdate;
             model.sites = allSites;

--- a/plugins/MultiSites/angularjs/dashboard/dashboard.directive.html
+++ b/plugins/MultiSites/angularjs/dashboard/dashboard.directive.html
@@ -24,10 +24,6 @@
                 <span ng-class="{multisites_asc: !model.reverse && 'nb_pageviews' == model.sortColumn, multisites_desc: model.reverse && 'nb_pageviews' == model.sortColumn}" class="arrow"></span>
                 <span class="heading">{{ 'General_ColumnPageviews'|translate }}</span>
             </th>
-            <th id="actions" class="multisites-column" ng-click="model.sortBy('nb_actions')" ng-class="{columnSorted: 'nb_actions' == model.sortColumn}">
-                <span ng-class="{multisites_asc: !model.reverse && 'nb_actions' == model.sortColumn, multisites_desc: model.reverse && 'nb_actions' == model.sortColumn}" class="arrow"></span>
-                <span class="heading">{{ 'General_Actions'|translate }}</span>
-            </th>
 
             <th ng-if="displayRevenueColumn" id="revenue" class="multisites-column" ng-click="model.sortBy('revenue')" ng-class="{columnSorted: 'revenue' == model.sortColumn}">
                 <span ng-class="{multisites_asc: !model.reverse && 'revenue' == model.sortColumn, multisites_desc: model.reverse && 'revenue' == model.sortColumn}" class="arrow"></span>

--- a/plugins/MultiSites/angularjs/dashboard/dashboard.directive.html
+++ b/plugins/MultiSites/angularjs/dashboard/dashboard.directive.html
@@ -5,7 +5,7 @@
         {{ 'General_AllWebsitesDashboard'|translate }}
         <span class='smallTitle'
               title="{{ 'General_EvolutionSummaryGeneric'|translate:('General_NVisits'|translate:model.totalVisits):date:model.lastVisits:model.lastVisitsDate:(model.totalVisits|evolution:model.lastVisits)}}"
-              ng-bind-html="'General_TotalVisitsPageviewsRevenue' | translate:('<strong>'+model.totalVisits+'</strong>'):('<strong>'+model.totalActions+'</strong>'):('<strong>' + model.totalRevenue + '</strong>')">
+              ng-bind-html="'General_TotalVisitsPageviewsActionsRevenue' | translate:('<strong>'+model.totalVisits+'</strong>'):('<strong>'+model.totalPageviews+'</strong>'):('<strong>'+model.totalActions+'</strong>'):('<strong>' + model.totalRevenue + '</strong>')">
         </span>
     </h2>
 
@@ -23,6 +23,10 @@
             <th id="pageviews" class="multisites-column" ng-click="model.sortBy('nb_pageviews')" ng-class="{columnSorted: 'nb_pageviews' == model.sortColumn}">
                 <span ng-class="{multisites_asc: !model.reverse && 'nb_pageviews' == model.sortColumn, multisites_desc: model.reverse && 'nb_pageviews' == model.sortColumn}" class="arrow"></span>
                 <span class="heading">{{ 'General_ColumnPageviews'|translate }}</span>
+            </th>
+            <th id="actions" class="multisites-column" ng-click="model.sortBy('nb_actions')" ng-class="{columnSorted: 'nb_actions' == model.sortColumn}">
+                <span ng-class="{multisites_asc: !model.reverse && 'nb_actions' == model.sortColumn, multisites_desc: model.reverse && 'nb_actions' == model.sortColumn}" class="arrow"></span>
+                <span class="heading">{{ 'General_Actions'|translate }}</span>
             </th>
 
             <th ng-if="displayRevenueColumn" id="revenue" class="multisites-column" ng-click="model.sortBy('revenue')" ng-class="{columnSorted: 'revenue' == model.sortColumn}">

--- a/plugins/MultiSites/angularjs/site/site.directive.html
+++ b/plugins/MultiSites/angularjs/site/site.directive.html
@@ -16,6 +16,9 @@
     <td class="multisites-column">
         {{ website.nb_pageviews }}
     </td>
+    <td class="multisites-column">
+        {{ website.nb_actions }}
+    </td>
     <td ng-if="displayRevenueColumn" class="multisites-column">
         {{ website.revenue }}
     </td>

--- a/plugins/MultiSites/angularjs/site/site.directive.html
+++ b/plugins/MultiSites/angularjs/site/site.directive.html
@@ -16,9 +16,6 @@
     <td class="multisites-column">
         {{ website.nb_pageviews }}
     </td>
-    <td class="multisites-column">
-        {{ website.nb_actions }}
-    </td>
     <td ng-if="displayRevenueColumn" class="multisites-column">
         {{ website.revenue }}
     </td>

--- a/plugins/MultiSites/tests/Integration/ControllerTest.php
+++ b/plugins/MultiSites/tests/Integration/ControllerTest.php
@@ -37,9 +37,11 @@ class ControllerTest extends SystemTestCase
         $this->assertEquals(array(
             'label' => 'Site 1',
             'nb_visits' => 2,
+            'nb_actions' => 4,
             'nb_pageviews' => 3,
             'revenue' => '$ 2541',
             'visits_evolution' => '100%',
+            'actions_evolution' => '100%',
             'pageviews_evolution' => '100%',
             'revenue_evolution' => '100%',
             'idsite' => 1,
@@ -53,6 +55,7 @@ class ControllerTest extends SystemTestCase
             'totals' => array(
                 'nb_pageviews' => 8,
                 'nb_visits' => 5,
+                'nb_actions' => 12,
                 'revenue' => 5082,
                 'nb_visits_lastdate' => 0,
             ),

--- a/plugins/MultiSites/tests/Integration/DashboardTest.php
+++ b/plugins/MultiSites/tests/Integration/DashboardTest.php
@@ -56,6 +56,7 @@ class DashboardTest extends IntegrationTestCase
         $expectedTotals = array(
             'nb_pageviews' => 0,
             'nb_visits' => 0,
+            'nb_actions' => 0,
             'revenue' => 0,
             'nb_visits_lastdate' => 0,
         );
@@ -65,9 +66,11 @@ class DashboardTest extends IntegrationTestCase
             array (
                 'label' => 'Site 1',
                 'nb_visits' => 0,
+                'nb_actions' => 0,
                 'nb_pageviews' => 0,
                 'revenue' => '$ 0',
                 'visits_evolution' => '0%',
+                'actions_evolution' => '0%',
                 'pageviews_evolution' => '0%',
                 'revenue_evolution' => '0%',
                 'idsite' => 1,
@@ -77,9 +80,11 @@ class DashboardTest extends IntegrationTestCase
             array (
                 'label' => 'Site 2',
                 'nb_visits' => 0,
+                'nb_actions' => 0,
                 'nb_pageviews' => 0,
                 'revenue' => '$ 0',
                 'visits_evolution' => '0%',
+                'actions_evolution' => '0%',
                 'pageviews_evolution' => '0%',
                 'revenue_evolution' => '0%',
                 'idsite' => 2,
@@ -89,9 +94,11 @@ class DashboardTest extends IntegrationTestCase
             array (
                 'label' => 'Site 3',
                 'nb_visits' => 0,
+                'nb_actions' => 0,
                 'nb_pageviews' => 0,
                 'revenue' => '$ 0',
                 'visits_evolution' => '0%',
+                'actions_evolution' => '0%',
                 'pageviews_evolution' => '0%',
                 'revenue_evolution' => '0%',
                 'idsite' => 3,
@@ -111,9 +118,11 @@ class DashboardTest extends IntegrationTestCase
             array (
                 'label' => 'Site 2',
                 'nb_visits' => 0,
+                'nb_actions' => 0,
                 'nb_pageviews' => 0,
                 'revenue' => '$ 0',
                 'visits_evolution' => '0%',
+                'actions_evolution' => '0%',
                 'pageviews_evolution' => '0%',
                 'revenue_evolution' => '0%',
                 'idsite' => 2,


### PR DESCRIPTION
Fixes #8288

Show the total number of actions in the header:

<img width="1154" alt="capture d ecran 2015-08-12 a 10 31 41" src="https://cloud.githubusercontent.com/assets/720328/9219751/58752eea-40dd-11e5-884d-55d88fed56a1.png">

I had to change the translation key `TotalVisitsPageviewsRevenue` to `TotalVisitsPageviewsActionsRevenue`, is it worth mentioning it in the changelog?
