### PR TITLE
For a Piwik PRO developer always specify a max version for a plugin by default

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -132,7 +132,7 @@ enabled = 0
 disable_merged_assets = 0
 
 ; Set to 1 if you are a Piwik Pro Developer.
-piwikpro_developer = 1
+piwikpro_developer = 0
 
 [General]
 

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -131,6 +131,9 @@ enabled = 0
 ; Note that for quick debugging, instead of using below setting, you can add `&disable_merged_assets=1` to the Piwik URL
 disable_merged_assets = 0
 
+; Set to 1 if you are a Piwik Pro Developer.
+piwikpro_developer = 1
+
 [General]
 
 ; the following settings control whether Unique Visitors `nb_uniq_visitors` and Unique users `nb_users` will be processed for different period types.

--- a/core/Development.php
+++ b/core/Development.php
@@ -22,6 +22,7 @@ use Exception;
 class Development
 {
     private static $isEnabled = null;
+    private static $isPiwikProDeveloper = null;
 
     /**
      * Returns `true` if development mode is enabled and `false` otherwise.
@@ -35,6 +36,20 @@ class Development
         }
 
         return self::$isEnabled;
+    }
+
+    /**
+     * Returns `true` if the developer is a piwik pro developer.
+     *
+     * @return bool
+     */
+    public static function isPiwikProDeveloper()
+    {
+        if (is_null(self::$isPiwikProDeveloper)) {
+            self::$isPiwikProDeveloper = (bool) Config::getInstance()->Development['piwikpro_developer'];
+        }
+
+        return self::$isPiwikProDeveloper;
     }
 
     /**

--- a/plugins/CoreConsole/Commands/DevelopmentEnable.php
+++ b/plugins/CoreConsole/Commands/DevelopmentEnable.php
@@ -25,6 +25,7 @@ class DevelopmentEnable extends ConsoleCommand
         $this->setName('development:enable');
         $this->setAliases(array('development:disable'));
         $this->setDescription('Enable or disable development mode. See config/global.ini.php in section [Development] for more information');
+        $this->addOption('piwikpro', null, InputOption::VALUE_NONE, 'Enabled the Piwik PRO developer mode');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -43,6 +44,10 @@ class DevelopmentEnable extends ConsoleCommand
             $development['enabled'] = 0;
             $development['disable_merged_assets'] = 0;
             $message = 'Development mode disabled';
+        }
+
+        if ($input->hasOption('piwikpro')) {
+            $development['piwikpro_developer'] = 1;
         }
 
         $config->Development = $development;

--- a/plugins/CoreConsole/Commands/GeneratePlugin.php
+++ b/plugins/CoreConsole/Commands/GeneratePlugin.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\CoreConsole\Commands;
 
+use Piwik\Development;
 use Piwik\Filesystem;
 use Piwik\Plugins\ExamplePlugin\ExamplePlugin;
 use Piwik\Version;
@@ -46,13 +47,18 @@ class GeneratePlugin extends GeneratePluginBase
         $info   = $plugin->getInformation();
         $exampleDescription = $info['description'];
 
+        $piwikVersion = '>=' . Version::VERSION;
+        if (Development::isPiwikProDeveloper()) {
+            $piwikVersion .= ',<=' . Version::VERSION;
+        }
+
         if ($isTheme) {
             $exampleFolder = PIWIK_INCLUDE_PATH . '/plugins/ExampleTheme';
             $replace       = array(
                 'ExampleTheme'       => $pluginName,
                 $exampleDescription  => $description,
                 '0.1.0'              => $version,
-                'PIWIK_VERSION'      => Version::VERSION
+                'PIWIK_VERSION'      => $piwikVersion
             );
             $whitelistFiles = array();
 
@@ -63,7 +69,7 @@ class GeneratePlugin extends GeneratePluginBase
                 'ExamplePlugin'      => $pluginName,
                 $exampleDescription  => $description,
                 '0.1.0'              => $version,
-                'PIWIK_VERSION'      => Version::VERSION
+                'PIWIK_VERSION'      => $piwikVersion
             );
             $whitelistFiles = array(
                 '/ExamplePlugin.php',

--- a/plugins/ExamplePlugin/plugin.json
+++ b/plugins/ExamplePlugin/plugin.json
@@ -4,7 +4,7 @@
   "description": "Piwik Platform showcase: how to create widgets, menus, scheduled tasks, a custom archiver, plugin tests, and a AngularJS component.",
   "theme": false,
   "require": {
-    "piwik": ">=PIWIK_VERSION"
+    "piwik": "PIWIK_VERSION"
   },
   "authors": [
     {


### PR DESCRIPTION
refs #8695

This is to be defined whether it's actually needed / wanted by Piwik PRO developers. 

Piwik PRO developers would enable Piwik PRO mode initially with 

`./console development:enable --piwikpro`

Following `development:enable` commands would not need this flag as we wouldn't change it afterwards anymore. It would be otherwise forgotton and annoying to always having to add this flag.

When this mode is enabled, and a plugin is generated, we automatically specify a maximum supported Piwik version in `plugin.json`. Instead of 

``` json
    "require": {
        "piwik": ">=2.15.0-rc1"
    },
```

we specify

``` json
    "require": {
        "piwik": ">=2.15.0-rc1,<=2.15.0-rc1"
    },
```

for Piwik PRO developers. From my understanding in #8695 this is what Piwik PRO developers want. So far it was specified in `.travis.yml`. Please note that when a max version is specified, it cannot be installed on a later Piwik version. This is something that needs to be configured.

Also see related PR https://github.com/piwik/travis-scripts/pull/21
