### PR TITLE
Segment editor ui tests

### DIFF
--- a/tests/UI/specs/SegmentSelectorEditor_spec.js
+++ b/tests/UI/specs/SegmentSelectorEditor_spec.js
@@ -86,13 +86,13 @@ describe("SegmentSelectorEditorTest", function () {
 
     it("should add an OR condition when a segment dimension is dragged to the OR placeholder section", function (done) {
         expect.screenshot("drag_or_condition").to.be.captureSelector(selectorsToCapture, function (page) {
-            page.dragDrop('.segmentEditorPanel li[data-metric=entryPageTitle]', '.segmentEditorPanel .segment-add-or .ui-droppable');
+            page.dragDrop('.segmentEditorPanel li[data-metric=outlinkUrl]', '.segmentEditorPanel .segment-add-or .ui-droppable');
         }, done);
     });
 
     it("should add an AND condition when a segment dimension is dragged to the AND placeholder section", function (done) {
         expect.screenshot("drag_and_condition").to.be.captureSelector(selectorsToCapture, function (page) {
-            page.dragDrop('.segmentEditorPanel li[data-metric=pageTitle]', '.segmentEditorPanel .segment-add-row .ui-droppable');
+            page.dragDrop('.segmentEditorPanel li[data-metric=outlinkUrl]', '.segmentEditorPanel .segment-add-row .ui-droppable');
         }, done);
     });
 


### PR DESCRIPTION
Last night I overwrote the UI tests a bit too quickly in: https://github.com/piwik/piwik-ui-tests/commit/acb60ce853ad04fcc6e58436173497cbf39eee70

some of the UI tests regressed so this PR fixes it to make sure our UI tests still test what they're supposed to
