### PR TITLE
Move CustomVariables::getNumUsableCustomVariables logic to DI so tests do not need to access database

### DIFF
--- a/core/Tracker/Cache.php
+++ b/core/Tracker/Cache.php
@@ -26,21 +26,11 @@ class Cache
     private static $cacheIdGeneral = 'general';
 
     /**
-     * Public for tests only
-     * @var \Piwik\Cache\Lazy
-     */
-    public static $cache;
-
-    /**
      * @return \Piwik\Cache\Lazy
      */
     private static function getCache()
     {
-        if (is_null(self::$cache)) {
-            self::$cache = PiwikCache::getLazyCache();
-        }
-
-        return self::$cache;
+        return PiwikCache::getLazyCache();
     }
 
     private static function getTtl()

--- a/plugins/CustomVariables/CustomVariables.php
+++ b/plugins/CustomVariables/CustomVariables.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\CustomVariables;
 
 use Piwik\ArchiveProcessor;
+use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Tracker\Cache;
 use Piwik\Tracker;
@@ -77,25 +78,8 @@ class CustomVariables extends \Piwik\Plugin
         $cacheKey = 'CustomVariables.NumUsableCustomVariables';
 
         if (!array_key_exists($cacheKey, $cache)) {
-
-            $minCustomVar = null;
-
-            foreach (Model::getScopes() as $scope) {
-                $model = new Model($scope);
-                $highestIndex = $model->getHighestCustomVarIndex();
-
-                if (!isset($minCustomVar)) {
-                    $minCustomVar = $highestIndex;
-                }
-
-                if ($highestIndex < $minCustomVar) {
-                    $minCustomVar = $highestIndex;
-                }
-            }
-
-            if (!isset($minCustomVar)) {
-                $minCustomVar = 0;
-            }
+            $metadataProvider = StaticContainer::get('Piwik\Plugins\CustomVariables\CustomVariablesMetadataProvider');
+            $minCustomVar = $metadataProvider->getNumUsableCustomVariables();
 
             $cache[$cacheKey] = $minCustomVar;
             Cache::setCacheGeneral($cache);

--- a/plugins/CustomVariables/CustomVariablesMetadataProvider.php
+++ b/plugins/CustomVariables/CustomVariablesMetadataProvider.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CustomVariables;
+
+/**
+ * Provides information about installed custom variable slots, such as,
+ * the number of usable custom variables.
+ */
+class CustomVariablesMetadataProvider
+{
+    /**
+     * @var Model[]
+     */
+    private $logTableModels;
+
+    public function __construct(array $logTableModels)
+    {
+        $this->logTableModels = $logTableModels;
+    }
+
+    public function getNumUsableCustomVariables()
+    {
+        $minCustomVar = null;
+
+        foreach ($this->logTableModels as $model) {
+            $highestIndex = $model->getHighestCustomVarIndex();
+
+            if (!isset($minCustomVar)) {
+                $minCustomVar = $highestIndex;
+            }
+
+            if ($highestIndex < $minCustomVar) {
+                $minCustomVar = $highestIndex;
+            }
+        }
+
+        if (!isset($minCustomVar)) {
+            $minCustomVar = 0;
+        }
+
+        return $minCustomVar;
+    }
+}

--- a/plugins/CustomVariables/Model.php
+++ b/plugins/CustomVariables/Model.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\CustomVariables;
 
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\DataTable;
 use Piwik\Db;
 use Piwik\Log;
@@ -149,6 +150,9 @@ class Model
         }
     }
 
+    /**
+     * @deprecated use 'Piwik\Plugins\CustomVariables\Model.all' DI entry instead
+     */
     public static function getScopes()
     {
         return array(self::SCOPE_PAGE, self::SCOPE_VISIT, self::SCOPE_CONVERSION);
@@ -156,9 +160,9 @@ class Model
 
     public static function install()
     {
-        foreach (self::getScopes() as $scope) {
-            $model = new Model($scope);
-
+        /** @var Model[] $models */
+        $models = StaticContainer::get('Piwik\Plugins\CustomVariables\Model.all');
+        foreach ($models as $model) {
             try {
                 $maxCustomVars   = self::DEFAULT_CUSTOM_VAR_COUNT;
                 $customVarsToAdd = $maxCustomVars - $model->getCurrentNumCustomVars();
@@ -174,14 +178,12 @@ class Model
 
     public static function uninstall()
     {
-        foreach (self::getScopes() as $scope) {
-            $model = new Model($scope);
-
+        /** @var Model[] $models */
+        $models = StaticContainer::get('Piwik\Plugins\CustomVariables\Model.all');
+        foreach ($models as $model) {
             while ($model->getHighestCustomVarIndex()) {
                 $model->removeCustomVariable();
             }
         }
     }
-
 }
-

--- a/plugins/CustomVariables/config/config.php
+++ b/plugins/CustomVariables/config/config.php
@@ -1,9 +1,27 @@
 <?php
 
+use Piwik\Plugins\CustomVariables\Model;
+
 return array(
 
     'tracker.request.processors' => DI\add(array(
         DI\get('Piwik\Plugins\CustomVariables\Tracker\CustomVariablesRequestProcessor'),
     )),
+
+    'Piwik\Plugins\CustomVariables\Model.page' => DI\object('Piwik\Plugins\CustomVariables\Model')
+        ->constructor(Model::SCOPE_PAGE),
+    'Piwik\Plugins\CustomVariables\Model.visit' => DI\object('Piwik\Plugins\CustomVariables\Model')
+        ->constructor(Model::SCOPE_VISIT),
+    'Piwik\Plugins\CustomVariables\Model.conversion' => DI\object('Piwik\Plugins\CustomVariables\Model')
+        ->constructor(Model::SCOPE_CONVERSION),
+
+    'Piwik\Plugins\CustomVariables\Model.all' => array(
+        DI\get('Piwik\Plugins\CustomVariables\Model.page'),
+        DI\get('Piwik\Plugins\CustomVariables\Model.visit'),
+        DI\get('Piwik\Plugins\CustomVariables\Model.conversion'),
+    ),
+
+    'Piwik\Plugins\CustomVariables\CustomVariablesMetadataProvider' => DI\object()
+        ->constructor(DI\get('Piwik\Plugins\CustomVariables\Model.all')),
 
 );

--- a/plugins/CustomVariables/config/test.php
+++ b/plugins/CustomVariables/config/test.php
@@ -1,0 +1,8 @@
+<?php
+
+return array(
+
+    'Piwik\Plugins\CustomVariables\tests\Mock\CustomVariablesMetadataProvider' => DI\object()
+        ->constructor(DI\get('Piwik\Plugins\CustomVariables\Model.all')),
+
+);

--- a/plugins/CustomVariables/tests/Mock/CustomVariablesMetadataProvider.php
+++ b/plugins/CustomVariables/tests/Mock/CustomVariablesMetadataProvider.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CustomVariables\tests\Mock;
+
+use Piwik\Plugins\CustomVariables\Model;
+
+/**
+ * Mock CustomVariablesMetadataProvider used during tests when it is necessary to get
+ * the custom variable count w/o database access.
+ */
+class CustomVariablesMetadataProvider extends \Piwik\Plugins\CustomVariables\CustomVariablesMetadataProvider
+{
+    public function getNumUsableCustomVariables()
+    {
+        return Model::DEFAULT_CUSTOM_VAR_COUNT;
+    }
+}

--- a/tests/LocalTracker.php
+++ b/tests/LocalTracker.php
@@ -44,7 +44,6 @@ class Piwik_LocalTracker extends PiwikTracker
         }
 
         // unset cached values
-        Cache::$cache = null;
         Tracker\Visit::$dimensions = null;
 
         // save some values

--- a/tests/PHPUnit/System/AutoSuggestAPITest.php
+++ b/tests/PHPUnit/System/AutoSuggestAPITest.php
@@ -178,8 +178,6 @@ class AutoSuggestAPITest extends SystemTestCase
             }
         } catch (\Exception $ex) {
             $exception = $ex;
-
-            echo $ex->getMessage()."\n".$ex->getTraceAsString()."\n";
         }
 
         $environment->destroy();

--- a/tests/PHPUnit/System/AutoSuggestAPITest.php
+++ b/tests/PHPUnit/System/AutoSuggestAPITest.php
@@ -162,30 +162,20 @@ class AutoSuggestAPITest extends SystemTestCase
 
         $segments = array();
 
-        $environment = new Environment(null);
+        $environment = new Environment(null, self::provideContainerConfigBeforeClass());
 
         $exception = null;
         try {
             $environment->init();
             $environment->getContainer()->get('Piwik\Plugin\Manager')->loadActivatedPlugins();
 
-            foreach (Dimension::getAllDimensions() as $dimension) {
-                if ($dimension instanceof CustomVariableName
-                    || $dimension instanceof CustomVariableValue
-                ) {
-                    continue; // added manually below
-                }
+            /** @var \Piwik\Plugins\API\API $api */
+            $api = $environment->getContainer()->get('Piwik\Plugins\API\API');
 
-                foreach ($dimension->getSegments() as $segment) {
-                    $segments[] = $segment->getSegment();
-                }
+            $segments = array();
+            foreach ($api->getSegmentsMetadata(self::$fixture->idSite) as $segmentInfo) {
+                $segments[] = $segmentInfo['segment'];
             }
-
-            // add CustomVariables manually since the data provider may not have access to the DB
-            for ($i = 1; $i != Model::DEFAULT_CUSTOM_VAR_COUNT + 1; ++$i) {
-                $segments = array_merge($segments, self::getCustomVariableSegments($i));
-            }
-            $segments = array_merge($segments, self::getCustomVariableSegments());
         } catch (\Exception $ex) {
             $exception = $ex;
 
@@ -201,22 +191,14 @@ class AutoSuggestAPITest extends SystemTestCase
         return $segments;
     }
 
-    private static function getCustomVariableSegments($columnIndex = null)
+    public static function provideContainerConfigBeforeClass()
     {
-        $result = array(
-            'customVariableName',
-            'customVariableValue',
-            'customVariablePageName',
-            'customVariablePageValue',
+        return array(
+
+            'Piwik\Plugins\CustomVariables\CustomVariablesMetadataProvider' =>
+                \DI\get('Piwik\Plugins\CustomVariables\tests\Mock\CustomVariablesMetadataProvider'),
+
         );
-
-        if ($columnIndex !== null) {
-            foreach ($result as &$name) {
-                $name = $name . $columnIndex;
-            }
-        }
-
-        return $result;
     }
 }
 


### PR DESCRIPTION
This PR creates a new class, CustomVariablesMetadataProvider, which contains the main logic for `CustomVariables::getNumUsableCustomVariables`. A mock class is defined and used by AutoSuggestAPITest so `API.getSegmentsMetadata` can be used in the data provider instead of having to define them manually.

Additional changes in this PR:
- Removed `Piwik\Tracker\Cache::$cache`. Since the Cache instance comes from DI, we don't need the static variable anymore.
- Moved `CustomVariables\Model` instances to DI (one per 'scope').

Fixes #8756 
