### PR TITLE
show tooltip for longer titles in popovers

### DIFF
--- a/plugins/CoreHome/javascripts/popover.js
+++ b/plugins/CoreHome/javascripts/popover.js
@@ -142,7 +142,17 @@ var Piwik_Popover = (function () {
 
         /** Set the title of the popover */
         setTitle: function (titleHtml) {
+            var titleText = $('<div>' + titleHtml + '</div>').text();
+            if (titleText.length > 60) {
+                titleHtml = $('<span>').attr('class', 'tooltip').attr('title', titleText).html(titleHtml);
+            }
             container.dialog('option', 'title', titleHtml);
+            try {
+                $('.tooltip', container.parentNode).tooltip('destroy');
+            } catch (e) {}
+            if (titleText.length > 60) {
+                $('.tooltip', container.parentNode).tooltip({track: true, items: '.tooltip'});
+            }
         },
 
         /** Set inner HTML of the popover */

--- a/plugins/CoreHome/javascripts/popover.js
+++ b/plugins/CoreHome/javascripts/popover.js
@@ -142,7 +142,7 @@ var Piwik_Popover = (function () {
 
         /** Set the title of the popover */
         setTitle: function (titleHtml) {
-            var titleText = $('<div>' + titleHtml + '</div>').text();
+            var titleText = piwikHelper.htmlDecode(titleHtml);
             if (titleText.length > 60) {
                 titleHtml = $('<span>').attr('class', 'tooltip').attr('title', titleText).html(titleHtml);
             }


### PR DESCRIPTION
This "hack" will show tooltips for titles in popovers that are longer than 60 chars

fixes #9266
