### PR TITLE
Always take the minimum number of custom variables from all log tables instead of maximum

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -216,7 +216,7 @@ class GoalManager
         // Copy Custom Variables from Visit row to the Goal conversion
         // Otherwise, set the Custom Variables found in the cookie sent with this request
         $goal += $visitCustomVariables;
-        $maxCustomVariables = CustomVariables::getMaxCustomVariables();
+        $maxCustomVariables = CustomVariables::getNumUsableCustomVariables();
 
         for ($i = 1; $i <= $maxCustomVariables; $i++) {
             if (isset($visitorInformation['custom_var_k' . $i])

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -540,7 +540,7 @@ class Request
         }
 
         $customVariables = array();
-        $maxCustomVars   = CustomVariables::getMaxCustomVariables();
+        $maxCustomVars   = CustomVariables::getNumUsableCustomVariables();
 
         foreach ($customVar as $id => $keyValue) {
             $id = (int)$id;

--- a/core/Tracker/TrackerCodeGenerator.php
+++ b/core/Tracker/TrackerCodeGenerator.php
@@ -63,7 +63,7 @@ class TrackerCodeGenerator
         if ($mergeSubdomains || $mergeAliasUrls) {
             $options .= $this->getJavascriptTagOptions($idSite, $mergeSubdomains, $mergeAliasUrls);
         }
-        $maxCustomVars = CustomVariables::getMaxCustomVariables();
+        $maxCustomVars = CustomVariables::getNumUsableCustomVariables();
 
         if ($visitorCustomVariables && count($visitorCustomVariables) > 0) {
             $options .= '  // you can set up to ' . $maxCustomVars . ' custom variables for each visitor' . PHP_EOL;

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -256,7 +256,7 @@ class VisitorRecognizer
             array_unshift($fields, 'visit_first_action_time');
             array_unshift($fields, 'visit_last_action_time');
 
-            for ($index = 1; $index <= CustomVariables::getMaxCustomVariables(); $index++) {
+            for ($index = 1; $index <= CustomVariables::getNumUsableCustomVariables(); $index++) {
                 $fields[] = 'custom_var_k' . $index;
                 $fields[] = 'custom_var_v' . $index;
             }

--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -292,7 +292,7 @@ class Controller extends ControllerAdmin
 
         $view->defaultReportSiteName = Site::getNameFor($view->idSite);
         $view->defaultSiteRevenue = \Piwik\Metrics\Formatter::getCurrencySymbol($view->idSite);
-        $view->maxCustomVariables = CustomVariables::getMaxCustomVariables();
+        $view->maxCustomVariables = CustomVariables::getNumUsableCustomVariables();
 
         $allUrls = APISitesManager::getInstance()->getSiteUrlsFromId($view->idSite);
         if (isset($allUrls[1])) {

--- a/plugins/CustomVariables/Archiver.php
+++ b/plugins/CustomVariables/Archiver.php
@@ -66,7 +66,7 @@ class Archiver extends \Piwik\Plugin\Archiver
     {
         $this->dataArray = new DataArray();
 
-        $maxCustomVariables = CustomVariables::getMaxCustomVariables();
+        $maxCustomVariables = CustomVariables::getNumUsableCustomVariables();
         for ($i = 1; $i <= $maxCustomVariables; $i++) {
             $this->aggregateCustomVariable($i);
         }

--- a/plugins/CustomVariables/Commands/Info.php
+++ b/plugins/CustomVariables/Commands/Info.php
@@ -28,7 +28,7 @@ class Info extends ConsoleCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $maxVars = CustomVariables::getMaxCustomVariables();
+        $maxVars = CustomVariables::getNumUsableCustomVariables();
 
         if ($this->hasEverywhereSameAmountOfVariables()) {
             $this->writeSuccessMessage($output, array(

--- a/plugins/CustomVariables/tests/Commands/SetNumberOfCustomVariablesTest.php
+++ b/plugins/CustomVariables/tests/Commands/SetNumberOfCustomVariablesTest.php
@@ -65,7 +65,7 @@ class SetNumberOfCustomVariablesTest extends IntegrationTestCase
 
     public function testExecute_ShouldAddMaxCustomVars_IfNumberIsHigherThanActual()
     {
-        $this->assertEquals(5, CustomVariables::getMaxCustomVariables());
+        $this->assertEquals(5, CustomVariables::getNumUsableCustomVariables());
 
         $result = $this->executeCommand(6);
 
@@ -77,13 +77,13 @@ class SetNumberOfCustomVariablesTest extends IntegrationTestCase
         $this->assertContains('Added a variable in scope "Conversion" having the index 6', $result);
         $this->assertContains('Your Piwik is now configured for 6 custom variables.', $result);
 
-        $this->assertEquals(6, CustomVariables::getMaxCustomVariables());
+        $this->assertEquals(6, CustomVariables::getNumUsableCustomVariables());
     }
 
     public function testExecute_ShouldRemoveMaxCustomVars_IfNumberIsLessThanActual()
     {
         $this->executeCommand(6, true);
-        $this->assertEquals(6, CustomVariables::getMaxCustomVariables());
+        $this->assertEquals(6, CustomVariables::getNumUsableCustomVariables());
 
         $result = $this->executeCommand(5);
 
@@ -95,18 +95,18 @@ class SetNumberOfCustomVariablesTest extends IntegrationTestCase
         $this->assertContains('Removed a variable in scope "Conversion" having the index 6', $result);
         $this->assertContains('Your Piwik is now configured for 5 custom variables.', $result);
 
-        $this->assertEquals(5, CustomVariables::getMaxCustomVariables());
+        $this->assertEquals(5, CustomVariables::getNumUsableCustomVariables());
     }
 
     public function testExecute_AddMultiple_RemoveMultiple()
     {
-        $this->assertEquals(5, CustomVariables::getMaxCustomVariables());
+        $this->assertEquals(5, CustomVariables::getNumUsableCustomVariables());
 
         $this->executeCommand(9);
-        $this->assertEquals(9, CustomVariables::getMaxCustomVariables());
+        $this->assertEquals(9, CustomVariables::getNumUsableCustomVariables());
 
         $this->executeCommand(6);
-        $this->assertEquals(6, CustomVariables::getMaxCustomVariables());
+        $this->assertEquals(6, CustomVariables::getNumUsableCustomVariables());
     }
 
     /**

--- a/plugins/CustomVariables/tests/Integration/CustomVariablesTest.php
+++ b/plugins/CustomVariables/tests/Integration/CustomVariablesTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\CustomVariables\tests;
 use Piwik\Plugins\CustomVariables\CustomVariables;
+use Piwik\Plugins\CustomVariables\Model;
 use Piwik\Tracker\Cache;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -18,27 +19,85 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class CustomVariablesTest extends IntegrationTestCase
 {
-    public function testGetMaxCustomVariables_ShouldDetectCorrectNumberOfVariables()
+    public function test_getNumUsableCustomVariables_ShouldDetectCorrectNumberOfVariables()
     {
         Cache::clearCacheGeneral();
-        $this->assertSame(5, CustomVariables::getMaxCustomVariables());
+        $this->assertSame(5, CustomVariables::getNumUsableCustomVariables());
     }
 
-    public function testGetMaxCustomVariables_ShouldCacheTheResult()
+    public function test_getNumUsableCustomVariables_ShouldCacheTheResult()
     {
-        CustomVariables::getMaxCustomVariables();
+        CustomVariables::getNumUsableCustomVariables();
         $cache = Cache::getCacheGeneral();
 
-        $this->assertSame(5, $cache['CustomVariables.MaxNumCustomVariables']);
+        $this->assertSame(5, $cache['CustomVariables.NumUsableCustomVariables']);
     }
 
-    public function testGetMaxCustomVariables_ShouldReadFromCacheIfPossible()
+    public function test_getNumUsableCustomVariables_ShouldReadFromCacheIfPossible()
     {
         $cache = Cache::getCacheGeneral();
-        $cache['CustomVariables.MaxNumCustomVariables'] = 10;
+        $cache['CustomVariables.NumUsableCustomVariables'] = 10;
         Cache::setCacheGeneral($cache);
 
-        $this->assertSame(10, CustomVariables::getMaxCustomVariables());
+        $this->assertSame(10, CustomVariables::getNumUsableCustomVariables());
     }
+
+    public function test_getNumUsableCustomVariables_ShouldReturnMinVariables_IfOneTableHasLessEntriesThanOthers()
+    {
+        $this->assertEquals(5, CustomVariables::getNumUsableCustomVariables());
+
+        $scopes = Model::getScopes();
+
+        // removing custom vars step by step... as soon as one custom var is removed,
+        // it should return the min count of available variables
+        for ($i = 4; $i != -1; $i--) {
+            foreach ($scopes as $scope) {
+                $this->dropCustomVar($scope);
+                $this->assertSame($i, CustomVariables::getNumUsableCustomVariables());
+            }
+        }
+
+        $this->assertEquals(0, CustomVariables::getNumUsableCustomVariables());
+
+        // add custom var, only once all custom vars are written it should write return a higher custom var number
+        for ($i = 1; $i != 7; $i++) {
+            foreach ($scopes as $index => $scope) {
+                $isLastIndex = $index === (count($scopes) - 1);
+
+                $this->addCustomVar($scope);
+
+                if ($isLastIndex) {
+                    $this->assertSame($i, CustomVariables::getNumUsableCustomVariables());
+                    // all scopes have been added, it should consider all custom var counts
+                } else {
+                    $this->assertSame($i - 1, CustomVariables::getNumUsableCustomVariables());
+                    // at least one scope is not added and should therefore return the old custom var count until all
+                    // tables have been updated
+                }
+            }
+        }
+
+        $this->assertEquals(6, CustomVariables::getNumUsableCustomVariables());
+    }
+
+    private function dropCustomVar($scope)
+    {
+        $this->clearCache();
+        $model = new Model($scope);
+        $model->removeCustomVariable();
+    }
+
+    private function addCustomVar($scope)
+    {
+        $this->clearCache();
+        $model = new Model($scope);
+        $model->addCustomVariable();
+    }
+
+    private function clearCache()
+    {
+        Cache::clearCacheGeneral();
+    }
+
 
 }

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -33,7 +33,7 @@ class Model
      */
     public function queryActionsForVisit($idVisit, $actionsLimit)
     {
-        $maxCustomVariables = CustomVariables::getMaxCustomVariables();
+        $maxCustomVariables = CustomVariables::getNumUsableCustomVariables();
 
         $sqlCustomVariables = '';
         for ($i = 1; $i <= $maxCustomVariables; $i++) {

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -250,7 +250,7 @@ class Visitor implements VisitorInterface
         $actionDetails = $model->queryActionsForVisit($idVisit, $actionsLimit);
 
         $formatter = new Formatter();
-        $maxCustomVariables = CustomVariables::getMaxCustomVariables();
+        $maxCustomVariables = CustomVariables::getNumUsableCustomVariables();
 
         foreach ($actionDetails as $actionIdx => &$actionDetail) {
             $actionDetail =& $actionDetails[$actionIdx];


### PR DESCRIPTION
fixes #8555 

I checked Piwik and PiwikPRO plugins and couldn't find any usages of `getMaxCustomVariables`. Added some tests to make sure it works as expected and also did some manual tests of the `info` and `set-max-custom-variables` command on top of the automated tests. Should work as expected.
