### PR TITLE
Transitions should work as expected even when used along with a Goal segment 

### DIFF
--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -222,8 +222,8 @@ class API extends \Piwik\Plugin\API
         if ($actionType != 'title') {
             // specific setup for page urls
             $types[Action::TYPE_PAGE_URL] = 'followingPages';
-            $dimension = 'if ( %s.idaction_url IS NULL, %s.idaction_name, %s.idaction_url )';
-            $dimension = str_replace('%s', 'log_link_visit_action', $dimension );
+            $dimension = 'if ( %1$s.idaction_url IS NULL, %1$s.idaction_name, %1$s.idaction_url )';
+            $dimension = sprintf($dimension, 'log_link_visit_action' );
             // site search referrers are logged with url=NULL
             // when we find one, we have to join on name
             $joinLogActionColumn = $dimension;
@@ -406,8 +406,8 @@ class API extends \Piwik\Plugin\API
         if ($dimension == 'idaction_url_ref') {
             // site search referrers are logged with url_ref=NULL
             // when we find one, we have to join on name_ref
-            $dimension = 'if ( %s.idaction_url_ref IS NULL, %s.idaction_name_ref, %s.idaction_url_ref )';
-            $dimension = str_replace('%s', 'log_link_visit_action', $dimension );
+            $dimension = 'if ( %1$s.idaction_url_ref IS NULL, %1$s.idaction_name_ref, %1$s.idaction_url_ref )';
+            $dimension = sprintf($dimension, 'log_link_visit_action');
             $joinLogActionOn = $dimension;
         } else {
             $joinLogActionOn = $dimension;

--- a/plugins/Transitions/API.php
+++ b/plugins/Transitions/API.php
@@ -222,7 +222,8 @@ class API extends \Piwik\Plugin\API
         if ($actionType != 'title') {
             // specific setup for page urls
             $types[Action::TYPE_PAGE_URL] = 'followingPages';
-            $dimension = 'if ( idaction_url IS NULL, idaction_name, idaction_url )';
+            $dimension = 'if ( %s.idaction_url IS NULL, %s.idaction_name, %s.idaction_url )';
+            $dimension = str_replace('%s', 'log_link_visit_action', $dimension );
             // site search referrers are logged with url=NULL
             // when we find one, we have to join on name
             $joinLogActionColumn = $dimension;
@@ -405,7 +406,8 @@ class API extends \Piwik\Plugin\API
         if ($dimension == 'idaction_url_ref') {
             // site search referrers are logged with url_ref=NULL
             // when we find one, we have to join on name_ref
-            $dimension = 'if ( idaction_url_ref IS NULL, idaction_name_ref, idaction_url_ref )';
+            $dimension = 'if ( %s.idaction_url_ref IS NULL, %s.idaction_name_ref, %s.idaction_url_ref )';
+            $dimension = str_replace('%s', 'log_link_visit_action', $dimension );
             $joinLogActionOn = $dimension;
         } else {
             $joinLogActionOn = $dimension;

--- a/tests/PHPUnit/System/TransitionsTest.php
+++ b/tests/PHPUnit/System/TransitionsTest.php
@@ -79,6 +79,18 @@ class TransitionsTest extends SystemTestCase
                 'limitBeforeGrouping' => 2
             )
         ));
+
+        $return[] = array('Transitions.getTransitionsForPageUrl', array( // test w/ segment
+            'idSite'                 => self::$fixture->idSite,
+            'date'                   => self::$fixture->dateTime,
+            'periods'                => array('day'),
+            'testSuffix'             => '_withSegment',
+            'segment'                => 'visitConvertedGoalId!%3D2',
+            'otherRequestParameters' => array(
+                'pageUrl'             => 'http://example.org/page/one.html',
+                'limitBeforeGrouping' => 2
+            )
+        ));
         return $return;
     }
 

--- a/tests/PHPUnit/System/TransitionsTest.php
+++ b/tests/PHPUnit/System/TransitionsTest.php
@@ -91,6 +91,15 @@ class TransitionsTest extends SystemTestCase
                 'limitBeforeGrouping' => 2
             )
         ));
+        $return[] = array('Transitions.getTransitionsForPageTitle', array(
+            'idSite'                 => self::$fixture->idSite,
+            'date'                   => self::$fixture->dateTime,
+            'periods'                => array('day'),
+            'testSuffix'             => '_withSegment',
+            'otherRequestParameters' => array(
+                'pageTitle'          => 'page title - page/one.html',
+            )
+        ));
         return $return;
     }
 

--- a/tests/PHPUnit/System/expected/test_Transitions_withSegment__Transitions.getTransitionsForPageTitle_day.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions_withSegment__Transitions.getTransitionsForPageTitle_day.xml
@@ -3,42 +3,58 @@
 	<date>Sat, Mar 6</date>
 	<previousPages>
 		<row>
-			<label>example.org/the/third_page.html?foo=bar</label>
+			<label>page title - the/third_page.html?foo=bar</label>
 			<referrals>3</referrals>
 		</row>
 		<row>
-			<label>example.org/sub/dir/page2.html</label>
+			<label>page title - sub/dir/page2.html</label>
 			<referrals>2</referrals>
 		</row>
 		<row>
-			<label>Others</label>
-			<referrals>2</referrals>
+			<label>page title - the/third_page.html?foo=baz#anchor1</label>
+			<referrals>1</referrals>
+		</row>
+		<row>
+			<label>page title - the/third_page.html?foo=baz#anchor2</label>
+			<referrals>1</referrals>
 		</row>
 	</previousPages>
 	<previousSiteSearches>
+		<row>
+			<label>mykwd</label>
+			<referrals>1</referrals>
+		</row>
 		<row>
 			<label>anotherkwd</label>
 			<referrals>1</referrals>
 		</row>
 	</previousSiteSearches>
 	<pageMetrics>
-		<loops>2</loops>
-		<pageviews>18</pageviews>
-		<entries>4</entries>
-		<exits>7</exits>
+		<loops>5</loops>
+		<pageviews>17</pageviews>
+		<entries>3</entries>
+		<exits>3</exits>
 	</pageMetrics>
 	<followingPages>
 		<row>
-			<label>example.org/the/third_page.html?foo=baz</label>
-			<referrals>3</referrals>
-		</row>
-		<row>
-			<label>example.org/sub/dir/page2.html</label>
+			<label>page title - sub/dir/page2.html</label>
 			<referrals>2</referrals>
 		</row>
 		<row>
-			<label>Others</label>
-			<referrals>3</referrals>
+			<label>page title - the/third_page.html?foo=bar</label>
+			<referrals>2</referrals>
+		</row>
+		<row>
+			<label>page title - the/third_page.html?foo=baz#anchor1</label>
+			<referrals>2</referrals>
+		</row>
+		<row>
+			<label>page title - the/third_page.html?foo=baz#anchor2</label>
+			<referrals>1</referrals>
+		</row>
+		<row>
+			<label>page title - page3.html</label>
+			<referrals>1</referrals>
 		</row>
 	</followingPages>
 	<followingSiteSearches>
@@ -93,17 +109,6 @@
 			<details>
 				<row>
 					<label>http://www.external.com.vn/referrerPage-counted.html</label>
-					<referrals>1</referrals>
-				</row>
-			</details>
-		</row>
-		<row>
-			<label>From Campaigns</label>
-			<shortName>campaign</shortName>
-			<visits>1</visits>
-			<details>
-				<row>
-					<label>testcampaign testkeyword</label>
 					<referrals>1</referrals>
 				</row>
 			</details>

--- a/tests/PHPUnit/System/expected/test_Transitions_withSegment__Transitions.getTransitionsForPageUrl_day.xml
+++ b/tests/PHPUnit/System/expected/test_Transitions_withSegment__Transitions.getTransitionsForPageUrl_day.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<error message="SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'idaction_url' in field list is ambiguous
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
+</result>


### PR DESCRIPTION
- We add a system reproducing the issue
- we fix the issue by prefixing the DB field by the table alias, to prevent error when a segment joins another table that has some field names in common

fixes #9822
