### PR TITLE
Fix behaviour of reset password form on error

### DIFF
--- a/plugins/Login/javascripts/login.js
+++ b/plugins/Login/javascripts/login.js
@@ -63,7 +63,7 @@
             var ajaxDone = function (response) {
                 $('.loadingPiwik').hide();
 
-                var isSuccess = response.indexOf('id="login_error"') === -1,
+                var isSuccess = response.indexOf('message_error') === -1,
                     fadeOutIds = '#message_container';
                 if (isSuccess) {
                     fadeOutIds += ',#reset_form,#reset_form_nav';

--- a/tests/UI/specs/Login_spec.js
+++ b/tests/UI/specs/Login_spec.js
@@ -60,6 +60,14 @@ describe("Login", function () {
         }, done);
     });
 
+    it("should show reset password form and error message on error", function (done) {
+        expect.screenshot("password_reset_error").to.be.capture(function (page) {
+            page.sendKeys("#reset_form_login", "superUserLogin");
+            page.sendKeys("#reset_form_password", "superUserPass2");
+            page.click("#reset_form_submit", 3000);
+        }, done);
+    });
+
     it("should send email when password reset form submitted", function (done) {
         expect.screenshot("password_reset").to.be.capture(function (page) {
             page.sendKeys("#reset_form_login", "superUserLogin");


### PR DESCRIPTION
The javascript for the reset password form didn't work as expected anymore as the markup for an error message changed. Thus, when the form has an error only the error message was displayed anymore. The form itself got hidden.

I've also added a new UI test to prove the error message and form are displayed on error
