### PR TITLE
Allow any plugin system setting to be overwritten in the config file

### DIFF
--- a/core/Settings/SystemSetting.php
+++ b/core/Settings/SystemSetting.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Settings;
 
+use Piwik\Config;
 use Piwik\Piwik;
 
 /**
@@ -58,6 +59,10 @@ class SystemSetting extends Setting
      */
     public function isWritableByCurrentUser()
     {
+        if ($this->hasConfigValue()) {
+            return false;
+        }
+
         return $this->writableByCurrentUser;
     }
 
@@ -80,4 +85,34 @@ class SystemSetting extends Setting
     {
         return 30;
     }
+
+    public function getValue()
+    {
+        $defaultValue = parent::getValue(); // we access value first to make sure permissions are checked
+
+        $configValue = $this->getValueFromConfig();
+
+        if (isset($configValue)) {
+            $defaultValue = $configValue;
+            settype($defaultValue, $this->type);
+        }
+
+        return $defaultValue;
+    }
+
+    private function hasConfigValue()
+    {
+        $value = $this->getValueFromConfig();
+        return isset($value);
+    }
+
+    private function getValueFromConfig()
+    {
+        $config = Config::getInstance()->{$this->pluginName};
+
+        if (!empty($config) && array_key_exists($this->name, $config)) {
+            return $config[$this->name];
+        }
+    }
+
 }


### PR DESCRIPTION
fixes https://github.com/piwik/plugin-QueuedTracking/issues/21 

Plugin settings are configured in the UI under "Administration => Plugin Settings". However, sometimes one might want to define a different config value on different servers (for example in a load balanced environment) see for example https://github.com/piwik/plugin-QueuedTracking/issues/21

For example one might want to enabled QueuedTracking on one server, but disable it on another and use log importer instead on the other server. 

To overwrite a plugin system setting specify the plugin name and plugin setting name in the `config/config.ini.php` file like this:

``` ini
[PluginName]
pluginSettingName = pluginSettingValue
```

Actual example for plugin QueuedTracking:

``` ini
[QueuedTracking]
processDuringTrackingRequest = 0
queueEnabled = 1
```

Important: 
- Setting names are case sensitive
- Once a plugin setting is configured in the config file, the value can be no longer changed in the UI since we cannot modify the config file eg in a load balanced environment etc. A side effect of this is to being able to hide specific system settings for users by specifying them in the config
- In another pull request we will offer the possibility to see a all configured config values, and also to see all available plugin names + plugin system setting names that can be configured including documentation
