### PR TITLE
Checkout Git submodules after composer install (closes #9349)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,8 @@
             "Piwik\\Composer\\ScriptHandler::buildXhprof"
         ],
         "post-install-cmd": [
-            "Piwik\\Composer\\ScriptHandler::buildXhprof"
+            "Piwik\\Composer\\ScriptHandler::buildXhprof",
+            "which git > /dev/null && git submodule update --init --recursive || echo 'Please install git or manually install `libs/PiwikTracker`'"
         ]
     }
 }


### PR DESCRIPTION
If you install Piwik through `composer create-project --prefer-source piwik/piwik`, submodules should be checked out now, if Git is installed.

Tested like this:

```
-> % cat packages.json 
{
    "package": {
        "name": "piwik/piwik",
        "version": "1.0.0",
        "source": {
            "type": "git",
            "url": "https://github.com/JohnMaguire/piwik.git",
            "reference": "bugfix/9349-composer-installation-missing-PiwikTracker"
        }
    }
}
-> % composer create-project piwik/piwik --prefer-source --repository-url packages.json
```

Verification that it worked:

```
-> % ls libs/PiwikTracker 
composer.json  LICENSE  PiwikTracker.php  README.m
```

If Git can't be found in the `PATH`, the message "Please install git or manually install `libs/PiwikTracker`" will be displayed.
