### PR TITLE
 fix a problem issues #9257 https://github.com/piwik/piwik/issues/9257

### DIFF
--- a/plugins/Referrers/Columns/Keyword.php
+++ b/plugins/Referrers/Columns/Keyword.php
@@ -44,7 +44,11 @@ class Keyword extends Base
         $information = $this->getReferrerInformationFromRequest($request);
 
         if (!empty($information['referer_keyword'])) {
-            return substr($information['referer_keyword'], 0, 255);
+            if (function_exists('mb_substr')) {
+                return mb_substr($information['referer_keyword'], 0, 255, 'UTF-8');
+            } else {  
+                return substr($information['referer_keyword'], 0, 255);
+            }
         }
 
         return $information['referer_keyword'];

--- a/plugins/Referrers/Columns/Keyword.php
+++ b/plugins/Referrers/Columns/Keyword.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\Referrers\Columns;
 
+use Piwik\Common;
 use Piwik\Piwik;
 use Piwik\Plugins\Referrers\Segment;
 use Piwik\Tracker\Request;
@@ -44,11 +45,7 @@ class Keyword extends Base
         $information = $this->getReferrerInformationFromRequest($request);
 
         if (!empty($information['referer_keyword'])) {
-            if (function_exists('mb_substr')) {
-                return mb_substr($information['referer_keyword'], 0, 255, 'UTF-8');
-            } else {  
-                return substr($information['referer_keyword'], 0, 255);
-            }
+            return Common::mb_substr($information['referer_keyword'], 0, 255);
         }
 
         return $information['referer_keyword'];

--- a/plugins/Referrers/Columns/ReferrerName.php
+++ b/plugins/Referrers/Columns/ReferrerName.php
@@ -38,10 +38,12 @@ class ReferrerName extends Base
         $information = $this->getReferrerInformationFromRequest($request);
 
         if (!empty($information['referer_name'])) {
-
-            return substr($information['referer_name'], 0, 70);
+            if (function_exists('mb_substr')) {
+                return mb_substr($information['referer_name'], 0, 70, 'UTF-8');
+            } else {
+                return substr($information['referer_name'], 0, 70);
+            }
         }
-
         return $information['referer_name'];
     }
 

--- a/plugins/Referrers/Columns/ReferrerName.php
+++ b/plugins/Referrers/Columns/ReferrerName.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\Referrers\Columns;
 
+use Piwik\Common;
 use Piwik\Plugins\Referrers\Segment;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
@@ -38,11 +39,7 @@ class ReferrerName extends Base
         $information = $this->getReferrerInformationFromRequest($request);
 
         if (!empty($information['referer_name'])) {
-            if (function_exists('mb_substr')) {
-                return mb_substr($information['referer_name'], 0, 70, 'UTF-8');
-            } else {
-                return substr($information['referer_name'], 0, 70);
-            }
+            return Common::mb_substr($information['referer_name'], 0, 70);
         }
         return $information['referer_name'];
     }


### PR DESCRIPTION
When pk campaign = (utm_campaign =) is used, which is utf-8, string will cut 70 "bytes" without boundary. #9257
