### PR TITLE
refs #9419 always set character set latin1

### DIFF
--- a/core/Db/BatchInsert.php
+++ b/core/Db/BatchInsert.php
@@ -74,10 +74,9 @@ class BatchInsert
                     'null'             => 'NULL',
                 );
 
-                // hack for charset mismatch
-                if (!DbHelper::isDatabaseConnectionUTF8() && !isset(Config::getInstance()->database['charset'])) {
-                    $fileSpec['charset'] = 'latin1';
-                }
+                // see https://github.com/piwik/piwik/issues/9419#issuecomment-170851440
+                // if charset is utf8 we get this error: Invalid utf8 character string: '"x':
+                $fileSpec['charset'] = 'latin1';
 
                 self::createCSVFile($filePath, $fileSpec, $values);
 


### PR DESCRIPTION
In https://github.com/piwik/piwik/issues/6497 we set the charset in the config to utf8 by default. This caused that latin1 was not set anymore and causes failures on MySQL 5.7. By forcing charset latin1 the load data infile of archives works again.
