### PR TITLE
Workaround chrome bug: in enriched headline use <div> w/ ng-transclude

### DIFF
--- a/plugins/CoreHome/angularjs/enrichedheadline/enrichedheadline.directive.html
+++ b/plugins/CoreHome/angularjs/enrichedheadline/enrichedheadline.directive.html
@@ -1,6 +1,6 @@
 <div class="enrichedHeadline"
     ng-mouseenter="view.showIcons=true" ng-mouseleave="view.showIcons=false">
-    <span ng-show="!editUrl" class="title" ng-transclude></span>
+    <div ng-show="!editUrl" class="title" ng-transclude></div>
     <a ng-show="editUrl" class="title" href="{{ editUrl }}"
        title="{{ 'CoreHome_ClickToEditX'|translate:featureName }}"
        ng-transclude></a>

--- a/plugins/CoreHome/angularjs/enrichedheadline/enrichedheadline.directive.less
+++ b/plugins/CoreHome/angularjs/enrichedheadline/enrichedheadline.directive.less
@@ -11,6 +11,7 @@
 
     .title {
         color: @color-black-piwik;
+        display:inline-block;
     }
 
     .inlineHelp {


### PR DESCRIPTION
Chrome does not correctly apply CSS to nested `<span>` elements which causes a problem for enriched headlines which uses ng-transclude on `<span>`. Using a `<div>` w/ `display:inline-block` fixes this.

Fixes #8740
