### PR TITLE
Additional events in archiving lifecycle

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -330,6 +330,8 @@ class CronArchive
         $this->logSection("START");
         $this->logger->info("Starting Piwik reports archiving...");
 
+        Piwik::postEvent('CronArchive.start', array($timer));
+
         do {
             $idSite = $this->websites->getNextSiteId();
 
@@ -418,6 +420,9 @@ class CronArchive
                 ? self::NO_ERROR
                 : (count($this->errors) . " errors."))
         );
+
+        Piwik::postEvent('CronArchive.end', array($timer));
+
         $this->logger->info($timer->__toString());
     }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -277,6 +277,13 @@ class CronArchive
 
     public function init()
     {
+        /**
+         * This event is triggered during initializing archiving.
+         *
+         * @param CronArchive $this
+         */
+        Piwik::postEvent('CoreArchive.run.start', array($this));
+
         SettingsServer::setMaxExecutionTime(0);
 
         $this->archivingStartingTime = time();
@@ -329,8 +336,6 @@ class CronArchive
 
         $this->logSection("START");
         $this->logger->info("Starting Piwik reports archiving...");
-
-        Piwik::postEvent('CronArchive.start', array($timer));
 
         do {
             $idSite = $this->websites->getNextSiteId();
@@ -421,8 +426,6 @@ class CronArchive
                 : (count($this->errors) . " errors."))
         );
 
-        Piwik::postEvent('CronArchive.end', array($timer));
-
         $this->logger->info($timer->__toString());
     }
 
@@ -445,6 +448,13 @@ class CronArchive
 
         $summary = count($this->errors) . " total errors during this script execution, please investigate and try and fix these errors.";
         $this->logFatalError($summary);
+
+        /**
+         * This event is triggered after archivization.
+         *
+         * @param CronArchive $this
+         */
+        Piwik::postEvent('CoreArchive.run.finish', array($this));
     }
 
     public function logFatalError($m)

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -450,7 +450,7 @@ class CronArchive
         $this->logFatalError($summary);
 
         /**
-         * This event is triggered after archivization.
+         * This event is triggered after archiving.
          *
          * @param CronArchive $this
          */


### PR DESCRIPTION
Hello @piwik/core-team,

I created this PR, because sometimes we need to inject into archiving lifecycle, especially we want to detect when archiving was started and finished. I added two additional events (look at changes). Please review this: Maybe should I pass more arguments into those events ? Maybe then it would be more useful ?
