### PR TITLE
Themes: make currently selected menu item colors themable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
  * New segment `actionType` lets you segment all actions of a given type, eg. `actionType==events` or `actionType==downloads`. Action types values are: `pageviews`, `contents`, `sitesearches`, `events`, `outlinks`, `downloads`
  * The JavaScript Tracker method `PiwikTracker.setDomains()` can now handle paths. This means when setting eg `_paq.push(['setDomains, '*.piwik.org/website1'])` all link that goes to the same domain `piwik.org` but to any other path than `website1/*` will be treated as outlink.
  * It is now possible to pass an option `php-cli-options` to the `core:archive` command. The given cli options will be forwarded to the actual PHP command. This allows to for example specifiy a different memory limit for the archiving process like this: `./console core:archive --php-cli-options="-d memory_limit=8G"`
+ * New less variable `@theme-color-menu-contrast-textSelected` that lets you specify the color of a selected menu item.
 
 ### Internal change
  * When generating a new plugin skeleton via `generate:plugin` command, plugin name must now contain only letters and numbers.

--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -265,6 +265,7 @@
 
             &.sfActive {
               .item {
+                color: @theme-color-menu-contrast-textSelected;
                 background-color: @theme-color-background-base;
                 decoration: none;
               }

--- a/plugins/ExampleTheme/stylesheets/theme.less
+++ b/plugins/ExampleTheme/stylesheets/theme.less
@@ -12,6 +12,7 @@
 
 @theme-color-menu-contrast-text:       #666666;
 @theme-color-menu-contrast-textActive: #0d0d0d;
+@theme-color-menu-contrast-textSelected: @theme-color-menu-contrast-text;
 @theme-color-menu-contrast-background: #f2f2f2;
 
 @theme-color-text:                     #0d0d0d;

--- a/plugins/Morpheus/stylesheets/theme.less
+++ b/plugins/Morpheus/stylesheets/theme.less
@@ -13,6 +13,7 @@
 @theme-color-base-series:              #ee3024;
 
 @theme-color-menu-contrast-text: @theme-color-text;
+@theme-color-menu-contrast-textSelected: @theme-color-menu-contrast-text;
 @theme-color-menu-contrast-textActive: @theme-color-brand;
 @theme-color-menu-contrast-background: @theme-color-background-tinyContrast;
 


### PR DESCRIPTION
This new variable is needed as the menu is otherwise not really themable when using a dark background color. 

You can reproduce this by specifying a theme with

``` less
@theme-color-menu-contrast-text: white;
@theme-color-menu-contrast-textActive: gray;
@theme-color-menu-contrast-background: black;
```

it can be now fixed by specifying on top 

``` less
@theme-color-menu-contrast-textSelected: darkgrey;
```

It was not needed with current theme as both the background color and the menu background color is pretty light. However it does not work with a light background color but dark menu background color.
