### PR TITLE
Refactor ArchiveInvalidator: dependency decoupling, responsibility limiting and code reorganization

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -554,7 +554,7 @@ class Archive
             }
 
             try {
-                $invalidator->markArchivesAsInvalidated($siteIdsToActuallyInvalidate, $date, false);
+                $invalidator->markArchivesAsInvalidated($siteIdsToActuallyInvalidate, array(Date::factory($date)), false);
             } catch (\Exception $e) {
                 Site::clearCache();
                 throw $e;

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -18,8 +18,6 @@ use Piwik\Plugins\CoreAdminHome\Tasks\ArchivesToPurgeDistributedList;
 use Piwik\Plugins\PrivacyManager\PrivacyManager;
 use Piwik\Period;
 use Piwik\Period\Week;
-use Piwik\Plugins\SitesManager\Model as SitesManagerModel;
-use Piwik\Site;
 
 /**
  * Service that can be used to invalidate archives or add archive references to a list so they will
@@ -129,9 +127,6 @@ class ArchiveInvalidator
     {
         $this->findOlderDateWithLogs();
         $datesToInvalidate = $this->getDatesToInvalidateFromString($dates);
-        $minDate = $this->getMinimumDateToInvalidate($datesToInvalidate);
-
-        $this->updateSiteCreatedTime($idSites, $minDate);
 
         $datesByMonth = $this->getDatesByYearMonth($datesToInvalidate);
         $this->markArchivesInvalidatedFor($idSites, $period, $datesByMonth);
@@ -145,38 +140,6 @@ class ArchiveInvalidator
         }
 
         return $this->makeOutputLogs();
-    }
-
-    private function updateSiteCreatedTime($idSites, Date $minDate)
-    {
-        $idSites    = Site::getIdSitesFromIdSitesString($idSites);
-        $minDateSql = $minDate->subDay(1)->getDatetime();
-
-        $model = new SitesManagerModel();
-        $model->updateSiteCreatedTime($idSites, $minDateSql);
-    }
-
-    /**
-     * @param $toInvalidate
-     * @return bool|Date
-     * @throws \Exception
-     */
-    private function getMinimumDateToInvalidate($toInvalidate)
-    {
-        /* @var $date Date */
-        $minDate = false;
-        foreach ($toInvalidate as $date) {
-            // Keep track of the minimum date for each website
-            if ($minDate === false
-                || $date->isEarlier($minDate)
-            ) {
-                $minDate = $date;
-            }
-        }
-        if (empty($minDate)) {
-            throw new \Exception("Check the 'dates' parameter is a valid date.");
-        }
-        return $minDate;
     }
 
     /**

--- a/plugins/CoreAdminHome/Commands/FixDuplicateLogActions.php
+++ b/plugins/CoreAdminHome/Commands/FixDuplicateLogActions.php
@@ -12,6 +12,7 @@ use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\Actions;
 use Piwik\Archive\ArchiveInvalidator;
+use Piwik\Date;
 use Piwik\Plugin\ConsoleCommand;
 use Piwik\Plugins\CoreAdminHome\Model\DuplicateActionRemover;
 use Piwik\Timer;
@@ -126,8 +127,8 @@ class FixDuplicateLogActions extends ConsoleCommand
     {
         $output->write("Invalidating archives affected by duplicates fixed...");
         foreach ($archivesAffected as $archiveInfo) {
-            $this->archiveInvalidator->markArchivesAsInvalidated(
-                array($archiveInfo['idsite']), $archiveInfo['server_time'], $period = false);
+            $dates = array(Date::factory($archiveInfo['server_time']));
+            $this->archiveInvalidator->markArchivesAsInvalidated(array($archiveInfo['idsite']), $dates, $period = false);
         }
         $output->writeln("Done.");
     }

--- a/plugins/SitesManager/Model.php
+++ b/plugins/SitesManager/Model.php
@@ -314,7 +314,7 @@ class Model
     /**
      * Updates the field ts_created for the specified websites.
      *
-     * @param $idSites int Id Site to update ts_created
+     * @param $idSites int[] Id Site to update ts_created
      * @param string Date to set as creation date.
      *
      * @ignore

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -126,6 +126,7 @@ class SitesManager extends \Piwik\Plugin
         $array['sitesearch_keyword_parameters'] = $this->getTrackerSearchKeywordParameters($website);
         $array['sitesearch_category_parameters'] = $this->getTrackerSearchCategoryParameters($website);
         $array['timezone'] = $this->getTimezoneFromWebsite($website);
+        $array['ts_created'] = $website['ts_created'];
     }
 
     /**

--- a/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
+++ b/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
@@ -42,7 +42,7 @@ class SitesManagerRequestProcessor extends RequestProcessor
         $idSite = $request->getIdSite();
 
         $createdTimeTimestamp = $this->getSiteCreatedTime($idSite);
-        $requestTimestamp = Date::factory($request->getCurrentTimestamp());
+        $requestTimestamp = Date::factory((int) $request->getCurrentTimestamp());
 
         // replicating old Piwik logic, see:
         // https://github.com/piwik/piwik/blob/baa6da86266c7c44bc2d65821c7ffe042c2f4716/core/Archive/ArchiveInvalidator.php#L150

--- a/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
+++ b/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
@@ -34,11 +34,6 @@ class SitesManagerRequestProcessor extends RequestProcessor
     {
         // if we successfully record some data and the date is older than the site's created time,
         // update the created time so the data will be viewable in the UI
-        $visitorNotFoundInDb = $request->getMetadata('CoreHome', 'visitorNotFoundInDb');
-        if ($visitorNotFoundInDb) {
-            return;
-        }
-
         $idSite = $request->getIdSite();
 
         $createdTimeTimestamp = $this->getSiteCreatedTime($idSite);

--- a/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
+++ b/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
@@ -42,6 +42,10 @@ class SitesManagerRequestProcessor extends RequestProcessor
         $idSite = $request->getIdSite();
 
         $createdTimeTimestamp = $this->getSiteCreatedTime($idSite);
+        if (empty($createdTimeTimestamp)) {
+            return;
+        }
+
         $requestTimestamp = Date::factory((int) $request->getCurrentTimestamp());
 
         // replicating old Piwik logic, see:
@@ -60,8 +64,11 @@ class SitesManagerRequestProcessor extends RequestProcessor
     private function getSiteCreatedTime($idSite)
     {
         $attributes = Cache::getCacheWebsiteAttributes($idSite);
-        $tsCreated = isset($attributes['ts_created']) ? $attributes['ts_created'] : 0;
-        return Date::factory($tsCreated);
+        if (!isset($attributes['ts_created'])) {
+            return null;
+        }
+
+        return Date::factory($attributes['ts_created']);
     }
 
     private function updateSiteCreatedTime($idSite, Date $timestamp)

--- a/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
+++ b/plugins/SitesManager/Tracker/SitesManagerRequestProcessor.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\SitesManager\Tracker;
+
+use Piwik\Date;
+use Piwik\Tracker\Cache;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\RequestProcessor;
+use Piwik\Tracker\Visit\VisitProperties;
+use Piwik\Plugins\SitesManager\Model as SitesManagerModel;
+
+/**
+ * Handles site specific logic during tracking.
+ */
+class SitesManagerRequestProcessor extends RequestProcessor
+{
+    /**
+     * @var SitesManagerModel
+     */
+    private $sitesManagerModel;
+
+    public function __construct(SitesManagerModel $sitesManagerModel)
+    {
+        $this->sitesManagerModel = $sitesManagerModel;
+    }
+
+    public function recordLogs(VisitProperties $visitProperties, Request $request)
+    {
+        // if we successfully record some data and the date is older than the site's created time,
+        // update the created time so the data will be viewable in the UI
+        $visitorNotFoundInDb = $request->getMetadata('CoreHome', 'visitorNotFoundInDb');
+        if ($visitorNotFoundInDb) {
+            return;
+        }
+
+        $idSite = $request->getIdSite();
+
+        $createdTimeTimestamp = $this->getSiteCreatedTime($idSite);
+        if ($request->getCurrentTimestamp() < $createdTimeTimestamp) {
+            $this->updateSiteCreatedTime($idSite, $request->getCurrentTimestamp());
+        }
+    }
+
+    private function getSiteCreatedTime($idSite)
+    {
+        $attributes = Cache::getCacheWebsiteAttributes($idSite);
+        $tsCreated = isset($attributes['ts_created']) ? $attributes['ts_created'] : 0;
+        return Date::factory($tsCreated)->getTimestamp();
+    }
+
+    private function updateSiteCreatedTime($idSite, $timestamp)
+    {
+        $this->sitesManagerModel->updateSiteCreatedTime(array($idSite), Date::factory($timestamp)->getDatetime());
+        Cache::deleteCacheWebsiteAttributes($idSite);
+    }
+}

--- a/plugins/SitesManager/config/config.php
+++ b/plugins/SitesManager/config/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+
+    'tracker.request.processors' => DI\add(array(
+        DI\get('Piwik\Plugins\SitesManager\Tracker\SitesManagerRequestProcessor'),
+    )),
+
+);

--- a/plugins/SitesManager/tests/Integration/TrackingTest.php
+++ b/plugins/SitesManager/tests/Integration/TrackingTest.php
@@ -32,7 +32,7 @@ class TrackingTest extends IntegrationTestCase
         Fixture::checkResponse($t->doTrackPageView('page view'));
 
         $createdTime = $this->getSiteCreatedTime($idSite = 1);
-        $this->assertEquals('2014-05-05 05:05:05', $createdTime);
+        $this->assertEquals('2014-05-04 00:00:00', $createdTime);
     }
 
     public function test_TrackingOldVisit_ThatIsExcluded_DoesNotResetCreatedTime()

--- a/plugins/SitesManager/tests/Integration/TrackingTest.php
+++ b/plugins/SitesManager/tests/Integration/TrackingTest.php
@@ -53,6 +53,23 @@ class TrackingTest extends IntegrationTestCase
         $this->assertEquals('2014-12-31 00:00:00', $createdTime);
     }
 
+    public function test_TrackingOldVisit_ForSiteWithNoTsCreatedTime_DoesNotResetCreatedTime()
+    {
+        Fixture::createWebsite('2015-01-01 00:00:00');
+
+        $this->unsetCreatedTime($idSite = 1);
+
+        $createdTime = $this->getSiteCreatedTime($idSite = 1);
+        $this->assertEquals(null, $createdTime);
+
+        $t = $this->getLocalTracker();
+        $t->setForceVisitDateTime('2014-08-06 07:53:09');
+        Fixture::checkResponse($t->doTrackPageView('page view'));
+
+        $createdTime = $this->getSiteCreatedTime($idSite = 1);
+        $this->assertEquals(null, $createdTime);
+    }
+
     private function getLocalTracker()
     {
         return self::$fixture->getTracker($idSite = 1, '2015-01-01', $defaultInit = true, $useLocalTracker = true);
@@ -61,6 +78,11 @@ class TrackingTest extends IntegrationTestCase
     private function getSiteCreatedTime($idSite)
     {
         return Db::fetchOne("SELECT ts_created FROM " . Common::prefixTable('site') . " WHERE idsite = ?", array($idSite));
+    }
+
+    private function unsetCreatedTime($idSite)
+    {
+        Db::query("UPDATE " . Common::prefixTable('site') . " SET ts_created = NULL WHERE idsite = ?", array($idSite));
     }
 
     protected static function configureFixture($fixture)

--- a/plugins/SitesManager/tests/Integration/TrackingTest.php
+++ b/plugins/SitesManager/tests/Integration/TrackingTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\SitesManager\tests\Integration;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Plugins\SitesManager;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group SitesManager
+ * @group SitesManager_Integration
+ */
+class TrackingTest extends IntegrationTestCase
+{
+    public function test_TrackingOldVisits_ResetsSiteCreatedTime_SoDataCanBeViewedInUI()
+    {
+        Fixture::createWebsite('2015-01-01 00:00:00');
+
+        $createdTime = $this->getSiteCreatedTime($idSite = 1);
+        $this->assertEquals('2014-12-31 00:00:00', $createdTime);
+
+        $t = $this->getLocalTracker();
+        $t->setForceVisitDateTime('2014-05-05 05:05:05');
+        Fixture::checkResponse($t->doTrackPageView('page view'));
+
+        $createdTime = $this->getSiteCreatedTime($idSite = 1);
+        $this->assertEquals('2014-05-05 05:05:05', $createdTime);
+    }
+
+    public function test_TrackingOldVisit_ThatIsExcluded_DoesNotResetCreatedTime()
+    {
+        Fixture::createWebsite('2015-01-01 00:00:00');
+
+        SitesManager\API::getInstance()->setGlobalExcludedIps('123.44.67.43');
+
+        $createdTime = $this->getSiteCreatedTime($idSite = 1);
+        $this->assertEquals('2014-12-31 00:00:00', $createdTime);
+
+        $t = $this->getLocalTracker();
+        $t->setForceVisitDateTime('2014-05-05 05:05:05');
+        $t->setIp('123.44.67.43');
+        Fixture::checkResponse($t->doTrackPageView('page view'));
+
+        $createdTime = $this->getSiteCreatedTime($idSite = 1);
+        $this->assertEquals('2014-12-31 00:00:00', $createdTime);
+    }
+
+    private function getLocalTracker()
+    {
+        return self::$fixture->getTracker($idSite = 1, '2015-01-01', $defaultInit = true, $useLocalTracker = true);
+    }
+
+    private function getSiteCreatedTime($idSite)
+    {
+        return Db::fetchOne("SELECT ts_created FROM " . Common::prefixTable('site') . " WHERE idsite = ?", array($idSite));
+    }
+
+    protected static function configureFixture($fixture)
+    {
+        parent::configureFixture($fixture);
+
+        $fixture->createSuperUser = true;
+    }
+}

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -135,7 +135,12 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
         $this->rememberReportsForManySitesAndDates();
 
         $idSites = array(2, 10, 7, 5);
-        $dates   = '2014-04-05,2014-04-08,2010-10-10';
+        $dates = array(
+            Date::factory('2014-04-05'),
+            Date::factory('2014-04-08'),
+            Date::factory('2010-10-10'),
+        );
+
         $this->invalidator->markArchivesAsInvalidated($idSites, $dates, false);
         $reports = $this->invalidator->getRememberedArchivedReportsThatShouldBeInvalidated();
 


### PR DESCRIPTION
This PR includes the following changes:
- ArchiveInvalidator's dependency on SitesManager has been removed. The code that updates a sites created time has been moved to tracker, since it's reason for existence is to make sure if visits are tracked before a site's creation date, those visits will still be displayed in the UI. This code was moved to a new RequestProcessor located within the SitesManager plugin (so core is no longer dependent on SitesManager for this at least).
- The date parsing logic was moved from ArchiveInvalidator to callers. The ArchiveInvalidator service now takes well-formed input only. At least for the dates.
- Some code related to PrivacyManager dependency was grouped closer together in ArchiveInvalidator.php both physically and in terms of code execution.
