### PR TITLE
Display a footer message below Custom Variables report which explains why some metrics  are not set

### DIFF
--- a/plugins/CustomVariables/Reports/GetCustomVariables.php
+++ b/plugins/CustomVariables/Reports/GetCustomVariables.php
@@ -34,5 +34,39 @@ class GetCustomVariables extends Base
         $view->config->addTranslation('label', Piwik::translate('CustomVariables_ColumnCustomVariableName'));
         $view->requestConfig->filter_sort_column = 'nb_actions';
         $view->requestConfig->filter_sort_order  = 'desc';
+
+        if($this->isReportContainsUnsetVisitsColumns()) {
+            $message = $this->getFooterMessageExplanationMissingMetrics();
+            $view->config->show_footer_message = $message;
+        }
+    }
+
+    /**
+     * @return array
+     */
+    protected function getFooterMessageExplanationMissingMetrics()
+    {
+        $metrics = sprintf("'%s', '%s' %s '%s'",
+            Piwik::translate('General_ColumnNbVisits'),
+            Piwik::translate('General_ColumnNbUniqVisitors'),
+            Piwik::translate('General_And'),
+            Piwik::translate('General_ColumnNbUsers')
+        );
+        $messageStart = Piwik::translate('Note: %s metrics are available for Custom Variables of scope \'visit\' only.', $metrics);
+
+        $messageEnd = Piwik::translate('For Custom Variables of scope \'page\', the column value for these metrics is %s', array('\'-\''));
+
+        return $messageStart . ' ' . $messageEnd;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isReportContainsUnsetVisitsColumns()
+    {
+        $report = $this->fetch();
+        $visits = $report->getColumn('nb_visits');
+        $isVisitsMetricsSometimesUnset = in_array(false, $visits);
+        return $isVisitsMetricsSometimesUnset;
     }
 }

--- a/plugins/CustomVariables/lang/en.json
+++ b/plugins/CustomVariables/lang/en.json
@@ -17,6 +17,8 @@
         "CreatingCustomVariableTakesTime": "Creating a new custom variable slot can take a long time depending on the size of your database. Therefore it is only possible to do this via a command which needs to be executed on the command line.",
         "CurrentAvailableCustomVariables": "Currently you can use up to %s Custom Variables per site.",
         "ToCreateCustomVarExecute": "To create a new custom variable slot execute the following command within your Piwik installation: ",
-        "SlotsReportIsGeneratedOverTime": "Data for this report will be populated over time. It may take a day or two to see any data and a few weeks until the report is fully accurate."
+        "SlotsReportIsGeneratedOverTime": "Data for this report will be populated over time. It may take a day or two to see any data and a few weeks until the report is fully accurate.",
+        "MetricsAreOnlyAvailableForVisitScope": "Note: %1$s metrics are available for Custom Variables of scope %2$s only.",
+        "MetricsNotAvailableForPageScope": "For Custom Variables of scope %1$s, the column value for these metrics is %2$s"
     }
 }


### PR DESCRIPTION
 Goal: minimise user confusion and support requests.
 The message is only displayed when the report table contains Custom Variable of scope 'page'.
 If the report only contains Custom Variable of scope 'visit' the message won't be shown.

Fixes  #8128
