### PR TITLE
When archiving fails with a SQL exception, also output the plugin name in the exception message to help troubleshooting

### DIFF
--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -136,8 +136,8 @@ class PluginsArchiver
                         $pluginName
                     );
                 } catch (Exception $e) {
-                    $Klass = get_class($e);
-                    $exception = new $Klass($e->getMessage() . " - caused by plugin $pluginName", $e->getCode(), $e);
+                    $className = get_class($e);
+                    $exception = new $className($e->getMessage() . " - caused by plugin $pluginName", $e->getCode(), $e);
 
                     throw $exception;
                 }

--- a/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link    http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\Integration\Archive;
+
+use Piwik\ArchiveProcessor\PluginsArchiver;
+use Piwik\Config;
+use Piwik\Segment;
+use Piwik\Site;
+use Piwik\Db;
+use Piwik\ArchiveProcessor\Parameters;
+use Exception;
+use Piwik\Plugin\Archiver;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Period\Factory as PeriodFactory;
+use Piwik\Tracker\Db\DbException;
+
+class CustomArchiver extends Archiver
+{
+
+    public function aggregateDayReport()
+    {
+        throw new DbException('Failed query foo bar', 42);
+    }
+
+    public function aggregateMultipleReports()
+    {
+        throw new DbException('Failed query foo bar baz', 43);
+    }
+
+}
+
+class CustomPluginsArchiver extends PluginsArchiver
+{
+    protected function getPluginArchivers()
+    {
+        return array(
+            'MyPluginName' => 'Piwik\Tests\Integration\Archive\CustomArchiver'
+        );
+    }
+
+}
+
+/**
+ * @group PluginsArchiver
+ * @group PluginsArchiverTest
+ * @group Core
+ */
+class PluginsArchiverTest extends IntegrationTestCase
+{
+
+    /**
+     * @var PluginsArchiver
+     */
+    private $pluginsArchiver;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2015-01-01 00:00:00');
+
+        $this->pluginsArchiver = new CustomPluginsArchiver($this->createArchiveProcessorParamaters(), $isTemporary = false);
+    }
+
+    private function createArchiveProcessorParamaters()
+    {
+        $oPeriod = PeriodFactory::makePeriodFromQueryParams('UTC', 'day', '2015-01-01');
+
+        $segment = new Segment(false, array(1));
+        $params  = new Parameters(new Site(1), $oPeriod, $segment);
+
+        return $params;
+    }
+
+    /**
+     * @expectedException \Piwik\Tracker\Db\DbException
+     * @expectedExceptionMessage Failed query foo bar - caused by plugin MyPluginName
+     * @expectedExceptionCode 42
+     */
+    public function test_purgeOutdatedArchives_PurgesCorrectTemporaryArchives_WhileKeepingNewerTemporaryArchives_WithBrowserTriggeringEnabled()
+    {
+        $this->pluginsArchiver->callAggregateAllPlugins(1, 1);
+    }
+
+}


### PR DESCRIPTION
fixes #8600

It should append eg `- caused by plugin Actions`. Not sure if there's a better way but seems to do the job.

An example output:

```
INFO [2015-08-20 09:35:47] Will pre-process for website id = 1, period = day, date = last52
INFO [2015-08-20 09:35:47] - pre-processing all visits
ERROR [2015-08-20 09:35:49] Got invalid response from API request: ?module=API&method=API.get&idSite=1&period=day&date=last52&format=php&trigger=archivephp. Response was 'a:2:{s:6:"result";s:5:"error";s:7:"message";s:127:"SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens - caused by plugin Actions";}'
```
