### PR TITLE
New --overwrite option for generate:plugin to aid in automation

### DIFF
--- a/plugins/CoreConsole/Commands/GeneratePlugin.php
+++ b/plugins/CoreConsole/Commands/GeneratePlugin.php
@@ -28,7 +28,8 @@ class GeneratePlugin extends GeneratePluginBase
             ->setDescription('Generates a new plugin/theme including all needed files')
             ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Plugin name ([a-Z0-9_-])')
             ->addOption('description', null, InputOption::VALUE_REQUIRED, 'Plugin description, max 150 characters')
-            ->addOption('pluginversion', null, InputOption::VALUE_OPTIONAL, 'Plugin version');
+            ->addOption('pluginversion', null, InputOption::VALUE_OPTIONAL, 'Plugin version')
+            ->addOption('overwrite', null, InputOption::VALUE_NONE, 'Generate even if plugin directory already exists.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -115,9 +116,11 @@ class GeneratePlugin extends GeneratePluginBase
      */
     protected function getPluginName(InputInterface $input, OutputInterface $output)
     {
+        $overwrite = $input->getOption('overwrite');
+
         $self = $this;
 
-        $validate = function ($pluginName) use ($self) {
+        $validate = function ($pluginName) use ($self, $overwrite) {
             if (empty($pluginName)) {
                 throw new \RuntimeException('You have to enter a plugin name');
             }
@@ -128,7 +131,9 @@ class GeneratePlugin extends GeneratePluginBase
 
             $pluginPath = $self->getPluginPath($pluginName);
 
-            if (file_exists($pluginPath)) {
+            if (file_exists($pluginPath)
+                && !$overwrite
+            ) {
                 throw new \RuntimeException('A plugin with this name already exists');
             }
 

--- a/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
+++ b/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
@@ -39,7 +39,9 @@ class GenerateTravisYmlFile extends ConsoleCommand
              ->addOption('php-versions', null, InputOption::VALUE_OPTIONAL,
                 "List of PHP versions to test against, ie, 5.4,5.5,5.6. Defaults to: 5.3.3,5.4,5.5,5.6.")
              ->addOption('dump', null, InputOption::VALUE_REQUIRED, "Debugging option. Saves the output .travis.yml to the specified file.")
-             ->addOption('repo-root-dir', null, InputOption::VALUE_REQUIRED, "Path to the repo for whom a .travis.yml file will be generated for.");
+             ->addOption('repo-root-dir', null, InputOption::VALUE_REQUIRED, "Path to the repo for whom a .travis.yml file will be generated for.")
+             ->addOption('force-php-tests', null, InputOption::VALUE_NONE, "Forces the presence of the PHP tests jobs for plugin builds.")
+             ->addOption('force-ui-tests', null, InputOption::VALUE_NONE, "Forces the presence of the UI tests jobs for plugin builds.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
The new option will force the command to generate even if the plugin dir exists and has files in it. Intended use is for cloning a git repo & then running the command.

EDIT: also includes options for https://github.com/piwik/travis-scripts/pull/13
