### PR TITLE
Add new segment ActionUrl + new operators starts with and ends with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
 
 ### New APIs
  * Add your own SMS/Text provider by creating a new class in the `SMSProvider` directory of your plugin. The class has to extend `Piwik\Plugins\MobileMessaging\SMSProvider` and implement the required methods.
- 
+ * Segments can now be composed by a union of multiple segments. To do this set an array of segments that shall be used for that segment `$segment->setUnionOfSegments(array('outlinkUrl', 'downloadUrl'))` instead of defining a SQL column.
+
 ## Piwik 2.15.0 
 
 ### New commands

--- a/core/Plugin/Segment.php
+++ b/core/Plugin/Segment.php
@@ -7,6 +7,7 @@
  *
  */
 namespace Piwik\Plugin;
+use Exception;
 
 /**
  * Creates a new segment that can be used for instance within the {@link \Piwik\Columns\Dimension::configureSegment()}
@@ -123,6 +124,7 @@ class Segment
     public function setSegment($segment)
     {
         $this->segment = $segment;
+        $this->check();
     }
 
     /**
@@ -166,6 +168,7 @@ class Segment
     public function setSqlSegment($sqlSegment)
     {
         $this->sqlSegment = $sqlSegment;
+        $this->check();
     }
 
     /**
@@ -178,6 +181,7 @@ class Segment
     public function setUnionOfSegments($segments)
     {
         $this->unionOfSegments = $segments;
+        $this->check();
     }
 
     /**
@@ -322,5 +326,16 @@ class Segment
     public function setRequiresAtLeastViewAccess($requiresAtLeastViewAccess)
     {
         $this->requiresAtLeastViewAccess = $requiresAtLeastViewAccess;
+    }
+
+    private function check()
+    {
+        if ($this->sqlSegment && $this->unionOfSegments) {
+            throw new Exception(sprintf('Union of segments and SQL segment is set for segment "%s", use only one of them', $this->name));
+        }
+
+        if ($this->segment && $this->unionOfSegments && in_array($this->segment, $this->unionOfSegments, true)) {
+            throw new Exception(sprintf('The segment %s contains a union segment to itself', $this->name));
+        }
     }
 }

--- a/core/Plugin/Segment.php
+++ b/core/Plugin/Segment.php
@@ -51,6 +51,7 @@ class Segment
     private $acceptValues;
     private $permission;
     private $suggestedValuesCallback;
+    private $unionOfSegments;
 
     /**
      * If true, this segment will only be visible to the user if the user has view access
@@ -168,6 +169,27 @@ class Segment
     }
 
     /**
+     * Set a list of segments that should be used instead of fetching the values from a single column.
+     * All set segments will be applied via an OR operator.
+     *
+     * @param array $segments
+     * @api
+     */
+    public function setUnionOfSegments($segments)
+    {
+        $this->unionOfSegments = $segments;
+    }
+
+    /**
+     * @return array
+     * @ignore
+     */
+    public function getUnionOfSegments()
+    {
+        return $this->unionOfSegments;
+    }
+
+    /**
      * @return string
      * @ignore
      */
@@ -193,6 +215,15 @@ class Segment
     public function getType()
     {
         return $this->type;
+    }
+
+    /**
+     * @return string
+     * @ignore
+     */
+    public function getName()
+    {
+        return $this->name;
     }
 
     /**
@@ -240,6 +271,10 @@ class Segment
             'segment'    => $this->segment,
             'sqlSegment' => $this->sqlSegment,
         );
+
+        if (!empty($this->unionOfSegments)) {
+            $segment['unionOfSegments'] = $this->unionOfSegments;
+        }
 
         if (!empty($this->sqlFilter)) {
             $segment['sqlFilter'] = $this->sqlFilter;

--- a/core/Tracker/TableLogAction.php
+++ b/core/Tracker/TableLogAction.php
@@ -65,12 +65,20 @@ class TableLogAction
         $sql = 'SELECT idaction FROM ' . Common::prefixTable('log_action') . ' WHERE %s AND type = ' . $actionType . ' )';
 
         switch ($matchType) {
-            case '=@':
+            case SegmentExpression::MATCH_CONTAINS:
                 // use concat to make sure, no %s occurs because some plugins use %s in their sql
                 $where = '( name LIKE CONCAT(\'%\', ?, \'%\') ';
                 break;
-            case '!@':
+            case SegmentExpression::MATCH_DOES_NOT_CONTAIN:
                 $where = '( name NOT LIKE CONCAT(\'%\', ?, \'%\') ';
+                break;
+            case SegmentExpression::MATCH_STARTS_WITH:
+                // use concat to make sure, no %s occurs because some plugins use %s in their sql
+                $where = '( name LIKE CONCAT(?, \'%\') ';
+                break;
+            case SegmentExpression::MATCH_ENDS_WITH:
+                // use concat to make sure, no %s occurs because some plugins use %s in their sql
+                $where = '( name LIKE CONCAT(\'%\', ?) ';
                 break;
             default:
                 throw new \Exception("This match type $matchType is not available for action-segments.");

--- a/lang/en.json
+++ b/lang/en.json
@@ -264,6 +264,8 @@
         "OperationIsNot": "Is not",
         "OperationLessThan": "Less than",
         "OperationNotEquals": "Not Equals",
+        "OperationStartsWith": "Starts with",
+        "OperationEndsWith": "Ends with",
         "OptionalSmtpPort": "Optional. Defaults to 25 for unencrypted and TLS SMTP, and 465 for SSL SMTP.",
         "Options": "Options",
         "OrCancel": "or %s Cancel %s",

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -129,14 +129,6 @@ class API extends \Piwik\Plugin\API
                     $segment->setPermission($isAuthenticatedWithViewAccess);
                 }
 
-                if ($segment->getSqlSegment() && $segment->getUnionOfSegments()) {
-                    throw new \Exception(sprintf('Union of segments and SQL segment is set for segment "%s", use only one of them', $segment->getName()));
-                }
-
-                if ($segment->getUnionOfSegments() && in_array($segment->getSegment(), $segment->getUnionOfSegments(), true)) {
-                    throw new \Exception(sprintf('The segment %s contains a union segment to itself', $segment->getName()));
-                }
-
                 $segments[] = $segment->toArray();
             }
         }

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -129,6 +129,14 @@ class API extends \Piwik\Plugin\API
                     $segment->setPermission($isAuthenticatedWithViewAccess);
                 }
 
+                if ($segment->getSqlSegment() && $segment->getUnionOfSegments()) {
+                    throw new \Exception(sprintf('Union of segments and SQL segment is set for segment "%s", use only one of them', $segment->getName()));
+                }
+
+                if ($segment->getUnionOfSegments() && in_array($segment->getSegment(), $segment->getUnionOfSegments(), true)) {
+                    throw new \Exception(sprintf('The segment %s contains a union segment to itself', $segment->getName()));
+                }
+
                 $segments[] = $segment->toArray();
             }
         }
@@ -493,9 +501,60 @@ class API extends \Piwik\Plugin\API
         if (empty(Config::getInstance()->General['enable_segment_suggested_values'])) {
             return array();
         }
+
         Piwik::checkUserHasViewAccess($idSite);
 
         $maxSuggestionsToReturn = 30;
+        $segment = $this->findSegment($segmentName, $idSite);
+
+        // if segment has suggested values callback then return result from it instead
+        $suggestedValuesCallbackRequiresTable = false;
+        if (isset($segment['suggestedValuesCallback'])) {
+            $suggestedValuesCallbackRequiresTable = $this->doesSuggestedValuesCallbackNeedData(
+                $segment['suggestedValuesCallback']);
+
+            if (!$suggestedValuesCallbackRequiresTable) {
+                return call_user_func($segment['suggestedValuesCallback'], $idSite, $maxSuggestionsToReturn);
+            }
+        }
+
+        // if period=range is disabled, do not proceed
+        if (!Period\Factory::isPeriodEnabledForAPI('range')) {
+            return array();
+        }
+
+        if (!empty($segment['unionOfSegments'])) {
+            $values = array();
+            foreach ($segment['unionOfSegments'] as $unionSegmentName) {
+                $unionSegment = $this->findSegment($unionSegmentName, $idSite);
+
+                try {
+                    $result = $this->getSuggestedValuesForSegmentName($idSite, $unionSegment, $maxSuggestionsToReturn);
+                    if (!empty($result)) {
+                        $values = array_merge($result, $values);
+                    }
+                } catch (\Exception $e) {
+                    // we ignore if there was no data found for $unionSegmentName
+                }
+            }
+
+            if (empty($values)) {
+                throw new \Exception("There was no data to suggest for $segmentName");
+            }
+
+        } else {
+            $values = $this->getSuggestedValuesForSegmentName($idSite, $segment, $maxSuggestionsToReturn);
+        }
+
+        $values = $this->getMostFrequentValues($values);
+        $values = array_slice($values, 0, $maxSuggestionsToReturn);
+        $values = array_map(array('Piwik\Common', 'unsanitizeInputValue'), $values);
+
+        return $values;
+    }
+
+    private function findSegment($segmentName, $idSite)
+    {
         $segmentsMetadata = $this->getSegmentsMetadata($idSite, $_hideImplementationData = false);
 
         $segmentFound = false;
@@ -505,26 +564,16 @@ class API extends \Piwik\Plugin\API
                 break;
             }
         }
+
         if (empty($segmentFound)) {
-            throw new \Exception("Requested segment not found.");
+            throw new \Exception("Requested segment $segmentName not found.");
         }
 
-        // if segment has suggested values callback then return result from it instead
-        $suggestedValuesCallbackRequiresTable = false;
-        if (isset($segmentFound['suggestedValuesCallback'])) {
-            $suggestedValuesCallbackRequiresTable = $this->doesSuggestedValuesCallbackNeedData(
-                $segmentFound['suggestedValuesCallback']);
+        return $segmentFound;
+    }
 
-            if (!$suggestedValuesCallbackRequiresTable) {
-                return call_user_func($segmentFound['suggestedValuesCallback'], $idSite, $maxSuggestionsToReturn);
-            }
-        }
-
-        // if period=range is disabled, do not proceed
-        if (!Period\Factory::isPeriodEnabledForAPI('range')) {
-            return array();
-        }
-
+    private function getSuggestedValuesForSegmentName($idSite, $segment, $maxSuggestionsToReturn)
+    {
         $startDate = Date::now()->subDay(60)->toString();
         $requestLastVisits = "method=Live.getLastVisitsDetails
         &idSite=$idSite
@@ -533,6 +582,8 @@ class API extends \Piwik\Plugin\API
         &format=original
         &serialize=0
         &flat=1";
+
+        $segmentName = $segment['segment'];
 
         // Select non empty fields only
         // Note: this optimization has only a very minor impact
@@ -548,21 +599,17 @@ class API extends \Piwik\Plugin\API
 
         $request = new Request($requestLastVisits);
         $table = $request->process();
+
         if (empty($table)) {
             throw new \Exception("There was no data to suggest for $segmentName");
         }
 
-        if ($suggestedValuesCallbackRequiresTable) {
-            $values = call_user_func($segmentFound['suggestedValuesCallback'], $idSite, $maxSuggestionsToReturn, $table);
+        if (isset($segment['suggestedValuesCallback']) &&
+            $this->doesSuggestedValuesCallbackNeedData($segment['suggestedValuesCallback'])) {
+            $values = call_user_func($segment['suggestedValuesCallback'], $idSite, $maxSuggestionsToReturn, $table);
         } else {
             $values = $this->getSegmentValuesFromVisitorLog($segmentName, $table);
         }
-
-        $values = $this->getMostFrequentValues($values);
-
-        $values = array_slice($values, 0, $maxSuggestionsToReturn);
-
-        $values = array_map(array('Piwik\Common', 'unsanitizeInputValue'), $values);
 
         return $values;
     }

--- a/plugins/Actions/Columns/ActionUrl.php
+++ b/plugins/Actions/Columns/ActionUrl.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\Actions\Columns;
+
+use Piwik\Piwik;
+use Piwik\Plugin\Dimension\ActionDimension;
+use Piwik\Plugins\Actions\Segment;
+
+class ActionUrl extends ActionDimension
+{
+    public function getName()
+    {
+        return Piwik::translate('Actions_ColumnActionURL');
+    }
+
+    protected function configureSegments()
+    {
+        $segment = new Segment();
+        $segment->setSegment('actionUrl');
+        $segment->setName('Actions_ColumnActionURL');
+        $segment->setUnionOfSegments(array('pageUrl', 'downloadUrl', 'outlinkUrl'));
+
+        $this->addSegment($segment);
+    }
+
+}

--- a/plugins/Actions/lang/en.json
+++ b/plugins/Actions/lang/en.json
@@ -2,6 +2,7 @@
     "Actions": {
         "AvgGenerationTimeTooltip": "Average based on %s hit(s) %s between %s and %s",
         "ColumnClickedURL": "Clicked URL",
+        "ColumnActionURL": "Action URL",
         "ColumnClicks": "Clicks",
         "ColumnClicksDocumentation": "The number of times this link was clicked.",
         "ColumnDownloadURL": "Download URL",

--- a/plugins/CustomVariables/Columns/Base.php
+++ b/plugins/CustomVariables/Columns/Base.php
@@ -16,7 +16,7 @@ use Piwik\Plugins\CustomVariables\CustomVariables;
 
 class Base extends VisitDimension
 {
-    protected function configureSegmentsFor($fieldPrefix, $segmentNameSuffix)
+    protected function configureSegmentsFor($segmentNameSuffix)
     {
         $numCustomVariables = CustomVariables::getNumUsableCustomVariables();
 
@@ -25,10 +25,7 @@ class Base extends VisitDimension
         $segment->setSegment('customVariable' . $segmentNameSuffix);
         $segment->setName($this->getName() . ' (' . Piwik::translate('CustomVariables_ScopeVisit') . ')');
         $segment->setCategory('CustomVariables_CustomVariables');
-        $segment->setSqlSegment($this->getSegmentColumns('log_visit.' . $fieldPrefix, $numCustomVariables));
-        $segment->setSuggestedValuesCallback(function ($idSite, $ignore, DataTable $table) use ($segmentNameSuffix) {
-            return $table->getColumnsStartingWith('customVariable' . $segmentNameSuffix);
-        });
+        $segment->setUnionOfSegments($this->getSegmentColumns('customVariable' . $segmentNameSuffix, $numCustomVariables));
         $this->addSegment($segment);
 
         $segment = new Segment();
@@ -36,10 +33,7 @@ class Base extends VisitDimension
         $segment->setSegment('customVariablePage' . $segmentNameSuffix);
         $segment->setName($this->getName() . ' (' . Piwik::translate('CustomVariables_ScopePage') . ')');
         $segment->setCategory('CustomVariables_CustomVariables');
-        $segment->setSqlSegment($this->getSegmentColumns('log_link_visit_action.' . $fieldPrefix, $numCustomVariables));
-        $segment->setSuggestedValuesCallback(function ($idSite, $ignore, DataTable $table) use ($segmentNameSuffix) {
-            return $table->getColumnsStartingWith('customVariablePage' . $segmentNameSuffix);
-        });
+        $segment->setUnionOfSegments($this->getSegmentColumns('customVariablePage' . $segmentNameSuffix, $numCustomVariables));
         $this->addSegment($segment);
     }
 

--- a/plugins/CustomVariables/Columns/CustomVariableName.php
+++ b/plugins/CustomVariables/Columns/CustomVariableName.php
@@ -14,7 +14,7 @@ class CustomVariableName extends Base
 {
     protected function configureSegments()
     {
-        $this->configureSegmentsFor('custom_var_k', 'Name');
+        $this->configureSegmentsFor('Name');
     }
 
     public function getName()

--- a/plugins/CustomVariables/Columns/CustomVariableValue.php
+++ b/plugins/CustomVariables/Columns/CustomVariableValue.php
@@ -14,7 +14,7 @@ class CustomVariableValue extends Base
 {
     protected function configureSegments()
     {
-        $this->configureSegmentsFor('custom_var_v', 'Value');
+        $this->configureSegmentsFor('Value');
     }
 
     public function getName()

--- a/plugins/SegmentEditor/SegmentSelectorControl.php
+++ b/plugins/SegmentEditor/SegmentSelectorControl.php
@@ -115,6 +115,8 @@ class SegmentSelectorControl extends UIControl
             'General_OperationGreaterThan',
             'General_OperationContains',
             'General_OperationDoesNotContain',
+            'General_OperationStartsWith',
+            'General_OperationEndsWith',
             'General_OperationIs',
             'General_OperationIsNot',
             'General_OperationContains',

--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -49,6 +49,8 @@ Segmentation = (function($) {
         self.availableMatches["dimension"]["!="] = self.translations['General_OperationIsNot'];
         self.availableMatches["dimension"]["=@"] = self.translations['General_OperationContains'];
         self.availableMatches["dimension"]["!@"] = self.translations['General_OperationDoesNotContain'];
+        self.availableMatches["dimension"]["=^"] = self.translations['General_OperationStartsWith'];
+        self.availableMatches["dimension"]["=$"] = self.translations['General_OperationEndsWith'];
 
         segmentation.prototype.setAvailableSegments = function (segments) {
             this.availableSegments = segments;
@@ -264,7 +266,7 @@ Segmentation = (function($) {
         };
 
         var findAndExplodeByMatch = function(metric){
-            var matches = ["==" , "!=" , "<=", ">=", "=@" , "!@","<",">"];
+            var matches = ["==" , "!=" , "<=", ">=", "=@" , "!@","<",">", "=^", "=$"];
             var newMetric = {};
             var minPos = metric.length;
             var match, index;

--- a/plugins/SegmentEditor/lang/en.json
+++ b/plugins/SegmentEditor/lang/en.json
@@ -26,6 +26,7 @@
         "YouMayChangeSetting": "Alternatively you may change the setting in the config file (%s), or edit this Segment and choose '%s'.",
         "YouMustBeLoggedInToCreateSegments": "You must be logged in to create and edit custom visitor segments.",
         "YouDontHaveAccessToCreateSegments": "You don't have the required access level to create and edit segments.",
-        "AddingSegmentForAllWebsitesDisabled": "Adding segments for all websites has been disabled."
+        "AddingSegmentForAllWebsitesDisabled": "Adding segments for all websites has been disabled.",
+        "SegmentXIsAUnionOf": "%s is a union of these segments:"
     }
 }

--- a/plugins/SegmentEditor/templates/_segmentSelector.twig
+++ b/plugins/SegmentEditor/templates/_segmentSelector.twig
@@ -61,6 +61,8 @@
                 <option value=">">{{ 'General_OperationGreaterThan'|translate }}</option>
                 <option value="=@">{{ 'General_OperationContains'|translate }}</option>
                 <option value="!@">{{ 'General_OperationDoesNotContain'|translate }}</option>
+                <option value="=^">{{ 'General_OperationStartsWith'|translate }}</option>
+                <option value="=$">{{ 'General_OperationEndsWith'|translate }}</option>
             </select>
         </div>
         <div class="segment-input metricValueBlock">

--- a/plugins/SegmentEditor/templates/_segmentSelector.twig
+++ b/plugins/SegmentEditor/templates/_segmentSelector.twig
@@ -99,7 +99,17 @@
                     <a class="metric_category" href="#">{{ category }}</a>
                     <ul style="display:none;">
                         {% for segmentInCategory in segmentsInCategory %}
-                            <li data-metric="{{ segmentInCategory.segment }}"><a class="ddmetric" href="#">{{ segmentInCategory.name }}</a></li>
+                            {% set title = segmentInCategory.name %}
+                            {% if segmentInCategory.unionOfSegments is defined and segmentInCategory.unionOfSegments %}
+                                {% set title = 'SegmentEditor_SegmentXIsAUnionOf'|translate(title) %}
+                                {% for unionSegment in segmentInCategory.unionOfSegments %}
+                                    {% set title = title ~ ' ' ~ unionSegment %}
+                                    {% if not loop.last  %}
+                                        {% set title = title ~ ',' %}
+                                    {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                            <li data-metric="{{ segmentInCategory.segment }}" title="{{ title|e('html_attr') }}"><a class="ddmetric" href="#">{{ segmentInCategory.name }}</a></li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -94,8 +94,7 @@ class SegmentTest extends IntegrationTestCase
 
             // test multiple column segments
             array('customVariableName==abc;customVariableValue==def', array(
-                'where' => ' ((log_visit.custom_var_k1 = ?) OR (log_visit.custom_var_k2 = ?) OR (log_visit.custom_var_k3 = ?) OR (log_visit.custom_var_k4 = ?) OR (log_visit.custom_var_k5 = ?))'
-                         . ' AND ((log_visit.custom_var_v1 = ?) OR (log_visit.custom_var_v2 = ?) OR (log_visit.custom_var_v3 = ?) OR (log_visit.custom_var_v4 = ?) OR (log_visit.custom_var_v5 = ?)) ',
+                'where' => ' (log_visit.custom_var_k1 = ? OR log_visit.custom_var_k2 = ? OR log_visit.custom_var_k3 = ? OR log_visit.custom_var_k4 = ? OR log_visit.custom_var_k5 = ?) AND (log_visit.custom_var_v1 = ? OR log_visit.custom_var_v2 = ? OR log_visit.custom_var_v3 = ? OR log_visit.custom_var_v4 = ? OR log_visit.custom_var_v5 = ? )',
                 'bind' => array(
                     'abc', 'abc', 'abc', 'abc', 'abc',
                     'def', 'def', 'def', 'def', 'def',

--- a/tests/PHPUnit/System/AutoSuggestAPITest.php
+++ b/tests/PHPUnit/System/AutoSuggestAPITest.php
@@ -17,7 +17,6 @@ use Piwik\Plugins\CustomVariables\Columns\CustomVariableValue;
 use Piwik\Plugins\CustomVariables\Model;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tests\Fixtures\ManyVisitsWithGeoIP;
-use Piwik\Tests\Framework\Fixture;
 use Piwik\Tracker\Cache;
 
 /**

--- a/tests/PHPUnit/System/TwoVisitsWithCustomVariablesSegmentContainsTest.php
+++ b/tests/PHPUnit/System/TwoVisitsWithCustomVariablesSegmentContainsTest.php
@@ -48,6 +48,13 @@ class TwoVisitsWithCustomVariablesSegmentContainsTest extends SystemTestCase
             array("pageTitle=@Profile pa", '_SegmentPageTitleContains', $api),
             array("pageUrl!@user/profile", '_SegmentPageUrlExcludes', $api),
             array("pageTitle!@Profile pa", '_SegmentPageTitleExcludes', $api),
+            // starts with
+            array('pageUrl=^example.org/home', '_SegmentPageUrlStartsWith', array('Actions.getPageUrls')),
+            array('pageTitle=^Profile pa', '_SegmentPageTitleStartsWith', array('Actions.getPageTitles')),
+
+            // ends with
+            array('pageUrl=$er/profile', '_SegmentPageUrlEndsWith', array('Actions.getPageUrls')),
+            array('pageTitle=$page', '_SegmentPageTitleEndsWith', array('Actions.getPageTitles')),
         );
 
         foreach ($segmentsToTest as $segment) {

--- a/tests/PHPUnit/System/TwoVisitsWithCustomVariablesSegmentMatchNONETest.php
+++ b/tests/PHPUnit/System/TwoVisitsWithCustomVariablesSegmentMatchNONETest.php
@@ -67,7 +67,7 @@ class TwoVisitsWithCustomVariablesSegmentMatchNONETest extends SystemTestCase
             $matchNone = $segment . '!=' . $value;
 
             // deviceType != campaign matches ALL visits, but we want to match None
-            if($segment == 'deviceType') {
+            if ($segment == 'deviceType') {
                 $matchNone = $segment . '==car%20browser';
             }
             $segmentExpression[] = $matchNone;

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionUrl__API.getSuggestedValuesForSegment.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionUrl__API.getSuggestedValuesForSegment.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>http://piwik.net/grue/lair</row>
+	<row>http://piwik.net/space/quest/iv</row>
+	<row>http://example-outlink.org/1.html</row>
+	<row>http://example.org/path/file1.zip</row>
+	<row>http://example.org/path/file0.zip</row>
+	<row>http://example-outlink.org/0.html</row>
+	<row>http://example.org/path/file2.zip</row>
+	<row>http://example.org/path/file3.zip</row>
+	<row>http://example-outlink.org/3.html</row>
+	<row>http://example-outlink.org/2.html</row>
+	<row>http://example.org/path/file4.zip</row>
+	<row>http://example.org/path/file5.zip</row>
+	<row>http://example.org/path/file8.zip</row>
+	<row>http://example-outlink.org/6.html</row>
+	<row>http://example-outlink.org/7.html</row>
+	<row>http://example-outlink.org/5.html</row>
+	<row>http://example-outlink.org/4.html</row>
+	<row>http://example.org/path/file7.zip</row>
+	<row>http://example-outlink.org/8.html</row>
+	<row>http://example.org/path/file6.zip</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionUrl__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionUrl__VisitsSummary.get_range.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_visits>18</nb_visits>
+	<nb_actions>18</nb_actions>
+	<nb_visits_converted>18</nb_visits_converted>
+	<bounce_count>18</bounce_count>
+	<sum_visit_length>0</sum_visit_length>
+	<max_actions>1</max_actions>
+	<bounce_rate>100%</bounce_rate>
+	<nb_actions_per_visit>1</nb_actions_per_visit>
+	<avg_time_on_site>0</avg_time_on_site>
+</result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_customVariableName__API.getSuggestedValuesForSegment.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_customVariableName__API.getSuggestedValuesForSegment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<row>Cvar 5 name</row>
 	<row>Cvar 1 name</row>
+	<row>Cvar 5 name</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_customVariablePageValue__API.getSuggestedValuesForSegment.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_customVariablePageValue__API.getSuggestedValuesForSegment.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<row>CAT</row>
+	<row>Cvar5 PAGE value is 0</row>
 	<row>Cvar5 PAGE value is 1</row>
 	<row>Cvar2 PAGE value is 1</row>
 	<row>Cvar2 PAGE value is 0</row>
-	<row>Cvar5 PAGE value is 0</row>
-	<row>Cvar5 PAGE value is 3</row>
 	<row>Cvar2 PAGE value is 3</row>
-	<row>Cvar2 PAGE value is 2</row>
 	<row>Cvar5 PAGE value is 2</row>
-	<row>Cvar5 PAGE value is 4</row>
-	<row>Cvar2 PAGE value is 4</row>
-	<row>Cvar2 PAGE value is 7</row>
-	<row>Cvar5 PAGE value is 8</row>
-	<row>Cvar2 PAGE value is 8</row>
-	<row>Cvar5 PAGE value is 7</row>
-	<row>Cvar2 PAGE value is 6</row>
+	<row>Cvar5 PAGE value is 3</row>
+	<row>Cvar2 PAGE value is 2</row>
 	<row>Cvar2 PAGE value is 5</row>
-	<row>Cvar5 PAGE value is 6</row>
+	<row>Cvar2 PAGE value is 4</row>
+	<row>Cvar2 PAGE value is 6</row>
+	<row>Cvar5 PAGE value is 8</row>
 	<row>Cvar5 PAGE value is 5</row>
+	<row>Cvar5 PAGE value is 6</row>
+	<row>Cvar5 PAGE value is 4</row>
+	<row>Cvar5 PAGE value is 7</row>
+	<row>Cvar2 PAGE value is 8</row>
+	<row>Cvar2 PAGE value is 7</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_customVariableValue__API.getSuggestedValuesForSegment.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_customVariableValue__API.getSuggestedValuesForSegment.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<row>Cvar5 value is 1</row>
-	<row>Cvar1 value is 0</row>
 	<row>Cvar1 value is 1</row>
+	<row>Cvar1 value is 0</row>
+	<row>Cvar5 value is 1</row>
 	<row>Cvar5 value is 0</row>
 	<row>Cvar1 value is 3</row>
-	<row>Cvar5 value is 3</row>
-	<row>Cvar5 value is 2</row>
 	<row>Cvar1 value is 2</row>
-	<row>Cvar5 value is 4</row>
+	<row>Cvar5 value is 2</row>
+	<row>Cvar5 value is 3</row>
 	<row>Cvar1 value is 4</row>
 	<row>Cvar5 value is 7</row>
-	<row>Cvar1 value is 7</row>
-	<row>Cvar5 value is 8</row>
-	<row>Cvar1 value is 6</row>
-	<row>Cvar5 value is 6</row>
-	<row>Cvar5 value is 5</row>
 	<row>Cvar1 value is 5</row>
+	<row>Cvar5 value is 6</row>
+	<row>Cvar1 value is 7</row>
+	<row>Cvar5 value is 5</row>
+	<row>Cvar5 value is 8</row>
 	<row>Cvar1 value is 8</row>
+	<row>Cvar5 value is 4</row>
+	<row>Cvar1 value is 6</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
@@ -416,6 +416,17 @@
 	<row>
 		<type>dimension</type>
 		<category>Actions</category>
+		<name>Action URL</name>
+		<segment>actionUrl</segment>
+		<unionOfSegments>
+			<row>pageUrl</row>
+			<row>downloadUrl</row>
+			<row>outlinkUrl</row>
+		</unionOfSegments>
+	</row>
+	<row>
+		<type>dimension</type>
+		<category>Actions</category>
 		<name>Clicked URL</name>
 		<segment>outlinkUrl</segment>
 	</row>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
@@ -274,6 +274,13 @@
 		<category>Custom Variables</category>
 		<name>Custom Variable name (scope visit)</name>
 		<segment>customVariableName</segment>
+		<unionOfSegments>
+			<row>customVariableName1</row>
+			<row>customVariableName2</row>
+			<row>customVariableName3</row>
+			<row>customVariableName4</row>
+			<row>customVariableName5</row>
+		</unionOfSegments>
 	</row>
 	<row>
 		<type>dimension</type>
@@ -310,6 +317,13 @@
 		<category>Custom Variables</category>
 		<name>Custom Variable name (scope page)</name>
 		<segment>customVariablePageName</segment>
+		<unionOfSegments>
+			<row>customVariablePageName1</row>
+			<row>customVariablePageName2</row>
+			<row>customVariablePageName3</row>
+			<row>customVariablePageName4</row>
+			<row>customVariablePageName5</row>
+		</unionOfSegments>
 	</row>
 	<row>
 		<type>dimension</type>
@@ -346,6 +360,13 @@
 		<category>Custom Variables</category>
 		<name>Custom Variable value (scope page)</name>
 		<segment>customVariablePageValue</segment>
+		<unionOfSegments>
+			<row>customVariablePageValue1</row>
+			<row>customVariablePageValue2</row>
+			<row>customVariablePageValue3</row>
+			<row>customVariablePageValue4</row>
+			<row>customVariablePageValue5</row>
+		</unionOfSegments>
 	</row>
 	<row>
 		<type>dimension</type>
@@ -382,6 +403,13 @@
 		<category>Custom Variables</category>
 		<name>Custom Variable value (scope visit)</name>
 		<segment>customVariableValue</segment>
+		<unionOfSegments>
+			<row>customVariableValue1</row>
+			<row>customVariableValue2</row>
+			<row>customVariableValue3</row>
+			<row>customVariableValue4</row>
+			<row>customVariableValue5</row>
+		</unionOfSegments>
 	</row>
 	<row>
 		<type>dimension</type>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_SegmentPageTitleEndsWith__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_SegmentPageTitleEndsWith__Actions.getPageTitles_day.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label> Homepage</label>
+		<nb_visits>2</nb_visits>
+		<nb_uniq_visitors>2</nb_uniq_visitors>
+		<nb_hits>2</nb_hits>
+		<sum_time_spent>360</sum_time_spent>
+		<entry_nb_uniq_visitors>1</entry_nb_uniq_visitors>
+		<entry_nb_visits>1</entry_nb_visits>
+		<entry_nb_actions>3</entry_nb_actions>
+		<entry_sum_visit_length>364</entry_sum_visit_length>
+		<entry_bounce_count>0</entry_bounce_count>
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_time_on_page>180</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>50%</exit_rate>
+	</row>
+	<row>
+		<label> Profile page</label>
+		<nb_visits>1</nb_visits>
+		<nb_uniq_visitors>1</nb_uniq_visitors>
+		<nb_hits>1</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>0%</exit_rate>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_SegmentPageTitleStartsWith__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_SegmentPageTitleStartsWith__Actions.getPageTitles_day.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label> Profile page</label>
+		<nb_visits>1</nb_visits>
+		<nb_uniq_visitors>1</nb_uniq_visitors>
+		<nb_hits>1</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>0%</exit_rate>
+	</row>
+	<row>
+		<label> Profile page for user *_)%</label>
+		<nb_visits>1</nb_visits>
+		<nb_uniq_visitors>1</nb_uniq_visitors>
+		<nb_hits>1</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>100%</exit_rate>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlEndsWith__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlEndsWith__Actions.getPageUrls_day.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>user</label>
+		<nb_visits>1</nb_visits>
+		<nb_hits>2</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>100%</exit_rate>
+		<subtable>
+			<row>
+				<label>/profile</label>
+				<nb_visits>1</nb_visits>
+				<nb_uniq_visitors>1</nb_uniq_visitors>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>100%</exit_rate>
+				<url>http://example.org/user/profile</url>
+			</row>
+		</subtable>
+	</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlStartsWith__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlStartsWith__Actions.getPageUrls_day.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<label>/homepage</label>
+		<nb_visits>2</nb_visits>
+		<nb_uniq_visitors>2</nb_uniq_visitors>
+		<nb_hits>2</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<entry_nb_uniq_visitors>1</entry_nb_uniq_visitors>
+		<entry_nb_visits>1</entry_nb_visits>
+		<entry_nb_actions>3</entry_nb_actions>
+		<entry_sum_visit_length>364</entry_sum_visit_length>
+		<entry_bounce_count>0</entry_bounce_count>
+		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
+		<exit_nb_visits>1</exit_nb_visits>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>0%</bounce_rate>
+		<exit_rate>50%</exit_rate>
+		<url>http://example.org/homepage</url>
+		<segment>pageUrl==http%3A%2F%2Fexample.org%2Fhomepage</segment>
+	</row>
+</result>

--- a/tests/PHPUnit/Unit/Segment/SegmentExpressionTest.php
+++ b/tests/PHPUnit/Unit/Segment/SegmentExpressionTest.php
@@ -72,6 +72,7 @@ class SegmentExpressionTest extends \PHPUnit_Framework_TestCase
             array('A==B,C==D', array('where' => " (A = ? OR C = ? )", 'bind' => array('B', 'D'))),
             array('A!=B;C==D', array('where' => " ( A IS NULL OR A <> ? ) AND C = ? ", 'bind' => array('B', 'D'))),
             array('A!=B;C==D,E!=Hello World!=', array('where' => " ( A IS NULL OR A <> ? ) AND (C = ? OR ( E IS NULL OR E <> ? ) )", 'bind' => array('B', 'D', 'Hello World!='))),
+            array('A=@B;C=$D', array('where' => " A LIKE ? AND C LIKE ? ", 'bind' => array('%B%', '%D'))),
 
             array('A>B', array('where' => " A > ? ", 'bind' => array('B'))),
             array('A<B', array('where' => " A < ? ", 'bind' => array('B'))),
@@ -83,6 +84,8 @@ class SegmentExpressionTest extends \PHPUnit_Framework_TestCase
 
             array('A=@B_', array('where' => " A LIKE ? ", 'bind' => array('%B\_%'))),
             array('A!@B%', array('where' => " ( A IS NULL OR A NOT LIKE ? ) ", 'bind' => array('%B\%%'))),
+            array('A=$B%', array('where' => " A LIKE ? ", 'bind' => array('%B\%'))),
+            array('A=^B%', array('where' => " A LIKE ? ", 'bind' => array('B\%%'))),
         );
     }
 


### PR DESCRIPTION
fixes #9224 
fixes #8076

I know it would have been better to issue different PRs for these two issues but to validate whether we actually need #8076 and #9225 I had to develop them kinda at the same time. 

There is a new feature to combine multiple segments via `OR` called `unionOfSegments`. I also used them for custom variables already. I would have used the existing `setSqlSegments(array(...))` but it was not possible to use this for action urls as they are referenced with `log_action` under different `type` IDs.

The UI will now show a title in the segment editor segment list on hover if a segment is a union of different segments (eg hover `actionUrl` or `Custom Variables Name`)
