### PR TITLE
Improving extendibility of Login plugin

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -114,7 +114,7 @@ class Controller extends \Piwik\Plugin\Controller
         $view->infoMessage = nl2br($infoMessage);
         $view->addForm($form);
         $this->configureView($view);
-        self::setHostValidationVariablesView($view);
+        static::setHostValidationVariablesView($view);
 
         return $view->render();
     }
@@ -337,7 +337,7 @@ class Controller extends \Piwik\Plugin\Controller
      */
     public function logout()
     {
-        self::clearSession();
+        static::clearSession();
 
         $logoutUrl = @Config::getInstance()->General['login_logout_url'];
         if (empty($logoutUrl)) {

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -96,7 +96,7 @@ class Login extends \Piwik\Plugin
      */
     public static function initAuthenticationFromCookie(\Piwik\Auth $auth, $activateCookieAuth)
     {
-        if (self::isModuleIsAPI() && !$activateCookieAuth) {
+        if (static::isModuleIsAPI() && !$activateCookieAuth) {
             return;
         }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/piwik/piwik/pull/8723 to improve extendibility of the Login plugin. This is not (currently) required for my own plugin, but others could profit from it - see e.g. https://github.com/torosian/LoginRevokable/issues/2.

These are just the Login classes extended by my own and the above plugin. And none of the other Login plugins seems to extend any additional Login classes. So that I didn't do this improvement on other files of Login.
