### PR TITLE
New command 'database:optimize-archive-tables' to optimize archive tables (even if on InnoDB).

### DIFF
--- a/core/DataAccess/ArchiveTableCreator.php
+++ b/core/DataAccess/ArchiveTableCreator.php
@@ -33,7 +33,7 @@ class ArchiveTableCreator
     protected static function getTable(Date $date, $type)
     {
         $tableNamePrefix = "archive_" . $type;
-        $tableName = $tableNamePrefix . "_" . $date->toString('Y_m');
+        $tableName = $tableNamePrefix . "_" . self::getTableMonthFromDate($date);
         $tableName = Common::prefixTable($tableName);
 
         self::createArchiveTablesIfAbsent($tableName, $tableNamePrefix);
@@ -98,6 +98,11 @@ class ArchiveTableCreator
         $date      = str_replace(array('archive_numeric_', 'archive_blob_'), '', $tableName);
 
         return $date;
+    }
+
+    public static function getTableMonthFromDate(Date $date)
+    {
+        return $date->toString('Y_m');
     }
 
     public static function getTypeFromTableName($tableName)

--- a/plugins/CoreAdminHome/Commands/OptimizeArchiveTables.php
+++ b/plugins/CoreAdminHome/Commands/OptimizeArchiveTables.php
@@ -27,7 +27,7 @@ class OptimizeArchiveTables extends ConsoleCommand
 
     protected function configure()
     {
-        $this->setName('core:optimize-archive-tables');
+        $this->setName('database:optimize-archive-tables');
         $this->setDescription("Runs an OPTIMIZE TABLE query on the specified archive tables.");
         $this->addArgument("dates", InputArgument::IS_ARRAY | InputArgument::REQUIRED,
             "The months of the archive tables to optimize. Use '" . self::ALL_TABLES_STRING. "' for all dates or '" .

--- a/plugins/CoreAdminHome/Commands/OptimizeArchiveTables.php
+++ b/plugins/CoreAdminHome/Commands/OptimizeArchiveTables.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\Commands;
+
+use Piwik\Common;
+use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\Date;
+use Piwik\Db;
+use Piwik\Plugin\ConsoleCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Administration command that optimizes archive tables (even if they use InnoDB).
+ */
+class OptimizeArchiveTables extends ConsoleCommand
+{
+    const ALL_TABLES_STRING = 'all';
+    const CURRENT_MONTH_STRING = 'now';
+
+    protected function configure()
+    {
+        $this->setName('core:optimize-archive-tables');
+        $this->setDescription("Runs an OPTIMIZE TABLE query on the specified archive tables.");
+        $this->addArgument("dates", InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+            "The months of the archive tables to optimize. Use '" . self::ALL_TABLES_STRING. "' for all dates or '" .
+            self::CURRENT_MONTH_STRING . "' to optimize the current month only.");
+        $this->setHelp("This command can be used to ease or automate maintenance. Instead of manually running "
+            . "OPTIMIZE TABLE queries, the command can be used.");
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $tableMonths = $this->getTableMonthsToOptimize($input);
+
+        foreach ($tableMonths as $month) {
+            $this->optimizeTable($output, 'archive_numeric_' . $month);
+            $this->optimizeTable($output, 'archive_blob_' . $month);
+        }
+    }
+
+    private function optimizeTable(OutputInterface $output, $table)
+    {
+        $output->write("Optimizing table '$table'...");
+
+        $table = Common::prefixTable($table);
+        Db::optimizeTables($table, $force = true);
+
+        $output->writeln("Done.");
+    }
+
+    private function getTableMonthsToOptimize(InputInterface $input)
+    {
+        $dateSpecifier = $input->getArgument('dates');
+        if (count($dateSpecifier) === 1) {
+            $dateSpecifier = reset($dateSpecifier);
+
+            if ($dateSpecifier == self::ALL_TABLES_STRING) {
+                return $this->getAllArchiveTableMonths();
+            } else if ($dateSpecifier == self::CURRENT_MONTH_STRING) {
+                $now = Date::factory('now');
+                return array($now->toString('Y') . '_' . $now->toString('m'));
+            }
+        }
+
+        $tableMonths = array();
+        foreach ($dateSpecifier as $date) {
+            $date = Date::factory($date);
+            $tableMonths[] = $date->toString('Y') . '_' . $date->toString('m');
+        }
+        return $tableMonths;
+    }
+
+    private function getAllArchiveTableMonths()
+    {
+        $tableMonths = array();
+        foreach (ArchiveTableCreator::getTablesArchivesInstalled() as $table) {
+            $tableMonths[] = ArchiveTableCreator::getDateFromTableName($table);
+        }
+        return $tableMonths;
+    }
+}

--- a/plugins/CoreAdminHome/Commands/OptimizeArchiveTables.php
+++ b/plugins/CoreAdminHome/Commands/OptimizeArchiveTables.php
@@ -33,7 +33,8 @@ class OptimizeArchiveTables extends ConsoleCommand
             "The months of the archive tables to optimize. Use '" . self::ALL_TABLES_STRING. "' for all dates or '" .
             self::CURRENT_MONTH_STRING . "' to optimize the current month only.");
         $this->setHelp("This command can be used to ease or automate maintenance. Instead of manually running "
-            . "OPTIMIZE TABLE queries, the command can be used.");
+            . "OPTIMIZE TABLE queries, the command can be used.\n\nYou should run the command if you find your "
+            . "archive tables grow and do not shrink after purging. Optimizing them will reclaim some space.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/plugins/CoreAdminHome/tests/Integration/Commands/OptimizeArchiveTablesTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/OptimizeArchiveTablesTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Integration\Commands;
+
+use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\Date;
+use Piwik\Tests\Framework\TestCase\ConsoleCommandTestCase;
+
+
+/**
+ * @group Core
+ */
+class OptimizeArchiveTablesTest extends ConsoleCommandTestCase
+{
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        ArchiveTableCreator::getNumericTable(Date::factory('2015-01-01'));
+        ArchiveTableCreator::getNumericTable(Date::factory('2015-02-02'));
+        ArchiveTableCreator::getNumericTable(Date::factory('2015-03-03'));
+    }
+
+    /**
+     * @dataProvider getDatesToTest
+     */
+    public function test_Command_OptimizesCorrectTables($dates, $expectedOptimizedTableDates)
+    {
+        $code = $this->applicationTester->run(array(
+            'command' => 'database:optimize-archive-tables',
+            'dates' => $dates,
+            '--dry-run' => true,
+        ));
+
+        $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
+
+        $output = $this->applicationTester->getDisplay();
+
+        preg_match_all('/Optimizing table \'([^\']+)\'/', $output, $matches);
+        $tablesOptimized = $matches[1];
+
+        $expectedOptimizedTables = array();
+        foreach ($expectedOptimizedTableDates as $date) {
+            $expectedOptimizedTables[] = 'archive_numeric_' . $date;
+            $expectedOptimizedTables[] = 'archive_blob_' . $date;
+        }
+
+        $this->assertEquals($expectedOptimizedTables, $tablesOptimized);
+    }
+
+    public function getDatesToTest()
+    {
+        return array(
+            array(
+                array('all'),
+                array('2015_01', '2015_02', '2015_03'),
+            ),
+
+            array(
+                array('now'),
+                array(date('Y_m')),
+            ),
+
+            array(
+                array('2015-01-01', '2015-02-03', '2014-01-01', '2013-05-12', '2015-05-05'),
+                array('2015_01', '2015_02', '2014_01', '2013_05', '2015_05'),
+            ),
+
+            array(
+                array('last1'),
+                array(Date::factory('now')->subMonth(1)->toString('Y_m')),
+            ),
+
+            array(
+                array('last5'),
+                array(
+                    Date::factory('now')->subMonth(1)->toString('Y_m'),
+                    Date::factory('now')->subMonth(2)->toString('Y_m'),
+                    Date::factory('now')->subMonth(3)->toString('Y_m'),
+                    Date::factory('now')->subMonth(4)->toString('Y_m'),
+                    Date::factory('now')->subMonth(5)->toString('Y_m'),
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
I added a quick command to make it easier to maintain or automate maintenance of Piwik. The command forces an optimization of one or more archive tables. I've noticed while supporting some users that even when using InnoDB, it can be necessary to rebuild archive tables. I also noticed, running the queries manually can be tedious and undesired (from the user's perspective), so I created this (small) command.
