### PR TITLE
Fix changing password in usersmanager can result in an error

### DIFF
--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -459,7 +459,7 @@ class Controller extends ControllerAdmin
             $sessionInitializer = new SessionInitializer();
             $auth = StaticContainer::get('Piwik\Auth');
             $auth->setLogin($userLogin);
-            $auth->setPassword($password);
+            $auth->setPassword($newPassword);
             $sessionInitializer->initSession($auth, $rememberMe = false);
         }
     }


### PR DESCRIPTION
It might show an error, a user then has to reload and log in with the new password.

fixes #9763
