### PR TITLE
Events reports: option to view all columns: min, max and avg values

### DIFF
--- a/plugins/Events/Events.php
+++ b/plugins/Events/Events.php
@@ -9,9 +9,11 @@
 namespace Piwik\Plugins\Events;
 
 use Piwik\Common;
+use Piwik\DataTable;
 use Piwik\Piwik;
 use Piwik\Plugin\Report;
 use Piwik\Plugin\ViewDataTable;
+use Piwik\Plugins\CoreVisualizations\Visualizations\HtmlTable\AllColumns;
 
 class Events extends \Piwik\Plugin
 {
@@ -145,8 +147,18 @@ class Events extends \Piwik\Plugin
         }
 
         $view->config->show_flatten_table = true;
-        $view->config->show_table_all_columns = false;
         $view->requestConfig->filter_sort_column = 'nb_events';
+
+        if ($view->isViewDataTableId(AllColumns::ID)) {
+            $view->config->filters[] = function (DataTable $table) use ($view) {
+                $view->config->columns_to_display = array('label', 'nb_events', 'sum_event_value', 'avg_event_value', 'min_event_value', 'max_event_value');
+
+                if (!in_array($view->requestConfig->filter_sort_column, $view->config->columns_to_display)) {
+                    $view->requestConfig->filter_sort_column = 'nb_events';
+                }
+            };
+            $view->config->show_pivot_by_subtable = false;
+        }
 
         $labelTranslation = $this->getColumnTranslation($apiMethod);
         $view->config->addTranslation('label', $labelTranslation);

--- a/plugins/Events/Events.php
+++ b/plugins/Events/Events.php
@@ -26,7 +26,8 @@ class Events extends \Piwik\Plugin
             'Metrics.getDefaultMetricDocumentationTranslations' => 'addMetricDocumentationTranslations',
             'Metrics.getDefaultMetricTranslations' => 'addMetricTranslations',
             'ViewDataTable.configure'   => 'configureViewDataTable',
-            'Live.getAllVisitorDetails' => 'extendVisitorDetails'
+            'Live.getAllVisitorDetails' => 'extendVisitorDetails',
+            'AssetManager.getStylesheetFiles' => 'getStylesheetFiles',
         );
     }
 
@@ -151,7 +152,18 @@ class Events extends \Piwik\Plugin
 
         if ($view->isViewDataTableId(AllColumns::ID)) {
             $view->config->filters[] = function (DataTable $table) use ($view) {
-                $view->config->columns_to_display = array('label', 'nb_events', 'sum_event_value', 'avg_event_value', 'min_event_value', 'max_event_value');
+                $columsToDisplay = array('label');
+
+                $columns = $table->getColumns();
+                if (in_array('nb_visits', $columns)) {
+                    $columsToDisplay[] = 'nb_visits';
+                }
+
+                if (in_array('nb_uniq_visitors', $columns)) {
+                    $columsToDisplay[] = 'nb_uniq_visitors';
+                }
+
+                $view->config->columns_to_display = array_merge($columsToDisplay, array('nb_events', 'sum_event_value', 'avg_event_value', 'min_event_value', 'max_event_value'));
 
                 if (!in_array($view->requestConfig->filter_sort_column, $view->config->columns_to_display)) {
                     $view->requestConfig->filter_sort_column = 'nb_events';
@@ -245,5 +257,10 @@ class Events extends \Piwik\Plugin
     public function getSecondaryDimensionFromRequest()
     {
         return Common::getRequestVar('secondaryDimension', false, 'string');
+    }
+
+    public function getStylesheetFiles(&$stylesheets)
+    {
+        $stylesheets[] = "plugins/Events/stylesheets/datatable.less";
     }
 }

--- a/plugins/Events/stylesheets/datatable.less
+++ b/plugins/Events/stylesheets/datatable.less
@@ -1,0 +1,7 @@
+div[data-report="Events.getAaction"].dataTableVizAllColumns,
+div[data-report="Events.getName"].dataTableVizAllColumns,
+div[data-report="Events.getCategory"].dataTableVizAllColumns {
+  .dataTableWrapper {
+    width:1000px;
+  }
+}


### PR DESCRIPTION
fixes #6761 

Please notice in https://github.com/piwik/piwik/issues/6761#issuecomment-164633279 I asked whether we should also show metric "Events with values", "Visits" and "Unique visits (if present)".

In #9398 I issued another PR that can be merged optionally. This will make sure we remember if someone selected "tableAllColumns" the next time one clicks on the report again. It also makes sure to remember other settings. 
