### PR TITLE
Forward php cli options to the archiver commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 This is a changelog for Piwik platform developers. All changes for our HTTP API's, Plugins, Themes, etc will be listed here.
 
-## Piwik 2.15.1
+## Piwik 2.16.0
 
 ### New features
  * New segment `actionType` lets you segment all actions of a given type, eg. `actionType==events` or `actionType==downloads`. Action types values are: `pageviews`, `contents`, `sitesearches`, `events`, `outlinks`, `downloads`
  * The JavaScript Tracker method `PiwikTracker.setDomains()` can now handle paths. This means when setting eg `_paq.push(['setDomains, '*.piwik.org/website1'])` all link that goes to the same domain `piwik.org` but to any other path than `website1/*` will be treated as outlink.
+ * It is now possible to pass an option `php-cli-options` to the `core:archive` command. The given cli options will be forwarded to the actual PHP command. This allows to for example specifiy a different memory limit for the archiving process like this: `./console core:archive --php-cli-options="-d memory_limit=8G"`
 
 ### Internal change
  * When generating a new plugin skeleton via `generate:plugin` command, plugin name must now contain only letters and numbers.

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -56,6 +56,8 @@ class CliMulti
      */
     private $urlToPiwik = null;
 
+    private $phpCliOptions = '';
+
     public function __construct()
     {
         $this->supportsAsync = $this->supportsAsync();
@@ -87,6 +89,15 @@ class CliMulti
         }
 
         return $results;
+    }
+
+    /**
+     * Forwards the given configuration options to the PHP cli command.
+     * @param string $phpCliOptions  eg "-d memory_limit=8G -c=path/to/php.ini"
+     */
+    public function setPhpCliConfigurationOptions($phpCliOptions)
+    {
+        $this->phpCliOptions = (string) $phpCliOptions;
     }
 
     /**
@@ -142,8 +153,8 @@ class CliMulti
         $bin = $this->findPhpBinary();
         $superuserCommand = $this->runAsSuperUser ? "--superuser" : "";
 
-        return sprintf('%s %s/console climulti:request -q --piwik-domain=%s %s %s > %s 2>&1 &',
-                       $bin, PIWIK_INCLUDE_PATH, escapeshellarg($hostname), $superuserCommand, escapeshellarg($query), $outputFile);
+        return sprintf('%s %s %s/console climulti:request -q --piwik-domain=%s %s %s > %s 2>&1 &',
+                       $bin, $this->phpCliOptions, PIWIK_INCLUDE_PATH, escapeshellarg($hostname), $superuserCommand, escapeshellarg($query), $outputFile);
     }
 
     private function getResponse()

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -129,6 +129,12 @@ class CronArchive
     public $shouldStartProfiler = false;
 
     /**
+     * Given options will be forwarded to the PHP command if the archiver is executed via CLI.
+     * @var string
+     */
+    public $phpCliConfigurationOptions = '';
+
+    /**
      * If HTTP requests are used to initiate archiving, this controls whether invalid SSL certificates should
      * be accepted or not by each request.
      *
@@ -896,9 +902,7 @@ class CronArchive
         $this->requests += count($urls);
 
         $cliMulti = $this->makeCliMulti();
-        $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
         $cliMulti->setConcurrentProcessesLimit($this->getConcurrentRequestsPerWebsite());
-        $cliMulti->runAsSuperUser();
         $response = $cliMulti->request($urls);
 
         foreach ($urls as $index => $url) {
@@ -979,8 +983,6 @@ class CronArchive
 
         try {
             $cliMulti  = $this->makeCliMulti();
-            $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
-            $cliMulti->runAsSuperUser();
             $responses = $cliMulti->request(array($url));
 
             $response  = !empty($responses) ? array_shift($responses) : null;
@@ -1712,6 +1714,9 @@ class CronArchive
     {
         $cliMulti = StaticContainer::get('Piwik\CliMulti');
         $cliMulti->setUrlToPiwik($this->urlToPiwik);
+        $cliMulti->setPhpCliConfigurationOptions($this->phpCliConfigurationOptions);
+        $cliMulti->setAcceptInvalidSSLCertificate($this->acceptInvalidSSLCertificate);
+        $cliMulti->runAsSuperUser();
         return $cliMulti;
     }
 

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -41,6 +41,7 @@ class CoreArchiver extends ConsoleCommand
         $archiver->forceTimeoutPeriod = $input->getOption("force-timeout-for-periods");
         $archiver->shouldArchiveAllPeriodsSince = $input->getOption("force-all-periods");
         $archiver->restrictToDateRange = $input->getOption("force-date-range");
+        $archiver->phpCliConfigurationOptions = $input->getOption("php-cli-options");
 
         $restrictToPeriods = $input->getOption("force-periods");
         $restrictToPeriods = explode(',', $restrictToPeriods);
@@ -116,5 +117,6 @@ class CoreArchiver extends ConsoleCommand
         $command->addOption('accept-invalid-ssl-certificate', null, InputOption::VALUE_NONE,
             "It is _NOT_ recommended to use this argument. Instead, you should use a valid SSL certificate!\nIt can be "
             . "useful if you specified --url=https://... or if you are using Piwik with force_ssl=1");
+        $command->addOption('php-cli-options', null, InputOption::VALUE_OPTIONAL, 'Forwards the PHP configuration options to the PHP CLI command. For example "-d memory_limit=8G". Note: These options are only applied if the archiver actually uses CLI and not HTTP.', $default = '');
     }
 }

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Integration;
 
-use Piwik\Archiver\Request;
 use Piwik\CliMulti;
 use Piwik\Container\StaticContainer;
 use Piwik\CronArchive;


### PR DESCRIPTION
refs #9258

See also https://github.com/piwik/piwik/pull/9498 which fixes another part of that issue

One can now specify eg `./console core:archive --php-cli-options="-d memory_limit=8G"` and these options will be forwarded to the PHP cli command. Eg this might result in `/home/vagrant/.phpbrew/php/php-5.5.28/bin/php -q -d memory_limit=8G /home/vagrant/www/piwik/console climulti:request --piwik-domain='' --superuser 'module=API&method=API.get&idSite=1...`

In this case `-q` is set by PHP binary finder and not related to the given options. 

Be aware that if `API.get` did trigger another CliMulti request these options would be not forward again (basically recursive). I'm not sure if `API.get` does trigger another CliMulti request somehow but I don't think so.

Initially I wanted to detect PHP Cli configuration options automatically when console is called like this `php -d memory_limit=8G console core:archive ...` but I did not find a way to get these passed options. 
