### PR TITLE
Fix exit page url was not correct when last action was a download or outlink

### DIFF
--- a/core/Tracker/Action.php
+++ b/core/Tracker/Action.php
@@ -248,12 +248,12 @@ abstract class Action
 
     public function getIdActionUrlForEntryAndExitIds()
     {
-        return $this->getIdActionUrl();
+        return false;
     }
 
     public function getIdActionNameForEntryAndExitIds()
     {
-        return $this->getIdActionName();
+        return false;
     }
 
     public function getIdActionName()

--- a/core/Tracker/ActionPageview.php
+++ b/core/Tracker/ActionPageview.php
@@ -51,6 +51,16 @@ class ActionPageview extends Action
         return true;
     }
 
+    public function getIdActionUrlForEntryAndExitIds()
+    {
+        return $this->getIdActionUrl();
+    }
+
+    public function getIdActionNameForEntryAndExitIds()
+    {
+        return $this->getIdActionName();
+    }
+
     private function cleanupActionName($actionName)
     {
         // get the delimiter, by default '/'; BC, we read the old action_category_delimiter first (see #1067)

--- a/plugins/Actions/Columns/VisitTotalActions.php
+++ b/plugins/Actions/Columns/VisitTotalActions.php
@@ -79,8 +79,9 @@ class VisitTotalActions extends VisitDimension
         }
 
         $actionType = $action->getActionType();
+        $types = array(Action::TYPE_SITE_SEARCH, Action::TYPE_EVENT, Action::TYPE_OUTLINK, Action::TYPE_DOWNLOAD);
 
-        if (in_array($actionType, array(Action::TYPE_SITE_SEARCH, Action::TYPE_EVENT))) {
+        if (in_array($actionType, $types)) {
             return $increment;
         }
 

--- a/plugins/Contents/Actions/ActionContent.php
+++ b/plugins/Contents/Actions/ActionContent.php
@@ -40,15 +40,4 @@ class ActionContent extends Action
         );
     }
 
-    // Do not track this Event URL as Entry/Exit Page URL (leave the existing entry/exit)
-    public function getIdActionUrlForEntryAndExitIds()
-    {
-        return false;
-    }
-
-    // Do not track this Event Name as Entry/Exit Page Title (leave the existing entry/exit)
-    public function getIdActionNameForEntryAndExitIds()
-    {
-        return false;
-    }
 }

--- a/plugins/Events/Actions/ActionEvent.php
+++ b/plugins/Events/Actions/ActionEvent.php
@@ -73,18 +73,6 @@ class ActionEvent extends Action
         return array('idaction_url' => $actionUrl);
     }
 
-    // Do not track this Event URL as Entry/Exit Page URL (leave the existing entry/exit)
-    public function getIdActionUrlForEntryAndExitIds()
-    {
-        return false;
-    }
-
-    // Do not track this Event Name as Entry/Exit Page Title (leave the existing entry/exit)
-    public function getIdActionNameForEntryAndExitIds()
-    {
-        return false;
-    }
-
     public function writeDebugInfo()
     {
         $write = parent::writeDebugInfo();


### PR DESCRIPTION
Use case:
- A user is on page 'example.com/foo/bar'.
- User clicks on outlink 'example.org/outlink'

So far Piwik has stored a `visit_exit_idaction_url=example.org/outlink` with type id `2` (for outlink). The exit page should be still `example.com/foo/bar` though.  

Same for downloads. If last action was an outlink or download we did not count an exit for the actual last page.

FYI: The page title was tracked correctly but not the page url

On hold as it requires DB schema changes see #9345 
