### PR TITLE
Console generator: Do not automatically convert first character to uppercase

### DIFF
--- a/plugins/CoreConsole/Commands/GenerateArchiver.php
+++ b/plugins/CoreConsole/Commands/GenerateArchiver.php
@@ -30,7 +30,7 @@ class GenerateArchiver extends GeneratePluginBase
         $this->checkAndUpdateRequiredPiwikVersion($pluginName, $output);
 
         $exampleFolder  = PIWIK_INCLUDE_PATH . '/plugins/ExamplePlugin';
-        $replace        = array('ExamplePlugin' => ucfirst($pluginName), 'EXAMPLEPLUGIN' => strtoupper($pluginName));
+        $replace        = array('ExamplePlugin' => $pluginName, 'EXAMPLEPLUGIN' => strtoupper($pluginName));
         $whitelistFiles = array('/Archiver.php');
 
         $this->copyTemplateToPlugin($exampleFolder, $pluginName, $replace, $whitelistFiles);

--- a/plugins/CoreConsole/Commands/GeneratePluginBase.php
+++ b/plugins/CoreConsole/Commands/GeneratePluginBase.php
@@ -31,7 +31,7 @@ abstract class GeneratePluginBase extends ConsoleCommand
 
     private function getRelativePluginPath($pluginName)
     {
-        return '/plugins/' . ucfirst($pluginName);
+        return '/plugins/' . $pluginName;
     }
 
     private function createFolderWithinPluginIfNotExists($pluginNameOrCore, $folder)
@@ -324,8 +324,6 @@ abstract class GeneratePluginBase extends ConsoleCommand
         } else {
             $validate($pluginName);
         }
-
-        $pluginName = ucfirst($pluginName);
 
         return $pluginName;
     }


### PR DESCRIPTION
A plugin does not have to start with an uppercase. There are even plugins on the marketplace with a lower letter see eg http://plugins.piwik.org/cacheBuster

FYI: The plugin generator still does a `ucfirst` on the plugin name so new plugins will be named with a letter case automatically which should be the recommended way.
