### PR TITLE
Show an error message if installing a plugin fails

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -440,16 +440,10 @@ class Manager
     public function installLoadedPlugins()
     {
         Log::debug("Loaded plugins: " . implode(", ", array_keys($this->getLoadedPlugins())));
-        $messages = array();
+        
         foreach ($this->getLoadedPlugins() as $plugin) {
-            try {
-                $this->installPluginIfNecessary($plugin);
-            } catch (\Exception $e) {
-                $messages[] = $e->getMessage();
-            }
+            $this->installPluginIfNecessary($plugin);
         }
-
-        return $messages;
     }
 
     /**

--- a/core/Plugin/PluginException.php
+++ b/core/Plugin/PluginException.php
@@ -8,14 +8,28 @@
 
 namespace Piwik\Plugin;
 
+use Piwik\Common;
+
 class PluginException extends \Exception
 {
     public function __construct($pluginName, $message)
     {
-        parent::__construct("There was a problem installing the plugin " . $pluginName . ": " . $message . "
-				If this plugin has already been installed, and if you want to hide this message</b>, you must add the following line under the
-				[PluginsInstalled]
-				entry in your config/config.ini.php file:
-				PluginsInstalled[] = $pluginName");
+        $pluginName = Common::sanitizeInputValue($pluginName);
+        $message = Common::sanitizeInputValue($message);
+
+        parent::__construct("There was a problem installing the plugin $pluginName: <br /><br />
+                $message
+                <br /><br />
+                If you want to hide this message you must remove the following line under the [Plugins] entry in your
+                'config/config.ini.php' file to disable this plugin.<br />
+                Plugins[] = $pluginName
+                <br /><br />If this plugin has already been installed, you must add the following line under the
+                [PluginsInstalled] entry in your 'config/config.ini.php' file:<br />
+                PluginsInstalled[] = $pluginName");
+    }
+
+    public function isHtmlMessage()
+    {
+        return true;
     }
 }


### PR DESCRIPTION
fixes #9160

Error message will look like this:

![image](https://cloud.githubusercontent.com/assets/273120/11193745/3f14887a-8d0d-11e5-9745-debcf32771e2.png)

Initial error message suggested to just add the plugin to the `PluginsInstalled` list to hide the message but this is wrong since most likely the plugin is not installed yet. Many users won't know whether the plugin is already installed or not. Therefore we are rather recommending to disable the plugin. 

I was thinking about using a translation there but as such an error occurs very early in the bootstrapping. The translations won't be loaded yet and we cannot even load plugin translations safely as there might be problems with plugins etc. to load correct language. Some day it would be nice to make this error message understandable in a way that someone doesn't have to understand the language. Eg with a Github-like diff with red and green colors and an arrow etc :) Such an error should occur rarely though so it might be ok like this for now.

Initially I wanted to show a notification when the plugin fails to install but this is not trivial as such an error occurs early in the bootstrapping. Notifications require a session and at this point the sessions are not yet loaded and we don't even know if the system is supposed to or even can start a session. Plugins are installed during `FrontController::init` and we don't know whether we are in a CLI mode, API call etc. Safest way is to let the error handler take care of it which makes sure to format the error message in a correct way (eg in an API call it will format the API error message).
Even saving all plugins installed error messages temporarily and outputting them later in `dispatch` is not safe since we don't know whether this method will be called and there might be nested dispatch calls which can lead to errors etc.
