### PR TITLE
Make sure to forward xhprof and testmode to all archiving requests

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -969,14 +969,6 @@ class CronArchive
     {
         $url = $this->makeRequestUrl($url);
 
-        if ($this->shouldStartProfiler) {
-            $url .= "&xhprof=2";
-        }
-
-        if ($this->testmode) {
-            $url .= "&testmode=1";
-        }
-
         try {
             $cliMulti  = $this->makeCliMulti();
             $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
@@ -1603,7 +1595,17 @@ class CronArchive
      */
     private function makeRequestUrl($url)
     {
-        return $url . self::APPEND_TO_API_REQUEST;
+        $url = $url . self::APPEND_TO_API_REQUEST;
+
+        if ($this->shouldStartProfiler) {
+            $url .= "&xhprof=2";
+        }
+
+        if ($this->testmode) {
+            $url .= "&testmode=1";
+        }
+
+        return $url;
     }
 
     /**


### PR DESCRIPTION
This is part 1 of #9258

I will issue another PR for forwarding PHP options in case we can do it.
