### PR TITLE
New sentence after a successful Piwik installation

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -562,6 +562,10 @@ pivot_by_filter_enable_fetch_by_segment = 0
 ; on a per-request basis;
 pivot_by_filter_default_column_limit = 10
 
+; If set to 0 it will disable Piwik Pro advertisements in some places. For example in the installation screen, the
+; Piwik Pro Ad widget will be removed etc.
+piwik_pro_ads_enabled = 1
+
 [Tracker]
 
 ; Piwik uses "Privacy by default" model. When one of your users visit multiple of your websites tracked in this Piwik,

--- a/core/PiwikPro/Advertising.php
+++ b/core/PiwikPro/Advertising.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\PiwikPro;
+
+use Piwik\Plugin;
+use Piwik\Config;
+
+/**
+ * Piwik PRO Advertising related methods. Lets you for example check whether advertising is enabled, generate
+ * links for differnt landing pages etc.
+ *
+ * @api
+ */
+class Advertising
+{
+    /**
+     * @var Plugin\Manager
+     */
+    private $pluginManager;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    public function __construct(Plugin\Manager $pluginManager, Config $config)
+    {
+        $this->pluginManager = $pluginManager;
+        $this->config = $config;
+    }
+
+    /**
+     * Returns true if it is ok to show some Piwik PRO advertising in the Piwik UI.
+     * @return bool
+     */
+    public function arePiwikProAdsEnabled()
+    {
+        if ($this->pluginManager->isPluginInstalled('EnterpriseAdmin')
+            || $this->pluginManager->isPluginInstalled('LoginAdmin')
+            || $this->pluginManager->isPluginInstalled('CloudAdmin')
+            || $this->pluginManager->isPluginInstalled('WhiteLabel')) {
+            return false;
+        }
+
+        $showAds = $this->config->General['piwik_pro_ads_enabled'];
+
+        return !empty($showAds);
+    }
+
+    /**
+     * Generates a link for promoting the Piwik Cloud.
+     *
+     * @param string $campaignMedium
+     * @param string $campaignContent
+     * @return string
+     */
+    public function getPromoLinkForCloud($campaignMedium, $campaignContent = '')
+    {
+        $url = 'https://piwik.pro/cloud/';
+        $campaign = $this->getCampaignParametersForPromoLink($name = 'Upgrade_to_Cloud', $campaignMedium, $campaignContent);
+
+        $url .= '?' . $campaign;
+
+        return $url;
+    }
+
+    /**
+     * Generates a link for promoting Piwik On Premises.
+     * @param string $campaignMedium
+     * @param string $campaignContent
+     * @return string
+     */
+    public function getPromoLinkForOnPremises($campaignMedium, $campaignContent = '')
+    {
+        $url = 'https://piwik.pro/c/upgrade/';
+        $campaign = $this->getCampaignParametersForPromoLink($name = 'Upgrade_to_Pro', $campaignMedium, $campaignContent);
+
+        $url .= '?' . $campaign;
+
+        return $url;
+    }
+
+    /**
+     * Generates campaign URL parameters that can be used with any promotion link for Piwik PRO.
+     *
+     * @param string $campaignName
+     * @param string $campaignMedium
+     * @param string $content Optional
+     * @return string URL parameters without a leading ? or &
+     */
+    public function getCampaignParametersForPromoLink($campaignName, $campaignMedium, $content = '')
+    {
+        $campaignName = sprintf('pk_campaign=%s&pk_medium=%s&pk_source=Piwik_App', $campaignName, $campaignMedium);
+
+        if (!empty($content)) {
+            $campaignName .= '&pk_content=' . $content;
+        }
+
+        return $campaignName;
+    }
+}

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -87,6 +87,9 @@ class Twig
         $this->addFilter_percentage();
         $this->addFilter_percent();
         $this->addFilter_percentEvolution();
+        $this->addFilter_piwikProAdLink();
+        $this->addFilter_piwikProOnPremisesAdLink();
+        $this->addFilter_piwikProCloudAdLink();
         $this->addFilter_prettyDate();
         $this->addFilter_safeDecodeRaw();
         $this->addFilter_number();
@@ -319,6 +322,60 @@ class Twig
             return NumberFormatter::getInstance()->formatPercentEvolution($string);
         });
         $this->twig->addFilter($percentage);
+    }
+
+    protected function addFilter_piwikProAdLink()
+    {
+        $twigEnv = $this->getTwigEnvironment();
+        $ads = $this->getPiwikProAdvertising();
+
+        $piwikProAd = new Twig_SimpleFilter('piwikProPromoLink', function ($url, $campaignName, $campaignMedium, $campaignContent = '') use ($twigEnv, $ads) {
+
+            $campaign = $ads->getCampaignParametersForPromoLink($campaignName, $campaignMedium, $campaignContent);
+
+            if (strpos($url, '?') === false) {
+                $url .= '?' . $campaign;
+            } else {
+                $url .= '&' . $campaign;
+            }
+
+            return twig_escape_filter($twigEnv, $url, 'html_attr');
+
+        }, array('is_safe' => array('html_attr')));
+        $this->twig->addFilter($piwikProAd);
+    }
+
+    protected function addFilter_piwikProOnPremisesAdLink()
+    {
+        $twigEnv = $this->getTwigEnvironment();
+        $ads = $this->getPiwikProAdvertising();
+        $piwikProAd = new Twig_SimpleFilter('piwikProOnPremisesPromoLink', function ($medium, $content = '') use ($twigEnv, $ads) {
+
+            $url = $ads->getPromoLinkForOnPremises($medium, $content);
+
+            return twig_escape_filter($twigEnv, $url, 'html_attr');
+
+        }, array('is_safe' => array('html_attr')));
+        $this->twig->addFilter($piwikProAd);
+    }
+
+    protected function addFilter_piwikProCloudAdLink()
+    {
+        $twigEnv = $this->getTwigEnvironment();
+        $ads = $this->getPiwikProAdvertising();
+        $piwikProAd = new Twig_SimpleFilter('piwikProCloudPromoLink', function ($medium, $content = '') use ($twigEnv, $ads) {
+
+            $url = $ads->getPromoLinkForCloud($medium, $content);
+
+            return twig_escape_filter($twigEnv, $url, 'html_attr');
+
+        }, array('is_safe' => array('html_attr')));
+        $this->twig->addFilter($piwikProAd);
+    }
+
+    private function getPiwikProAdvertising()
+    {
+        return StaticContainer::get('Piwik\PiwikPro\Advertising');
     }
 
     protected function addFilter_number()

--- a/core/View.php
+++ b/core/View.php
@@ -10,6 +10,7 @@ namespace Piwik;
 
 use Exception;
 use Piwik\AssetManager\UIAssetCacheBuster;
+use Piwik\Container\StaticContainer;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 use Piwik\View\ViewInterface;
 use Twig_Environment;
@@ -85,6 +86,7 @@ if (!defined('PIWIK_USER_PATH')) {
  *                  which is outputted in the template, eg, `{{ postEvent('MyPlugin.event') }}`
  * - **isPluginLoaded**: Returns true if the supplied plugin is loaded, false if otherwise.
  *                       `{% if isPluginLoaded('Goals') %}...{% endif %}`
+ * - **arePiwikProAdsEnabled**: Returns true if it is ok to show some Piwik PRO advertising in the UI
  *
  * ### Examples
  *
@@ -226,7 +228,10 @@ class View implements ViewInterface
             $this->latest_version_available = UpdateCheck::isNewestVersionAvailable();
             $this->disableLink = Common::getRequestVar('disableLink', 0, 'int');
             $this->isWidget = Common::getRequestVar('widget', 0, 'int');
-            
+
+            $piwikProAds = StaticContainer::get('Piwik\PiwikPro\Advertising');
+            $this->arePiwikProAdsEnabled = $piwikProAds->arePiwikProAdsEnabled();
+
             if (Development::isEnabled()) {
                 $cacheBuster = rand(0, 10000);
             } else {

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -42,6 +42,8 @@
         "PasswordDoNotMatch": "password do not match",
         "PasswordRepeat": "Password (repeat)",
         "PercentDone": "%s %% Done",
+        "PiwikProAdTitle": "Advanced Analytics & Services",
+        "PiwikProAdText": "Add premium functionality and unlock the full power with %1$sPiwik PRO On-Premises%2$s, or get your own hassle-free Piwik hosted in the %3$sPiwik PRO Cloud%4$s.",
         "PleaseFixTheFollowingErrors": "Please fix the following errors",
         "DefaultSettings": "Default Piwik settings",
         "DefaultSettingsHelp": "Piwik comes with default settings. You can customize them now or do so later in the admin screen.",

--- a/plugins/Installation/templates/finished.twig
+++ b/plugins/Installation/templates/finished.twig
@@ -17,6 +17,16 @@
     <p>{{ 'Installation_WeHopeYouWillEnjoyPiwik'|translate }}</p>
     <p><i>{{ 'Installation_HappyAnalysing'|translate }}</i></p>
 
+    {% if arePiwikProAdsEnabled %}
+        <h3>{{ 'Installation_PiwikProAdTitle'|translate }}</h3>
+        <p>
+            {% set linkOnPremises = 'Installation_End'|piwikProOnPremisesPromoLink %}
+            {% set linkOnCloud = 'Installation_End'|piwikProCloudPromoLink %}
+
+            {{ 'Installation_PiwikProAdText'|translate('<a rel="noreferrer" target="_blank" href="' ~ linkOnPremises ~ '">','</a>', '<a  rel="noreferrer"  target="_blank" href="' ~ linkOnCloud ~ '">','</a>')|raw }}
+        </p>
+    {% endif %}
+
     <h3>{{ 'Installation_DefaultSettings'|translate }}</h3>
     <p>{{ 'Installation_DefaultSettingsHelp'|translate }}</p>
 

--- a/tests/PHPUnit/Framework/Mock/FakeConfig.php
+++ b/tests/PHPUnit/Framework/Mock/FakeConfig.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Piwik\Tests\Framework\Mock;
+
+use Piwik\Config;
+
+class FakeConfig extends Config
+{
+    private $configValues = array();
+
+    public function __construct($configValues = array())
+    {
+        $this->configValues = $configValues;
+    }
+
+    public function &__get($name)
+    {
+        if (isset($this->configValues[$name])) {
+            return $this->configValues[$name];
+        }
+    }
+
+    public function __set($name, $value)
+    {
+         $this->configValues[$name] = $value;
+    }
+
+}

--- a/tests/PHPUnit/Framework/Mock/Plugin/Manager.php
+++ b/tests/PHPUnit/Framework/Mock/Plugin/Manager.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Piwik\Tests\Framework\Mock\Plugin;
+
+class Manager extends \Piwik\Plugin\Manager
+{
+    private $installedPlugins = array();
+
+    public function __construct()
+    {
+    }
+
+    public function setInstalledPlugins($pluginsList)
+    {
+        $this->installedPlugins = $pluginsList;
+    }
+
+    public function isPluginInstalled($pluginName)
+    {
+        return in_array($pluginName, $this->installedPlugins);
+    }
+
+}

--- a/tests/PHPUnit/Integration/PiwikPro/AdvertisingTest.php
+++ b/tests/PHPUnit/Integration/PiwikPro/AdvertisingTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\PiwikPro;
+
+use Piwik\Config;
+use Piwik\PiwikPro\Advertising;
+use Piwik\Plugin;
+use Piwik\Tests\Framework\Mock\FakeConfig;
+use Piwik\Tests\Framework\Mock\Plugin\Manager;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group PiwikPro
+ * @group Advertising
+ * @group Integration
+ */
+class AdvertisingTest extends IntegrationTestCase
+{
+    /**
+     * @var Advertising
+     */
+    private $advertising;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var Manager
+     */
+    private $pluginManager;
+
+    public function setUp()
+    {
+        $this->config = new FakeConfig(array('General' => array('piwik_pro_ads_enabled' => '1')));
+        $this->pluginManager = new Manager();
+
+        $this->advertising = $this->buildAdvertising($this->config);
+    }
+
+    public function test_arePiwikProAdsEnabled_ActuallyEnabled()
+    {
+        $enabled = $this->advertising->arePiwikProAdsEnabled();
+
+        $this->assertTrue($enabled);
+    }
+
+    public function test_arePiwikProAdsEnabled_Disabled()
+    {
+        $this->config->General = array('piwik_pro_ads_enabled' => '0');
+
+        $enabled = $this->advertising->arePiwikProAdsEnabled();
+
+        $this->assertFalse($enabled);
+    }
+
+    public function test_arePiwikProAdsEnabled_shouldBeDisabledWhenCloudPluginIsInstalled()
+    {
+        $enabled = $this->advertising->arePiwikProAdsEnabled();
+        $this->assertTrue($enabled);
+
+        $this->pluginManager->setInstalledPlugins(array('CloudAdmin'));
+
+        $enabled = $this->advertising->arePiwikProAdsEnabled();
+        $this->assertFalse($enabled);
+    }
+
+    public function test_arePiwikProAdsEnabled_shouldBeDisabledWhenEnterprisePluginIsInstalled()
+    {
+        $enabled = $this->advertising->arePiwikProAdsEnabled();
+        $this->assertTrue($enabled);
+
+        $this->pluginManager->setInstalledPlugins(array('EnterpriseAdmin'));
+
+        $enabled = $this->advertising->arePiwikProAdsEnabled();
+        $this->assertFalse($enabled);
+    }
+
+    public function test_shouldBeEnabledByDefault()
+    {
+        $enabled = $this->buildAdvertising(Config::getInstance());
+
+        $this->assertTrue($enabled->arePiwikProAdsEnabled());
+    }
+
+    public function test_getPromoLinkForOnPremises_WithoutContent()
+    {
+        $link = $this->advertising->getPromoLinkForOnPremises('Installation_End');
+
+        $this->assertSame('https://piwik.pro/c/upgrade/?pk_campaign=Upgrade_to_Pro&pk_medium=Installation_End&pk_source=Piwik_App', $link);
+    }
+
+    public function test_getPromoLinkForOnPremises_WithContent()
+    {
+        $link = $this->advertising->getPromoLinkForOnPremises('Installation_End', 'TestContent');
+
+        $this->assertSame('https://piwik.pro/c/upgrade/?pk_campaign=Upgrade_to_Pro&pk_medium=Installation_End&pk_source=Piwik_App&pk_content=TestContent', $link);
+    }
+
+    public function test_getPromoLinkForCloud_WithoutContent()
+    {
+        $link = $this->advertising->getPromoLinkForCloud('Installation_End');
+
+        $this->assertSame('https://piwik.pro/cloud/?pk_campaign=Upgrade_to_Cloud&pk_medium=Installation_End&pk_source=Piwik_App', $link);
+    }
+
+    public function test_getPromoLinkForCloud_WithContent()
+    {
+        $link = $this->advertising->getPromoLinkForCloud('Installation_End', 'TestContent');
+
+        $this->assertSame('https://piwik.pro/cloud/?pk_campaign=Upgrade_to_Cloud&pk_medium=Installation_End&pk_source=Piwik_App&pk_content=TestContent', $link);
+    }
+
+    public function test_getCampaignParametersForPromoLink_withoutContent()
+    {
+        $link = $this->advertising->getCampaignParametersForPromoLink('MyName', 'Installation_Start');
+
+        $this->assertSame('pk_campaign=MyName&pk_medium=Installation_Start&pk_source=Piwik_App', $link);
+    }
+
+    public function test_getCampaignParametersForPromoLink_withContent()
+    {
+        $link = $this->advertising->getCampaignParametersForPromoLink('MyName', 'Installation_Start', 'MyContent');
+
+        $this->assertSame('pk_campaign=MyName&pk_medium=Installation_Start&pk_source=Piwik_App&pk_content=MyContent', $link);
+    }
+
+    private function buildAdvertising($config)
+    {
+        return new Advertising($this->pluginManager, $config);
+    }
+}


### PR DESCRIPTION
fixes #9648 
- Adds new config setting `[General]piwik_pro_ads_enabled` to enable/disable it.
- Adds new class to check whether it is enabled, to generate links etc. This is all tested
- Adds new twig filters to easily link to landing pages

I was thinking about putting this logic into plugin but then it might get hard re the twig filters which are defined in core. We cannot access anything in core that is defined in a plugin. We could technically but it is not good.

The new class `Advertising` will be public API as eg PiwikPRO plugins will need to check whether they can add a top menu link or not.

Be good to have this merged soon as it will be a foundation for other issues that I will be working on in a bit.
