### PR TITLE
Fix bug in optimize archive tables command: do not overwrite argument array w/ single value.

### DIFF
--- a/plugins/CoreAdminHome/Commands/OptimizeArchiveTables.php
+++ b/plugins/CoreAdminHome/Commands/OptimizeArchiveTables.php
@@ -66,9 +66,9 @@ class OptimizeArchiveTables extends ConsoleCommand
 
     private function getTableMonthsToOptimize(InputInterface $input)
     {
-        $dateSpecifier = $input->getArgument('dates');
-        if (count($dateSpecifier) === 1) {
-            $dateSpecifier = reset($dateSpecifier);
+        $dateSpecifiers = $input->getArgument('dates');
+        if (count($dateSpecifiers) === 1) {
+            $dateSpecifier = reset($dateSpecifiers);
 
             if ($dateSpecifier == self::ALL_TABLES_STRING) {
                 return $this->getAllArchiveTableMonths();
@@ -90,7 +90,7 @@ class OptimizeArchiveTables extends ConsoleCommand
         }
 
         $tableMonths = array();
-        foreach ($dateSpecifier as $date) {
+        foreach ($dateSpecifiers as $date) {
             $date = Date::factory($date);
             $tableMonths[] = ArchiveTableCreator::getTableMonthFromDate($date);
         }

--- a/plugins/CoreAdminHome/tests/Integration/Commands/OptimizeArchiveTablesTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/OptimizeArchiveTablesTest.php
@@ -87,6 +87,11 @@ class OptimizeArchiveTablesTest extends ConsoleCommandTestCase
                     Date::factory('now')->subMonth(5)->toString('Y_m'),
                 ),
             ),
+
+            array(
+                array('2015-01-01'),
+                array('2015_01'),
+            ),
         );
     }
 }


### PR DESCRIPTION
As title. Includes new test.

Fixes #9004
