### PR TITLE
Fix unreplaced translations in transitions

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -843,7 +843,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                                     if (oldDate) {
                                         $('span', annotations).each(function () {
                                             if ($(this).attr('data-date') == oldDate) {
-                                                $(this).attr('title', viewAndAdd.replace("%s", oldDate));
+                                                $(this).attr('title', sprintf(viewAndAdd, oldDate));
                                                 return false;
                                             }
                                         });
@@ -851,10 +851,10 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
                                     // change the tooltip of the clicked evolution icon
                                     if (manager.is(':hidden')) {
-                                        spanSelf.attr('title', viewAndAdd.replace("%s", date));
+                                        spanSelf.attr('title', sprintf(viewAndAdd, date));
                                     }
                                     else {
-                                        spanSelf.attr('title', hideNotes.replace("%s", date));
+                                        spanSelf.attr('title', sprintf(hideNotes, date));
                                     }
                                 }
                             );

--- a/plugins/CoreHome/javascripts/popover.js
+++ b/plugins/CoreHome/javascripts/popover.js
@@ -85,7 +85,7 @@ var Piwik_Popover = (function () {
             var loadingMessage = popoverSubject ? translations.General_LoadingPopoverFor :
                 translations.General_LoadingPopover;
 
-            loadingMessage = loadingMessage.replace(/%s/, popoverName);
+            loadingMessage = sprintf(loadingMessage, popoverName);
 
             var p1 = $(document.createElement('p')).addClass('Piwik_Popover_Loading_Name');
             loading.append(p1.text(loadingMessage));

--- a/plugins/Live/javascripts/live.js
+++ b/plugins/Live/javascripts/live.js
@@ -245,7 +245,7 @@ $(function() {
                 var visitorsCountMessage = translations['one_visitor'];
             }
             else {
-                var visitorsCountMessage = translations['visitors'].replace('%s', visitors);
+                var visitorsCountMessage = sprintf(translations['visitors'], visitors);
             }
             $('.simple-realtime-visitor-counter', element)
               .attr('title', visitorsCountMessage)
@@ -255,15 +255,15 @@ $(function() {
             var metrics = $('.simple-realtime-metric', element);
 
             var visitsText = data['visits'] == 1
-              ? translations['one_visit'] : translations['visits'].replace('%s', data['visits']);
+              ? translations['one_visit'] : sprintf(translations['visits'], data['visits']);
             $(metrics[0]).text(visitsText);
 
             var actionsText = data['actions'] == 1
-              ? translations['one_action'] : translations['actions'].replace('%s', data['actions']);
+              ? translations['one_action'] : sprintf(translations['actions'], data['actions']);
             $(metrics[1]).text(actionsText);
 
             var lastMinutesText = lastMinutes == 1
-              ? translations['one_minute'] : translations['minutes'].replace('%s', lastMinutes);
+              ? translations['one_minute'] : sprintf(translations['minutes'], lastMinutes);
             $(metrics[2]).text(lastMinutesText);
 
             scheduleAnotherRequest();

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -7,28 +7,11 @@
 
 function _pk_translate(translationStringId, values) {
 
-    function sprintf (translation, values) {
-        var index = 0;
-        return (translation+'').replace(/(%(.\$)?s+)/g, function(match, number) {
-
-            var replaced = match;
-            if (match != '%s') {
-                index = parseInt(match.substr(1, 1)) - 1;
-            }
-
-            if (typeof values[index] != 'undefined') {
-                replaced = values[index];
-            }
-
-            index++;
-            return replaced;
-        });
-    }
-
     if( typeof(piwik_translations[translationStringId]) != 'undefined' ){
         var translation = piwik_translations[translationStringId];
         if (typeof values != 'undefined' && values && values.length) {
-            return sprintf(translation, values);
+            values.unshift(translation);
+            return sprintf.apply(null, values);
         }
 
         return translation;

--- a/plugins/Transitions/javascripts/transitions.js
+++ b/plugins/Transitions/javascripts/transitions.js
@@ -268,7 +268,7 @@ Piwik_Transitions.prototype.preparePopover = function () {
                 var share = NumberFormatter.formatPercent(Math.round(self.model.pageviews / totalNbPageviews * 1000) / 10);
 
                 var text = Piwik_Transitions_Translations.ShareOfAllPageviews;
-                text = text.replace(/%s/, NumberFormatter.formatNumber(self.model.pageviews)).replace(/%s/, share);
+                text = sprintf(text, NumberFormatter.formatNumber(self.model.pageviews), share);
                 text += '<br /><em>' + Piwik_Transitions_Translations.DateRange + ' ' + self.model.date + '</em>';
 
                 var title = '<h3>' + piwikHelper.addBreakpointsToUrl(self.actionName) + '</h3>';
@@ -419,7 +419,7 @@ Piwik_Transitions.prototype.renderCenterBox = function () {
 Piwik_Transitions.prototype.addTooltipShowingPercentageOfAllPageviews = function(element, metric) {
     var tip = Piwik_Transitions_Translations.XOfAllPageviews;
     var percentage = this.model.getPercentage(metric, true);
-    tip = tip.replace(/%s/, '<strong>' + percentage + '</strong>');
+    tip = sprintf(tip, '<strong>' + percentage + '</strong>');
 
     element.tooltip({
         track: true,
@@ -572,7 +572,7 @@ Piwik_Transitions.prototype.renderOpenGroup = function (groupName, side, onlyBg)
         }
 
         var tooltip = Piwik_Transitions_Translations.XOfY;
-        tooltip = '<strong>' + tooltip.replace(/%s/, data.referrals + '</strong>').replace(/%s/, nbTransitions);
+        tooltip = '<strong>' + sprintf(tooltip, data.referrals, nbTransitions) + '</strong>';
         tooltip = this.model.getShareInGroupTooltip(tooltip, groupName);
 
         var fullLabel = label;
@@ -1403,7 +1403,7 @@ Piwik_Transitions_Model.prototype.getGroupTitle = function (groupName) {
 
 Piwik_Transitions_Model.prototype.getShareInGroupTooltip = function (share, groupName) {
     var tip = this.shareInGroupTexts[groupName];
-    return tip.replace(/%s/, share);
+    return sprintf(tip, share);
 };
 
 Piwik_Transitions_Model.prototype.getDetailsForGroup = function (groupName) {
@@ -1500,10 +1500,10 @@ Piwik_Transitions_Ajax.prototype.callApi = function (method, params, callback) {
                     if (typeof params.actionName != 'undefined') {
                         var url = params.actionName;
                         url = piwikHelper.addBreakpointsToUrl(url);
-                        errorTitle = errorTitle.replace(/%s/, '<span>' + url + '</span>');
+                        errorTitle = sprintf(errorTitle, '<span>' + url + '</span>');
                     }
 
-                    errorMessage = errorMessage.replace(/%s/g, '<br />');
+                    errorMessage = sprintf(errorMessage, '<br />');
                     Piwik_Popover.showError(errorTitle, errorMessage, errorBack);
                 };
 

--- a/plugins/UsersManager/javascripts/usersManager.js
+++ b/plugins/UsersManager/javascripts/usersManager.js
@@ -142,8 +142,7 @@ function bindUpdateSuperUserAccess() {
         message = 'UsersManager_ConfirmProhibitOtherUsersSuperUserAccess';
     }
 
-    message = _pk_translate(message);
-    message = message.replace('%s', login);
+    message = _pk_translate(message, [login]);
 
     $('#superUserAccessConfirm h2').text(message);
 

--- a/tests/UI/specs/Transitions_spec.js
+++ b/tests/UI/specs/Transitions_spec.js
@@ -28,6 +28,7 @@ describe("Transitions", function () {
         expect.screenshot('transitions_popup_urls').to.be.captureSelector('.ui-dialog', function (page) {
             page.load("?" + urlBase + "#/" + generalParams + "&module=Actions&action=menuGetPageUrls&"
                     + "popover=RowAction$3ATransitions$3Aurl$3Ahttp$3A$2F$2Fpiwik.net$2Fdocs$2Fmanage-websites$2F");
+            page.mouseMove('.Transitions_CurveTextRight');
         }, done);
     });
 });


### PR DESCRIPTION
Another case where `%s` has been replaced manually.
To avoid that I've replace this and other occurrences with usage of `sprintf`. 
Also adjusted the transitions UI test to hover a number, so the tooltip is displayed where replacing didn't work.

fixes #9799
