### PR TITLE
Making UsersManager extendable

### DIFF
--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -482,6 +482,20 @@ class Piwik
     }
 
     /**
+     * Returns the name of the UsersManager plugin currently being used.
+     * Must be used since it is not allowed to hardcode 'UsersManager' in URLs
+     * in case another UsersManager plugin is being used.
+     *
+     * @return string
+     * @api
+     */
+    public static function getUsersManagerPluginName()
+    {
+        $pluginName = explode('\\', get_class(StaticContainer::get('UsersManager_API')));
+        return $pluginName[2];
+    }
+
+    /**
      * Returns the plugin currently being used to display the page
      *
      * @return Plugin

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -73,7 +73,6 @@ class Manager
         'CoreVisualizations',
         'Installation',
         'SitesManager',
-        'UsersManager',
         'Intl',
         'API',
         'Proxy',

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -96,6 +96,7 @@ class Twig
         $this->addFunction_postEvent();
         $this->addFunction_isPluginLoaded();
         $this->addFunction_getJavascriptTranslations();
+        $this->addFunction_getUsersManagerPluginName();
 
         $this->twig->addTokenParser(new RenderTokenParser());
 
@@ -111,6 +112,14 @@ class Twig
             }
         );
         $this->twig->addTest($test);
+    }
+
+    protected function addFunction_getUsersManagerPluginName()
+    {
+        $getUsersManagerPluginName = new Twig_SimpleFunction('getUsersManagerPluginName', function () {
+            return Piwik::getUsersManagerPluginName();
+        });
+        $this->twig->addFunction($getUsersManagerPluginName);
     }
 
     protected function addFunction_getJavascriptTranslations()

--- a/plugins/CoreHome/Menu.php
+++ b/plugins/CoreHome/Menu.php
@@ -37,7 +37,7 @@ class Menu extends \Piwik\Plugin\Menu
                 $menu->addItem($login, null, array('module' => 'API', 'action' => 'listAllAPI'), 998);
             }
         } else {
-            $menu->addItem($login, null, array('module' => 'UsersManager', 'action' => 'userSettings'), 998);
+            $menu->addItem($login, null, array('module' => $this->getUsersManagerModule(), 'action' => 'userSettings'), 998);
         }
 
         $module = $this->getLoginModule();
@@ -60,4 +60,8 @@ class Menu extends \Piwik\Plugin\Menu
         return Piwik::getLoginPluginName();
     }
 
+    protected function getUsersManagerModule()
+    {
+        return Piwik::getUsersManagerPluginName();
+    }
 }

--- a/plugins/Morpheus/templates/user.twig
+++ b/plugins/Morpheus/templates/user.twig
@@ -10,7 +10,7 @@
         {% set topMenuAction = 'index' %}
     {% else %}
         {% if currentModule != 'Feedback' %}
-            {% set topMenuModule = 'UsersManager' %}
+            {% set topMenuModule = getUsersManagerPluginName() %}
             {% set topMenuAction = 'userSettings' %}
         {% endif %}
     {% endif %}

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -38,12 +38,12 @@ class API extends \Piwik\Plugin\API
     /**
      * @var Model
      */
-    private $model;
+    protected $model;
 
     const PREFERENCE_DEFAULT_REPORT = 'defaultReport';
     const PREFERENCE_DEFAULT_REPORT_DATE = 'defaultReportDate';
 
-    private static $instance = null;
+    protected static $instance = null;
 
     public function __construct(Model $model)
     {
@@ -68,14 +68,14 @@ class API extends \Piwik\Plugin\API
                 // Exception is caught below and corrected
                 throw new Exception('UsersManager_API must inherit API');
             }
-            self::$instance = $instance;
+            static::$instance = $instance;
             
         } catch (Exception $e) {
-            self::$instance = StaticContainer::get('Piwik\Plugins\UsersManager\API');
-            StaticContainer::getContainer()->set('UsersManager_API', self::$instance);
+            static::$instance = StaticContainer::get(get_called_class());
+            StaticContainer::getContainer()->set('UsersManager_API', static::$instance);
         }
 
-        return self::$instance;
+        return static::$instance;
     }
 
     /**
@@ -147,7 +147,7 @@ class API extends \Piwik\Plugin\API
             $preferences = Option::getLike($optionNameMatchAllUsers);
 
             foreach($preferences as $optionName => $optionValue) {
-                $lastUnderscore = strrpos($optionName, self::OPTION_NAME_PREFERENCE_SEPARATOR);
+                $lastUnderscore = strrpos($optionName, static::OPTION_NAME_PREFERENCE_SEPARATOR);
                 $userName = substr($optionName, 0, $lastUnderscore);
                 $preference = substr($optionName, $lastUnderscore + 1);
                 $userPreferences[$userName][$preference] = $optionValue;
@@ -156,29 +156,29 @@ class API extends \Piwik\Plugin\API
         return $userPreferences;
     }
 
-    private function getPreferenceId($login, $preference)
+    protected function getPreferenceId($login, $preference)
     {
-        if(false !== strpos($preference, self::OPTION_NAME_PREFERENCE_SEPARATOR)) {
+        if(false !== strpos($preference, static::OPTION_NAME_PREFERENCE_SEPARATOR)) {
             throw new Exception("Preference name cannot contain underscores.");
         }
-        return $login . self::OPTION_NAME_PREFERENCE_SEPARATOR . $preference;
+        return $login . static::OPTION_NAME_PREFERENCE_SEPARATOR . $preference;
     }
 
-    private function getPreferenceValue($userLogin, $preferenceName)
+    protected function getPreferenceValue($userLogin, $preferenceName)
     {
         return Option::get($this->getPreferenceId($userLogin, $preferenceName));
     }
 
-    private function getDefaultUserPreference($preferenceName, $login)
+    protected function getDefaultUserPreference($preferenceName, $login)
     {
         switch ($preferenceName) {
-            case self::PREFERENCE_DEFAULT_REPORT:
+            case static::PREFERENCE_DEFAULT_REPORT:
                 $viewableSiteIds = \Piwik\Plugins\SitesManager\API::getInstance()->getSitesIdWithAtLeastViewAccess($login);
                 if (!empty($viewableSiteIds)) {
                     return reset($viewableSiteIds);
                 }
                 return false;
-            case self::PREFERENCE_DEFAULT_REPORT_DATE:
+            case static::PREFERENCE_DEFAULT_REPORT_DATE:
                 return Config::getInstance()->General['default_day'];
             default:
                 return false;
@@ -354,7 +354,7 @@ class API extends \Piwik\Plugin\API
         return $this->model->getUserByEmail($userEmail);
     }
 
-    private function checkLogin($userLogin)
+    protected function checkLogin($userLogin)
     {
         if ($this->userExists($userLogin)) {
             throw new Exception(Piwik::translate('UsersManager_ExceptionLoginExists', $userLogin));
@@ -363,7 +363,7 @@ class API extends \Piwik\Plugin\API
         Piwik::checkValidLoginString($userLogin);
     }
 
-    private function checkEmail($email)
+    protected function checkEmail($email)
     {
         if ($this->userEmailExists($email)) {
             throw new Exception(Piwik::translate('UsersManager_ExceptionEmailExists', $email));
@@ -374,7 +374,7 @@ class API extends \Piwik\Plugin\API
         }
     }
 
-    private function getCleanAlias($alias, $userLogin)
+    protected function getCleanAlias($alias, $userLogin)
     {
         if (empty($alias)) {
             $alias = $userLogin;
@@ -680,7 +680,7 @@ class API extends \Piwik\Plugin\API
      * @param string $userLogin user login
      * @throws Exception if the user doesn't exist
      */
-    private function checkUserExists($userLogin)
+    protected function checkUserExists($userLogin)
     {
         if (!$this->userExists($userLogin)) {
             throw new Exception(Piwik::translate("UsersManager_ExceptionUserDoesNotExist", $userLogin));
@@ -693,28 +693,28 @@ class API extends \Piwik\Plugin\API
      * @param string $userEmail user email
      * @throws Exception if the user doesn't exist
      */
-    private function checkUserEmailExists($userEmail)
+    protected function checkUserEmailExists($userEmail)
     {
         if (!$this->userEmailExists($userEmail)) {
             throw new Exception(Piwik::translate("UsersManager_ExceptionUserDoesNotExist", $userEmail));
         }
     }
 
-    private function checkUserIsNotAnonymous($userLogin)
+    protected function checkUserIsNotAnonymous($userLogin)
     {
         if ($userLogin == 'anonymous') {
             throw new Exception(Piwik::translate("UsersManager_ExceptionEditAnonymous"));
         }
     }
 
-    private function checkUserHasNotSuperUserAccess($userLogin)
+    protected function checkUserHasNotSuperUserAccess($userLogin)
     {
         if (Piwik::hasTheUserSuperUserAccess($userLogin)) {
             throw new Exception(Piwik::translate("UsersManager_ExceptionSuperUserAccess"));
         }
     }
 
-    private function checkAccessType($access)
+    protected function checkAccessType($access)
     {
         $accessList = Access::getListAccess();
 
@@ -726,7 +726,7 @@ class API extends \Piwik\Plugin\API
         }
     }
 
-    private function isUserTheOnlyUserHavingSuperUserAccess($userLogin)
+    protected function isUserTheOnlyUserHavingSuperUserAccess($userLogin)
     {
         $superUsers = $this->getUsersHavingSuperUserAccess();
 

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -33,7 +33,7 @@ class Controller extends ControllerAdmin
     /**
      * @var Translator
      */
-    private $translator;
+    protected $translator;
 
     public function __construct(Translator $translator)
     {
@@ -139,7 +139,7 @@ class Controller extends ControllerAdmin
         return $view->render();
     }
 
-    private function hasAnonymousUserViewAccess($usersAccessByWebsite)
+    protected function hasAnonymousUserViewAccess($usersAccessByWebsite)
     {
         $anonymousHasViewAccess = false;
 
@@ -203,7 +203,7 @@ class Controller extends ControllerAdmin
             throw new Exception("some metadata is missing in getDefaultDates()");
         }
 
-        $allowedPeriods = self::getEnabledPeriodsInUI();
+        $allowedPeriods = static::getEnabledPeriodsInUI();
         $allowedDates = array_intersect($mappingDatesToPeriods, $allowedPeriods);
         $dates = array_intersect_key($dates, $allowedDates);
 
@@ -400,7 +400,7 @@ class Controller extends ControllerAdmin
         return $toReturn;
     }
 
-    private function noAdminAccessToWebsite($idSiteSelected, $defaultReportSiteName, $message)
+    protected function noAdminAccessToWebsite($idSiteSelected, $defaultReportSiteName, $message)
     {
         $view = new View('@UsersManager/noWebsiteAdminAccess');
 
@@ -412,7 +412,7 @@ class Controller extends ControllerAdmin
         return $view->render();
     }
 
-    private function processPasswordChange($userLogin)
+    protected function processPasswordChange($userLogin)
     {
         $alias = Common::getRequestVar('alias');
         $email = Common::getRequestVar('email');
@@ -453,7 +453,7 @@ class Controller extends ControllerAdmin
     /**
      * @return string
      */
-    private function getIgnoreCookieSalt()
+    protected function getIgnoreCookieSalt()
     {
         return md5(SettingsPiwik::getSalt());
     }

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -54,7 +54,7 @@ class Controller extends ControllerAdmin
     {
         Piwik::checkUserIsNotAnonymous();
 
-        $view = new View('@UsersManager/index');
+        $view = new View('@' . Piwik::getUsersManagerPluginName() . '/index');
 
         $IdSitesAdmin = APISitesManager::getInstance()->getSitesIdWithAdminAccess();
         $idSiteSelected = 1;
@@ -225,7 +225,7 @@ class Controller extends ControllerAdmin
     {
         Piwik::checkUserIsNotAnonymous();
 
-        $view = new View('@UsersManager/userSettings');
+        $view = new View('@' . Piwik::getUsersManagerPluginName() . '/userSettings');
 
         $userLogin = Piwik::getCurrentUserLogin();
         $user = APIUsersManager::getInstance()->getUser($userLogin);
@@ -273,7 +273,7 @@ class Controller extends ControllerAdmin
     {
         Piwik::checkUserHasSuperUserAccess();
 
-        $view = new View('@UsersManager/anonymousSettings');
+        $view = new View('@' . Piwik::getUsersManagerPluginName() . '/anonymousSettings');
 
         $view->availableDefaultDates = $this->getDefaultDates();
 
@@ -402,7 +402,7 @@ class Controller extends ControllerAdmin
 
     protected function noAdminAccessToWebsite($idSiteSelected, $defaultReportSiteName, $message)
     {
-        $view = new View('@UsersManager/noWebsiteAdminAccess');
+        $view = new View('@' . Piwik::getUsersManagerPluginName() . '/noWebsiteAdminAccess');
 
         $view->idSiteSelected = $idSiteSelected;
         $view->defaultReportSiteName = $defaultReportSiteName;

--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -120,7 +120,7 @@ class UsersManager extends \Piwik\Plugin
 
         $l = strlen($input);
 
-        return $l >= self::PASSWORD_MIN_LENGTH && $l <= self::PASSWORD_MAX_LENGTH;
+        return $l >= static::PASSWORD_MIN_LENGTH && $l <= static::PASSWORD_MAX_LENGTH;
     }
 
     public static function checkPassword($password)
@@ -143,9 +143,9 @@ class UsersManager extends \Piwik\Plugin
          */
         Piwik::postEvent('UsersManager.checkPassword', array($password));
 
-        if (!self::isValidPasswordString($password)) {
-            throw new Exception(Piwik::translate('UsersManager_ExceptionInvalidPassword', array(self::PASSWORD_MIN_LENGTH,
-                self::PASSWORD_MAX_LENGTH)));
+        if (!static::isValidPasswordString($password)) {
+            throw new Exception(Piwik::translate('UsersManager_ExceptionInvalidPassword', array(static::PASSWORD_MIN_LENGTH,
+                static::PASSWORD_MAX_LENGTH)));
         }
     }
 

--- a/plugins/UsersManager/config/config.php
+++ b/plugins/UsersManager/config/config.php
@@ -1,0 +1,5 @@
+<?php
+
+return array(
+    'UsersManager_API' => DI\object('Piwik\Plugins\UsersManager\API')
+);

--- a/plugins/UsersManager/templates/userSettings.twig
+++ b/plugins/UsersManager/templates/userSettings.twig
@@ -12,6 +12,8 @@
 
 <form id="userSettingsTable">
 
+    {% block settingsTable %}
+
     <div class="form-group">
         <label for="username">{{ 'General_Username'|translate }}</label>
         <div class="form-help">{{ 'UsersManager_YourUsernameCannotBeChanged'|translate }}</div>
@@ -97,6 +99,8 @@
             {% if not isSuperUser %}{{ 'UsersManager_EmailYourAdministrator'|translate(invalidHostMailLinkStart,'</a>')|raw }}{% endif %}
         </div>
     {% endif %}
+
+    {% endblock %}
 
     {% import 'ajaxMacros.twig' as ajax %}
     {{ ajax.errorDiv('ajaxErrorUserSettings') }}


### PR DESCRIPTION
This is what's necessary to be able to create one's own plugin based on the core UsersManager plugin.

E.g.: A working (with Piwik 2.14.3 with this change applied) UsersManager-extending plugin implementation is https://github.com/Joey3000/piwik-UsersManagerEncrypted. That plugin works with https://github.com/Joey3000/piwik-LoginEncrypted (currently the forUMEncrypted project branch) to do the same (i.e. encryption) for passwords handled by the UsersManager - i.e. on user addition and change by the super user, and on change of user's own password. The plugin is tiny, because it relies on the existing core plugin which, even disabled, is still present in the system.

I hope it would be possible to merge this into 2.15.0, because there won't be breaking changes for existing plugins (like in https://github.com/piwik/piwik/pull/8681 for the Login plugin), because there aren't any.

Thanks in advance!

P.S.: For details, please refer to description and comments of the included commits.
