### PR TITLE
Caching id actions in general cache for faster segmented archive SQL queries

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -162,6 +162,8 @@ enable_segments_subquery_cache = 0
 ; Any segment subquery that matches more than segments_subquery_cache_limit IDs will not be cached,
 ; and the original subquery executed instead.
 segments_subquery_cache_limit  = 100000
+; TTL: Time to live for cache files, in seconds. Default to 60 minutes
+segments_subquery_cache_ttl  = 3600
 
 ; when set to 1, all requests to Piwik will return a maintenance message without connecting to the DB
 ; this is useful when upgrading using the shell command, to prevent other users from accessing the UI while Upgrade is in progress

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -157,6 +157,9 @@ enable_processing_unique_visitors_multiple_sites = 0
 enabled_periods_UI = "day,week,month,year,range"
 enabled_periods_API = "day,week,month,year,range"
 
+; whether to enable subquery cache for Custom Segment archiving queries
+enable_segments_subquery_cache = 0
+
 ; when set to 1, all requests to Piwik will return a maintenance message without connecting to the DB
 ; this is useful when upgrading using the shell command, to prevent other users from accessing the UI while Upgrade is in progress
 maintenance_mode = 0

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -159,6 +159,9 @@ enabled_periods_API = "day,week,month,year,range"
 
 ; whether to enable subquery cache for Custom Segment archiving queries
 enable_segments_subquery_cache = 0
+; Any segment subquery that matches more than segments_subquery_cache_limit IDs will not be cached,
+; and the original subquery executed instead.
+segments_subquery_cache_limit  = 100000
 
 ; when set to 1, all requests to Piwik will return a maintenance message without connecting to the DB
 ; this is useful when upgrading using the shell command, to prevent other users from accessing the UI while Upgrade is in progress

--- a/core/Segment/SegmentExpression.php
+++ b/core/Segment/SegmentExpression.php
@@ -192,6 +192,12 @@ class SegmentExpression
                 // eg. pageUrl!=DoesNotExist
                 // Not equal to NULL means it matches all rows
                 $sqlExpression = self::SQL_WHERE_MATCHES_ALL_ROWS;
+            } elseif($matchType == self::MATCH_CONTAINS
+                  || $matchType == self::MATCH_DOES_NOT_CONTAIN) {
+                // no action was found for CONTAINS / DOES NOT CONTAIN
+                // eg. pageUrl=@DoesNotExist -> matches no row
+                // eg. pageUrl!@DoesNotExist -> matches no rows
+                $sqlExpression = self::SQL_WHERE_DO_NOT_MATCH_ANY_ROW;
             } else {
                 // it is not expected to reach this code path
                 throw new Exception("Unexpected match type $matchType for your segment. " .
@@ -280,8 +286,13 @@ class SegmentExpression
             }
 
             $sqlExpressions[] = $sqlExpression;
+
             if ($value !== null) {
-                $values[] = $value;
+                if(is_array($value)) {
+                    $values = array_merge($values, $value);
+                } else {
+                    $values[] = $value;
+                }
             }
 
             $this->checkFieldIsAvailable($field, $availableTables);

--- a/core/Tracker/TableLogAction.php
+++ b/core/Tracker/TableLogAction.php
@@ -10,6 +10,7 @@
 namespace Piwik\Tracker;
 
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\Segment\SegmentExpression;
 
 /**
@@ -188,11 +189,8 @@ class TableLogAction
         // special case
         $sql = TableLogAction::getSelectQueryWhereNameContains($matchType, $actionType);
 
-        return array(
-            // mark that the returned value is an sql-expression instead of a literal value
-            'SQL'  => $sql,
-            'bind' => $valueToMatch,
-        );
+        $cache = new TableLogAction\Cache();
+        return $cache->getIdActionFromSegment($valueToMatch, $sql);
     }
 
     /**

--- a/core/Tracker/TableLogAction/Cache.php
+++ b/core/Tracker/TableLogAction/Cache.php
@@ -42,8 +42,8 @@ class Cache
 
         $ids = self::getIdsFromCache($valueToMatch, $sql);
 
-        if(is_null($ids)) {
-            return $ids;
+        if(count($ids) == 0) {
+            return null;
         }
 
         $sql = Common::getSqlStringFieldsArray($ids);
@@ -73,7 +73,7 @@ class Cache
             return $cache->fetch($cacheKey);
         }
 
-        $ids = $this->fetchIdsFromDb($valueToMatch, $sql);
+        $ids = $this->fetchActionIdsFromDb($valueToMatch, $sql);
 
         $cache->save($cacheKey, $ids, $this->lifetime);
 
@@ -103,7 +103,7 @@ class Cache
      * @return array|null
      * @throws \Exception
      */
-    private function fetchIdsFromDb($valueToMatch, $sql)
+    private function fetchActionIdsFromDb($valueToMatch, $sql)
     {
         $idActions = \Piwik\Db::fetchAll($sql, $valueToMatch);
 
@@ -112,11 +112,6 @@ class Cache
             $ids[] = $idAction['idaction'];
         }
 
-        if (!empty($ids)) {
-            return $ids;
-        }
-
-        // no action was found for CONTAINS / DOES NOT CONTAIN
-        return null;
+        return $ids;
     }
 }

--- a/core/Tracker/TableLogAction/Cache.php
+++ b/core/Tracker/TableLogAction/Cache.php
@@ -42,7 +42,7 @@ class Cache
     {
         $this->isEnabled = (bool)Config::getInstance()->General['enable_segments_subquery_cache'];
         $this->limitActionIds = Config::getInstance()->General['segments_subquery_cache_limit'];
-        $this->lifetime = 60 * 10;
+        $this->lifetime = Config::getInstance()->General['segments_subquery_cache_ttl'];
         $this->logger = StaticContainer::get('Psr\Log\LoggerInterface');
     }
 

--- a/core/Tracker/TableLogAction/Cache.php
+++ b/core/Tracker/TableLogAction/Cache.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Tracker\TableLogAction;
+
+use Piwik\Common;
+use Piwik\Config;
+
+class Cache
+{
+    public $enable;
+    protected $lifetime;
+
+    public function __construct()
+    {
+        $this->enable = Config::getInstance()->General['enable_segments_subquery_cache'];
+        $this->lifetime = 60 * 10;
+    }
+
+    /**
+     * @param $valueToMatch
+     * @param $sql
+     * @return array|null
+     * @throws \Exception
+     */
+    public function getIdActionFromSegment($valueToMatch, $sql)
+    {
+        if (!$this->enable) {
+            return array(
+                // mark that the returned value is an sql-expression instead of a literal value
+                'SQL' => $sql,
+                'bind' => $valueToMatch,
+            );
+        }
+
+        $ids = self::getIdsFromCache($valueToMatch, $sql);
+
+        if(is_null($ids)) {
+            return $ids;
+        }
+
+        $sql = Common::getSqlStringFieldsArray($ids);
+        $bind = $ids;
+
+        return array(
+            // mark that the returned value is an sql-expression instead of a literal value
+            'SQL'  => $sql,
+            'bind' => $bind,
+        );
+    }
+
+
+    /**
+     * @param $valueToMatch
+     * @param $sql
+     * @return array|bool|float|int|string
+     */
+    private function getIdsFromCache($valueToMatch, $sql)
+    {
+        $cache = \Piwik\Cache::getLazyCache();
+
+        $cacheKey = $this->getCacheKey($valueToMatch, $sql);
+
+        if ($cache->contains($cacheKey) === true) {
+            return $cache->fetch($cacheKey);
+        }
+
+        $ids = $this->fetchIdsFromDb($valueToMatch, $sql);
+
+        $cache->save($cacheKey, $ids, $this->lifetime);
+
+        return $ids;
+    }
+
+    /**
+     * @param $valueToMatch
+     * @param $sql
+     * @return string
+     * @throws
+     */
+    private function getCacheKey($valueToMatch, $sql)
+    {
+        if(is_array($valueToMatch)) {
+            throw new \Exception("value to match is an array: this is not expected");
+        }
+
+        $uniqueKey = md5($sql . $valueToMatch);
+        $cacheKey = 'TableLogAction.getIdActionFromSegment.' . $uniqueKey;
+        return $cacheKey;
+    }
+
+    /**
+     * @param $valueToMatch
+     * @param $sql
+     * @return array|null
+     * @throws \Exception
+     */
+    private function fetchIdsFromDb($valueToMatch, $sql)
+    {
+        $idActions = \Piwik\Db::fetchAll($sql, $valueToMatch);
+
+        $ids = array();
+        foreach ($idActions as $idAction) {
+            $ids[] = $idAction['idaction'];
+        }
+
+        if (!empty($ids)) {
+            return $ids;
+        }
+
+        // no action was found for CONTAINS / DOES NOT CONTAIN
+        return null;
+    }
+}

--- a/core/Tracker/TableLogAction/Cache.php
+++ b/core/Tracker/TableLogAction/Cache.php
@@ -16,6 +16,7 @@ class Cache
 {
     public $enable;
     protected $lifetime;
+    static public $hits = 0;
 
     public function __construct()
     {
@@ -68,6 +69,7 @@ class Cache
         $cacheKey = $this->getCacheKey($valueToMatch, $sql);
 
         if ($cache->contains($cacheKey) === true) {
+            self::$hits++;
             return $cache->fetch($cacheKey);
         }
 

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -700,7 +700,7 @@ class SegmentTest extends IntegrationTestCase
             ));
 
         $cache = new TableLogAction\Cache();
-        $this->assertTrue( empty($cache->enable) );
+        $this->assertTrue( empty($cache->isEnabled) );
         $this->assertCacheWasHit($hit = 0);
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
@@ -770,7 +770,7 @@ class SegmentTest extends IntegrationTestCase
             ));
 
         $cache = new TableLogAction\Cache();
-        $this->assertTrue( !empty($cache->enable) );
+        $this->assertTrue( !empty($cache->isEnabled) );
 
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -644,7 +644,7 @@ class SegmentTest extends IntegrationTestCase
     public function test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withoutCache()
     {
         $this->disableSubqueryCache();
-        $this->assertCacheIsNotUsed();
+        $this->assertCacheWasHit($hit = 0);
 
         list($pageUrlFoundInDb, $actionIdFoundInDb) = $this->insertActions();
 
@@ -701,11 +701,11 @@ class SegmentTest extends IntegrationTestCase
 
         $cache = new TableLogAction\Cache();
         $this->assertTrue( empty($cache->enable) );
-        $this->assertCacheIsNotUsed();
+        $this->assertCacheWasHit($hit = 0);
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
-    public function test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheIsEmpty()
+    public function test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheSave()
     {
         $this->enableSubqueryCache();
 
@@ -778,16 +778,16 @@ class SegmentTest extends IntegrationTestCase
     public function test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheisHit()
     {
         $this->enableSubqueryCache();
-        $this->assertCacheIsNotUsed();
+        $this->assertCacheWasHit($hits = 0);
 
-        $this->test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheIsEmpty();
-        $this->assertCacheWasUsed($hits = 4);
+        $this->test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheSave();
+        $this->assertCacheWasHit($hits = 0);
 
-        $this->test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheIsEmpty();
-        $this->assertCacheWasUsed($hits = 4 + 4);
+        $this->test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheSave();
+        $this->assertCacheWasHit($hits = 4);
 
-        $this->test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheIsEmpty();
-        $this->assertCacheWasUsed($hits = 4 + 4 + 4);
+        $this->test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheSave();
+        $this->assertCacheWasHit($hits = 4 + 4);
     }
 
     public function provideContainerConfig()
@@ -828,14 +828,9 @@ class SegmentTest extends IntegrationTestCase
         return array($pageUrlFoundInDb, $actionIdFoundInDb);
     }
 
-    private function assertCacheIsNotUsed()
+    private function assertCacheWasHit($expectedHits)
     {
-        $this->assertTrue(TableLogAction\Cache::$hits == 0, "expected cache was not used, but cache was hit " . TableLogAction\Cache::$hits . " times");
-    }
-
-    private function assertCacheWasUsed($expectedHits)
-    {
-        $this->assertTrue(TableLogAction\Cache::$hits == $expectedHits, "expected cache was used $expectedHits times, but got " . TableLogAction\Cache::$hits . " cache hits instead");
+        $this->assertTrue(TableLogAction\Cache::$hits == $expectedHits, "expected cache was hit $expectedHits time(s), but got " . TableLogAction\Cache::$hits . " cache hits instead.");
     }
 
     private function disableSubqueryCache()

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -9,6 +9,7 @@
 namespace Piwik\Tests\Integration;
 
 use Exception;
+use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Db;
@@ -35,6 +36,8 @@ class SegmentTest extends IntegrationTestCase
     public function tearDown()
     {
         parent::tearDown();
+
+        Cache::getLazyCache()->flushAll();
     }
 
     static public function removeExtraWhiteSpaces($valueToFilter)
@@ -774,7 +777,6 @@ class SegmentTest extends IntegrationTestCase
     public function test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheisHit()
     {
         $this->enableSubqueryCache();
-        TableLogAction\Cache::$hits = 0;
         $this->assertCacheIsNotUsed();
 
         $this->test_getSelectQuery_whenPageUrlDoesNotExist_asBothStatements_OR_AND_withCacheIsEmpty();

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -38,6 +38,7 @@ class SegmentTest extends IntegrationTestCase
         parent::tearDown();
 
         Cache::getLazyCache()->flushAll();
+        TableLogAction\Cache::$hits = 0;
     }
 
     static public function removeExtraWhiteSpaces($valueToFilter)

--- a/tests/PHPUnit/Unit/Segment/SegmentExpressionTest.php
+++ b/tests/PHPUnit/Unit/Segment/SegmentExpressionTest.php
@@ -10,6 +10,10 @@ namespace Piwik\Tests\Unit;
 
 use Piwik\Segment\SegmentExpression;
 
+/**
+ * @group SegmentExpressionTest
+ * @group Segment
+ */
 class SegmentExpressionTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
### How to enable

To enable, set: `enable_segments_subquery_cache = 1` under `[General]` in config/config.ini.php
### Tweak cache

```
; Any segment subquery that matches more than segments_subquery_cache_limit IDs will not be cached,
; and the original subquery executed instead.
segments_subquery_cache_limit  = 100000


; TTL: Time to live for cache files, in seconds. Default to 60 minutes
segments_subquery_cache_ttl  = 3600

```
