### PR TITLE
Administration > Diagnostics > Config file lets Super User view all config values in the UI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "piwik/decompress": "~1.0",
         "piwik/network": "~0.1.0",
         "piwik/cache": "~0.2.5",
-        "piwik/ini": "^1.0.3",
+        "piwik/ini": "^1.0.6",
         "php-di/php-di": "5.0.0-beta1",
         "psr/log": "~1.0",
         "monolog/monolog": "~1.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "09112ef01f28686b387148c407503c7c",
-    "content-hash": "ff9b83524f413ac80daad8eb47099042",
+    "hash": "de61be52972a0fe8fe751306c271f4b8",
+    "content-hash": "68130b067cdceef8346b47d858b763a3",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -300,7 +300,6 @@
                 "phpdoc",
                 "reflection"
             ],
-            "abandoned": "php-di/phpdoc-reader",
             "time": "2014-08-21 08:20:45"
         },
         {
@@ -875,16 +874,16 @@
         },
         {
             "name": "piwik/ini",
-            "version": "1.0.4",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/piwik/component-ini.git",
-                "reference": "9269255fd187e5bda2e5778041c8d143eb615b0a"
+                "reference": "bd2711ba4d5e20e4ca09b6829dc2831576b59dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/piwik/component-ini/zipball/9269255fd187e5bda2e5778041c8d143eb615b0a",
-                "reference": "9269255fd187e5bda2e5778041c8d143eb615b0a",
+                "url": "https://api.github.com/repos/piwik/component-ini/zipball/bd2711ba4d5e20e4ca09b6829dc2831576b59dc3",
+                "reference": "bd2711ba4d5e20e4ca09b6829dc2831576b59dc3",
                 "shasum": ""
             },
             "require": {
@@ -904,7 +903,7 @@
             "license": [
                 "LGPL-3.0"
             ],
-            "time": "2015-04-21 04:59:09"
+            "time": "2016-01-14 21:13:33"
         },
         {
             "name": "piwik/network",
@@ -1551,7 +1550,7 @@
                 "performance",
                 "profiling"
             ],
-            "time": "2015-02-26 14:37:51"
+            "time": "2014-08-28 17:34:52"
         },
         {
             "name": "guzzle/guzzle",

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -104,6 +104,8 @@ class Twig
         $this->twig->addTokenParser(new RenderTokenParser());
 
         $this->addTest_false();
+        $this->addTest_true();
+        $this->addTest_emptyString();
     }
 
     private function addTest_false()
@@ -112,6 +114,28 @@ class Twig
             'false',
             function ($value) {
                 return false === $value;
+            }
+        );
+        $this->twig->addTest($test);
+    }
+
+    private function addTest_true()
+    {
+        $test = new Twig_SimpleTest(
+            'true',
+            function ($value) {
+                return true === $value;
+            }
+        );
+        $this->twig->addTest($test);
+    }
+
+    private function addTest_emptyString()
+    {
+        $test = new Twig_SimpleTest(
+            'emptyString',
+            function ($value) {
+                return '' === $value;
             }
         );
         $this->twig->addTest($test);

--- a/plugins/Diagnostics/ConfigReader.php
+++ b/plugins/Diagnostics/ConfigReader.php
@@ -115,21 +115,13 @@ class ConfigReader
     private function isKeyAPassword($key)
     {
         $key = strtolower($key);
-
-        if (strpos($key, 'password') !== false) {
-            return true;
-        }
-
-        if (strpos($key, 'secret') !== false) {
-            return true;
-        }
-
-        if (strpos($key, 'apikey') !== false) {
-            return true;
-        }
-
-        if (strpos($key, 'privatekey') !== false) {
-            return true;
+        $passwordFields = array(
+            'password', 'secret', 'apikey', 'privatekey', 'admin_pass'
+        );
+        foreach ($passwordFields as $value) {
+            if (strpos($key, $value) !== false) {
+                return true;
+            }
         }
 
         if ($key === 'salt') {

--- a/plugins/Diagnostics/ConfigReader.php
+++ b/plugins/Diagnostics/ConfigReader.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Plugins\Diagnostics;
+
+use Piwik\Development;
+use Piwik\Ini\IniReader;
+use Piwik\Application\Kernel\GlobalSettingsProvider;
+use Piwik\Settings;
+
+/**
+ * A diagnostic report contains all the results of all the diagnostics.
+ */
+class ConfigReader
+{
+    /**
+     * @var GlobalSettingsProvider
+     */
+    private $settings;
+
+    /**
+     * @var IniReader
+     */
+    private $iniReader;
+
+    public function __construct(GlobalSettingsProvider $settings, IniReader $iniReader)
+    {
+        $this->settings = $settings;
+        $this->iniReader = $iniReader;
+    }
+
+    public function getConfigValuesFromFiles()
+    {
+        $ini = $this->settings->getIniFileChain();
+        $descriptions = $this->iniReader->readComments($this->settings->getPathGlobal());
+
+        $copy = array();
+        foreach ($ini->getAll() as $category => $values) {
+            if ($this->shouldSkipCategory($category)) {
+                continue;
+            }
+
+            $local = $this->getFromLocalConfig($category);
+            if (empty($local)) {
+                $local = array();
+            }
+
+            $global = $this->getFromGlobalConfig($category);
+            if (empty($global)) {
+                $global = array();
+            }
+
+            $copy[$category] = array();
+            foreach ($values as $key => $value) {
+
+                $newValue = $value;
+                if (strpos(strtolower($key), 'password') !== false) {
+                    $newValue = str_pad('', strlen($value), '*');
+                }
+
+                $defaultValue = null;
+                if (array_key_exists($key, $global)) {
+                    $defaultValue = $global[$key];
+                }
+
+                $description = '';
+                if (!empty($descriptions[$category][$key])) {
+                    $description = trim($descriptions[$category][$key]);
+                }
+
+                $copy[$category][$key] = array(
+                    'value' => $newValue,
+                    'description' => $description,
+                    'isCustomValue' => array_key_exists($key, $local),
+                    'defaultValue' => $defaultValue,
+                );
+            }
+        }
+
+        return $copy;
+    }
+
+    private function shouldSkipCategory($category)
+    {
+        $category = strtolower($category);
+        if ($category === 'database') {
+            return true;
+        }
+
+        $developmentOnlySections = array('database_tests', 'tests', 'debugtests');
+
+        return !Development::isEnabled() && in_array($category, $developmentOnlySections);
+    }
+
+    public function getFromGlobalConfig($name)
+    {
+        return $this->settings->getIniFileChain()->getFrom($this->settings->getPathGlobal(), $name);
+    }
+
+    public function getFromLocalConfig($name)
+    {
+        return $this->settings->getIniFileChain()->getFrom($this->settings->getPathLocal(), $name);
+    }
+
+    /**
+     * Adds config values that can be used to overwrite a plugin system setting and adds a description + default value
+     * for already existing configured config values that overwrite a plugin system setting.
+     *
+     * @param array $configValues
+     * @param \Piwik\Plugin\Settings[] $pluginSettings
+     * @return array
+     */
+    public function addConfigValuesFromPluginSettings($configValues, $pluginSettings)
+    {
+        foreach ($pluginSettings as $pluginSetting) {
+            $pluginName = $pluginSetting->getPluginName();
+            $configs[$pluginName] = array();
+
+            foreach ($pluginSetting->getSettings() as $setting) {
+                if ($setting instanceof Settings\SystemSetting && $setting->isReadableByCurrentUser()) {
+
+                    $description = '';
+                    if (!empty($setting->description)) {
+                        $description .= $setting->description . ' ';
+                    }
+
+                    if (!empty($setting->inlineHelp)) {
+                        $description .= $setting->inlineHelp;
+                    }
+
+                    if (isset($configValues[$pluginName][$setting->getName()])) {
+                        $configValues[$pluginName][$setting->getName()]['defaultValue'] = $setting->defaultValue;
+                        $configValues[$pluginName][$setting->getName()]['description']  = trim($description);
+                    } else {
+                        $defaultValue = $setting->getValue();
+                        $configValues[$pluginName][$setting->getName()] = array(
+                            'value' => null,
+                            'description' => trim($description),
+                            'isCustomValue' => false,
+                            'defaultValue' => $defaultValue
+                        );
+                    }
+                }
+            }
+
+            if (empty($configValues[$pluginName])) {
+                unset($configValues[$pluginName]);
+            }
+        }
+
+        return $configValues;
+    }
+}

--- a/plugins/Diagnostics/ConfigReader.php
+++ b/plugins/Diagnostics/ConfigReader.php
@@ -60,7 +60,7 @@ class ConfigReader
 
                 $newValue = $value;
                 if ($this->isKeyAPassword($key)) {
-                    $newValue = $this->maskPassword($value);
+                    $newValue = $this->getMaskedPassword();
                 }
 
                 $defaultValue = null;
@@ -107,9 +107,9 @@ class ConfigReader
         return $this->settings->getIniFileChain()->getFrom($this->settings->getPathLocal(), $name);
     }
 
-    private function maskPassword($password)
+    private function getMaskedPassword()
     {
-        return str_pad('', strlen($password), '*');
+        return '******';
     }
 
     private function isKeyAPassword($key)
@@ -169,7 +169,7 @@ class ConfigReader
 
                         if ($setting->uiControlType === PluginSettings::CONTROL_PASSWORD) {
                             $value = $configValues[$pluginName][$name]['value'];
-                            $configValues[$pluginName][$name]['value'] = $this->maskPassword($value);
+                            $configValues[$pluginName][$name]['value'] = $this->getMaskedPassword();
                         }
                     } else {
                         $defaultValue = $setting->getValue();

--- a/plugins/Diagnostics/Controller.php
+++ b/plugins/Diagnostics/Controller.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Diagnostics;
+
+use Piwik\Config;
+use Piwik\Piwik;
+use Piwik\View;
+use Piwik\Settings;
+
+/**
+ * A controller let's you for example create a page that can be added to a menu. For more information read our guide
+ * http://developer.piwik.org/guides/mvc-in-piwik or have a look at the our API references for controller and view:
+ * http://developer.piwik.org/api-reference/Piwik/Plugin/Controller and
+ * http://developer.piwik.org/api-reference/Piwik/View
+ */
+class Controller extends \Piwik\Plugin\ControllerAdmin
+{
+    /**
+     * @var ConfigReader
+     */
+    private $configReader;
+
+    public function __construct(ConfigReader $configReader)
+    {
+        $this->configReader = $configReader;
+        parent::__construct();
+    }
+
+    public function configfile()
+    {
+        Piwik::checkUserHasSuperUserAccess();
+
+        $allSettings = Settings\Manager::getAllPluginSettings();
+
+        $configValues = $this->configReader->getConfigValuesFromFiles();
+        $configValues = $this->configReader->addConfigValuesFromPluginSettings($configValues, $allSettings);
+        $configValues = $this->sortConfigValues($configValues);
+
+        return $this->renderTemplate('configfile', array(
+            'allConfigValues' => $configValues
+        ));
+    }
+
+    private function sortConfigValues($configValues)
+    {
+        // we sort by sections alphabetically
+        uksort($configValues, function ($section1, $section2) {
+            return strcasecmp($section1, $section2);
+        });
+
+        foreach ($configValues as $category => &$settings) {
+            // we sort keys alphabetically but list the ones that are changed first
+            uksort($settings, function ($setting1, $setting2) use ($settings) {
+                if ($settings[$setting1]['isCustomValue'] && !$settings[$setting2]['isCustomValue']) {
+                    return -1;
+                } elseif (!$settings[$setting1]['isCustomValue'] && $settings[$setting2]['isCustomValue']) {
+                    return 1;
+                }
+                return strcasecmp($setting1, $setting2);
+            });
+        }
+
+        return $configValues;
+    }
+
+}

--- a/plugins/Diagnostics/Diagnostics.php
+++ b/plugins/Diagnostics/Diagnostics.php
@@ -12,4 +12,19 @@ use Piwik\Plugin;
 
 class Diagnostics extends Plugin
 {
+    /**
+     * @see Piwik\Plugin::registerEvents
+     */
+    public function registerEvents()
+    {
+        return array(
+            'AssetManager.getStylesheetFiles' => 'getStylesheetFiles',
+        );
+    }
+
+    public function getStylesheetFiles(&$stylesheets)
+    {
+        $stylesheets[] = "plugins/Diagnostics/stylesheets/configfile.less";
+    }
+
 }

--- a/plugins/Diagnostics/Menu.php
+++ b/plugins/Diagnostics/Menu.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Diagnostics;
+
+use Piwik\Menu\MenuAdmin;
+use Piwik\Piwik;
+
+/**
+ * This class allows you to add, remove or rename menu items.
+ * To configure a menu (such as Admin Menu, Reporting Menu, User Menu...) simply call the corresponding methods as
+ * described in the API-Reference http://developer.piwik.org/api-reference/Piwik/Menu/MenuAbstract
+ */
+class Menu extends \Piwik\Plugin\Menu
+{
+    public function configureAdminMenu(MenuAdmin $menu)
+    {
+        if (Piwik::hasUserSuperUserAccess()) {
+            $menu->addDiagnosticItem('Diagnostics_ConfigFileTitle', $this->urlForAction('configfile'), $orderId = 30);
+        }
+    }
+
+}

--- a/plugins/Diagnostics/Test/Integration/ConfigReaderTest.php
+++ b/plugins/Diagnostics/Test/Integration/ConfigReaderTest.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Diagnostics\Test\Integration\Commands;
+
+use Piwik\Application\Kernel\GlobalSettingsProvider;
+use Piwik\Ini\IniReader;
+use Piwik\Plugins\Diagnostics\ConfigReader;
+use Piwik\Plugins\ExampleSettingsPlugin\Settings;
+use Piwik\Tests\Fixtures\OneVisitorTwoVisits;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * TODO: This could be a unit test if we could inject the ArchiveTableDao in the command
+ * @group Diagnostics
+ * @group Plugins
+ */
+class ConfigReaderTest extends IntegrationTestCase
+{
+    /**
+     * @var ConfigReader
+     */
+    private $configReader;
+
+    public function setUp()
+    {
+        $settings = new GlobalSettingsProvider($this->configPath('global.ini.php'), $this->configPath('config.ini.php'), $this->configPath('common.config.ini.php'));
+        $this->configReader = new ConfigReader($settings, new IniReader());
+    }
+
+    public function test_getConfigValuesFromFiles()
+    {
+        $fileConfig = $this->configReader->getConfigValuesFromFiles();
+
+        $expected = array (
+            'Category' =>
+                array (
+                    'key1' =>
+                        array (
+                            'value' => 'value_overwritten',
+                            'description' => '',
+                            'isCustomValue' => true,
+                            'defaultValue' => 'value1',
+                        ),
+                    'key2' =>
+                        array (
+                            'value' => 'valueCommon',
+                            'description' => '',
+                            'isCustomValue' => false,
+                            'defaultValue' => 'value2',
+                        ),
+                    'key3' =>
+                        array (
+                            'value' => '${@piwik(crash))}',
+                            'description' => '',
+                            'isCustomValue' => false,
+                            'defaultValue' => NULL,
+                        ),
+                ),
+            'CategoryOnlyInGlobalFile' =>
+                array (
+                    'key3' =>
+                        array (
+                            'value' => 'value3',
+                            'description' => 'test comment',
+                            'isCustomValue' => false,
+                            'defaultValue' => 'value3',
+                        ),
+                    'key4' =>
+                        array (
+                            'value' => 'value4',
+                            'description' => 'test comment 4',
+                            'isCustomValue' => false,
+                            'defaultValue' => 'value4',
+                        ),
+                ),
+            'TestArray' =>
+                array (
+                    'installed' =>
+                        array (
+                            'value' =>
+                                array (
+                                    0 => 'plugin"1',
+                                    1 => 'plugin2',
+                                    2 => 'plugin3',
+                                ),
+                            'description' => 'test comment 2
+with multiple lines',
+                            'isCustomValue' => true,
+                            'defaultValue' =>
+                                array (
+                                    0 => 'plugin1',
+                                    1 => 'plugin4',
+                                ),
+                        ),
+                ),
+            'TestArrayOnlyInGlobalFile' =>
+                array (
+                    'my_array' =>
+                        array (
+                            'value' =>
+                                array (
+                                    0 => 'value1',
+                                    1 => 'value2',
+                                ),
+                            'description' => '',
+                            'isCustomValue' => false,
+                            'defaultValue' =>
+                                array (
+                                    0 => 'value1',
+                                    1 => 'value2',
+                                ),
+                        ),
+                ),
+            'GeneralSection' =>
+                array (
+                    'password' =>
+                        array (
+                            'value' => '****',
+                            'description' => '',
+                            'isCustomValue' => true,
+                            'defaultValue' => NULL,
+                        ),
+                    'login' =>
+                        array (
+                            'value' => 'tes"t',
+                            'description' => '',
+                            'isCustomValue' => true,
+                            'defaultValue' => NULL,
+                        ),
+                ),
+            'TestOnlyInCommon' =>
+                array (
+                    'value' =>
+                        array (
+                            'value' => 'commonValue',
+                            'description' => '',
+                            'isCustomValue' => false,
+                            'defaultValue' => NULL,
+                        ),
+                ),
+            'Tracker' =>
+                array (
+                    'commonConfigTracker' =>
+                        array (
+                            'value' => 'commonConfigTrackerValue',
+                            'description' => '',
+                            'isCustomValue' => false,
+                            'defaultValue' => NULL,
+                        ),
+                ),
+        );
+        $this->assertEquals($expected, $fileConfig);
+    }
+
+    public function test_addConfigValuesFromPluginSettings()
+    {
+        $settings = new Settings();
+
+        $configValues = $this->configReader->addConfigValuesFromPluginSettings(array(), array($settings));
+
+        $expected = array (
+            'ExampleSettingsPlugin' =>
+                array (
+                    'metric' =>
+                        array (
+                            'value' => NULL,
+                            'description' => 'Choose the metric that should be displayed in the browser tab',
+                            'isCustomValue' => false,
+                            'defaultValue' => 'nb_visits',
+                        ),
+                    'browsers' =>
+                        array (
+                            'value' => NULL,
+                            'description' => 'The value will be only displayed in the following browsers',
+                            'isCustomValue' => false,
+                            'defaultValue' =>
+                                array (
+                                    0 => 'firefox',
+                                    1 => 'chromium',
+                                    2 => 'safari',
+                                ),
+                        ),
+                    'description' =>
+                        array (
+                            'value' => NULL,
+                            'description' => 'This description will be displayed next to the value',
+                            'isCustomValue' => false,
+                            'defaultValue' => 'This is the value:
+Another line',
+                        ),
+                    'password' =>
+                        array (
+                            'value' => NULL,
+                            'description' => 'Password for the 3rd API where we fetch the value',
+                            'isCustomValue' => false,
+                            'defaultValue' => NULL,
+                        ),
+                ),
+        );
+        $this->assertEquals($expected, $configValues);
+    }
+
+    public function test_addConfigValuesFromPluginSettings_shouldAddDescriptionAndDefaultValueForExistingConfigValues()
+    {
+        $settings = new Settings();
+
+        $existing = array(
+            'ExampleSettingsPlugin' =>
+                array (
+                    'metric' =>
+                        array (
+                            'value' => NULL,
+                            'description' => '',
+                            'isCustomValue' => false,
+                            'defaultValue' => null,
+                        ),
+                    )
+        );
+
+        $configValues = $this->configReader->addConfigValuesFromPluginSettings($existing, array($settings));
+
+        $this->assertSame('Choose the metric that should be displayed in the browser tab', $configValues['ExampleSettingsPlugin']['metric']['description']);
+        $this->assertSame('nb_visits', $configValues['ExampleSettingsPlugin']['metric']['defaultValue']);
+    }
+
+    private function configPath($file)
+    {
+        return PIWIK_INCLUDE_PATH . '/tests/resources/Config/' . $file;
+    }
+}
+
+AnalyzeArchiveTableTest::$fixture = new OneVisitorTwoVisits();

--- a/plugins/Diagnostics/Test/Integration/ConfigReaderTest.php
+++ b/plugins/Diagnostics/Test/Integration/ConfigReaderTest.php
@@ -121,7 +121,7 @@ with multiple lines',
                 array (
                     'password' =>
                         array (
-                            'value' => '****',
+                            'value' => '******',
                             'description' => '',
                             'isCustomValue' => true,
                             'defaultValue' => NULL,
@@ -249,7 +249,7 @@ Another line',
 
         $configValues = $this->configReader->addConfigValuesFromPluginSettings($existing, array($settings));
 
-        $this->assertSame('****', $configValues['ExampleSettingsPlugin']['metric']['value']);
+        $this->assertSame('******', $configValues['ExampleSettingsPlugin']['metric']['value']);
     }
 
     private function configPath($file)

--- a/plugins/Diagnostics/Test/Integration/ConfigReaderTest.php
+++ b/plugins/Diagnostics/Test/Integration/ConfigReaderTest.php
@@ -191,7 +191,7 @@ with multiple lines',
                             'value' => NULL,
                             'description' => 'This description will be displayed next to the value',
                             'isCustomValue' => false,
-                            'defaultValue' => 'This is the value:
+                            'defaultValue' => 'This is the value: 
 Another line',
                         ),
                     'password' =>
@@ -227,6 +227,29 @@ Another line',
 
         $this->assertSame('Choose the metric that should be displayed in the browser tab', $configValues['ExampleSettingsPlugin']['metric']['description']);
         $this->assertSame('nb_visits', $configValues['ExampleSettingsPlugin']['metric']['defaultValue']);
+    }
+
+    public function test_addConfigValuesFromPluginSettings_shouldMaskValueIfTypeIsPassword()
+    {
+        $settings = new Settings();
+        $settings->metric->uiControlType = Settings::CONTROL_PASSWORD;
+
+        $existing = array(
+            'ExampleSettingsPlugin' =>
+                array (
+                    'metric' =>
+                        array (
+                            'value' => 'test',
+                            'description' => '',
+                            'isCustomValue' => false,
+                            'defaultValue' => null,
+                        ),
+                    )
+        );
+
+        $configValues = $this->configReader->addConfigValuesFromPluginSettings($existing, array($settings));
+
+        $this->assertSame('****', $configValues['ExampleSettingsPlugin']['metric']['value']);
     }
 
     private function configPath($file)

--- a/plugins/Diagnostics/lang/en.json
+++ b/plugins/Diagnostics/lang/en.json
@@ -1,0 +1,8 @@
+{
+    "Diagnostics": {
+        "ConfigFileTitle": "Config file",
+        "ConfigFileIntroduction": "Here you can view the Piwik configuration. If you are running Piwik in a load balanced environment the page might be different depending from which server this page is loaded. Rows with a different background color are changed config values that are specified for example in the %s file.",
+        "HideUnchanged": "If you want to see only changed values you can %shide all unchanged values%s.",
+        "Sections": "Sections"
+    }
+}

--- a/plugins/Diagnostics/lang/en.json
+++ b/plugins/Diagnostics/lang/en.json
@@ -1,8 +1,8 @@
 {
     "Diagnostics": {
         "ConfigFileTitle": "Config file",
-        "ConfigFileIntroduction": "Here you can view the Piwik configuration. If you are running Piwik in a load balanced environment the page might be different depending from which server this page is loaded. Rows with a different background color are changed config values that are specified for example in the %s file.",
-        "HideUnchanged": "If you want to see only changed values you can %shide all unchanged values%s.",
+        "ConfigFileIntroduction": "Here you can view the Piwik configuration. If you are running Piwik in a load balanced environment the page might be different depending from which server this page is loaded. Rows with a different background color are changed config values that are specified for example in the %1$s file.",
+        "HideUnchanged": "If you want to see only changed values you can %1$shide all unchanged values%2$s.",
         "Sections": "Sections"
     }
 }

--- a/plugins/Diagnostics/plugin.json
+++ b/plugins/Diagnostics/plugin.json
@@ -1,6 +1,3 @@
 {
-    "description": "Performs diagnostics to check that Piwik is installed and runs correctly.",
-    "require": {
-        "piwik": ">=2.16.0-b2"
-    }
+    "description": "Performs diagnostics to check that Piwik is installed and runs correctly."
 }

--- a/plugins/Diagnostics/plugin.json
+++ b/plugins/Diagnostics/plugin.json
@@ -1,3 +1,6 @@
 {
-  "description": "Performs diagnostics to check that Piwik is installed and runs correctly."
+    "description": "Performs diagnostics to check that Piwik is installed and runs correctly.",
+    "require": {
+        "piwik": ">=2.16.0-b2"
+    }
 }

--- a/plugins/Diagnostics/stylesheets/configfile.less
+++ b/plugins/Diagnostics/stylesheets/configfile.less
@@ -1,0 +1,22 @@
+.diagnostics.configfile {
+  .custom-value {
+    background-color: @theme-color-background-tinyContrast;
+  }
+
+  .defaultValue {
+    font-style: italic;
+  }
+
+  td.name {
+    max-width: 330px;
+    word-wrap: break-word;
+    width: 25%;
+  }
+
+  td.value {
+    word-wrap: break-word;
+    max-width: 400px;
+    width: 25%;
+  }
+
+}

--- a/plugins/Diagnostics/templates/configfile.twig
+++ b/plugins/Diagnostics/templates/configfile.twig
@@ -1,0 +1,55 @@
+{% extends 'admin.twig' %}
+
+{% macro humanReadableValue(value) %}
+    {% if value is false %}
+        false
+    {% elseif value is true %}
+        true
+    {% elseif value is null %}
+    {% elseif value is emptyString %}
+        ''
+    {% else %}
+        {{ value|join(', ') }}
+    {% endif %}
+{% endmacro %}
+
+{% block content %}
+    <h2 piwik-enriched-headline>{{ 'Diagnostics_ConfigFileTitle'|translate }}</h2>
+    <p>
+        {{ 'Diagnostics_ConfigFileIntroduction'|translate('<code>"config/config.ini.php"</code>')|raw }}
+        {{ 'Diagnostics_HideUnchanged'|translate('<a ng-click="hideGlobalConfigValues=!hideGlobalConfigValues">', '</a>')|raw }}
+
+        <h3>{{ 'Diagnostics_Sections'|translate }}</h3>
+        {% for category, values in allConfigValues %}
+            <a href="#{{ category|e('html_attr') }}">{{ category }}</a><br />
+        {% endfor %}
+    </p>
+
+    <table class="simple-table diagnostics configfile">
+        <tbody>
+        {% for category, configValues in allConfigValues %}
+            <tr><td colspan="3"><a name="{{ category|e('html_attr') }}"></a><h3>{{ category }}</h3></td></tr>
+
+            {% for key, configEntry in configValues %}
+                <tr {% if configEntry.isCustomValue %}class="custom-value"{% else %}ng-hide="hideGlobalConfigValues"{% endif %}>
+                    <td class="name">{{ key }}{% if configEntry.value is iterable %}[]{% endif %}</td>
+                    <td class="value">
+                        {{ _self.humanReadableValue(configEntry.value) }}
+                    </td>
+                    <td class="description">
+                        {{ configEntry.description }}
+
+                        {% if (configEntry.isCustomValue or configEntry.value is null) and configEntry.defaultValue is not null %}
+                            {% if configEntry.description %}<br />{% endif %}
+
+                            {{ 'General_Default'|translate }}:
+                            <span class="defaultValue">{{ _self.humanReadableValue(configEntry.defaultValue) }}<span>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+        {% endfor %}
+        </tbody>
+    </table>
+
+{% endblock %}

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -498,6 +498,12 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         }, done);
     });
 
+    it('should load the config file page correctly', function (done) {
+        expect.screenshot('admin_diagnostics_configfile').to.be.captureSelector('.pageWrap', function (page) {
+            page.load("?" + generalParams + "&module=Diagnostics&action=configfile");
+        }, done);
+    });
+
     it('should load the Settings > Visitor Generator admin page correctly', function (done) {
         expect.screenshot('admin_visitor_generator').to.be.captureSelector('.pageWrap', function (page) {
             page.load("?" + generalParams + "&module=VisitorGenerator&action=index");

--- a/tests/resources/Config/global.ini.php
+++ b/tests/resources/Config/global.ini.php
@@ -3,10 +3,14 @@ key1 = value1
 key2 = value2
 
 [CategoryOnlyInGlobalFile]
+; test comment
 key3 = "value3"
+; test comment 4
 key4 = value4
 
 [TestArray]
+; test comment 2
+; with multiple lines
 installed[] = plugin1
 installed[] = plugin4
 


### PR DESCRIPTION
- We list all config values that are defined either in global, common or local ini
- We list all config values that could be defined to overwrite a plugin system setting
- We mark all config values that were changed eg in config.ini.php
- It is possible to view only changed config values
- We show default values from global.ini.php or from the plugin settings if we know the default value and if the config value is changed
- We show the description of a config entry if one is available (comment in ini file or plugin setting description / inline help)
- Available under Diagnostics for super users
- We always hide `database`
- We replace all config keys that contain the term `password`, `salt`, `apikey`, `privatekey` or `secret` with `****` (I looked through Piwik / Piwik PRO plugins to see which kinda keys could contain too sensitive data)
- We also replace system setting values that are of type `password` with `****`
- If development is not enabled we also hide more sections `database_tests`, `debugtests` and `tests`

This is especially useful for https://github.com/piwik/piwik/pull/9521 to see which plugin settings can be overwritten and which ones are defined. It also helps when we ask users to check their config etc.

@mattab can you change the `ConfigFileIntroduction` translation maybe?
