### PR TITLE
Fix plugin update might be shown several times

### DIFF
--- a/plugins/CorePluginsAdmin/Marketplace.php
+++ b/plugins/CorePluginsAdmin/Marketplace.php
@@ -114,14 +114,14 @@ class Marketplace
             $pluginsHavingUpdate = array();
         }
 
-        foreach ($pluginsHavingUpdate as &$updatePlugin) {
+        foreach ($pluginsHavingUpdate as $key => $updatePlugin) {
             foreach ($loadedPlugins as $loadedPlugin) {
                 if (!empty($updatePlugin['name'])
                     && $loadedPlugin->getPluginName() == $updatePlugin['name']
                 ) {
                     $updatePlugin['currentVersion'] = $loadedPlugin->getVersion();
                     $updatePlugin['isActivated'] = $pluginManager->isPluginActivated($updatePlugin['name']);
-                    $updatePlugin = $this->addMissingRequirements($updatePlugin);
+                    $pluginsHavingUpdate[$key] = $this->addMissingRequirements($updatePlugin);
                     break;
                 }
             }


### PR DESCRIPTION
fixes #6737 

I just ran into this issue and debugged it. Problem was the reference as there is another loop like 

```
foreach ($pluginsHavingUpdate as &$updatePlugin) {
}
foreach ($pluginsHavingUpdate as $updatePlugin) {
}
```

Another solution would have been to use `as $updatePlugin2` in second loop but references should be avoided in general where possible. 

After changing it the plugin update was no longer shown twice
