### PR TITLE
actionType is a segment of type "dimension"

### DIFF
--- a/plugins/Actions/Columns/ActionType.php
+++ b/plugins/Actions/Columns/ActionType.php
@@ -47,7 +47,7 @@ class ActionType extends ActionDimension
         $segment->setSegment('actionType');
         $segment->setName('Actions_ActionType');
         $segment->setSqlSegment('log_action.type');
-        $segment->setType(Segment::TYPE_METRIC);
+        $segment->setType(Segment::TYPE_DIMENSION);
         $segment->setAcceptedValues(sprintf('A type of action, such as: %s', implode(', ', $types)));
         $segment->setSqlFilter(function ($type) use ($types) {
             if (array_key_exists($type, $types)) {

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
@@ -59,13 +59,6 @@
 		<permission>1</permission>
 	</row>
 	<row>
-		<type>metric</type>
-		<category>Actions</category>
-		<name>Action Type</name>
-		<segment>actionType</segment>
-		<acceptedValues>A type of action, such as: pageviews, contents, sitesearches, events, outlinks, downloads</acceptedValues>
-	</row>
-	<row>
 		<type>dimension</type>
 		<category>Visit Location</category>
 		<name>City</name>
@@ -454,6 +447,13 @@
 		<category>Custom Variables</category>
 		<name>Custom Variable value 5 (scope visit)</name>
 		<segment>customVariableValue5</segment>
+	</row>
+	<row>
+		<type>dimension</type>
+		<category>Actions</category>
+		<name>Action Type</name>
+		<segment>actionType</segment>
+		<acceptedValues>A type of action, such as: pageviews, contents, sitesearches, events, outlinks, downloads</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>


### PR DESCRIPTION
Setting proper segment type to our new segment `actionType` #9314  

This will fix the automatically generated documentation at http://developer.piwik.org/api-reference/reporting-api-segmentation which currently lists actionType in its own category.
