### PR TITLE
Make pchart lib PHP7 compatible

### DIFF
--- a/libs/pChart/class/pData.class.php
+++ b/libs/pChart/class/pData.class.php
@@ -67,7 +67,7 @@
                         "7"=>array("R"=>224,"G"=>176,"B"=>46,"Alpha"=>100));
 
    /* Class creator */
-   function pData()
+   function __construct()
     {
      $this->Data = "";
      $this->Data["XAxisDisplay"]	= AXIS_FORMAT_DEFAULT;

--- a/libs/pChart/class/pImage.class.php
+++ b/libs/pChart/class/pImage.class.php
@@ -82,7 +82,7 @@
    var $LastChartLayout	= CHART_LAST_LAYOUT_REGULAR;	// Last layout : regular or stacked
 
    /* Class constructor */
-   function pImage($XSize,$YSize,$DataSet=NULL,$TransparentBackground=FALSE)
+   function __construct($XSize,$YSize,$DataSet=NULL,$TransparentBackground=FALSE)
     {
      $this->TransparentBackground = $TransparentBackground;
 

--- a/libs/pChart/class/pPie.class.php
+++ b/libs/pChart/class/pPie.class.php
@@ -36,7 +36,7 @@
    var $LabelPos = "" ;
 
    /* Class creator */
-   function pPie($Object,$pDataObject)
+   function __construct($Object,$pDataObject)
     {
      /* Cache the pChart object reference */
      $this->pChartObject = $Object;


### PR DESCRIPTION
fixes #9652 

I tested all possible graph types including no data message: 'evolution', 'verticalBar', 'pie' and '3dPie'

No warning appeared anymore afterwards. When adding the file it converted line endings see https://github.com/piwik/piwik/issues/9492 (that's why I am committing it with whitespace change) . 

For a proper diff see https://github.com/piwik/piwik/compare/9652?w=1
