### PR TITLE
Forward selected segment to transition in overlay

### DIFF
--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -236,7 +236,11 @@ var Piwik_Overlay = (function () {
 
             // handle transitions link
             $transitionsLink.click(function () {
-                DataTable_RowActions_Transitions.launchForUrl(iframeCurrentPageNormalized);
+                var unescapedSegment = null;
+                if (segment) {
+                    unescapedSegment = unescape(segment);
+                }
+                DataTable_RowActions_Transitions.launchForUrl(iframeCurrentPageNormalized, unescapedSegment);
                 return false;
             });
 

--- a/plugins/Transitions/javascripts/transitions.js
+++ b/plugins/Transitions/javascripts/transitions.js
@@ -17,8 +17,12 @@ function DataTable_RowActions_Transitions(dataTable) {
 DataTable_RowActions_Transitions.prototype = new DataTable_RowAction;
 
 /** Static helper method to launch transitions from anywhere */
-DataTable_RowActions_Transitions.launchForUrl = function (url) {
-    broadcast.propagateNewPopoverParameter('RowAction', 'Transitions:url:' + url);
+DataTable_RowActions_Transitions.launchForUrl = function (url, segment) {
+    var value = 'Transitions:url:' + url;
+    if (segment) {
+        value += ':segment:' + segment;
+    }
+    broadcast.propagateNewPopoverParameter('RowAction', value);
 };
 
 DataTable_RowActions_Transitions.isPageUrlReport = function (module, action) {
@@ -63,6 +67,15 @@ DataTable_RowActions_Transitions.prototype.performAction = function (label, tr, 
 };
 
 DataTable_RowActions_Transitions.prototype.doOpenPopover = function (link) {
+    var posSegment = (link+'').indexOf(':segment:');
+    var segment = null;
+
+    // handle and remove ':segment:$SEGMENT' from link
+    if (posSegment && posSegment > 0) {
+        segment = link.substring(posSegment + (':segment:'.length));
+        link = link.substring(0, posSegment);
+    }
+
     var parts = link.split(':');
     if (parts.length < 2) {
         return;
@@ -73,9 +86,9 @@ DataTable_RowActions_Transitions.prototype.doOpenPopover = function (link) {
     var actionName = parts.join(':');
 
     if (this.transitions === null) {
-        this.transitions = new Piwik_Transitions(actionType, actionName, this);
+        this.transitions = new Piwik_Transitions(actionType, actionName, this, segment);
     } else {
-        this.transitions.reset(actionType, actionName);
+        this.transitions.reset(actionType, actionName, segment);
     }
     this.transitions.showPopover();
 };


### PR DESCRIPTION
refs #9129 #9256

In #9129 I added the feature to apply a segment to overlay. This PR will forward the segment to the transition popup when clicking on the transition link in the left sidebar of the overlay page.

FYI: I tried to forward segment to row action as well but this would be lots of work and is not trivial.

I need this method (`DataTable_RowActions_Transitions.launchForUrl(iframeCurrentPageNormalized, segment`) in other plugins as well
