### PR TITLE
Use of static local variable in FrontController hinders ability to test

### DIFF
--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -66,6 +66,11 @@ class FrontController extends Singleton
     public static $enableDispatch = true;
 
     /**
+     * @var bool
+     */
+    private $initialized = false;
+
+    /**
      * Executes the requested plugin controller method.
      *
      * @throws Exception|\Piwik\PluginDeactivatedException in case the plugin doesn't exist, the action doesn't exist,
@@ -197,11 +202,11 @@ class FrontController extends Singleton
      */
     public function init()
     {
-        static $initialized = false;
-        if ($initialized) {
+        if ($this->initialized) {
             return;
         }
-        $initialized = true;
+
+        $this->initialized = true;
 
         $tmpPath = StaticContainer::get('path.tmp');
 


### PR DESCRIPTION
In FrontController::init() a static local variable is used so the FrontController will not be init-ed more than once. Unfortunately since it is static, it affects all instances of FrontController even after a test environment is destroyed and a new one created. And since it is local, there is no way for it to be reset.

This PR moves the variable to a member.
