### PR TITLE
Attempting to fix UI test

### DIFF
--- a/tests/UI/specs/ActionsDataTable_spec.js
+++ b/tests/UI/specs/ActionsDataTable_spec.js
@@ -33,7 +33,9 @@ describe("ActionsDataTable", function () {
 
     it("should flatten table when flatten link clicked", function (done) {
         expect.screenshot('flattened').to.be.capture(function (page) {
-            $('.foldDataTableFooterDrawer').click(); // open the footer icons controls
+            page.evaluate(function () {
+                $('.foldDataTableFooterDrawer').click(); // open the footer icons controls
+            });
             page.mouseMove('.tableConfiguration');
             page.click('.dataTableFlatten');
         }, done);

--- a/tests/UI/specs/ActionsDataTable_spec.js
+++ b/tests/UI/specs/ActionsDataTable_spec.js
@@ -33,6 +33,7 @@ describe("ActionsDataTable", function () {
 
     it("should flatten table when flatten link clicked", function (done) {
         expect.screenshot('flattened').to.be.capture(function (page) {
+            $('.foldDataTableFooterDrawer').click(); // open the footer icons controls
             page.mouseMove('.tableConfiguration');
             page.click('.dataTableFlatten');
         }, done);


### PR DESCRIPTION
Failing build: https://travis-ci.org/piwik/piwik/jobs/105077424

Example UI screenshot fail: http://builds-artifacts.piwik.org/piwik/piwik/master/17793/ActionsDataTable_subtables_loaded

UI tests started to fail, and after investigating I'm left confused. The footer control bar is now closed on the "processed" screenshots while it should be opened. I can't find any reason why the footer controls would now be closed. Trying here to open them specifically in the test where they now appear closed.

Follows UP: https://github.com/piwik/piwik/pull/9618
