### PR TITLE
New segment: ActionType

### DIFF
--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -45,6 +45,21 @@ class LogQueryBuilder
     }
 
 
+    private function hasJoinedTableAlreadyManually($tableToFind, $joinToFind, $tables)
+    {
+        foreach ($tables as $index => $table) {
+            if (is_array($table)
+                && !empty($table['table'])
+                && $table['table'] === $tableToFind
+                && (!isset($table['tableAlias']) || $table['tableAlias'] === $tableToFind)
+                && isset($table['joinOn']) && $table['joinOn'] === $joinToFind) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Generate the join sql based on the needed tables
      * @param array $tables tables to join
@@ -113,6 +128,12 @@ class LogQueryBuilder
 
                 if ($linkVisitActionsTableAvailable && $table === 'log_action') {
                     $join = "log_link_visit_action.idaction_url = log_action.idaction";
+
+                    if ($this->hasJoinedTableAlreadyManually($table, $join, $tables)) {
+                        $actionsTableAvailable = true;
+                        continue;
+                    }
+
                 } elseif ($linkVisitActionsTableAvailable && $table == "log_conversion") {
                     // have actions, need conversions => join on idvisit
                     $join = "log_conversion.idvisit = log_link_visit_action.idvisit";

--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -44,6 +44,50 @@ class LogQueryBuilder
         );
     }
 
+    private function getIndexIfTableInTables($tableToFind, $tables)
+    {
+        $index = array_search($tableToFind, $tables);
+        
+        if (false !== $index) {
+            return $index;
+        }
+
+        foreach ($tables as $index => $table) {
+            if (is_array($table)
+                && !empty($table['table'])
+                && $table['table'] === $tableToFind
+                && (!isset($table['tableAlias']) || $table['tableAlias'] === $tableToFind)) {
+                return $index;
+            }
+        }
+
+        return false;
+    }
+
+    private function swapPositionOfTableEntries($tables, $index1, $index2)
+    {
+        $table1 = $tables[$index1];
+        $table2 = $tables[$index2];
+
+        $tables[$index1] = $table2;
+        $tables[$index2] = $table1;
+
+        return $tables;
+    }
+
+    private function hasJoinedTableAlreadyManually($tableToFind, $tables)
+    {
+        foreach ($tables as $index => $table) {
+            if (is_array($table)
+                && !empty($table['table'])
+                && $table['table'] === $tableToFind
+                && (!isset($table['tableAlias']) || $table['tableAlias'] === $tableToFind)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Generate the join sql based on the needed tables
@@ -53,7 +97,7 @@ class LogQueryBuilder
      */
     private function generateJoinsString(&$tables)
     {
-        $knownTables = array("log_action", "log_visit", "log_link_visit_action", "log_conversion", "log_conversion_item");
+        $knownTables = array('log_action', 'log_visit', 'log_link_visit_action', 'log_conversion', 'log_conversion_item');
         $visitsAvailable = $linkVisitActionsTableAvailable = $conversionsAvailable = $conversionItemAvailable = $actionsTableAvailable = false;
         $joinWithSubSelect = false;
         $sql = '';
@@ -61,33 +105,30 @@ class LogQueryBuilder
         // make sure the tables are joined in the right order
         // base table first, then action before conversion
         // this way, conversions can be left joined on idvisit
-        $actionIndex = array_search("log_link_visit_action", $tables);
-        $conversionIndex = array_search("log_conversion", $tables);
+        $actionIndex = $this->getIndexIfTableInTables("log_link_visit_action", $tables);
+        $conversionIndex = $this->getIndexIfTableInTables("log_conversion", $tables);
         if ($actionIndex > 0 && $conversionIndex > 0 && $actionIndex > $conversionIndex) {
-            $tables[$actionIndex] = "log_conversion";
-            $tables[$conversionIndex] = "log_link_visit_action";
+            $tables = $this->swapPositionOfTableEntries($tables, $actionIndex, $conversionIndex);
         }
 
         // same as above: action before visit
-        $actionIndex = array_search("log_link_visit_action", $tables);
-        $visitIndex = array_search("log_visit", $tables);
+        $actionIndex = $this->getIndexIfTableInTables("log_link_visit_action", $tables);
+        $visitIndex = $this->getIndexIfTableInTables("log_visit", $tables);
         if ($actionIndex > 0 && $visitIndex > 0 && $actionIndex > $visitIndex) {
-            $tables[$actionIndex] = "log_visit";
-            $tables[$visitIndex] = "log_link_visit_action";
+            $tables = $this->swapPositionOfTableEntries($tables, $actionIndex, $visitIndex);
         }
 
         // we need to add log_link_visit_action dynamically to join eg visit with action
-        $linkVisitAction = array_search("log_link_visit_action", $tables);
-        $actionIndex     = array_search("log_action", $tables);
+        $linkVisitAction = $this->getIndexIfTableInTables("log_link_visit_action", $tables);
+        $actionIndex     = $this->getIndexIfTableInTables("log_action", $tables);
         if ($linkVisitAction === false && $actionIndex > 0) {
             $tables[] = "log_link_visit_action";
         }
 
-        $linkVisitAction = array_search("log_link_visit_action", $tables);
-        $actionIndex     = array_search("log_action", $tables);
+        $linkVisitAction = $this->getIndexIfTableInTables("log_link_visit_action", $tables);
+        $actionIndex     = $this->getIndexIfTableInTables("log_action", $tables);
         if ($linkVisitAction > 0 && $actionIndex > 0 && $linkVisitAction > $actionIndex) {
-            $tables[$actionIndex] = "log_link_visit_action";
-            $tables[$linkVisitAction] = "log_action";
+            $tables = $this->swapPositionOfTableEntries($tables, $linkVisitAction, $actionIndex);
         }
 
         foreach ($tables as $i => $table) {
@@ -109,8 +150,7 @@ class LogQueryBuilder
             if ($i == 0) {
                 // first table
                 $sql .= $tableSql;
-            } else {
-
+            } elseif (!$this->hasJoinedTableAlreadyManually($table, $tables)) {
                 if ($linkVisitActionsTableAvailable && $table === 'log_action') {
                     $join = "log_link_visit_action.idaction_url = log_action.idaction";
                 } elseif ($linkVisitActionsTableAvailable && $table == "log_conversion") {

--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -53,7 +53,7 @@ class ArchivingHelper
                 unset($row[PiwikMetrics::INDEX_SITE_SEARCH_HAS_NO_RESULT]);
             }
 
-            if ($row['type'] == Action::TYPE_CONTENT) {
+            if (in_array($row['type'], array(Action::TYPE_CONTENT, Action::TYPE_EVENT))) {
                 continue;
             }
 

--- a/plugins/Actions/Columns/ActionType.php
+++ b/plugins/Actions/Columns/ActionType.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\Actions\Columns;
+
+use Piwik\Piwik;
+use Piwik\Plugin\Dimension\ActionDimension;
+use Piwik\Plugins\Actions\Segment;
+use Piwik\Tracker\Action;
+use Exception;
+
+/**
+ * This example dimension only defines a name and does not track any data. It's supposed to be only used in reports.
+ *
+ * See {@link http://developer.piwik.org/api-reference/Piwik/Columns\Dimension} for more information.
+ */
+class ActionType extends ActionDimension
+{
+    private $types = array(
+        Action::TYPE_PAGE_URL => 'pageviews',
+        Action::TYPE_CONTENT => 'contents',
+        Action::TYPE_SITE_SEARCH => 'sitesearches',
+        Action::TYPE_EVENT => 'events',
+        Action::TYPE_OUTLINK => 'outlinks',
+        Action::TYPE_DOWNLOAD => 'downloads'
+    );
+
+    /**
+     * The name of the dimension which will be visible for instance in the UI of a related report and in the mobile app.
+     * @return string
+     */
+    public function getName()
+    {
+        return Piwik::translate('Actions_ActionType');
+    }
+
+    protected function configureSegments()
+    {
+        $types = $this->types;
+
+        $segment = new Segment();
+        $segment->setSegment('actionType');
+        $segment->setName('Actions_ActionType');
+        $segment->setSqlSegment('log_action.type');
+        $segment->setType(Segment::TYPE_METRIC);
+        $segment->setAcceptedValues(sprintf('A type of action, such as: %s', implode(', ', $types)));
+        $segment->setSqlFilter(function ($type) use ($types) {
+            if (array_key_exists($type, $types)) {
+                return $type;
+            }
+
+            $index = array_search(strtolower(trim(urldecode($type))), $types);
+
+            if ($index === false) {
+                throw new Exception("actionType must be one of: " . implode(', ', $types));
+            }
+
+            return $index;
+        });
+        $segment->setSuggestedValuesCallback(function ($idSite, $maxSuggestionsToReturn) use ($types) {
+            return array_slice(array_values($types), 0, $maxSuggestionsToReturn);
+        });
+        $this->addSegment($segment);
+    }
+}

--- a/plugins/Actions/lang/en.json
+++ b/plugins/Actions/lang/en.json
@@ -61,6 +61,7 @@
         "WidgetPageUrlsFollowingSearch": "Pages Following a Site Search",
         "WidgetSearchCategories": "Search Categories",
         "WidgetSearchKeywords": "Site Search Keywords",
-        "WidgetSearchNoResultKeywords": "Search Keywords with No Results"
+        "WidgetSearchNoResultKeywords": "Search Keywords with No Results",
+        "ActionType": "Action Type"
     }
 }

--- a/plugins/Events/Actions/ActionEvent.php
+++ b/plugins/Events/Actions/ActionEvent.php
@@ -60,9 +60,17 @@ class ActionEvent extends Action
 
     protected function getActionsToLookup()
     {
-        return array(
-            'idaction_url' => $this->getUrlAndType()
-        );
+        $actionUrl = false;
+
+        $url = $this->getActionUrl();
+
+        if (!empty($url)) {
+            // normalize urls by stripping protocol and www
+            $url = Tracker\PageUrl::normalizeUrl($url);
+            $actionUrl = array($url['url'], $this->getActionType(), $url['prefixId']);
+        }
+
+        return array('idaction_url' => $actionUrl);
     }
 
     // Do not track this Event URL as Entry/Exit Page URL (leave the existing entry/exit)

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -286,7 +286,7 @@ class Visitor implements VisitorInterface
                 unset($actionDetails[$actionIdx]);
                 continue;
 
-            } elseif ($actionDetail['type'] == Action::TYPE_EVENT_CATEGORY) {
+            } elseif ($actionDetail['type'] == Action::TYPE_EVENT) {
                 // Handle Event
                 if (strlen($actionDetail['pageTitle']) > 0) {
                     $actionDetail['eventName'] = $actionDetail['pageTitle'];

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -301,7 +301,7 @@ class Visitor implements VisitorInterface
             }
 
             // Event value / Generation time
-            if ($actionDetail['type'] == Action::TYPE_EVENT_CATEGORY) {
+            if ($actionDetail['type'] == Action::TYPE_EVENT) {
                 if (strlen($actionDetail['custom_float']) > 0) {
                     $actionDetail['eventValue'] = round($actionDetail['custom_float'], self::EVENT_VALUE_PRECISION);
                 }
@@ -310,7 +310,7 @@ class Visitor implements VisitorInterface
             }
             unset($actionDetail['custom_float']);
 
-            if ($actionDetail['type'] != Action::TYPE_EVENT_CATEGORY) {
+            if ($actionDetail['type'] != Action::TYPE_EVENT) {
                 unset($actionDetail['eventCategory']);
                 unset($actionDetail['eventAction']);
             }
@@ -423,7 +423,7 @@ class Visitor implements VisitorInterface
                     $details['type'] = 'search';
                     $details['icon'] = 'plugins/Morpheus/images/search_ico.png';
                     break;
-                case Action::TYPE_EVENT_CATEGORY:
+                case Action::TYPE_EVENT:
                     $details['type'] = 'event';
                     $details['icon'] = 'plugins/Morpheus/images/event.png';
                     break;

--- a/plugins/SegmentEditor/SegmentSelectorControl.php
+++ b/plugins/SegmentEditor/SegmentSelectorControl.php
@@ -46,9 +46,10 @@ class SegmentSelectorControl extends UIControl
 
         $segments = APIMetadata::getInstance()->getSegmentsMetadata($this->idSite);
 
+        $visitTitle = Piwik::translate('General_Visit');
         $segmentsByCategory = array();
         foreach ($segments as $segment) {
-            if ($segment['category'] == Piwik::translate('General_Visit')
+            if ($segment['category'] == $visitTitle
                 && ($segment['type'] == 'metric' && $segment['segment'] != 'visitIp')
             ) {
                 $metricsLabel = Piwik::translate('General_Metrics');
@@ -57,7 +58,6 @@ class SegmentSelectorControl extends UIControl
             }
             $segmentsByCategory[$segment['category']][] = $segment;
         }
-        uksort($segmentsByCategory, array($this, 'sortSegmentCategories'));
 
         $this->createRealTimeSegmentsIsEnabled = Config::getInstance()->General['enable_create_realtime_segments'];
         $this->segmentsByCategory   = $segmentsByCategory;
@@ -98,15 +98,6 @@ class SegmentSelectorControl extends UIControl
         }
 
         return (bool) $savedSegment['auto_archive'];
-    }
-
-    public function sortSegmentCategories($a, $b)
-    {
-        // Custom Variables last
-        if ($a == Piwik::translate('CustomVariables_CustomVariables')) {
-            return 1;
-        }
-        return 0;
     }
 
     private function getTranslations()

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -418,6 +418,53 @@ class SegmentTest extends IntegrationTestCase
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
+    public function test_getSelectQuery_whenJoinLogLinkVisitActionOnActionOnVisit_WithSameTableAliasButDifferentJoin()
+    {
+        $actionType = 3;
+        $idSite = 1;
+        $select = 'log_link_visit_action.custom_dimension_1,
+                  log_action.name as url,
+                  sum(log_link_visit_action.time_spent) as `13`,
+                  sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`';
+        $from  = array(
+            'log_link_visit_action',
+            array('table' => 'log_visit', 'joinOn' => 'log_visit.idvisit = log_link_visit_action.idvisit'),
+            array('table' => 'log_action', 'joinOn' => 'log_link_visit_action.idaction_name = log_action.idaction')
+        );
+        $where = 'log_link_visit_action.server_time >= ?
+                  AND log_link_visit_action.server_time <= ?
+                  AND log_link_visit_action.idsite = ?';
+        $bind = array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite);
+
+        $segment = 'actionType==' . $actionType;
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind);
+
+        $logVisitTable = Common::prefixTable('log_visit');
+        $logActionTable = Common::prefixTable('log_action');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+
+        $expected = array(
+            "sql"  => "
+             SELECT log_link_visit_action.custom_dimension_1,
+                    log_action.name as url,
+                    sum(log_link_visit_action.time_spent) as `13`,
+                    sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
+             FROM $logLinkVisitActionTable AS log_link_visit_action
+                  LEFT JOIN $logVisitTable AS log_visit
+                       ON log_visit.idvisit = log_link_visit_action.idvisit
+                  LEFT JOIN $logActionTable AS log_action
+                       ON (log_link_visit_action.idaction_name = log_action.idaction AND log_link_visit_action.idaction_url = log_action.idaction)
+             WHERE ( log_link_visit_action.server_time >= ?
+                 AND log_link_visit_action.server_time <= ?
+                 AND log_link_visit_action.idsite = ? )
+                 AND ( log_action.type = ? )",
+            "bind" => array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite, $actionType));
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
     /**
      * visit is joined on action, then conversion is joined
      * make sure that conversion is joined on action not visit

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -486,7 +486,7 @@ class SegmentTest extends IntegrationTestCase
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
-    public function test_getSelectQuery_whenJoinLogLinkVisitActionOnActionOnVisit()
+    public function test_getSelectQuery_whenJoinLogLinkVisitActionOnActionOnVisit_WithDifferentTableAlias()
     {
         $actionType = 3;
         $idSite = 1;
@@ -524,6 +524,53 @@ class SegmentTest extends IntegrationTestCase
                        ON visitAlias.idvisit = log_link_visit_action.idvisit
                   LEFT JOIN $logActionTable AS actionAlias
                        ON log_link_visit_action.idaction_url = actionAlias.idaction
+                  LEFT JOIN $logActionTable AS log_action
+                       ON log_link_visit_action.idaction_url = log_action.idaction
+             WHERE ( log_link_visit_action.server_time >= ?
+                 AND log_link_visit_action.server_time <= ?
+                 AND log_link_visit_action.idsite = ? )
+                 AND ( log_action.type = ? )",
+            "bind" => array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite, $actionType));
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function test_getSelectQuery_whenJoinLogLinkVisitActionOnActionOnVisit_WithSameTableAlias()
+    {
+        $actionType = 3;
+        $idSite = 1;
+        $select = 'log_link_visit_action.custom_dimension_1,
+                  log_action.name as url,
+                  sum(log_link_visit_action.time_spent) as `13`,
+                  sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`';
+        $from  = array(
+            'log_link_visit_action',
+             array('table' => 'log_visit', 'joinOn' => 'log_visit.idvisit = log_link_visit_action.idvisit'),
+             array('table' => 'log_action', 'joinOn' => 'log_link_visit_action.idaction_url = log_action.idaction')
+        );
+        $where = 'log_link_visit_action.server_time >= ?
+                  AND log_link_visit_action.server_time <= ?
+                  AND log_link_visit_action.idsite = ?';
+        $bind = array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite);
+
+        $segment = 'actionType==' . $actionType;
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind);
+
+        $logVisitTable = Common::prefixTable('log_visit');
+        $logActionTable = Common::prefixTable('log_action');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+
+        $expected = array(
+            "sql"  => "
+             SELECT log_link_visit_action.custom_dimension_1,
+                    log_action.name as url,
+                    sum(log_link_visit_action.time_spent) as `13`,
+                    sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
+             FROM $logLinkVisitActionTable AS log_link_visit_action
+                  LEFT JOIN $logVisitTable AS log_visit
+                       ON log_visit.idvisit = log_link_visit_action.idvisit
                   LEFT JOIN $logActionTable AS log_action
                        ON log_link_visit_action.idaction_url = log_action.idaction
              WHERE ( log_link_visit_action.server_time >= ?

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -486,7 +486,7 @@ class SegmentTest extends IntegrationTestCase
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
-    public function test_getSelectQuery_whenJoinLogLinkVisitActionOnActionOnVisit_WithDifferentTableAlias()
+    public function test_getSelectQuery_whenJoinLogLinkVisitActionOnActionOnVisit()
     {
         $actionType = 3;
         $idSite = 1;
@@ -524,53 +524,6 @@ class SegmentTest extends IntegrationTestCase
                        ON visitAlias.idvisit = log_link_visit_action.idvisit
                   LEFT JOIN $logActionTable AS actionAlias
                        ON log_link_visit_action.idaction_url = actionAlias.idaction
-                  LEFT JOIN $logActionTable AS log_action
-                       ON log_link_visit_action.idaction_url = log_action.idaction
-             WHERE ( log_link_visit_action.server_time >= ?
-                 AND log_link_visit_action.server_time <= ?
-                 AND log_link_visit_action.idsite = ? )
-                 AND ( log_action.type = ? )",
-            "bind" => array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite, $actionType));
-
-        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
-    }
-
-    public function test_getSelectQuery_whenJoinLogLinkVisitActionOnActionOnVisit_WithSameTableAlias()
-    {
-        $actionType = 3;
-        $idSite = 1;
-        $select = 'log_link_visit_action.custom_dimension_1,
-                  log_action.name as url,
-                  sum(log_link_visit_action.time_spent) as `13`,
-                  sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`';
-        $from  = array(
-            'log_link_visit_action',
-             array('table' => 'log_visit', 'joinOn' => 'log_visit.idvisit = log_link_visit_action.idvisit'),
-             array('table' => 'log_action', 'joinOn' => 'log_link_visit_action.idaction_url = log_action.idaction')
-        );
-        $where = 'log_link_visit_action.server_time >= ?
-                  AND log_link_visit_action.server_time <= ?
-                  AND log_link_visit_action.idsite = ?';
-        $bind = array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite);
-
-        $segment = 'actionType==' . $actionType;
-        $segment = new Segment($segment, $idSites = array());
-
-        $query = $segment->getSelectQuery($select, $from, $where, $bind);
-
-        $logVisitTable = Common::prefixTable('log_visit');
-        $logActionTable = Common::prefixTable('log_action');
-        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
-
-        $expected = array(
-            "sql"  => "
-             SELECT log_link_visit_action.custom_dimension_1,
-                    log_action.name as url,
-                    sum(log_link_visit_action.time_spent) as `13`,
-                    sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
-             FROM $logLinkVisitActionTable AS log_link_visit_action
-                  LEFT JOIN $logVisitTable AS log_visit
-                       ON log_visit.idvisit = log_link_visit_action.idvisit
                   LEFT JOIN $logActionTable AS log_action
                        ON log_link_visit_action.idaction_url = log_action.idaction
              WHERE ( log_link_visit_action.server_time >= ?

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -161,7 +161,7 @@ class SegmentTest extends IntegrationTestCase
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
-    public function test_getSelectQuery_whenJoinVisitOnAction()
+    public function test_getSelectQuery_whenJoinVisitOnLogLinkVisitAction()
     {
         $select = '*';
         $from = 'log_link_visit_action';
@@ -225,7 +225,7 @@ class SegmentTest extends IntegrationTestCase
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
-    public function test_getSelectQuery_whenJoinConversionOnAction()
+    public function test_getSelectQuery_whenJoinConversionOnLogLinkVisitAction()
     {
         $select = '*';
         $from = 'log_link_visit_action';
@@ -375,7 +375,7 @@ class SegmentTest extends IntegrationTestCase
      * visit is joined on action, then conversion is joined
      * make sure that conversion is joined on action not visit
      */
-    public function test_getSelectQuery_whenJoinVisitAndConversionOnAction()
+    public function test_getSelectQuery_whenJoinVisitAndConversionOnLogLinkVisitAction()
     {
         $select = '*';
         $from = 'log_link_visit_action';
@@ -445,6 +445,171 @@ class SegmentTest extends IntegrationTestCase
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
+    public function test_getSelectQuery_whenJoinVisitOnAction()
+    {
+        $actionType = 3;
+        $idSite = 1;
+        $select = 'count(distinct log_visit.idvisitor) AS `1`,
+                   count(*) AS `2`,
+                   sum(log_visit.visit_total_actions) AS `3`';
+        $from  = 'log_visit';
+        $where = 'log_visit.visit_last_action_time >= ?
+				AND log_visit.visit_last_action_time <= ?
+				AND log_visit.idsite IN (?)';
+        $bind = array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite);
+
+        $segment = 'actionType==' . $actionType;
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind);
+
+        $logVisitTable = Common::prefixTable('log_visit');
+        $logActionTable = Common::prefixTable('log_action');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+
+        $expected = array(
+            "sql"  => "
+             SELECT count(distinct log_inner.idvisitor) AS `1`, count(*) AS `2`, sum(log_inner.visit_total_actions) AS `3` FROM ( SELECT log_visit.idvisitor, log_visit.visit_total_actions
+             FROM $logVisitTable AS log_visit
+                LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action
+                    ON log_link_visit_action.idvisit = log_visit.idvisit
+                LEFT JOIN $logActionTable AS log_action
+                    ON log_link_visit_action.idaction_url = log_action.idaction
+             WHERE ( log_visit.visit_last_action_time >= ?
+                    AND log_visit.visit_last_action_time <= ?
+                    AND log_visit.idsite IN (?) )
+                    AND ( log_action.type = ? )
+             GROUP BY log_visit.idvisit
+             ORDER BY NULL ) AS log_inner",
+            "bind" => array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite, $actionType));
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function test_getSelectQuery_whenJoinLogLinkVisitActionOnActionOnVisit()
+    {
+        $actionType = 3;
+        $idSite = 1;
+        $select = 'log_link_visit_action.custom_dimension_1,
+                  actionAlias.name as url,
+                  sum(log_link_visit_action.time_spent) as `13`,
+                  sum(case visitAlias.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`';
+        $from  = array(
+            'log_link_visit_action',
+             array('table' => 'log_visit', 'tableAlias' => 'visitAlias', 'joinOn' => 'visitAlias.idvisit = log_link_visit_action.idvisit'),
+             array('table' => 'log_action', 'tableAlias' => 'actionAlias', 'joinOn' => 'log_link_visit_action.idaction_url = actionAlias.idaction')
+        );
+        $where = 'log_link_visit_action.server_time >= ?
+                  AND log_link_visit_action.server_time <= ?
+                  AND log_link_visit_action.idsite = ?';
+        $bind = array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite);
+
+        $segment = 'actionType==' . $actionType;
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind);
+
+        $logVisitTable = Common::prefixTable('log_visit');
+        $logActionTable = Common::prefixTable('log_action');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+
+        $expected = array(
+            "sql"  => "
+             SELECT log_link_visit_action.custom_dimension_1,
+                    actionAlias.name as url,
+                    sum(log_link_visit_action.time_spent) as `13`,
+                    sum(case visitAlias.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
+             FROM $logLinkVisitActionTable AS log_link_visit_action
+                  LEFT JOIN $logVisitTable AS visitAlias
+                       ON visitAlias.idvisit = log_link_visit_action.idvisit
+                  LEFT JOIN $logActionTable AS actionAlias
+                       ON log_link_visit_action.idaction_url = actionAlias.idaction
+                  LEFT JOIN $logActionTable AS log_action
+                       ON log_link_visit_action.idaction_url = log_action.idaction
+             WHERE ( log_link_visit_action.server_time >= ?
+                 AND log_link_visit_action.server_time <= ?
+                 AND log_link_visit_action.idsite = ? )
+                 AND ( log_action.type = ? )",
+            "bind" => array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite, $actionType));
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function test_getSelectQuery_whenJoinLogLinkVisitActionOnAction()
+    {
+        $actionType = 3;
+        $idSite = 1;
+        $select = 'log_link_visit_action.custom_dimension_1,
+                  sum(log_link_visit_action.time_spent) as `13`';
+        $from  = 'log_link_visit_action';
+        $where = 'log_link_visit_action.server_time >= ?
+                  AND log_link_visit_action.server_time <= ?
+                  AND log_link_visit_action.idsite = ?';
+        $bind = array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite);
+
+        $segment = 'actionType==' . $actionType;
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind);
+
+        $logActionTable = Common::prefixTable('log_action');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+
+        $expected = array(
+            "sql"  => "
+             SELECT log_link_visit_action.custom_dimension_1, sum(log_link_visit_action.time_spent) as `13`
+             FROM $logLinkVisitActionTable AS log_link_visit_action
+                  LEFT JOIN $logActionTable AS log_action
+                        ON log_link_visit_action.idaction_url = log_action.idaction
+             WHERE ( log_link_visit_action.server_time >= ?
+                 AND log_link_visit_action.server_time <= ?
+                 AND log_link_visit_action.idsite = ? )
+                 AND ( log_action.type = ? )",
+            "bind" => array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite, $actionType));
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    public function test_getSelectQuery_whenJoinConversionOnAction()
+    {
+        $actionType = 3;
+        $idSite = 1;
+        $select = 'log_conversion.idgoal AS `idgoal`,
+                   log_conversion.custom_dimension_1 AS `custom_dimension_1`,
+                   count(*) AS `1`,
+                   count(distinct log_conversion.idvisit) AS `3`,';
+        $from  = 'log_conversion';
+        $where = 'log_conversion.server_time >= ?
+				  AND log_conversion.server_time <= ?
+				  AND log_conversion.idsite IN (?)';
+        $bind = array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite);
+
+        $segment = 'actionType==' . $actionType;
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind);
+
+        $logConversionsTable = Common::prefixTable('log_conversion');
+        $logActionTable = Common::prefixTable('log_action');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+
+        $expected = array(
+            "sql"  => "
+             SELECT log_conversion.idgoal AS `idgoal`, log_conversion.custom_dimension_1 AS `custom_dimension_1`, count(*) AS `1`, count(distinct log_conversion.idvisit) AS `3`,
+             FROM $logConversionsTable AS log_conversion
+                  LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action
+                       ON log_conversion.idvisit = log_link_visit_action.idvisit
+                  LEFT JOIN $logActionTable AS log_action
+                       ON log_link_visit_action.idaction_url = log_action.idaction
+             WHERE ( log_conversion.server_time >= ?
+                 AND log_conversion.server_time <= ?
+                 AND log_conversion.idsite IN (?) )
+                 AND ( log_action.type = ? )",
+            "bind" => array('2015-11-30 11:00:00', '2015-12-01 10:59:59', $idSite, $actionType));
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
     public function test_getSelectQuery_whenUnionOfSegmentsAreUsed()
     {
         $select = 'log_visit.*';
@@ -455,12 +620,15 @@ class SegmentTest extends IntegrationTestCase
         $segment = 'actionUrl=@myTestUrl';
         $segment = new Segment($segment, $idSites = array());
 
+        $logVisitTable = Common::prefixTable('log_visit');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+
         $query = $segment->getSelectQuery($select, $from, $where, $bind);
 
         $expected = array(
             "sql"  => " SELECT log_inner.* FROM (
-                          SELECT log_visit.* FROM log_visit AS log_visit
-                          LEFT JOIN log_link_visit_action AS log_link_visit_action
+                          SELECT log_visit.* FROM $logVisitTable AS log_visit
+                          LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action
                             ON log_link_visit_action.idvisit = log_visit.idvisit
                           WHERE (( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 1 )) )
                                 OR ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 3 )) )
@@ -471,7 +639,7 @@ class SegmentTest extends IntegrationTestCase
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
 
-    public function test_getSelectQuery_whenJoinConversionOnAction_segmentUsesPageUrl()
+    public function test_getSelectQuery_whenJoinConversionOnLogLinkVisitAction_segmentUsesPageUrl()
     {
         $this->insertPageUrlAsAction('example.com/anypage');
         $this->insertPageUrlAsAction('example.com/anypage_bis');

--- a/tests/PHPUnit/System/TwoVisitsWithCustomVariablesSegmentMatchNONETest.php
+++ b/tests/PHPUnit/System/TwoVisitsWithCustomVariablesSegmentMatchNONETest.php
@@ -64,6 +64,9 @@ class TwoVisitsWithCustomVariablesSegmentMatchNONETest extends SystemTestCase
             if ($segment == 'visitEcommerceStatus') {
                 $value = 'none';
             }
+            if ($segment == 'actionType') {
+                $value = 'pageviews';
+            }
             $matchNone = $segment . '!=' . $value;
 
             // deviceType != campaign matches ALL visits, but we want to match None

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionType__API.getSuggestedValuesForSegment.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionType__API.getSuggestedValuesForSegment.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>pageviews</row>
+	<row>contents</row>
+	<row>sitesearches</row>
+	<row>events</row>
+	<row>outlinks</row>
+	<row>downloads</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionType__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionType__VisitsSummary.get_range.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_visits>35</nb_visits>
+	<nb_actions>95</nb_actions>
+	<nb_visits_converted>35</nb_visits_converted>
+	<bounce_count>18</bounce_count>
+	<sum_visit_length>27557</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>51%</bounce_rate>
+	<nb_actions_per_visit>2.7</nb_actions_per_visit>
+	<avg_time_on_site>787</avg_time_on_site>
+</result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_day.xml
@@ -9,7 +9,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>21</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -114,7 +114,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>20</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -219,7 +219,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>16</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -233,7 +233,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>17</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -247,7 +247,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>19</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -261,7 +261,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>22</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -290,7 +290,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/finishedMovie</url>
-				<pageIdAction>23</pageIdAction>
+				<pageIdAction>25</pageIdAction>
 				
 				<pageId>24</pageId>
 				<eventCategory>event category Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long ---&gt; SHOULD APPEAR IN TEST OUTPUT NOT TRUNCATED &lt;---</eventCategory>
@@ -397,7 +397,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>18</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -526,7 +526,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>2</pageId>
 				<eventCategory>Music</eventCategory>
@@ -546,7 +546,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>3</pageId>
 				<eventCategory>Music</eventCategory>
@@ -566,7 +566,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>4</pageId>
 				<eventCategory>Music</eventCategory>
@@ -586,7 +586,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>5</pageId>
 				<eventCategory>Music</eventCategory>
@@ -606,7 +606,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>6</pageId>
 				<eventCategory>Music</eventCategory>
@@ -626,7 +626,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>7</pageId>
 				<eventCategory>Music</eventCategory>
@@ -647,7 +647,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>8</pageId>
 				<eventCategory>Music</eventCategory>
@@ -669,7 +669,7 @@
 				<type>action</type>
 				<url>http://example.org/movies</url>
 				<pageTitle>Movie Theater</pageTitle>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>13</pageIdAction>
 				
 				<pageId>9</pageId>
 				<generationTime>0.67s</generationTime>
@@ -681,7 +681,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>10</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -695,7 +695,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>11</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -709,7 +709,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>12</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -723,7 +723,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>13</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -737,7 +737,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>14</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -751,7 +751,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>15</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -857,7 +857,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>45</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -958,7 +958,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>44</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1059,7 +1059,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>40</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1073,7 +1073,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>41</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1087,7 +1087,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>43</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1101,7 +1101,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>46</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1130,7 +1130,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/finishedMovie</url>
-				<pageIdAction>23</pageIdAction>
+				<pageIdAction>25</pageIdAction>
 				
 				<pageId>48</pageId>
 				<eventCategory>event category Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long ---&gt; SHOULD APPEAR IN TEST OUTPUT NOT TRUNCATED &lt;---</eventCategory>
@@ -1233,7 +1233,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>42</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1358,7 +1358,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>26</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1378,7 +1378,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>27</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1398,7 +1398,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>28</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1418,7 +1418,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>29</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1438,7 +1438,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>30</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1458,7 +1458,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>31</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1479,7 +1479,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>32</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1501,7 +1501,7 @@
 				<type>action</type>
 				<url>http://example.org/movies</url>
 				<pageTitle>Movie Theater</pageTitle>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>13</pageIdAction>
 				
 				<pageId>33</pageId>
 				<generationTime>0.67s</generationTime>
@@ -1513,7 +1513,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>34</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1527,7 +1527,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>35</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1541,7 +1541,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>36</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1555,7 +1555,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>37</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1569,7 +1569,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>38</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1583,7 +1583,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>39</pageId>
 				<eventCategory>Movie</eventCategory>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_month.xml
@@ -9,7 +9,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>21</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -114,7 +114,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>20</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -219,7 +219,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>16</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -233,7 +233,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>17</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -247,7 +247,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>19</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -261,7 +261,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>22</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -290,7 +290,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/finishedMovie</url>
-				<pageIdAction>23</pageIdAction>
+				<pageIdAction>25</pageIdAction>
 				
 				<pageId>24</pageId>
 				<eventCategory>event category Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long ---&gt; SHOULD APPEAR IN TEST OUTPUT NOT TRUNCATED &lt;---</eventCategory>
@@ -397,7 +397,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>18</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -526,7 +526,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>2</pageId>
 				<eventCategory>Music</eventCategory>
@@ -546,7 +546,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>3</pageId>
 				<eventCategory>Music</eventCategory>
@@ -566,7 +566,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>4</pageId>
 				<eventCategory>Music</eventCategory>
@@ -586,7 +586,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>5</pageId>
 				<eventCategory>Music</eventCategory>
@@ -606,7 +606,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>6</pageId>
 				<eventCategory>Music</eventCategory>
@@ -626,7 +626,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>7</pageId>
 				<eventCategory>Music</eventCategory>
@@ -647,7 +647,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>8</pageId>
 				<eventCategory>Music</eventCategory>
@@ -669,7 +669,7 @@
 				<type>action</type>
 				<url>http://example.org/movies</url>
 				<pageTitle>Movie Theater</pageTitle>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>13</pageIdAction>
 				
 				<pageId>9</pageId>
 				<generationTime>0.67s</generationTime>
@@ -681,7 +681,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>10</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -695,7 +695,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>11</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -709,7 +709,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>12</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -723,7 +723,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>13</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -737,7 +737,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>14</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -751,7 +751,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>15</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -857,7 +857,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>45</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -958,7 +958,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>44</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1059,7 +1059,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>40</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1073,7 +1073,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>41</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1087,7 +1087,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>43</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1101,7 +1101,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>46</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1130,7 +1130,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/finishedMovie</url>
-				<pageIdAction>23</pageIdAction>
+				<pageIdAction>25</pageIdAction>
 				
 				<pageId>48</pageId>
 				<eventCategory>event category Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long Extremely long ---&gt; SHOULD APPEAR IN TEST OUTPUT NOT TRUNCATED &lt;---</eventCategory>
@@ -1233,7 +1233,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>42</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1358,7 +1358,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>26</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1378,7 +1378,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>27</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1398,7 +1398,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>28</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1418,7 +1418,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>29</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1438,7 +1438,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>30</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1458,7 +1458,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>31</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1479,7 +1479,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/webradio</url>
-				<pageIdAction>2</pageIdAction>
+				<pageIdAction>3</pageIdAction>
 				
 				<pageId>32</pageId>
 				<eventCategory>Music</eventCategory>
@@ -1501,7 +1501,7 @@
 				<type>action</type>
 				<url>http://example.org/movies</url>
 				<pageTitle>Movie Theater</pageTitle>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>13</pageIdAction>
 				
 				<pageId>33</pageId>
 				<generationTime>0.67s</generationTime>
@@ -1513,7 +1513,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>34</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1527,7 +1527,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>35</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1541,7 +1541,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>36</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1555,7 +1555,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>37</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1569,7 +1569,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>38</pageId>
 				<eventCategory>Movie</eventCategory>
@@ -1583,7 +1583,7 @@
 			<row>
 				<type>event</type>
 				<url>http://example.org/movies</url>
-				<pageIdAction>12</pageIdAction>
+				<pageIdAction>14</pageIdAction>
 				
 				<pageId>39</pageId>
 				<eventCategory>Movie</eventCategory>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_offsetAndLimit_1__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_offsetAndLimit_1__Live.getLastVisitsDetails_month.xml
@@ -62,7 +62,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file8.zip</url>
 				<pageTitle />
-				<pageIdAction>46</pageIdAction>
+				<pageIdAction>47</pageIdAction>
 				
 				<pageId>48</pageId>
 				<timeSpent>180</timeSpent>
@@ -74,7 +74,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/8.html</url>
 				<pageTitle />
-				<pageIdAction>47</pageIdAction>
+				<pageIdAction>48</pageIdAction>
 				
 				<pageId>49</pageId>
 				<timeSpent>180</timeSpent>
@@ -85,7 +85,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>50</pageId>
 				<eventCategory>Cat8</eventCategory>
@@ -360,7 +360,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file7.zip</url>
 				<pageTitle />
-				<pageIdAction>41</pageIdAction>
+				<pageIdAction>42</pageIdAction>
 				
 				<pageId>42</pageId>
 				<timeSpent>180</timeSpent>
@@ -372,7 +372,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/7.html</url>
 				<pageTitle />
-				<pageIdAction>42</pageIdAction>
+				<pageIdAction>43</pageIdAction>
 				
 				<pageId>43</pageId>
 				<timeSpent>180</timeSpent>
@@ -383,7 +383,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>44</pageId>
 				<eventCategory>Cat7</eventCategory>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_offsetAndLimit_2__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_offsetAndLimit_2__Live.getLastVisitsDetails_month.xml
@@ -191,7 +191,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file6.zip</url>
 				<pageTitle />
-				<pageIdAction>36</pageIdAction>
+				<pageIdAction>37</pageIdAction>
 				
 				<pageId>37</pageId>
 				<timeSpent>180</timeSpent>
@@ -203,7 +203,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/6.html</url>
 				<pageTitle />
-				<pageIdAction>37</pageIdAction>
+				<pageIdAction>38</pageIdAction>
 				
 				<pageId>38</pageId>
 				<timeSpent>180</timeSpent>
@@ -214,7 +214,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>39</pageId>
 				<eventCategory>Cat6</eventCategory>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_sortByIdVisit__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_sortByIdVisit__Live.getLastVisitsDetails_month.xml
@@ -173,7 +173,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file8.zip</url>
 				<pageTitle />
-				<pageIdAction>46</pageIdAction>
+				<pageIdAction>47</pageIdAction>
 				
 				<pageId>48</pageId>
 				<timeSpent>180</timeSpent>
@@ -185,7 +185,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/8.html</url>
 				<pageTitle />
-				<pageIdAction>47</pageIdAction>
+				<pageIdAction>48</pageIdAction>
 				
 				<pageId>49</pageId>
 				<timeSpent>180</timeSpent>
@@ -196,7 +196,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>50</pageId>
 				<eventCategory>Cat8</eventCategory>
@@ -471,7 +471,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file7.zip</url>
 				<pageTitle />
-				<pageIdAction>41</pageIdAction>
+				<pageIdAction>42</pageIdAction>
 				
 				<pageId>42</pageId>
 				<timeSpent>180</timeSpent>
@@ -483,7 +483,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/7.html</url>
 				<pageTitle />
-				<pageIdAction>42</pageIdAction>
+				<pageIdAction>43</pageIdAction>
 				
 				<pageId>43</pageId>
 				<timeSpent>180</timeSpent>
@@ -494,7 +494,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>44</pageId>
 				<eventCategory>Cat7</eventCategory>
@@ -787,7 +787,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file6.zip</url>
 				<pageTitle />
-				<pageIdAction>36</pageIdAction>
+				<pageIdAction>37</pageIdAction>
 				
 				<pageId>37</pageId>
 				<timeSpent>180</timeSpent>
@@ -799,7 +799,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/6.html</url>
 				<pageTitle />
-				<pageIdAction>37</pageIdAction>
+				<pageIdAction>38</pageIdAction>
 				
 				<pageId>38</pageId>
 				<timeSpent>180</timeSpent>
@@ -810,7 +810,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>39</pageId>
 				<eventCategory>Cat6</eventCategory>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_sortDesc__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_sortDesc__Live.getLastVisitsDetails_month.xml
@@ -173,7 +173,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file8.zip</url>
 				<pageTitle />
-				<pageIdAction>46</pageIdAction>
+				<pageIdAction>47</pageIdAction>
 				
 				<pageId>48</pageId>
 				<timeSpent>180</timeSpent>
@@ -185,7 +185,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/8.html</url>
 				<pageTitle />
-				<pageIdAction>47</pageIdAction>
+				<pageIdAction>48</pageIdAction>
 				
 				<pageId>49</pageId>
 				<timeSpent>180</timeSpent>
@@ -196,7 +196,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>50</pageId>
 				<eventCategory>Cat8</eventCategory>
@@ -471,7 +471,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file7.zip</url>
 				<pageTitle />
-				<pageIdAction>41</pageIdAction>
+				<pageIdAction>42</pageIdAction>
 				
 				<pageId>42</pageId>
 				<timeSpent>180</timeSpent>
@@ -483,7 +483,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/7.html</url>
 				<pageTitle />
-				<pageIdAction>42</pageIdAction>
+				<pageIdAction>43</pageIdAction>
 				
 				<pageId>43</pageId>
 				<timeSpent>180</timeSpent>
@@ -494,7 +494,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>44</pageId>
 				<eventCategory>Cat7</eventCategory>
@@ -787,7 +787,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file6.zip</url>
 				<pageTitle />
-				<pageIdAction>36</pageIdAction>
+				<pageIdAction>37</pageIdAction>
 				
 				<pageId>37</pageId>
 				<timeSpent>180</timeSpent>
@@ -799,7 +799,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/6.html</url>
 				<pageTitle />
-				<pageIdAction>37</pageIdAction>
+				<pageIdAction>38</pageIdAction>
 				
 				<pageId>38</pageId>
 				<timeSpent>180</timeSpent>
@@ -810,7 +810,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>39</pageId>
 				<eventCategory>Cat6</eventCategory>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest__Live.getLastVisitsDetails_month.xml
@@ -173,7 +173,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file8.zip</url>
 				<pageTitle />
-				<pageIdAction>46</pageIdAction>
+				<pageIdAction>47</pageIdAction>
 				
 				<pageId>48</pageId>
 				<timeSpent>180</timeSpent>
@@ -185,7 +185,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/8.html</url>
 				<pageTitle />
-				<pageIdAction>47</pageIdAction>
+				<pageIdAction>48</pageIdAction>
 				
 				<pageId>49</pageId>
 				<timeSpent>180</timeSpent>
@@ -196,7 +196,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>50</pageId>
 				<eventCategory>Cat8</eventCategory>
@@ -471,7 +471,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file7.zip</url>
 				<pageTitle />
-				<pageIdAction>41</pageIdAction>
+				<pageIdAction>42</pageIdAction>
 				
 				<pageId>42</pageId>
 				<timeSpent>180</timeSpent>
@@ -483,7 +483,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/7.html</url>
 				<pageTitle />
-				<pageIdAction>42</pageIdAction>
+				<pageIdAction>43</pageIdAction>
 				
 				<pageId>43</pageId>
 				<timeSpent>180</timeSpent>
@@ -494,7 +494,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>44</pageId>
 				<eventCategory>Cat7</eventCategory>
@@ -787,7 +787,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file6.zip</url>
 				<pageTitle />
-				<pageIdAction>36</pageIdAction>
+				<pageIdAction>37</pageIdAction>
 				
 				<pageId>37</pageId>
 				<timeSpent>180</timeSpent>
@@ -799,7 +799,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/6.html</url>
 				<pageTitle />
-				<pageIdAction>37</pageIdAction>
+				<pageIdAction>38</pageIdAction>
 				
 				<pageId>38</pageId>
 				<timeSpent>180</timeSpent>
@@ -810,7 +810,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>39</pageId>
 				<eventCategory>Cat6</eventCategory>
@@ -1085,7 +1085,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file5.zip</url>
 				<pageTitle />
-				<pageIdAction>31</pageIdAction>
+				<pageIdAction>32</pageIdAction>
 				
 				<pageId>31</pageId>
 				<timeSpent>180</timeSpent>
@@ -1097,7 +1097,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/5.html</url>
 				<pageTitle />
-				<pageIdAction>32</pageIdAction>
+				<pageIdAction>33</pageIdAction>
 				
 				<pageId>32</pageId>
 				<timeSpent>180</timeSpent>
@@ -1108,7 +1108,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>33</pageId>
 				<eventCategory>Cat5</eventCategory>
@@ -1401,7 +1401,7 @@
 				<type>download</type>
 				<url>http://example.org/path/file4.zip</url>
 				<pageTitle />
-				<pageIdAction>26</pageIdAction>
+				<pageIdAction>27</pageIdAction>
 				
 				<pageId>26</pageId>
 				<timeSpent>180</timeSpent>
@@ -1413,7 +1413,7 @@
 				<type>outlink</type>
 				<url>http://example-outlink.org/4.html</url>
 				<pageTitle />
-				<pageIdAction>27</pageIdAction>
+				<pageIdAction>28</pageIdAction>
 				
 				<pageId>27</pageId>
 				<timeSpent>180</timeSpent>
@@ -1424,7 +1424,7 @@
 			<row>
 				<type>event</type>
 				<url>http://piwik.net/space/quest/iv</url>
-				<pageIdAction>4</pageIdAction>
+				<pageIdAction>8</pageIdAction>
 				
 				<pageId>28</pageId>
 				<eventCategory>Cat4</eventCategory>

--- a/tests/PHPUnit/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_day.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_day.xml
@@ -25,7 +25,7 @@
 		<loops>2</loops>
 		<pageviews>18</pageviews>
 		<entries>4</entries>
-		<exits>6</exits>
+		<exits>7</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>
@@ -38,7 +38,7 @@
 		</row>
 		<row>
 			<label>Others</label>
-			<referrals>4</referrals>
+			<referrals>3</referrals>
 		</row>
 	</followingPages>
 	<followingSiteSearches>

--- a/tests/PHPUnit/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_month.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions__Transitions.getTransitionsForPageUrl_month.xml
@@ -25,7 +25,7 @@
 		<loops>2</loops>
 		<pageviews>21</pageviews>
 		<entries>4</entries>
-		<exits>7</exits>
+		<exits>9</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>
@@ -38,7 +38,7 @@
 		</row>
 		<row>
 			<label>Others</label>
-			<referrals>5</referrals>
+			<referrals>3</referrals>
 		</row>
 	</followingPages>
 	<followingSiteSearches>

--- a/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_day.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_day.xml
@@ -25,7 +25,7 @@
 		<loops>2</loops>
 		<pageviews>18</pageviews>
 		<entries>4</entries>
-		<exits>6</exits>
+		<exits>7</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>
@@ -42,10 +42,6 @@
 		</row>
 		<row>
 			<label>example.org/page3.html</label>
-			<referrals>1</referrals>
-		</row>
-		<row>
-			<label>example.org/page/search.html</label>
 			<referrals>1</referrals>
 		</row>
 	</followingPages>

--- a/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_month.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions_noLimit__Transitions.getTransitionsForPageUrl_month.xml
@@ -25,7 +25,7 @@
 		<loops>2</loops>
 		<pageviews>21</pageviews>
 		<entries>4</entries>
-		<exits>7</exits>
+		<exits>9</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>
@@ -38,10 +38,6 @@
 		</row>
 		<row>
 			<label>example.org/the/third_page.html?foo=bar</label>
-			<referrals>2</referrals>
-		</row>
-		<row>
-			<label>example.org/page/search.html</label>
 			<referrals>2</referrals>
 		</row>
 		<row>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
@@ -59,6 +59,13 @@
 		<permission>1</permission>
 	</row>
 	<row>
+		<type>metric</type>
+		<category>Actions</category>
+		<name>Action Type</name>
+		<segment>actionType</segment>
+		<acceptedValues>A type of action, such as: pageviews, contents, sitesearches, events, outlinks, downloads</acceptedValues>
+	</row>
+	<row>
 		<type>dimension</type>
 		<category>Visit Location</category>
 		<name>City</name>


### PR DESCRIPTION
This PR defines a new segment ActionType. This is especially useful when for example viewing a CustomDimensions report in scope Action. By default custom dimensions are tracked across all actions. By using eg a segment `actionType=pageviews` one can see all custom dimensions tracked for pageviews. Or maybe someone wants to see all Custom Dimension values for downloads and outlinks etc. 

In order to make this work we had to change how event urls are tracked as the segment works on the SQL segment `log_action.type`. So far, when an event was tracked, we looked for a URL having the type `1` (Pageview) in `log_action`. To be actually able to segment for events we are now using type `10` in `log_action` when request was an event. Downside is we create many more entries in `log_action` for each URL used in an event tracking call.  On the good side we now have more accurate statistics in Transition reports where exit rate and referrer are calculated more correctly since they did not differentiate between events and a pageview.

We also identified at some point it might be useful to completely remove the `type` column from `log_action` table and instead store the type of the action in `log_link_visit_action`. This would help to avoid creating many duplicated entries in `log_action`.

Re failing tests:
- There is a failing test in CustomDimensions plugin. We need to fix that test once we actually merged it. Otherwise we'd have to fix this test in a branch in CustomDimension and later change the submodule back to master in CustomDimensions once this PR is merged 
- Some UI tests fail because the order of Segments failed. This is expected for now and not a problem
