### PR TITLE
Add possibility to set a system setting is writable/not writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This is a changelog for Piwik platform developers. All changes for our HTTP API's, Plugins, Themes, etc will be listed here.
 
+## Piwik 2.16.1
+
+### New features
+ * New method `setIsWritableByCurrentUser` for `SystemSetting` to change the writable permission for certain system settings via DI.
+
 ## Piwik 2.16.0
 
 ### New features

--- a/core/Settings/SystemSetting.php
+++ b/core/Settings/SystemSetting.php
@@ -67,6 +67,16 @@ class SystemSetting extends Setting
     }
 
     /**
+     * Set whether setting is writable or not. For example to hide setting from the UI set it to false.
+     *
+     * @param bool $isWritable
+     */
+    public function setIsWritableByCurrentUser($isWritable)
+    {
+        $this->writableByCurrentUser = (bool) $isWritable;
+    }
+
+    /**
      * Returns `true` if this setting can be displayed for the current user, `false` if otherwise.
      *
      * @return bool

--- a/plugins/Diagnostics/ConfigReader.php
+++ b/plugins/Diagnostics/ConfigReader.php
@@ -116,7 +116,7 @@ class ConfigReader
     {
         $key = strtolower($key);
         $passwordFields = array(
-            'password', 'secret', 'apikey', 'privatekey', 'admin_pass'
+            'password', 'secret', 'apikey', 'privatekey', 'admin_pass', 'md5', 'sha1'
         );
         foreach ($passwordFields as $value) {
             if (strpos($key, $value) !== false) {

--- a/tests/PHPUnit/Integration/Settings/SystemSettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/SystemSettingTest.php
@@ -175,6 +175,21 @@ class SystemSettingTest extends IntegrationTestCase
         $this->assertFalse($setting->isWritableByCurrentUser());
     }
 
+    public function test_setIsWritableByCurrentUser()
+    {
+        $this->setSuperUser();
+        $setting = $this->addSystemSetting('myusersetting', 'mytitle');
+        $setting->setPluginName('MyPluginName');
+
+        $this->assertTrue($setting->isWritableByCurrentUser());
+
+        $setting->setIsWritableByCurrentUser(false);
+        $this->assertFalse($setting->isWritableByCurrentUser());
+
+        $setting->setIsWritableByCurrentUser(true);
+        $this->assertTrue($setting->isWritableByCurrentUser());
+    }
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed


### PR DESCRIPTION
Useful for cloud to hide settings from UI. 

BTW: Settings can be also hidden by specifying them in the UI.
