### PR TITLE
Use classList API if available

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -402,7 +402,7 @@ if (typeof JSON2 !== 'object') {
     location, top, onerror, document, referrer, parent, links, href, protocol, name, GearsFactory,
     performance, mozPerformance, msPerformance, webkitPerformance, timing, requestStart,
     responseEnd, event, which, button, srcElement, type, target,
-    parentNode, tagName, hostname, className,
+    parentNode, tagName, hostname, className,classList,
     userAgent, cookieEnabled, platform, mimeTypes, enabledPlugin, javaEnabled,
     XMLHttpRequest, ActiveXObject, open, setRequestHeader, onreadystatechange, send, readyState, status,
     getTime, getTimeAlias, setTime, toGMTString, getHours, getMinutes, getSeconds,
@@ -1403,7 +1403,17 @@ if (typeof Piwik !== 'object') {
             },
             hasNodeCssClass: function (node, klassName)
             {
-                if (node && klassName && node.className) {
+                if(!node || !klassName) {
+                    return false;
+                }
+
+                // For modern browsers cf http://caniuse.com/#search=classList
+                if(node.classList) {
+                    return node.classList.contains(klassName);
+                }
+
+                // Compat mode
+                if (node.className) {
                     var classes = typeof node.className === "string" ? node.className.split(' ') : [];
                     if (-1 !== indexOfArray(classes, klassName)) {
                         return true;
@@ -1493,7 +1503,7 @@ if (typeof Piwik !== 'object') {
                     var foundNodes = nodeToSearch.getElementsByClassName(className);
                     return this.htmlCollectionToArray(foundNodes);
                 }
-                
+
                 var children = getChildrenFromNode(nodeToSearch);
 
                 if (!children || !children.length) {


### PR DESCRIPTION
We can use the ClassList API if available on modern browsers cf [Compat-table](http://caniuse.com/#search=classList)

[There is a bug with IE11](https://connect.microsoft.com/IE/Feedback/Details/920755/) (multiples arguments, with add/remove), but it's not  problem
