### PR TITLE
Make sure to return correct IP when all IPs are excluded

### DIFF
--- a/core/IP.php
+++ b/core/IP.php
@@ -101,7 +101,7 @@ class IP
      *
      * @param string $csv Comma separated list of elements.
      * @param array $excludedIps Optional list of excluded IP addresses (or IP address ranges).
-     * @return string Last (non-excluded) IP address in the list.
+     * @return string Last (non-excluded) IP address in the list or an empty string if all given IPs are excluded.
      */
     public static function getLastIpFromList($csv, $excludedIps = null)
     {
@@ -115,6 +115,8 @@ class IP
                     return $element;
                 }
             }
+
+            return '';
         }
         return trim(Common::sanitizeInputValue($csv));
     }

--- a/tests/PHPUnit/Unit/IPTest.php
+++ b/tests/PHPUnit/Unit/IPTest.php
@@ -10,11 +10,12 @@
 
 namespace Piwik\Tests\Unit;
 
-use Piwik\Common;
 use Piwik\Config;
 use Piwik\IP;
-use Piwik\Tests\Framework\Mock\TestConfig;
 
+/**
+ * @group Core
+ */
 class IPTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -83,7 +84,6 @@ class IPTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getIpFromHeaderTestData
-     * @group Core
      */
     public function testGetIpFromHeader($description, $test)
     {
@@ -111,8 +111,6 @@ class IPTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group Core
-     *
      * @dataProvider getIpTestData
      */
     public function testGetNonProxyIpFromHeader($ip)
@@ -121,8 +119,6 @@ class IPTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group Core
-     *
      * @dataProvider getIpTestData
      */
     public function testGetNonProxyIpFromHeader2($ip)
@@ -134,8 +130,6 @@ class IPTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group Core
-     *
      * @dataProvider getIpTestData
      */
     public function testGetNonProxyIpFromHeader3($ip)
@@ -155,6 +149,20 @@ class IPTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * See https://github.com/piwik/piwik/issues/8721
+     */
+    public function testGetNonProxyIpFromHeader4_ShouldReturnDefaultIp_IfDefaultIpIsGivenMultipleTimes()
+    {
+        // 1.1.1.1 is a trusted proxy
+        $_SERVER['REMOTE_ADDR'] = '1.1.1.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = $_SERVER['REMOTE_ADDR'];
+        $_SERVER['HTTP_CF_CONNECTING_IP'] = $_SERVER['REMOTE_ADDR'];
+
+        $this->assertEquals('1.1.1.1', IP::getNonProxyIpFromHeader('1.1.1.1', array('HTTP_X_FORWARDED_FOR', 'HTTP_CF_CONNECTING_IP')));
+        unset($_SERVER['HTTP_CF_CONNECTING_IP']);
+    }
+
+    /**
      * Dataprovider for testGetLastIpFromList
      */
     public function getLastIpFromListTestData()
@@ -170,8 +178,6 @@ class IPTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group Core
-     *
      * @dataProvider getLastIpFromListTestData
      */
     public function testGetLastIpFromList($csv, $expected)
@@ -181,5 +187,11 @@ class IPTest extends \PHPUnit_Framework_TestCase
 
         // with excluded Ips
         $this->assertEquals($expected, IP::getLastIpFromList($csv . ', 10.10.10.10', array('10.10.10.10')));
+    }
+
+    public function testGetLastIpFromList_shouldReturnAnEmptyString_IfMultipleIpsAreGivenButAllAreExcluded()
+    {
+        // with excluded Ips
+        $this->assertEquals('', IP::getLastIpFromList('10.10.10.10, 10.10.10.10', array('10.10.10.10')));
     }
 }


### PR DESCRIPTION
refs #8721 

I tried to reproduce #8721 with the given server data from https://github.com/piwik/piwik/issues/8721#issuecomment-138337201

I did not get `0.0.0.0` but it returned `82.197.211.195, 82.197.211.195` which is wrong as well as it should be `82.197.211.195`.

Problem was it called 

```
$excludedIps = array($defaultIp = '82.197.211.195')
Ip::getLastIpFromList($csv = '82.197.211.195, 82.197.211.195', $excludedIps);
```

In this case it returned `82.197.211.195, 82.197.211.195` as it did detect there were multiple IPs given but then returned the same `$csv` as non of them were allowed. The `$defaultIp` was the same as the ones specified in other headers from:

```
proxy_client_headers[] = "HTTP_X_FORWARDED_FOR"
proxy_client_headers[] = "HTTP_CF_CONNECTING_IP"
proxy_client_headers[] = "HTTP_CLIENT_IP"
proxy_client_headers[] = "REMOTE_ADDR";

$_SERVER['REMOTE_ADDR'] = '82.197.211.195';
$_SERVER['HTTP_X_FORWARDED_FOR'] = '82.197.211.195';
$_SERVER['HTTP_CF_CONNECTING_IP'] = '82.197.211.195';
```

In the users case it was actually not needed to specify multiple `proxy_client_headers`. I'm not sure if it will actually fix the issue but it was a bug
