### PR TITLE
Fixes escaping in tag clouds

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/Cloud.php
+++ b/plugins/CoreVisualizations/Visualizations/Cloud.php
@@ -174,6 +174,8 @@ class Cloud extends Visualization
      */
     private function truncateWordIfNeeded($word)
     {
+        $word = Common::unsanitizeInputValue($word);
+
         if (Common::mb_strlen($word) > $this->truncatingLimit) {
             return Common::mb_substr($word, 0, $this->truncatingLimit - 3) . '...';
         }

--- a/plugins/CoreVisualizations/templates/_dataTableViz_tagCloud.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_tagCloud.twig
@@ -1,7 +1,7 @@
 {% set cloudColumn = properties.columns_to_display[1] %}
 <div class="tagCloud">
 {% for word,value in cloudValues %}
-    <span title="{{ value.word }} ({{ value.value }} {{ properties.translations[cloudColumn]|default(cloudColumn) }})" class="word size{{ value.size }}
+    <span title="{{ value.word|rawSafeDecoded }} ({{ value.value }} {{ properties.translations[cloudColumn]|default(cloudColumn) }})" class="word size{{ value.size }}
     {# we strike tags with 0 hits #}
     {% if value.value == 0 %}valueIsZero{% endif %}">
     {% if labelMetadata[value.word].url is not sameas(false) %}
@@ -10,7 +10,7 @@
     {% if labelMetadata[value.word].logo is not sameas(false) %}
         <img src="{{ labelMetadata[value.word].logo }}" width="{{ value.logoWidth }}" />
     {% else %}
-        {{ value.wordTruncated }}
+        {{ value.wordTruncated|rawSafeDecoded }}
     {% endif %}
     {% if labelMetadata[value.word].url is not sameas(false) %}</a>{% endif %}
     </span>


### PR DESCRIPTION
As it can be seen in the UI tests, the words in tag clouds might get displayed escaped:

![image](https://cloud.githubusercontent.com/assets/1579355/12004301/39137382-ab4e-11e5-8339-460e0f8f0a22.png)

With this changes it looks correct:

![image](https://cloud.githubusercontent.com/assets/1579355/12004723/fdbb9098-ab71-11e5-8668-3437391517eb.png)
