### PR TITLE
Default visit custom variables array in GoalManager class.

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -224,7 +224,7 @@ class GoalManager
     public function recordGoals(VisitProperties $visitProperties, Request $request)
     {
         $visitorInformation = $visitProperties->getProperties();
-        $visitCustomVariables = $request->getMetadata('CustomVariables', 'visitCustomVariables');
+        $visitCustomVariables = $request->getMetadata('CustomVariables', 'visitCustomVariables') ?: array();
 
         /** @var Action $action */
         $action = $request->getMetadata('Actions', 'action');


### PR DESCRIPTION
As title. Avoids error that occurs if CustomVariables is disabled.

Fixes #8622
