### PR TITLE
Remove middle vertical alignment of alert icons.

### DIFF
--- a/plugins/Morpheus/stylesheets/ui/_alerts.less
+++ b/plugins/Morpheus/stylesheets/ui/_alerts.less
@@ -20,7 +20,6 @@
         left: 20px;
         line-height: 100%; // line-height = font-size
         font-size: 24px;
-        .alert-icon-center-vertically(24px);
     }
 
     a {
@@ -45,7 +44,6 @@
     &:before {
         color: #afafaf;
         font-size: 20px;
-        .alert-icon-center-vertically(20px);
     }
 }
 .alert-warning {


### PR DESCRIPTION
As title. They are now aligned w/ the top of the notification text.

Fixes #9011
