### PR TITLE
Web cron should not timeout

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -277,6 +277,8 @@ class CronArchive
 
     public function init()
     {
+        SettingsServer::setMaxExecutionTime(0);
+
         $this->archivingStartingTime = time();
 
         // Note: the order of methods call matters here.


### PR DESCRIPTION
Reproduce issue
- set `max_execution_time = 3` in php.ini
- open the [web cron](http://piwik.org/docs/setup-auto-archiving/#web-cron-when-your-web-host-does-not-support-cron-tasks)
- got: Fatal error: Maximum execution time of 3 seconds exceeded in /home/matt/dev/piwik-master/core/CronArchive.php on line

After this change, the archive.php does not timeout anymore. 
