### PR TITLE
Remove outline in login form as it clooks weird on firefox 44

### DIFF
--- a/plugins/Login/stylesheets/login.less
+++ b/plugins/Login/stylesheets/login.less
@@ -126,6 +126,7 @@
     #login_form_login,
     #reset_form_login {
         background: @theme-color-background-base url(../../Morpheus/images/login-sprite.png) no-repeat;
+        outline: 0;
     }
 
     #login_form_password,


### PR DESCRIPTION
fixes #9659

FYI: It's probably still shown in other areas
