### PR TITLE
Fix total time of visit is not the sum of times of page visits if heartbeat feature is used

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -407,6 +407,10 @@ class Request
     {
         $this->params[$name] = $value;
         unset($this->paramsCache[$name]);
+
+        if ($name === 'cdt') {
+            $this->cdtCache = null;
+        }
     }
 
     private function hasParam($name)

--- a/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_day.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -117,8 +117,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_month.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_month.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -117,8 +117,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/Contents/tests/System/expected/test_Contents_contentInteractionMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_contentInteractionMatch__Live.getLastVisitsDetails_day.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -117,8 +117,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/Contents/tests/System/expected/test_Contents_contentTargetMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_contentTargetMatch__Live.getLastVisitsDetails_day.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -117,8 +117,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/Contents/tests/System/expected/test_ContentscontentNameOrPieceMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_ContentscontentNameOrPieceMatch__Live.getLastVisitsDetails_day.xml
@@ -14,8 +14,8 @@
 				
 				<pageId>1</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -117,8 +117,8 @@
 				
 				<pageId>13</pageId>
 				<generationTime>0.33s</generationTime>
-				<timeSpent>270</timeSpent>
-				<timeSpentPretty>4 min 30s</timeSpentPretty>
+				<timeSpent>271</timeSpent>
+				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/plugins/CoreHome/Columns/VisitLastActionTime.php
+++ b/plugins/CoreHome/Columns/VisitLastActionTime.php
@@ -51,6 +51,10 @@ class VisitLastActionTime extends VisitDimension
      */
     public function onExistingVisit(Request $request, Visitor $visitor, $action)
     {
+        if ($request->getParam('ping') == 1) {
+            return false;
+        }
+        
         return $this->onNewVisit($request, $visitor, $action);
     }
 }

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -28,8 +28,6 @@ class PingRequestProcessor extends RequestProcessor
             $request->setMetadata('Goals', 'goalsConverted', array());
             $request->setMetadata('Goals', 'visitIsConverted', false);
 
-            $request->setParam('cdt', $visitProperties->getProperty('visit_last_action_time'));
-
             // When a ping request is received more than 30 min after the last request/ping,
             // we choose not to create a new visit.
             if ($request->getMetadata('CoreHome', 'isNewVisit')) {

--- a/plugins/Heartbeat/Tracker/PingRequestProcessor.php
+++ b/plugins/Heartbeat/Tracker/PingRequestProcessor.php
@@ -28,6 +28,8 @@ class PingRequestProcessor extends RequestProcessor
             $request->setMetadata('Goals', 'goalsConverted', array());
             $request->setMetadata('Goals', 'visitIsConverted', false);
 
+            $request->setParam('cdt', $visitProperties->getProperty('visit_last_action_time'));
+
             // When a ping request is received more than 30 min after the last request/ping,
             // we choose not to create a new visit.
             if ($request->getMetadata('CoreHome', 'isNewVisit')) {

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -367,17 +367,16 @@ class Visitor implements VisitorInterface
             if ($nextActionFound) {
                 $actionDetail['timeSpent'] = $actionDetails[$actionIdx + 1]['timeSpentRef'];
             } else {
+
                 // Last action of a visit.
                 // By default, Piwik does not know how long the user stayed on the page
                 // If enableHeartBeatTimer() is used in piwik.js then we can find the accurate time on page for the last pageview
-                $timeOfLastActionOrPingInVisitRow = $visitorDetailsArray['lastActionTimestamp'];
-
-                $timeOfLastAction = Date::factory($actionDetail['serverTimePretty'])->getTimestamp();
-
-                $timeSpentOnPage = $timeOfLastActionOrPingInVisitRow - $timeOfLastAction;
+                $visitTotalTime = $visitorDetailsArray['visitDuration'];
+                $timeSpentOnAllActionsApartFromLastOne = ($visitorDetailsArray['lastActionTimestamp'] - $visitorDetailsArray['firstActionTimestamp']);
+                $timeSpentOnPage = $visitTotalTime - $timeSpentOnAllActionsApartFromLastOne;
 
                 // Safe net, we assume the time is correct when it's more than 10 seconds
-                if($timeSpentOnPage > 10) {
+                if ($timeSpentOnPage > 10) {
                     $actionDetail['timeSpent'] = $timeSpentOnPage;
                 }
             }

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -359,6 +359,8 @@ class Visitor implements VisitorInterface
             $ecommerceConversion['itemDetails'] = $itemsDetails;
         }
 
+        $actionDetails = array_values($actionDetails);
+
         // Enrich with time spent per action
         foreach($actionDetails as $actionIdx => &$actionDetail) {
 

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -374,16 +374,19 @@ class Visitor implements VisitorInterface
                 // By default, Piwik does not know how long the user stayed on the page
                 // If enableHeartBeatTimer() is used in piwik.js then we can find the accurate time on page for the last pageview
                 $visitTotalTime = $visitorDetailsArray['visitDuration'];
-                $timeSpentOnAllActionsApartFromLastOne = ($visitorDetailsArray['lastActionTimestamp'] - $visitorDetailsArray['firstActionTimestamp']);
+                $timeOfLastAction = Date::factory($actionDetail['serverTimePretty'])->getTimestamp();
+
+                $timeSpentOnAllActionsApartFromLastOne = ($timeOfLastAction - $visitorDetailsArray['firstActionTimestamp']);
                 $timeSpentOnPage = $visitTotalTime - $timeSpentOnAllActionsApartFromLastOne;
 
                 // Safe net, we assume the time is correct when it's more than 10 seconds
                 if ($timeSpentOnPage > 10) {
                     $actionDetail['timeSpent'] = $timeSpentOnPage;
                 }
+
             }
 
-            if(isset($actionDetail['timeSpent'])) {
+            if (isset($actionDetail['timeSpent'])) {
                 $actionDetail['timeSpentPretty'] = $formatter->getPrettyTimeFromSeconds($actionDetail['timeSpent'], true);
             }
 

--- a/tests/PHPUnit/System/expected/test_OneVisitor_NoKeywordSpecified__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitor_NoKeywordSpecified__Live.getLastVisitsDetails_day.xml
@@ -113,8 +113,8 @@
 				<pageIdAction>2</pageIdAction>
 				
 				<pageId>1</pageId>
-				<timeSpent>1080</timeSpent>
-				<timeSpentPretty>18 min 0s</timeSpentPretty>
+				<timeSpent>1084</timeSpent>
+				<timeSpentPretty>18 min 4s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__Live.getLastVisitsDetails_month.xml
@@ -154,8 +154,8 @@
 				<pageIdAction>10</pageIdAction>
 				<serverTimePretty>Mar 6, 2010 16:28:33</serverTimePretty>
 				<pageId>9</pageId>
-				<timeSpent>720</timeSpent>
-				<timeSpentPretty>12 min 0s</timeSpentPretty>
+				<timeSpent>721</timeSpent>
+				<timeSpentPretty>12 min 1s</timeSpentPretty>
 				<icon />
 				<timestamp>1267892913</timestamp>
 			</row>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_LiveEcommerceStatusOrdered__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_LiveEcommerceStatusOrdered__Live.getLastVisitsDetails_day.xml
@@ -226,8 +226,8 @@
 						<customVariablePageValue5>Category TWO LEFT in cart</customVariablePageValue5>
 					</row>
 				</customVariables>
-				<timeSpent>360</timeSpent>
-				<timeSpentPretty>6 min 0s</timeSpentPretty>
+				<timeSpent>361</timeSpent>
+				<timeSpentPretty>6 min 1s</timeSpentPretty>
 				<icon />
 				
 			</row>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems__Live.getLastVisitsDetails_day.xml
@@ -87,8 +87,8 @@
 						<customVariablePageValue5>Category TWO LEFT in cart</customVariablePageValue5>
 					</row>
 				</customVariables>
-				<timeSpent>360</timeSpent>
-				<timeSpentPretty>6 min 0s</timeSpentPretty>
+				<timeSpent>361</timeSpent>
+				<timeSpentPretty>6 min 1s</timeSpentPretty>
 				<icon />
 				
 			</row>
@@ -430,8 +430,8 @@
 						<customVariablePageValue5>Category TWO LEFT in cart</customVariablePageValue5>
 					</row>
 				</customVariables>
-				<timeSpent>360</timeSpent>
-				<timeSpentPretty>6 min 0s</timeSpentPretty>
+				<timeSpent>361</timeSpent>
+				<timeSpentPretty>6 min 1s</timeSpentPretty>
 				<icon />
 				
 			</row>


### PR DESCRIPTION
We can fix the incorrect action time by not updating `visit_last_action_time` see problem explained in https://github.com/piwik/piwik/issues/9610#issuecomment-173689254 . A ping is not really an action so it should not update `visit_last_action_time`.

This changes behaviour of heart beat in a way that the "time spent on last action" can be max 30 minutes (or custom value specified in `visit_standard_length` config setting). Why? So far we updated `visit_last_action_time` on each ping request and set it to now. This kept the visitors session active and the `VisitorRecognizer` would find an existing visit even if the user did not click within 30 minutes but if there were ping request.

Now the `visit_last_action_time` is no longer updated. This means after 30 minutes of sending ping requests the `VisitorRecognizer` will no longer find an existing visit and therefore all further ping requests will be aborted by this line https://github.com/piwik/piwik/blob/2.16.0-b6/plugins/Heartbeat/Tracker/PingRequestProcessor.php#L33-L35

fixes  #9610 
