### PR TITLE
Fix function header (comment only)

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -48,7 +48,7 @@ class Controller extends \Piwik\Plugin\Controller
      * @param PasswordResetter $passwordResetter
      * @param AuthInterface $auth
      * @param SessionInitializer $authenticatedSessionFactory
-\     */
+     */
     public function __construct($passwordResetter = null, $auth = null, $sessionInitializer = null)
     {
         parent::__construct();


### PR DESCRIPTION
Incorrect function header causes the function being marked red on Github - see https://github.com/piwik/piwik/blob/ecdd6607a9392d911aef44fc7e898546f9548424/plugins/Login/Controller.php#L51
