### PR TITLE
[fixes #8707] Fix for fopen method in http class if url is not reachable

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -426,7 +426,9 @@ class Http
 
             // save to file
             if (is_resource($file)) {
-                $handle = fopen($aUrl, 'rb', false, $ctx);
+                if (!($handle = fopen($aUrl, 'rb', false, $ctx))) {
+                    throw new Exception("Unable to open $aUrl");
+                }
                 while (!feof($handle)) {
                     $response = fread($handle, 8192);
                     $fileLength += strlen($response);


### PR DESCRIPTION
see #8707 for more details
