### PR TITLE
Clicking too fast can result in nothingness

### DIFF
--- a/plugins/CoreHome/angularjs/history/history.service.js
+++ b/plugins/CoreHome/angularjs/history/history.service.js
@@ -84,8 +84,10 @@
                     hash = hash.substring(1);
                 }
             }
-
-            if (hash) {
+            
+            if (location.hash === '#?' + hash) {
+                loadCurrentPage(); // it would not trigger a location change success event as URL is the same, call it manually
+            } else if (hash) {
                 $location.search(hash);
             } else {
                 // NOTE: this works around a bug in angularjs. when unsetting the hash (ie, removing in the URL),


### PR DESCRIPTION
fixes #8845 #8319

FYI: We cannot use `$location.hash();` here as it would not return anything. The hash would be in this case after '#?this=is&search=true#thisIshash'. `$location.search` returns an object and cannot be used for such a comparison.

BTW: This is fixed in 3.0 branch already
