### PR TITLE
Add possibility to post content via Http class

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -125,6 +125,7 @@ class Http
      * @param string $httpMethod The HTTP method to use. Defaults to `'GET'`.
      * @param string $httpUsername HTTP Auth username
      * @param string $httpPassword HTTP Auth password
+     * @param array|string $requestBody If $httpMethod is 'POST' this may accept an array of variables or a string that needs to be posted
      *
      * @throws Exception
      * @return bool  true (or string/array) on success; false on HTTP response error code (1xx or 4xx)
@@ -143,7 +144,8 @@ class Http
         $getExtendedInfo = false,
         $httpMethod = 'GET',
         $httpUsername = null,
-        $httpPassword = null
+        $httpPassword = null,
+        $requestBody = null
     ) {
         if ($followDepth > 5) {
             throw new Exception('Too many redirects (' . $followDepth . ')');
@@ -151,6 +153,10 @@ class Http
 
         $contentLength = 0;
         $fileLength = 0;
+
+        if (!empty($requestBody) && is_array($requestBody)) {
+            $requestBody = http_build_query($requestBody);
+        }
 
         // Piwik services behave like a proxy, so we should act like one.
         $xff = 'X-Forwarded-For: '
@@ -251,9 +257,16 @@ class Http
                 . $xff . "\r\n"
                 . $via . "\r\n"
                 . $rangeHeader
-                . "Connection: close\r\n"
-                . "\r\n";
+                . "Connection: close\r\n";
             fwrite($fsock, $requestHeader);
+
+            if (strtolower($httpMethod) === 'post' && !empty($requestBody)) {
+                fwrite($fsock, self::buildHeadersForPost($requestBody));
+                fwrite($fsock, "\r\n");
+                fwrite($fsock, $requestBody);
+            } else {
+                fwrite($fsock, "\r\n");
+            }
 
             $streamMetaData = array('timed_out' => false);
             @stream_set_blocking($fsock, true);
@@ -421,6 +434,14 @@ class Http
                     }
                 }
 
+                if (strtolower($httpMethod) === 'post' && !empty($requestBody)) {
+                    $postHeader  = self::buildHeadersForPost($requestBody);
+                    $postHeader .= "\r\n";
+                    $stream_options['http']['method']  = 'POST';
+                    $stream_options['http']['header'] .= $postHeader;
+                    $stream_options['http']['content'] = $requestBody;
+                }
+
                 $ctx = stream_context_create($stream_options);
             }
 
@@ -497,6 +518,11 @@ class Http
             @curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $httpMethod);
             if ($httpMethod == 'HEAD') {
                 @curl_setopt($ch, CURLOPT_NOBODY, true);
+            }
+
+            if (strtolower($httpMethod) === 'post' && !empty($requestBody)) {
+                curl_setopt($ch, CURLOPT_POST, 1);
+                curl_setopt($ch, CURLOPT_POSTFIELDS, $requestBody);
             }
 
             if (!empty($httpUsername) && !empty($httpPassword)) {
@@ -594,6 +620,14 @@ class Http
                 'data'    => $response
             );
         }
+    }
+
+    private static function buildHeadersForPost($requestBody)
+    {
+        $postHeader  = "Content-Type: application/x-www-form-urlencoded\r\n";
+        $postHeader .= "Content-Length: " . strlen($requestBody) . "\r\n";
+
+        return $postHeader;
     }
 
     /**

--- a/tests/PHPUnit/Integration/Http/Post.php
+++ b/tests/PHPUnit/Integration/Http/Post.php
@@ -1,0 +1,29 @@
+<?php
+
+// used in integration tests to see if POST method works.
+// for security reasons we allow max 3 post vars, each key and value is only allowed to have max 6 hex characters
+
+function accept($key)
+{
+    if (ctype_xdigit($key) && strlen($key) <= 6) {
+        return $key;
+    }
+}
+
+if (count($_POST) > 4) {
+    exit;
+}
+
+$values = array();
+foreach ($_POST as $key => $value) {
+    if (accept($key) && accept($value)) {
+        $values[$key] = $value;
+    }
+}
+
+if (!empty($_SERVER['REQUEST_METHOD']) && strtolower($_SERVER['REQUEST_METHOD']) === 'post') {
+    $values['method'] = 'post';
+}
+
+echo json_encode($values);
+exit;

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -170,6 +170,58 @@ class HttpTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getMethodsToTest
      */
+    public function testHttpPost_ViaString($method)
+    {
+        $result = Http::sendHttpRequestBy(
+            $method,
+            Fixture::getRootUrl() . 'tests/PHPUnit/Integration/Http/Post.php',
+            30,
+            $userAgent = null,
+            $destinationPath = null,
+            $file = null,
+            $followDepth = 0,
+            $acceptLanguage = false,
+            $acceptInvalidSslCertificate = false,
+            $byteRange = false,
+            $getExtendedInfo = false,
+            $httpMethod = 'POST',
+            $httpUsername = '',
+            $httpPassword = '',
+            'abc12=43&abfec=abcdef'
+        );
+
+        $this->assertEquals('{"abc12":"43","abfec":"abcdef","method":"post"}', $result);
+    }
+
+    /**
+     * @dataProvider getMethodsToTest
+     */
+    public function testHttpPost_ViaArray($method)
+    {
+        $result = Http::sendHttpRequestBy(
+            $method,
+            Fixture::getRootUrl() . 'tests/PHPUnit/Integration/Http/Post.php',
+            30,
+            $userAgent = null,
+            $destinationPath = null,
+            $file = null,
+            $followDepth = 0,
+            $acceptLanguage = false,
+            $acceptInvalidSslCertificate = false,
+            $byteRange = false,
+            $getExtendedInfo = false,
+            $httpMethod = 'POST',
+            $httpUsername = '',
+            $httpPassword = '',
+            array('adf2' => '44', 'afc23' => 'ab12')
+        );
+
+        $this->assertEquals('{"adf2":"44","afc23":"ab12","method":"post"}', $result);
+    }
+
+    /**
+     * @dataProvider getMethodsToTest
+     */
     public function testHttpsWorksWithValidCertificate($method)
     {
         $result = Http::sendHttpRequestBy($method, 'https://builds.piwik.org/LATEST', 10);


### PR DESCRIPTION
fixes #3325
Needed for premium plugins since I have to post an accessToken to the Marketplace API as we do not want to have the token in the URL and the webserver logs.

Tested it manually with all 3 methods (socket, fopen and curl) and always worked. Also worked with an HTTPS url. 

Note: We cannot add a parameter for this to `Http::sendHttpRequest` method since it would break API. (Other plugins may extend this class and overwrite methods similar to https://github.com/piwik/piwik/issues/9531 )
