### PR TITLE
use consistent wording "processed" to make it clear the segment will be processed across all websites

### DIFF
--- a/plugins/SegmentEditor/lang/en.json
+++ b/plugins/SegmentEditor/lang/en.json
@@ -17,7 +17,7 @@
         "SaveAndApply": "Save & Apply",
         "SegmentDisplayedAllWebsites": "all websites",
         "SegmentDisplayedThisWebsiteOnly": "this website only",
-        "SegmentIsDisplayedForWebsite": "and displayed for",
+        "SegmentIsDisplayedForWebsite": "and processed for",
         "SegmentNotApplied": "Segment '%s' not applied",
         "SegmentNotAppliedMessage": "You are requesting data for the Custom Segment '%s', this Piwik configuration currently prevents real time processing of reports for performance reasons.",
         "SelectSegmentOfVisits": "Select a segment of visits:",


### PR DESCRIPTION
we found this was confusing while reviewing our technical training
