### PR TITLE
Wrong place of CoreArchive.run.finish event

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -285,7 +285,7 @@ class CronArchive
          *
          * @param CronArchive $this
          */
-        Piwik::postEvent('CoreArchive.run.start', array($this));
+        Piwik::postEvent('CoreArchive.init.start', array($this));
 
         SettingsServer::setMaxExecutionTime(0);
 
@@ -457,8 +457,8 @@ class CronArchive
          *
          * @param CronArchive $this
          */
-        Piwik::postEvent('CoreArchive.run.finish', array($this));
-        
+        Piwik::postEvent('CoreArchive.end', array($this));
+
         if (empty($this->errors)) {
             // No error -> Logs the successful script execution until completion
             Option::set(self::OPTION_ARCHIVING_FINISHED_TS, time());

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -452,6 +452,13 @@ class CronArchive
      */
     public function end()
     {
+        /**
+         * This event is triggered after archiving.
+         *
+         * @param CronArchive $this
+         */
+        Piwik::postEvent('CoreArchive.run.finish', array($this));
+        
         if (empty($this->errors)) {
             // No error -> Logs the successful script execution until completion
             Option::set(self::OPTION_ARCHIVING_FINISHED_TS, time());
@@ -466,13 +473,6 @@ class CronArchive
 
         $summary = count($this->errors) . " total errors during this script execution, please investigate and try and fix these errors.";
         $this->logFatalError($summary);
-
-        /**
-         * This event is triggered after archiving.
-         *
-         * @param CronArchive $this
-         */
-        Piwik::postEvent('CoreArchive.run.finish', array($this));
     }
 
     public function logFatalError($m)


### PR DESCRIPTION
Hi @mattab & @tsteur,

Do you remember about my latest PR which concerns the archiving lifecycle events: https://github.com/piwik/piwik/pull/8738

There is a small mistake, because the event `CoreArchive.run.finish` will execute only when we have some errors. In the other case it will never execute: https://github.com/andrzejewsky/piwik/blob/8d2ac648f6d222a8c4e2767b5fc4e7041bee68ea/core/CronArchive.php#L440

This event should be placed at beginning of the `end()` method.
