### PR TITLE
Disable ONLY_FULL_GROUP_BY Mysql mode when creating connection

### DIFF
--- a/core/Db.php
+++ b/core/Db.php
@@ -33,6 +33,8 @@ use Piwik\Db\Adapter;
  */
 class Db
 {
+    const SQL_MODE = 'STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE';
+
     private static $connection = null;
 
     private static $logQueries = true;

--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -10,6 +10,7 @@ namespace Piwik\Db\Adapter;
 
 use Exception;
 use Piwik\Config;
+use Piwik\Db;
 use Piwik\Db\AdapterInterface;
 use Piwik\Piwik;
 use Zend_Config;
@@ -57,7 +58,7 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
 
         parent::_connect();
 
-        $this->_connection->query('SET sql_mode = "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"');
+        $this->_connection->query('SET sql_mode = "' . Db::SQL_MODE . '"');
     }
 
     /**

--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -49,6 +49,17 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
         return 3306;
     }
 
+    protected function _connect()
+    {
+        if ($this->_connection) {
+            return;
+        }
+
+        parent::_connect();
+
+        $this->_connection->query('SET sql_mode = "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"');
+    }
+
     /**
      * Check MySQL version
      *

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -12,6 +12,7 @@ use Exception;
 use PDO;
 use PDOException;
 use Piwik\Config;
+use Piwik\Db;
 use Piwik\Db\AdapterInterface;
 use Piwik\Piwik;
 use Zend_Config;
@@ -75,7 +76,7 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         // MYSQL_ATTR_USE_BUFFERED_QUERY will use more memory when enabled
         // $this->_connection->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
 
-        $this->_connection->exec('SET sql_mode = "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"');
+        $this->_connection->exec('SET sql_mode = "' . Db::SQL_MODE . '"');
     }
 
     /**

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -61,12 +61,21 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
          */
         $this->_connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
+        return $this->_connection;
+    }
+
+    protected function _connect()
+    {
+        if ($this->_connection) {
+            return;
+        }
+
+        parent::_connect();
+
         // MYSQL_ATTR_USE_BUFFERED_QUERY will use more memory when enabled
         // $this->_connection->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
 
         $this->_connection->exec('SET sql_mode = "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"');
-
-        return $this->_connection;
     }
 
     /**

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -64,6 +64,8 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
         // MYSQL_ATTR_USE_BUFFERED_QUERY will use more memory when enabled
         // $this->_connection->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
 
+        $this->_connection->exec('SET sql_mode = "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE"');
+
         return $this->_connection;
     }
 


### PR DESCRIPTION
refs #5124 

Workaround for Piwik not being compatible with mysql mode `ONLY_FULL_GROUP_BY`. Idea is to disable it until we have a proper solution (being compatible) for it.

I'm not sure re the SQL modes that we set but was recommended by a user in https://github.com/piwik/piwik/issues/5124#issuecomment-131165462 and sounds reasonable. We could make it configurable but would prefer to do this only when needed.
