### PR TITLE
Do not load a report by dimension as a widget so it remembers last used report settings

### DIFF
--- a/plugins/CoreHome/javascripts/corehome.js
+++ b/plugins/CoreHome/javascripts/corehome.js
@@ -149,7 +149,9 @@
             var widgetUniqueId = widgetParams.module + widgetParams.action;
             currentWidgetLoading = widgetUniqueId;
 
-            widgetsHelper.loadWidgetAjax(widgetUniqueId, widgetParams, function (response) {
+            var ajaxRequest = new ajaxHelper();
+            ajaxRequest.addParams(widgetParams, 'get');
+            ajaxRequest.setCallback(function (response) {
                 // if the widget that was loaded was not for the latest clicked link, do nothing w/ the response
                 if (widgetUniqueId != currentWidgetLoading) {
                     return;
@@ -160,7 +162,8 @@
 
                 // scroll to report
                 piwikHelper.lazyScrollTo(report, 400);
-            }, function (deferred, status) {
+            });
+            ajaxRequest.setErrorCallback(function (deferred, status) {
                 if (status == 'abort' || !deferred || deferred.status < 400 || deferred.status >= 600) {
                     return;
                 }
@@ -174,6 +177,8 @@
 
                 report.css('display', 'inline-block').html('<div class="dimensionLoadingError">' + errorMessage + '</div>');
             });
+            ajaxRequest.setFormat('html');
+            ajaxRequest.send(false);
         });
     });
 


### PR DESCRIPTION
refs #6761 

In https://github.com/piwik/piwik/blob/2.15.0/core/ViewDataTable/Factory.php#L107 we load `savedViewDataTableParameters` only if it is not a widget. Why? Widgets are shown in the dashboard and there someone might want to use different settings for a report than in the standalone report on a page. Eg in the report page "Custom Variables" someone might want to see the table with all columns whereas the report in the dashboard should show only the normal table. Also we save dashboard parameters in a separate table. 

The ReportByDimension component used an existing method `loadWidgetAjax()` which always set the parameter `widget=1`. So we never remembered any setting for reports in `ReportByDimension`. As there is not much logic we do not have to reuse that method and can simply request the report manually. The `widget=1` parameter should not be needed.
