### PR TITLE
make sure &gt; can be used in segments when using bulk requests

### DIFF
--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -59,6 +59,7 @@ class APITest extends IntegrationTestCase
             "method%3dVisitsSummary.get%26token_auth%3d$token%26idSite%3d1%26date%3d2015-01-26%26period%3dday",
             "method%3dVisitsSummary.get%26idSite%3d1%26date%3d2015-01-26%26period%3dday",
             "method%3dVisitsSummary.get%26idSite%3d1%26token_auth%3danonymous%26date%3d2015-01-26%26period%3dday",
+            "method%3dVisitsSummary.get%26token_auth%3d$token%26idSite%3d1%26date%3d2015-01-26%26period%3dday%26segment%3dvisitDuration%3d%3d30%3bactions%3e2",
         );
         $response = $this->api->getBulkRequest($urls);
 
@@ -67,6 +68,7 @@ class APITest extends IntegrationTestCase
         $this->assertSame(0, $response[1]['nb_visits']);
         $this->assertResponseIsPermissionError($response[2]);
         $this->assertResponseIsPermissionError($response[3]);
+        $this->assertResponseIsSuccess($response[4]);
     }
 
     private function assertResponseIsPermissionError($response)


### PR DESCRIPTION
fixes #9393 

In https://github.com/piwik/piwik/issues/9393#issuecomment-165226307 I thought about fixing it in `API/Request` and even initially implemented it this way but after a lot of thinking it should be rather fixed in `getBulkRequest` as the problem is actually specific to bulk requests.  There is already this unsanitize https://github.com/piwik/piwik/blob/2.16.0-b1/plugins/API/API.php#L483 which is undone by `Request`. So we should also fix it in `getBulkRequest` again where the initial `unsanitize` was done.
