### PR TITLE
Catch exceptions in ScheduledReports generation so reports will still generate if individual reports fail

### DIFF
--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -37,10 +37,7 @@ class Proxy extends Singleton
     // when a parameter doesn't have a default value we use this
     private $noDefaultValue;
 
-    /**
-     * protected constructor
-     */
-    protected function __construct()
+    public function __construct()
     {
         $this->noDefaultValue = new NoDefaultValue();
     }

--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -177,17 +177,17 @@ abstract class ReportRenderer extends BaseFactory
         $filename = ReportRenderer::makeFilenameWithExtension($filename, $extension);
 
         ProxyHttp::overrideCacheControlHeaders();
-        header('Content-Description: File Transfer');
-        header('Content-Type: ' . $contentType);
-        header('Content-Disposition: attachment; filename="' . str_replace('"', '\'', basename($filename)) . '";');
-        header('Content-Length: ' . strlen($content));
+        Common::sendHeader('Content-Description: File Transfer');
+        Common::sendHeader('Content-Type: ' . $contentType);
+        Common::sendHeader('Content-Disposition: attachment; filename="' . str_replace('"', '\'', basename($filename)) . '";');
+        Common::sendHeader('Content-Length: ' . strlen($content));
 
         echo $content;
     }
 
     protected static function inlineToBrowser($contentType, $content)
     {
-        header('Content-Type: ' . $contentType);
+        Common::sendHeader('Content-Type: ' . $contentType);
         echo $content;
     }
 

--- a/core/Singleton.php
+++ b/core/Singleton.php
@@ -63,4 +63,12 @@ class Singleton
         $class = get_called_class();
         self::$instances[$class] = $instance;
     }
+
+    /**
+     * @ignore
+     */
+    public static function clearAll()
+    {
+        self::$instances = array();
+    }
 }

--- a/plugins/API/RowEvolution.php
+++ b/plugins/API/RowEvolution.php
@@ -360,9 +360,16 @@ class RowEvolution
         unset($metadata['logos']);
 
         $subDataTables = $dataTable->getDataTables();
+        if (empty($subDataTables)) {
+            throw new \Exception("Unexpected state: row evolution API call returned empty DataTable\\Map.");
+        }
+
         $firstDataTable = reset($subDataTables);
+        $this->checkDataTableInstance($firstDataTable);
         $firstDataTableRow = $firstDataTable->getFirstRow();
+
         $lastDataTable = end($subDataTables);
+        $this->checkDataTableInstance($lastDataTable);
         $lastDataTableRow = $lastDataTable->getFirstRow();
 
         // Process min/max values
@@ -532,5 +539,12 @@ class RowEvolution
         $label = str_replace(LabelFilter::SEPARATOR_RECURSIVE_LABEL, ' - ', $label);
         $label = SafeDecodeLabel::decodeLabelSafe($label);
         return $label;
+    }
+
+    private function checkDataTableInstance($lastDataTable)
+    {
+        if (!($lastDataTable instanceof DataTable)) {
+            throw new \Exception("Unexpected state: row evolution returned DataTable\\Map w/ incorrect child table type: " . get_class($lastDataTable));
+        }
     }
 }

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -26,6 +26,9 @@ use Piwik\Site;
 use Piwik\Tracker;
 use Piwik\Translate;
 use Piwik\Translation\Translator;
+use Piwik\Url;
+use Piwik\UrlHelper;
+use Psr\Log\LoggerInterface;
 
 /**
  * The ScheduledReports API lets you manage Scheduled Email reports, as well as generate, download or email any existing report.
@@ -59,6 +62,16 @@ class API extends \Piwik\Plugin\API
 
     // static cache storing reports
     public static $cache = array();
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
 
     /**
      * Creates a new report and schedules it.
@@ -377,7 +390,20 @@ class API extends \Piwik\Plugin\API
                 $params['segment'] = false;
             }
 
-            $processedReport = Request::processRequest('API.getProcessedReport', $params);
+            try {
+                $processedReport = Request::processRequest('API.getProcessedReport', $params);
+            } catch (\Exception $ex) {
+                // NOTE: can't use warning or error because the log message will appear in the UI as a notification
+                $this->logger->info("Error getting '?{report}' when generating scheduled report: {exception}", array(
+                    'report' => http_build_query($params),
+                    'exception' => $ex->getMessage(),
+                ));
+
+                $this->logger->debug($ex);
+
+                continue;
+            }
+
             $processedReport['segment'] = $segment;
 
             // TODO add static method getPrettyDate($period, $date) in Period

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -40,6 +40,7 @@ use Piwik\Plugins\UsersManager\UsersManager;
 use Piwik\ReportRenderer;
 use Piwik\SettingsPiwik;
 use Piwik\SettingsServer;
+use Piwik\Singleton;
 use Piwik\Site;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
@@ -350,6 +351,7 @@ class Fixture extends \PHPUnit_Framework_Assert
         PiwikCache::getEagerCache()->flushAll();
         ArchiveTableCreator::clear();
         \Piwik\Plugins\ScheduledReports\API::$cache = array();
+        Singleton::clearAll();
 
         $_GET = $_REQUEST = array();
         Translate::reset();


### PR DESCRIPTION
As title. Includes test + some checks in RowEvolution to avoid unexpected fatal errors. (This happened to one user, but it seems there was no easy way to debug the issue.)
