### PR TITLE
Fix hardcoded Login module references

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -879,7 +879,7 @@ abstract class Controller
             $currentLogin = Piwik::getCurrentUserLogin();
             $emails = implode(',', Piwik::getAllSuperUserAccessEmailAddresses());
             $errorMessage  = sprintf(Piwik::translate('CoreHome_NoPrivilegesAskPiwikAdmin'), $currentLogin, "<br/><a href='mailto:" . $emails . "?subject=Access to Piwik for user $currentLogin'>", "</a>");
-            $errorMessage .= "<br /><br />&nbsp;&nbsp;&nbsp;<b><a href='index.php?module=" . StaticContainer::get('Piwik\Auth')->getName() . "&amp;action=logout'>&rsaquo; " . Piwik::translate('General_Logout') . "</a></b><br />";
+            $errorMessage .= "<br /><br />&nbsp;&nbsp;&nbsp;<b><a href='index.php?module=" . Piwik::getLoginPluginName() . "&amp;action=logout'>&rsaquo; " . Piwik::translate('General_Logout') . "</a></b><br />";
 
             $ex = new NoPrivilegesException($errorMessage);
             $ex->setIsHtmlMessage();

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -176,7 +176,7 @@ class Controller extends \Piwik\Plugin\Controller
             </div>',
             Piwik::translate('General_Error'),
             htmlentities($errorMessage, Common::HTML_ENCODING_QUOTE_STYLE, 'UTF-8', $doubleEncode = false),
-            'index.php?module=Login',
+            'index.php?module=' . Piwik::getLoginPluginName(),
             Piwik::translate('Login_LogIn')
         );
     }

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -57,11 +57,11 @@ class Login extends \Piwik\Plugin
         $frontController = FrontController::getInstance();
 
         if (Common::isXmlHttpRequest()) {
-            echo $frontController->dispatch('Login', 'ajaxNoAccess', array($exception->getMessage()));
+            echo $frontController->dispatch(Piwik::getLoginPluginName(), 'ajaxNoAccess', array($exception->getMessage()));
             return;
         }
 
-        echo $frontController->dispatch('Login', 'login', array($exception->getMessage()));
+        echo $frontController->dispatch(Piwik::getLoginPluginName(), 'login', array($exception->getMessage()));
     }
 
     /**


### PR DESCRIPTION
This does following:

I. Fixes hardcoded use of the Login plugin name:
1. For `plugins/Login/Login.php`, this prevents the "Login plugin not active" exception page appearances. Those can be reproduced using following simple test (just an example):
   
   a. Install and activate another Login module (tested with LoginEncrypted - the core Login plugin will be automatically deactivated)
   b. Add another user and set it to be super user as well
   c. Log out and log back in as the newly created super user
   d. Delete the newly created super-user (i.e. oneself)
   ==> Instead of the login page, a "Login plugin not active" exception page appears
2. For `plugins/Login/Controller.php`, this corrects the displayed link to the login page. To reproduce (just an example):
   
   a. Send an ajax request with no access; or: patch in a new Exception somewhere (e.g. at the beginning of `plugins/Login/Login.php->login()` and load the login page) showing the return of `plugins/Login/Controller.php->ajaxNoAccess()`

II. Fixes an inconsistency in obtaining the name of the currently active Login module in `core/Plugin/Controller.php`. It should, like any other module, use `Piwik::getLoginPluginName()` instead of replicating it by accessing `StaticContainer::get('Piwik\Auth')->getName()` directly. This was done to prevent possible future issues in case that `Piwik::getLoginPluginName()` changes.

P.S.: Note to the point (I) above: Please note that checking, within the Login plugin code, which Login module is currently active is nothing new. Because the core Login module code is called also when the plugin is disabled, it already needs to find it out, as it does e.g. in https://github.com/piwik/piwik/blob/2.15.0-b7/plugins/Login/Login.php#L74 (using a released version as example, just so that the line number does not change in future).
