### PR TITLE
Fix checking of $HTTP_RAW_POST_DATA for PHP7

### DIFF
--- a/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
@@ -65,16 +65,12 @@ class PhpSettingsCheck implements Diagnostic
             'session.auto_start=0',
         );
 
-        if ($this->isPhpVersionAtLeast56() && ! defined("HHVM_VERSION")) {
-            // always_populate_raw_post_data must be -1
+        if (version_compare(PHP_VERSION, '5.6', '=') && ! defined("HHVM_VERSION")) {
+            // always_populate_raw_post_data must be -1 for PHP 5.6.*
+            // but not in PHP7 as the feature has been removed
             $requiredSettings[] = 'always_populate_raw_post_data=-1';
         }
 
         return $requiredSettings;
-    }
-
-    private function isPhpVersionAtLeast56()
-    {
-        return version_compare(PHP_VERSION, '5.6', '>=');
     }
 }


### PR DESCRIPTION
Due to populating of raw post data being deprecated in PHP5.6 We
needed to set the ini value `always_populate_raw_post_data` to
`-1` in order to avoid deprecation warnings and the like. However
this feature has been removed in PHP7. The knock on to this is
that regardless of wether the `php.ini` contains the line
`always_populate_raw_post_data=-1` the `ini_get` function evaluates
to 0/false. Thus we only need to check for this ini setting being
-1 for PHP5.6

I haven’t added any tests for this yet.
