### PR TITLE
Fix System tests by not using 'date=today' in tests

### DIFF
--- a/plugins/CustomVariables/API.php
+++ b/plugins/CustomVariables/API.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\CustomVariables;
 
 use Piwik\API\Request;
 use Piwik\Archive;
+use Piwik\Container\StaticContainer;
 use Piwik\DataTable;
 use Piwik\Date;
 use Piwik\Metrics;
@@ -137,8 +138,10 @@ class API extends \Piwik\Plugin\API
         );
 
         /** @var DataTable $customVarUsages */
+        $today = StaticContainer::get('CustomVariables.today');
+        $date = '2008-12-12,' . $today;
         $customVarUsages = Request::processRequest('CustomVariables.getCustomVariables',
-            array('idSite' => $idSite, 'period' => 'range', 'date' => '2008-12-12,today',
+            array('idSite' => $idSite, 'period' => 'range', 'date' => $date,
                   'format' => 'original', 'serialize' => '0')
         );
 

--- a/plugins/CustomVariables/config/config.php
+++ b/plugins/CustomVariables/config/config.php
@@ -1,9 +1,11 @@
 <?php
 
 return array(
-
     'tracker.request.processors' => DI\add(array(
         DI\get('Piwik\Plugins\CustomVariables\Tracker\CustomVariablesRequestProcessor'),
     )),
+
+    // in tests we do not use 'today' to make tests results deterministic
+    'CustomVariables.today' => 'today',
 
 );

--- a/plugins/CustomVariables/config/test.php
+++ b/plugins/CustomVariables/config/test.php
@@ -1,0 +1,4 @@
+<?php
+return array(
+    'CustomVariables.today' => '2015-01-01'
+);

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
@@ -45,7 +45,7 @@
 	<reportMetadata>
 		<row>
 			
-			<idsubdatatable>5527</idsubdatatable>
+			<idsubdatatable>5117</idsubdatatable>
 		</row>
 	</reportMetadata>
 	<reportTotal>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumns___API.getProcessedReport_day.xml
@@ -54,7 +54,7 @@
 	<reportMetadata>
 		<row>
 			
-			<idsubdatatable>5531</idsubdatatable>
+			<idsubdatatable>5121</idsubdatatable>
 		</row>
 	</reportMetadata>
 	<reportTotal>


### PR DESCRIPTION
we need tests to have deterministic 'idsubdatatable'
