### PR TITLE
Revert "fix average time on page determined by using unique pageviews instead of hits"

### DIFF
--- a/plugins/Actions/Columns/Metrics/AverageTimeOnPage.php
+++ b/plugins/Actions/Columns/Metrics/AverageTimeOnPage.php
@@ -34,7 +34,7 @@ class AverageTimeOnPage extends ProcessedMetric
     public function compute(Row $row)
     {
         $sumTimeSpent = $this->getMetric($row, 'sum_time_spent');
-        $visits = $this->getMetric($row, 'nb_hits');
+        $visits = $this->getMetric($row, 'nb_visits');
 
         return Piwik::getQuotientSafe($sumTimeSpent, $visits, $precision = 0);
     }
@@ -46,6 +46,6 @@ class AverageTimeOnPage extends ProcessedMetric
 
     public function getDependentMetrics()
     {
-        return array('sum_time_spent', 'nb_hits');
+        return array('sum_time_spent', 'nb_visits');
     }
 }

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_range.xml
@@ -13,7 +13,7 @@
 		<entry_sum_visit_length>54</entry_sum_visit_length>
 		<entry_bounce_count>8</entry_bounce_count>
 		<exit_nb_visits>8</exit_nb_visits>
-		<avg_time_on_page>13</avg_time_on_page>
+		<avg_time_on_page>17</avg_time_on_page>
 		<bounce_rate>89%</bounce_rate>
 		<exit_rate>80%</exit_rate>
 		<avg_time_generation>0.389</avg_time_generation>
@@ -31,7 +31,7 @@
 				<entry_sum_visit_length>54</entry_sum_visit_length>
 				<entry_bounce_count>5</entry_bounce_count>
 				<exit_nb_visits>5</exit_nb_visits>
-				<avg_time_on_page>17</avg_time_on_page>
+				<avg_time_on_page>24</avg_time_on_page>
 				<bounce_rate>83%</bounce_rate>
 				<exit_rate>71%</exit_rate>
 				<avg_time_generation>0.443</avg_time_generation>
@@ -49,7 +49,7 @@
 						<entry_sum_visit_length>54</entry_sum_visit_length>
 						<entry_bounce_count>4</entry_bounce_count>
 						<exit_nb_visits>4</exit_nb_visits>
-						<avg_time_on_page>22</avg_time_on_page>
+						<avg_time_on_page>30</avg_time_on_page>
 						<bounce_rate>80%</bounce_rate>
 						<exit_rate>80%</exit_rate>
 						<avg_time_generation>0.089</avg_time_generation>
@@ -70,7 +70,7 @@
 								<sum_daily_nb_uniq_visitors>5</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>5</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>4</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>22</avg_time_on_page>
+								<avg_time_on_page>30</avg_time_on_page>
 								<bounce_rate>80%</bounce_rate>
 								<exit_rate>80%</exit_rate>
 								<avg_time_generation>0.089</avg_time_generation>
@@ -91,7 +91,7 @@
 						<entry_sum_visit_length>0</entry_sum_visit_length>
 						<entry_bounce_count>1</entry_bounce_count>
 						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>5</avg_time_on_page>
+						<avg_time_on_page>8</avg_time_on_page>
 						<bounce_rate>100%</bounce_rate>
 						<exit_rate>50%</exit_rate>
 						<avg_time_generation>0.974</avg_time_generation>
@@ -112,7 +112,7 @@
 								<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>5</avg_time_on_page>
+								<avg_time_on_page>8</avg_time_on_page>
 								<bounce_rate>100%</bounce_rate>
 								<exit_rate>50%</exit_rate>
 								<avg_time_generation>0.974</avg_time_generation>
@@ -542,7 +542,7 @@
 		<entry_sum_visit_length>0</entry_sum_visit_length>
 		<entry_bounce_count>4</entry_bounce_count>
 		<exit_nb_visits>5</exit_nb_visits>
-		<avg_time_on_page>7</avg_time_on_page>
+		<avg_time_on_page>10</avg_time_on_page>
 		<bounce_rate>100%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 		<avg_time_generation>0.255</avg_time_generation>
@@ -563,7 +563,7 @@
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>3</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>10</avg_time_on_page>
+				<avg_time_on_page>17</avg_time_on_page>
 				<bounce_rate>100%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.255</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_range.xml
@@ -13,7 +13,7 @@
 		<entry_sum_visit_length>54</entry_sum_visit_length>
 		<entry_bounce_count>8</entry_bounce_count>
 		<exit_nb_visits>8</exit_nb_visits>
-		<avg_time_on_page>13</avg_time_on_page>
+		<avg_time_on_page>17</avg_time_on_page>
 		<bounce_rate>89%</bounce_rate>
 		<exit_rate>80%</exit_rate>
 		<avg_time_generation>0.389</avg_time_generation>
@@ -31,7 +31,7 @@
 				<entry_sum_visit_length>54</entry_sum_visit_length>
 				<entry_bounce_count>5</entry_bounce_count>
 				<exit_nb_visits>5</exit_nb_visits>
-				<avg_time_on_page>17</avg_time_on_page>
+				<avg_time_on_page>24</avg_time_on_page>
 				<bounce_rate>83%</bounce_rate>
 				<exit_rate>71%</exit_rate>
 				<avg_time_generation>0.443</avg_time_generation>
@@ -49,7 +49,7 @@
 						<entry_sum_visit_length>54</entry_sum_visit_length>
 						<entry_bounce_count>4</entry_bounce_count>
 						<exit_nb_visits>4</exit_nb_visits>
-						<avg_time_on_page>22</avg_time_on_page>
+						<avg_time_on_page>30</avg_time_on_page>
 						<bounce_rate>80%</bounce_rate>
 						<exit_rate>80%</exit_rate>
 						<avg_time_generation>0.089</avg_time_generation>
@@ -70,7 +70,7 @@
 								<sum_daily_nb_uniq_visitors>5</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>5</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>4</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>22</avg_time_on_page>
+								<avg_time_on_page>30</avg_time_on_page>
 								<bounce_rate>80%</bounce_rate>
 								<exit_rate>80%</exit_rate>
 								<avg_time_generation>0.089</avg_time_generation>
@@ -91,7 +91,7 @@
 						<entry_sum_visit_length>0</entry_sum_visit_length>
 						<entry_bounce_count>1</entry_bounce_count>
 						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>5</avg_time_on_page>
+						<avg_time_on_page>8</avg_time_on_page>
 						<bounce_rate>100%</bounce_rate>
 						<exit_rate>50%</exit_rate>
 						<avg_time_generation>0.974</avg_time_generation>
@@ -112,7 +112,7 @@
 								<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>5</avg_time_on_page>
+								<avg_time_on_page>8</avg_time_on_page>
 								<bounce_rate>100%</bounce_rate>
 								<exit_rate>50%</exit_rate>
 								<avg_time_generation>0.974</avg_time_generation>
@@ -542,7 +542,7 @@
 		<entry_sum_visit_length>0</entry_sum_visit_length>
 		<entry_bounce_count>4</entry_bounce_count>
 		<exit_nb_visits>5</exit_nb_visits>
-		<avg_time_on_page>7</avg_time_on_page>
+		<avg_time_on_page>10</avg_time_on_page>
 		<bounce_rate>100%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 		<avg_time_generation>0.255</avg_time_generation>
@@ -563,7 +563,7 @@
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>3</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>10</avg_time_on_page>
+				<avg_time_on_page>17</avg_time_on_page>
 				<bounce_rate>100%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.255</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_day.xml
@@ -12,7 +12,7 @@
 		<entry_nb_actions>10</entry_nb_actions>
 		<entry_sum_visit_length>54</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
-		<avg_time_on_page>33</avg_time_on_page>
+		<avg_time_on_page>83</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<avg_time_generation>0.443</avg_time_generation>
@@ -29,7 +29,7 @@
 				<entry_nb_actions>10</entry_nb_actions>
 				<entry_sum_visit_length>54</entry_sum_visit_length>
 				<entry_bounce_count>0</entry_bounce_count>
-				<avg_time_on_page>33</avg_time_on_page>
+				<avg_time_on_page>83</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<avg_time_generation>0.443</avg_time_generation>
@@ -42,7 +42,7 @@
 						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 						<min_time_generation>0.624</min_time_generation>
 						<max_time_generation>1.324</max_time_generation>
-						<avg_time_on_page>8</avg_time_on_page>
+						<avg_time_on_page>15</avg_time_on_page>
 						<bounce_rate>0%</bounce_rate>
 						<exit_rate>0%</exit_rate>
 						<avg_time_generation>0.974</avg_time_generation>
@@ -56,7 +56,7 @@
 								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 								<min_time_generation>0.624</min_time_generation>
 								<max_time_generation>1.324</max_time_generation>
-								<avg_time_on_page>8</avg_time_on_page>
+								<avg_time_on_page>15</avg_time_on_page>
 								<bounce_rate>0%</bounce_rate>
 								<exit_rate>0%</exit_rate>
 								<avg_time_generation>0.974</avg_time_generation>
@@ -76,7 +76,7 @@
 						<entry_nb_actions>10</entry_nb_actions>
 						<entry_sum_visit_length>54</entry_sum_visit_length>
 						<entry_bounce_count>0</entry_bounce_count>
-						<avg_time_on_page>50</avg_time_on_page>
+						<avg_time_on_page>151</avg_time_on_page>
 						<bounce_rate>0%</bounce_rate>
 						<exit_rate>0%</exit_rate>
 						<avg_time_generation>0.089</avg_time_generation>
@@ -95,7 +95,7 @@
 								<entry_nb_actions>10</entry_nb_actions>
 								<entry_sum_visit_length>54</entry_sum_visit_length>
 								<entry_bounce_count>0</entry_bounce_count>
-								<avg_time_on_page>50</avg_time_on_page>
+								<avg_time_on_page>151</avg_time_on_page>
 								<bounce_rate>0%</bounce_rate>
 								<exit_rate>0%</exit_rate>
 								<avg_time_generation>0.089</avg_time_generation>
@@ -161,7 +161,7 @@
 		<min_time_generation>0.234</min_time_generation>
 		<max_time_generation>0.294</max_time_generation>
 		<exit_nb_visits>1</exit_nb_visits>
-		<avg_time_on_page>17</avg_time_on_page>
+		<avg_time_on_page>52</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 		<avg_time_generation>0.255</avg_time_generation>
@@ -177,7 +177,7 @@
 				<max_time_generation>0.294</max_time_generation>
 				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>17</avg_time_on_page>
+				<avg_time_on_page>52</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.255</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_range.xml
@@ -13,7 +13,7 @@
 		<entry_sum_visit_length>54</entry_sum_visit_length>
 		<entry_bounce_count>8</entry_bounce_count>
 		<exit_nb_visits>8</exit_nb_visits>
-		<avg_time_on_page>13</avg_time_on_page>
+		<avg_time_on_page>17</avg_time_on_page>
 		<bounce_rate>89%</bounce_rate>
 		<exit_rate>80%</exit_rate>
 		<avg_time_generation>0.389</avg_time_generation>
@@ -31,7 +31,7 @@
 				<entry_sum_visit_length>54</entry_sum_visit_length>
 				<entry_bounce_count>5</entry_bounce_count>
 				<exit_nb_visits>5</exit_nb_visits>
-				<avg_time_on_page>17</avg_time_on_page>
+				<avg_time_on_page>24</avg_time_on_page>
 				<bounce_rate>83%</bounce_rate>
 				<exit_rate>71%</exit_rate>
 				<avg_time_generation>0.443</avg_time_generation>
@@ -49,7 +49,7 @@
 						<entry_sum_visit_length>54</entry_sum_visit_length>
 						<entry_bounce_count>4</entry_bounce_count>
 						<exit_nb_visits>4</exit_nb_visits>
-						<avg_time_on_page>22</avg_time_on_page>
+						<avg_time_on_page>30</avg_time_on_page>
 						<bounce_rate>80%</bounce_rate>
 						<exit_rate>80%</exit_rate>
 						<avg_time_generation>0.089</avg_time_generation>
@@ -70,7 +70,7 @@
 								<sum_daily_nb_uniq_visitors>5</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>5</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>4</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>22</avg_time_on_page>
+								<avg_time_on_page>30</avg_time_on_page>
 								<bounce_rate>80%</bounce_rate>
 								<exit_rate>80%</exit_rate>
 								<avg_time_generation>0.089</avg_time_generation>
@@ -91,7 +91,7 @@
 						<entry_sum_visit_length>0</entry_sum_visit_length>
 						<entry_bounce_count>1</entry_bounce_count>
 						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>5</avg_time_on_page>
+						<avg_time_on_page>8</avg_time_on_page>
 						<bounce_rate>100%</bounce_rate>
 						<exit_rate>50%</exit_rate>
 						<avg_time_generation>0.974</avg_time_generation>
@@ -112,7 +112,7 @@
 								<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>5</avg_time_on_page>
+								<avg_time_on_page>8</avg_time_on_page>
 								<bounce_rate>100%</bounce_rate>
 								<exit_rate>50%</exit_rate>
 								<avg_time_generation>0.974</avg_time_generation>
@@ -542,7 +542,7 @@
 		<entry_sum_visit_length>0</entry_sum_visit_length>
 		<entry_bounce_count>4</entry_bounce_count>
 		<exit_nb_visits>5</exit_nb_visits>
-		<avg_time_on_page>7</avg_time_on_page>
+		<avg_time_on_page>10</avg_time_on_page>
 		<bounce_rate>100%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 		<avg_time_generation>0.255</avg_time_generation>
@@ -563,7 +563,7 @@
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>3</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>10</avg_time_on_page>
+				<avg_time_on_page>17</avg_time_on_page>
 				<bounce_rate>100%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.255</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_LabelFilter_titles__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_LabelFilter_titles__Actions.getPageTitles_day.xml
@@ -14,7 +14,7 @@
 		<entry_nb_actions>9</entry_nb_actions>
 		<entry_sum_visit_length>1441</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
-		<avg_time_on_page>279</avg_time_on_page>
+		<avg_time_on_page>1116</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<avg_time_generation>0.626</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_NonUnicode__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_NonUnicode__Actions.getPageTitles_day.xml
@@ -9,7 +9,7 @@
 		<nb_hits_following_search>2</nb_hits_following_search>
 		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
-		<avg_time_on_page>180</avg_time_on_page>
+		<avg_time_on_page>360</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 	</row>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_LabelReservedCharactersHierarchical__API.getRowEvolution_day.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_LabelReservedCharactersHierarchical__API.getRowEvolution_day.xml
@@ -249,7 +249,7 @@
 				<change>-100%</change>
 			</nb_visits_1>
 			<nb_visits_2>
-				<name>Google - justice )(&amp;^#%$ not &amp;#039;&quot; corruption! (Visits)</name>
+				<name>Google - justice )(&amp;^#%$ not &amp;#039;" corruption! (Visits)</name>
 				<min>0</min>
 				<max>1</max>
 			</nb_visits_2>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_flatFilters__Referrers.getSearchEngines_month.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_flatFilters__Referrers.getSearchEngines_month.xml
@@ -14,7 +14,7 @@
 		<logo>plugins/Referrers/images/searchEngines/google.com.png</logo>
 	</row>
 	<row>
-		<label>Google - justice )(&amp;^#%$ not &amp;#039;&quot; corruption!</label>
+		<label>Google - justice )(&amp;^#%$ not &amp;#039;" corruption!</label>
 		<nb_visits>8</nb_visits>
 		<nb_actions>8</nb_actions>
 		<max_actions>1</max_actions>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_multipleDates_lastNoData__API.getRowEvolution_month.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_multipleDates_lastNoData__API.getRowEvolution_month.xml
@@ -33,7 +33,7 @@
 				<change>-100%</change>
 			</nb_visits_0>
 			<nb_visits_1>
-				<name>justice )(&amp;^#%$ not &amp;#039;&quot; corruption! (Visits)</name>
+				<name>justice )(&amp;^#%$ not &amp;#039;" corruption! (Visits)</name>
 				<min>0</min>
 				<max>8</max>
 				<change>-100%</change>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
@@ -62,7 +62,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_hits>2</nb_hits>
 				<bounce_rate>0%</bounce_rate>
-				<avg_time_on_page>00:01:48</avg_time_on_page>
+				<avg_time_on_page>00:03:36</avg_time_on_page>
 				<exit_rate>0%</exit_rate>
 			</row>
 		</result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_month.xml
@@ -62,7 +62,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_hits>2</nb_hits>
 				<bounce_rate>0%</bounce_rate>
-				<avg_time_on_page>00:01:48</avg_time_on_page>
+				<avg_time_on_page>00:03:36</avg_time_on_page>
 				<exit_rate>0%</exit_rate>
 			</row>
 		</result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
@@ -62,7 +62,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_hits>2</nb_hits>
 				<bounce_rate>0%</bounce_rate>
-				<avg_time_on_page>00:01:48</avg_time_on_page>
+				<avg_time_on_page>00:03:36</avg_time_on_page>
 				<exit_rate>0%</exit_rate>
 			</row>
 		</result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_month.xml
@@ -62,7 +62,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_hits>2</nb_hits>
 				<bounce_rate>0%</bounce_rate>
-				<avg_time_on_page>00:01:48</avg_time_on_page>
+				<avg_time_on_page>00:03:36</avg_time_on_page>
 				<exit_rate>0%</exit_rate>
 			</row>
 		</result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageTitlesFollowingSiteSearch_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageTitlesFollowingSiteSearch_day.xml
@@ -20,7 +20,7 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>216</sum_time_spent>
 				<nb_hits_following_search>1</nb_hits_following_search>
-				<avg_time_on_page>108</avg_time_on_page>
+				<avg_time_on_page>216</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 			</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageTitlesFollowingSiteSearch_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageTitlesFollowingSiteSearch_month.xml
@@ -20,7 +20,7 @@
 				<sum_time_spent>216</sum_time_spent>
 				<nb_hits_following_search>1</nb_hits_following_search>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-				<avg_time_on_page>108</avg_time_on_page>
+				<avg_time_on_page>216</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 			</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageTitles_day.xml
@@ -32,7 +32,7 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>216</sum_time_spent>
 				<nb_hits_following_search>1</nb_hits_following_search>
-				<avg_time_on_page>108</avg_time_on_page>
+				<avg_time_on_page>216</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 			</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageTitles_month.xml
@@ -32,7 +32,7 @@
 				<sum_time_spent>216</sum_time_spent>
 				<nb_hits_following_search>1</nb_hits_following_search>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-				<avg_time_on_page>108</avg_time_on_page>
+				<avg_time_on_page>216</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 			</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageUrlsFollowingSiteSearch_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageUrlsFollowingSiteSearch_day.xml
@@ -21,7 +21,7 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>216</sum_time_spent>
 				<nb_hits_following_search>1</nb_hits_following_search>
-				<avg_time_on_page>108</avg_time_on_page>
+				<avg_time_on_page>216</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url>http://example.org/index.htm?random=PAGEVIEW, NOT SEARCH&amp;mykwd=&amp;IS_FOLLOWING_SEARCH ONCE</url>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageUrlsFollowingSiteSearch_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageUrlsFollowingSiteSearch_month.xml
@@ -21,7 +21,7 @@
 				<sum_time_spent>216</sum_time_spent>
 				<nb_hits_following_search>1</nb_hits_following_search>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-				<avg_time_on_page>108</avg_time_on_page>
+				<avg_time_on_page>216</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url>http://example.org/index.htm?random=PAGEVIEW, NOT SEARCH&amp;mykwd=&amp;IS_FOLLOWING_SEARCH ONCE</url>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageUrls_day.xml
@@ -36,7 +36,7 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>216</sum_time_spent>
 				<nb_hits_following_search>1</nb_hits_following_search>
-				<avg_time_on_page>108</avg_time_on_page>
+				<avg_time_on_page>216</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url>http://example.org/index.htm?random=PAGEVIEW, NOT SEARCH&amp;mykwd=&amp;IS_FOLLOWING_SEARCH ONCE</url>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getPageUrls_month.xml
@@ -36,7 +36,7 @@
 				<sum_time_spent>216</sum_time_spent>
 				<nb_hits_following_search>1</nb_hits_following_search>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-				<avg_time_on_page>108</avg_time_on_page>
+				<avg_time_on_page>216</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url>http://example.org/index.htm?random=PAGEVIEW, NOT SEARCH&amp;mykwd=&amp;IS_FOLLOWING_SEARCH ONCE</url>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getSiteSearchKeywords_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getSiteSearchKeywords_day.xml
@@ -8,7 +8,7 @@
 				<nb_hits>6</nb_hits>
 				<sum_time_spent>468</sum_time_spent>
 				<nb_pages_per_search>3</nb_pages_per_search>
-				<avg_time_on_page>78</avg_time_on_page>
+				<avg_time_on_page>234</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 			</row>
@@ -52,7 +52,7 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>54</sum_time_spent>
 				<nb_pages_per_search>2</nb_pages_per_search>
-				<avg_time_on_page>27</avg_time_on_page>
+				<avg_time_on_page>54</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 			</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getSiteSearchKeywords_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_AllSites__Actions.getSiteSearchKeywords_month.xml
@@ -18,7 +18,7 @@
 				<nb_hits>6</nb_hits>
 				<sum_time_spent>468</sum_time_spent>
 				<nb_pages_per_search>3</nb_pages_per_search>
-				<avg_time_on_page>78</avg_time_on_page>
+				<avg_time_on_page>234</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 			</row>
@@ -50,7 +50,7 @@
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>54</sum_time_spent>
 				<nb_pages_per_search>2</nb_pages_per_search>
-				<avg_time_on_page>27</avg_time_on_page>
+				<avg_time_on_page>54</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 			</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageTitlesFollowingSiteSearch_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageTitlesFollowingSiteSearch_day.xml
@@ -18,7 +18,7 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>216</sum_time_spent>
 		<nb_hits_following_search>1</nb_hits_following_search>
-		<avg_time_on_page>108</avg_time_on_page>
+		<avg_time_on_page>216</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 	</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageTitlesFollowingSiteSearch_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageTitlesFollowingSiteSearch_month.xml
@@ -18,7 +18,7 @@
 		<sum_time_spent>216</sum_time_spent>
 		<nb_hits_following_search>1</nb_hits_following_search>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<avg_time_on_page>108</avg_time_on_page>
+		<avg_time_on_page>216</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 	</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageTitles_day.xml
@@ -30,7 +30,7 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>216</sum_time_spent>
 		<nb_hits_following_search>1</nb_hits_following_search>
-		<avg_time_on_page>108</avg_time_on_page>
+		<avg_time_on_page>216</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 	</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageTitles_month.xml
@@ -30,7 +30,7 @@
 		<sum_time_spent>216</sum_time_spent>
 		<nb_hits_following_search>1</nb_hits_following_search>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<avg_time_on_page>108</avg_time_on_page>
+		<avg_time_on_page>216</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 	</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageUrlsFollowingSiteSearch_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageUrlsFollowingSiteSearch_day.xml
@@ -19,7 +19,7 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>216</sum_time_spent>
 		<nb_hits_following_search>1</nb_hits_following_search>
-		<avg_time_on_page>108</avg_time_on_page>
+		<avg_time_on_page>216</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<url>http://example.org/index.htm?random=PAGEVIEW, NOT SEARCH&amp;mykwd=&amp;IS_FOLLOWING_SEARCH ONCE</url>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageUrlsFollowingSiteSearch_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageUrlsFollowingSiteSearch_month.xml
@@ -19,7 +19,7 @@
 		<sum_time_spent>216</sum_time_spent>
 		<nb_hits_following_search>1</nb_hits_following_search>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<avg_time_on_page>108</avg_time_on_page>
+		<avg_time_on_page>216</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<url>http://example.org/index.htm?random=PAGEVIEW, NOT SEARCH&amp;mykwd=&amp;IS_FOLLOWING_SEARCH ONCE</url>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageUrls_day.xml
@@ -34,7 +34,7 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>216</sum_time_spent>
 		<nb_hits_following_search>1</nb_hits_following_search>
-		<avg_time_on_page>108</avg_time_on_page>
+		<avg_time_on_page>216</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<url>http://example.org/index.htm?random=PAGEVIEW, NOT SEARCH&amp;mykwd=&amp;IS_FOLLOWING_SEARCH ONCE</url>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getPageUrls_month.xml
@@ -34,7 +34,7 @@
 		<sum_time_spent>216</sum_time_spent>
 		<nb_hits_following_search>1</nb_hits_following_search>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<avg_time_on_page>108</avg_time_on_page>
+		<avg_time_on_page>216</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<url>http://example.org/index.htm?random=PAGEVIEW, NOT SEARCH&amp;mykwd=&amp;IS_FOLLOWING_SEARCH ONCE</url>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getSiteSearchKeywords_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getSiteSearchKeywords_day.xml
@@ -6,7 +6,7 @@
 		<nb_hits>6</nb_hits>
 		<sum_time_spent>468</sum_time_spent>
 		<nb_pages_per_search>3</nb_pages_per_search>
-		<avg_time_on_page>78</avg_time_on_page>
+		<avg_time_on_page>234</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 	</row>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getSiteSearchKeywords_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_NotLastNPeriods__Actions.getSiteSearchKeywords_month.xml
@@ -16,7 +16,7 @@
 		<nb_hits>6</nb_hits>
 		<sum_time_spent>468</sum_time_spent>
 		<nb_pages_per_search>3</nb_pages_per_search>
-		<avg_time_on_page>78</avg_time_on_page>
+		<avg_time_on_page>234</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 	</row>
@@ -48,7 +48,7 @@
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>54</sum_time_spent>
 		<nb_pages_per_search>2</nb_pages_per_search>
-		<avg_time_on_page>27</avg_time_on_page>
+		<avg_time_on_page>54</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 	</row>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
@@ -88,7 +88,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_hits>2</nb_hits>
 				<bounce_rate>0%</bounce_rate>
-				<avg_time_on_page>00:03:00</avg_time_on_page>
+				<avg_time_on_page>00:06:00</avg_time_on_page>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.31s</avg_time_generation>
 			</row>
@@ -117,7 +117,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_hits>2</nb_hits>
 				<bounce_rate>0%</bounce_rate>
-				<avg_time_on_page>00:03:00</avg_time_on_page>
+				<avg_time_on_page>00:06:00</avg_time_on_page>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.31s</avg_time_generation>
 			</row>
@@ -146,7 +146,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_hits>2</nb_hits>
 				<bounce_rate>0%</bounce_rate>
-				<avg_time_on_page>00:03:00</avg_time_on_page>
+				<avg_time_on_page>00:06:00</avg_time_on_page>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.31s</avg_time_generation>
 			</row>
@@ -175,7 +175,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_hits>2</nb_hits>
 				<bounce_rate>0%</bounce_rate>
-				<avg_time_on_page>00:03:00</avg_time_on_page>
+				<avg_time_on_page>00:06:00</avg_time_on_page>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.31s</avg_time_generation>
 			</row>
@@ -204,7 +204,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_hits>2</nb_hits>
 				<bounce_rate>0%</bounce_rate>
-				<avg_time_on_page>00:03:00</avg_time_on_page>
+				<avg_time_on_page>00:06:00</avg_time_on_page>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.31s</avg_time_generation>
 			</row>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_day.xml
@@ -99,7 +99,7 @@
 				<max_time_generation>0.452</max_time_generation>
 				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.313</avg_time_generation>
@@ -155,7 +155,7 @@
 				<max_time_generation>0.452</max_time_generation>
 				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.313</avg_time_generation>
@@ -211,7 +211,7 @@
 				<max_time_generation>0.452</max_time_generation>
 				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.313</avg_time_generation>
@@ -267,7 +267,7 @@
 				<max_time_generation>0.452</max_time_generation>
 				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.313</avg_time_generation>
@@ -323,7 +323,7 @@
 				<max_time_generation>0.452</max_time_generation>
 				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.313</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_month.xml
@@ -51,7 +51,7 @@
 				<exit_nb_visits>8</exit_nb_visits>
 				<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>8</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.313</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_week.xml
@@ -97,7 +97,7 @@
 				<exit_nb_visits>6</exit_nb_visits>
 				<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>6</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.313</avg_time_generation>
@@ -138,7 +138,7 @@
 				<exit_nb_visits>2</exit_nb_visits>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>2</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.313</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Actions.getPageUrls_year.xml
@@ -51,7 +51,7 @@
 				<exit_nb_visits>8</exit_nb_visits>
 				<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>8</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.313</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_day.xml
@@ -98,7 +98,7 @@
 			<max_time_generation>0.452</max_time_generation>
 			<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 			<exit_nb_visits>1</exit_nb_visits>
-			<avg_time_on_page>180</avg_time_on_page>
+			<avg_time_on_page>360</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>100%</exit_rate>
 			<avg_time_generation>0.313</avg_time_generation>
@@ -154,7 +154,7 @@
 			<max_time_generation>0.452</max_time_generation>
 			<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 			<exit_nb_visits>1</exit_nb_visits>
-			<avg_time_on_page>180</avg_time_on_page>
+			<avg_time_on_page>360</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>100%</exit_rate>
 			<avg_time_generation>0.313</avg_time_generation>
@@ -210,7 +210,7 @@
 			<max_time_generation>0.452</max_time_generation>
 			<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 			<exit_nb_visits>1</exit_nb_visits>
-			<avg_time_on_page>180</avg_time_on_page>
+			<avg_time_on_page>360</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>100%</exit_rate>
 			<avg_time_generation>0.313</avg_time_generation>
@@ -266,7 +266,7 @@
 			<max_time_generation>0.452</max_time_generation>
 			<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 			<exit_nb_visits>1</exit_nb_visits>
-			<avg_time_on_page>180</avg_time_on_page>
+			<avg_time_on_page>360</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>100%</exit_rate>
 			<avg_time_generation>0.313</avg_time_generation>
@@ -322,7 +322,7 @@
 			<max_time_generation>0.452</max_time_generation>
 			<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 			<exit_nb_visits>1</exit_nb_visits>
-			<avg_time_on_page>180</avg_time_on_page>
+			<avg_time_on_page>360</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>100%</exit_rate>
 			<avg_time_generation>0.313</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_month.xml
@@ -50,7 +50,7 @@
 			<exit_nb_visits>8</exit_nb_visits>
 			<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
 			<sum_daily_exit_nb_uniq_visitors>8</sum_daily_exit_nb_uniq_visitors>
-			<avg_time_on_page>180</avg_time_on_page>
+			<avg_time_on_page>360</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>100%</exit_rate>
 			<avg_time_generation>0.313</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_week.xml
@@ -96,7 +96,7 @@
 			<exit_nb_visits>6</exit_nb_visits>
 			<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 			<sum_daily_exit_nb_uniq_visitors>6</sum_daily_exit_nb_uniq_visitors>
-			<avg_time_on_page>180</avg_time_on_page>
+			<avg_time_on_page>360</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>100%</exit_rate>
 			<avg_time_generation>0.313</avg_time_generation>
@@ -137,7 +137,7 @@
 			<exit_nb_visits>2</exit_nb_visits>
 			<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 			<sum_daily_exit_nb_uniq_visitors>2</sum_daily_exit_nb_uniq_visitors>
-			<avg_time_on_page>180</avg_time_on_page>
+			<avg_time_on_page>360</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>100%</exit_rate>
 			<avg_time_generation>0.313</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Actions.getPageUrls_year.xml
@@ -50,7 +50,7 @@
 			<exit_nb_visits>8</exit_nb_visits>
 			<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
 			<sum_daily_exit_nb_uniq_visitors>8</sum_daily_exit_nb_uniq_visitors>
-			<avg_time_on_page>180</avg_time_on_page>
+			<avg_time_on_page>360</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>100%</exit_rate>
 			<avg_time_generation>0.313</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_csv__ScheduledReports.generateReport_month.original.csv
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_csv__ScheduledReports.generateReport_month.original.csv
@@ -113,7 +113,7 @@ Page URLs
 label,nb_visits,nb_hits,bounce_rate,avg_time_on_page,exit_rate,avg_time_generation
 /index.htm,9,9,11%,00:05:20,11%,0.3s
 Page URL not defined,9,17,0%,00:00:00,0%,0.22s
-/thankyou,8,16,0%,00:03:00,100%,0.31s
+/thankyou,8,16,0%,00:06:00,100%,0.31s
 /products,1,1,100%,00:00:00,100%,0.15s
 
 Entry pages

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_month.original.html
@@ -2550,7 +2550,7 @@
                                                                                                 8
                                                                                     </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                00:03:00
+                                                                                                00:06:00
                                                                                     </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
                                                                                                 0%

--- a/tests/PHPUnit/System/expected/test_UrlNormalization_pagesSegmentedRef__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_UrlNormalization_pagesSegmentedRef__Actions.getPageUrls_day.xml
@@ -10,7 +10,7 @@
 		<entry_sum_visit_length>2161</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
 		<exit_nb_visits>1</exit_nb_visits>
-		<avg_time_on_page>420</avg_time_on_page>
+		<avg_time_on_page>630</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>25%</exit_rate>
 		<subtable>
@@ -25,7 +25,7 @@
 				<entry_nb_actions>8</entry_nb_actions>
 				<entry_sum_visit_length>2161</entry_sum_visit_length>
 				<entry_bounce_count>0</entry_bounce_count>
-				<avg_time_on_page>540</avg_time_on_page>
+				<avg_time_on_page>1080</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url>http://example.org/foo/bar.html</url>
@@ -36,7 +36,7 @@
 				<nb_uniq_visitors>1</nb_uniq_visitors>
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>720</sum_time_spent>
-				<avg_time_on_page>360</avg_time_on_page>
+				<avg_time_on_page>720</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url>https://www.example.org/foo/bar2.html</url>

--- a/tests/PHPUnit/System/expected/test_UrlNormalization_pagesSegmented__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_UrlNormalization_pagesSegmented__Actions.getPageUrls_day.xml
@@ -5,7 +5,7 @@
 		<nb_visits>1</nb_visits>
 		<nb_hits>2</nb_hits>
 		<sum_time_spent>360</sum_time_spent>
-		<avg_time_on_page>180</avg_time_on_page>
+		<avg_time_on_page>360</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<subtable>
@@ -15,7 +15,7 @@
 				<nb_uniq_visitors>1</nb_uniq_visitors>
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>360</sum_time_spent>
-				<avg_time_on_page>180</avg_time_on_page>
+				<avg_time_on_page>360</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url>https://www.example.org/foo/bar2.html</url>

--- a/tests/PHPUnit/System/expected/test_UrlNormalization_titles__Actions.getPageTitles_day.xml
+++ b/tests/PHPUnit/System/expected/test_UrlNormalization_titles__Actions.getPageTitles_day.xml
@@ -89,7 +89,7 @@
 		<sum_time_spent>720</sum_time_spent>
 		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
-		<avg_time_on_page>360</avg_time_on_page>
+		<avg_time_on_page>720</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 	</row>

--- a/tests/PHPUnit/System/expected/test_UrlNormalization_urls__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_UrlNormalization_urls__Actions.getPageUrls_day.xml
@@ -10,7 +10,7 @@
 		<entry_sum_visit_length>2161</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
 		<exit_nb_visits>1</exit_nb_visits>
-		<avg_time_on_page>420</avg_time_on_page>
+		<avg_time_on_page>630</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>25%</exit_rate>
 		<subtable>
@@ -25,7 +25,7 @@
 				<entry_nb_actions>8</entry_nb_actions>
 				<entry_sum_visit_length>2161</entry_sum_visit_length>
 				<entry_bounce_count>0</entry_bounce_count>
-				<avg_time_on_page>540</avg_time_on_page>
+				<avg_time_on_page>1080</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url>http://example.org/foo/bar.html</url>
@@ -36,7 +36,7 @@
 				<nb_uniq_visitors>1</nb_uniq_visitors>
 				<nb_hits>2</nb_hits>
 				<sum_time_spent>720</sum_time_spent>
-				<avg_time_on_page>360</avg_time_on_page>
+				<avg_time_on_page>720</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<url>https://www.example.org/foo/bar2.html</url>

--- a/tests/PHPUnit/System/expected/test_VisitsInPast_InvalidateOldReportsWebsite2_OldReportsShouldAppear__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_VisitsInPast_InvalidateOldReportsWebsite2_OldReportsShouldAppear__Actions.getPageUrls_month.xml
@@ -11,7 +11,7 @@
 			<entry_sum_visit_length>361</entry_sum_visit_length>
 			<entry_bounce_count>0</entry_bounce_count>
 			<exit_nb_visits>1</exit_nb_visits>
-			<avg_time_on_page>72</avg_time_on_page>
+			<avg_time_on_page>120</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>33%</exit_rate>
 			<subtable>
@@ -50,7 +50,7 @@
 					<exit_nb_visits>1</exit_nb_visits>
 					<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 					<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-					<avg_time_on_page>180</avg_time_on_page>
+					<avg_time_on_page>360</avg_time_on_page>
 					<bounce_rate>0%</bounce_rate>
 					<exit_rate>100%</exit_rate>
 					<url>http://example.org/category/Pageyy</url>

--- a/tests/PHPUnit/System/expected/test_VisitsInPast_InvalidateOldReportsWebsite2_OldReportsShouldNotAppear__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_VisitsInPast_InvalidateOldReportsWebsite2_OldReportsShouldNotAppear__Actions.getPageUrls_month.xml
@@ -11,7 +11,7 @@
 			<entry_sum_visit_length>361</entry_sum_visit_length>
 			<entry_bounce_count>0</entry_bounce_count>
 			<exit_nb_visits>1</exit_nb_visits>
-			<avg_time_on_page>72</avg_time_on_page>
+			<avg_time_on_page>120</avg_time_on_page>
 			<bounce_rate>0%</bounce_rate>
 			<exit_rate>33%</exit_rate>
 			<subtable>
@@ -50,7 +50,7 @@
 					<exit_nb_visits>1</exit_nb_visits>
 					<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 					<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-					<avg_time_on_page>180</avg_time_on_page>
+					<avg_time_on_page>360</avg_time_on_page>
 					<bounce_rate>0%</bounce_rate>
 					<exit_rate>100%</exit_rate>
 					<url>http://example.org/category/Pageyy</url>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_scheduled_report_in_csv__ScheduledReports.generateReport_week.original.csv
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_scheduled_report_in_csv__ScheduledReports.generateReport_week.original.csv
@@ -210,7 +210,7 @@ nb_pageviews,nb_uniq_pageviews,nb_downloads,nb_uniq_downloads,nb_outlinks,nb_uni
 
 Page URLs
 label,nb_visits,nb_hits,bounce_rate,avg_time_on_page,exit_rate
-/index.htm,4,16,0%,00:03:23,100%
+/index.htm,4,16,0%,00:13:30,100%
 
 Entry pages
 label,entry_nb_visits,entry_bounce_count,bounce_rate
@@ -222,7 +222,7 @@ label,nb_visits,exit_nb_visits,exit_rate
 
 Page titles
 label,nb_visits,nb_hits,bounce_rate,avg_time_on_page,exit_rate
- View product left in cart,3,9,0%,00:02:00,100%
+ View product left in cart,3,9,0%,00:06:00,100%
  Another Product page,1,1,0%,00:06:00,0%
  Another Product page with multiple categories,1,1,0%,00:00:00,100%
  Another Product page with no category,1,1,0%,00:00:00,0%

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_week.original.html
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_week.original.html
@@ -3778,7 +3778,7 @@
                                                                                                 4
                                                                                     </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                00:03:23
+                                                                                                00:13:30
                                                                                     </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
                                                                                                 0%
@@ -3920,7 +3920,7 @@
                                                                                                 3
                                                                                     </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                00:02:00
+                                                                                                00:06:00
                                                                                     </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
                                                                                                 0%

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__Live.getVisitorProfile.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__Live.getVisitorProfile.xml
@@ -38,14 +38,14 @@
 	<firstVisit>
 		
 		
-		
+		<daysAgo>0</daysAgo>
 		<referrerType>campaign</referrerType>
 		<referralSummary>Campaign: campaign name - yeah! - campaign keyword - right...</referralSummary>
 	</firstVisit>
 	<lastVisit>
 		
 		
-		
+		<daysAgo>0</daysAgo>
 		<referrerType>campaign</referrerType>
 		<referralSummary>Campaign: campaign name - yeah! - campaign keyword - right...</referralSummary>
 	</lastVisit>

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__Live.getVisitorProfile.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__Live.getVisitorProfile.xml
@@ -38,14 +38,14 @@
 	<firstVisit>
 		
 		
-		
+		<daysAgo>0</daysAgo>
 		<referrerType>campaign</referrerType>
 		<referralSummary>Campaign: campaign name - yeah! - campaign keyword - right...</referralSummary>
 	</firstVisit>
 	<lastVisit>
 		
 		
-		
+		<daysAgo>0</daysAgo>
 		<referrerType>campaign</referrerType>
 		<referralSummary>Campaign: campaign name - yeah! - campaign keyword - right...</referralSummary>
 	</lastVisit>


### PR DESCRIPTION
 this PR seems to start failing UI tests which I really don't understand how it could be related to this change.

so Reverting piwik/piwik#9618 to see if UI tests pass again....
