### PR TITLE
SettingsServer.php - in_array() expects parameter 2

### DIFF
--- a/core/SettingsServer.php
+++ b/core/SettingsServer.php
@@ -127,9 +127,14 @@ class SettingsServer
     {
         static $gd = null;
         if (is_null($gd)) {
+            $gd = false;
+
             $extensions = @get_loaded_extensions();
-            $gd = in_array('gd', $extensions) && function_exists('imageftbbox');
+            if (is_array($extensions)) {
+                $gd = in_array('gd', $extensions) && function_exists('imageftbbox');
+            }
         }
+
         return $gd;
     }
 


### PR DESCRIPTION
fixes #9090 

An alternative fix might be to call `get_loaded_extensions($zend_extensions = true)` which then should always return extensions but not 100% sure and would be slower anyway.
