### PR TITLE
Better check for valid plugin names

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -499,7 +499,7 @@ class Manager
     {
         $existingPlugins = $this->readPluginsDirectory();
         $isPluginInFilesystem = array_search($pluginName, $existingPlugins) !== false;
-        return Filesystem::isValidFilename($pluginName)
+        return $this->isValidPluginName($pluginName)
         && $isPluginInFilesystem;
     }
 
@@ -896,6 +896,11 @@ class Manager
         return $newPlugin;
     }
 
+    public function isValidPluginName($pluginName)
+    {
+        return (bool) preg_match('/^[a-zA-Z]([a-zA-Z0-9]*)$/D', $pluginName);
+    }
+
     /**
      * @param $pluginName
      * @return Plugin
@@ -906,8 +911,8 @@ class Manager
         $pluginFileName = sprintf("%s/%s.php", $pluginName, $pluginName);
         $pluginClassName = $pluginName;
 
-        if (!Filesystem::isValidFilename($pluginName)) {
-            throw new \Exception(sprintf("The plugin filename '%s' is not a valid filename", $pluginFileName));
+        if (!$this->isValidPluginName($pluginName)) {
+            throw new \Exception(sprintf("The plugin filename '%s' is not a valid plugin name", $pluginFileName));
         }
 
         $path = self::getPluginsDirectory() . $pluginFileName;

--- a/plugins/CoreConsole/Commands/GeneratePlugin.php
+++ b/plugins/CoreConsole/Commands/GeneratePlugin.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\CoreConsole\Commands;
 use Piwik\Filesystem;
 use Piwik\Plugins\ExamplePlugin\ExamplePlugin;
 use Piwik\Version;
+use Piwik\Plugin;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -125,8 +126,8 @@ class GeneratePlugin extends GeneratePluginBase
                 throw new \RuntimeException('You have to enter a plugin name');
             }
 
-            if (!Filesystem::isValidFilename($pluginName)) {
-                throw new \RuntimeException(sprintf('The plugin name %s is not valid', $pluginName));
+            if (!Plugin\Manager::getInstance()->isValidPluginName($pluginName)) {
+                throw new \RuntimeException(sprintf('The plugin name %s is not valid. The name must start with a letter and is only allowed to contain numbers and letters.', $pluginName));
             }
 
             $pluginPath = $self->getPluginPath($pluginName);

--- a/tests/PHPUnit/Integration/Plugin/ManagerTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ManagerTest.php
@@ -84,6 +84,36 @@ class ManagerTest extends IntegrationTestCase
         $this->assertFalse($this->manager->isPluginActivated('ExampleTheme'));
     }
 
+    /**
+     * @dataProvider getPluginNameProvider
+     */
+    public function test_isValidPluginName($expectedIsValid, $pluginName)
+    {
+        $valid = $this->manager->isValidPluginName($pluginName);
+        $this->assertSame($expectedIsValid, $valid);
+    }
+
+    public function getPluginNameProvider()
+    {
+        return array(
+            array(true, 'a'),
+            array(true, 'a0'),
+            array(true, 'pluginNameTest'),
+            array(true, 'PluginNameTest'),
+            array(true, 'PluginNameTest92323232eerwrwere938'),
+            array(false, ''),
+            array(false, '0'),
+            array(false, '0a'),
+            array(false, 'a.'),
+            array(false, 'a-'),
+            array(false, 'a_'),
+            array(false, 'a-ererer'),
+            array(false, 'a_ererer'),
+            array(false, '..'),
+            array(false, '/'),
+        );
+    }
+
     private function getCacheForTrackerPlugins()
     {
         return PiwikCache::getEagerCache();


### PR DESCRIPTION
fixes #9171 

First I hesitated to make this change in plugin manager as well and not only in the plugin generator as I was afraid of breaking existing plugins. On the other side a plugin starting with a number or containing a `-` or `.` could not have worked before as it wouldn't be a valid plugin name.

If it is still too risky as there could be a plugin not defining a `Plugin` class then we can remove the check in `Plugin\Manager` again.

I also thought about forcing a capital letter first but this would actually break plugin names.

FYI: I already adjusted the check in Marketplace, will update the server soon and also check for developer.piwik.org 
