### PR TITLE
askForDeleteConfirmation with --no-interaction should default to true

### DIFF
--- a/plugins/CoreAdminHome/Commands/DeleteLogsData.php
+++ b/plugins/CoreAdminHome/Commands/DeleteLogsData.php
@@ -168,6 +168,10 @@ class DeleteLogsData extends ConsoleCommand
 
     private function askForDeleteConfirmation(InputInterface $input, OutputInterface $output)
     {
+        if ($input->getOption('no-interaction')) {
+            return true;
+        }
+
         $helper   = $this->getHelper('question');
         $question = new ConfirmationQuestion('<comment>You are about to delete log data. This action cannot be undone, are you sure you want to continue? (Y/N)</comment> ', false);
 


### PR DESCRIPTION
When using option --no-interaction, askForDeleteConfirmation should default to true
Fixes #9316
