### PR TITLE
Add 'all' in the Row count selector to be able to display all rows, and optionally export them all

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -249,8 +249,9 @@ default_language = en
 datatable_default_limit = 10
 
 ; Each datatable report has a Row Limit selector at the bottom right.
-; By default you can select from 5 to 500 rows. You may customise the values below:
-datatable_row_limits = "5,10,25,50,100,250,500"
+; By default you can select from 5 to 500 rows. You may customise the values below
+; -1 will be displayed as 'all' and it will export all rows (filter_limit=-1)
+datatable_row_limits = "5,10,25,50,100,250,500,-1"
 
 ; default number of rows returned in API responses
 ; this value is overwritten by the '# Rows to display' selector.

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -252,6 +252,7 @@ class CoreHome extends \Piwik\Plugin
         $translationKeys[] = 'Intl_Day_Min_StandAlone_6';
         $translationKeys[] = 'Intl_Day_Min_StandAlone_7';
         $translationKeys[] = 'General_And';
+        $translationKeys[] = 'General_All';
         $translationKeys[] = 'General_Search';
         $translationKeys[] = 'General_Clear';
         $translationKeys[] = 'General_MoreDetails';

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -506,13 +506,20 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             };
         }
 
+        function getFilterLimitAsString(limit) {
+            if (limit == '-1') {
+                return _pk_translate('General_All').toLowerCase();
+            }
+            return limit;
+        }
+
         // setup limit control
-        $('.limitSelection', domElem).append('<div><span>' + self.param[limitParamName] + '</span></div><ul></ul>');
+        $('.limitSelection', domElem).append('<div><span value="'+ self.param[limitParamName] +'">' + getFilterLimitAsString(self.param[limitParamName]) + '</span></div><ul></ul>');
 
         if (self.props.show_limit_control) {
             $('.limitSelection ul', domElem).hide();
             for (var i = 0; i < numbers.length; i++) {
-                $('.limitSelection ul', domElem).append('<li value="' + numbers[i] + '"><span>' + numbers[i] + '</span></li>');
+                $('.limitSelection ul', domElem).append('<li value="' + numbers[i] + '"><span>' + getFilterLimitAsString(numbers[i]) + '</span></li>');
             }
             $('.limitSelection ul li:last', domElem).addClass('last');
 
@@ -535,12 +542,12 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                     $('.limitSelection', domElem).is('.visible') ? hide() : show();
                 });
                 $('.limitSelection ul li', domElem).on('click', function (event) {
-                    var limit = parseInt($(event.target).text());
+                    var limit = parseInt($(event.target).closest('li').attr('value'));
 
                     hide();
                     if (limit != self.param[limitParamName]) {
                         setLimitValue(self.param, limit);
-                        $('.limitSelection>div>span', domElem).text(limit);
+                        $('.limitSelection>div>span', domElem).text( getFilterLimitAsString(limit)).attr('value', limit);
                         self.reloadAjaxDataTable();
 
                         var data = {};
@@ -1045,7 +1052,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                 $(this).attr('href', function () {
                     var url = $(this).attr('href') + '&token_auth=' + piwik.token_auth;
 
-                    var limit = $('.limitSelection>div>span', domElem).text();
+                    var limit = $('.limitSelection>div>span', domElem).attr('value');
                     var defaultLimit = $(this).attr('filter_limit');
                     if (!limit || 'undefined' === limit || defaultLimit == -1) {
                         limit = defaultLimit;


### PR DESCRIPTION
fixes #9068
