### PR TITLE
Site selectors are not rendered correctly in dialogs

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -378,7 +378,9 @@
       font-size: 11px;
     }
   }
+}
 
+#root, .ui-dialog, .ngdialog {
   .borderedControl {
     background-color: @theme-color-background-base;
     border: 1px solid @theme-color-background-tinyContrast;


### PR DESCRIPTION
As title. Due to .borderedControl CSS only being applied to children of #root. This change applies the CSS to .ui-dialog + .ngdialog elements as well. Not sure if there is a better approach as I am not too familiar w/ the top control / left menu changes.
