### PR TITLE
fixes single quote bug in rowevolution

### DIFF
--- a/plugins/CoreHome/DataTableRowAction/RowEvolution.php
+++ b/plugins/CoreHome/DataTableRowAction/RowEvolution.php
@@ -91,7 +91,7 @@ class RowEvolution
         if (!is_array($this->label)) {
             throw new Exception("Expected label to be an array, got instead: " . $this->label);
         }
-        $this->label = $this->label[0];
+        $this->label = Common::unsanitizeInputValue($this->label[0]);
 
         if ($this->label === '') throw new Exception("Parameter label not set.");
 

--- a/tests/PHPUnit/Fixtures/TwoSitesManyVisitsOverSeveralDaysWithSearchEngineReferrers.php
+++ b/tests/PHPUnit/Fixtures/TwoSitesManyVisitsOverSeveralDaysWithSearchEngineReferrers.php
@@ -23,7 +23,7 @@ class TwoSitesManyVisitsOverSeveralDaysWithSearchEngineReferrers extends Fixture
     public $keywords = array(
         'free > proprietary', // testing a keyword containing >
         'peace "," not war', // testing a keyword containing ,
-        'justice )(&^#%$ NOT corruption!',
+        'justice )(&^#%$ NOT \'" corruption!',
     );
 
     public function setUp()

--- a/tests/PHPUnit/System/expected/test_RowEvolution_LabelReservedCharactersHierarchical__API.getRowEvolution_day.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_LabelReservedCharactersHierarchical__API.getRowEvolution_day.xml
@@ -249,7 +249,7 @@
 				<change>-100%</change>
 			</nb_visits_1>
 			<nb_visits_2>
-				<name>Google - justice )(&amp;^#%$ not corruption! (Visits)</name>
+				<name>Google - justice )(&amp;^#%$ not &amp;#039;" corruption! (Visits)</name>
 				<min>0</min>
 				<max>1</max>
 			</nb_visits_2>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_flatFilters__Referrers.getSearchEngines_month.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_flatFilters__Referrers.getSearchEngines_month.xml
@@ -14,7 +14,7 @@
 		<logo>plugins/Referrers/images/searchEngines/google.com.png</logo>
 	</row>
 	<row>
-		<label>Google - justice )(&amp;^#%$ not corruption!</label>
+		<label>Google - justice )(&amp;^#%$ not &amp;#039;" corruption!</label>
 		<nb_visits>8</nb_visits>
 		<nb_actions>8</nb_actions>
 		<max_actions>1</max_actions>
@@ -23,7 +23,7 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
-		<url>http://google.com/search?q=justice+%29%28%26%5E%23%25%24+not+corruption%21</url>
+		<url>http://google.com/search?q=justice+%29%28%26%5E%23%25%24+not+%27%22+corruption%21</url>
 		<logo>plugins/Referrers/images/searchEngines/google.com.png</logo>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_multipleDates_lastNoData__API.getRowEvolution_month.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_multipleDates_lastNoData__API.getRowEvolution_month.xml
@@ -33,7 +33,7 @@
 				<change>-100%</change>
 			</nb_visits_0>
 			<nb_visits_1>
-				<name>justice )(&amp;^#%$ not corruption! (Visits)</name>
+				<name>justice )(&amp;^#%$ not &amp;#039;" corruption! (Visits)</name>
 				<min>0</min>
 				<max>8</max>
 				<change>-100%</change>


### PR DESCRIPTION
unsanitize label for row evolution (fixes #8393)

the displayed label in row evolution is given as get param. Maybe due to changes in the history service it might be escaped now, so we need to unsanitize before using it.
