### PR TITLE
urldecode parameters when getting from $_SERVER['QUERY_STRING']

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -412,6 +412,9 @@ class Request
             return array();
         }
         $GET = UrlHelper::getArrayFromQueryString($_SERVER['QUERY_STRING']);
+        foreach ($GET as $name => $value) {
+            $GET[$name] = urldecode($value);
+        }
         return $GET;
     }
 


### PR DESCRIPTION
As title. When getting query parameters from QUERY_STRING server var, make sure to urldecode since it is not done by PHP.

Should fix the issue when the segment param is obtained directly from QUERY_STRING. However, I can't test the fix since I cannot reproduce it locally. @mattab Perhaps you could apply this to demo & check if it works?

Fixes #8813
