### PR TITLE
Piwik\Plugins\Login\Controller class: Change private variables and methods to protected.

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -31,17 +31,17 @@ class Controller extends \Piwik\Plugin\Controller
     /**
      * @var PasswordResetter
      */
-    private $passwordResetter;
+    protected $passwordResetter;
 
     /**
      * @var Auth
      */
-    private $auth;
+    protected $auth;
 
     /**
      * @var SessionInitializer
      */
-    private $sessionInitializer;
+    protected $sessionInitializer;
 
     /**
      * Constructor.
@@ -124,7 +124,7 @@ class Controller extends \Piwik\Plugin\Controller
      *
      * @param View $view
      */
-    private function configureView($view)
+    protected function configureView($view)
     {
         $this->setBasicVariablesView($view);
 
@@ -261,7 +261,7 @@ class Controller extends \Piwik\Plugin\Controller
      * @param QuickForm2 $form
      * @return array Error message(s) if an error occurs.
      */
-    private function resetPasswordFirstStep($form)
+    protected function resetPasswordFirstStep($form)
     {
         $loginMail = $form->getSubmitValue('form_login');
         $password  = $form->getSubmitValue('form_password');


### PR DESCRIPTION
To the Piwik\Plugins\Login\Controller class: The current use of "private" prevents class variable and method inheritance in child classes. The "protected" ones on the other hand, offer the same access control, but can be inherited.

Impact: I'm working on a plugin to encrypt the transmitted password. That plugin "extends" many of the classes of the core Login plugin. The current usage of "private" forces me to, unnecessarily duplicate (copy-paste) the "private" members of the Login parent class, without any modification. I tested this patch with 2.14.3 and it works flawlessly with my (future) plugin.

Also, it maybe could help https://github.com/torosian/LoginRevokable/issues/2.

Thanks in advance.
