### PR TITLE
Fixes calculation of fillup columns for subtables

### DIFF
--- a/plugins/Actions/javascripts/actionsDataTable.js
+++ b/plugins/Actions/javascripts/actionsDataTable.js
@@ -318,7 +318,12 @@
 
             $('tr#' + idToReplace, root).after(response).remove();
 
-            var missingColumns = (response.prev().find('td').size() - response.find('td').size());
+            var requiredColumnCount = 0, availableColumnCount = 0;
+
+            response.prev().find('td').each(function(){ requiredColumnCount += $(this).attr('colspan') || 1; });
+            response.find('td').each(function(){ availableColumnCount += $(this).attr('colspan') || 1; });
+
+            var missingColumns = requiredColumnCount - availableColumnCount;
             for (var i = 0; i < missingColumns; i++) {
                 // if the subtable has fewer columns than the parent table, add some columns.
                 // this happens for example, when the parent table has performance metrics and the subtable doesn't.

--- a/tests/UI/specs/ActionsDataTable_spec.js
+++ b/tests/UI/specs/ActionsDataTable_spec.js
@@ -38,8 +38,7 @@ describe("ActionsDataTable", function () {
         }, done);
     });
 
-    // Test is skipped as it randomly fails http://builds-artifacts.piwik.org/ui-tests.master/2433.1/screenshot-diffs/diffviewer.html
-    it.skip("should exclude low population rows when exclude low population link clicked", function (done) {
+    it("should exclude low population rows when exclude low population link clicked", function (done) {
         expect.screenshot('exclude_low_population').to.be.capture(function (page) {
             page.mouseMove('.tableConfiguration');
             page.click('.dataTableExcludeLowPopulation');
@@ -48,10 +47,6 @@ describe("ActionsDataTable", function () {
 
     it("should load normal view when switch to view hierarchical view link is clicked", function (done) {
         expect.screenshot('unflattened').to.be.capture(function (page) {
-            // exclude low population (copied from exclude_low_population test above as it was 'skipped')
-            page.mouseMove('.tableConfiguration');
-            page.click('.dataTableExcludeLowPopulation');
-
             page.mouseMove('.tableConfiguration');
             page.click('.dataTableFlatten');
         }, done);


### PR DESCRIPTION
When subtables are loaded for action tables, the subtable response is checked for missing columns.
This check didn't respect colspans, so it failed for those.

fixes #7219
