### PR TITLE
Run UI tests in two different jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ env:
     # All tests after another
     - TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL
     - TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI
-    - TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL
+    - TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL UITEST_EXTRA_OPTIONS="--run-first-half-only"
+    - TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL UITEST_EXTRA_OPTIONS="--run-second-half-only"
   global:
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR
     - SKIP_INSTALL_MYSQL_56=1
@@ -60,7 +61,9 @@ matrix:
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL
     # run UI tests on PHP 5.3.3 only
     - php: 5.6
-      env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL
+      env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL UITEST_EXTRA_OPTIONS="--run-first-half-only"
+    - php: 5.6
+      env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL UITEST_EXTRA_OPTIONS="--run-second-half-only"
     # run all tests not on PHP 5.6 and run MySQLI tests only on 5.6
     - php: 5.6
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=PDO_MYSQL

--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -66,6 +66,10 @@ Application.prototype.printHelpAndExit = function () {
     console.log("  --screenshot-repo:        Specifies the github repository that contains the expected screenshots");
     console.log("                            to link to in the diffviewer. For use with travis build.");
     console.log("  --core:                   Only execute UI tests that are for Piwik core or Piwik core plugins.");
+    console.log("  --first-half:             Only execute first half of all the test suites. Will be only applied if no")
+    console.log("                            specific plugin or test-files requested");
+    console.log("  --second-half:            Only execute second half of all the test suites. Will be only applied if no")
+    console.log("                            specific plugin or test-files requested");
 
     phantom.exit(0);
 };
@@ -128,6 +132,24 @@ Application.prototype.loadTestModules = function () {
     if (options.plugin) {
         mocha.suite.suites = mocha.suite.suites.filter(function (suite) {
             return suite.baseDirectory.match(new RegExp("\/plugins\/" + options.plugin + "\/"));
+        });
+    }
+
+    var specificTestsRequested = options.plugin || options.tests.length;
+
+    if ((options['run-first-half-only'] || options['run-second-half-only']) && !specificTestsRequested) {
+        // run only first 50% of the test suites or only run last 50% of the test suites.
+        // we apply this option only if not a specific plugin or test suite was requested. Only there for travis to
+        // split tests into multiple jobs.
+        var numTestsFirstHalf = Math.round(mocha.suite.suites.length / 2);
+        numTestsFirstHalf += 5; // run a few more test suits in first half as UiIntegrationTests contain many tests
+        mocha.suite.suites = mocha.suite.suites.filter(function (suite, index) {
+            if (options['run-first-half-only'] && index < numTestsFirstHalf) {
+                return true;
+            } else if (options['run-second-half-only'] && index >= numTestsFirstHalf) {
+                return true;
+            }
+            return false;
         });
     }
 


### PR DESCRIPTION
refs #8222 and see https://github.com/piwik/piwik/issues/8222#issuecomment-136132922

Example run: https://travis-ci.org/piwik/piwik/builds/78185419

Instead of having 1 job that takes about 35-45 minutes we now have 2 jobs that take about 17-24minutes each. As mentioned in the issue we could also split it into three jobs but then other commits take longer to start maybe as we need more jobs. We can see how it goes and still change things later.

Not sure if we can close #8222 afterwards for now? I'd close I think as goal of `the UI tests should run ideally in less than 20 or 25 minutes` is satisfied. They are even faster then `AllTests` job
