### PR TITLE
fixes: popovers might clear page content

### DIFF
--- a/plugins/CoreHome/angularjs/history/history.service.js
+++ b/plugins/CoreHome/angularjs/history/history.service.js
@@ -57,7 +57,7 @@
             var searchObject = $location.search(),
                 searchString = [];
             for (var name in searchObject) {
-                if (!searchObject.hasOwnProperty(name)) {
+                if (!searchObject.hasOwnProperty(name) || name == '_') {
                     continue;
                 }
 


### PR DESCRIPTION
Currently the popovers in administration of Piwik (e.g. plugin popover in marketplace) might clear the original page content when opening or closing it.
That is due to a "fix" for angularjs (See https://github.com/piwik/piwik/blob/master/plugins/CoreHome/angularjs/history/history.service.js#L91-L95)
Opening and closing a popover triggers a hash change, which clears the content to replace it with new one if the hash is present.
With this small change the param added to fix angularjs is ignored for loading pages.
