### PR TITLE
Show an error message in case we deactivate a plugin because of missing dependencies

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -18,9 +18,11 @@ use Piwik\Container\StaticContainer;
 use Piwik\EventDispatcher;
 use Piwik\Filesystem;
 use Piwik\Log;
+use Piwik\Notification;
 use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\PluginDeactivatedException;
+use Piwik\Session;
 use Piwik\Theme;
 use Piwik\Tracker;
 use Piwik\Translation\Translator;
@@ -828,6 +830,15 @@ class Manager
 
                 if ($newPlugin->hasMissingDependencies()) {
                     $this->deactivatePlugin($pluginName);
+
+                    // add this state we do not know yet whether current user has super user access. We do not even know
+                    // if someone is actually logged in.
+                    $message  = sprintf('We disabled the plugin %s as it has missing dependencies.', $pluginName);
+                    $message .= ' Please contact your Piwik administrator.';
+
+                    $notification = new Notification($message);
+                    $notification->context = Notification::CONTEXT_ERROR;
+                    Notification\Manager::notify('PluginManager_PluginDeactivated', $notification);
                     continue;
                 }
 

--- a/libs/README.md
+++ b/libs/README.md
@@ -30,3 +30,4 @@ third-party libraries:
    - ZF-10871 - undefined variables when socket support disabled
    - fix #6980 ("Array to string conversion") in `Zend/Session/Exception.php`
    - fix Zend/Validate using deprecated iconv_set_encoding()
+   - Make sure sessions work when storing notifications

--- a/libs/Zend/Session.php
+++ b/libs/Zend/Session.php
@@ -491,6 +491,10 @@ class Zend_Session extends Zend_Session_Abstract
             self::regenerateId();
         }
 
+        if (isset($_SESSION['data']) && is_string($_SESSION['data'])) {
+            $_SESSION = unserialize(base64_decode($_SESSION['data']));
+        }
+
         // run validators if they exist
         if (isset($_SESSION['__ZF']['VALID'])) {
             self::_processValidators();
@@ -688,8 +692,17 @@ class Zend_Session extends Zend_Session_Abstract
             parent::$_writable = false;
         }
 
+        if (isset($_SESSION)) {
+            $sessionBkp = $_SESSION;
+            $_SESSION = array('data' => base64_encode(serialize($_SESSION)));
+        }
+
         session_write_close();
         self::$_writeClosed = true;
+
+        if (isset($sessionBkp)) {
+            $_SESSION = $sessionBkp;
+        }
     }
 
 


### PR DESCRIPTION
refs #4485 

See https://github.com/piwik/piwik/issues/4485#issuecomment-160474430 we may silently disable / deactivate plugins in case the requirements of a plugin are no longer met. In this case we do now simply output a trivial error message by triggering a notification.

The notification may or may not be seen depending on if the plugin was disabled automatically while a UI page was requested. Also it may be printed to any user, or anonymous user. However this is rather very unlikely.  Problem is we do not know at the time of checking for these conditions whether someone is logged in etc. Also sessions won't be started at that time so we cannot persist it under circumstances.

Initially it was not possible to trigger a notification there at all since the session was not loaded at that time of bootstrapping Piwik. I changed the notification manager to only store persistent notifications in session from now on since all others don't need to be stored there (non persistent notifications get deleted at some point anyway). Also in case a session becomes available later, there is a chance that we may copy a notification from the local cache into the session to make sure it will be displayed in the UI.

We also make sure notifications are stored in sessions.
