### PR TITLE
VisitorMap doesnt show anything when segment parameter is URL-encoded

### DIFF
--- a/plugins/UserCountryMap/Controller.php
+++ b/plugins/UserCountryMap/Controller.php
@@ -225,15 +225,17 @@ class Controller extends \Piwik\Plugin\Controller
         $params['format'] = 'json';
         $params['showRawMetrics'] = 1;
         if (empty($params['segment'])) {
-            $segment = \Piwik\API\Request::getRawSegmentFromRequest();
-            if (!empty($segment)) {
-                $params['segment'] = urldecode($segment);
-            }
+            $params['segment'] = Request::getRawSegmentFromRequest();
+        }
+
+        if (!empty($params['segment'])) {
+            $params['segment'] = urldecode($params['segment']);
         }
 
         if ($encode) {
             $params = json_encode($params);
         }
+
         return $params;
     }
 


### PR DESCRIPTION
fixes #8813 

took me a long time to reproduce. Used segment `&segment=pageTitle%3D%3DAbout%2520ExampleCode%3BcountryCode%3D%3Dde`
