### PR TITLE
Wrap plugin name if plugin name is very long

### DIFF
--- a/plugins/CorePluginsAdmin/stylesheets/plugins_admin.less
+++ b/plugins/CorePluginsAdmin/stylesheets/plugins_admin.less
@@ -93,6 +93,14 @@ table.entityTable tr td a.uninstall {
 
 #plugins {
 
+    .inactive-plugin,
+    .active-plugin {
+        .name {
+            max-width: 200px;
+            word-wrap: break-word;
+        }
+    }
+
     .plugin-desc-missingrequirements {
         font-weight:bold;
         font-style: italic;

--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -153,7 +153,7 @@
             {% set isDefaultTheme = isTheme and name == 'Morpheus' %}
             {% if (plugin.alwaysActivated is defined and not plugin.alwaysActivated) or isTheme %}
                 <tr {% if plugin.activated %}class="active-plugin"{% else %}class="inactive-plugin"{% endif %} data-filter-status="{% if plugin.activated %}active{% else %}inactive{% endif %}" data-filter-origin="{% if plugin.isCorePlugin %}core{% else %}noncore{% endif %}">
-                    <td class="name" style="white-space:nowrap;">
+                    <td class="name">
                         <a name="{{ name|e('html_attr') }}"></a>
                         {% if not plugin.isCorePlugin and name in marketplacePluginNames -%}
                             <a href="javascript:void(0);" class="plugin-details"


### PR DESCRIPTION
"AnonymousPiwikUsageMeasurement" is pretty long and when disable word wrap the actual available text for description gets pretty short. Instead limit the available width for plugin names.

refs #4589 
