### PR TITLE
Add idSegments as SQL comment in segment archiving SQL

### DIFF
--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -15,20 +15,16 @@ use Piwik\Segment\SegmentExpression;
 
 class LogQueryBuilder
 {
-    public function __construct(SegmentExpression $segmentExpression)
-    {
-        $this->segmentExpression = $segmentExpression;
-    }
-
-    public function getSelectQueryString($select, $from, $where, $bind, $groupBy, $orderBy, $limit)
+    public function getSelectQueryString(SegmentExpression $segmentExpression, $select, $from, $where, $bind, $groupBy,
+                                         $orderBy, $limit)
     {
         if (!is_array($from)) {
             $from = array($from);
         }
 
-        if (!$this->segmentExpression->isEmpty()) {
-            $this->segmentExpression->parseSubExpressionsIntoSqlExpressions($from);
-            $segmentSql = $this->segmentExpression->getSql();
+        if (!$segmentExpression->isEmpty()) {
+            $segmentExpression->parseSubExpressionsIntoSqlExpressions($from);
+            $segmentSql = $segmentExpression->getSql();
             $where = $this->getWhereMatchBoth($where, $segmentSql['where']);
             $bind = array_merge($bind, $segmentSql['bind']);
         }

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\LogQueryBuilder;
 use Piwik\Plugins\API\API;
 use Piwik\Segment\SegmentExpression;
@@ -72,6 +73,11 @@ class Segment
     protected $idSites = null;
 
     /**
+     * @var LogQueryBuilder
+     */
+    private $segmentQueryBuilder;
+
+    /**
      * Truncate the Segments to 8k
      */
     const SEGMENT_TRUNCATE_LIMIT = 8192;
@@ -86,6 +92,8 @@ class Segment
      */
     public function __construct($segmentCondition, $idSites)
     {
+        $this->segmentQueryBuilder = StaticContainer::get('Piwik\DataAccess\LogQueryBuilder');
+
         $segmentCondition = trim($segmentCondition);
         if (!SettingsPiwik::isSegmentationEnabled()
             && !empty($segmentCondition)
@@ -253,8 +261,8 @@ class Segment
             $limit = (int) $offset . ', ' . (int) $limit;
         }
 
-        $segmentQuery = new LogQueryBuilder($segmentExpression);
-        return $segmentQuery->getSelectQueryString($select, $from, $where, $bind, $groupBy, $orderBy, $limit);
+        return $this->segmentQueryBuilder->getSelectQueryString($segmentExpression, $select, $from, $where, $bind,
+            $groupBy, $orderBy, $limit);
     }
 
     /**

--- a/core/Segment/SegmentExpression.php
+++ b/core/Segment/SegmentExpression.php
@@ -49,7 +49,7 @@ class SegmentExpression
         $this->tree = $this->parseTree();
     }
 
-    public function getSegmentString()
+    public function getSegmentDefinition()
     {
         return $this->string;
     }

--- a/core/Segment/SegmentExpression.php
+++ b/core/Segment/SegmentExpression.php
@@ -49,6 +49,11 @@ class SegmentExpression
         $this->tree = $this->parseTree();
     }
 
+    public function getSegmentString()
+    {
+        return $this->string;
+    }
+
     public function isEmpty()
     {
         return count($this->tree) == 0;

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -370,7 +370,7 @@ class API extends \Piwik\Plugin\API
     /**
      * Returns stored segments that are set to be archived during cron archiving.
      *
-     * @param bool|false $idSite
+     * @param int|bool $idSite
      * @return array
      */
     public function getSegmentsToAutoArchive($idSite = false)
@@ -380,6 +380,8 @@ class API extends \Piwik\Plugin\API
         } else {
             Piwik::checkUserHasSuperUserAccess();
         }
+
+        $idSite = (int)$idSite;
 
         $cacheKey = 'SegmentEditor.getSegmentsToAutoArchive_' . (!empty($idSite) ? $idSite : 'enabled_all');
         if (!$this->transientCache->contains($cacheKey)) {

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -29,15 +29,9 @@ class API extends \Piwik\Plugin\API
      */
     private $model;
 
-    /**
-     * @var TransientCache
-     */
-    private $transientCache;
-
-    public function __construct(Model $model, TransientCache $transientCache)
+    public function __construct(Model $model)
     {
         $this->model = $model;
-        $this->transientCache = $transientCache;
     }
 
     protected function checkSegmentValue($definition, $idSite)
@@ -365,31 +359,6 @@ class API extends \Piwik\Plugin\API
         }
 
         return $segments;
-    }
-
-    /**
-     * Returns stored segments that are set to be archived during cron archiving.
-     *
-     * @param int|bool $idSite
-     * @return array
-     */
-    public function getSegmentsToAutoArchive($idSite = false)
-    {
-        if (!empty($idSite)) {
-            Piwik::checkUserHasAdminAccess($idSite);
-        } else {
-            Piwik::checkUserHasSuperUserAccess();
-        }
-
-        $idSite = (int)$idSite;
-
-        $cacheKey = 'SegmentEditor.getSegmentsToAutoArchive_' . (!empty($idSite) ? $idSite : 'enabled_all');
-        if (!$this->transientCache->contains($cacheKey)) {
-            $result = $this->model->getSegmentsToAutoArchive($idSite);
-
-            $this->transientCache->save($cacheKey, $result);
-        }
-        return $this->transientCache->fetch($cacheKey);
     }
 
     /**

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -23,6 +23,16 @@ use Piwik\Segment;
  */
 class API extends \Piwik\Plugin\API
 {
+    /**
+     * @var Model
+     */
+    private $model;
+
+    public function __construct(Model $model)
+    {
+        $this->model = $model;
+    }
+
     protected function checkSegmentValue($definition, $idSite)
     {
         // unsanitize so we don't record the HTML entitied segment
@@ -201,7 +211,7 @@ class API extends \Piwik\Plugin\API
 
     private function getModel()
     {
-        return new Model();
+        return $this->model;
     }
 
     /**

--- a/plugins/SegmentEditor/Model.php
+++ b/plugins/SegmentEditor/Model.php
@@ -51,14 +51,13 @@ class Model
         $bind = array();
 
         $whereIdSite = '';
-        if (empty($idSite)) {
-            $whereIdSite .= 'enable_only_idsite = 0 AND';
-        } else if ($idSite != 'all') {
-            $whereIdSite = '(enable_only_idsite = ? OR enable_only_idsite = 0) AND';
+        if (!empty($idSite)) {
+            $whereIdSite = 'enable_only_idsite = ? OR ';
             $bind[] = $idSite;
         }
 
-        $sql = $this->buildQuerySortedByName("$whereIdSite deleted = 0 AND auto_archive = 1");
+        $sql = $this->buildQuerySortedByName("($whereIdSite enable_only_idsite = 0)
+                                              AND deleted = 0 AND auto_archive = 1");
 
         $segments = $this->getDb()->fetchAll($sql, $bind);
 

--- a/plugins/SegmentEditor/Model.php
+++ b/plugins/SegmentEditor/Model.php
@@ -51,13 +51,14 @@ class Model
         $bind = array();
 
         $whereIdSite = '';
-        if (!empty($idSite)) {
-            $whereIdSite = 'enable_only_idsite = ? OR ';
+        if (empty($idSite)) {
+            $whereIdSite .= 'enable_only_idsite = 0 AND';
+        } else if ($idSite != 'all') {
+            $whereIdSite = '(enable_only_idsite = ? OR enable_only_idsite = 0) AND';
             $bind[] = $idSite;
         }
 
-        $sql = $this->buildQuerySortedByName("($whereIdSite enable_only_idsite = 0)
-                                              AND deleted = 0 AND auto_archive = 1");
+        $sql = $this->buildQuerySortedByName("$whereIdSite deleted = 0 AND auto_archive = 1");
 
         $segments = $this->getDb()->fetchAll($sql, $bind);
 

--- a/plugins/SegmentEditor/SegmentQueryDecorator.php
+++ b/plugins/SegmentEditor/SegmentQueryDecorator.php
@@ -8,8 +8,8 @@
 
 namespace Piwik\Plugins\SegmentEditor;
 
-use Piwik\Access;
 use Piwik\DataAccess\LogQueryBuilder;
+use Piwik\Plugins\SegmentEditor\Services\StoredSegmentService;
 use Piwik\Segment\SegmentExpression;
 
 /**
@@ -21,13 +21,13 @@ use Piwik\Segment\SegmentExpression;
 class SegmentQueryDecorator extends LogQueryBuilder
 {
     /**
-     * @var API
+     * @var StoredSegmentService
      */
-    private $segmentEditorApi;
+    private $storedSegmentService;
 
-    public function __construct(API $segmentEditorApi)
+    public function __construct(StoredSegmentService $storedSegmentService)
     {
-        $this->segmentEditorApi = $segmentEditorApi;
+        $this->storedSegmentService = $storedSegmentService;
     }
 
     public function getSelectQueryString(SegmentExpression $segmentExpression, $select, $from, $where, $bind, $groupBy,
@@ -46,10 +46,7 @@ class SegmentQueryDecorator extends LogQueryBuilder
 
     private function getSegmentIdOfExpression(SegmentExpression $segmentExpression)
     {
-        $segmentEditorApi = $this->segmentEditorApi;
-        $allSegments = Access::doAsSuperUser(function () use ($segmentEditorApi) {
-            return $segmentEditorApi->getSegmentsToAutoArchive('all');
-        });
+        $allSegments = $this->storedSegmentService->getSegmentsToAutoArchive('all');
 
         $idSegments = array();
         foreach ($allSegments as $segment) {

--- a/plugins/SegmentEditor/SegmentQueryDecorator.php
+++ b/plugins/SegmentEditor/SegmentQueryDecorator.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\SegmentEditor;
+
+use Piwik\Access;
+use Piwik\DataAccess\LogQueryBuilder;
+use Piwik\Segment\SegmentExpression;
+
+/**
+ * Decorates segment sub-queries in archiving queries w/ the idSegment of the segment, if
+ * a stored segment exists.
+ *
+ * This class is configured for use in SegmentEditor's DI config.
+ */
+class SegmentQueryDecorator extends LogQueryBuilder
+{
+    /**
+     * @var API
+     */
+    private $segmentEditorApi;
+
+    public function __construct(API $segmentEditorApi)
+    {
+        $this->segmentEditorApi = $segmentEditorApi;
+    }
+
+    public function getSelectQueryString(SegmentExpression $segmentExpression, $select, $from, $where, $bind, $groupBy,
+                                         $orderBy, $limit)
+    {
+        $result = parent::getSelectQueryString($segmentExpression, $select, $from, $where, $bind, $groupBy, $orderBy,
+            $limit);
+
+        $idSegments = $this->getSegmentIdOfExpression($segmentExpression);
+        if (!empty($idSegments)) {
+            $result['sql'] = "/* idSegments = [" . implode(', ', $idSegments) . "] */\n" . $result['sql'];
+        }
+
+        return $result;
+    }
+
+    private function getSegmentIdOfExpression(SegmentExpression $segmentExpression)
+    {
+        $segmentEditorApi = $this->segmentEditorApi;
+        $allSegments = Access::doAsSuperUser(function () use ($segmentEditorApi) {
+            return $segmentEditorApi->getSegmentsToAutoArchive('all');
+        });
+
+        $idSegments = array();
+        foreach ($allSegments as $segment) {
+            if ($segmentExpression->getSegmentString() == $segment['definition']) {
+                $idSegments[] = $segment['idsegment'];
+            }
+        }
+        return $idSegments;
+    }
+}

--- a/plugins/SegmentEditor/SegmentQueryDecorator.php
+++ b/plugins/SegmentEditor/SegmentQueryDecorator.php
@@ -53,7 +53,7 @@ class SegmentQueryDecorator extends LogQueryBuilder
 
         $idSegments = array();
         foreach ($allSegments as $segment) {
-            if ($segmentExpression->getSegmentString() == $segment['definition']) {
+            if ($segmentExpression->getSegmentDefinition() == $segment['definition']) {
                 $idSegments[] = $segment['idsegment'];
             }
         }

--- a/plugins/SegmentEditor/SegmentQueryDecorator.php
+++ b/plugins/SegmentEditor/SegmentQueryDecorator.php
@@ -49,7 +49,7 @@ class SegmentQueryDecorator extends LogQueryBuilder
         }
 
         if (!empty($prefixParts)) {
-            $result['sql'] = "/* " . implode(', ', $prefixParts) . " */\n";
+            $result['sql'] = "/* " . implode(', ', $prefixParts) . " */\n" . $result['sql'];
         }
 
         return $result;

--- a/plugins/SegmentEditor/Services/StoredSegmentService.php
+++ b/plugins/SegmentEditor/Services/StoredSegmentService.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\SegmentEditor\Services;
+
+use Piwik\Plugins\SegmentEditor\Model;
+use Piwik\Cache\Transient as TransientCache;
+
+
+/**
+ * Service layer class for stored segments.
+ */
+class StoredSegmentService
+{
+    /**
+     * @var Model
+     */
+    private $model;
+
+    /**
+     * @var TransientCache
+     */
+    private $transientCache;
+
+    public function __construct(Model $model, TransientCache $transientCache)
+    {
+        $this->model = $model;
+        $this->transientCache = $transientCache;
+    }
+
+    /**
+     * Returns stored segments that are set to be archived during cron archiving.
+     *
+     * @param int|bool $idSite
+     * @return array
+     */
+    public function getSegmentsToAutoArchive($idSite = false)
+    {
+        if ($idSite != 'all') {
+            $idSite = (int)$idSite;
+        }
+
+        $cacheKey = 'SegmentEditor.getSegmentsToAutoArchive_' . (!empty($idSite) ? $idSite : 'enabled_all');
+        if (!$this->transientCache->contains($cacheKey)) {
+            $result = $this->model->getSegmentsToAutoArchive($idSite);
+
+            $this->transientCache->save($cacheKey, $result);
+        }
+        return $this->transientCache->fetch($cacheKey);
+    }
+}

--- a/plugins/SegmentEditor/Services/StoredSegmentService.php
+++ b/plugins/SegmentEditor/Services/StoredSegmentService.php
@@ -34,20 +34,15 @@ class StoredSegmentService
     }
 
     /**
-     * Returns stored segments that are set to be archived during cron archiving.
+     * Returns all stored segments that haven't been deleted.
      *
-     * @param int|bool $idSite
      * @return array
      */
-    public function getSegmentsToAutoArchive($idSite = false)
+    public function getAllSegmentsAndIgnoreVisibility()
     {
-        if ($idSite != 'all') {
-            $idSite = (int)$idSite;
-        }
-
-        $cacheKey = 'SegmentEditor.getSegmentsToAutoArchive_' . (!empty($idSite) ? $idSite : 'enabled_all');
+        $cacheKey = 'SegmentEditor.getAllSegmentsAndIgnoreVisibility';
         if (!$this->transientCache->contains($cacheKey)) {
-            $result = $this->model->getSegmentsToAutoArchive($idSite);
+            $result = $this->model->getAllSegmentsAndIgnoreVisibility();
 
             $this->transientCache->save($cacheKey, $result);
         }

--- a/plugins/SegmentEditor/config/config.php
+++ b/plugins/SegmentEditor/config/config.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+
+    'Piwik\DataAccess\LogQueryBuilder' => DI\get('Piwik\Plugins\SegmentEditor\SegmentQueryDecorator'),
+
+);

--- a/plugins/SegmentEditor/tests/Integration/SegmentQueryDecoratorTest.php
+++ b/plugins/SegmentEditor/tests/Integration/SegmentQueryDecoratorTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\SegmentEditor\tests\Integration;
+
+use Piwik\Plugins\SegmentEditor\API;
+use Piwik\Plugins\SegmentEditor\SegmentQueryDecorator;
+use Piwik\Segment;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group SegmentEditor
+ * @group SegmentEditor_Integration
+ */
+class SegmentQueryDecoratorTest extends IntegrationTestCase
+{
+    /**
+     * @var SegmentQueryDecorator
+     */
+    private $segmentQueryDecorator;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2011-01-01');
+        Fixture::createWebsite('2011-01-01');
+        Fixture::createWebsite('2011-01-01');
+
+        $this->segmentQueryDecorator = self::$fixture->piwikEnvironment->getContainer()->get(
+            'Piwik\Plugins\SegmentEditor\SegmentQueryDecorator');
+
+        /** @var API $segmentEditorApi */
+        $segmentEditorApi = self::$fixture->piwikEnvironment->getContainer()->get(
+            'Piwik\Plugins\SegmentEditor\API');
+        $segmentEditorApi->add('segment 1', 'visitCount<2', $idSite = false, $autoArchive = true);
+        $segmentEditorApi->add('segment 2', 'countryCode==fr', $idSite = false, $autoArchive = true);
+        $segmentEditorApi->add('segment 3', 'visitCount<2', 1, $autoArchive = true);
+        $segmentEditorApi->add('segment 4', 'visitCount<2', 2, $autoArchive = true);
+
+        // test that segments w/ auto archive == false aren't included
+        $segmentEditorApi->add('segment 5', 'visitCount<2', 3, $autoArchive = false);
+        $segmentEditorApi->add('segment 6', 'countryCode!=fr', 3, $autoArchive = false);
+    }
+
+    /**
+     * @dataProvider getTestDataForSegmentSqlTest
+     */
+    public function test_SegmentSql_IsCorrectlyDecoratedWithIdSegment($segment, $expectedPrefix)
+    {
+        $segment = new Segment($segment, array());
+
+        $query = $segment->getSelectQuery('*', 'log_visit');
+        $sql = $query['sql'];
+
+        if (empty($expectedPrefix)) {
+            $this->assertStringStartsNotWith("/* idSegments", $sql);
+        } else {
+            $this->assertStringStartsWith($expectedPrefix, $sql);
+        }
+    }
+
+    public function getTestDataForSegmentSqlTest()
+    {
+        return array(
+            array('countryCode==fr', '/* idSegments = [2] */'),
+            array('visitCount<2', '/* idSegments = [1, 3, 4] */'),
+            array('', null),
+            array('countryCode!=fr', null),
+        );
+    }
+}

--- a/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
+++ b/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
@@ -79,8 +79,8 @@ class SegmentQueryDecoratorTest extends \PHPUnit_Framework_TestCase
 
     private function getMockSegmentEditorApi()
     {
-        $mock = $this->getMock('Piwik\Plugins\SegmentEditor\API', array('getSegmentsToAutoArchive'), array(), '',
-            $callOriginalConstructor = false);
+        $mock = $this->getMock('Piwik\Plugins\SegmentEditor\Services\StoredSegmentService',
+            array('getSegmentsToAutoArchive'), array(), '', $callOriginalConstructor = false);
         $mock->expects($this->any())->method('getSegmentsToAutoArchive')->willReturn(self::$storedSegments);
         return $mock;
     }

--- a/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
+++ b/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\SegmentEditor\tests\Unit;
 
 use Piwik\Plugins\SegmentEditor\SegmentQueryDecorator;
+use Piwik\Plugins\SegmentEditor\Services\StoredSegmentService;
 use Piwik\Segment\SegmentExpression;
 
 /**
@@ -33,8 +34,9 @@ class SegmentQueryDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $mockApi = $this->getMockSegmentEditorApi();
-        $this->decorator = new SegmentQueryDecorator($mockApi);
+        /** @var StoredSegmentService $service */
+        $service = $this->getMockSegmentEditorService();
+        $this->decorator = new SegmentQueryDecorator($service);
     }
 
     public function test_getSelectQueryString_DoesNotDecorateSql_WhenNoSegmentUsed()
@@ -77,7 +79,7 @@ class SegmentQueryDecoratorTest extends \PHPUnit_Framework_TestCase
         $this->assertStringStartsWith('/* idSegments = [2, 4] */', $query['sql']);
     }
 
-    private function getMockSegmentEditorApi()
+    private function getMockSegmentEditorService()
     {
         $mock = $this->getMock('Piwik\Plugins\SegmentEditor\Services\StoredSegmentService',
             array('getSegmentsToAutoArchive'), array(), '', $callOriginalConstructor = false);

--- a/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
+++ b/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
@@ -82,8 +82,8 @@ class SegmentQueryDecoratorTest extends \PHPUnit_Framework_TestCase
     private function getMockSegmentEditorService()
     {
         $mock = $this->getMock('Piwik\Plugins\SegmentEditor\Services\StoredSegmentService',
-            array('getSegmentsToAutoArchive'), array(), '', $callOriginalConstructor = false);
-        $mock->expects($this->any())->method('getSegmentsToAutoArchive')->willReturn(self::$storedSegments);
+            array('getAllSegmentsAndIgnoreVisibility'), array(), '', $callOriginalConstructor = false);
+        $mock->expects($this->any())->method('getAllSegmentsAndIgnoreVisibility')->willReturn(self::$storedSegments);
         return $mock;
     }
 }

--- a/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
+++ b/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\SegmentEditor\tests\Unit;
+
+use Piwik\Plugins\SegmentEditor\SegmentQueryDecorator;
+use Piwik\Segment\SegmentExpression;
+
+/**
+ * @group SegmentEditor
+ * @group SegmentEditor_Unit
+ */
+class SegmentQueryDecoratorTest extends \PHPUnit_Framework_TestCase
+{
+    public static $storedSegments = array(
+        array('definition' => 'countryCode==abc', 'idsegment' => 1),
+        array('definition' => 'region!=FL', 'idsegment' => 2),
+        array('definition' => 'browserCode==def;visitCount>2', 'idsegment' => 3),
+        array('definition' => 'region!=FL', 'idsegment' => 4),
+    );
+
+    /**
+     * @var SegmentQueryDecorator
+     */
+    private $decorator;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $mockApi = $this->getMockSegmentEditorApi();
+        $this->decorator = new SegmentQueryDecorator($mockApi);
+    }
+
+    public function test_getSelectQueryString_DoesNotDecorateSql_WhenNoSegmentUsed()
+    {
+        $expression = new SegmentExpression('');
+        $expression->parseSubExpressions();
+
+        $query = $this->decorator->getSelectQueryString($expression, '*', 'log_visit', '', array(), '', '', '');
+
+        $this->assertStringStartsNotWith('/* idSegments', $query['sql']);
+    }
+
+    public function test_getSelectQueryString_DoesNotDecorateSql_WhenNoSegmentMatchesUsedSegment()
+    {
+        $expression = new SegmentExpression('referrerName==ooga');
+        $expression->parseSubExpressions();
+
+        $query = $this->decorator->getSelectQueryString($expression, '*', 'log_visit', '', array(), '', '', '');
+
+        $this->assertStringStartsNotWith('/* idSegments', $query['sql']);
+    }
+
+    public function test_getSelectQueryString_DecoratesSql_WhenOneSegmentMatchesUsedSegment()
+    {
+        $expression = new SegmentExpression('browserCode==def;visitCount>2');
+        $expression->parseSubExpressions();
+
+        $query = $this->decorator->getSelectQueryString($expression, '*', 'log_visit', '', array(), '', '', '');
+
+        $this->assertStringStartsWith('/* idSegments = [3] */', $query['sql']);
+    }
+
+    public function test_getSelectQueryString_DecoratesSql_WhenMultipleStoredSegmentsMatchUsedSegment()
+    {
+        $expression = new SegmentExpression('region!=FL');
+        $expression->parseSubExpressions();
+
+        $query = $this->decorator->getSelectQueryString($expression, '*', 'log_visit', '', array(), '', '', '');
+
+        $this->assertStringStartsWith('/* idSegments = [2, 4] */', $query['sql']);
+    }
+
+    private function getMockSegmentEditorApi()
+    {
+        $mock = $this->getMock('Piwik\Plugins\SegmentEditor\API', array('getSegmentsToAutoArchive'), array(), '',
+            $callOriginalConstructor = false);
+        $mock->expects($this->any())->method('getSegmentsToAutoArchive')->willReturn(self::$storedSegments);
+        return $mock;
+    }
+}


### PR DESCRIPTION
This PR adds a comment like `/* idSegments = [1, 2, 3] */` to all segment archiving SQL, if the requested segment matches the definition of a stored segment.

The addition is made non-intrusively by decorating LogQueryBuilder, instead of referencing SegmentEditor in core. This change should function, even if the SegmentEditor plugin is disabled.

Fixes #8752 
## Additional Changes
- LogQueryBuilder was turned into a stateless service class and put in DI.
- SegmentEditor\Model was put in DI.
- SegmentEditor\Model::getSegmentsToAutoArchive is exposed in an API method and modified so we can query for all sites. The result is stored in the transient cache.
## TODO
- [x] Add unit test for SegmentQueryDecorator (using mocks).
- [x] Add integration test for SegmentQueryDecorator (which adds stored segments to the database).
