### PR TITLE
Remove redundant loadInitialSites call in siteselector angular directive/controller.

### DIFF
--- a/plugins/CoreHome/angularjs/siteselector/siteselector.controller.js
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.controller.js
@@ -38,7 +38,5 @@
             return piwik.helper.getCurrentQueryStringWithParametersModified(newParameters) +
             '#' + piwik.helper.getQueryStringWithParametersModified(hash.substring(1), newParameters);
         };
-
-        siteSelectorModel.loadInitialSites();
     }
 })();


### PR DESCRIPTION
As title. Fixes #8780.

The method is called in both the directive & controller. On the second call, the requests in the first are aborted, so removing the extra call removes the extra requests.
