### PR TITLE
Regression: columns query parameter is never urldecoded in PHP so it cannot be encoded in JS.

### DIFF
--- a/plugins/CoreHome/angularjs/history/history.service.js
+++ b/plugins/CoreHome/angularjs/history/history.service.js
@@ -67,7 +67,12 @@
                     searchObject[name] = searchObject[name][searchObject[name].length - 1];
                 }
 
-                searchString.push(name + '=' + encodeURIComponent(searchObject[name]));
+                var value = searchObject[name];
+                if (name != 'columns') { // the columns query parameter is not urldecoded in PHP code. TODO: this should be fixed in 3.0
+                    value = encodeURIComponent(value);
+                }
+
+                searchString.push(name + '=' + value);
             }
             searchString = searchString.join('&');
 

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -81,7 +81,8 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
     // visitors pages
     it('should load visitors > overview page correctly', function (done) {
         expect.screenshot("visitors_overview").to.be.captureSelector('.pageWrap,.expandDataTableFooterDrawer', function (page) {
-            page.load("?" + urlBase + "#" + generalParams + "&module=VisitsSummary&action=index");
+            // use columns query param to make sure columns works when supplied in URL fragment
+            page.load("?" + urlBase + "#" + generalParams + "&module=VisitsSummary&action=index&columns=nb_visits,nb_actions");
         }, done);
     });
 


### PR DESCRIPTION
When the `&columns=` query parameter is supplied in the URL fragment the `history` angular service will encode the parameter. In PHP, however, Piwik will never decode the parameter, so values like:

`nb_visits%2Cnb_actions`

will be interpreted incorrectly.

We can't change `Common::getRequestVar` to url decode for 2.15 in order to maintain BC, so this change makes sure columns is not url encoded when being detected in the history service.
