### PR TITLE
Revert Outline around focused elements as it does not fully work

### DIFF
--- a/plugins/CoreHome/javascripts/corehome.js
+++ b/plugins/CoreHome/javascripts/corehome.js
@@ -193,12 +193,4 @@ $( document ).ready(function() {
         $(window).scrollTo($('a[name="main"]'));
     });
 
-    // Only use the "outline" CSS property on focus, when the keyboard is being used (do not show the outline when clicking with the mouse)
-    $("body").on("mousedown", "*", function(e) {
-        if (($(this).is(":focus") || $(this).is(e.target)) && $(this).css("outline-style") == "none") {
-            $(this).css("outline", "none").on("blur", function() {
-                $(this).off("blur").css("outline", "");
-            });
-        }
-    });
 });

--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -1,8 +1,3 @@
- body {
-     :focus {
-         outline:@theme-color-background-highContrast solid 2px;
-     }
- }
 
  #header {
   padding: 0 15px;


### PR DESCRIPTION
Revert https://github.com/piwik/piwik/pull/9600 
https://github.com/piwik/piwik/pull/9604

Problem is: sometimes when using the mouse, the outline is displayed, causing the design to look rather bad. Expected: outline should only show when the keyboard is used.
