### PR TITLE
Measure mysql version in API release check

### DIFF
--- a/plugins/CoreUpdater/ReleaseChannel.php
+++ b/plugins/CoreUpdater/ReleaseChannel.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\CoreUpdater;
 
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Db;
 use Piwik\Http;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\Url;
@@ -23,6 +24,7 @@ abstract class ReleaseChannel extends BaseReleaseChannel
         $parameters = array(
             'piwik_version'   => Version::VERSION,
             'php_version'     => PHP_VERSION,
+            'mysql_version'   => Db::get()->getServerVersion(),
             'release_channel' => $this->getId(),
             'url'             => Url::getCurrentUrlWithoutQueryString(),
             'trigger'         => Common::getRequestVar('module', '', 'string'),

--- a/plugins/CoreUpdater/Test/Integration/ReleaseChannelTest.php
+++ b/plugins/CoreUpdater/Test/Integration/ReleaseChannelTest.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\CoreUpdater\Test\ReleaseChannel;
 
 use Piwik\Config;
+use Piwik\Db;
 use Piwik\Plugins\CoreUpdater\ReleaseChannel;
 use Piwik\UpdateCheck;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -56,11 +57,12 @@ class ReleaseChannelTest extends IntegrationTestCase
     {
         $version = Version::VERSION;
         $phpVersion = urlencode(PHP_VERSION);
+        $mysqlVersion = Db::get()->getServerVersion();
         $url = urlencode(Url::getCurrentUrlWithoutQueryString());
 
         $urlToCheck = $this->channel->getUrlToCheckForLatestAvailableVersion();
 
-        $this->assertStringStartsWith("http://api.piwik.org/1.0/getLatestVersion/?piwik_version=$version&php_version=$phpVersion&release_channel=my_channel&url=$url&trigger=&timezone=", $urlToCheck);
+        $this->assertStringStartsWith("http://api.piwik.org/1.0/getLatestVersion/?piwik_version=$version&php_version=$phpVersion&mysql_version=$mysqlVersion&release_channel=my_channel&url=$url&trigger=&timezone=", $urlToCheck);
     }
 
 }


### PR DESCRIPTION
refs #9734

We need to know the MySQL version otherwise we cannot return the supported Piwik version for a given instance. Depending on PHP version and MySQL version we will report what the latest Piwik version can be used by an instance.
