### PR TITLE
Fixing issues causing omnifixture setup to fail.

### DIFF
--- a/tests/PHPUnit/Fixtures/ManySitesImportedLogsWithXssAttempts.php
+++ b/tests/PHPUnit/Fixtures/ManySitesImportedLogsWithXssAttempts.php
@@ -57,6 +57,11 @@ class ManySitesImportedLogsWithXssAttempts extends ManySitesImportedLogs
             self::createWebsite($this->dateTime, $ecommerce = 0, $siteName = 'Piwik test two',
                 $siteUrl = 'http://example-site-two.com');
         }
+
+        if (!self::siteCreated($idSite = 3)) {
+            self::createWebsite($this->dateTime, $ecommerce = 0, $siteName = 'Piwik test three',
+                $siteUrl = 'http://example-site-three.com');
+        }
     }
 
     public function addAnnotations()

--- a/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
+++ b/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
@@ -265,13 +265,6 @@ class ManyVisitsWithGeoIP extends Fixture
 
     public static function unsetLocationProvider()
     {
-        // also fails on other PHP, is it really needed?
-        return;
-
-        // this randomly fails on PHP 5.3
-        if(strpos(PHP_VERSION, '5.3') === 0) {
-            return;
-        }
         try {
             LocationProvider::setCurrentProvider('default');
         } catch(Exception $e) {

--- a/tests/PHPUnit/Fixtures/ManyVisitsWithMockLocationProvider.php
+++ b/tests/PHPUnit/Fixtures/ManyVisitsWithMockLocationProvider.php
@@ -33,6 +33,8 @@ class ManyVisitsWithMockLocationProvider extends Fixture
         $this->setUpWebsitesAndGoals();
         $this->setMockLocationProvider();
         $this->trackVisits();
+
+        ManyVisitsWithGeoIP::unsetLocationProvider();
     }
 
     public function tearDown()

--- a/tests/PHPUnit/Fixtures/OmniFixture.php
+++ b/tests/PHPUnit/Fixtures/OmniFixture.php
@@ -32,11 +32,29 @@ class OmniFixture extends Fixture
 
     public $fixtures = array();
 
+    private function requireAllFixtures()
+    {
+        $fixturesToLoad = array(
+            '/tests/PHPUnit/Fixtures/*.php',
+            '/tests/UI/Fixtures/*.php',
+            '/plugins/*/tests/Fixtures/*.php',
+            '/plugins/*/Test/Fixtures/*.php',
+        );
+
+        foreach($fixturesToLoad as $fixturePath) {
+            foreach (glob(PIWIK_INCLUDE_PATH . $fixturePath) as $file) {
+                require_once $file;
+            }
+        }
+    }
+
     /**
      * Constructor.
      */
     public function __construct()
     {
+        $this->requireAllFixtures();
+
         $date = $this->month . '-01';
 
         $classes = get_declared_classes();
@@ -94,6 +112,8 @@ class OmniFixture extends Fixture
     public function setUp()
     {
         foreach ($this->fixtures as $fixture) {
+            echo "Setting up " . get_class($fixture) . "...\n";
+
             $fixture->setUp();
         }
 
@@ -108,6 +128,8 @@ class OmniFixture extends Fixture
     public function tearDown()
     {
         foreach ($this->fixtures as $fixture) {
+            echo "Tearing down " . get_class($fixture) . "...\n";
+
             $fixture->tearDown();
         }
     }

--- a/tests/PHPUnit/Framework/Mock/LocationProvider.php
+++ b/tests/PHPUnit/Framework/Mock/LocationProvider.php
@@ -27,6 +27,11 @@ class LocationProvider extends CountryLocationProvider
         if (isset($this->ipToLocations[$ip])) {
             $result = $this->ipToLocations[$ip];
         } else {
+            if (!isset(self::$locations[$this->currentLocation])) {
+                throw new \Exception("Unknown location index in mock LocationProvider {$this->currentLocation}. This "
+                    . "shouldn't ever happen, it is likely something is using the mock LocationProvider when it should be using a real one.");
+            }
+
             $result = self::$locations[$this->currentLocation];
             $this->currentLocation = ($this->currentLocation + 1) % count(self::$locations);
 


### PR DESCRIPTION
Contains the following fixes:
- Create a 3rd website in ManySitesImportedLogsWithXssAttempts since base type now creates 3 sites.
- Re-enable ManyVisitsWithGeoIP::unsetLocationProvider(). It is required.
- Unset location provider in ManyVisitsWithMockLocationProvider after tracking is done.
- Require fixtures manually in OmniFixture.
- Throw an exception in LocationProvider to get more than a notice (though the exception is hidden by the tracker).
