### PR TITLE
Fix strpos() expects parameter 1 to be string

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -135,9 +135,8 @@ class Filesystem
 
             $output = @shell_exec($command);
             if ($output) {
-                $output = explode("\n", trim($output));
-
                 $commandFailed = (false !== strpos($output, "no file systems processed"));
+                $output = explode("\n", trim($output));
                 if (!$commandFailed
                     && count($output) > 1) {
                     // check if filesystem is NFS


### PR DESCRIPTION
fixes #9117 
