### PR TITLE
Layout tweak for phone number listing in scheduled report

### DIFF
--- a/plugins/MobileMessaging/templates/reportParametersScheduledReports.twig
+++ b/plugins/MobileMessaging/templates/reportParametersScheduledReports.twig
@@ -6,15 +6,16 @@
     <td>
     <div class="entityInlineHelp">
     {% if phoneNumbers|length == 0 %}
-        {{ 'MobileMessaging_MobileReport_NoPhoneNumbers'|translate }}
+        <div><span class="icon-info"></span> {{ 'MobileMessaging_MobileReport_NoPhoneNumbers'|translate }}
     {% else %}
+        <ul class="clearfix">
         {% for phoneNumber in phoneNumbers %}
-        <label><input name='phoneNumbers' type='checkbox' id='{{ phoneNumber }}'/>{{ phoneNumber }}</label>
-        <br/>
+            <li class="clear"><label><input name='phoneNumbers' type='checkbox' id='{{ phoneNumber }}'/>{{ phoneNumber }}</label></li>
         {% endfor %}
-        {{ 'MobileMessaging_MobileReport_AdditionalPhoneNumbers'|translate }}
+        </ul>
+        <div><span class="icon-info"></span> {{ 'MobileMessaging_MobileReport_AdditionalPhoneNumbers'|translate }}
     {% endif %}
-        <a href='{{ linkTo({'module':"MobileMessaging", 'action': 'index', 'updated':null}) }}'>{{ 'MobileMessaging_MobileReport_MobileMessagingSettingsLink'|translate }}</a>
+        <a href="{{ linkTo({'module':"MobileMessaging", 'action': 'index', 'updated':null}) }}">{{ 'MobileMessaging_MobileReport_MobileMessagingSettingsLink'|translate }}</a></div>
     </div>
     <script>
     $(function () {


### PR DESCRIPTION
Refs #4615  2)

List of phone numbers in scheduled reports now look like this:

![image](https://cloud.githubusercontent.com/assets/1579355/9837682/63dedd2a-5a47-11e5-8346-3fd2491bda91.png)
