### PR TITLE
Display action details in visitor profile (if other than pageviews)

### DIFF
--- a/plugins/Live/VisitorProfile.php
+++ b/plugins/Live/VisitorProfile.php
@@ -57,8 +57,12 @@ class VisitorProfile
             // individual goal conversions are stored in action details
             foreach ($visit->getColumn('actionDetails') as $action) {
                 $this->handleIfGoalAction($action);
+                $this->handleIfEventAction($action);
+                $this->handleIfDownloadAction($action);
+                $this->handleIfOutlinkAction($action);
                 $this->handleIfEcommerceAction($action);
                 $this->handleIfSiteSearchAction($action);
+                $this->handleIfPageViewAction($action);
                 $this->handleIfPageGenerationTime($action);
             }
             $this->handleGeoLocation($visit);
@@ -150,6 +154,50 @@ class VisitorProfile
     private function isEcommerceEnabled()
     {
         return $this->isEcommerceEnabled;
+    }
+
+    /**
+     * @param $action
+     */
+    private function handleIfEventAction($action)
+    {
+        if ($action['type'] != 'event') {
+            return;
+        }
+        $this->profile['totalEvents']++;
+    }
+
+    /**
+     * @param $action
+     */
+    private function handleIfDownloadAction($action)
+    {
+        if ($action['type'] != 'download') {
+            return;
+        }
+        $this->profile['totalDownloads']++;
+    }
+
+    /**
+     * @param $action
+     */
+    private function handleIfOutlinkAction($action)
+    {
+        if ($action['type'] != 'outlink') {
+            return;
+        }
+        $this->profile['totalOutlinks']++;
+    }
+
+    /**
+     * @param $action
+     */
+    private function handleIfPageViewAction($action)
+    {
+        if ($action['type'] != 'action') {
+            return;
+        }
+        $this->profile['totalPageViews']++;
     }
 
     /**
@@ -283,7 +331,11 @@ class VisitorProfile
         $this->profile['totalVisits'] = 0;
         $this->profile['totalVisitDuration'] = 0;
         $this->profile['totalActions'] = 0;
+        $this->profile['totalEvents'] = 0;
+        $this->profile['totalOutlinks'] = 0;
+        $this->profile['totalDownloads'] = 0;
         $this->profile['totalSearches'] = 0;
+        $this->profile['totalPageViews'] = 0;
         $this->profile['totalPageViewsWithTiming'] = 0;
         $this->profile['totalGoalConversions'] = 0;
         $this->profile['totalConversionsByGoal'] = array();

--- a/plugins/Live/lang/en.json
+++ b/plugins/Live/lang/en.json
@@ -36,6 +36,7 @@
         "VisitorsLastVisit": "This visitor's last visit was %s days ago.",
         "VisitsFrom": "%1$s%2$s visits%3$s from",
         "VisitSummary": "Spent a total of %1$s%2$s on the website%3$s, and %4$sviewed %5$s pages in %6$s visits.%7$s",
+        "VisitSummaryWithActionDetails": "Spent a total of %1$s%2$s on the website%3$s, and %4$sperformed %5$s actions (%6$s) in %7$s visits.%8$s",
         "RowActionTooltipDefault": "Show Visitor Log segmented by this row",
         "RowActionTooltipWithDimension": "Show Visitor Log segmented by this %s",
         "RowActionTooltipTitle": "Open segmented Visitor Log",

--- a/plugins/Live/templates/getVisitorProfilePopup.twig
+++ b/plugins/Live/templates/getVisitorProfilePopup.twig
@@ -40,7 +40,17 @@
                 <div class="visitor-profile-summary">
                     <h1>{{ 'General_Summary'|translate }}</h1>
                     <div>
-                        <p>{{ 'Live_VisitSummary'|translate('<strong>' ~ visitorData.totalVisitDurationPretty ~ '</strong>', '', '', '<strong>', visitorData.totalActions, visitorData.totalVisits, '</strong>')|raw }}</p>
+                        {% if visitorData.totalPageViews != visitorData.totalActions %}
+                            {% set actionDetails = [] %}
+                            {% if visitorData.totalPageViews > 0 %}{% set actionDetails = actionDetails|merge([visitorData.totalPageViews ~ ' ' ~ 'General_ColumnPageviews'|translate]) %}{% endif %}
+                            {% if visitorData.totalEvents > 0 %}{% set actionDetails = actionDetails|merge([visitorData.totalEvents ~ ' ' ~ 'Events_Events'|translate]) %}{% endif %}
+                            {% if visitorData.totalDownloads > 0 %}{% set actionDetails = actionDetails|merge([visitorData.totalDownloads ~ ' ' ~ 'General_Downloads'|translate]) %}{% endif %}
+                            {% if visitorData.totalOutlinks > 0 %}{% set actionDetails = actionDetails|merge([visitorData.totalOutlinks ~ ' ' ~ 'General_Outlinks'|translate]) %}{% endif %}
+                            {% if visitorData.totalSearches > 0 %}{% set actionDetails = actionDetails|merge([visitorData.totalSearches ~ ' ' ~ 'Actions_ColumnSearches'|translate]) %}{% endif %}
+                            <p>{{ 'Live_VisitSummaryWithActionDetails'|translate('<strong>' ~ visitorData.totalVisitDurationPretty ~ '</strong>', '', '', '<strong>', visitorData.totalActions, actionDetails|join(', ') , visitorData.totalVisits, '</strong>')|raw }}</p>
+                        {% else %}
+                            <p>{{ 'Live_VisitSummary'|translate('<strong>' ~ visitorData.totalVisitDurationPretty ~ '</strong>', '', '', '<strong>', visitorData.totalActions, visitorData.totalVisits, '</strong>')|raw }}</p>
+                        {% endif %}
                         <p>{% if visitorData.totalGoalConversions %}<strong>{% endif %}{{ 'Live_ConvertedNGoals'|translate(visitorData.totalGoalConversions) }}{% if visitorData.totalGoalConversions %}</strong>{% endif %}
                         {%- if visitorData.totalGoalConversions %} (
                             {%- for idGoal, totalConversions in visitorData.totalConversionsByGoal -%}


### PR DESCRIPTION
Atm in visitor profile the number of viewed pages might be incorrect, as the total number of actions is used. That includes the number of downloads, outlinks, searches and events.

with this changes the are now two possible views.

the first will be displayed when only page views were performed (no other actions):

![image](https://cloud.githubusercontent.com/assets/1579355/12079674/c05457f4-b241-11e5-99aa-0032189cdb09.png)

if also other actions have been performed they will be displayed in detail:

![image](https://cloud.githubusercontent.com/assets/1579355/12079650/2d78af52-b241-11e5-8226-5df5c8a14fb6.png)

fixes #8855
