### PR TITLE
Try to use path from MySQL "secure_file_priv" system variable for batch inserting via load infile

### DIFF
--- a/core/Db/BatchInsert.php
+++ b/core/Db/BatchInsert.php
@@ -56,12 +56,14 @@ class BatchInsert
      */
     public static function tableInsertBatch($tableName, $fields, $values, $throwException = false)
     {
-        $filePath = StaticContainer::get('path.tmp') . '/assets/' . $tableName . '-' . Common::generateUniqId() . '.csv';
-
         $loadDataInfileEnabled = Config::getInstance()->General['enable_load_data_infile'];
 
         if ($loadDataInfileEnabled
             && Db::get()->hasBulkLoader()) {
+
+            $path = self::getBestPathForLoadData();
+            $filePath = $path . $tableName . '-' . Common::generateUniqId() . '.csv';
+
             try {
                 $fileSpec = array(
                     'delim'            => "\t",
@@ -94,15 +96,34 @@ class BatchInsert
                     throw $e;
                 }
             }
+
+            // if all else fails, fallback to a series of INSERTs
+            if (file_exists($filePath)) {
+                @unlink($filePath);
+            }
         }
 
-        // if all else fails, fallback to a series of INSERTs
-        if(file_exists($filePath)){
-            @unlink($filePath);
-        }
-        
         self::tableInsertBatchIterate($tableName, $fields, $values);
+
         return false;
+    }
+
+    private static function getBestPathForLoadData()
+    {
+        try {
+            $path = Db::fetchOne('SELECT @@secure_file_priv'); // was introduced in 5.0.38
+        } catch (Exception $e) {
+            // we do not rethrow exception as an error is expected if MySQL is < 5.0.38
+            // in this case tableInsertBatch might still work
+        }
+
+        if (empty($path) || !is_dir($path) || !is_writable($path)) {
+            $path = StaticContainer::get('path.tmp') . '/assets/';
+        } elseif (!Common::stringEndsWith($path, '/')) {
+            $path .= '/';
+        }
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION
fixes https://github.com/piwik/piwik/issues/9528

Background:
See https://github.com/piwik/piwik/issues/9419#issuecomment-170851440 and https://github.com/piwik/piwik/issues/9419#issuecomment-171588963

From https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_secure_file_priv

> If set to the name of a directory, the server limits import and export operations to work only with files in that directory.  ...
> 
> ... Before MySQL 5.7.6, this variable is empty by default. As of 5.7.6, the default value is platform specific ...

So since 5.7.6 eg the default value is `/var/lib/mysql-files` instead of being empty. This means `load data ...` only works when the file was placed within that directory. If it is not in that directory the following error might occur

``` log
SQLSTATE[HY000]: General error: 1290 The MySQL server is running with the --secure-file-priv option so it cannot execute this statement
```

However, this applies to `LOAD DATA INFILE`. The fallback `LOAD DATA LOCAL INFILE` still seems to work even if we put the file not into the specified directory. Background for this: When using batch insert, by default we try to use the more secure way `LOAD DATA INFILE` and if this fails for some reason we try to use  `LOAD DATA LOCAL INFILE` if possible. Using the `LOCAL` keyword means the client reads the file and sends it to the server. This fallback way using `LOCAL` is only used when there are no restrictions re `open_basedir` and `safemode`. 

This means by default it should still work even when we don't put the CSV file into the `secure_file_priv` directory unless there were restrictions made to the mentioned methods in which it would always fail.

This patch introduces a change to trying to use the directory as specified in the `secure_file_priv` variable. If that directory actually exists, eg `/var/lib/mysql-files`, and if we are allowed to write into this directory, we will put the CSV file into the specified directory and read it from there. If the setting is not specified, or if we are not allowed to write into this directory, which should be the case by default, we will use the regular `tmp/assets` directory as it might still work fine via the fallback way with `LOCAL`.

Also to be considered is that `secure_file_priv` was introduced in MySQL 5.0.38 so for all previous versions the `tmp/assets` directory will be fine anyway. 
