### PR TITLE
Fix AutoSuggestAPITest w/ small refactor to API.getSegmentsMetadata & Plugin\Segment

### DIFF
--- a/core/Plugin/Segment.php
+++ b/core/Plugin/Segment.php
@@ -53,6 +53,12 @@ class Segment
     private $suggestedValuesCallback;
 
     /**
+     * TODO
+     * @var bool
+     */
+    private $requiresAtLeastViewAccess = false;
+
+    /**
      * @ignore
      */
     final public function __construct()
@@ -254,5 +260,25 @@ class Segment
         }
 
         return $segment;
+    }
+
+    /**
+     * TODO
+     * @return boolean
+     * @ignore
+     */
+    public function isRequiresAtLeastViewAccess()
+    {
+        return $this->requiresAtLeastViewAccess;
+    }
+
+    /**
+     * TODO
+     * @param boolean $requiresAtLeastViewAccess
+     * @ignore
+     */
+    public function setRequiresAtLeastViewAccess($requiresAtLeastViewAccess)
+    {
+        $this->requiresAtLeastViewAccess = $requiresAtLeastViewAccess;
     }
 }

--- a/core/Plugin/Segment.php
+++ b/core/Plugin/Segment.php
@@ -53,7 +53,9 @@ class Segment
     private $suggestedValuesCallback;
 
     /**
-     * TODO
+     * If true, this segment will only be visible to the user if the user has view access
+     * to one of the requested sites (see API.getSegmentsMetadata).
+     *
      * @var bool
      */
     private $requiresAtLeastViewAccess = false;
@@ -263,7 +265,10 @@ class Segment
     }
 
     /**
-     * TODO
+     * Returns true if this segment should only be visible to the user if the user has view access
+     * to one of the requested sites (see API.getSegmentsMetadata), false if it should always be
+     * visible to the user (even the anonymous user).
+     *
      * @return boolean
      * @ignore
      */
@@ -273,7 +278,9 @@ class Segment
     }
 
     /**
-     * TODO
+     * Sets whether the segment should only be visible if the user requesting it has view access
+     * to one of the requested sites and if the user is not the anonymous user.
+     *
      * @param boolean $requiresAtLeastViewAccess
      * @ignore
      */

--- a/plugins/CoreHome/Columns/UserId.php
+++ b/plugins/CoreHome/Columns/UserId.php
@@ -12,7 +12,9 @@ use Piwik\Cache;
 use Piwik\DataTable;
 use Piwik\DataTable\Map;
 use Piwik\Period\Range;
+use Piwik\Piwik;
 use Piwik\Plugin\Dimension\VisitDimension;
+use Piwik\Plugin\Segment;
 use Piwik\Plugins\VisitsSummary\API as VisitsSummaryApi;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
@@ -32,6 +34,19 @@ class UserId extends VisitDimension
      * @var string
      */
     protected $columnType = 'VARCHAR(200) NULL';
+
+    protected function configureSegments()
+    {
+        $segment = new Segment();
+        $segment->setType('dimension');
+        $segment->setSegment('userId');
+        $segment->setCategory(Piwik::translate('General_Visit'));
+        $segment->setName('General_UserId');
+        $segment->setAcceptedValues('any non empty unique string identifying the user (such as an email address or a username).');
+        $segment->setSqlSegment('log_visit.user_id');
+        $segment->setRequiresAtLeastViewAccess(true);
+        $this->addSegment($segment);
+    }
 
     /**
      * @param Request $request

--- a/plugins/CoreHome/Columns/VisitId.php
+++ b/plugins/CoreHome/Columns/VisitId.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreHome\Columns;
+
+use Piwik\Piwik;
+use Piwik\Plugin\Dimension\VisitDimension;
+use Piwik\Plugin\Segment;
+
+/**
+ * TODO
+ */
+class VisitId extends VisitDimension
+{
+    protected function configureSegments()
+    {
+        parent::configureSegments();
+
+        $segment = new Segment();
+        $segment->setType('dimension');
+        $segment->setCategory(Piwik::translate('General_Visit'));
+        $segment->setName(Piwik::translate('General_Visit') . " ID");
+        $segment->setSegment('visitId');
+        $segment->setAcceptedValues('Any integer.');
+        $segment->setSqlSegment('log_visit.idvisit');
+        $segment->setRequiresAtLeastViewAccess(true);
+        $this->addSegment($segment);
+    }
+}

--- a/plugins/CoreHome/Columns/VisitId.php
+++ b/plugins/CoreHome/Columns/VisitId.php
@@ -13,7 +13,8 @@ use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugin\Segment;
 
 /**
- * TODO
+ * Dimension for the log_visit.idvisit column. This column is added in the CREATE TABLE
+ * statement, so this dimension exists only to configure a segment.
  */
 class VisitId extends VisitDimension
 {

--- a/plugins/CoreHome/Columns/VisitIp.php
+++ b/plugins/CoreHome/Columns/VisitIp.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreHome\Columns;
+
+use Piwik\Piwik;
+use Piwik\Plugin\Dimension\VisitDimension;
+use Piwik\Plugin\Segment;
+
+/**
+ * TODO
+ */
+class VisitIp extends VisitDimension
+{
+    protected function configureSegments()
+    {
+        parent::configureSegments();
+
+        $segment = new Segment();
+        $segment->setType('metric');
+        $segment->setCategory(Piwik::translate('General_Visit'));
+        $segment->setName('General_VisitorIP');
+        $segment->setSegment('visitIp');
+        $segment->setAcceptedValues('13.54.122.1. </code>Select IP ranges with notation: <code>visitIp>13.54.122.0;visitIp<13.54.122.255');
+        $segment->setSqlSegment('log_visit.location_ip');
+        $segment->setSqlFilterValue(array('Piwik\Network\IPUtils', 'stringToBinaryIP'));
+        $segment->setRequiresAtLeastViewAccess(true);
+        $this->addSegment($segment);
+    }
+}

--- a/plugins/CoreHome/Columns/VisitIp.php
+++ b/plugins/CoreHome/Columns/VisitIp.php
@@ -13,7 +13,8 @@ use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugin\Segment;
 
 /**
- * TODO
+ * Dimension for the log_visit.location_ip column. This column is added in the CREATE TABLE
+ * statement, so this dimension exists only to configure a segment.
  */
 class VisitIp extends VisitDimension
 {

--- a/plugins/CoreHome/Columns/VisitorId.php
+++ b/plugins/CoreHome/Columns/VisitorId.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreHome\Columns;
+
+use Piwik\Piwik;
+use Piwik\Plugin\Dimension\VisitDimension;
+use Piwik\Plugin\Segment;
+
+/**
+ * TODO
+ */
+class VisitorId extends VisitDimension
+{
+    protected function configureSegments()
+    {
+        parent::configureSegments();
+
+        $segment = new Segment();
+        $segment->setType('dimension');
+        $segment->setCategory(Piwik::translate('General_Visit'));
+        $segment->setName('General_VisitorID');
+        $segment->setSegment('visitorId');
+        $segment->setAcceptedValues('34c31e04394bdc63 - any 16 Hexadecimal chars ID, which can be fetched using the Tracking API function getVisitorId()');
+        $segment->setSqlSegment('log_visit.idvisitor');
+        $segment->setSqlFilterValue(array('Piwik\Common', 'convertVisitorIdToBin'));
+        $segment->setRequiresAtLeastViewAccess(true);
+        $this->addSegment($segment);
+    }
+}

--- a/plugins/CoreHome/Columns/VisitorId.php
+++ b/plugins/CoreHome/Columns/VisitorId.php
@@ -13,7 +13,8 @@ use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugin\Segment;
 
 /**
- * TODO
+ * Dimension for the log_visit.idvisitor column. This column is added in the CREATE TABLE
+ * statement, so this dimension exists only to configure a segment.
  */
 class VisitorId extends VisitDimension
 {

--- a/plugins/CustomVariables/Model.php
+++ b/plugins/CustomVariables/Model.php
@@ -18,6 +18,7 @@ class Model
     const SCOPE_PAGE = 'log_link_visit_action';
     const SCOPE_VISIT = 'log_visit';
     const SCOPE_CONVERSION = 'log_conversion';
+    const DEFAULT_CUSTOM_VAR_COUNT = 5;
 
     private $scope = null;
 
@@ -159,7 +160,7 @@ class Model
             $model = new Model($scope);
 
             try {
-                $maxCustomVars   = 5;
+                $maxCustomVars   = self::DEFAULT_CUSTOM_VAR_COUNT;
                 $customVarsToAdd = $maxCustomVars - $model->getCurrentNumCustomVars();
 
                 for ($index = 0; $index < $customVarsToAdd; $index++) {

--- a/tests/PHPUnit/System/AutoSuggestAPITest.php
+++ b/tests/PHPUnit/System/AutoSuggestAPITest.php
@@ -8,8 +8,11 @@
 namespace Piwik\Tests\System;
 
 use Piwik\API\Request;
+use Piwik\Application\Environment;
+use Piwik\Columns\Dimension;
 use Piwik\Common;
 use Piwik\Date;
+use Piwik\Plugins\CustomVariables\Model;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tests\Fixtures\ManyVisitsWithGeoIP;
 use Piwik\Tests\Framework\Fixture;
@@ -45,15 +48,12 @@ class AutoSuggestAPITest extends SystemTestCase
 
     public function getApiForTesting()
     {
-        // we will test all segments from all plugins
-        Fixture::loadAllPlugins();
-
         $idSite = self::$fixture->idSite;
-        $apiForTesting = array();
+        $segments = self::getSegmentsMetadata();
 
-        $segments = \Piwik\Plugins\API\API::getInstance()->getSegmentsMetadata(self::$fixture->idSite);
+        $apiForTesting = array();
         foreach ($segments as $segment) {
-            $apiForTesting[] = $this->getApiForTestingForSegment($idSite, $segment['segment']);
+            $apiForTesting[] = $this->getApiForTestingForSegment($idSite, $segment);
         }
 
         if (self::isMysqli() || self::isTravisCI()) {
@@ -119,11 +119,11 @@ class AutoSuggestAPITest extends SystemTestCase
 
     public function getAnotherApiForTesting()
     {
-        $segments = self::getSegmentsMetadata(self::$fixture->idSite);
+        $segments = self::getSegmentsMetadata();
 
         $apiForTesting = array();
         foreach ($segments as $segment) {
-            if(self::isTravisCI() && $segment['segment'] == 'deviceType') {
+            if(self::isTravisCI() && $segment == 'deviceType') {
                 // test started failing after bc19503 and I cannot understand why
                 continue;
             }
@@ -131,8 +131,8 @@ class AutoSuggestAPITest extends SystemTestCase
                                      array('idSite'            => self::$fixture->idSite,
                                            'date'              => date("Y-m-d", strtotime(self::$fixture->dateTime)) . ',today',
                                            'period'            => 'range',
-                                           'testSuffix'        => '_' . $segment['segment'],
-                                           'segmentToComplete' => $segment['segment']));
+                                           'testSuffix'        => '_' . $segment,
+                                           'segmentToComplete' => $segment));
         }
         return $apiForTesting;
     }
@@ -153,15 +153,45 @@ class AutoSuggestAPITest extends SystemTestCase
         $this->assertGreaterThan($minimumSegmentsToTest, self::$processed, $message);
     }
 
-    public static function getSegmentsMetadata($idSite)
+    public static function getSegmentsMetadata()
     {
         // Refresh cache for CustomVariables\Model
         Cache::clearCacheGeneral();
 
-        \Piwik\Plugins\CustomVariables\Model::install();
+        $segments = array();
 
-        // Segment matching NONE
-        $segments = \Piwik\Plugins\API\API::getInstance()->getSegmentsMetadata($idSite);
+        $environment = new Environment(null);
+
+        $exception = null;
+        try {
+            $environment->init();
+            $environment->getContainer()->get('Piwik\Plugin\Manager')->loadActivatedPlugins();
+
+            foreach (Dimension::getAllDimensions() as $dimension) {
+                foreach ($dimension->getSegments() as $segment) {
+                    $segments[] = $segment->getSegment();
+                }
+            }
+
+            // add CustomVariables manually since the data provider may not have access to the DB
+            for ($i = 1; $i != Model::DEFAULT_CUSTOM_VAR_COUNT + 1; ++$i) {
+                $segments[] = 'customVariableName' . $i;
+                $segments[] = 'customVariableValue' . $i;
+                $segments[] = 'customVariablePageName' . $i;
+                $segments[] = 'customVariablePageValue' . $i;
+            }
+        } catch (\Exception $ex) {
+            $exception = $ex;
+
+            echo $ex->getMessage()."\n".$ex->getTraceAsString()."\n";
+        }
+
+        $environment->destroy();
+
+        if (!empty($exception)) {
+            throw $exception;
+        }
+
         return $segments;
     }
 }

--- a/tests/PHPUnit/System/TwoVisitsWithCustomVariablesSegmentMatchNONETest.php
+++ b/tests/PHPUnit/System/TwoVisitsWithCustomVariablesSegmentMatchNONETest.php
@@ -48,7 +48,7 @@ class TwoVisitsWithCustomVariablesSegmentMatchNONETest extends SystemTestCase
 
     public function getSegmentToTest()
     {
-        $segments = AutoSuggestAPITest::getSegmentsMetadata(self::$fixture->idSite);
+        $segments = AutoSuggestAPITest::getSegmentsMetadata();
 
         $minimumExpectedSegmentsCount = 55; // as of Piwik 1.12
         $this->assertGreaterThan($minimumExpectedSegmentsCount, count($segments));
@@ -57,18 +57,18 @@ class TwoVisitsWithCustomVariablesSegmentMatchNONETest extends SystemTestCase
         $seenVisitorId = false;
         foreach ($segments as $segment) {
             $value = 'campaign';
-            if ($segment['segment'] == 'visitorId') {
+            if ($segment == 'visitorId') {
                 $seenVisitorId = true;
                 $value = '34c31e04394bdc63';
             }
-            if ($segment['segment'] == 'visitEcommerceStatus') {
+            if ($segment == 'visitEcommerceStatus') {
                 $value = 'none';
             }
-            $matchNone = $segment['segment'] . '!=' . $value;
+            $matchNone = $segment . '!=' . $value;
 
             // deviceType != campaign matches ALL visits, but we want to match None
-            if($segment['segment'] == 'deviceType') {
-                $matchNone = $segment['segment'] . '==car%20browser';
+            if($segment == 'deviceType') {
+                $matchNone = $segment . '==car%20browser';
             }
             $segmentExpression[] = $matchNone;
         }

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
@@ -198,7 +198,7 @@
 		<category>Visit</category>
 		<name>Visit ID</name>
 		<segment>visitId</segment>
-		<acceptedValues>Any integer. </acceptedValues>
+		<acceptedValues>Any integer.</acceptedValues>
 		<permission>1</permission>
 	</row>
 	<row>


### PR DESCRIPTION
This PR modifies AutoSuggestAPITest (and one or two others) so the data providers do not connect to the database. Changes include:
- Moving the segments defined in API.getSegmentsMetadata to new Dimension instances that define segments.
- Creating a new non-API property in Plugin\Segment that will hide the segment from API.getSegmentsMetadata if the current user does not have view access to the requested sites.
- Modifying tests to go through dimensions to collect all segments instead of using the API method. CustomVariable segments are added manually instead of trying to find the number of columns in the tables.

@mattab or @tsteur please review, not sure what side effects this change will have.
