### PR TITLE
removed order by idsite for Model

### DIFF
--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -395,7 +395,7 @@ class Model
         $groupBy = false;
         $limit = $limit >= 1 ? (int)$limit : 0;
         $offset = $offset >= 1 ? (int)$offset : 0;
-        $orderBy = "idsite, visit_last_action_time " . $filterSortOrder;
+        $orderBy = "visit_last_action_time " . $filterSortOrder;
         $orderByParent = "sub.visit_last_action_time " . $filterSortOrder;
 
         $subQuery = $segment->getSelectQuery($select, $from, $where, $whereBind, $orderBy, $groupBy, $limit, $offset);

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -51,7 +51,7 @@ class ModelTest extends IntegrationTestCase
                     WHERE log_visit.idsite in (?)
                       AND log_visit.visit_last_action_time >= ?
                       AND log_visit.visit_last_action_time <= ?
-                    ORDER BY idsite, visit_last_action_time DESC
+                    ORDER BY visit_last_action_time DESC
                     LIMIT 100
                  ) AS sub
                  GROUP BY sub.idvisit
@@ -87,7 +87,7 @@ class ModelTest extends IntegrationTestCase
                     WHERE log_visit.idsite in (?)
                       AND log_visit.visit_last_action_time >= ?
                       AND log_visit.visit_last_action_time <= ?
-                    ORDER BY idsite, visit_last_action_time DESC
+                    ORDER BY visit_last_action_time DESC
                     LIMIT 15, 100
                  ) AS sub
                  GROUP BY sub.idvisit
@@ -131,10 +131,10 @@ class ModelTest extends IntegrationTestCase
                           AND log_visit.visit_last_action_time >= ?
                           AND log_visit.visit_last_action_time <= ? )
                           AND ( log_link_visit_action.custom_var_k1 = ? )
-                        ORDER BY idsite, visit_last_action_time DESC
+                        ORDER BY visit_last_action_time DESC
                         LIMIT 100
                         ) AS log_inner
-                    ORDER BY idsite, visit_last_action_time DESC
+                    ORDER BY visit_last_action_time DESC
                     LIMIT 100
                  ) AS sub
                  GROUP BY sub.idvisit


### PR DESCRIPTION
It prevented display of visits to be ordered by most important dimension - Time when MetaSites plugin was enabled.
