### PR TITLE
Only add piwik-expand-on-click to the controls that need it

### DIFF
--- a/core/View/UIControl.php
+++ b/core/View/UIControl.php
@@ -60,6 +60,13 @@ class UIControl extends \Piwik\View
     public $cssClass = "";
 
     /**
+     * HTML Attributes for the root element
+     *
+     * @var string
+     */
+    public $htmlAttributes = array();
+
+    /**
      * The inner view that renders the actual control content.
      *
      * @var View
@@ -125,6 +132,7 @@ class UIControl extends \Piwik\View
         $this->templateVars['cssIdentifier'] = $this->cssIdentifier;
         $this->templateVars['cssClass'] = $this->cssClass;
         $this->templateVars['jsClass'] = $this->jsClass;
+        $this->templateVars['htmlAttributes'] = $this->htmlAttributes;
         $this->templateVars['jsNamespace'] = $this->jsNamespace;
         $this->templateVars['implOverride'] = $override;
 

--- a/plugins/CoreHome/angularjs/selector/selector.directive.js
+++ b/plugins/CoreHome/angularjs/selector/selector.directive.js
@@ -18,6 +18,7 @@
         return {
             restrict: 'A',
             link: function(scope, element, attr) {
+
                 element.find('.title').on('click', function () {
                     element.toggleClass('expanded');
                 });

--- a/plugins/CoreHome/templates/_uiControl.twig
+++ b/plugins/CoreHome/templates/_uiControl.twig
@@ -1,7 +1,9 @@
 <div class="{{ cssIdentifier }} {{ cssClass }}"
-     piwik-expand-on-click
-     data-props="{{ clientSideProperties|json_encode }}"
-     data-params="{{ clientSideParameters|json_encode }}">
-     {% render implView with implOverride %}
+    {% for name,value in htmlAttributes %}
+         {{ name }}="{{ value|e('html_attr') }}"
+    {% endfor %}
+    data-props="{{ clientSideProperties|json_encode }}"
+    data-params="{{ clientSideParameters|json_encode }}">
+{% render implView with implOverride %}
 </div>
 <script>$(document).ready(function () { require('{{ jsNamespace }}').{{ jsClass }}.initElements(); });</script>

--- a/plugins/Dashboard/DashboardSettingsControlBase.php
+++ b/plugins/Dashboard/DashboardSettingsControlBase.php
@@ -24,6 +24,7 @@ abstract class DashboardSettingsControlBase extends UIControl
         parent::__construct();
 
         $this->cssClass = "borderedControl piwikTopControl dashboardSettings";
+        $this->htmlAttributes = array('piwik-expand-on-click' => '');
         $this->dashboardActions = array();
         $this->generalActions = array();
     }


### PR DESCRIPTION
refs #8993 

This is needed for #8993 . Otherwise the comparison dashboard, which is a UI control that contains other UI controls, gets a `piwik-expand-on-click` as well which results in selectors that do not open. Eg segment selector used to have this `piwik-expand-on-click` as well which is responsible to expand the dropdown when clicking on it. This would work but the comparison dashboard would do the same and close it immediately again.

Also for various other reasons I had to remove `piwik-expand-on-click` from SegmentSelector as it otherwise did not behave correctly anymore. The only side effect will be that pressing `escape` won't close it anymore.

Everything should work as before otherwise.
