### PR TITLE
Disable outline everywhere in Firefox as it adds a thick border everywhere

### DIFF
--- a/plugins/Morpheus/stylesheets/general/_default.less
+++ b/plugins/Morpheus/stylesheets/general/_default.less
@@ -36,6 +36,12 @@ blockquote, q {
     outline: auto;
 }
 
+@-moz-document url-prefix() { 
+  :focus {
+     outline:0;
+  }
+}
+
 /* remember to highlight inserts somehow! */
 ins {
     text-decoration: none;


### PR DESCRIPTION
refs #9659
