### PR TITLE
Always show apply button in date selector

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -11,7 +11,7 @@
         "AllWebsitesDashboard": "All Websites dashboard",
         "And": "and",
         "API": "API",
-        "ApplyDateRange": "Apply Date Range",
+        "Apply": "Apply",
         "ArchivingInlineHelp": "For medium to high traffic websites, it is recommended to disable Piwik archiving to trigger from the browser. Instead, we recommend that you setup a cron job to process Piwik reports every hour.",
         "ArchivingTriggerDescription": "Recommended for larger Piwik installs, you need to %ssetup a cron job%s to process the reports automatically.",
         "AuthenticationMethodSmtp": "Authentication method for SMTP",

--- a/plugins/CoreHome/javascripts/calendar.js
+++ b/plugins/CoreHome/javascripts/calendar.js
@@ -294,7 +294,6 @@
         var togglePeriodPickers = function (showSingle) {
             $('#periodString').find('.period-date').toggle(showSingle);
             $('#periodString').find('.period-range').toggle(!showSingle);
-            $('#calendarRangeApply').toggle(!showSingle);
         };
 
         //
@@ -382,6 +381,40 @@
             var id = $(e.target).attr('for');
             changePeriodOnClick($('#' + id));
         });
+
+        $("#otherPeriods").find("label,input").on('dblclick', function (e) {
+            var id = $(e.target).attr('for');
+            changePeriodOnClick($('#' + id));
+        });
+
+        // Apply date range button will reload the page with the selected range
+        $('#calendarApply')
+            .on('click', function () {
+                var $selectedPeriod = $('#periodMore [name=period]:checked');
+
+                if (!$selectedPeriod.is('#period_id_range')) {
+                    changePeriodOnClick($selectedPeriod);
+                    return true;
+                }
+
+                var dateFrom = $('#inputCalendarFrom').val(),
+                    dateTo = $('#inputCalendarTo').val(),
+                    oDateFrom = $.datepicker.parseDate('yy-mm-dd', dateFrom),
+                    oDateTo = $.datepicker.parseDate('yy-mm-dd', dateTo);
+
+                if (!isValidDate(oDateFrom)
+                    || !isValidDate(oDateTo)
+                    || oDateFrom > oDateTo) {
+                    $('#alert').find('h2').text(_pk_translate('General_InvalidDateRange'));
+                    piwikHelper.modalConfirm('#alert', {});
+                    return false;
+                }
+                piwikHelper.showAjaxLoading('ajaxLoadingCalendar');
+                broadcast.propagateNewPage('period=range&date=' + dateFrom + ',' + dateTo);
+            })
+            .show();
+
+
 
         // when non-range period is clicked, change the period & refresh the date picker
         $("#otherPeriods").find("input").on('click', function (e) {
@@ -487,27 +520,6 @@
             // If not called, the first date appears light brown instead of dark brown
             $('.ui-state-hover').removeClass('ui-state-hover');
 
-            // Apply date range button will reload the page with the selected range
-            $('#calendarRangeApply')
-                .on('click', function () {
-                    var request_URL = $(e.target).val();
-                    var dateFrom = $('#inputCalendarFrom').val(),
-                        dateTo = $('#inputCalendarTo').val(),
-                        oDateFrom = $.datepicker.parseDate('yy-mm-dd', dateFrom),
-                        oDateTo = $.datepicker.parseDate('yy-mm-dd', dateTo);
-
-                    if (!isValidDate(oDateFrom)
-                        || !isValidDate(oDateTo)
-                        || oDateFrom > oDateTo) {
-                        $('#alert').find('h2').text(_pk_translate('General_InvalidDateRange'));
-                        piwikHelper.modalConfirm('#alert', {});
-                        return false;
-                    }
-                    piwikHelper.showAjaxLoading('ajaxLoadingCalendar');
-                    broadcast.propagateNewPage('period=range&date=' + dateFrom + ',' + dateTo);
-                })
-                .show();
-
             // Bind the input fields to update the calendar's date when date is manually changed
             $('#inputCalendarFrom, #inputCalendarTo')
                 .keyup(function (e) {
@@ -520,7 +532,7 @@
                     }
                     $("#calendar" + fromOrTo).datepicker("setDate", newDate);
                     if (e.keyCode == 13) {
-                        $('#calendarRangeApply').click();
+                        $('#calendarApply').click();
                     }
                 });
             return true;

--- a/plugins/CoreHome/stylesheets/coreHome.less
+++ b/plugins/CoreHome/stylesheets/coreHome.less
@@ -110,10 +110,8 @@ div.ui-datepicker {
     line-height: 12px;
 }
 
-#calendarRangeApply {
-    display: none;
+#calendarApply {
     margin-top: 10px;
-    margin-left: 10px;
 }
 
 #invalidDateRange {

--- a/plugins/CoreHome/templates/_periodSelect.twig
+++ b/plugins/CoreHome/templates/_periodSelect.twig
@@ -26,7 +26,7 @@
                 <br/>
             {% endfor %}
 			</span>
-            <input tabindex="3" type="submit" value="{{ 'General_ApplyDateRange'|translate }}" id="calendarRangeApply" class="btn"/>
+            <input tabindex="3" type="submit" value="{{ 'General_Apply'|translate }}" id="calendarApply" class="btn"/>
             {% import 'ajaxMacros.twig' as ajax %}
             {{ ajax.loadingDiv('ajaxLoadingCalendar') }}
         </div>

--- a/tests/UI/specs/PeriodSelector_spec.js
+++ b/tests/UI/specs/PeriodSelector_spec.js
@@ -83,7 +83,7 @@ describe("PeriodSelector", function () {
         expect.screenshot("date_range_selected").to.be.captureSelector('#periodString', function (page) {
             page.click('#calendarFrom .ui-datepicker-calendar a:contains(10)');
             page.click('#calendarTo .ui-datepicker-calendar a:contains(18)');
-            page.mouseMove('#calendarRangeApply');
+            page.mouseMove('#calendarApply');
         }, done);
     });
 });

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -583,7 +583,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
                     $('#period_id_range').click();
                     $('#inputCalendarFrom').val('2012-08-02');
                     $('#inputCalendarTo').val('2012-08-12');
-                    setTimeout(function () {$('#calendarRangeApply').click();}, 500);
+                    setTimeout(function () {$('#calendarApply').click();}, 500);
                 });
             });
         }, done);

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -580,7 +580,12 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             page.evaluate(function () {
                 $(document).ready(function () {
                     $('#date').click();
-                    $('#period_id_range').click();
+                });
+            });
+            // we need to make sure there to wait for a bit till date is opened and period selected
+            page.click('#period_id_range');
+            page.evaluate(function () {
+                $(document).ready(function () {
                     $('#inputCalendarFrom').val('2012-08-02');
                     $('#inputCalendarTo').val('2012-08-12');
                     setTimeout(function () {$('#calendarApply').click();}, 500);


### PR DESCRIPTION
fixes #8864 

Looks like this:

![image](https://cloud.githubusercontent.com/assets/273120/10302509/41b7a9b6-6c0d-11e5-8166-aa724c0b9203.png)

The right side of the selector does now take more space which looks maybe a bit weird. I'd suggest to increase the font size of the data selectors from 10px to 11px or 12px and the font size of each date in the calendar view from 11px to 12px. Then they are about even and it will be easier to select a date since they are tiny :)
