### PR TITLE
When detecting the referrer name, consider a path of a different website if possible and not only domain

### DIFF
--- a/plugins/Referrers/tests/Integration/Columns/ReferrerNameTest.php
+++ b/plugins/Referrers/tests/Integration/Columns/ReferrerNameTest.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\Referrers\tests\Integration\Columns;
 
 use Piwik\Common;
+use Piwik\Plugins\Referrers\Columns\ReferrerName;
 use Piwik\Plugins\Referrers\Columns\ReferrerType;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -19,16 +20,16 @@ use Piwik\Tracker\Visitor;
 
 /**
  * @group Referrers
- * @group ReferrerTypeTest
- * @group ReferrerType
+ * @group ReferrerNameTest
+ * @group ReferrerName
  * @group Plugins
  */
-class ReferrerTypeTest extends IntegrationTestCase
+class ReferrerNameTest extends IntegrationTestCase
 {
     /**
      * @var ReferrerType
      */
-    private $referrerType;
+    private $referrerName;
     private $idSite1 = 1;
     private $idSite2 = 2;
     private $idSite3 = 3;
@@ -46,7 +47,7 @@ class ReferrerTypeTest extends IntegrationTestCase
         Fixture::createWebsite($date, $ecommerce, $name = 'test2', $url = 'http://piwik.org/');
         Fixture::createWebsite($date, $ecommerce, $name = 'test3', $url = 'http://piwik.pro/');
 
-        $this->referrerType = new ReferrerType();
+        $this->referrerName = new ReferrerName();
     }
 
     public function tearDown()
@@ -63,7 +64,7 @@ class ReferrerTypeTest extends IntegrationTestCase
     public function test_onNewVisit_shouldDetectCorrectReferrerType($expectedType, $idSite, $url, $referrerUrl)
     {
         $request = $this->getRequest(array('idsite' => $idSite, 'url' => $url, 'urlref' => $referrerUrl));
-        $type = $this->referrerType->onNewVisit($request, $this->getNewVisitor(), $action = null);
+        $type = $this->referrerName->onNewVisit($request, $this->getNewVisitor(), $action = null);
 
         $this->assertSame($expectedType, $type);
     }
@@ -73,45 +74,46 @@ class ReferrerTypeTest extends IntegrationTestCase
         $url = 'http://piwik.org/foo/bar';
         $referrer = 'http://piwik.org';
 
-        // $expectedType,                             $idSite,        $url, $referrerUrl
+        $directEntryReferrerName = '';
+
         return array(
             // domain matches but path does not match for idsite1
-            array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite1, $url, $referrer),
-            array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite1, $url, $referrer . '/'),
+            array('piwik.org',              $this->idSite1, $url, $referrer),
+            array('piwik.org',              $this->idSite1, $url, $referrer . '/'),
             // idSite2 matches any piwik.org path so this is a direct entry for it
-            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite2, $url, $referrer),
-            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite2, $url, $referrer . '/'),
+            array($directEntryReferrerName, $this->idSite2, $url, $referrer),
+            array($directEntryReferrerName, $this->idSite2, $url, $referrer . '/'),
             // idSite3 has different domain so it is coming from different website
-            array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite3, $url, $referrer),
-            array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite3, $url, $referrer . '/'),
+            array('piwik.org',              $this->idSite3, $url, $referrer),
+            array('piwik.org',              $this->idSite3, $url, $referrer . '/'),
 
-            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite1, $url, $referrer . '/foo/bar/baz'),
-            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite1, $url, $referrer . '/foo/bar/baz/'),
-            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite1, $url, $referrer . '/foo/bar/baz?x=5'),
+            array($directEntryReferrerName, $this->idSite1, $url, $referrer . '/foo/bar/baz'),
+            array($directEntryReferrerName, $this->idSite1, $url, $referrer . '/foo/bar/baz/'),
+            array($directEntryReferrerName, $this->idSite1, $url, $referrer . '/foo/bar/baz?x=5'),
+            array($directEntryReferrerName, $this->idSite1, $url, $referrer . '/fOo/BaR/baz?x=5'),
             // /not/xyz belongs to different website
-            array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite1, $url, $referrer . '/not/xyz'),
-            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite2, $url, $referrer . '/not/xyz'),
+            array('piwik.org',              $this->idSite1, $url, $referrer . '/not/xyz'),
+            array($directEntryReferrerName, $this->idSite2, $url, $referrer . '/not/xyz'),
 
             // /foo/bar/baz belongs to different website
-            array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite2, $url, $referrer . '/foo/bar/baz'),
-
-            // website as it is from different domain anyway
-            array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite3, $url, $referrer . '/foo/bar/baz'),
+            array('piwik.org/foo/bar',      $this->idSite2, $url, $referrer . '/foo/bar/baz'),
+            array('piwik.org/foo/bar',      $this->idSite3, $url, $referrer . '/foo/bar'),
+            array('piwik.org/foo/bar',      $this->idSite3, $url, $referrer . '/fOo/BaR'),
 
             // should detect campaign independent of domain / path
-            array(Common::REFERRER_TYPE_CAMPAIGN,     $this->idSite1, $url . '?pk_campaign=test', $referrer),
-            array(Common::REFERRER_TYPE_CAMPAIGN,     $this->idSite2, $url . '?pk_campaign=test', $referrer),
-            array(Common::REFERRER_TYPE_CAMPAIGN,     $this->idSite3, $url . '?pk_campaign=test', $referrer),
+            array('test',                   $this->idSite1, $url . '?pk_campaign=test', $referrer),
+            array('testfoobar',             $this->idSite2, $url . '?pk_campaign=testfoobar', $referrer),
+            array('test',                   $this->idSite3, $url . '?pk_campaign=test', $referrer),
 
-            array(Common::REFERRER_TYPE_SEARCH_ENGINE, $this->idSite3, $url, 'http://google.com/search?q=piwik'),
+            array('Google',                 $this->idSite3, $url, 'http://google.com/search?q=piwik'),
 
             // testing case for backwards compatibility where url has same domain as urlref but the domain is not known to any website
-            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite3, 'http://example.com/foo', 'http://example.com/bar'),
-            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite3, 'http://example.com/foo', 'http://example.com'),
-            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite3, 'http://example.com', 'http://example.com/bar'),
+            array($directEntryReferrerName, $this->idSite3, 'http://example.com/foo', 'http://example.com/bar'),
+            array($directEntryReferrerName, $this->idSite3, 'http://example.com/foo', 'http://example.com'),
+            array($directEntryReferrerName, $this->idSite3, 'http://example.com',     'http://example.com/bar'),
 
             // testing case where domain of referrer is not known to any site but neither is the URL, url != urlref
-            array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite3, 'http://example.org', 'http://example.com/bar'),
+            array('example.com',            $this->idSite3, 'http://example.org',     'http://example.com/bar'),
         );
     }
 

--- a/plugins/SitesManager/SiteUrls.php
+++ b/plugins/SitesManager/SiteUrls.php
@@ -110,6 +110,27 @@ class SiteUrls
         return $matchingSites;
     }
 
+    public function getPathMatchingUrl($parsedUrl, $urlsGroupedByHost)
+    {
+        if (empty($parsedUrl['host'])) {
+            return null;
+        }
+
+        $urlHost = $this->toCanonicalHost($parsedUrl['host']);
+        $urlPath = $this->getCanonicalPathFromParsedUrl($parsedUrl);
+
+        $matchingSites = null;
+        if (isset($urlsGroupedByHost[$urlHost])) {
+            $paths = $urlsGroupedByHost[$urlHost];
+
+            foreach ($paths as $path => $idSites) {
+                if (0 === strpos($urlPath, $path)) {
+                    return $path;
+                }
+            }
+        }
+    }
+
     public function getAllCachedSiteUrls()
     {
         $cache    = $this->getCache();

--- a/plugins/SitesManager/tests/Integration/SiteUrlsTest.php
+++ b/plugins/SitesManager/tests/Integration/SiteUrlsTest.php
@@ -243,6 +243,52 @@ class SiteUrlsTest extends IntegrationTestCase
         );
     }
 
+    /**
+     * @dataProvider getTestPathMatchingUrl
+     */
+    public function test_getPathMatchingUrl($expectedMatchSites, $parsedUrl)
+    {
+        $urlsGroupedByHost = array(
+            'apache.piwik' => array(
+                '/foo/second/' => array(2),
+                '/foo/sec/' => array(4),
+                '/foo/bar/' => array(1),
+                '/third/' => array(3),
+                '/test/' => array(1, 2),
+                '/' => array(1, 3)
+            ),
+            'example.org' => array(
+                '/foo/test/two/' => array(3),
+                '/foo/second/' => array(6),
+                '/' => array(2, 5)
+            ),
+        );
+        $matchedSites = $this->siteUrls->getPathMatchingUrl($parsedUrl, $urlsGroupedByHost);
+
+        $this->assertSame($expectedMatchSites, $matchedSites);
+    }
+
+    public function getTestPathMatchingUrl()
+    {
+        return array(
+            array('/', array('host' => 'apache.piwik')),
+            array('/', array('host' => 'apache.piwik', 'path' => '/')),
+            array('/', array('host' => 'apache.piwik', 'path' => '')),
+            array(null, array('host' => 'test.piwik')),
+            array(null, array('host' => 'test.apache.piwik')), // we do not match subdomains, only exact domain match
+
+            array('/foo/bar/', array('host' => 'apache.piwik', 'path' => '/foo/bar')),
+            array('/foo/bar/', array('host' => 'apache.piwik', 'path' => '/foo/bar/')),
+            array('/foo/bar/', array('host' => 'apache.piwik', 'path' => '/foo/bar/baz/')),
+            array('/', array('host' => 'apache.piwik', 'path' => '/foo/baz/bar/')),
+            array('/third/', array('host' => 'apache.piwik', 'path' => '/third/bar/baz/')),
+
+            array('/foo/second/', array('host' => 'example.org', 'path' => '/foo/second/')),
+            array('/', array('host' => 'example.org', 'path' => '/foo/secon')),
+            array(null, array('host' => 'example.pro', 'path' => '/foo/second/')),
+        );
+    }
+
     private function assertSiteUrls($expectedUrls)
     {
         $urls = $this->siteUrls->getAllSiteUrls();


### PR DESCRIPTION
refs #9320 

Use case:
- Eg Configured website URL for idSite 2 is 'http://example.com/subsite1', website URL for idSite 1 is 'http://example.org'
- User navigates from 'http://example.com/subsite1/about' to `http://example.org`. 

In the past we would have used `example.com` as website referrer, but the correct website referrer in this case is actually `example.com/subsite1` see  eg

![image](https://cloud.githubusercontent.com/assets/273120/11616349/50fc75b8-9cdd-11e5-953b-b3843b3a37cc.png)

![image](https://cloud.githubusercontent.com/assets/273120/11616360/8595245a-9cdd-11e5-9029-d149afea0695.png)

In the subtable I decided to still show the full path of the URL to make sure row evolution, click to external URL etc works. For a while I was thinking to show `/` instead of `freehtml5` in the subtable but think this would be actually not right. Not sure though.
