### PR TITLE
Dialogs implemented with angular will not display on reload or via URL

### DIFF
--- a/plugins/CoreHome/angularjs/dialogtoggler/dialogtoggler-urllistener.service.js
+++ b/plugins/CoreHome/angularjs/dialogtoggler/dialogtoggler-urllistener.service.js
@@ -83,6 +83,8 @@
             service.checkUrlForDialog();
         });
 
+        service.checkUrlForDialog(); // check on initial page load
+
         return service;
     }
 })();


### PR DESCRIPTION
When an angular dialog is loaded by URL (ie, if the URL contains popover=... and it wasn't modified via JS, but was loaded directly), the dialog will not display.

This PR fixes this. Should not be merged w/o tests, though.

TODO:
- [ ] Add some angular tests for angular dialog service.
- [ ] Maybe add a UI test for the service w/ a dummy dialog directive.
