### PR TITLE
Allow tracker requests to be manipulated before handled

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -394,6 +394,12 @@ class Request
         return $this->paramsCache[$name];
     }
 
+    public function setParam($name, $value)
+    {
+        $this->params[$name] = $value;
+        unset($this->paramsCache[$name]);
+    }
+
     private function hasParam($name)
     {
         return isset($this->params[$name]);

--- a/core/Tracker/RequestProcessor.php
+++ b/core/Tracker/RequestProcessor.php
@@ -35,12 +35,15 @@ use Piwik\Tracker\Visit\VisitProperties;
  * When Piwik handles a single tracking request, it gathers all available RequestProcessors and
  * invokes their methods in sequence.
  *
- * The first method called is {@link self::processRequestParams()}. RequestProcessors should use
+ * The first method called is {@link self::manipulateRequest()}. By default this is a no-op, but
+ * RequestProcessors can use it to manipulate tracker requests before they are processed.
+ *
+ * The second method called is {@link self::processRequestParams()}. RequestProcessors should use
  * this method to compute request metadata and set visit properties using the tracking request.
  * An example includes the ActionRequestProcessor, which uses this method to determine the action
  * being tracked.
  *
- * The second method called is {@link self::afterRequestProcessed()}. RequestProcessors should
+ * The third method called is {@link self::afterRequestProcessed()}. RequestProcessors should
  * use this method to either compute request metadata/visit properties using other plugins'
  * request metadata, OR override other plugins' request metadata to tweak tracker behavior.
  * An example of the former can be seen in the GoalsRequestProcessor which uses the action
@@ -48,7 +51,7 @@ use Piwik\Tracker\Visit\VisitProperties;
  * conversions. An example of the latter can be seen in the PingRequestProcessor, which on
  * ping requests, aborts conversion recording and new visit recording.
  *
- * After these two methods are called, either {@link self::onNewVisit()} or {@link self::onExistingVisit()}
+ * After these methods are called, either {@link self::onNewVisit()} or {@link self::onExistingVisit()}
  * is called. Generally, plugins should favor defining Dimension classes instead of using these methods,
  * however sometimes it is not possible (as is the case with the CustomVariables plugin).
  *
@@ -83,6 +86,19 @@ abstract class RequestProcessor
     /**
      * This is the first method called when processing a tracker request.
      *
+     * Derived classes can use this method to manipulate a tracker request before the request
+     * is handled. Plugins could change the URL, add custom variables, etc.
+     *
+     * @param Request $request
+     */
+    public function manipulateRequest(Request $request)
+    {
+        // empty
+    }
+
+    /**
+     * This is the second method called when processing a tracker request.
+     *
      * Derived classes should use this method to set request metadata based on the tracking
      * request alone. They should not try to access request metadata from other plugins,
      * since they may not be set yet.
@@ -99,7 +115,7 @@ abstract class RequestProcessor
     }
 
     /**
-     * This is the second method called when processing a tracker request.
+     * This is the third method called when processing a tracker request.
      *
      * Derived classes should use this method to set request metadata that needs request metadata
      * from other plugins, or to override request metadata from other plugins to change

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -113,6 +113,12 @@ class Visit implements VisitInterface
      */
     public function handle()
     {
+        foreach ($this->requestProcessors as $processor) {
+            Common::printDebug("Executing " . get_class($processor) . "::manipulateRequest()...");
+
+            $processor->manipulateRequest($this->request);
+        }
+
         $this->visitProperties = new VisitProperties();
 
         foreach ($this->requestProcessors as $processor) {


### PR DESCRIPTION
Includes two changes (neither are public API):
- New method `setParam()` in Tracker\Request that allows setting request parameters in a tracker Request.
- New method RequestProcessor::manipulateRequest that allows plugins to manipulate a request before it is handled (again, not yet public API).

This PR is required for plugin compatibility.
