### PR TITLE
Fixes broken footer toggling when widgets are/were maximized

### DIFF
--- a/plugins/Annotations/stylesheets/annotations.less
+++ b/plugins/Annotations/stylesheets/annotations.less
@@ -27,10 +27,6 @@
   margin-bottom: -5px;
 }
 
-.ui-dialog .evolution-annotations > span {
-  top: 25px;
-}
-
 body > .widget .evolution-annotations > span {
   top: -25px;
 }

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1422,19 +1422,23 @@ $.extend(DataTable.prototype, UIControl.prototype, {
     },
 
     handleExpandFooter: function (domElem) {
-        if (this.isWithinDialog(domElem)) {
-            return;
-        }
-
         var footerIcons = $('.dataTableFooterIcons', domElem);
 
         if (!footerIcons.length) {
             return;
         }
 
+        if (this.isWithinDialog(domElem)) {
+            $('.dataTableFeatures', domElem).addClass('expanded');
+        }
+
         var self = this;
         function toggleFooter(event)
         {
+            if (self.isWithinDialog(domElem)) {
+                return;
+            }
+
             var icons = $('.dataTableFooterIcons', domElem);
             $('.dataTableFeatures', domElem).toggleClass('expanded');
 

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1425,6 +1425,10 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             return;
         }
 
+        if (this.isWithinDialog(domElem)) {
+            $('.dataTableFeatures', domElem).addClass('expanded');
+        }
+
         var self = this;
         function toggleFooter(event)
         {

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1428,10 +1428,6 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             return;
         }
 
-        if (this.isWithinDialog(domElem)) {
-            $('.dataTableFeatures', domElem).addClass('expanded');
-        }
-
         var self = this;
         function toggleFooter(event)
         {

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -781,9 +781,6 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                         ;
 
                     var annotationsCss = {left: 6}; // padding-left of .jqplot-graph element (in _dataTableViz_jqplotGraph.tpl)
-                    if (self.isWithinDialog(domElem)) {
-                        annotationsCss['top'] = -datatableFeatures.height() - annotationAxisHeight + noteSize / 2;
-                    }
 
                     // set position of evolution annotation icons
                     annotations.css(annotationsCss);

--- a/plugins/Dashboard/javascripts/dashboardWidget.js
+++ b/plugins/Dashboard/javascripts/dashboardWidget.js
@@ -295,6 +295,8 @@
 
             var width = Math.floor($('body').width() * 0.7);
 
+            var isFooterExpanded = $('.dataTableFeatures', this.element).hasClass('expanded');
+
             var self = this;
             this.element.dialog({
                 title: '',
@@ -305,6 +307,9 @@
                 autoOpen: true,
                 close: function (event, ui) {
                     self.isMaximised = false;
+                    if (!isFooterExpanded) {
+                        $('.dataTableFeatures', self.element).removeClass('expanded');
+                    }
                     $('body').off('.dashboardWidget');
                     $(this).dialog("destroy");
                     $('#' + self.uniqueId + '-placeholder').replaceWith(this);
@@ -315,6 +320,7 @@
                 }
             });
             this.element.find('div.piwik-graph').trigger('resizeGraph');
+            $('.dataTableFeatures', this.element).addClass('expanded');
 
             var currentWidget = this.element;
             $('body').on('click.dashboardWidget', function (ev) {


### PR DESCRIPTION
Fixes #6734 
When maximizing a widget the footer will now automatically be shown. While the widget is maximized the footer cannot be collapsed (until it is closed again)
When the maximized widget is closed the state of the footer (shown or not) is recovered from before maximizing the widget.
