### PR TITLE
Do not serialize Request::processRequest API request 

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -388,6 +388,7 @@ class Request
     {
         $params = array();
         $params['format'] = 'original';
+        $params['serialize'] = '0';
         $params['module'] = 'API';
         $params['method'] = $method;
         $params = $paramOverride + $params;

--- a/plugins/CustomVariables/API.php
+++ b/plugins/CustomVariables/API.php
@@ -142,7 +142,7 @@ class API extends \Piwik\Plugin\API
         $date = '2008-12-12,' . $today;
         $customVarUsages = Request::processRequest('CustomVariables.getCustomVariables',
             array('idSite' => $idSite, 'period' => 'range', 'date' => $date,
-                  'format' => 'original', 'serialize' => '0')
+                  'format' => 'original')
         );
 
         foreach ($customVarUsages->getRows() as $row) {

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -365,7 +365,6 @@ class API extends \Piwik\Plugin\API
                 'date'    => $date,
                 'idGoal'  => $idGoal,
                 'columns' => $columns,
-                'serialize' => '0',
                 'format_metrics' => 'bc'
             ));
 

--- a/plugins/MultiSites/API.php
+++ b/plugins/MultiSites/API.php
@@ -147,7 +147,6 @@ class API extends \Piwik\Plugin\API
                       'limit'       => SettingsPiwik::getWebsitesCountToDisplay(),
                       'showColumns' => '',
                       'hideColumns' => '',
-                      'serialize'   => 0,
                       'format'      => 'original'));
 
             if (!empty($sites)) {

--- a/plugins/Overlay/Controller.php
+++ b/plugins/Overlay/Controller.php
@@ -85,7 +85,6 @@ class Controller extends \Piwik\Plugin\Controller
             'label' => $label,
             'format' => 'original',
             'format_metrics' => 0,
-            'serialize' => '0'
         );
 
         if (!empty($segment)) {

--- a/plugins/VisitFrequency/API.php
+++ b/plugins/VisitFrequency/API.php
@@ -45,7 +45,6 @@ class API extends \Piwik\Plugin\API
             'segment'   => $segment,
             'columns'   => implode(',', $columns),
             'format'    => 'original',
-            'serialize' => 0, // tests set this to 1
             'format_metrics' => 0
         );
 

--- a/tests/PHPUnit/Integration/ReportTest.php
+++ b/tests/PHPUnit/Integration/ReportTest.php
@@ -474,7 +474,8 @@ class ReportTest extends IntegrationTestCase
                 'format' => 'original',
                 'module' => 'API',
                 'method' => 'ExampleReport.getExampleReport',
-                'format_metrics' => 'bc'
+                'format_metrics' => 'bc',
+                'serialize' => '0'
             )
         )->willReturn("result");
         Proxy::setSingletonInstance($proxyMock);
@@ -497,7 +498,8 @@ class ReportTest extends IntegrationTestCase
                 'format' => 'original',
                 'module' => 'API',
                 'method' => 'Referrers.getSearchEnginesFromKeywordId',
-                'format_metrics' => 'bc'
+                'format_metrics' => 'bc',
+                'serialize' => '0'
             )
         )->willReturn("result");
         Proxy::setSingletonInstance($proxyMock);


### PR DESCRIPTION
Otherwise when serialize=1 is set on any URL for controller or API it will fail as it would return the serialized string instead of an expected `array` or `DataTable`. In the past we always had to set it manually when using `Request::processRequest` as all GET + POST params of the initial request are forwarded to this by default. It was not clear that someone had to set `serialize=0` each time one does a `Request::processRequest`.
