### PR TITLE
Display 'Report generated Xs ago' in help tooltip

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -619,7 +619,7 @@ class Archive
             if ($isNumeric) {
                 $row['value'] = $this->formatNumericValue($row['value']);
             } else {
-                $result->addMetadata($row['idsite'], $periodStr, 'ts_archived', $row['ts_archived']);
+                $result->addMetadata($row['idsite'], $periodStr, DataTable::ARCHIVED_DATE_METADATA_NAME, $row['ts_archived']);
             }
 
             $result->set($row['idsite'], $periodStr, $row['name'], $row['value']);

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -170,7 +170,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     const MAX_DEPTH_DEFAULT = 15;
 
     /** Name for metadata that describes when a report was archived. */
-    const ARCHIVED_DATE_METADATA_NAME = 'archived_date';
+    const ARCHIVED_DATE_METADATA_NAME = 'ts_archived';
 
     /** Name for metadata that describes which columns are empty and should not be shown. */
     const EMPTY_COLUMNS_METADATA_NAME = 'empty_column';

--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -359,7 +359,7 @@ class Visualization extends ViewDataTable
             $this->metadata = $this->dataTable->getAllTableMetadata();
 
             if (isset($this->metadata[DataTable::ARCHIVED_DATE_METADATA_NAME])) {
-                $this->config->report_last_updated_message = $this->makePrettyArchivedOnText();
+                $this->reportLastUpdatedMessage = $this->makePrettyArchivedOnText();
             }
         }
 

--- a/plugins/CoreHome/templates/_dataTable.twig
+++ b/plugins/CoreHome/templates/_dataTable.twig
@@ -12,7 +12,7 @@
      data-params="{% if clientSideParameters is empty %}{}{% else %}{{ clientSideParameters|json_encode }}{% endif %}">
     <div class="reportDocumentation">
         {% if properties.documentation|default is not empty %}<p>{{ properties.documentation|raw }}</p>{% endif %}
-        {% if reportLastUpdatedMessage is defined %}<span class='helpDate'>{{ reportLastUpdatedMessage }}</span>{% endif %}
+        {% if reportLastUpdatedMessage is defined %}<span class='helpDate'>{{ reportLastUpdatedMessage|raw }}</span>{% endif %}
     </div>
     <div class="dataTableWrapper">
         {% if error is defined %}

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -41,6 +41,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         testEnvironment.save();
     });
 
+
     // dashboard tests
     it("should load dashboard1 correctly", function (done) {
         expect.screenshot("dashboard1").to.be.captureSelector('.pageWrap,.expandDataTableFooterDrawer', function (page) {
@@ -152,6 +153,15 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
     it('should load the actions > pages page correctly', function (done) {
         expect.screenshot('actions_pages').to.be.captureSelector('.pageWrap,.expandDataTableFooterDrawer', function (page) {
             page.load("?" + urlBase + "#" + generalParams + "&module=Actions&action=menuGetPageUrls");
+        }, done);
+    });
+
+    // actions pages
+    it('should load the actions > pages help tooltip, including the "Report generated time"', function (done) {
+        expect.screenshot('actions_pages_tooltip_help').to.be.captureSelector('.pageWrap,.expandDataTableFooterDrawer', function (page) {
+            page.load("?" + urlBase + "#" + generalParams + "&module=Actions&action=menuGetPageUrls");
+            page.mouseMove('h2[piwik-enriched-headline]');
+            page.click(".helpIcon");
         }, done);
     });
 


### PR DESCRIPTION
When clicking on Help icon, the "Report generated Xs ago" will now display.

![tooltip with report generated 13 min ago](https://cloud.githubusercontent.com/assets/466765/10651831/4222e70a-78ae-11e5-9e76-b9ce2d08b7aa.png)

This feature was initially implemented in May 2012 in  https://github.com/piwik/piwik/issues/1052 but we did not have UI test back then, and when it broke a few months later we did not notice.

If no UI test fail I will add one to make sure this feature is tested and won't regress
