### PR TITLE
Only trigger piwikSwitchPage JS event when about to change piwik page.

### DIFF
--- a/plugins/CoreHome/javascripts/menu.js
+++ b/plugins/CoreHome/javascripts/menu.js
@@ -21,7 +21,6 @@ menu.prototype =
             return;
         }
 
-        $('#secondNavBar').trigger('piwikSwitchPage', this);
         $('#secondNavBar').removeClass('open fadeInLeft');
 
         var $link = $(this);
@@ -45,6 +44,8 @@ menu.prototype =
 
 
             } else if (href) {
+                $('#secondNavBar').trigger('piwikSwitchPage', this);
+
                 broadcast.propagateAjax(href.substr(1));
             }
 


### PR DESCRIPTION
Triggering when not changing the page causes Piwik to destroy graphs, w/o them ever being replaced.

Fixes #9018
