### PR TITLE
Show selected/current website in websites selector

### DIFF
--- a/plugins/CoreHome/templates/_siteSelectHeader.twig
+++ b/plugins/CoreHome/templates/_siteSelectHeader.twig
@@ -1,3 +1,3 @@
 <div class="top_bar_sites_selector piwikTopControl">
-    <div piwik-siteselector class="sites_autocomplete"></div>
+    <div piwik-siteselector show-selected-site="true" class="sites_autocomplete"></div>
 </div>

--- a/plugins/CustomVariables/templates/manage.twig
+++ b/plugins/CustomVariables/templates/manage.twig
@@ -2,7 +2,7 @@
 
 {% block topcontrols %}
     <div class="top_bar_sites_selector piwikTopControl">
-        <div piwik-siteselector class="sites_autocomplete"></div>
+        <div piwik-siteselector show-selected-site="true" class="sites_autocomplete"></div>
     </div>
 {% endblock %}
 

--- a/plugins/UsersManager/templates/index.twig
+++ b/plugins/UsersManager/templates/index.twig
@@ -15,6 +15,7 @@
         {% endset %}
 
         <div piwik-siteselector
+             show-selected-site="true"
              class="sites_autocomplete"
              siteid="{{ idSiteSelected }}"
              sitename="{{ defaultReportSiteName }}"

--- a/plugins/UsersManager/templates/userSettings.twig
+++ b/plugins/UsersManager/templates/userSettings.twig
@@ -65,6 +65,7 @@
             {{ 'General_DashboardForASpecificWebsite'|translate }}
         </label>
         <div piwik-siteselector
+             show-selected-site="true"
              class="sites_autocomplete"
              siteid="{{ defaultReportIdSite }}"
              sitename="{{ defaultReportSiteName }}"


### PR DESCRIPTION
fixes #9025

There were several ways to implement this. Eg change `showSelectedSite` to `true` by default in the selector or to remove this setting but I did not want to break any API so changing it in several places instead.
