### PR TITLE
Do not manually include fixture files during tests so one plugin can't break tests of another

### DIFF
--- a/plugins/TestRunner/Commands/TestsSetupFixture.php
+++ b/plugins/TestRunner/Commands/TestsSetupFixture.php
@@ -240,19 +240,6 @@ class TestsSetupFixture extends ConsoleCommand
     {
         require_once PIWIK_INCLUDE_PATH . '/libs/PiwikTracker/PiwikTracker.php';
 
-        $fixturesToLoad = array(
-            '/tests/PHPUnit/Fixtures/*.php',
-            '/tests/UI/Fixtures/*.php',
-            '/plugins/*/tests/Fixtures/*.php',
-            '/plugins/*/Test/Fixtures/*.php',
-        );
-
-        foreach($fixturesToLoad as $fixturePath) {
-            foreach (glob(PIWIK_INCLUDE_PATH . $fixturePath) as $file) {
-                require_once $file;
-            }
-        }
-
         $file = $input->getOption('file');
         if ($file) {
             if (is_file($file)) {

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -60,18 +60,6 @@ function setupRootContainer() {
 
 setupRootContainer(); // do it in a function so it doesn't appear in $_GLOBALS and so PHPUnit won't try to serialize it.
 
-// require test fixtures
-$fixturesToLoad = array(
-    '/tests/UI/Fixtures/*.php',
-    '/plugins/*/tests/Fixtures/*.php',
-    '/plugins/*/Test/Fixtures/*.php',
-);
-foreach($fixturesToLoad as $fixturePath) {
-    foreach (glob(PIWIK_INCLUDE_PATH . $fixturePath) as $file) {
-        require_once $file;
-    }
-}
-
 Locale::setDefaultLocale();
 
 function prepareServerVariables(Config $config)


### PR DESCRIPTION
Since autoloading is used now, we do not need to manually include fixture files during tests.

Fixes the case when one plugin has issue in fixture class making it impossible to run tests (since the tests:run will just fail).
