### PR TITLE
Document need to call setApiUrl() in js/README.md

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -22,6 +22,13 @@ The js/ folder contains:
   attempt to block tracking, you can change your tracking code to use "js/"
   instead of "piwik.js" and "piwik.php", respectively.
 
+  Note that in order for [Page Overlay](https://piwik.org/docs/page-overlay/) to work, the Piwik tracker method `setAPIUrl()` needs to be called with its parameter pointing to the root directory of Piwik. E.g.:
+
+  ```js
+  _paq.push(['setAPIUrl', u]);
+
+  ```
+
 ## Deployment
 
 * piwik.js is minified using YUICompressor 2.4.2.


### PR DESCRIPTION
If "js/" is used by the Piwik tracking code instead of "piwik.js" and "piwik.php", Page Overlay won't work unless setApiUrl() is called with its parameter pointing to the root directory of Piwik. See https://piwik.org/docs/page-overlay/#page-overlay-troubleshooting (last bullet point) for details.
