### PR TITLE
ensure case insensitivity of the the Page URL segment type

### DIFF
--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -15,8 +15,6 @@ use Piwik\Tracker;
 class Model
 {
 
-    private static $type; 
-    
     public function createAction($visitAction)
     {
         $fields = implode(", ", array_keys($visitAction));
@@ -171,6 +169,7 @@ class Model
         $sql   = "INSERT INTO $table (name, hash, type, url_prefix) VALUES (?,CRC32(?),?,?)";
 
         $db = $this->getDb();
+        $name = ($type == Action::TYPE_PAGE_URL) ? strtolower($name) : $name;
         $db->query($sql, array($name, $name, $type, $urlPrefix));
 
         $actionId = $db->lastInsertId();
@@ -191,10 +190,9 @@ class Model
 
     public function getIdActionMatchingNameAndType($name, $type)
     {
-        self::$type = $type;
         $sql  = $this->getSqlSelectActionId();
-
-        $bind = ($type == Action::TYPE_PAGE_URL) ? array($name, $type) : array($name, $name, $type);                                                  
+        $name = ($type == Action::TYPE_PAGE_URL) ? strtolower($name) : $name;
+        $bind = array($name, $name, $type);
         $idAction = $this->getDb()->fetchOne($sql, $bind);
 
         return $idAction;
@@ -424,10 +422,7 @@ class Model
 
     private function getSqlConditionToMatchSingleAction()
     {
-        //to preserve case insensitivy ignore the CRC32 hash field if the segment is of type pageUrl
-        return (self::$type == Action::TYPE_PAGE_URL) ? 
-          "( name = ? AND type = ? )" : 
-          "( hash = CRC32(?) AND name = ? AND type = ? )";
+        return "( hash = CRC32(?) AND name = ? AND type = ? )";
 
     }
 }

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -176,12 +176,12 @@ class Model
         return $actionId;
     }
 
-    private function getSqlSelectActionId()
+    private function getSqlSelectActionId($type)
     {
         // it is possible for multiple actions to exist in the DB (due to rare concurrency issues), so the ORDER BY and
         // LIMIT are important
         $sql = "SELECT idaction, type, name FROM " . Common::prefixTable('log_action')
-            . "  WHERE " . $this->getSqlConditionToMatchSingleAction() . " "
+            . "  WHERE " . $this->getSqlConditionToMatchSingleAction($type) . " "
             . "ORDER BY idaction ASC LIMIT 1";
 
         return $sql;
@@ -189,8 +189,7 @@ class Model
 
     public function getIdActionMatchingNameAndType($name, $type)
     {
-	$this->type = $type;
-        $sql  = $this->getSqlSelectActionId();
+        $sql  = $this->getSqlSelectActionId($type);
 
         $bind = ($type == Action::TYPE_PAGE_URL) ? array($name, $type) : array($name, $name, $type);                                                  
         $idAction = $this->getDb()->fetchOne($sql, $bind);
@@ -420,9 +419,9 @@ class Model
         return Tracker::getDatabase();
     }
 
-    private function getSqlConditionToMatchSingleAction()
-    {
-	//to preserve case insensitivy ignore the CRC32 hash field if the segment is of type pageUrl
+    private function getSqlConditionToMatchSingleAction($type = null)
+    {   
+    	//to preserve case insensitivy ignore the CRC32 hash field if the segment is of type pageUrl
         return ($this->type == Action::TYPE_PAGE_URL) ? 
           "( name = ? AND type = ? )" : 
           "( hash = CRC32(?) AND name = ? AND type = ? )";

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -189,9 +189,10 @@ class Model
 
     public function getIdActionMatchingNameAndType($name, $type)
     {
+	$this->type = $type;
         $sql  = $this->getSqlSelectActionId();
-        $bind = array($name, $name, $type);
 
+        $bind = ($type == Action::TYPE_PAGE_URL) ? array($name, $type) : array($name, $name, $type);                                                  
         $idAction = $this->getDb()->fetchOne($sql, $bind);
 
         return $idAction;
@@ -421,6 +422,10 @@ class Model
 
     private function getSqlConditionToMatchSingleAction()
     {
-        return "( hash = CRC32(?) AND name = ? AND type = ? )";
+	//to preserve case insensitivy ignore the CRC32 hash field if the segment is of type pageUrl
+        return ($this->type == Action::TYPE_PAGE_URL) ? 
+          "( name = ? AND type = ? )" : 
+          "( hash = CRC32(?) AND name = ? AND type = ? )";
+
     }
 }

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -193,6 +193,7 @@ class Model
         $sql  = $this->getSqlSelectActionId();
         $name = ($type == Action::TYPE_PAGE_URL) ? strtolower($name) : $name;
         $bind = array($name, $name, $type);
+
         $idAction = $this->getDb()->fetchOne($sql, $bind);
 
         return $idAction;
@@ -423,6 +424,5 @@ class Model
     private function getSqlConditionToMatchSingleAction()
     {
         return "( hash = CRC32(?) AND name = ? AND type = ? )";
-
     }
 }

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -422,7 +422,7 @@ class Model
     private function getSqlConditionToMatchSingleAction($type = null)
     {   
     	//to preserve case insensitivy ignore the CRC32 hash field if the segment is of type pageUrl
-        return ($this->type == Action::TYPE_PAGE_URL) ? 
+        return ($type == Action::TYPE_PAGE_URL) ? 
           "( name = ? AND type = ? )" : 
           "( hash = CRC32(?) AND name = ? AND type = ? )";
 


### PR DESCRIPTION
hello hello! the case sensitivity of the the Page URL segment type was not an issue with the field itself, which actually is of type utf8_general_ci, but rather with the CRC32 hashing of the field. upper/lower case variations of the same fundamental URL will produce unique hashes. this is a simple conditional fix to ignore the hash field when retrieving records for the Page URL segment type.
