### PR TITLE
Standardize password hash function usage

### DIFF
--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\Login;
 use Exception;
 use Piwik\AuthResult;
 use Piwik\Db;
+use Piwik\Piwik;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Plugins\UsersManager\UsersManager;
 use Piwik\Session;

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -12,13 +12,14 @@ use Exception;
 use Piwik\AuthResult;
 use Piwik\Db;
 use Piwik\Plugins\UsersManager\Model;
+use Piwik\Plugins\UsersManager\UsersManager;
 use Piwik\Session;
 
 class Auth implements \Piwik\Auth
 {
     protected $login;
     protected $token_auth;
-    protected $md5Password;
+    protected $hashedPassword;
 
     /**
      * @var Model
@@ -47,7 +48,7 @@ class Auth implements \Piwik\Auth
      */
     public function authenticate()
     {
-        if (!empty($this->md5Password)) { // favor authenticating by password
+        if (!empty($this->hashedPassword)) { // favor authenticating by password
             return $this->authenticateWithPassword($this->login, $this->getTokenAuthSecret());
         } elseif (is_null($this->login)) {
             return $this->authenticateWithToken($this->token_auth);
@@ -132,7 +133,7 @@ class Auth implements \Piwik\Auth
      */
     public function getTokenAuthSecret()
     {
-        return $this->md5Password;
+        return $this->hashedPassword;
     }
 
     /**
@@ -153,9 +154,9 @@ class Auth implements \Piwik\Auth
     public function setPassword($password)
     {
         if (empty($password)) {
-            $this->md5Password = null;
+            $this->hashedPassword = null;
         } else {
-            $this->md5Password = md5($password);
+            $this->hashedPassword = UsersManager::getPasswordHash($password);
         }
     }
 
@@ -163,19 +164,17 @@ class Auth implements \Piwik\Auth
      * Sets the password hash to use when authentication.
      *
      * @param string $passwordHash The password hash.
-     * @throws Exception if $passwordHash does not have 32 characters in it.
      */
     public function setPasswordHash($passwordHash)
     {
         if ($passwordHash === null) {
-            $this->md5Password = null;
+            $this->hashedPassword = null;
             return;
         }
 
-        if (strlen($passwordHash) != 32) {
-            throw new Exception("Invalid hash: incorrect length " . strlen($passwordHash));
-        }
+        // check that the password hash is valid (sanity check)
+        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('Login_ExceptionPasswordMD5HashExpected'))
 
-        $this->md5Password = $passwordHash;
+        $this->hashedPassword = $passwordHash;
     }
 }

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -173,7 +173,7 @@ class Auth implements \Piwik\Auth
         }
 
         // check that the password hash is valid (sanity check)
-        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('Login_ExceptionPasswordMD5HashExpected'))
+        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('Login_ExceptionPasswordMD5HashExpected'));
 
         $this->hashedPassword = $passwordHash;
     }

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -184,9 +184,10 @@ class Controller extends \Piwik\Plugin\Controller
      * Authenticate user and password.  Redirect if successful.
      *
      * @param string $login user name
-     * @param string $password md5 password
+     * @param string $password plain-text or hashed password
      * @param bool $rememberMe Remember me?
      * @param string $urlToRedirect URL to redirect to, if successfully authenticated
+     * @param bool $passwordHashed indicates if $password is hashed
      * @return string failure message if unable to authenticate
      */
     protected function authenticateAndRedirect($login, $password, $rememberMe, $urlToRedirect = false, $passwordHashed = false)

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -383,7 +383,7 @@ class PasswordResetter
      */
     protected function checkPasswordHash($passwordHash)
     {
-        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('Login_ExceptionPasswordMD5HashExpected'))
+        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('Login_ExceptionPasswordMD5HashExpected'));
     }
 
     /**

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -378,14 +378,12 @@ class PasswordResetter
      *
      * Derived classes can override this method to provide fewer or more checks.
      *
-     * @param string $password The password to check.
-     * @throws Exception if the password is not 32 bytes long.
+     * @param string $passwordHash The password hash to check.
+     * @throws Exception if the password hash length is incorrect.
      */
-    protected function checkPasswordHash($password)
+    protected function checkPasswordHash($passwordHash)
     {
-        if (strlen($password) != 32) {
-            throw new Exception(Piwik::translate('Login_ExceptionPasswordMD5HashExpected'));
-        }
+        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('Login_ExceptionPasswordMD5HashExpected'))
     }
 
     /**

--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -310,7 +310,7 @@ class PasswordResetter
     }
 
     /**
-     * Hashes a string. By default generates an MD5 hash.
+     * Hashes a string.
      *
      * Derived classes can override this to provide a different hashing implementation.
      *

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -783,13 +783,13 @@ class API extends \Piwik\Plugin\API
      * Generates a unique MD5 for the given login & password
      *
      * @param string $userLogin Login
-     * @param string $passwordHash hashed string of the password
+     * @param string $md5Password hashed string of the password (using current hash function; MD5-named for historical reasons)
      * @return string
      */
-    public function getTokenAuth($userLogin, $passwordHash)
+    public function getTokenAuth($userLogin, $md5Password)
     {
-        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('UsersManager_ExceptionPasswordMD5HashExpected'));
+        UsersManager::checkPasswordHash($md5Password, Piwik::translate('UsersManager_ExceptionPasswordMD5HashExpected'));
 
-        return md5($userLogin . $passwordHash);
+        return md5($userLogin . $md5Password);
     }
 }

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -342,7 +342,7 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * Returns the user information (login, password md5, alias, email, date_registered, etc.)
+     * Returns the user information (login, password hash, alias, email, date_registered, etc.)
      *
      * @param string $userLogin the user login
      *
@@ -359,7 +359,7 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * Returns the user information (login, password md5, alias, email, date_registered, etc.)
+     * Returns the user information (login, password hash, alias, email, date_registered, etc.)
      *
      * @param string $userEmail the user email
      *
@@ -783,16 +783,13 @@ class API extends \Piwik\Plugin\API
      * Generates a unique MD5 for the given login & password
      *
      * @param string $userLogin Login
-     * @param string $md5Password MD5ied string of the password
-     * @throws Exception
+     * @param string $passwordHash hashed string of the password
      * @return string
      */
-    public function getTokenAuth($userLogin, $md5Password)
+    public function getTokenAuth($userLogin, $passwordHash)
     {
-        if (strlen($md5Password) != 32) {
-            throw new Exception(Piwik::translate('UsersManager_ExceptionPasswordMD5HashExpected'));
-        }
+        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('UsersManager_ExceptionPasswordMD5HashExpected'))
 
-        return md5($userLogin . $md5Password);
+        return md5($userLogin . $passwordHash);
     }
 }

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -788,7 +788,7 @@ class API extends \Piwik\Plugin\API
      */
     public function getTokenAuth($userLogin, $passwordHash)
     {
-        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('UsersManager_ExceptionPasswordMD5HashExpected'))
+        UsersManager::checkPasswordHash($passwordHash, Piwik::translate('UsersManager_ExceptionPasswordMD5HashExpected'));
 
         return md5($userLogin . $passwordHash);
     }

--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -166,7 +166,7 @@ class UsersManager extends \Piwik\Plugin
      */
     public static function checkPasswordHash($passwordHash, $exceptionMessage)
     {
-        if (strlen($passwordHash) !== strlen(static::getPasswordHash('teststring'))) {
+        if (strlen($passwordHash) != 32) {  // MD5 hash length
             throw new Exception($exceptionMessage);
         }
     }

--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -157,6 +157,20 @@ class UsersManager extends \Piwik\Plugin
         return md5($password);
     }
 
+    /**
+     * Checks the password hash length. Used as a sanity check.
+     *
+     * @param string $passwordHash The password hash to check.
+     * @param string $exceptionMessage Message of the exception thrown.
+     * @throws Exception if the password hash length is incorrect.
+     */
+    public static function checkPasswordHash($passwordHash, $exceptionMessage)
+    {
+        if (strlen($passwordHash) !== strlen(static::getPasswordHash('teststring'))) {
+            throw new Exception($exceptionMessage);
+        }
+    }
+
     public function getClientSideTranslationKeys(&$translationKeys)
     {
         $translationKeys[] = "General_OrCancel";


### PR DESCRIPTION
As preparation for introduction of a stronger **password** hash function in https://github.com/piwik/piwik/issues/5728, this standardizes the usage of the current password hash function across the Login and UsersManager plugins. Specifically:
- Use `UsersManager::getPasswordHash()` throughout, instead of previous direct use of `md5()` in some places.
- Concentrate the hash length sanity check in the newly created `UsersManager::checkPasswordHash()`. Previously, `UsersManager\API` and `Login\PasswordResetter` classes did it separately. Both checks were moved into the newly created function in the `UsersManager` class, as that is also where other `public static` password check functions reside.
- Replace the "md5" string with "hash" in affected variable names and comments.

No functional change is intended.

~~One little caveat is that I can't test at the moment. It would be great if someone could take this on a test ride.~~

---

To summarize the hash function uses by the Login and UsersManager plugins:
- The **password** hash function is now centralized in (https://github.com/piwik/piwik/blob/c54fc9e4e6072e7bffbb1a02b1c11645c50038e4/plugins/UsersManager/UsersManager.php#L153):
  
  ``` php
  public static function getPasswordHash($password)
  {
      // if change here, should also edit the installation process
      // to change how the root pwd is saved in the config file
      return md5($password);
  }
  ```

Following hash function uses were not modified:
- **`token_auth`** hash function is controlled by (https://github.com/piwik/piwik/blob/c54fc9e4e6072e7bffbb1a02b1c11645c50038e4/plugins/UsersManager/API.php#L789) (apparently for DB storage - this could be something for https://github.com/piwik/piwik/issues/9457):
  
  ``` php
  public function getTokenAuth($userLogin, $passwordHash)
  {
      UsersManager::checkPasswordHash($passwordHash, Piwik::translate('UsersManager_ExceptionPasswordMD5HashExpected'))
  
      return md5($userLogin . $passwordHash);
  }
  ```
  
    As well as by (https://github.com/Joey3000/piwik/blob/c54fc9e4e6072e7bffbb1a02b1c11645c50038e4/plugins/Login/SessionInitializer.php#L235) (apparently for cookie setting - this could be changed, e.g, at the same time as https://github.com/piwik/piwik/issues/9457 gets implemented, to have `token_auth` only change once):
  
  ``` php
  public static function getHashTokenAuth($login, $token_auth)
  {
      return md5($login . $token_auth);
  }
  ```
- **Password reset token** (per e-mail) is controlled by (https://github.com/piwik/piwik/blob/c54fc9e4e6072e7bffbb1a02b1c11645c50038e4/plugins/Login/PasswordResetter.php#L320):
  
  ``` php
  protected function hashData($data)
  {
      return Common::hash($data);
  }
  ```
