### PR TITLE
fix Wrong "Time Elapsed" in core:archive output

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -730,7 +730,8 @@ class CronArchive
             && !$shouldArchivePeriods
             && $this->shouldArchiveAllSites
         ) {
-            $this->logger->info("Skipped website id $idSite, no visits in the last " . $date . " days, " . $timerWebsite->__toString());
+            $humanReadableDate = $this->formatReadableDateRange($date);
+            $this->logger->info("Skipped website id $idSite, no visits in the $humanReadableDate days, " . $timerWebsite->__toString());
             $this->skipped++;
             return false;
         }
@@ -749,6 +750,19 @@ class CronArchive
         $segmentsThisSite = SettingsPiwik::getKnownSegmentsToArchiveForSite($idSite);
         $segments = array_unique(array_merge($segmentsAllSites, $segmentsThisSite));
         return $segments;
+    }
+
+    private function formatReadableDateRange($date)
+    {
+        if (0 === strpos($date, 'last')) {
+            $readable = 'last ' . str_replace('last', '', $date);
+        } elseif (0 === strpos($date, 'previous')) {
+            $readable = 'previous ' . str_replace('previous', '', $date);
+        } else {
+            $readable = 'last ' . $date;
+        }
+
+        return $readable;
     }
 
     /**
@@ -1242,7 +1256,8 @@ class CronArchive
     private function logArchivedWebsite($idSite, $period, $date, $segmentsCount, $visitsInLastPeriods, $visitsToday, Timer $timer)
     {
         if (strpos($date, 'last') === 0 || strpos($date, 'previous') === 0) {
-            $visitsInLastPeriods = (int)$visitsInLastPeriods . " visits in last " . $date . " " . $period . "s, ";
+            $humanReadable = $this->formatReadableDateRange($date);
+            $visitsInLastPeriods = (int)$visitsInLastPeriods . " visits in $humanReadable " . $period . "s, ";
             $thisPeriod = $period == "day" ? "today" : "this " . $period;
             $visitsInLastPeriod = (int)$visitsToday . " visits " . $thisPeriod . ", ";
         } else {


### PR DESCRIPTION
refs #8621

Should write only once `last` or `previous` and if it showed `last18` it will now show `last 18` 
