### PR TITLE
Remove translators email adresses from translation files

### DIFF
--- a/lang/am.json
+++ b/lang/am.json
@@ -61,7 +61,6 @@
         "Settings": "ቅንብሮች",
         "Table": "ሰንጠረዥ",
         "TagCloud": "መለያ Cloud",
-        "TranslatorEmail": "info@addismap.com",
         "TranslatorName": "Alazar Tekle of <a href=\"http:\/\/www.addismap.com\">Addis Map<\/a> \/ <a href=\"http:\/\/www.map.et\">Ethiopia Map<\/a>",
         "Unknown": "ያልታወቀ",
         "VBarGraph": "አቀባዊ አሞሌ ግራፍ",

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -215,7 +215,6 @@
         "TagCloud": "سحابة وسوم",
         "Total": "مجموع",
         "TotalRevenue": "إجمالي الإيرادات",
-        "TranslatorEmail": "mustafa@i-translate.info, benkheil.abdelouali@gmail.com",
         "TranslatorName": "Mustafa Rawi, Benkheil Abdelouali",
         "Unknown": "غير معروف",
         "Upload": "رفع",

--- a/lang/be.json
+++ b/lang/be.json
@@ -231,7 +231,6 @@
         "Tax": "Падатак",
         "Total": "Агульна",
         "TotalRevenue": "Агульны прыбытак",
-        "TranslatorEmail": "by.marcis@gmail.com, albanardua@gmail.com, iflexion.1@gmail.com",
         "TranslatorName": "Marcis G, <a href=\"http:\/\/finfact.org\">Alban 'r4bble' Ardua<\/a>, Iflexion design",
         "UniquePurchases": "Унікальныя пакупкі",
         "Unknown": "Невядома",

--- a/lang/bg.json
+++ b/lang/bg.json
@@ -345,7 +345,6 @@
         "TotalRatioTooltip": "Това е %1$s от всички %2$s %3$s.",
         "TotalRevenue": "Общо приход",
         "TransitionsRowActionTooltip": "Вижте какво посетителите са правили преди и след посещаването на тази страница",
-        "TranslatorEmail": "kristalin[at]kividesign[dot]com, Virosss[at]abv[dot]bg, tomivr[at]abv[dot]bg, pak69[at]abv[dot]bg, pamir[at]abv[dot]bg",
         "TranslatorName": "Kristalin Chavdarov, <a href=\"http:\/\/coffebreak.info\">Андон Иванов<\/a>, Tom Atanasov, Dimitar Stamenov, Панайотис Кондоянис",
         "UniquePurchases": "Уникални поръчки",
         "Unknown": "Неизвестен",

--- a/lang/bn.json
+++ b/lang/bn.json
@@ -52,7 +52,6 @@
         "SmtpUsername": "SMTP ব্যবহারকারীর নাম",
         "Table": "সারণি",
         "Total": "সর্বমোট",
-        "TranslatorEmail": "-",
         "TranslatorName": "Anjan Dutta, Rezaul Hasan",
         "Upload": "আপলোড",
         "Username": "ব্যবহারকারীর নাম",

--- a/lang/bs.json
+++ b/lang/bs.json
@@ -273,7 +273,6 @@
         "TimeOnPage": "Vrijeme na stranici",
         "Total": "Ukupno",
         "TotalRevenue": "Ukupna zarada",
-        "TranslatorEmail": "translations@piwik.org",
         "TranslatorName": "Piwik",
         "UniquePurchases": "Jedinstvene narudžbe",
         "Unknown": "Nepoznato",

--- a/lang/ca.json
+++ b/lang/ca.json
@@ -310,7 +310,6 @@
         "TotalRevenue": "Total Ingressos",
         "TransitionsRowActionTooltip": "Observar que van fer els visitants abans i desprès de veure aquesta pàgina",
         "TransitionsRowActionTooltipTitle": "Obre les transicions",
-        "TranslatorEmail": "isb1009 [at] [don't write this] astronomipedia [dot] es,jjuvan@grn.cat",
         "TranslatorName": "Isaac Sánchez Barrera, Joan Juvanteny",
         "UniquePurchases": "Compres úniques",
         "Unknown": "Desconegut",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -351,7 +351,6 @@
         "TotalRevenue": "Celková hodnota",
         "TransitionsRowActionTooltip": "Podívejte se, co dělali návštěvníci před a po návštěvě této stránky",
         "TransitionsRowActionTooltipTitle": "Otevřít přechody",
-        "TranslatorEmail": "info@joomladev.eu, salab@email.cz, michal@cihar.com",
         "TranslatorName": "Filip Bartmann, Jakub Baláš, Michal Čihař",
         "UniquePurchases": "Jedineční nakupující",
         "Unknown": "Neznámý",

--- a/lang/cy.json
+++ b/lang/cy.json
@@ -199,7 +199,6 @@
         "Tax": "Treth",
         "Total": "Cyfanswm",
         "TotalRevenue": "Cyfanswm Refeniw",
-        "TranslatorEmail": "hefinw@deudraeth.net",
         "TranslatorName": "Hefin Williams",
         "UniquePurchases": "Pryniant Unigol",
         "Unknown": "Anadnabyddus",

--- a/lang/da.json
+++ b/lang/da.json
@@ -345,7 +345,6 @@
         "TotalRevenue": "Indtægter i alt",
         "TransitionsRowActionTooltip": "See hvad besøgende gjorde før og efter de så denne side",
         "TransitionsRowActionTooltipTitle": "Åben overgange",
-        "TranslatorEmail": "danieljuhl@gmail.com, jsm@janz.dk",
         "TranslatorName": "<a href=\"http:\/\/danieljuhl.dk\/\">Daniel Juhl<\/a>, jan madsen",
         "UniquePurchases": "Unikke køb",
         "Unknown": "Ukendt",

--- a/lang/de.json
+++ b/lang/de.json
@@ -356,7 +356,6 @@
         "TotalVisitsPageviewsActionsRevenue": "(Gesamt: %s Besuche, %s Seitenansichten, %s Aktionen, %s Einnahmen)",
         "TransitionsRowActionTooltip": "Die Aktionen vor und nach dieser Seite auswerten",
         "TransitionsRowActionTooltipTitle": "Transitions öffnen",
-        "TranslatorEmail": "frank@bueltge.de, piwik@thorstentaube.de, arthur.borens@gmx.de, mail@marco-ziesing.de, andreas.just@cmsmadesimple.de, halfdan@xnorfz.de, ich@pascal90.de, christian@conlabz.de, michael.stenz@email.de, djsoldier1988@gmail.com, de@piwik.org,sebastian.gumprich@38.de",
         "TranslatorName": "Frank Bueltge, Thorsten Taube, Arthur W. Borens, Marco Ziesing, Andreas Just, Fabian Becker, Henry Müller, Pascal Herbert, Christian W. Schneider, Michael Stenz, Itransition, Timo Besenreuther",
         "UniquePurchases": "Eindeutige Käufe",
         "Unknown": "unbekannt",

--- a/lang/el.json
+++ b/lang/el.json
@@ -356,7 +356,6 @@
         "TotalVisitsPageviewsActionsRevenue": "(Σύνολα: %s επισκέψεις, %s προβολές σελίδων, %s ενέργειες, %s κέρδος)",
         "TransitionsRowActionTooltip": "Δείτε τι έκαναν οι επισκέπτες πριν και μετά την προβολή αυτής της σελίδας",
         "TransitionsRowActionTooltipTitle": "Άνοιγμα Μεταβάσεων",
-        "TranslatorEmail": "jimaek@hotmail.com, info@onsite.net.gr, papaz_p@yahoo.com",
         "TranslatorName": "Jim Black www.jblack.info, Γεώργιος Τέλλος OnSite.Net VoIP & IT Solutions, Παναγιώτης Παπάζογλου Δρ. Δασολόγος-Περιβαλλοντολόγος, <a href=\"http:\/\/www.lourdas.name\">Λούρδας Βασίλειος<\/a>",
         "UniquePurchases": "Μοναδικές Παραγγελίες",
         "Unknown": "Άγνωστο",

--- a/lang/en.json
+++ b/lang/en.json
@@ -356,7 +356,6 @@
         "TotalVisitsPageviewsActionsRevenue": "(Total: %s visits, %s pageviews, %s actions, %s revenue)",
         "TransitionsRowActionTooltip": "See what visitors did before and after viewing this page",
         "TransitionsRowActionTooltipTitle": "Open Transitions",
-        "TranslatorEmail": "hello@piwik.org",
         "TranslatorName": "-",
         "UniquePurchases": "Unique Purchases",
         "Unknown": "Unknown",

--- a/lang/es.json
+++ b/lang/es.json
@@ -355,7 +355,6 @@
         "TotalRevenue": "Ingresos totales",
         "TransitionsRowActionTooltip": "Vea que hicieron los visitantes antes y después de observar esta página",
         "TransitionsRowActionTooltipTitle": "Transiciones abiertas",
-        "TranslatorEmail": "ahriman89@gmail.com, ddiods@hotmail.com, fersfeir@niux.com.ar, magallania@gmail.com, dave96@dtecno.com, hnicolas.suero@gmail.com, paolo@psdmedia.se,",
         "TranslatorName": "Marcos Alberto Sanmartín Pereira, David Ernesto Soto Vásquez, Fernando SFEIR, Darío Hereñu, David Álvarez Robert, Adrián Seldes, Héctor Nicolás Suero",
         "UniquePurchases": "Compras únicas",
         "Unknown": "Desconocido",

--- a/lang/et.json
+++ b/lang/et.json
@@ -262,7 +262,6 @@
         "TotalRevenue": "Kogutulu",
         "TransitionsRowActionTooltip": "Vaata mida külastajad tegid enne ja peale selle lehe vaatamist",
         "TransitionsRowActionTooltipTitle": "Ava üleminekud",
-        "TranslatorEmail": "aivo.koger@gmail.com, toomingas.k@gmail.com",
         "TranslatorName": "<a href=\"http:\/\/ee.linkedin.com\/in\/aivokoger\/\">Aivo Koger<\/a>, Kaido Toomingas",
         "UniquePurchases": "Unikaalseid oste",
         "Unknown": "Tundmatu",

--- a/lang/eu.json
+++ b/lang/eu.json
@@ -127,7 +127,6 @@
         "SmtpUsername": "SMTP erabiltzaile-izena",
         "Table": "Taula",
         "TagCloud": "Etiketa-hodeia",
-        "TranslatorEmail": "librezale@librezale.org",
         "TranslatorName": "Librezale.org",
         "Unknown": "Ezezaguna",
         "Username": "Erabiltzaile-izena",

--- a/lang/fa.json
+++ b/lang/fa.json
@@ -315,7 +315,6 @@
         "TotalRevenue": "درآمد کل",
         "TransitionsRowActionTooltip": "کارهایی که بازدیدکنندگان قبل و بعد از دیدن این صفحه انجام داده اند را ببینید",
         "TransitionsRowActionTooltipTitle": "انتقال های باز",
-        "TranslatorEmail": "rasez_secure@yahoo.com, info[at]sweddata[.]com , info[at]parsigate[.]com , Hojat.ghanad@gmail.com",
         "TranslatorName": "reza abbasi, <a href=\"http:\/\/parsigate.com\">ParsiGate and Sweddata<\/a>, Hojat Ghanad",
         "UniquePurchases": "خرید های متفاوت",
         "Unknown": "ناشناس",

--- a/lang/fi.json
+++ b/lang/fi.json
@@ -346,7 +346,6 @@
         "TotalRevenue": "Tulot yhteensä",
         "TransitionsRowActionTooltip": "Näe mitä kävijät tekivät ennen ja jälkeen tällä sivulla käymistä",
         "TransitionsRowActionTooltipTitle": "Avaa muutokset",
-        "TranslatorEmail": "olli@jarva.fi, sara@alennuskoodia.fi",
         "TranslatorName": "<a href=\"http:\/\/olli.jarva.fi\/\">Olli Jarva<\/a>, <a href=\"http:\/\/www.alennuskoodia.fi\/\">Alennuskoodia.fi<\/a>",
         "UniquePurchases": "Uniikit ostot",
         "Unknown": "Tuntematon",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -356,7 +356,6 @@
         "TotalVisitsPageviewsActionsRevenue": "(Total : %s visites, %s pages vues, %s actions, %s revenu)",
         "TransitionsRowActionTooltip": "Visualisez ce que les visiteurs ont fait après avoir visité cette page",
         "TransitionsRowActionTooltipTitle": "Ouvrir les transitions",
-        "TranslatorEmail": "admin@get-surf.com, piwik@ludovicevrard.be, daniel@castronovo.fr,",
         "TranslatorName": "<a href=\"http:\/\/microsofttouch.fr\/default\/b\/vincent\/default.aspx\">Vincent BIRET<\/a>, <a href=\"http:\/\/www.ludovicevrard.com\">Ludovic Evrard<\/a>, Daniel Castronovo",
         "UniquePurchases": "Achats uniques",
         "Unknown": "Inconnu",

--- a/lang/gl.json
+++ b/lang/gl.json
@@ -114,7 +114,6 @@
         "Settings": "Configuración",
         "Table": "Táboa",
         "TagCloud": "Nube de etiquetas",
-        "TranslatorEmail": "info@ousli.org",
         "TranslatorName": "OUSLI - Ourense Software Libre, Antonio Andina",
         "Unknown": "Descoñecido",
         "Username": "Usuario",

--- a/lang/he.json
+++ b/lang/he.json
@@ -190,7 +190,6 @@
         "Table": "טבלה",
         "TagCloud": "ענן תגים",
         "Total": "סך הכל",
-        "TranslatorEmail": "nirlah@gmail.com",
         "TranslatorName": "<a href=\"http:\/\/www.nirlah.com\">Nirlah - Nir Lahad<\/a>",
         "Unknown": "לא ידוע",
         "Upload": "העלאה",

--- a/lang/hi.json
+++ b/lang/hi.json
@@ -341,7 +341,6 @@
         "TotalRevenue": "कुल राजस्व",
         "TransitionsRowActionTooltip": "पहले और इस पृष्ठ को देखने के बाद दर्शकों ने क्या किया देखें",
         "TransitionsRowActionTooltipTitle": "ओपन बदलाव",
-        "TranslatorEmail": "ashish@ajoft.com",
         "TranslatorName": "<a href=\"http:\/\/www.ajoft.com\/\">Ajoft Softwares<\/a> , <a href=http:\/\/search-sos.org>Ritesh Kumar<\/a> , <a href=http:\/\/www.best-whiteningstrips.com\/>Rahul Patil<\/a>",
         "UniquePurchases": "अद्वितीय खरीद",
         "Unknown": "अज्ञात",

--- a/lang/hr.json
+++ b/lang/hr.json
@@ -260,7 +260,6 @@
         "Tax": "Porez",
         "Total": "Ukupno",
         "TotalRevenue": "Ukupan prihod",
-        "TranslatorEmail": "riba@ml1.net, mirko@domidona.com",
         "TranslatorName": "Tomislav Ribičić, Mirko Lednicki",
         "UniquePurchases": "Jedinstvene kupovine",
         "Unknown": "Nepoznato",

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -219,7 +219,6 @@
         "Tax": "Adó",
         "Total": "Összesítve",
         "TotalRevenue": "Teljes bevétel",
-        "TranslatorEmail": "en@innen.hu, fityazz@yahoo.co.uk, kw@kardiweb.org",
         "TranslatorName": "József Jároli, Viktor Horvath & Mr. Balu, KardiWeb",
         "UniquePurchases": "Egyedi vásárlások",
         "Unknown": "Ismeretlen",

--- a/lang/id.json
+++ b/lang/id.json
@@ -312,7 +312,6 @@
         "TotalRevenue": "Jumalh Pendapatan",
         "TransitionsRowActionTooltip": "Lihat apa yang pengujung lakukan sebelum dan sesudah melihat halaman ini",
         "TransitionsRowActionTooltipTitle": "Buka Peralihan",
-        "TranslatorEmail": "translationsproject-b@yuah.web.id, jakenenator@gmail.com, hendry.lee@gmail.com",
         "TranslatorName": "<a href=\"http:\/\/alihbahasa.yuah.web.id\/?asal=piwikfl\">Bayu Aditya H<\/a>, Djaka PM, Hendry Lee",
         "UniquePurchases": "Pembelian Unik",
         "Unknown": "TakTahu",

--- a/lang/is.json
+++ b/lang/is.json
@@ -136,7 +136,6 @@
         "SmtpUsername": "SMTP notendanafn",
         "Table": "Tafla",
         "TagCloud": "Klisjuský",
-        "TranslatorEmail": "annaj@hi.is, ivarbj@hi.is, johannbg@gmail.com",
         "TranslatorName": "Anna Jonna Ármannsdóttir, Ívar Björn Hilmarsson, Jóhann B. Guðmundsson",
         "Unknown": "Óþekkt",
         "Username": "Notandanafn",

--- a/lang/it.json
+++ b/lang/it.json
@@ -354,7 +354,6 @@
         "TotalRevenue": "Totale guadagni",
         "TransitionsRowActionTooltip": "Guarda cosa hanno fatto i visitatori prima e dopo aver visto questa pagina",
         "TransitionsRowActionTooltipTitle": "Apri Transizioni",
-        "TranslatorEmail": "php_staff@yahoo.it, francesco@pixelstyle.it, contact@yusefmaali.net, aepic@cilea.it, fabriziorocca.bolzano@gmail.com, tmosbyd@gmail.com, info@alfioemanuele.it, giovanni94m@yahoo.it, blau@anche.no",
         "TranslatorName": "Alessandro Coscia, Giovdi, Yusef Maali, Andrea Marchitelli (CILEA), Fabrizio Rocca, Ted Mosby, Alfio E. Fresta, Giovanni Matina, Blau",
         "UniquePurchases": "Acquisti unici",
         "Unknown": "Sconosciuto",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -347,7 +347,6 @@
         "TotalRevenue": "総収益",
         "TransitionsRowActionTooltip": "訪問者が、このページの表示前後に何をしていたか見てください",
         "TransitionsRowActionTooltipTitle": "トランジションを開く",
-        "TranslatorEmail": "hello@piwik.org",
         "TranslatorName": "Takafumi\/Drupal Japan - http:\/\/drupal.jp Takeshi Ueda\/Piwik Japan Team - http:\/\/piwikjapan.org",
         "UniquePurchases": "ユニークな購入",
         "Unknown": "不明",

--- a/lang/ka.json
+++ b/lang/ka.json
@@ -158,7 +158,6 @@
         "SmtpUsername": "SMTP მომხმრებელი",
         "Table": "ცხრილი",
         "TagCloud": "ტეგების ერთობლიობა",
-        "TranslatorEmail": "kasia@pawel.com",
         "TranslatorName": "Kasia",
         "Unknown": "უცნობი",
         "Username": "მომხმარებლის სახელი",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -291,7 +291,6 @@
         "TotalRevenue": "총 수익",
         "TransitionsRowActionTooltip": "이 페이지를 조회하기 이전의 방문자 행동 추적",
         "TransitionsRowActionTooltipTitle": "트렌지션 열기",
-        "TranslatorEmail": "soulofpure@hotmail.com, to@firejune.com",
         "TranslatorName": "Jong-In Kim, <a href=\"http:\/\/firejune.com\">Joon Kyoung<\/a>",
         "UniquePurchases": "고유 주문",
         "Unknown": "알수없음",

--- a/lang/lt.json
+++ b/lang/lt.json
@@ -215,7 +215,6 @@
         "TimeAgo": "prieš %s",
         "Total": "Iš viso",
         "TotalRevenue": "Pajamų iš viso",
-        "TranslatorEmail": "info@teraxit.com",
         "TranslatorName": "Donatas Stonys (Blue Whale SEO)",
         "UniquePurchases": "Unikalūs pirkimai",
         "Unknown": "Nežinoma",

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -216,7 +216,6 @@
         "Tax": "Nodokļi",
         "Total": "Kopā",
         "TotalRevenue": "Kopējie ienākumi",
-        "TranslatorEmail": "piwik@apps.lv",
         "TranslatorName": "Ēriks Remess",
         "UniquePurchases": "Unikāli pirkumi",
         "Unknown": "Nezināms",

--- a/lang/nb.json
+++ b/lang/nb.json
@@ -331,7 +331,6 @@
         "Total": "Totalt",
         "TotalRatioTooltip": "Dette er %1$s av alle %2$s %3$s.",
         "TotalVisitsPageviewsActionsRevenue": "(Totalt: %s besøk, %s sidevisninger, %s handlinger, %s inntekter)",
-        "TranslatorEmail": "hans@nordhaug.priv.no",
         "TranslatorName": "Hans Fredrik Nordhaug",
         "UniquePurchases": "Unike kjøp",
         "Unknown": "Ukjent",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -355,7 +355,6 @@
         "TotalRevenue": "Totale Inkomsten",
         "TransitionsRowActionTooltip": "Bekijk wat bezoekers voor en na het bekijken van deze pagina deden",
         "TransitionsRowActionTooltipTitle": "Open transities",
-        "TranslatorEmail": "martijn@mvanlaar.net, hannes@randomize.be, benkheil.abdelouali@gmail.com, info@depree.nl, richardmastop@gmail.com",
         "TranslatorName": "Martijn van Laar, Hannes Bossuyt, Sigge Stegeman, Taco Vader, Benkheil Abdelouali, Ko de Pree, Richard Mastop",
         "UniquePurchases": "Unieke Aankopen",
         "Unknown": "Onbekend",

--- a/lang/nn.json
+++ b/lang/nn.json
@@ -240,7 +240,6 @@
         "Tax": "MVA",
         "Total": "Total",
         "TotalRevenue": "Totale inntekter",
-        "TranslatorEmail": "kristoffer.egil@bonarjee.in,simonboba@gmail.com",
         "TranslatorName": "Kristoffer Egil Bonarjee,Simon Hansen",
         "UniquePurchases": "Unike sal",
         "Unknown": "Ukjent",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -323,7 +323,6 @@
         "TotalRatioTooltip": "To jest %1$s wszystkich %2$s %3$s.",
         "TotalRevenue": "Przychody ogółem",
         "TransitionsRowActionTooltipTitle": "Otwarte przejścia",
-        "TranslatorEmail": "remigiusz.waszkiewicz@gmail.com, marcin@kowol.pl, maciej@brandnewmedia.pl, kontakt@awarchol.pl, onemac@onemac.pl, t.kornicki@lemonsky.pl",
         "TranslatorName": "<a href=\"http:\/\/eliteria.pl\">Remigiusz Waszkiewicz<\/a>, Marcin Kowol, Maciej Zawadziński, Artur Warchoł,AETERNUS, Tomasz Kornicki",
         "UniquePurchases": "Unikalnych zakupów",
         "Unknown": "Nieznany",

--- a/lang/pt-br.json
+++ b/lang/pt-br.json
@@ -348,7 +348,6 @@
         "TotalRevenue": "Total de Revendas",
         "TransitionsRowActionTooltip": "Veja o que os visitantes fizeram antes e depois de ver este página",
         "TransitionsRowActionTooltipTitle": "Transições abertas",
-        "TranslatorEmail": "marcusbacus@gmail.com, mah_ferraro@yahoo.com.br, ramilani@gmail.com, rodrigues_fernando@hotmail.com",
         "TranslatorName": "Marcos Napier, Marcela Ferraro, Zob, Raphael Milani, Fernando Fraga Rodrigues",
         "UniquePurchases": "Pedidos únicos",
         "Unknown": "Desconhecido",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -235,7 +235,6 @@
         "Tax": "Imposto",
         "Total": "Total",
         "TotalRevenue": "Total de Receitas",
-        "TranslatorEmail": "epages@epages.com.br, supsuper@gmail.com",
         "TranslatorName": "Rodrigo \"Acid Rain\" Kroehn, Daniel \"SupSuper\" Albano, Zob, AlexVasques",
         "UniquePurchases": "Compras Únicas",
         "Unknown": "Desconhecido",

--- a/lang/ro.json
+++ b/lang/ro.json
@@ -332,7 +332,6 @@
         "TotalRevenue": "Venit total",
         "TransitionsRowActionTooltip": "Vezi ce au făcut vizitatorii până la şi după vizionarea acestei pagini",
         "TransitionsRowActionTooltipTitle": "Treceri Deschise",
-        "TranslatorEmail": "astonsoftware@gmail.com, flo[at]inboxtranslation[dot]com",
         "TranslatorName": "astonsoftware, <a href=\"http:\/\/inboxtranslations.com\">Inbox Translation<\/a>, <a href=\"http:\/\/marcelbejgu.ro\">Marcel Bejgu<\/a>",
         "UniquePurchases": "Cumparaturi unice",
         "Unknown": "Necunoscut",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -347,7 +347,6 @@
         "TotalRevenue": "Общая прибыль",
         "TransitionsRowActionTooltip": "Посмотрите, что посетители делали до и после просмотра этой страницы",
         "TransitionsRowActionTooltipTitle": "Открыть переходы",
-        "TranslatorEmail": "ademaro@ya.ru, i@codax.ru, heyheyftw@gmail.com, onix@onix.name, taktip@gmail.com, djsoldier@mail.ru",
         "TranslatorName": "Ademaro, <a href=\"http:\/\/jokerintertactive.ru\/\">Joker Interactive<\/a>, <a href=\"http:\/\/codax.ru\/\">Важенин Илья (компания Codax)<\/a>, Nelde Maxim, Andrey, Vadim Nekhai",
         "UniquePurchases": "Уникальные покупки",
         "Unknown": "Неизвестно",

--- a/lang/sk.json
+++ b/lang/sk.json
@@ -352,7 +352,6 @@
         "TotalRevenue": "Celkový príjem",
         "TransitionsRowActionTooltip": "Pozrite si čo robili návštevníci pred a po prezretí si tejto stránky.",
         "TransitionsRowActionTooltipTitle": "Otvorené zmeny",
-        "TranslatorEmail": "miroslav.habara@gmail.com, zdenop@gmail.com, viktorin@automotopneu.sk",
         "TranslatorName": "Miroslav Habara, Zdenko Podobný, Juraj \"Lup0\" Viktorín, <a href=\"http:\/\/www.coupofy.com \">Ivanka<\/a>",
         "UniquePurchases": "Unikátne nákupy",
         "Unknown": "Neznáme",

--- a/lang/sl.json
+++ b/lang/sl.json
@@ -347,7 +347,6 @@
         "TotalRevenue": "Skupni prihodki",
         "TransitionsRowActionTooltip": "Poglejte kaj so obiskovalci počeli pred in potem, ko so obiskali to stran",
         "TransitionsRowActionTooltipTitle": "Odpri prehode",
-        "TranslatorEmail": "alazanski@tuts23.com, tom@hupso.com",
         "TranslatorName": "Aleksej Lazanski, <a href=\"http:\/\/www.hupso.com\">Tom Merc<\/a>",
         "UniquePurchases": "Edinstveni nakupi",
         "Unknown": "Neznano",

--- a/lang/sq.json
+++ b/lang/sq.json
@@ -346,7 +346,6 @@
         "TotalRevenue": "Të ardhura Gjithsej",
         "TransitionsRowActionTooltip": "See what visitors did before and after viewing this page",
         "TransitionsRowActionTooltipTitle": "Open Transitions",
-        "TranslatorEmail": "besnik@programeshqip.org",
         "TranslatorName": "Besnik Bleta",
         "UniquePurchases": "Blerje Unike",
         "Unknown": "I panjohur",

--- a/lang/sr.json
+++ b/lang/sr.json
@@ -348,7 +348,6 @@
         "TotalRevenue": "Ukupan prihod",
         "TransitionsRowActionTooltip": "Pogledajte šta su posetioci radili pre i posle posete ovoj stranici",
         "TransitionsRowActionTooltipTitle": "Otvori tranzicije",
-        "TranslatorEmail": "petar@benke.co.uk, info@maksin.ms, nikola@codingcat.com",
         "TranslatorName": "Petar Benke, Branislav Maksin, Nikola Stojković",
         "UniquePurchases": "Jedinstvene porudžbine",
         "Unknown": "Nepoznato",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -355,7 +355,6 @@
         "TotalRevenue": "Totala intäkter",
         "TransitionsRowActionTooltip": "Se vad besökarna gjorde före och efter att ha tittat på den här sidan",
         "TransitionsRowActionTooltipTitle": "Öppna övergångar",
-        "TranslatorEmail": "fredrik@lagun.se, tony@d0h.us",
         "TranslatorName": "<a href=\"http:\/\/xn--skmotoroptimering-zzb.se\/\">Sökmotoroptimering.se<\/a>, <a href=\"http:\/\/www.kampanjjakt.se\/\">Kampanjjakt.se<\/a>, <a href=\"http:\/\/www.lagun.se\/\">Fredrik Astrom<\/a>, <a href=\"http:\/\/www.dumsnal.se\/\">Tony<\/a>",
         "UniquePurchases": "Unika beställningar",
         "Unknown": "Okänt",

--- a/lang/ta.json
+++ b/lang/ta.json
@@ -178,7 +178,6 @@
         "Total": "மொத்தம்",
         "TotalRevenue": "மொத்த வருமானம்",
         "TransitionsRowActionTooltipTitle": "வெளிப்படையான மாற்றங்கள்",
-        "TranslatorEmail": "hello@piwik.org",
         "TranslatorName": "-",
         "UniquePurchases": "தனிப்பட்ட கொள்முதல்கள்",
         "Unknown": "தெரியாத",

--- a/lang/te.json
+++ b/lang/te.json
@@ -100,7 +100,6 @@
         "TagCloud": "ట్యాగు మేఘం",
         "Total": "మొత్తం",
         "TotalRevenue": "మొత్తం ఆదాయం",
-        "TranslatorEmail": "veeven@gmail.com",
         "TranslatorName": "వీవెన్ (Veeven)",
         "Upload": "ఎక్కించు",
         "Username": "వాడుకరి పేరు",

--- a/lang/th.json
+++ b/lang/th.json
@@ -259,7 +259,6 @@
         "TimeOnPage": "เวลาในหน้า",
         "Total": "รวม",
         "TotalRevenue": "รายได้รวม",
-        "TranslatorEmail": "jaideejung007@gmail.com",
         "TranslatorName": "coyoty, jaideejung007, ariesanywhere",
         "UniquePurchases": "Unique Purchases",
         "Unknown": "ไม่รู้จัก",

--- a/lang/tl.json
+++ b/lang/tl.json
@@ -300,7 +300,6 @@
         "Segment": "Bahagi",
         "SelectYesIfYouWantToSendEmailsViaServer": "Piliin ang \"Oo\" kung gusto mo o magpadala ng e-mail sa pamamagitan ng isang server sa halip na ang mga lokal na mail function.",
         "Table": "Talahanayan",
-        "TranslatorEmail": "hello@piwik.org",
         "TranslatorName": "<a href=\"http:\/\/intripid.com\/\">Intripid<\/a>",
         "View": "Tingnan",
         "Visitors": "Mga Bisita",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -264,7 +264,6 @@
         "Total": "Toplam",
         "TotalRevenue": "Toplam Kazanç",
         "TransitionsRowActionTooltipTitle": "Açık Geçişler",
-        "TranslatorEmail": "halfdan@xnorfz.de, dev@yazici.info, hello@emresaracoglu.com",
         "TranslatorName": "Fabian Becker, Emre Yazici, Emre Saraçoğlu, <a href=\"http:\/\/www.ugureskici.com\" target=\"_blank\">Uğur Eskici<\/a>",
         "UniquePurchases": "Tekil Satın Alımlar",
         "Unknown": "Bilinmeyen",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -156,7 +156,6 @@
         "SmtpUsername": "SMTP логін",
         "Table": "Таблиця",
         "TagCloud": "Хмара тегів",
-        "TranslatorEmail": "joseph.chereshnovsky@gmail.com, x.meglio@gmail.com",
         "TranslatorName": "<a href=\"http:\/\/webdevbyjoss.blogspot.com\/\">Joseph Chereshnovsky<\/a>, Anton Andriyevskyy",
         "Unknown": "Невідомо",
         "Username": "Логін",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -321,7 +321,6 @@
         "TotalRevenue": "Tổng doanh thu",
         "TransitionsRowActionTooltip": "Xem những gì khách truy cập đã làm trước và sau khi xem trang này.",
         "TransitionsRowActionTooltipTitle": "mở quá trình chuyển đổi",
-        "TranslatorEmail": "canhrgv@gmail.com",
         "TranslatorName": "Do Cong Anh",
         "UniquePurchases": "Mua sắm duy nhất",
         "Unknown": "Chưa rõ",

--- a/lang/zh-cn.json
+++ b/lang/zh-cn.json
@@ -323,7 +323,6 @@
         "TotalRevenue": "订单总额",
         "TransitionsRowActionTooltip": "查看访客浏览这个页面之前和之后的活动",
         "TransitionsRowActionTooltipTitle": "显示转换分析",
-        "TranslatorEmail": "admin@piwik.cn",
         "TranslatorName": "<a href=\"http:\/\/www.piwik.cn\/\">Jack Huang<\/a>, <a href=\"http:\/\/www.binaryoung.com\/\">Young<\/a>, Marine.Ming",
         "UniquePurchases": "唯一身份购买者",
         "Unknown": "未知",

--- a/lang/zh-tw.json
+++ b/lang/zh-tw.json
@@ -178,7 +178,6 @@
         "SmtpUsername": "SMTP 使用者名稱",
         "Table": "表格",
         "TagCloud": "標籤雲",
-        "TranslatorEmail": "pserics@gmail.com, php.twn@gmail.com",
         "TranslatorName": "<a href=\"http:\/\/www.freegroup.org\/\">Pseric<\/a>, Eros",
         "Unknown": "未知",
         "Username": "使用者名稱",


### PR DESCRIPTION
The translators email addresses where added to the translation files a long time ago, to be able to get in touch with them. As those data is already very old and outdated, I'd suggest to simply remove them as we won't use them anyway.
