### PR TITLE
Open popup in a new window when setting opt-out cookies

### DIFF
--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -151,7 +151,6 @@ class OptOutManager
         $this->view->trackVisits = $trackVisits;
         $this->view->nonce = Nonce::getNonce('Piwik_OptOut', 3600);
         $this->view->language = $lang;
-        $this->view->isSafari = $this->isUserAgentSafari();
         $this->view->showConfirmOnly = Common::getRequestVar('showConfirmOnly', false, 'int');
         $this->view->reloadUrl = $reloadUrl;
         $this->view->javascripts = $this->getJavascripts();
@@ -167,14 +166,5 @@ class OptOutManager
     protected function getDoNotTrackHeaderChecker()
     {
         return $this->doNotTrackHeaderChecker;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function isUserAgentSafari()
-    {
-        $userAgent = @$_SERVER['HTTP_USER_AGENT'] ?: '';
-        return strpos($userAgent, 'Safari') !== false && strpos($userAgent, 'Chrome') === false;
     }
 }

--- a/plugins/CoreAdminHome/templates/optOut.twig
+++ b/plugins/CoreAdminHome/templates/optOut.twig
@@ -10,20 +10,16 @@
     {% endif %}
 
     <script>
-        function submitForm(event, form, loadInNewWindow) {
+        function submitForm(event, form) {
             event.preventDefault();
 
-            if (loadInNewWindow) {
-                var newWindow = window.open(form.action + '&time=' + Date.now());
+            var newWindow = window.open(form.action + '&time=' + Date.now());
 
-                setInterval(function () {
-                    if (newWindow.closed) {
-                        window.location.reload();
-                    }
-                }, 1000);
-            } else {
-                form.submit();
-            }
+            setInterval(function () {
+                if (newWindow.closed) {
+                    window.location.reload();
+                }
+            }, 1000);
         }
     </script>
 
@@ -70,11 +66,10 @@
     <br/><br/>
 
     {% if not showConfirmOnly %}
-    {% set loadInNewWindow = true %}
-    <form method="post" action="?module=CoreAdminHome&amp;action=optOut{% if language %}&amp;language={{ language }}{% endif %}{% if loadInNewWindow %}&amp;setCookieInNewWindow=1{% endif %}" {% if loadInNewWindow %}target="_blank"{% endif %}>
+    <form method="post" action="?module=CoreAdminHome&amp;action=optOut{% if language %}&amp;language={{ language }}{% endif %}&amp;setCookieInNewWindow=1" target="_blank">
         <input type="hidden" name="nonce" value="{{ nonce }}" />
         <input type="hidden" name="fuzz" value="{{ "now"|date }}" />
-        <input onclick="submitForm(event, this.form, {{ loadInNewWindow|default(0) }});" type="checkbox" id="trackVisits" name="trackVisits" {% if trackVisits %}checked="checked"{% endif %} />
+        <input onclick="submitForm(event, this.form);" type="checkbox" id="trackVisits" name="trackVisits" {% if trackVisits %}checked="checked"{% endif %} />
         <label for="trackVisits"><strong>
         {% if trackVisits %}
             {{ 'CoreAdminHome_YouAreOptedIn'|translate }} {{ 'CoreAdminHome_ClickHereToOptOut'|translate }}

--- a/plugins/CoreAdminHome/templates/optOut.twig
+++ b/plugins/CoreAdminHome/templates/optOut.twig
@@ -16,10 +16,11 @@
             if (loadInNewWindow) {
                 var newWindow = window.open(form.action + '&time=' + Date.now());
 
-                // when the new window loads, reload this page
-                newWindow.addEventListener('unload', function () {
-                    window.location.reload();
-                }, false);
+                setInterval(function () {
+                    if (newWindow.closed) {
+                        window.location.reload();
+                    }
+                }, 1000);
             } else {
                 form.submit();
             }
@@ -49,7 +50,8 @@
      # otherwise we try to close the window immediately.
      #}
     {% if showConfirmOnly %}
-    <p>{{ 'CoreAdminHome_OptingYouOut'|translate }}</p><script>window.close();</script>
+    <p>{{ 'CoreAdminHome_OptingYouOut'|translate }}</p>
+    <script>window.close();</script>
     <noscript>
     {% endif %}
 
@@ -68,7 +70,7 @@
     <br/><br/>
 
     {% if not showConfirmOnly %}
-    {% set loadInNewWindow = trackVisits %}
+    {% set loadInNewWindow = true %}
     <form method="post" action="?module=CoreAdminHome&amp;action=optOut{% if language %}&amp;language={{ language }}{% endif %}{% if loadInNewWindow %}&amp;setCookieInNewWindow=1{% endif %}" {% if loadInNewWindow %}target="_blank"{% endif %}>
         <input type="hidden" name="nonce" value="{{ nonce }}" />
         <input type="hidden" name="fuzz" value="{{ "now"|date }}" />

--- a/plugins/CoreAdminHome/templates/optOut.twig
+++ b/plugins/CoreAdminHome/templates/optOut.twig
@@ -10,16 +10,21 @@
     {% endif %}
 
     <script>
-        function submitForm(event, form) {
-            event.preventDefault();
+        function submitForm(e, form) {
+            if (e.preventDefault) { // IE8 and below do not support preventDefault
+                e.preventDefault();
+            }
 
-            var newWindow = window.open(form.action + '&time=' + Date.now());
+            var now = Date.now ? Date.now() : (+(new Date())), // Date.now does not exist in < IE8
+                newWindow = window.open(form.action + '&time=' + now);
 
             setInterval(function () {
                 if (newWindow.closed) {
                     window.location.reload();
                 }
             }, 1000);
+
+            return false;
         }
     </script>
 

--- a/plugins/CoreAdminHome/templates/optOut.twig
+++ b/plugins/CoreAdminHome/templates/optOut.twig
@@ -68,7 +68,7 @@
     <br/><br/>
 
     {% if not showConfirmOnly %}
-    {% set loadInNewWindow = isSafari and trackVisits %}
+    {% set loadInNewWindow = trackVisits %}
     <form method="post" action="?module=CoreAdminHome&amp;action=optOut{% if language %}&amp;language={{ language }}{% endif %}{% if loadInNewWindow %}&amp;setCookieInNewWindow=1{% endif %}" {% if loadInNewWindow %}target="_blank"{% endif %}>
         <input type="hidden" name="nonce" value="{{ nonce }}" />
         <input type="hidden" name="fuzz" value="{{ "now"|date }}" />


### PR DESCRIPTION
This PR modifies the opt out form to always use a new window when setting the opt out cookies. This should work around all browsers that have issues w/ 3rd party cookies.

**Note: This approach will break when some pop-up blockers are used.**

**Also Note: This PR is not complete.**

Refs #8578 
# TODO
- [x] Test in IE11.
- [x] Test in Firefox.
- [x] Test in chrome.
- [x] Test in IE7, IE8, IE9.
- [x] Test in Safari on OS X.
