### PR TITLE
Reuse datatable's metadata when merging subtables

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1714,6 +1714,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
     public function mergeSubtables($labelColumn = false, $useMetadataColumn = false)
     {
         $result = new DataTable();
+        $result->setAllTableMetadata($this->getAllTableMetadata());
         foreach ($this->getRowsWithoutSummaryRow() as $row) {
             $subtable = $row->getSubtable();
             if ($subtable !== false) {

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -898,6 +898,14 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($unserialized[0][3], "found the id sub table in the serialized, not expected");
     }
 
+    public function testMergeSubtablesKeepsMetadata()
+    {
+        $dataTable = $this->_getDataTable1ForTest();
+        $dataTable->setMetadata('additionalMetadata', 'test');
+        $dataTable = $dataTable->mergeSubtables();
+        $this->assertEquals('test', $dataTable->getMetadata('additionalMetadata'));
+    }
+
     private function createDataTable($rows)
     {
         $useless1 = new DataTable;


### PR DESCRIPTION
As described in #9773 the all referrers goal metrics didn't contain the goal names.
After debugging a while I found out, that this is caused by `DataTable::mergeSubtables`, which is used to create the report. This method returns a complete new `DataTable` object. The metadata of the original datatable is lost.
As the `site` metadata is so missing in the new `DataTable` object, the goal metrics are not able to load the goal name.

Copying the metadata to the new datatable object fixes this issue.

Not sure if that might have any side effects...

fixes #9773
