### PR TITLE
Remove all usages of alter ignore

### DIFF
--- a/core/Updates/0.2.10.php
+++ b/core/Updates/0.2.10.php
@@ -29,7 +29,7 @@ class Updates_0_2_10 extends Updates
 			)'                                                                               => 1050,
 
             // 0.1.7 [463]
-            'ALTER IGNORE TABLE `' . Common::prefixTable('log_visit') . '`
+            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
 				 CHANGE `location_provider` `location_provider` VARCHAR( 100 ) DEFAULT NULL' => 1054,
 
             // 0.1.7 [470]
@@ -45,7 +45,7 @@ class Updates_0_2_10 extends Updates
 				CHANGE `message` `message` TEXT'                                             => 1054,
 
             // 0.2.2 [489]
-            'ALTER IGNORE TABLE `' . Common::prefixTable('site') . '`
+            'ALTER TABLE `' . Common::prefixTable('site') . '`
 				 CHANGE `feedburnerName` `feedburnerName` VARCHAR( 100 ) DEFAULT NULL'       => 1054,
         );
     }

--- a/core/Updates/0.2.27.php
+++ b/core/Updates/0.2.27.php
@@ -24,7 +24,7 @@ class Updates_0_2_27 extends Updates
             'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
 				ADD `visit_goal_converted` VARCHAR( 1 ) NOT NULL AFTER `visit_total_time`'           => 1060,
             // 0.2.27 [826]
-            'ALTER IGNORE TABLE `' . Common::prefixTable('log_visit') . '`
+            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
 				CHANGE `visit_goal_converted` `visit_goal_converted` TINYINT(1) NOT NULL'            => 1060,
 
             'CREATE TABLE `' . Common::prefixTable('goal') . "` (

--- a/core/Updates/1.5-b1.php
+++ b/core/Updates/1.5-b1.php
@@ -38,21 +38,22 @@ class Updates_1_5_b1 extends Updates
 										          INDEX index_idsite_servertime ( idsite, server_time )
 												)  DEFAULT CHARSET=utf8 '              => 1050,
 
-            'ALTER IGNORE TABLE `' . Common::prefixTable('log_visit') . '`
+            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
 				 ADD  visitor_days_since_order SMALLINT(5) UNSIGNED NOT NULL AFTER visitor_days_since_last,
 				 ADD  visit_goal_buyer TINYINT(1) NOT NULL AFTER visit_goal_converted' => 1060,
 
-            'ALTER IGNORE TABLE `' . Common::prefixTable('log_conversion') . '`
+            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
 				 ADD visitor_days_since_order SMALLINT(5) UNSIGNED NOT NULL AFTER visitor_days_since_first' => 1060,
-            'ALTER IGNORE TABLE `' . Common::prefixTable('log_conversion') . '`
+            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
 				 ADD idorder varchar(100) default NULL AFTER buster,
 				 ADD items SMALLINT UNSIGNED DEFAULT NULL,
 				 ADD revenue_subtotal float default NULL,
 				 ADD revenue_tax float default NULL,
 				 ADD  revenue_shipping float default NULL,
 				 ADD revenue_discount float default NULL,
-				 ADD UNIQUE KEY unique_idsite_idorder (idsite, idorder),
 				 MODIFY  idgoal int(10) NOT NULL'                                      => 1060,
+            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
+				 ADD UNIQUE KEY unique_idsite_idorder (idsite, idorder)' => 1060,
         );
     }
 

--- a/core/Updates/1.5-b1.php
+++ b/core/Updates/1.5-b1.php
@@ -19,6 +19,8 @@ class Updates_1_5_b1 extends Updates
 {
     public function getMigrationQueries(Updater $updater)
     {
+        $logConversionTable = Common::prefixTable('log_conversion');
+
         return array(
             'CREATE TABLE `' . Common::prefixTable('log_conversion_item') . '` (
 												  idsite int(10) UNSIGNED NOT NULL,
@@ -42,9 +44,9 @@ class Updates_1_5_b1 extends Updates
 				 ADD  visitor_days_since_order SMALLINT(5) UNSIGNED NOT NULL AFTER visitor_days_since_last,
 				 ADD  visit_goal_buyer TINYINT(1) NOT NULL AFTER visit_goal_converted' => 1060,
 
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
+            'ALTER TABLE `' . $logConversionTable . '`
 				 ADD visitor_days_since_order SMALLINT(5) UNSIGNED NOT NULL AFTER visitor_days_since_first' => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
+            'ALTER TABLE `' . $logConversionTable . '`
 				 ADD idorder varchar(100) default NULL AFTER buster,
 				 ADD items SMALLINT UNSIGNED DEFAULT NULL,
 				 ADD revenue_subtotal float default NULL,
@@ -53,7 +55,7 @@ class Updates_1_5_b1 extends Updates
 				 ADD revenue_discount float default NULL,
 				 MODIFY  idgoal int(10) NOT NULL'                                      => 1060,
             'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-				 ADD UNIQUE KEY unique_idsite_idorder (idsite, idorder)' => 1060,
+				 ADD UNIQUE KEY unique_idsite_idorder (idsite, idorder)' => 1061,
         );
     }
 


### PR DESCRIPTION
fixes #6623 

We were actually not using `ALTER IGNORE ...` much often anymore. The updates for Piwik `0.2.*` can be probably ignored anyway which leaves only the update in Piwik `1.5.0-b1`. 

From my understanding `ALTER IGNORE` mainly has an effect when there is for example a unique index added but the table has "duplicated rows". From those 3 `ALTER IGNORE` statements in `1.5-0-b1` there is actually only one alter table statement that adds an index. Meaning we can probably safely remove the `alter ignore` from the first two alter statements.

The other `alter ignore` can be ignored from the looks as well. Why? First we add a column `idorder default null`. Meaning `idorder` will be `null` for all rows. Then we add a unique index on `idsite, idorder`. The docs in https://docs.oracle.com/cd/E17952_01/refman-5.0-en/create-index.html say : 

> This constraint does not apply to NULL values except for the BDB storage engine. For other engines, a UNIQUE index permits multiple NULL values for columns that can contain NULL. If you specify a prefix value for a column in a UNIQUE index, the column values must be unique within the prefix. 

Meaning as all values will be `null` for `idorder` there won't be a duplicate anyway so the `ALTER IGNORE` should not really be needed. Otherwise we could perform a `DELETE` to remove duplicates manually before adding the index.

To be a bit more safe if there is any error during `add index` I moved it into a separate alter table to be sure that at least all columns are added.
