### PR TITLE
Make sure to compare referrer values lower case

### DIFF
--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -449,7 +449,7 @@ abstract class Base extends VisitDimension
 
     protected function hasReferrerColumnChanged(Visitor $visitor, $information, $infoName)
     {
-        return Common::mb_strtolower($visitor->getVisitorColumn($infoName)) != $information[$infoName];
+        return Common::mb_strtolower($visitor->getVisitorColumn($infoName)) != Common::mb_strtolower($information[$infoName]);
     }
 
     protected function doesLastActionHaveSameReferrer(Visitor $visitor, $referrerType)


### PR DESCRIPTION
refs #9299 

While debugging #9299 I noticed the check is a bit fragile. There is probably no actual issue but if one ever forgets to convert the `$information` to lowercase in referrer detection then Piwik creates many new visits.
