### PR TITLE
Links to plugin details didn't work

### DIFF
--- a/plugins/CorePluginsAdmin/javascripts/marketplace.js
+++ b/plugins/CorePluginsAdmin/javascripts/marketplace.js
@@ -13,7 +13,7 @@ $(document).ready(function () {
         watch: 'window'
     });
 
-    $('.marketplace').on('click', '.plugin-details', function (event) {
+    $('a.plugin-details[data-pluginName]').on('click', function (event) {
         event.preventDefault();
 
         var pluginName = $(this).attr('data-pluginName');

--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -15,13 +15,13 @@
             {% for name,plugin in pluginsHavingUpdate %}
                 <tr {% if plugin.isActivated|default(false) %}class="active-plugin"{% else %}class="inactive-plugin"{% endif %}>
                     <td class="name">
-                        <a href="javascript:void(0);" data-pluginName="{{ plugin.name|e('html_attr') }}">
+                        <a href="javascript:void(0);" data-pluginName="{{ plugin.name|e('html_attr') }}" class="plugin-details">
                             {{ plugin.name }}
                         </a>
                     </td>
                     <td class="vers">
                         {% if plugin.repositoryChangelogUrl %}
-                            <a href="javascript:void(0);" title="{{ 'CorePluginsAdmin_Changelog'|translate }}" data-activePluginTab="changelog" data-pluginName="{{ plugin.name|e('html_attr') }}">{{ plugin.currentVersion }} => {{ plugin.latestVersion }}</a>
+                            <a href="javascript:void(0);" title="{{ 'CorePluginsAdmin_Changelog'|translate }}" class="plugin-details" data-activePluginTab="changelog" data-pluginName="{{ plugin.name|e('html_attr') }}">{{ plugin.currentVersion }} => {{ plugin.latestVersion }}</a>
                         {% else %}
                             {{ plugin.currentVersion }} => {{ plugin.latestVersion }}
                         {% endif %}
@@ -156,7 +156,7 @@
                     <td class="name" style="white-space:nowrap;">
                         <a name="{{ name|e('html_attr') }}"></a>
                         {% if not plugin.isCorePlugin and name in marketplacePluginNames -%}
-                            <a href="javascript:void(0);"
+                            <a href="javascript:void(0);" class="plugin-details"
                                data-pluginName="{{ name|e('html_attr') }}"
                                >{{ name }}</a>
                         {%- else %}


### PR DESCRIPTION
fixes #8863 

Several links to plugin details in plugin list or plugin update notifications didn't work.
Now all links providing the data attribute pluginName and having the class plugin-details will automatically be linked to the related details.
