### PR TITLE
Make PHP tracking client PiwikTracker available through composer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,10 +53,6 @@
 # Note: when you add a submodule that SHOULD be left in the packaged release such as the few submodules below,
 #       then you MUST add these submodules names in the SUBMODULES_PACKAGED_WITH_CORE variable in:
 #       https://github.com/piwik/piwik-package/blob/master/scripts/build-package.sh
-[submodule "libs/PiwikTracker"]
-    path = libs/PiwikTracker
-    url = https://github.com/piwik/piwik-php-tracker.git
-    branch = master
 [submodule "misc/log-analytics"]
     path = misc/log-analytics
     url = https://github.com/piwik/piwik-log-analytics.git

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "pear/pear_exception": "~1.0.0",
         "piwik/referrer-spam-blacklist": "~1.0",
         "piwik/searchengine-and-social-list": "~1.0",
-        "tecnickcom/tcpdf": "~6.0"
+        "tecnickcom/tcpdf": "~6.0",
+        "piwik/piwik-php-tracker": "^1.0"
     },
     "require-dev": {
         "aws/aws-sdk-php": "2.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "15e909bee11271e304ee16ad4f649eb3",
-    "content-hash": "cba24c49efb5efab04417cc3bd0fba18",
+    "hash": "09112ef01f28686b387148c407503c7c",
+    "content-hash": "ff9b83524f413ac80daad8eb47099042",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -300,6 +300,7 @@
                 "phpdoc",
                 "reflection"
             ],
+            "abandoned": "php-di/phpdoc-reader",
             "time": "2014-08-21 08:20:45"
         },
         {
@@ -936,6 +937,46 @@
                 "LGPL-3.0"
             ],
             "time": "2014-10-23 03:30:23"
+        },
+        {
+            "name": "piwik/piwik-php-tracker",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/piwik/piwik-php-tracker.git",
+                "reference": "ac3e26bb3e2c8a428ccbf6ca663c2ef37fa47a5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/piwik/piwik-php-tracker/zipball/ac3e26bb3e2c8a428ccbf6ca663c2ef37fa47a5e",
+                "reference": "ac3e26bb3e2c8a428ccbf6ca663c2ef37fa47a5e",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "."
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "The Piwik Team",
+                    "email": "hello@piwik.org",
+                    "homepage": "http://piwik.org/the-piwik-team/"
+                }
+            ],
+            "description": "PHP Client for Piwik Analytics Tracking API",
+            "homepage": "http://piwik.org",
+            "keywords": [
+                "analytics",
+                "piwik",
+                "tracker"
+            ],
+            "time": "2015-11-11 02:55:37"
         },
         {
             "name": "piwik/referrer-spam-blacklist",

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+// PiwikTracker.php is now managed by composer. To prevent breaking existing
+// code, this file has been left as a redirect to its new location in the
+// vendor directory.
+if (!class_exists('PiwikTracker')) {
+    require_once __DIR__ . '/../../vendor/piwik/piwik-php-tracker/PiwikTracker.php';
+}

--- a/libs/PiwikTracker/PiwikTracker.php
+++ b/libs/PiwikTracker/PiwikTracker.php
@@ -13,3 +13,7 @@
 if (!class_exists('PiwikTracker')) {
     require_once __DIR__ . '/../../vendor/piwik/piwik-php-tracker/PiwikTracker.php';
 }
+
+if (PiwikTracker::VERSION !== 1) {
+    throw new Exception("Expected PiwikTracker in libs/PiwikTracker/PiwikTracker.php to be version 1 for keeping backward compatibility.");
+}


### PR DESCRIPTION
I am closing the pull request at #9353 as this supercedes it.

I wanted to post this pull request now for comments, although piwik/piwik-php-tracker#16 should be taken care of prior to this being merged. Additionally, once the new release is made, `composer update piwik/piwik-php-tracker` should be run again so that the dependency is up-to-date.

This allows PiwikTracker to be installed via the normal composer installation route (see #9349).

While there are still some submodules inside of piwik/piwik, none seem to be creating issues in my installation other than this missing dependency. :+1: 

I was unable to find information on recommended coding style, etc. so I went with my gut. If anything needs to be changed, simply let me know. :)
