### PR TITLE
Angular components are not rendered in dashboard view

### DIFF
--- a/plugins/Dashboard/javascripts/dashboardWidget.js
+++ b/plugins/Dashboard/javascripts/dashboardWidget.js
@@ -118,9 +118,12 @@
             var self = this, currentWidget = this.element;
 
             function onWidgetLoadedReplaceElementWithContent(loadedContent) {
-                $('.widgetContent', currentWidget).html(loadedContent);
-                $('.widgetContent', currentWidget).removeClass('loading');
-                $('.widgetContent', currentWidget).trigger('widget:create', [self]);
+                var $widgetContent = $('.widgetContent', currentWidget);
+
+                $widgetContent.html(loadedContent);
+                piwikHelper.compileAngularComponents($widgetContent);
+                $widgetContent.removeClass('loading');
+                $widgetContent.trigger('widget:create', [self]);
             }
 
             // Reading segment from hash tag (standard case) or from the URL (when embedding dashboard)


### PR DESCRIPTION
fixes #9035 

There is actually supposed to be a headline. Wasn't shown as angular components were not compiled there.
