### PR TITLE
Fix no data in segmented visitor log for urls with ampersand

### DIFF
--- a/core/Tracker/TableLogAction.php
+++ b/core/Tracker/TableLogAction.php
@@ -261,6 +261,8 @@ class TableLogAction
         $actionsTypesStoredUnsanitized = array(
             $actionType == Action::TYPE_DOWNLOAD,
             $actionType == Action::TYPE_OUTLINK,
+            $actionType == Action::TYPE_PAGE_URL,
+            $actionType == Action::TYPE_CONTENT,
         );
 
         return in_array($actionType, $actionsTypesStoredUnsanitized);


### PR DESCRIPTION
fixes #9192

In https://github.com/piwik/piwik/issues/7220 we fixed that URLs were sometimes stored encoded and sometimes not. This was about 9 months ago. Meanwhile most URLs should be actually stored correctly and therefore we no longer need to unsanitize the URL when applying the page url segment. It worked at least fine for me this way. 

I remember a conversation in February where we talked about the need to change something eg 6 months after the change in #7220 but I forgot what it was and couldn't find an issue for that.
