### PR TITLE
DB lock name should be less than 64 characters for MySQL compatibility

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -281,7 +281,12 @@ class Model
 
     public function deletePreviousArchiveStatus($numericTable, $archiveId, $doneFlag)
     {
-        $dbLockName = "deletePreviousArchiveStatus.$numericTable.$archiveId";
+        $tableWithoutLeadingPrefix = $numericTable;
+        if (strlen($numericTable) >= 23) {
+            $tableWithoutLeadingPrefix = substr($numericTable, strlen($numericTable) - 23);
+            // we need to make sure lock name is less than 64 characters see https://github.com/piwik/piwik/issues/9131
+        }
+        $dbLockName = "rmPrevArchiveStatus.$tableWithoutLeadingPrefix.$archiveId";
 
         // without advisory lock here, the DELETE would acquire Exclusive Lock
         $this->acquireArchiveTableLock($dbLockName);

--- a/tests/PHPUnit/Integration/DbTest.php
+++ b/tests/PHPUnit/Integration/DbTest.php
@@ -56,6 +56,41 @@ class DbTest extends IntegrationTestCase
         $this->assertSame($expected, $result);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessagelock name has to be 64 characters or less
+     */
+    public function test_getDbLock_shouldThrowAnException_IfDbLockNameIsTooLong()
+    {
+        Db::getDbLock(str_pad('test', 65, '1'));
+    }
+
+    public function test_getDbLock_shouldGetLock()
+    {
+        $db = Db::get();
+        $this->assertTrue(Db::getDbLock('MyLock'));
+        // same session still has lock
+        $this->assertTrue(Db::getDbLock('MyLock'));
+
+        Db::setDatabaseObject(null);
+        // different session, should not be able to acquire lock
+        $this->assertFalse(Db::getDbLock('MyLock', 1));
+        // different session cannot release lock
+        $this->assertFalse(Db::releaseDbLock('MyLock'));
+        Db::destroyDatabaseObject();
+
+        // release lock again by using previous session
+        Db::setDatabaseObject($db);
+        $this->assertTrue(Db::releaseDbLock('MyLock'));
+        Db::destroyDatabaseObject();
+    }
+
+    public function test_tableExists()
+    {
+        $this->assertFalse(Db::tableExists('noTExistIngTable'));
+        $this->assertTrue(Db::tableExists(Common::prefixTable('log_visit')));
+    }
+
     public function getDbAdapter()
     {
         return array(


### PR DESCRIPTION
fixes #9131
