### PR TITLE
In the website selector display tooltip with full website name

### DIFF
--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -133,6 +133,7 @@ class CoreHome extends \Piwik\Plugin
         $jsFiles[] = "plugins/CoreHome/angularjs/common/filters/length.js";
         $jsFiles[] = "plugins/CoreHome/angularjs/common/filters/trim.js";
         $jsFiles[] = "plugins/CoreHome/angularjs/common/filters/pretty-url.js";
+        $jsFiles[] = "plugins/CoreHome/angularjs/common/filters/htmldecode.js";
 
         $jsFiles[] = "plugins/CoreHome/angularjs/common/directives/directive.module.js";
         $jsFiles[] = "plugins/CoreHome/angularjs/common/directives/autocomplete-matched.js";
@@ -180,7 +181,6 @@ class CoreHome extends \Piwik\Plugin
         $translationKeys[] = 'General_Show';
         $translationKeys[] = 'General_Hide';
         $translationKeys[] = 'General_Website';
-        $translationKeys[] = 'General_ChooseWebsite';
         $translationKeys[] = 'Intl_Year_Short';
         $translationKeys[] = 'General_MultiSitesSummary';
         $translationKeys[] = 'General_SearchNoResults';
@@ -275,5 +275,6 @@ class CoreHome extends \Piwik\Plugin
         $translationKeys[] = 'CoreHome_Segments';
         $translationKeys[] = 'CoreHome_MenuEntries';
         $translationKeys[] = 'SitesManager_Sites';
+        $translationKeys[] = 'CoreHome_ChangeCurrentWebsite';
     }
 }

--- a/plugins/CoreHome/angularjs/common/filters/htmldecode.js
+++ b/plugins/CoreHome/angularjs/common/filters/htmldecode.js
@@ -1,0 +1,26 @@
+/*!
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+(function () {
+    angular.module('piwikApp.filter').filter('htmldecode', htmldecode);
+
+    htmldecode.$inject = ['piwik'];
+
+    /**
+     * Be aware that this filter can cause XSS so only use it when you're sure it is safe.
+     * Eg it should be safe when it is afterwards escaped by angular sanitize again.
+     */
+    function htmldecode(piwik) {
+
+        return function(text) {
+            if (text && text.length) {
+                return piwik.helper.htmlDecode(text);
+            }
+
+            return text;
+        };
+    }
+})();

--- a/plugins/CoreHome/angularjs/siteselector/siteselector.directive.html
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.directive.html
@@ -37,6 +37,7 @@
                     ng-hide="!showSelectedSite && activeSiteId==site.idsite">
                     <a piwik-ignore-click href="{{ getUrlForSiteId(site.idsite) }}"
                        piwik-autocomplete-matched="view.searchTerm"
+                       title="{{ site.name|htmldecode }}"
                        ng-bind-html="site.name"></a>
                 </li>
             </ul>

--- a/plugins/CoreHome/angularjs/siteselector/siteselector.directive.html
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.directive.html
@@ -16,7 +16,7 @@
     <a ng-click="view.showSitesList=!view.showSitesList; view.showSitesList && !model.isLoading && model.loadInitialSites();"
        piwik-onenter="view.showSitesList=!view.showSitesList; view.showSitesList && !model.isLoading && model.loadInitialSites();"
        href="javascript:void(0)"
-       title="{{ 'General_ChooseWebsite'|translate }}"
+       title="{{ 'CoreHome_ChangeCurrentWebsite'|translate:((selectedSite.name || model.firstSiteName)|htmldecode) }}"
        ng-class="{'loading': model.isLoading}"
        class="title">
         <span class="icon icon-arrow-bottom"

--- a/plugins/CoreHome/lang/en.json
+++ b/plugins/CoreHome/lang/en.json
@@ -52,6 +52,7 @@
         "QuickAccessTitle": "Search for %s. Shortcut: Press 'f' to search.",
         "MenuEntries": "Menu entries",
         "Segments": "Segments",
-        "AdblockIsMaybeUsed": "In case you are using an ad blocker, please disable it for this site to make sure Piwik works without any issues."
+        "AdblockIsMaybeUsed": "In case you are using an ad blocker, please disable it for this site to make sure Piwik works without any issues.",
+        "ChangeCurrentWebsite": "Choose a website, currently selected website: %s"
     }
 }


### PR DESCRIPTION
fixes #8569 

Old title: Choose website
New title: Choose a website, currently selected website: %s

This was not really an easy pick since the website name is escaped. I tried several solutions and came up with this one that should be hopefully XSS-safe since angular `$sanitize` should be used. I tried it eg with `<My website"'>;,?` and it was correctly displayed and escaped after I unescaped it with `piwikHelper`. I had to `htmlDecode` the website name, otherwise it would display `&#...;&#...;` etc

Would be good if someone had a look at it too.

Maybe we should do the same for the segment selector?
