### PR TITLE
Correctly parse all URL schemes in UrlHelper::isLookLikeUrl().

### DIFF
--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -107,8 +107,8 @@ class UrlHelper
      */
     public static function isLookLikeUrl($url)
     {
-        return preg_match('~^((ftp|news|http|https)?:)?//(.*)$~D', $url, $matches) !== 0
-        && strlen($matches[3]) > 0;
+        return preg_match('~^(([[:alpha:]][[:alnum:]+.-]*)?:)?//(.*)$~D', $url, $matches) !== 0
+            && strlen($matches[3]) > 0;
     }
 
     /**

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1483,7 +1483,10 @@ class API extends \Piwik\Plugin\API
 
         foreach ($urls as &$url) {
             $url = $this->removeTrailingSlash($url);
-            if (strpos($url, 'http') !== 0) {
+            $scheme = parse_url($url, PHP_URL_SCHEME);
+            if (empty($scheme)
+                && strpos($url, '://') === false
+            ) {
                 $url = 'http://' . $url;
             }
             $url = trim($url);

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -59,8 +59,8 @@ class ApiTest extends IntegrationTestCase
             array(array()), // no urls
             array(array("")),
             array(""),
-            array("httpww://piwik.net"),
-            array("httpww://piwik.net/gqg~#"),
+            array("5http://piwik.net"),
+            array("???://piwik.net"),
         );
     }
 
@@ -161,8 +161,8 @@ class ApiTest extends IntegrationTestCase
      */
     public function test_addSite_WithSeveralUrls_Succeeds_AndCreatesAliasUrls()
     {
-        $urls = array("http://piwik.net/", "http://piwik.com", "https://piwik.net/test/");
-        $urlsOK = array("http://piwik.net", "http://piwik.com", "https://piwik.net/test");
+        $urls = array("http://piwik.net/", "http://piwik.com", "https://piwik.net/test/", "piwik.net/another/test");
+        $urlsOK = array("http://piwik.net", "http://piwik.com", "http://piwik.net/another/test", "https://piwik.net/test");
         $idsite = API::getInstance()->addSite("super website", $urls);
         $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_INT, $idsite);
 

--- a/tests/PHPUnit/Unit/UrlHelperTest.php
+++ b/tests/PHPUnit/Unit/UrlHelperTest.php
@@ -30,6 +30,11 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
             array('https://www.tëteâ.org', true),
             array('http://汉语/漢語.cn', true), //chinese
 
+            array('rtp://whatever.com', true),
+            array('testhttp://test.com', true),
+            array('cylon://3.hmn', true),
+            array('://something.com', true),
+
             // valid network-path reference RFC3986
             array('//piwik.org', true),
             array('//piwik/hello?world=test&test', true),
@@ -45,7 +50,7 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
             array('jmleslangues.php', false),
             array('http://', false),
             array(' http://', false),
-            array('testhttp://test.com', false),
+            array('2fer://', false),
         );
     }
 

--- a/tests/UI/specs/Installation_spec.js
+++ b/tests/UI/specs/Installation_spec.js
@@ -112,8 +112,10 @@ describe("Installation", function () {
     it("should display the javascript tracking page when correct information is entered in the setup website page and next is clicked", function (done) {
         expect.screenshot("js_tracking").to.be.capture(function (page) {
             page.sendKeys('input[name=siteName]', 'Serenity');
-            page.sendKeys('input[name=url]', 'serenity.com');
             page.evaluate(function () {
+                // cannot use sendKeys since quickform does not use placeholder attribute
+                $('input[name=url]').val('serenity.com');
+                
                 $('select[name=timezone]').val('Europe/Paris');
                 $('select[name=ecommerce]').val('1');
             });


### PR DESCRIPTION
As title. Changed the regex to match all allowed schemes (as per the RFC: https://tools.ietf.org/html/rfc3986#section-3.1).

Fixes #8722
