### PR TITLE
Do not enable Provider plugin by default for new users

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -751,7 +751,6 @@ Plugins[] = VisitTime
 Plugins[] = VisitorInterest
 Plugins[] = ExampleAPI
 Plugins[] = ExampleRssWidget
-Plugins[] = Provider
 Plugins[] = Feedback
 Plugins[] = Monolog
 


### PR DESCRIPTION
 fixes #8826

follows up  #8785
