### PR TITLE
Show plugin updates for disabled plugins

### DIFF
--- a/plugins/CorePluginsAdmin/Marketplace.php
+++ b/plugins/CorePluginsAdmin/Marketplace.php
@@ -129,9 +129,7 @@ class Marketplace
 
         // remove plugins that have updates but for some reason are not loaded
         foreach ($pluginsHavingUpdate as $key => $updatePlugin) {
-            if (empty($updatePlugin['currentVersion'])
-                || empty($updatePlugin['isActivated'])
-            ) {
+            if (empty($updatePlugin['currentVersion'])) {
                 unset($pluginsHavingUpdate[$key]);
             }
         }


### PR DESCRIPTION
fixes #9065 

While debugging #6737 I noticed my system had an available update for a disabled plugin and it was not shown in the list as suspected in #9065 . By removing that line plugin was shown in the updater. Once I updated the plugin, it was no longer shown in the list.
