### PR TITLE
Show pointer cursor only on sparklines that are linked to a graph

### DIFF
--- a/plugins/CoreHome/javascripts/sparkline.js
+++ b/plugins/CoreHome/javascripts/sparkline.js
@@ -43,12 +43,13 @@ window.initializeSparklines = function () {
         // try to find sparklines and add them clickable behaviour
         graph.parent().find('div.sparkline').each(function () {
 
-            $(this).addClass('linked');
-
             // find the sparkline and get it's src attribute
             var sparklineUrl = $('img', this).attr('data-src');
 
             if (sparklineUrl != "") {
+
+                $(this).addClass('linked');
+
                 var params = broadcast.getValuesFromUrl(sparklineUrl);
                 for (var i = 0; i != sparklineUrlParamsToIgnore.length; ++i) {
                     delete params[sparklineUrlParamsToIgnore[i]];

--- a/plugins/CoreHome/javascripts/sparkline.js
+++ b/plugins/CoreHome/javascripts/sparkline.js
@@ -42,6 +42,9 @@ window.initializeSparklines = function () {
 
         // try to find sparklines and add them clickable behaviour
         graph.parent().find('div.sparkline').each(function () {
+
+            $(this).addClass('linked');
+
             // find the sparkline and get it's src attribute
             var sparklineUrl = $('img', this).attr('data-src');
 

--- a/plugins/CoreHome/stylesheets/sparklineColors.less
+++ b/plugins/CoreHome/stylesheets/sparklineColors.less
@@ -3,7 +3,7 @@ div.sparkline {
     border-bottom: 1px solid white;
 }
 
-div.sparkline:hover {
+div.sparkline.linked:hover {
     cursor: pointer;
     border-bottom: 1px dashed #c3c3c3;
 }


### PR DESCRIPTION
fixes #7084 
adds a new class "linked" to sparklines that are bounded to a graph to use it to determine if pointer cursor should be shown on hover.
