### PR TITLE
Use $location.search to store & change currently viewed page in UI instead of stead of $location.path

### DIFF
--- a/plugins/CoreHome/angularjs/history/history.service.js
+++ b/plugins/CoreHome/angularjs/history/history.service.js
@@ -75,7 +75,15 @@
                 }
             }
 
-            $location.search(hash);
+            if (hash) {
+                $location.search(hash);
+            } else {
+                // NOTE: this works around a bug in angularjs. when unsetting the hash (ie, removing in the URL),
+                // angular will enter an infinite loop of digests. this is because $locationWatch will trigger
+                // $locationChangeStart if $browser.url() != $location.absUrl(), and $browser.url() will contain
+                // the '#' character and $location.absUrl() will not. so the watch continues to trigger the event.
+                $location.search('_=');
+            }
 
             setTimeout(function () { $rootScope.$apply(); }, 1);
         }

--- a/plugins/CoreHome/angularjs/history/history.service.js
+++ b/plugins/CoreHome/angularjs/history/history.service.js
@@ -57,6 +57,16 @@
             var searchObject = $location.search(),
                 searchString = [];
             for (var name in searchObject) {
+                if (!searchObject.hasOwnProperty(name)) {
+                    continue;
+                }
+
+                // if more than one query parameter of the same name is supplied, angular will return all of them as
+                // an array. we only want to use the last one, though.
+                if (searchObject[name] instanceof Array) {
+                    searchObject[name] = searchObject[name][searchObject[name].length - 1];
+                }
+
                 searchString.push(name + '=' + encodeURIComponent(searchObject[name]));
             }
             searchString = searchString.join('&');

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -215,7 +215,7 @@ var broadcast = {
         }
 
         if (disableHistory) {
-            var newLocation = window.location.href.split('#')[0] + '#' + currentHashStr;
+            var newLocation = window.location.href.split('#')[0] + '#?' + currentHashStr;
             // window.location.replace changes the current url without pushing it on the browser's history stack
             window.location.replace(newLocation);
         }

--- a/plugins/Overlay/javascripts/Overlay_Helper.js
+++ b/plugins/Overlay/javascripts/Overlay_Helper.js
@@ -23,7 +23,7 @@ var Overlay_Helper = {
     getOverlayLink: function (idSite, period, date, link) {
         var url = 'index.php?module=Overlay&period=' + encodeURIComponent(period) + '&date=' + encodeURIComponent(date) + '&idSite=' + encodeURIComponent(idSite);
         if (link) {
-            url += '#l=' + Overlay_Helper.encodeFrameUrl(link);
+            url += '#?l=' + Overlay_Helper.encodeFrameUrl(link);
         }
         return url;
     }

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -114,6 +114,11 @@ var Piwik_Overlay = (function () {
     /** $.history callback for hash change */
     function hashChangeCallback(urlHash) {
         var location = broadcast.getParamValue('l', urlHash);
+
+        // angular will encode the value again since it is added as the fragment path, not the fragment query parameter,
+        // so we have to decode it again after getParamValue
+        location = decodeURIComponent(location);
+
         location = Overlay_Helper.decodeFrameUrl(location);
 
         if (!updateComesFromInsideFrame) {

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -111,14 +111,19 @@ var Piwik_Overlay = (function () {
         $fullScreenLink.show();
     }
 
-    /** $.history callback for hash change */
-    function hashChangeCallback(urlHash) {
+    function getOverlayLocationFromHash(urlHash) {
         var location = broadcast.getParamValue('l', urlHash);
 
         // angular will encode the value again since it is added as the fragment path, not the fragment query parameter,
         // so we have to decode it again after getParamValue
         location = decodeURIComponent(location);
 
+        return location;
+    }
+
+    /** $.history callback for hash change */
+    function hashChangeCallback(urlHash) {
+        var location = getOverlayLocationFromHash(urlHash);
         location = Overlay_Helper.decodeFrameUrl(location);
 
         if (!updateComesFromInsideFrame) {
@@ -248,7 +253,7 @@ var Piwik_Overlay = (function () {
             var locationParts = location.href.split('#');
             var currentLocation = '';
             if (locationParts.length > 1) {
-                currentLocation = broadcast.getParamValue('l', locationParts[1]);
+                currentLocation = getOverlayLocationFromHash(locationParts[1]);
             }
 
             var newLocation = Overlay_Helper.encodeFrameUrl(currentUrl);

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -614,5 +614,28 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         }, done);
     });
 
+    // extra segment tests
+    it('should load the row evolution page correctly when a segment is selected', function (done) {
+        var url = "?module=CoreHome&action=index&idSite=1&period=year&date=2012-01-13#?module=CustomVariables&action=menuGetCustomVariables&idSite=1&period=year&date=2012-01-13";
+        expect.page(url).contains('.ui-dialog > .ui-dialog-content > div.rowevolution:visible', 'segmented_rowevolution', function (page) {
+            page.click('.segmentationTitle');
+            page.click('.segname:contains(From Europe)');
 
+            page.mouseMove('table.dataTable tbody tr:first-child');
+            page.mouseMove('a.actionRowEvolution:visible'); // necessary to get popover to display
+            page.click('a.actionRowEvolution:visible');
+        }, done);
+    });
+
+    it('should load the segmented visitor log correctly when a segment is selected', function (done) {
+        var url = "?module=CoreHome&action=index&idSite=1&period=year&date=2012-01-13#?module=CustomVariables&action=menuGetCustomVariables&idSite=1&period=year&date=2012-01-13";
+        expect.page(url).contains('.ui-dialog > .ui-dialog-content > div.dataTableVizVisitorLog:visible', 'segmented_visitorlog', function (page) {
+            page.click('.segmentationTitle');
+            page.click('.segname:contains(From Europe)');
+
+            page.mouseMove('table.dataTable tbody tr:first-child');
+            page.mouseMove('a.actionSegmentVisitorLog:visible'); // necessary to get popover to display
+            page.click('a.actionSegmentVisitorLog:visible');
+        }, done);
+    });
 });


### PR DESCRIPTION
As title. Includes backwards compatibility for old URLs that use #/....

When using $location.path(), angular will decode the entire path before setting/getting, eventually resulting in the bug that occurs in #8776.

Please test extensively before merging. 

CC @tsteur I remember you saying angular search didn't work in some cases, if you remember why, could you take a look?

Fixes #8776
