### PR TITLE
fixes #7085 - small css tweak to improve some widget layouts

### DIFF
--- a/plugins/CoreHome/stylesheets/zen-mode.less
+++ b/plugins/CoreHome/stylesheets/zen-mode.less
@@ -87,6 +87,14 @@
   }
 }
 
+.widget {
+
+  h2:nth-of-type(n+2) {
+    padding-top: 40px!important;
+    margin-top: 0!important;
+  }
+}
+
 .dataTableFeatures .expandDataTableFooterDrawer {
   margin-bottom: -9px;
 }


### PR DESCRIPTION
see #7085 for broken layout.

It now looks like this:

![image](https://cloud.githubusercontent.com/assets/1579355/9827775/33a72bc4-58e6-11e5-8ac1-a27a21b1f3f2.png)

Note: UI test files needs update for the failing one after merge
