### PR TITLE
Exclude unneeded files/folders from git packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,3 +41,14 @@
 
 # Custom for Visual Studio
 *.cs     diff=csharp
+
+
+# Files excluded from git packages
+tests/ export-ignore
+.coveralls.yml export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore
+.gitmodules export-ignore
+.phpstorm.meta.php export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore


### PR DESCRIPTION
When requiring Piwik using composer there are all files included. Even those not required for running Piwik (like tests, .git files,...)

In order to exclude those files I've added some of them to .gitattributes as export-ignore.
Those files won't be included when git is used to build a package (e.g. download a repo as archive).

Those archives will also be used by composer when a specific version is requested. 

Note: If a composer project requires a specific branch or dev-master, composer uses git to fetch _all_ files instead of using an archive, so those files will still be included in that case.
