### PR TITLE
Add ng-cloak to search to prevent showing the template

### DIFF
--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -30,7 +30,7 @@
 
 {% macro menu(menu, anchorlink, cssClass) %}
     <div id="secondNavBar" class="{{ cssClass }}">
-        <div id="search">
+        <div id="search" ng-cloak>
             <div piwik-quick-access class="borderedControl"></div>
         </div>
         <ul class="navbar">


### PR DESCRIPTION
fixes #9034 

I couldn't reproduce it, not even with chromes screenshot feature.

BTW: This should not be dependent on the connection since the search does not really contain any such variables

Can we stop calling it awesome search? It's a search like on millions of other websites and apps ;)
