### PR TITLE
Use monolog in tracker for logging

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -570,7 +570,9 @@ use_third_party_id_cookie = 0
 debug = 0
 
 ; This option is an alternative to the debug option above. When set to 1, you can debug tracker request by adding
-; a debug=1 query paramater in the URL. All other HTTP requests will not have debug enabled.
+; a debug=1 query paramater in the URL. All other HTTP requests will not have debug enabled. For security reasons this
+; option should be only enabled if really needed and only for a short time frame. Otherwise anyone can set debug=1 and
+; see the log output as well.
 debug_on_demand = 0
 
 ; This setting is described in this FAQ: http://piwik.org/faq/how-to/faq_175/

--- a/core/Common.php
+++ b/core/Common.php
@@ -1274,15 +1274,17 @@ class Common
                 $info = var_export($info, true);
             }
 
+            $logger = StaticContainer::get('Psr\Log\LoggerInterface');
+
             if (is_array($info) || is_object($info)) {
                 $info = Common::sanitizeInputValues($info);
                 $out = var_export($info, true);
                 foreach (explode("\n", $out) as $line) {
-                    echo $line . "\n";
+                    $logger->debug($line);
                 }
             } else {
                 foreach (explode("\n", $info) as $line) {
-                    echo $line . "\n";
+                    $logger->debug($line);
                 }
             }
         }

--- a/plugins/Monolog/.gitignore
+++ b/plugins/Monolog/.gitignore
@@ -1,0 +1,1 @@
+tests/System/processed/*xml

--- a/plugins/Monolog/Handler/EchoHandler.php
+++ b/plugins/Monolog/Handler/EchoHandler.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Monolog\Handler;
+
+use Monolog\Handler\AbstractProcessingHandler;
+
+/**
+ * Simply echos all messages.
+ */
+class EchoHandler extends AbstractProcessingHandler
+{
+    protected function write(array $record)
+    {
+        $message = $record['level_name'] . ': ' . $record['message'];
+
+        echo $message . "\n";
+    }
+}

--- a/plugins/Monolog/config/config.php
+++ b/plugins/Monolog/config/config.php
@@ -11,17 +11,24 @@ return array(
 
     'Psr\Log\LoggerInterface' => DI\get('Monolog\Logger'),
 
+    'log.handler.classes' => DI\factory(function (ContainerInterface $c) {
+        $classes = array(
+            'file'     => 'Piwik\Plugins\Monolog\Handler\FileHandler',
+            'screen'   => 'Piwik\Plugins\Monolog\Handler\WebNotificationHandler',
+            'database' => 'Piwik\Plugins\Monolog\Handler\DatabaseHandler',
+        );
+
+        return $classes;
+    }),
     'log.handlers' => DI\factory(function (ContainerInterface $c) {
         if ($c->has('ini.log.log_writers')) {
             $writerNames = $c->get('ini.log.log_writers');
         } else {
             return array();
         }
-        $classes = array(
-            'file'     => 'Piwik\Plugins\Monolog\Handler\FileHandler',
-            'screen'   => 'Piwik\Plugins\Monolog\Handler\WebNotificationHandler',
-            'database' => 'Piwik\Plugins\Monolog\Handler\DatabaseHandler',
-        );
+
+        $classes = $c->get('log.handler.classes');
+
         $writerNames = array_map('trim', $writerNames);
         $writers = array();
         foreach ($writerNames as $writerName) {

--- a/plugins/Monolog/config/config.php
+++ b/plugins/Monolog/config/config.php
@@ -11,15 +11,11 @@ return array(
 
     'Psr\Log\LoggerInterface' => DI\get('Monolog\Logger'),
 
-    'log.handler.classes' => DI\factory(function (ContainerInterface $c) {
-        $classes = array(
-            'file'     => 'Piwik\Plugins\Monolog\Handler\FileHandler',
-            'screen'   => 'Piwik\Plugins\Monolog\Handler\WebNotificationHandler',
-            'database' => 'Piwik\Plugins\Monolog\Handler\DatabaseHandler',
-        );
-
-        return $classes;
-    }),
+    'log.handler.classes' => array(
+        'file'     => 'Piwik\Plugins\Monolog\Handler\FileHandler',
+        'screen'   => 'Piwik\Plugins\Monolog\Handler\WebNotificationHandler',
+        'database' => 'Piwik\Plugins\Monolog\Handler\DatabaseHandler',
+    ),
     'log.handlers' => DI\factory(function (ContainerInterface $c) {
         if ($c->has('ini.log.log_writers')) {
             $writerNames = $c->get('ini.log.log_writers');

--- a/plugins/Monolog/config/tracker.php
+++ b/plugins/Monolog/config/tracker.php
@@ -6,7 +6,7 @@ return array(
 
     'Psr\Log\LoggerInterface' => function (ContainerInterface $c) {
         $trackerDebug = $c->get("ini.Tracker.debug");
-        if ($trackerDebug == 1 || $GLOBALS['PIWIK_TRACKER_DEBUG']) {
+        if ($trackerDebug == 1 || !empty($GLOBALS['PIWIK_TRACKER_DEBUG'])) {
             return $c->get('Monolog\Logger');
         } else {
             return new \Psr\Log\NullLogger();

--- a/plugins/Monolog/config/tracker.php
+++ b/plugins/Monolog/config/tracker.php
@@ -6,11 +6,23 @@ return array(
 
     'Psr\Log\LoggerInterface' => function (ContainerInterface $c) {
         $trackerDebug = $c->get("ini.Tracker.debug");
-        if ($trackerDebug == 1) {
+        if ($trackerDebug == 1 || $GLOBALS['PIWIK_TRACKER_DEBUG']) {
             return $c->get('Monolog\Logger');
         } else {
             return new \Psr\Log\NullLogger();
         }
-    }
+    },
+
+    'log.handler.classes' => DI\decorate(function ($previous) {
+        if (isset($previous['screen'])) {
+            $previous['screen'] = 'Piwik\Plugins\Monolog\Handler\EchoHandler';
+        }
+
+        return $previous;
+    }),
+
+    'log.level' => DI\factory(function (ContainerInterface $c) {
+        return \Monolog\Logger::DEBUG;
+    })
 
 );

--- a/plugins/Monolog/tests/Integration/Fixture/LoggerWrapper.php
+++ b/plugins/Monolog/tests/Integration/Fixture/LoggerWrapper.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Monolog\Test\Integration\Fixture;
+namespace Piwik\Plugins\Monolog\tests\Integration\Fixture;
 
 use Piwik\Log;
 

--- a/plugins/Monolog/tests/Integration/LogTest.php
+++ b/plugins/Monolog/tests/Integration/LogTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Monolog\Test\Integration;
+namespace Piwik\Plugins\Monolog\tests\Integration;
 
 use Exception;
 use Piwik\Application\Environment;
@@ -15,7 +15,7 @@ use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Db;
 use Piwik\Log;
-use Piwik\Plugins\Monolog\Test\Integration\Fixture\LoggerWrapper;
+use Piwik\Plugins\Monolog\tests\Integration\Fixture\LoggerWrapper;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**

--- a/plugins/Monolog/tests/System/TrackerLoggingTest.php
+++ b/plugins/Monolog/tests/System/TrackerLoggingTest.php
@@ -27,13 +27,6 @@ class TrackerLoggingTest extends SystemTestCase
     {
         parent::setUp();
 
-        $testingEnvironment = self::$fixture->getTestEnvironment();
-        $configOverride = $testingEnvironment->configOverride;
-        $configOverride['Tracker']['debug'] = 1;
-        $configOverride['log']['log_writers'] = array('screen');
-        $testingEnvironment->configOverride = $configOverride;
-        $testingEnvironment->save();
-
         if (!Fixture::siteCreated($this->idSite)) {
             Fixture::createWebsite('2014-01-01 00:00:00');
         }

--- a/plugins/Monolog/tests/System/TrackerLoggingTest.php
+++ b/plugins/Monolog/tests/System/TrackerLoggingTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Monolog\tests\System;
+
+use Piwik\Config;
+use Piwik\Date;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+use PiwikTracker;
+
+/**
+ * @group Monolog
+ * @group TrackerLoggingTest
+ * @group Plugins
+ */
+class TrackerLoggingTest extends SystemTestCase
+{
+    private $idSite = 1;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $testingEnvironment = self::$fixture->getTestEnvironment();
+        $configOverride = $testingEnvironment->configOverride;
+        $configOverride['Tracker']['debug'] = 1;
+        $configOverride['log']['log_writers'] = array('screen');
+        $testingEnvironment->configOverride = $configOverride;
+        $testingEnvironment->save();
+
+        if (!Fixture::siteCreated($this->idSite)) {
+            Fixture::createWebsite('2014-01-01 00:00:00');
+        }
+    }
+
+    public function test_shouldReturnDebugOutput_IfDebugIsEnabled()
+    {
+        $this->setTrackerConfig(array('debug' => '1'));
+
+        $tracker = $this->buildTracker();
+        $this->assertTrackerResponseContainsLogOutput($tracker);
+    }
+
+    public function test_shouldReturnDebugOutput_IfDebugOnDemandIsEnabled()
+    {
+        $this->setTrackerConfig(array('debug_on_demand' => '1', 'debug' => 0));
+
+        $tracker = $this->buildTracker();
+        $tracker->setDebugStringAppend('debug=1');
+        $this->assertTrackerResponseContainsLogOutput($tracker);
+    }
+
+    public function test_shouldNotReturnDebugOutput_IfDebugOnDemandIsDisabled()
+    {
+        $this->setTrackerConfig(array('debug_on_demand' => '0', 'debug' => 0));
+
+        $tracker = $this->buildTracker();
+        $tracker->setDebugStringAppend('debug=1');
+
+        Fixture::checkResponse($tracker->doTrackPageView('incredible title!'));
+    }
+
+    private function buildTracker()
+    {
+        $t = Fixture::getTracker($this->idSite, Date::factory('2014-01-05 00:01:01')->getDatetime());
+        $t->setDebugStringAppend('debug=1');
+        $t->setTokenAuth(Fixture::getTokenAuth());
+        $t->setUrl('http://example.org/index1.htm');
+
+        return $t;
+    }
+
+    private function assertTrackerResponseContainsLogOutput(PiwikTracker $t)
+    {
+        $response = $t->doTrackPageView('incredible title!');
+
+        $this->assertStringStartsWith("DEBUG: Debug enabled - Input parameters: 
+DEBUG: array (
+DEBUG:   'idsite' => '1',
+DEBUG:   'rec' => '1',
+DEBUG:   'apiv' => '1',", $response);
+    }
+
+    private function setTrackerConfig($trackerConfig)
+    {
+        $testingEnvironment = self::$fixture->getTestEnvironment();
+        $configOverride = $testingEnvironment->configOverride;
+        $configOverride['Tracker'] = $trackerConfig;
+        $configOverride['log']['log_writers'] = array('screen');
+        $testingEnvironment->configOverride = $configOverride;
+        $testingEnvironment->save();
+    }
+
+    public static function provideContainerConfigBeforeClass()
+    {
+        return array(
+            'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger')
+        );
+    }
+
+}

--- a/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
+++ b/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Monolog\Test\Unit\Formatter;
+namespace Piwik\Plugins\Monolog\tests\Unit\Formatter;
 
 use DateTime;
 use Piwik\Plugins\Monolog\Formatter\LineMessageFormatter;

--- a/plugins/Monolog/tests/Unit/Processor/ClassNameProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/ClassNameProcessorTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Monolog\Test\Unit\Processor;
+namespace Piwik\Plugins\Monolog\tests\Unit\Processor;
 
 use Piwik\Plugins\Monolog\Processor\ClassNameProcessor;
 

--- a/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Monolog\Test\Unit\Processor;
+namespace Piwik\Plugins\Monolog\tests\Unit\Processor;
 
 use Piwik\Log;
 use Piwik\Plugins\Monolog\Processor\ExceptionToTextProcessor;

--- a/plugins/Monolog/tests/Unit/Processor/RequestIdProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/RequestIdProcessorTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Monolog\Test\Unit\Processor;
+namespace Piwik\Plugins\Monolog\tests\Unit\Processor;
 
 use PHPUnit_Framework_TestCase;
 use Piwik\Common;

--- a/plugins/Monolog/tests/Unit/Processor/SprintfProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/SprintfProcessorTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Monolog\Test\Unit\Processor;
+namespace Piwik\Plugins\Monolog\tests\Unit\Processor;
 
 use Piwik\Plugins\Monolog\Processor\SprintfProcessor;
 

--- a/plugins/Monolog/tests/Unit/Processor/TokenProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/TokenProcessorTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Monolog\Test\Unit\Processor;
+namespace Piwik\Plugins\Monolog\tests\Unit\Processor;
 
 use Piwik\Plugins\Monolog\Processor\TokenProcessor;
 

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -179,7 +179,11 @@ class TrackerTest extends IntegrationTestCase
 
     public function test_scheduledTasks_CanBeRunThroughTracker_WithOutputIncluded_IfDebugQueryParamUsed()
     {
-        $this->setScheduledTasksToRunInTracker();
+        $environment = $this->setScheduledTasksToRunInTracker();
+        $config = $environment->configOverride;
+        $config['log']['log_writers'] = array('screen');
+        $environment->configOverride = $config;
+        $environment->save();
 
         $urlToTest = $this->getSimpleTrackingUrl() . '&debug=1';
 
@@ -296,6 +300,8 @@ class TrackerTest extends IntegrationTestCase
         $testingEnvironment->addScheduledTask = true;
         $testingEnvironment->configOverride = array('Tracker' => array('scheduled_tasks_min_interval' => 1, 'debug_on_demand' => 1));
         $testingEnvironment->save();
+
+        return $testingEnvironment;
     }
 
     private function addFailingScheduledTaskToTracker($doFatalError)
@@ -381,4 +387,12 @@ class TrackerTest extends IntegrationTestCase
         Option::clearCachedOption(self::TASKS_STARTED_OPTION_NAME);
         $this->assertEquals(1, Option::get(self::TASKS_STARTED_OPTION_NAME));
     }
+
+    public static function provideContainerConfigBeforeClass()
+    {
+        return array(
+            'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger')
+        );
+    }
+
 }


### PR DESCRIPTION
refs #8593 

configuration didn't change. It works as before: `[Tracker]debug=1`
