### PR TITLE
Exclude unknown urls: Check whether known URL starts with path if one is defined, do no longer match subdomains

### DIFF
--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -114,8 +114,11 @@ class SitesManager extends \Piwik\Plugin
     {
         $idSite = (int) $idSite;
 
+        $urls = API::getInstance()->getSiteUrlsFromId($idSite);
+
         // add the 'hosts' entry in the website array
-        $array['hosts'] = $this->getTrackerHosts($idSite);
+        $array['urls']  = $urls;
+        $array['hosts'] = $this->getTrackerHosts($urls);
 
         $website = API::getInstance()->getSiteFromId($idSite);
         $array['exclude_unknown_urls'] = $website['exclude_unknown_urls'];
@@ -252,9 +255,8 @@ class SitesManager extends \Piwik\Plugin
      * @param int $idSite
      * @return array
      */
-    private function getTrackerHosts($idSite)
+    private function getTrackerHosts($urls)
     {
-        $urls = API::getInstance()->getSiteUrlsFromId($idSite);
         $hosts = array();
         foreach ($urls as $url) {
             $url = parse_url($url);

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -118,14 +118,36 @@ class VisitTest extends IntegrationTestCase
                 'http://x.com' => true,
             )),
             array(array('http://test.com', 'http://sub.test2.com'), true, array(
-                'http://sub.test.com' => true,
-                'http://sub.sub.test.com' => true,
+                'http://sub.test.com' => false, // we do not match subdomains
+                'http://sub.sub.test.com' => false,
                 'http://subtest.com' => false,
                 'http://test.com.org' => false,
+                'http://test2.com' => false,
                 'http://sub.test2.com' => true,
-                'http://x.sub.test2.com' => true,
+                'http://test.com' => true,
+                'http://x.sub.test2.com' => false,
                 'http://xsub.test2.com' => false,
                 'http://sub.test2.com.org' => false,
+            )),
+            array(array('http://test.com/path', 'http://test2.com/sub/dir'), true, array(
+                'http://test.com/path' => true, // test matching path
+                'http://test.com/path/' => true,
+                'http://test.com/path/test' => true,
+
+                'http://test.com/path1' => false,
+                'http://test.com/' => false,
+                'http://test.com' => false,
+                'http://test.com/foo' => false,
+                'http://sub.test.com/path' => false,  // we still do not match subdomains
+
+                'http://test2.com/sub/dir' => true,
+                'http://test2.com/sub/dir/' => true,
+                'http://test2.com/sub/dir/test' => true,
+
+                'http://test2.com/sub/foo/' => false,
+                'http://test2.com/sub/' => false,
+                'http://test2.com/' => false,
+                'http://test2.com/dir/sub' => false,
             )),
         );
     }
@@ -142,7 +164,7 @@ class VisitTest extends IntegrationTestCase
                 'rec'    => 1,
                 'url'    => $url
             )));
-            $this->assertEquals($isTracked, !$visitExclude->isExcluded());
+            $this->assertEquals($isTracked, !$visitExclude->isExcluded(), $url . ' is not returning expected result');
         }
     }
 


### PR DESCRIPTION
This PR is related to this checkbox in the "Manage Websites" screen 
![image](https://cloud.githubusercontent.com/assets/273120/11643247/7ad2f932-9da7-11e5-9efd-1c81cb40f3a5.png)

In https://github.com/piwik/piwik/issues/588 we added this feature to only track a request when it was actually sent from that domain. The description says the following:

> Only track visits and actions when the action URL starts with one of the above URLs.

However, it also allowed the tracking for any subdomain but it was not described in the UI. This PR fixes it to only perform an exact match (protocol http/https is still ignored). Also if any of these URLs specifies a path we do now check whether the path is present in the tracked URL (see https://github.com/piwik/piwik/pull/9320 where we already made similar changes).
