### PR TITLE
Improvements and fixes to the archive purging system

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -446,6 +446,14 @@ class CronArchive
             return;
         }
 
+        // TODO: this is a HACK to get the purgeOutdatedArchives task to work when run below. without
+        //       it, the task will not run because we no longer run the tasks through CliMulti.
+        //       harder to implement alternatives include:
+        //       - moving CronArchive logic to DI and setting a flag in the class when the whole process
+        //         runs
+        //       - setting a new DI environment for core:archive which CoreAdminHome can use to conditionally
+        //         enable/disable the task
+        $_GET['trigger'] = 'archivephp';
         CoreAdminHomeAPI::getInstance()->runScheduledTasks();
 
         $this->logSection("");

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -53,15 +53,15 @@ class Model
 
         $idSites = array_map(function ($v) { return (int)$v; }, $idSites);
 
-        $sql = "SELECT idsite, date1, date2, period,
+        $sql = "SELECT idsite, date1, date2, period, name,
                        GROUP_CONCAT(idarchive, '.', value ORDER BY ts_archived DESC) as archives
                   FROM `$archiveTable`
                  WHERE name LIKE 'done%'
                    AND value IN (" . ArchiveWriter::DONE_INVALIDATED . ','
-            . ArchiveWriter::DONE_OK . ','
-            . ArchiveWriter::DONE_OK_TEMPORARY . ")
+                                   . ArchiveWriter::DONE_OK . ','
+                                   . ArchiveWriter::DONE_OK_TEMPORARY . ")
                    AND idsite IN (" . implode(',', $idSites) . ")
-                 GROUP BY idsite, date1, date2, period";
+                 GROUP BY idsite, date1, date2, period, name";
 
         $archiveIds = array();
 

--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -51,11 +51,15 @@ class Tasks extends \Piwik\Plugin\Tasks
         $this->weekly('updateSpammerBlacklist');
     }
 
+    /**
+     * @return bool `true` if the purge was executed, `false` if it was skipped.
+     * @throws \Exception
+     */
     public function purgeOutdatedArchives()
     {
         if ($this->willPurgingCausePotentialProblemInUI()) {
             $this->logger->info("Purging temporary archives: skipped (browser triggered archiving not enabled & not running after core:archive)");
-            return;
+            return false;
         }
 
         $archiveTables = ArchiveTableCreator::getTablesArchivesInstalled();
@@ -86,6 +90,8 @@ class Tasks extends \Piwik\Plugin\Tasks
                 $this->logger->info("Skipping purging of archive tables *_{year}_{month}, year <= 1990.", array('year' => $year, 'month' => $month));
             }
         }
+
+        return true;
     }
 
     public function purgeInvalidatedArchives()


### PR DESCRIPTION
Contains two fixes for the archive purging system:

1) For purging invalidated archives, includes an extra group by in the GROUP_CONCAT query used to find invalidated archives that can be purged. By grouping by `name` too, we get less idarchives per row, which means the GROUP_CONCAT limit should not be hit.

2) Fixes a regression where the purgeOutdatedArchives task was skipped because it could no longer tell if it was executed during the core:archive command (since it does not use CliMulti anymore). Includes two new (light) tests for this use case.

Refs #7181 (should fix it, but will need confirmation)
