### PR TITLE
Tracker configId should be based on original IP, not on anonymised IP? 

### DIFF
--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -92,7 +92,7 @@ class VisitRequestProcessor extends RequestProcessor
         }
 
         // visitor recognition
-        $visitorId = $this->userSettings->getConfigId($request, $visitProperties->getProperty('location_ip'));
+        $visitorId = $this->userSettings->getConfigId($request, $request->getIpString());
         $request->setMetadata('CoreHome', 'visitorId', $visitorId);
 
         $isKnown = $this->visitorRecognizer->findKnownVisitor($visitorId, $visitProperties, $request);

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -19,6 +19,7 @@ use Piwik\Tracker\Settings;
 use Piwik\Tracker\Visit\VisitProperties;
 use Piwik\Tracker\VisitExcluded;
 use Piwik\Tracker\VisitorRecognizer;
+use Piwik\Plugins\PrivacyManager\Config as PrivacyManagerConfig;
 
 /**
  * Encapsulates core tracking logic related to visits.
@@ -91,8 +92,15 @@ class VisitRequestProcessor extends RequestProcessor
             return true;
         }
 
+        $privacyConfig = new PrivacyManagerConfig();
+
+        $ip = $request->getIpString();
+        if ($privacyConfig->useAnonymizedIpForVisitEnrichment) {
+            $ip = $visitProperties->getProperty('location_ip');
+        }
+
         // visitor recognition
-        $visitorId = $this->userSettings->getConfigId($request, $request->getIpString());
+        $visitorId = $this->userSettings->getConfigId($request, $ip);
         $request->setMetadata('CoreHome', 'visitorId', $visitorId);
 
         $isKnown = $this->visitorRecognizer->findKnownVisitor($visitorId, $visitProperties, $request);


### PR DESCRIPTION
fixes #7778

The fix is not ideal since it is code in core that accesses code from a plugin. Ideally, at some point, we would handle this logic only once right at the beginning, modify the IP based on `useAnonymizedIpForVisitEnrichment` setting and use the correct one everywhere. So we would not have to add this check for `useAnonymizedIpForVisitEnrichment` in various places and it would also work for other plugins out of the box
