### PR TITLE
Display useful message how to solve "Form security error" issue, when SSL may be mis-configured

### DIFF
--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -418,10 +418,6 @@ class FrontController extends Singleton
         if (Common::isPhpCliMode()) {
             return;
         }
-        // Only enable this feature after Piwik is already installed
-        if (!SettingsPiwik::isPiwikInstalled()) {
-            return;
-        }
         // proceed only when force_ssl = 1
         if (!SettingsPiwik::isHttpsForced()) {
             return;

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -427,6 +427,10 @@ class SettingsPiwik
      */
     public static function isHttpsForced()
     {
+        if (!SettingsPiwik::isPiwikInstalled()) {
+            // Only enable this feature after Piwik is already installed
+            return false;
+        }
         return Config::getInstance()->General['force_ssl'] == 1;
     }
 

--- a/core/Url.php
+++ b/core/Url.php
@@ -176,20 +176,10 @@ class Url
      */
     public static function getCurrentScheme()
     {
-        try {
-            $assume_secure_protocol = @Config::getInstance()->General['assume_secure_protocol'];
-        } catch (Exception $e) {
-            $assume_secure_protocol = false;
-        }
-        if ($assume_secure_protocol) {
+        if (self::isPiwikServerAssumeSecureConnectionIsUsed()) {
             return 'https';
         }
-        if(    (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true))
-            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')){
-
-            return 'https';
-        }
-        return 'http';
+        return self::getCurrentSchemeFromRequestHeader();
     }
 
     /**
@@ -685,5 +675,32 @@ class Url
     public static function getLocalHostnames()
     {
         return array('localhost', '127.0.0.1', '::1', '[::1]');
+    }
+
+    /**
+     * @return string
+     */
+    public static function getCurrentSchemeFromRequestHeader()
+    {
+        if ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true))
+            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+        ) {
+
+            return 'https';
+        }
+        return 'http';
+    }
+
+    /**
+     * @return bool
+     */
+    public static function isPiwikServerAssumeSecureConnectionIsUsed()
+    {
+        try {
+            $assume_secure_protocol = @Config::getInstance()->General['assume_secure_protocol'];
+        } catch (Exception $e) {
+            $assume_secure_protocol = false;
+        }
+        return $assume_secure_protocol;
     }
 }

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -17,8 +17,10 @@ use Piwik\Cookie;
 use Piwik\Log;
 use Piwik\Nonce;
 use Piwik\Piwik;
+use Piwik\ProxyHttp;
 use Piwik\QuickForm2;
 use Piwik\Session;
+use Piwik\SettingsPiwik;
 use Piwik\Url;
 use Piwik\View;
 
@@ -216,7 +218,41 @@ class Controller extends \Piwik\Plugin\Controller
     protected function getMessageExceptionNoAccess()
     {
         $message = Piwik::translate('Login_InvalidNonceOrHeadersOrReferrer', array('<a href="?module=Proxy&action=redirect&url=' . urlencode('http://piwik.org/faq/how-to-install/#faq_98') . '" target="_blank">', '</a>'));
-        // Should mention trusted_hosts or link to FAQ
+
+        $message .= $this->getMessageExceptionNoAccessWhenInsecureConnectionMayBeUsed($message);
+
+        return $message;
+    }
+
+    /**
+     * The Session cookie is set to a secure cookie, when SSL is mis-configured, it can cause the PHP session cookie ID to change on each page view.
+     * Indicate to user how to solve this particular use case by forcing secure connections.
+     *
+     * @param $message
+     * @return string
+     */
+    protected function getMessageExceptionNoAccessWhenInsecureConnectionMayBeUsed($message)
+    {
+        $message = '';
+
+        $isSecureConnectionLikelyNotUsed = Url::getCurrentSchemeFromRequestHeader() == 'http';
+        $hasSessionCookieSecureFlag = ProxyHttp::isHttps();
+        $isSecureConnectionAssumedByPiwikButNotForcedYet = Url::isPiwikServerAssumeSecureConnectionIsUsed() && !SettingsPiwik::isHttpsForced();
+        if (   $isSecureConnectionLikelyNotUsed
+            && $hasSessionCookieSecureFlag
+            && $isSecureConnectionAssumedByPiwikButNotForcedYet
+        ) {
+
+            $message = '<br/><br/>' . Piwik::translate('Login_InvalidNonceSSLMisconfigured',
+                    array(
+                        '<a href="?module=Proxy&action=redirect&url=' . urlencode('<a href="http://piwik.org/faq/how-to/faq_91/">') . '">',
+                        '</a>',
+                        'config/config.ini.php',
+                        '<pre>force_ssl=1</pre>',
+                        '<pre>[General]</pre>',
+                    )
+                );
+        }
         return $message;
     }
 
@@ -224,7 +260,6 @@ class Controller extends \Piwik\Plugin\Controller
      * Reset password action. Stores new password as hash and sends email
      * to confirm use.
      *
-     * @param none
      */
     function resetPassword()
     {
@@ -346,4 +381,5 @@ class Controller extends \Piwik\Plugin\Controller
             Url::redirectToUrl($logoutUrl);
         }
     }
+
 }

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -9,7 +9,6 @@
 namespace Piwik\Plugins\Login;
 
 use Exception;
-use Piwik\Auth as AuthInterface;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
@@ -17,10 +16,8 @@ use Piwik\Cookie;
 use Piwik\Log;
 use Piwik\Nonce;
 use Piwik\Piwik;
-use Piwik\ProxyHttp;
 use Piwik\QuickForm2;
 use Piwik\Session;
-use Piwik\SettingsPiwik;
 use Piwik\Url;
 use Piwik\View;
 
@@ -219,7 +216,7 @@ class Controller extends \Piwik\Plugin\Controller
     {
         $message = Piwik::translate('Login_InvalidNonceOrHeadersOrReferrer', array('<a href="?module=Proxy&action=redirect&url=' . urlencode('http://piwik.org/faq/how-to-install/#faq_98') . '" target="_blank">', '</a>'));
 
-        $message .= $this->getMessageExceptionNoAccessWhenInsecureConnectionMayBeUsed($message);
+        $message .= $this->getMessageExceptionNoAccessWhenInsecureConnectionMayBeUsed();
 
         return $message;
     }
@@ -228,21 +225,12 @@ class Controller extends \Piwik\Plugin\Controller
      * The Session cookie is set to a secure cookie, when SSL is mis-configured, it can cause the PHP session cookie ID to change on each page view.
      * Indicate to user how to solve this particular use case by forcing secure connections.
      *
-     * @param $message
      * @return string
      */
-    protected function getMessageExceptionNoAccessWhenInsecureConnectionMayBeUsed($message)
+    protected function getMessageExceptionNoAccessWhenInsecureConnectionMayBeUsed()
     {
         $message = '';
-
-        $isSecureConnectionLikelyNotUsed = Url::getCurrentSchemeFromRequestHeader() == 'http';
-        $hasSessionCookieSecureFlag = ProxyHttp::isHttps();
-        $isSecureConnectionAssumedByPiwikButNotForcedYet = Url::isPiwikServerAssumeSecureConnectionIsUsed() && !SettingsPiwik::isHttpsForced();
-        if (   $isSecureConnectionLikelyNotUsed
-            && $hasSessionCookieSecureFlag
-            && $isSecureConnectionAssumedByPiwikButNotForcedYet
-        ) {
-
+        if(Url::isSecureConnectionAssumedByPiwikButNotForcedYet()) {
             $message = '<br/><br/>' . Piwik::translate('Login_InvalidNonceSSLMisconfigured',
                     array(
                         '<a href="?module=Proxy&action=redirect&url=' . urlencode('<a href="http://piwik.org/faq/how-to/faq_91/">') . '">',
@@ -381,5 +369,4 @@ class Controller extends \Piwik\Plugin\Controller
             Url::redirectToUrl($logoutUrl);
         }
     }
-
 }

--- a/plugins/Login/lang/en.json
+++ b/plugins/Login/lang/en.json
@@ -5,7 +5,7 @@
         "ExceptionInvalidSuperUserAccessAuthenticationMethod": "A user with Super User access cannot be authenticated using the '%s' mechanism.",
         "ExceptionPasswordMD5HashExpected": "The password parameter is expected to be a MD5 hash of the password.",
         "InvalidNonceOrHeadersOrReferrer": "Form security failed. Please reload the form and check that your cookies are enabled. If you use a proxy server, you must %s configure Piwik to accept the proxy header%s that forwards the Host header. Also, check that your Referrer header is sent correctly.",
-        "InvalidNonceSSLMisconfigured": "Alternatively, you may %1$s force Piwik to use a secure connection%2$s: in your config file %3$s set %4$s below section %5$s",
+        "InvalidNonceSSLMisconfigured": "Also, you may %1$s force Piwik to use a secure connection%2$s: in your config file %3$s set %4$s below section %5$s",
         "InvalidOrExpiredToken": "Token is invalid or has expired.",
         "InvalidUsernameEmail": "Invalid username or e-mail address.",
         "LogIn": "Sign in",

--- a/plugins/Login/lang/en.json
+++ b/plugins/Login/lang/en.json
@@ -5,6 +5,7 @@
         "ExceptionInvalidSuperUserAccessAuthenticationMethod": "A user with Super User access cannot be authenticated using the '%s' mechanism.",
         "ExceptionPasswordMD5HashExpected": "The password parameter is expected to be a MD5 hash of the password.",
         "InvalidNonceOrHeadersOrReferrer": "Form security failed. Please reload the form and check that your cookies are enabled. If you use a proxy server, you must %s configure Piwik to accept the proxy header%s that forwards the Host header. Also, check that your Referrer header is sent correctly.",
+        "InvalidNonceSSLMisconfigured": "Alternatively, you may %1$s force Piwik to use a secure connection%2$s: in your config file %3$s set %4$s below section %5$s",
         "InvalidOrExpiredToken": "Token is invalid or has expired.",
         "InvalidUsernameEmail": "Invalid username or e-mail address.",
         "LogIn": "Sign in",


### PR DESCRIPTION
fixes #9407 

Suggested solution

![https](https://cloud.githubusercontent.com/assets/466765/11886832/40adcf4a-a593-11e5-8eec-1afcd5a33f8b.png)
