### PR TITLE
Fix XML or other response renderer header are not set

### DIFF
--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -97,7 +97,10 @@ class ResponseBuilder
         // apply the set of generic filters if asked in the URL
         // and we render the DataTable according to the format specified in the URL
         if ($value instanceof DataTableInterface) {
-            return $this->handleDataTable($value);
+            $table = $this->handleDataTable($value);
+            $this->sendHeaderIfEnabled();
+
+            return $table;
         }
 
         // Case an array is returned from the API call, we convert it to the requested format


### PR DESCRIPTION
Eg causes http://demo.piwik.org/index.php?module=API&method=Live.getLastVisitsDetails&format=XML&idSite=7&period=month&date=2016-01-12&expanded=1&token_auth=&filter_limit=10 to be returned as plain text.

Problem: Within the response renderer, in `handleDataTable`, after the API request was executed and the correct header already set, we perform another API request by https://github.com/piwik/piwik/blob/master/plugins/Intl/DateTimeFormatProvider.php#L110 which then sets a plain header.

Quick workaround is to just send it again. Possibly better workaround is to not set a header when `original` render is used. Or to only set it when `serialized=1` here: https://github.com/piwik/piwik/blob/master/plugins/API/Renderer/Original.php#L53  
We could change it to 

``` php
        if ($this->shouldSerialize()) {
            Common::sendHeader('Content-Type: text/plain; charset=utf-8');
        }
```
