### PR TITLE
Remove seeding in random number generator

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -584,10 +584,6 @@ class Common
         $chars = $alphabet;
         $str   = '';
 
-        list($usec, $sec) = explode(" ", microtime());
-        $seed = ((float)$sec + (float)$usec) * 100000;
-        mt_srand((int) $seed);
-
         for ($i = 0; $i < $length; $i++) {
             $rand_key = mt_rand(0, strlen($chars) - 1);
             $str .= substr($chars, $rand_key, 1);


### PR DESCRIPTION
This is done for the following reasons:
- Code clean-up. From https://secure.php.net/manual/en/function.mt-srand.php:
  
  > Note: There is no need to seed the random number generator with srand() or mt_srand() as this is done automatically.
- Re-seeding of a PRNG makes it more predictable. E.g., the `microtime()` which is used for the seeding:
  - On Windows (before Win8): seems to return 0, according to https://stackoverflow.com/questions/18889244/php-5-5-on-windows-microtime-behavior.
  - On other OSes: The current time is easily guessable, with the "microseconds" part brute-forcible.
  
  Because a PRNG's output sequence is equal for the same seed, the re-seeding could make more predictable not only the output of the `Common::getRandomString()` function modified here, but also subsequent calls of `mt_rand()`, which is currently used also in security-related context (see https://github.com/piwik/piwik/issues/9473).
  
  E.g. (not tested), a user could:
  - Trigger the call of `Common::getRandomString()` in https://github.com/piwik/piwik/blob/2.16.0-b2/plugins/Monolog/Handler/WebNotificationHandler.php#L46
  - Then predict the SMS phone number verification code in https://github.com/piwik/piwik/blob/2.16.0-b2/plugins/MobileMessaging/API.php#L104 (or any other point of https://github.com/piwik/piwik/issues/9473, as well as non-security related uses not mentioned there). (Although prediction of the SMS phone number verification code could probably be used for spam SMSes only, not a Piwik authentication bypass. At least for now, based on current SMS use for reports only.)

Note: The only other `rand()/mt_rand()` (re-)seeding is in the "Faker" library in https://github.com/piwik/plugin-VisitorGenerator/blob/1.2.2/libs/Faker/Faker/Generator.php#L137, but it doesn't seem to be used at the moment - see https://github.com/piwik/plugin-VisitorGenerator/blob/1.2.2/libs/Faker/readme.md#seeding-the-generator for its use case.
