### PR TITLE
Mobile Messaging: new SMS provider to help developers debug (available in development mode)

### DIFF
--- a/plugins/MobileMessaging/Controller.php
+++ b/plugins/MobileMessaging/Controller.php
@@ -94,7 +94,7 @@ class Controller extends ControllerAdmin
             $view->creditLeft = $mobileMessagingAPI->getCreditLeft();
         }
 
-        $view->smsProviders = SMSProvider::$availableSMSProviders;
+        $view->smsProviders = SMSProvider::getAvailableSMSProviders();
 
         // construct the list of countries from the lang files
         $countries = array();

--- a/plugins/MobileMessaging/SMSProvider.php
+++ b/plugins/MobileMessaging/SMSProvider.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\MobileMessaging;
 
 use Exception;
+use Piwik\Development;
 use Piwik\Piwik;
 use Piwik\BaseFactory;
 
@@ -23,7 +24,7 @@ abstract class SMSProvider extends BaseFactory
     const MAX_UCS2_CHARS_IN_ONE_UNIQUE_SMS = 70;
     const MAX_UCS2_CHARS_IN_ONE_CONCATENATED_SMS = 67;
 
-    public static $availableSMSProviders = array(
+    protected static $availableSMSProviders = array(
         'Clockwork' => 'You can use <a target="_blank" href="?module=Proxy&action=redirect&url=http://www.clockworksms.com/platforms/piwik/"><img src="plugins/MobileMessaging/images/Clockwork.png"/></a> to send SMS Reports from Piwik.<br/>
 			<ul>
 			<li> First, <a target="_blank" href="?module=Proxy&action=redirect&url=http://www.clockworksms.com/platforms/piwik/">get an API Key from Clockwork</a> (Signup is free!)
@@ -46,8 +47,24 @@ abstract class SMSProvider extends BaseFactory
     protected static function getInvalidClassIdExceptionMessage($id)
     {
         return Piwik::translate('MobileMessaging_Exception_UnknownProvider',
-            array($id, implode(', ', array_keys(self::$availableSMSProviders)))
+            array($id, implode(', ', array_keys(self::getAvailableSMSProviders())))
         );
+    }
+
+    /**
+     * Returns all available SMS Providers
+     * 
+     * @return array
+     */
+    public static function getAvailableSMSProviders()
+    {
+        $smsProviders = self::$availableSMSProviders;
+
+        if (Development::isEnabled()) {
+            $smsProviders['Development'] = 'Development SMS Provider<br />All sent SMS will be displayed as Notification';
+        }
+
+        return $smsProviders;
     }
 
     /**
@@ -65,7 +82,7 @@ abstract class SMSProvider extends BaseFactory
             throw new Exception(
                 Piwik::translate(
                     'MobileMessaging_Exception_UnknownProvider',
-                    array($providerName, implode(', ', array_keys(self::$availableSMSProviders)))
+                    array($providerName, implode(', ', array_keys(self::getAvailableSMSProviders())))
                 )
             );
         }

--- a/plugins/MobileMessaging/SMSProvider/Development.php
+++ b/plugins/MobileMessaging/SMSProvider/Development.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\MobileMessaging\SMSProvider;
+
+use Piwik\Notification;
+use Piwik\Plugins\MobileMessaging\SMSProvider;
+
+/**
+ * Used for development only
+ *
+ */
+class Development extends SMSProvider
+{
+
+    public function verifyCredential($apiKey)
+    {
+        return true;
+    }
+
+    public function sendSMS($apiKey, $smsText, $phoneNumber, $from)
+    {
+        $message = sprintf('An SMS was sent:<br />From: %s<br />To: %s<br />Message: %s', $from, $phoneNumber, $smsText);
+
+        $notification = new Notification($message);
+        $notification->raw = true;
+        $notification->context = Notification::CONTEXT_INFO;
+        Notification\Manager::notify('StubbedSMSProvider'.preg_replace('/[^a-z0-9]/', '', $phoneNumber), $notification);
+    }
+
+    public function getCreditLeft($apiKey)
+    {
+        return 'Balance: 42';
+    }
+}


### PR DESCRIPTION
While doing some testing for Mobile Messaging, I've written a small Development SMS provider.
All SMS that are sent through this provider will be shown as notification within Piwik.
Provider will be automatically available as soon as Development mode is on.
