### PR TITLE
Fix segment counts more conversion than All visits segment

### DIFF
--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -42,7 +42,7 @@ class LogQueryBuilder
             && strpos($from, 'log_link_visit_action') !== false);
 
         if ($useSpecialConversionGroupBy) {
-            $innerGroupBy = "concat(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)";
+            $innerGroupBy = "CONCAT(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)";
             $sql = $this->buildWrappedSelectQuery($select, $from, $where, $groupBy, $orderBy, $limit, $innerGroupBy);
         } elseif ($joinWithSubSelect) {
             $sql = $this->buildWrappedSelectQuery($select, $from, $where, $groupBy, $orderBy, $limit);

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -1174,7 +1174,7 @@ class SegmentTest extends IntegrationTestCase
                           AND log_conversion.server_time <= ?
                           AND log_conversion.idsite IN (?) )
                           AND ( ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 1 )) ) )
-                      GROUP BY concat(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)
+                      GROUP BY CONCAT(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)
                       ORDER BY NULL )
                 AS log_inner GROUP BY log_inner.idgoal",
             "bind" => $expectedBind);
@@ -1225,7 +1225,7 @@ class SegmentTest extends IntegrationTestCase
                           AND log_conversion.server_time <= ?
                           AND log_conversion.idsite IN (?) )
                           AND ( ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 1 )) ) )
-                      GROUP BY concat(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)
+                      GROUP BY CONCAT(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)
                       ORDER BY NULL )
                 AS log_inner GROUP BY log_inner.idgoal, log_inner.referer_type, log_inner.referer_name, log_inner.referer_keyword",
             "bind" => $expectedBind);
@@ -1273,7 +1273,7 @@ class SegmentTest extends IntegrationTestCase
                         AND ( (log_visit.visitor_returning = ?
                         OR log_visit.visitor_returning = ?)
                         AND ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 1 )) ) )
-                    GROUP BY concat(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)
+                    GROUP BY CONCAT(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)
                     ORDER BY NULL )
                 AS log_inner
                 GROUP BY log_inner.idgoal",

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -1140,6 +1140,148 @@ class SegmentTest extends IntegrationTestCase
         $this->assertCacheWasHit($hits = 2);
     }
 
+    // se https://github.com/piwik/piwik/issues/9194
+    public function test_getSelectQuery_whenQueryingLogConversionWithSegmentThatUsesLogLinkVisitAction_shouldUseSubselect()
+    {
+        $select = 'log_conversion.idgoal AS `idgoal`,
+			       count(*) AS `1`,
+			       count(distinct log_conversion.idvisit) AS `3`,
+			       ROUND(SUM(log_conversion.revenue),2) AS `2`,
+			       SUM(log_conversion.items) AS `8`';
+        $from = 'log_conversion';
+        $where = 'log_conversion.server_time >= ? AND log_conversion.server_time <= ? AND log_conversion.idsite IN (?)';
+        $groupBy = 'log_conversion.idgoal';
+        $bind = array('2015-10-14 11:00:00', '2015-10-15 10:59:59', 1);
+
+        $segment = 'pageUrl=@/';
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind, $orderBy = false, $groupBy);
+
+        $logConversionTable = Common::prefixTable('log_conversion');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+
+        $expectedBind = $bind;
+        $expectedBind[] = '/';
+        $expected = array(
+            "sql"  => "
+                SELECT log_inner.idgoal AS `idgoal`, count(*) AS `1`, count(distinct log_inner.idvisit) AS `3`, ROUND(SUM(log_inner.revenue),2) AS `2`, SUM(log_inner.items) AS `8`
+                FROM (
+                      SELECT log_conversion.idgoal, log_conversion.idvisit, log_conversion.revenue, log_conversion.items
+                      FROM $logConversionTable AS log_conversion
+                        LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action ON log_conversion.idvisit = log_link_visit_action.idvisit
+                      WHERE ( log_conversion.server_time >= ?
+                          AND log_conversion.server_time <= ?
+                          AND log_conversion.idsite IN (?) )
+                          AND ( ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 1 )) ) )
+                      GROUP BY concat(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)
+                      ORDER BY NULL )
+                AS log_inner GROUP BY log_inner.idgoal",
+            "bind" => $expectedBind);
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    // se https://github.com/piwik/piwik/issues/9194
+    public function test_getSelectQuery_whenQueryingLogConversionWithSegmentThatUsesLogLinkVisitActionAndGroupsForUsageInConversionsByTypeOfVisit_shouldUseSubselect()
+    {
+        $select = 'log_conversion.idgoal AS `idgoal`,
+                   log_conversion.referer_type AS `referer_type`,
+                   log_conversion.referer_name AS `referer_name`,
+                   log_conversion.referer_keyword AS `referer_keyword`,
+                   count(*) AS `1`,
+                   count(distinct log_conversion.idvisit) AS `3`,
+                   ROUND(SUM(log_conversion.revenue),2) AS `2`';
+
+        $from = 'log_conversion';
+        $where = 'log_conversion.server_time >= ? AND log_conversion.server_time <= ? AND log_conversion.idsite IN (?)';
+        $groupBy = 'log_conversion.idgoal, log_conversion.referer_type, log_conversion.referer_name, log_conversion.referer_keyword';
+        $bind = array('2015-10-14 11:00:00', '2015-10-15 10:59:59', 1);
+
+        $segment = 'pageUrl=@/';
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind, $orderBy = false, $groupBy);
+
+        $logConversionTable = Common::prefixTable('log_conversion');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+
+        $expectedBind = $bind;
+        $expectedBind[] = '/';
+        $expected = array(
+            "sql"  => "
+                SELECT log_inner.idgoal AS `idgoal`,
+                   log_inner.referer_type AS `referer_type`,
+                   log_inner.referer_name AS `referer_name`,
+                   log_inner.referer_keyword AS `referer_keyword`,
+                   count(*) AS `1`,
+                   count(distinct log_inner.idvisit) AS `3`,
+                   ROUND(SUM(log_inner.revenue),2) AS `2`
+                FROM (
+                      SELECT log_conversion.idgoal, log_conversion.referer_type, log_conversion.referer_name, log_conversion.referer_keyword, log_conversion.idvisit, log_conversion.revenue
+                      FROM $logConversionTable AS log_conversion
+                        LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action ON log_conversion.idvisit = log_link_visit_action.idvisit
+                      WHERE ( log_conversion.server_time >= ?
+                          AND log_conversion.server_time <= ?
+                          AND log_conversion.idsite IN (?) )
+                          AND ( ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 1 )) ) )
+                      GROUP BY concat(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)
+                      ORDER BY NULL )
+                AS log_inner GROUP BY log_inner.idgoal, log_inner.referer_type, log_inner.referer_name, log_inner.referer_keyword",
+            "bind" => $expectedBind);
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
+    // se https://github.com/piwik/piwik/issues/9194
+    public function test_getSelectQuery_whenQueryingLogConversionWithSegmentThatUsesLogLinkVisitActionAndLogVisit_shouldUseSubselectGroupedByIdVisitAndBuster()
+    {
+        $select = 'log_conversion.idgoal AS `idgoal`,
+			       count(*) AS `1`,
+			       count(distinct log_conversion.idvisit) AS `3`,
+			       ROUND(SUM(log_conversion.revenue),2) AS `2`';
+
+        $from = 'log_conversion';
+        $where = 'log_conversion.server_time >= ? AND log_conversion.server_time <= ? AND log_conversion.idsite IN (?)';
+        $groupBy = 'log_conversion.idgoal';
+        $bind = array('2015-10-14 11:00:00', '2015-10-15 10:59:59', 1);
+
+        $segment = 'visitorType==returning,visitorType==returningCustomer;pageUrl=@/';
+        $segment = new Segment($segment, $idSites = array());
+
+        $query = $segment->getSelectQuery($select, $from, $where, $bind, $orderBy = false, $groupBy);
+
+        $logConversionTable = Common::prefixTable('log_conversion');
+        $logLinkVisitActionTable = Common::prefixTable('log_link_visit_action');
+        $logVisitTable = Common::prefixTable('log_visit');
+
+        $expectedBind = $bind;
+        $expectedBind[] = 1;
+        $expectedBind[] = 2;
+        $expectedBind[] = '/';
+        $expected = array(
+            "sql"  => "
+                SELECT log_inner.idgoal AS `idgoal`, count(*) AS `1`, count(distinct log_inner.idvisit) AS `3`, ROUND(SUM(log_inner.revenue),2) AS `2`
+                FROM (
+                    SELECT log_conversion.idgoal, log_conversion.idvisit, log_conversion.revenue
+                    FROM $logConversionTable AS log_conversion
+                       LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action ON log_conversion.idvisit = log_link_visit_action.idvisit
+                       LEFT JOIN $logVisitTable AS log_visit ON log_visit.idvisit = log_link_visit_action.idvisit
+                    WHERE ( log_conversion.server_time >= ?
+                        AND log_conversion.server_time <= ?
+                        AND log_conversion.idsite IN (?) )
+                        AND ( (log_visit.visitor_returning = ?
+                        OR log_visit.visitor_returning = ?)
+                        AND ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 1 )) ) )
+                    GROUP BY concat(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)
+                    ORDER BY NULL )
+                AS log_inner
+                GROUP BY log_inner.idgoal",
+            "bind" => $expectedBind);
+
+        $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
+    }
+
     /**
      * @param $pageUrlFoundInDb
      * @return string

--- a/tests/PHPUnit/System/TrackGoalsAllowMultipleConversionsPerVisitTest.php
+++ b/tests/PHPUnit/System/TrackGoalsAllowMultipleConversionsPerVisitTest.php
@@ -50,11 +50,19 @@ class TrackGoalsAllowMultipleConversionsPerVisitTest extends SystemTestCase
     {
         $apiToCall = array(
             'VisitTime.getVisitInformationPerServerTime',
-            'VisitsSummary.get'
+            'VisitsSummary.get',
+            'Goals.get'
         );
 
         return array(
-            array($apiToCall, array('idSite' => self::$fixture->idSite, 'date' => self::$fixture->dateTime))
+            array($apiToCall, array('idSite' => self::$fixture->idSite, 'date' => self::$fixture->dateTime)),
+            array(array('Goals.get'), array(
+                'idSite' => self::$fixture->idSite,
+                'date' => self::$fixture->dateTime,
+                'segment' => 'pageUrl=@/',
+                'testSuffix' => '_withLogLinkVisitActionSegment'
+            )),
+
         );
     }
 

--- a/tests/PHPUnit/System/TrackGoalsOneConversionPerVisitTest.php
+++ b/tests/PHPUnit/System/TrackGoalsOneConversionPerVisitTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link    http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\System;
+
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+use Piwik\Tests\Fixtures\TwoVisitsWithCustomVariables;
+
+/**
+ * @group Plugins
+ * @group TrackGoalsOneConversionPerVisitTest
+ */
+class TrackGoalsOneConversionPerVisitTest extends SystemTestCase
+{
+    /**
+     * @var TwoVisitsWithCustomVariables
+     */
+    public static $fixture = null; // initialized below class definition
+
+    /**
+     * @dataProvider getApiForTesting
+     */
+    public function testApi($api, $params)
+    {
+        $this->runApiTests($api, $params);
+    }
+
+    public function getApiForTesting()
+    {
+        $apiToCall = array('Goals.get');
+
+        return array(
+            array($apiToCall, array(
+                'idSite'       => self::$fixture->idSite,
+                'date'         => self::$fixture->dateTime,
+                'periods'      => array('day'))),
+            // test for https://github.com/piwik/piwik/issues/9194 requesting log_conversion with log_link_visit_action segment
+            array($apiToCall, array(
+                'idSite' => self::$fixture->idSite,
+                'date' => self::$fixture->dateTime,
+                'segment' => 'pageUrl=@/',
+                'testSuffix' => '_withLogLinkVisitActionSegment'
+            )),
+            array($apiToCall, array(
+                'idSite' => self::$fixture->idSite,
+                'date' => self::$fixture->dateTime,
+                'segment' => 'visitCount>=1;pageUrl=@/',
+                'testSuffix' => '_withLogLinkVisitActionAndLogVisitSegment'
+            )),
+        );
+    }
+
+    public static function getOutputPrefix()
+    {
+        return 'trackGoals_oneConversionPerVisit';
+    }
+}
+
+TrackGoalsOneConversionPerVisitTest::$fixture = new TwoVisitsWithCustomVariables();
+TrackGoalsOneConversionPerVisitTest::$fixture->doExtraQuoteTests = false;

--- a/tests/PHPUnit/System/expected/test_trackGoals_allowMultipleConversionsPerVisit__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_trackGoals_allowMultipleConversionsPerVisit__Goals.get_day.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>8</nb_conversions>
+	<nb_visits_converted>2</nb_visits_converted>
+	<revenue>1332</revenue>
+	<conversion_rate>100%</conversion_rate>
+	<nb_conversions_new_visit>8</nb_conversions_new_visit>
+	<nb_visits_converted_new_visit>2</nb_visits_converted_new_visit>
+	<revenue_new_visit>1332</revenue_new_visit>
+	<conversion_rate_new_visit>100%</conversion_rate_new_visit>
+	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
+	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
+	<revenue_returning_visit>0</revenue_returning_visit>
+	<conversion_rate_returning_visit>0%</conversion_rate_returning_visit>
+</result>

--- a/tests/PHPUnit/System/expected/test_trackGoals_allowMultipleConversionsPerVisit_withLogLinkVisitActionSegment__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_trackGoals_allowMultipleConversionsPerVisit_withLogLinkVisitActionSegment__Goals.get_day.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>8</nb_conversions>
+	<nb_visits_converted>2</nb_visits_converted>
+	<revenue>1332</revenue>
+	<conversion_rate>100%</conversion_rate>
+	<nb_conversions_new_visit>8</nb_conversions_new_visit>
+	<nb_visits_converted_new_visit>2</nb_visits_converted_new_visit>
+	<revenue_new_visit>1332</revenue_new_visit>
+	<conversion_rate_new_visit>100%</conversion_rate_new_visit>
+	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
+	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
+	<revenue_returning_visit>0</revenue_returning_visit>
+	<conversion_rate_returning_visit>0%</conversion_rate_returning_visit>
+</result>

--- a/tests/PHPUnit/System/expected/test_trackGoals_oneConversionPerVisit__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_trackGoals_oneConversionPerVisit__Goals.get_day.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>3</nb_conversions>
+	<nb_visits_converted>2</nb_visits_converted>
+	<revenue>1000</revenue>
+	<conversion_rate>66.67%</conversion_rate>
+	<nb_conversions_new_visit>3</nb_conversions_new_visit>
+	<nb_visits_converted_new_visit>2</nb_visits_converted_new_visit>
+	<revenue_new_visit>1000</revenue_new_visit>
+	<conversion_rate_new_visit>66.67%</conversion_rate_new_visit>
+	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
+	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
+	<revenue_returning_visit>0</revenue_returning_visit>
+	<conversion_rate_returning_visit>0%</conversion_rate_returning_visit>
+</result>

--- a/tests/PHPUnit/System/expected/test_trackGoals_oneConversionPerVisit_withLogLinkVisitActionAndLogVisitSegment__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_trackGoals_oneConversionPerVisit_withLogLinkVisitActionAndLogVisitSegment__Goals.get_day.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>3</nb_conversions>
+	<nb_visits_converted>2</nb_visits_converted>
+	<revenue>1000</revenue>
+	<conversion_rate>100%</conversion_rate>
+	<nb_conversions_new_visit>3</nb_conversions_new_visit>
+	<nb_visits_converted_new_visit>2</nb_visits_converted_new_visit>
+	<revenue_new_visit>1000</revenue_new_visit>
+	<conversion_rate_new_visit>100%</conversion_rate_new_visit>
+	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
+	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
+	<revenue_returning_visit>0</revenue_returning_visit>
+	<conversion_rate_returning_visit>0%</conversion_rate_returning_visit>
+</result>

--- a/tests/PHPUnit/System/expected/test_trackGoals_oneConversionPerVisit_withLogLinkVisitActionSegment__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_trackGoals_oneConversionPerVisit_withLogLinkVisitActionSegment__Goals.get_day.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>3</nb_conversions>
+	<nb_visits_converted>2</nb_visits_converted>
+	<revenue>1000</revenue>
+	<conversion_rate>100%</conversion_rate>
+	<nb_conversions_new_visit>3</nb_conversions_new_visit>
+	<nb_visits_converted_new_visit>2</nb_visits_converted_new_visit>
+	<revenue_new_visit>1000</revenue_new_visit>
+	<conversion_rate_new_visit>100%</conversion_rate_new_visit>
+	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
+	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
+	<revenue_returning_visit>0</revenue_returning_visit>
+	<conversion_rate_returning_visit>0%</conversion_rate_returning_visit>
+</result>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_segmentMatchALL_noGoalData__Goals.get_week.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_segmentMatchALL_noGoalData__Goals.get_week.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<results>
+	<result idSite="1">
+		<result date="From 2009-12-28 to 2010-01-03">
+			<nb_conversions>3</nb_conversions>
+			<nb_visits_converted>2</nb_visits_converted>
+			<revenue>1000</revenue>
+			<conversion_rate>66.67%</conversion_rate>
+			<nb_conversions_new_visit>3</nb_conversions_new_visit>
+			<nb_visits_converted_new_visit>2</nb_visits_converted_new_visit>
+			<revenue_new_visit>1000</revenue_new_visit>
+			<conversion_rate_new_visit>66.67%</conversion_rate_new_visit>
+		</result>
+		<result date="From 2010-01-04 to 2010-01-10" />
+		<result date="From 2010-01-11 to 2010-01-17" />
+		<result date="From 2010-01-18 to 2010-01-24" />
+		<result date="From 2010-01-25 to 2010-01-31" />
+		<result date="From 2010-02-01 to 2010-02-07" />
+		<result date="From 2010-02-08 to 2010-02-14" />
+	</result>
+</results>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_segmentMatchALL_noGoalData_withLogLinkVisitActionSegment__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables_segmentMatchALL_noGoalData_withLogLinkVisitActionSegment__Goals.get_day.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_conversions>3</nb_conversions>
+	<nb_visits_converted>2</nb_visits_converted>
+	<revenue>1000</revenue>
+	<conversion_rate>100%</conversion_rate>
+	<nb_conversions_new_visit>3</nb_conversions_new_visit>
+	<nb_visits_converted_new_visit>2</nb_visits_converted_new_visit>
+	<revenue_new_visit>1000</revenue_new_visit>
+	<conversion_rate_new_visit>100%</conversion_rate_new_visit>
+	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
+	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
+	<revenue_returning_visit>0</revenue_returning_visit>
+	<conversion_rate_returning_visit>0%</conversion_rate_returning_visit>
+</result>


### PR DESCRIPTION
fixes #9194 fix "goal can be only converted once per visit" is not respected when segmenting goals with a log_link_visit_action segment

Problem: see https://github.com/piwik/piwik/issues/9194#issuecomment-164321612

Solution:
We need to use a subselect where we group by `concat(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)` to have only the actual number of conversions. The group by will remove some duplicates and keep the values of the first `log_conversion.*` entries.

This is actually quite difficult to solve as one can easily break something. As we want to have as minimal risk of breaking something in 2.15.1 as possible we go with an approach to target this problem very specifically in the code and go for a hacky solution.

BTW:
Ideally, segments would always use subselects instead of joins. This would prevent such problems in general but it would be slower and is not easy to change. 
