### PR TITLE
Fixed whitelabel compatibility while hovering datatable row

### DIFF
--- a/plugins/Morpheus/stylesheets/main.less
+++ b/plugins/Morpheus/stylesheets/main.less
@@ -375,7 +375,7 @@ table.dataTable {
 
       &:hover {
         td:not(.cellSubDataTable) {
-          background-color: @color-silver-l95;
+          background-color: @color-silver-l95 !important;
         }
 
         .cellSubDataTable td {


### PR DESCRIPTION
Whis will solve problem with overriding styles in whitelabel. Currently single cells override hover row background color.
