### PR TITLE
Login\Controller class: Change private members to protected

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -31,17 +31,17 @@ class Controller extends \Piwik\Plugin\Controller
     /**
      * @var PasswordResetter
      */
-    private $passwordResetter;
+    protected $passwordResetter;
 
     /**
      * @var Auth
      */
-    private $auth;
+    protected $auth;
 
     /**
      * @var SessionInitializer
      */
-    private $sessionInitializer;
+    protected $sessionInitializer;
 
     /**
      * Constructor.
@@ -124,7 +124,7 @@ class Controller extends \Piwik\Plugin\Controller
      *
      * @param View $view
      */
-    private function configureView($view)
+    protected function configureView($view)
     {
         $this->setBasicVariablesView($view);
 
@@ -261,7 +261,7 @@ class Controller extends \Piwik\Plugin\Controller
      * @param QuickForm2 $form
      * @return array Error message(s) if an error occurs.
      */
-    private function resetPasswordFirstStep($form)
+    protected function resetPasswordFirstStep($form)
     {
         $loginMail = $form->getSubmitValue('form_login');
         $password  = $form->getSubmitValue('form_password');


### PR DESCRIPTION
To the Piwik\Plugins\Login\Controller class: This change is to prevent extending classes (third-party login plugins reusing the core Login plugin implementation) from having to copy-paste \Login\Controller code which, if declared "private" cannot be part of the child class.

Please refer to https://github.com/piwik/piwik/pull/8681 for details - that PR, which is an exact copy, was merged into the Piwik 2.x branch, but then reverted to not break existing plugins. It was decided to do that on the 3.x branch instead, which this PR does.
