### PR TITLE
Adding role menu and menuitem to navigation menu trees and leafs

### DIFF
--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -2,7 +2,7 @@
     {% if name|slice(0,1) != '_' %}
         <li role="menuitem" title="{{ name|translate|e('html_attr') }}">
             <a class="item" href="{% if anchorlink %}#{% else %}index.php?{% endif %}{{ url|urlRewriteWithParameters|slice(1) }}">
-                {{ name|translate|e('html_attr') }}
+                {{ name|translate }}
             </a>
         </li>
     {% endif %}
@@ -15,7 +15,7 @@
                 <a class="item menuItem"
                    href='{% if anchorlink %}#?{% else %}index.php?{% endif %}{{ item.url|urlRewriteWithParameters|slice(1) }}'
                    {% if item.tooltip %}title="{{ item.tooltip|e('html_attr') }}"{% endif %}>
-                    {{ item.name|translate|e('html_attr') }}
+                    {{ item.name|translate }}
                 </a>
             {% endfor %}
         </div>
@@ -47,8 +47,7 @@
                 {% if hasSubmenuItem %}
                     <li role="menuitem" class="menuTab" title="{{ level1|translate|e('html_attr') }}" id="{% if level2._url is defined and level2._url is not empty %}{{ _self.getId(level2._url) }}{% endif %}">
                         <a class="item" href="">
-                            <span class="menu-icon {{ level2._icon|default('icon-arrow-right') }}"></span>
-                            {{ level1|translate|e('html_attr') }}
+                            <span class="menu-icon {{ level2._icon|default('icon-arrow-right') }}"></span>{{ level1|translate }}
                         </a>
 
                         <ul role="menu" title="{{ level1|translate|e('html_attr') }}">

--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -1,6 +1,6 @@
 {% macro submenuItem(name, url, anchorlink) %}
     {% if name|slice(0,1) != '_' %}
-        <li>
+        <li role="menuitem" title="{{ name|translate }}">
             <a class="item" href="{% if anchorlink %}#{% else %}index.php?{% endif %}{{ url|urlRewriteWithParameters|slice(1) }}">
                 {{ name|translate }}
             </a>
@@ -9,7 +9,7 @@
 {% endmacro %}
 
 {% macro groupedItem(name, group, anchorlink) %}
-    <li>
+    <li role="menuitem" title="{{ name|translate|e('html_attr') }}">
         <div piwik-menudropdown show-search="true" menu-title="{{ name|translate|e('html_attr') }}">
             {% for item in group.getItems %}
                 <a class="item menuItem"
@@ -33,7 +33,7 @@
         <div id="search" ng-cloak>
             <div piwik-quick-access class="borderedControl"></div>
         </div>
-        <ul class="navbar">
+        <ul role="menu" class="navbar">
             {% for level1,level2 in menu %}
                 {% set hasSubmenuItem = false %}
                 {% for name,urlParameters in level2 %}
@@ -45,15 +45,13 @@
                 {% endfor %}
 
                 {% if hasSubmenuItem %}
-                    <li id="{% if level2._url is defined and level2._url is not empty %}{{ _self.getId(level2._url) }}{% endif %}" class="menuTab">
+                    <li role="menuitem" title="{{ level1|translate }}" id="{% if level2._url is defined and level2._url is not empty %}{{ _self.getId(level2._url) }}{% endif %}" class="menuTab">
 
                         <a class="item" href="">
-                            <span class="menu-icon {{ level2._icon|default('icon-arrow-right') }}"></span>{{ level1|translate }}
-                            <span class="hidden">
-                             {{ 'CoreHome_Menu'|translate }}
-                           </span>
+                            <span class="menu-icon {{ level2._icon|default('icon-arrow-right') }}"></span>
+                            {{ level1|translate }}
                         </a>
-                        <ul>
+                        <ul role="menu" title="{{ level1|translate }}">
                             {% for name,urlParameters in level2 %}
                                 {% if urlParameters._url is defined and urlParameters._url is not iterable %}
                                     {{ _self.groupedItem(name,urlParameters._url, anchorlink) }}

--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -1,8 +1,8 @@
 {% macro submenuItem(name, url, anchorlink) %}
     {% if name|slice(0,1) != '_' %}
-        <li role="menuitem" title="{{ name|translate }}">
+        <li role="menuitem" title="{{ name|translate|e('html_attr') }}">
             <a class="item" href="{% if anchorlink %}#{% else %}index.php?{% endif %}{{ url|urlRewriteWithParameters|slice(1) }}">
-                {{ name|translate }}
+                {{ name|translate|e('html_attr') }}
             </a>
         </li>
     {% endif %}
@@ -15,7 +15,7 @@
                 <a class="item menuItem"
                    href='{% if anchorlink %}#?{% else %}index.php?{% endif %}{{ item.url|urlRewriteWithParameters|slice(1) }}'
                    {% if item.tooltip %}title="{{ item.tooltip|e('html_attr') }}"{% endif %}>
-                    {{ item.name|translate }}
+                    {{ item.name|translate|e('html_attr') }}
                 </a>
             {% endfor %}
         </div>
@@ -45,13 +45,13 @@
                 {% endfor %}
 
                 {% if hasSubmenuItem %}
-                    <li role="menuitem" title="{{ level1|translate }}" id="{% if level2._url is defined and level2._url is not empty %}{{ _self.getId(level2._url) }}{% endif %}" class="menuTab">
-
+                    <li role="menuitem" class="menuTab" title="{{ level1|translate|e('html_attr') }}" id="{% if level2._url is defined and level2._url is not empty %}{{ _self.getId(level2._url) }}{% endif %}">
                         <a class="item" href="">
                             <span class="menu-icon {{ level2._icon|default('icon-arrow-right') }}"></span>
-                            {{ level1|translate }}
+                            {{ level1|translate|e('html_attr') }}
                         </a>
-                        <ul role="menu" title="{{ level1|translate }}">
+
+                        <ul role="menu" title="{{ level1|translate|e('html_attr') }}">
                             {% for name,urlParameters in level2 %}
                                 {% if urlParameters._url is defined and urlParameters._url is not iterable %}
                                     {{ _self.groupedItem(name,urlParameters._url, anchorlink) }}


### PR DESCRIPTION
This pull request is a first solution to #9148 .

For better results in terms of a11y, I think would be better removing a href="" links from trees menu items (as seen in this [Success criteria example code](http://www.w3.org/WAI/GL/wiki/Using_ARIA_menus#Example_Code)) then managing hide/show behavior by using _aria-hidden="true"_ attribute or jquery code. This part is not covered in this pull request.

If you like the solution I could go on further with another pull request.
