### PR TITLE
Make transition and overlay row actions extendable by other plugins

### DIFF
--- a/plugins/Actions/Actions.php
+++ b/plugins/Actions/Actions.php
@@ -105,6 +105,7 @@ class Actions extends \Piwik\Plugin
     public function getJsFiles(&$jsFiles)
     {
         $jsFiles[] = "plugins/Actions/javascripts/actionsDataTable.js";
+        $jsFiles[] = "plugins/Actions/javascripts/rowactions.js";
     }
 
     public function isSiteSearchEnabled($idSites, $idSite)

--- a/plugins/Actions/javascripts/rowactions.js
+++ b/plugins/Actions/javascripts/rowactions.js
@@ -1,0 +1,65 @@
+$(function () {
+
+    function isActionsModule(params)
+    {
+        return params.module == 'Actions';
+    }
+
+    function isPageUrlReport(params) {
+        var action = params.action;
+
+        return isActionsModule(params) &&
+            (action == 'getPageUrls' || action == 'getEntryPageUrls' || action == 'getExitPageUrls' || action == 'getPageUrlsFollowingSiteSearch');
+    };
+
+    function isPageTitleReport(params) {
+        var action = params.action;
+
+        return isActionsModule(params) && (action == 'getPageTitles' || action == 'getPageTitlesFollowingSiteSearch');
+    };
+
+    function getLinkForTransitionAndOverlayPopover(tr)
+    {
+        var link = tr.find('> td:first > a').attr('href');
+        link = $('<textarea>').html(link).val(); // remove html entities
+        return link;
+    }
+
+    DataTable_RowActions_Transitions.registerReport({
+        isAvailableOnReport: function (dataTableParams) {
+            return isPageUrlReport(dataTableParams);
+        },
+        isAvailableOnRow: function (dataTableParams, tr) {
+            return isPageUrlReport(dataTableParams) && tr.find('> td:first span.label').parent().is('a')
+        },
+        trigger: function (tr, e, subTableLabel) {
+            var link = getLinkForTransitionAndOverlayPopover(tr);
+            this.openPopover('url:' + link);
+        }
+    });
+
+    DataTable_RowActions_Transitions.registerReport({
+        isAvailableOnReport: function (dataTableParams) {
+            return isPageTitleReport(dataTableParams);
+        },
+        isAvailableOnRow: function (dataTableParams, tr) {
+            return isPageTitleReport(dataTableParams);
+        },
+        trigger: function (tr, e, subTableLabel) {
+            DataTable_RowAction.prototype.trigger.apply(this, [tr, e, subTableLabel]);
+        }
+    });
+
+    DataTable_RowActions_Overlay.registerReport({
+        isAvailableOnReport: function (dataTableParams) {
+            return isPageUrlReport(dataTableParams);
+        },
+        onClick: function (actionA, tr, e) {
+            return {
+                link: getLinkForTransitionAndOverlayPopover(tr),
+                segment: null
+            }
+        }
+    });
+
+});


### PR DESCRIPTION
This is kinda needed for Custom Dimensions #9129 and another PRO plugin.

To make it work for custom dimensions I just added the code to transition and overlay plugin which was kinda bad as those two plugins are in core but custom dimensions is not. Ideally all the code that belongs to a plugin is also in that plugin. As I did not want to do this for another PRO plugin I might those row actions extendable. Meaning other plugins can decide on which report a Transition or Overlay row action is available and what to do when it gets triggered. The "API" is quite simple for now to keep things trivial as not more is needed for now. 

I already moved detection of URL / Title reports to the Actions plugin and moved detection of CustomDimensions to the plugin see https://github.com/piwik/plugin-CustomDimensions/compare/rowactions?expand=1

In another PRO plugin I will make use of it as well.
