### PR TITLE
Better error handling for custom logo upload

### DIFF
--- a/plugins/CoreAdminHome/CustomLogo.php
+++ b/plugins/CoreAdminHome/CustomLogo.php
@@ -196,16 +196,20 @@ class CustomLogo
         list($width, $height) = getimagesize($file);
         switch ($_FILES[$uploadFieldName]['type']) {
             case 'image/jpeg':
-                $image = imagecreatefromjpeg($file);
+                $image = @imagecreatefromjpeg($file);
                 break;
             case 'image/png':
-                $image = imagecreatefrompng($file);
+                $image = @imagecreatefrompng($file);
                 break;
             case 'image/gif':
-                $image = imagecreatefromgif ($file);
+                $image = @imagecreatefromgif ($file);
                 break;
             default:
                 return false;
+        }
+
+        if (!is_resource($image)) {
+            return false;
         }
 
         $targetWidth = round($width * $targetHeight / $height);

--- a/plugins/CoreAdminHome/javascripts/generalSettings.js
+++ b/plugins/CoreAdminHome/javascripts/generalSettings.js
@@ -123,6 +123,13 @@ $(document).ready(function () {
                 var frameContent = $(uploadFrame.contents()).find('body').html();
                 frameContent = $.trim(frameContent);
 
+                if ('0' === frameContent) {
+                    $('.uploaderror').show();
+                    setTimeout(function(){
+                        $('.uploaderror').fadeOut();
+                    }, 5000);
+                }
+
                 if ('1' === frameContent || '0' === frameContent) {
                     uploadFrame.remove();
                 }

--- a/plugins/CoreAdminHome/javascripts/generalSettings.js
+++ b/plugins/CoreAdminHome/javascripts/generalSettings.js
@@ -113,6 +113,7 @@ $(document).ready(function () {
 
     $("#logoUploadForm").submit(function (data) {
         var submittingForm = $(this);
+        $('.uploaderror').fadeOut();
         var frameName = "upload" + (new Date()).getTime();
         var uploadFrame = $("<iframe name=\"" + frameName + "\" />");
         uploadFrame.css("display", "none");
@@ -125,9 +126,6 @@ $(document).ready(function () {
 
                 if ('0' === frameContent) {
                     $('.uploaderror').show();
-                    setTimeout(function(){
-                        $('.uploaderror').fadeOut();
-                    }, 5000);
                 }
 
                 if ('1' === frameContent || '0' === frameContent) {

--- a/plugins/CoreAdminHome/lang/en.json
+++ b/plugins/CoreAdminHome/lang/en.json
@@ -49,6 +49,7 @@
         "JSTrackingIntro5": "If you want to do more than track page views, please check out the %1$sPiwik Javascript Tracking documentation%2$s for the list of available functions. Using these functions you can track goals, custom variables, ecommerce orders, abandoned carts and more.",
         "LogoNotWriteableInstruction": "To use your custom logo instead of the default Piwik logo, give write permission to this directory: %1$s Piwik needs write access for your logos stored in the files %2$s.",
         "FileUploadDisabled": "Uploading files is not enabled in your PHP configuration. To upload your custom logo please set %s in php.ini and restart your webserver.",
+        "LogoUploadFailed": "The uploaded file couldn't be processed. Please check if the file has a valid format.",
         "LogoUpload": "Select a Logo to upload",
         "FaviconUpload": "Select a Favicon to upload",
         "LogoUploadHelp": "Please upload a file in %s formats with a minimum height of %s pixels.",

--- a/plugins/CoreAdminHome/templates/generalSettings.twig
+++ b/plugins/CoreAdminHome/templates/generalSettings.twig
@@ -204,6 +204,9 @@
                 <input type="hidden" name="token_auth" value="{{ token_auth }}"/>
 
                 {% if logosWriteable %}
+                    <div class="alert alert-warning uploaderror" style="display:none;">
+                        {{ 'CoreAdminHome_LogoUploadFailed'|translate }}
+                    </div>
                     <div class="form-group">
                         <label for="customLogo">{{ 'CoreAdminHome_LogoUpload'|translate }}</label>
                         <div class="form-help">{{ 'CoreAdminHome_LogoUploadHelp'|translate("JPG / PNG / GIF", 110) }}</div>


### PR DESCRIPTION
As described in #7264 some errors while uploading a custom logo might occur.
Those errors weren't shown directly. Instead noting happened and the error is displayed after the next page reload.

To improve that behavior, I've suppressed those errors that might occur while opening an invalid file and implemented a simple error message that is displayed when the upload failed.

![image](https://cloud.githubusercontent.com/assets/1579355/12103637/235c0f06-b344-11e5-82be-66eb799f7fe0.png)

fixes #7264
