### PR TITLE
Fixes jumping effect in dashboard on widget hover

### DIFF
--- a/plugins/Dashboard/stylesheets/widget.less
+++ b/plugins/Dashboard/stylesheets/widget.less
@@ -45,18 +45,24 @@
         .button {
             margin: 16px 8px 0 0;
             opacity: 0.8;
-            visibility: hidden;
-            display:none;
             cursor: pointer;
             float: right;
         }
-    }
-    // TODO those 2 should probably be simplified eventually...
-    .widgetTop:hover .button {
-        visibility: visible;
-    }
-    .widgetTop.widgetTopHover .button {
-        display:block;
+        .buttons {
+            float: right;
+            position: absolute;
+            padding-left: 50px;
+            right: 8px;
+            display: none;
+            background: -moz-linear-gradient(left, rgba(255,255,255,0) 0%, @theme-color-widget-title-background 45px);
+            background: -webkit-linear-gradient(left,rgba(255,255,255,0) 0%, @theme-color-widget-title-background 45px);
+            background: linear-gradient(to right, rgba(255,255,255,0) 0%, @theme-color-widget-title-background 45px);
+            filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='@{theme-color-widget-title-background}',GradientType=1 );
+        }
+
+        &:hover .buttons {
+            display:block;
+        }
     }
 
     .widgetText {

--- a/plugins/Dashboard/templates/_widgetFactoryTemplate.twig
+++ b/plugins/Dashboard/templates/_widgetFactoryTemplate.twig
@@ -1,17 +1,19 @@
 <div id="widgetTemplate" style="display:none;">
     <div class="widget">
         <div class="widgetTop">
-            <div class="button" id="close">
-                <span class="icon-close" title="{{ 'General_Close'|translate }}"></span>
-            </div>
-            <div class="button" id="maximise">
-                <span class="icon-fullscreen" title="{{ 'Dashboard_Maximise'|translate }}"></span>
-            </div>
-            <div class="button" id="minimise">
-                <span class="icon-minimise" title="{{ 'Dashboard_Minimise'|translate }}"></span>
-            </div>
-            <div class="button" id="refresh">
-                <span class="icon-reload" title="{{ 'General_Refresh'|translate }}"></span>
+            <div class="buttons">
+                <div class="button" id="close">
+                    <span class="icon-close" title="{{ 'General_Close'|translate }}"></span>
+                </div>
+                <div class="button" id="maximise">
+                    <span class="icon-fullscreen" title="{{ 'Dashboard_Maximise'|translate }}"></span>
+                </div>
+                <div class="button" id="minimise">
+                    <span class="icon-minimise" title="{{ 'Dashboard_Minimise'|translate }}"></span>
+                </div>
+                <div class="button" id="refresh">
+                    <span class="icon-reload" title="{{ 'General_Refresh'|translate }}"></span>
+                </div>
             </div>
             <h3 class="widgetName">{% if widgetName is defined %}{{ widgetName }}{% endif %}
                 <div class="widgetNameOffScreen">


### PR DESCRIPTION
Fixes #9022.

To prevent the jumping effect I decided to choose a more complicate way.

The simplest way would have been to always force the line break getting visible when hovering, but imho it looked a bit ugly always having the free space in the right-top corner.

With this changes a background gradient is used, to hide some parts of the title, if it is too close to the buttons.

This is how it looks like by default and when hovering the widget:

![image](https://cloud.githubusercontent.com/assets/1579355/11914367/8a2c3ffc-a67f-11e5-95cb-57a776e9105a.png)

... and when hovering the title:

![image](https://cloud.githubusercontent.com/assets/1579355/11914369/a237ebf0-a67f-11e5-985d-e5aa22311beb.png)
