### PR TITLE
Add missing error control operator prefix '@' before ini_set()

### DIFF
--- a/libs/Zend/Session.php
+++ b/libs/Zend/Session.php
@@ -202,7 +202,7 @@ class Zend_Session extends Zend_Session_Abstract
         if (!self::$_defaultOptionsSet) {
             foreach (self::$_defaultOptions as $defaultOptionName => $defaultOptionValue) {
                 if (isset(self::$_defaultOptions[$defaultOptionName])) {
-                    ini_set("session.$defaultOptionName", $defaultOptionValue);
+                    @ini_set("session.$defaultOptionName", $defaultOptionValue);
                 }
             }
 
@@ -216,7 +216,7 @@ class Zend_Session extends Zend_Session_Abstract
 
             // set the ini based values
             if (array_key_exists($userOptionName, self::$_defaultOptions)) {
-                ini_set("session.$userOptionName", $userOptionValue);
+                @ini_set("session.$userOptionName", $userOptionValue);
             }
             elseif (isset(self::$_localOptions[$userOptionName])) {
                 self::${self::$_localOptions[$userOptionName]} = $userOptionValue;

--- a/libs/Zend/Validate/Hostname.php
+++ b/libs/Zend/Validate/Hostname.php
@@ -551,7 +551,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
             if (PHP_VERSION_ID < 50600) {
                 iconv_set_encoding('internal_encoding', 'UTF-8');
             } else {
-                ini_set('default_charset', 'UTF-8');
+                @ini_set('default_charset', 'UTF-8');
             }
 
             do {
@@ -652,7 +652,7 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
             if (PHP_VERSION_ID < 50600) {
                 iconv_set_encoding('internal_encoding', $origenc);
             } else {
-                ini_set('default_charset', $origenc);
+                @ini_set('default_charset', $origenc);
             }
 
             // If the input passes as an Internet domain name, and domain names are allowed, then the hostname

--- a/libs/Zend/Validate/StringLength.php
+++ b/libs/Zend/Validate/StringLength.php
@@ -205,7 +205,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
             if (PHP_VERSION_ID < 50600) {
                 $result = iconv_set_encoding('internal_encoding', $encoding);
             } else {
-                $result = ini_set('default_charset', $encoding);
+                $result = @ini_set('default_charset', $encoding);
             }
             if (!$result) {
                 require_once 'Zend/Validate/Exception.php';
@@ -215,7 +215,7 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
             if (PHP_VERSION_ID < 50600) {
                 iconv_set_encoding('internal_encoding', $orig);
             } else {
-                ini_set('default_charset', $orig);
+                @ini_set('default_charset', $orig);
             }
         }
 


### PR DESCRIPTION
Background: https://github.com/piwik/piwik/issues/8824#issuecomment-141843420

This PR adds `@` where missing before `ini_set()`.

**Important:**
The ini_set() presence check-and-show-error block in https://github.com/piwik/piwik/blob/2.15.0-b8/core/testMinimumPhpVersion.php#L35 is **not** being modified by this PR. Please let me know if it needs to be removed.
