### PR TITLE
UsersManager: Select a site with admin access automatically

### DIFF
--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -53,6 +53,7 @@ class Controller extends ControllerAdmin
     function index()
     {
         Piwik::checkUserIsNotAnonymous();
+        Piwik::checkUserHasSomeAdminAccess();
 
         $view = new View('@UsersManager/index');
 
@@ -68,6 +69,12 @@ class Controller extends ControllerAdmin
             $usersAccessByWebsite = array();
             $defaultReportSiteName = $this->translator->translate('UsersManager_ApplyToAllWebsites');
         } else {
+
+            if (!Piwik::isUserHasAdminAccess($idSiteSelected) && count($IdSitesAdmin) > 0) {
+                // make sure to show a website where user actually has admin access
+                $idSiteSelected = $IdSitesAdmin[0];
+            }
+
             $defaultReportSiteName = Site::getNameFor($idSiteSelected);
             try {
                 $usersAccessByWebsite = Request::processRequest('UsersManager.getUsersAccessFromSite', array('idSite' => $idSiteSelected));


### PR DESCRIPTION
fixes #9376 

I checked the JavaScript code and tested that the functionality actually works on the `idSite` defined by the website selector and not by the `idSite` defined in the URL. I could also perform a redirect if someone prefers that solution as it would be more fail proof in the future maybe.  
