### PR TITLE
Force PHP default_charset INI setting to UTF-8 to prevent possible issues when PHP is not configured to use UTF-8

### DIFF
--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -18,6 +18,7 @@ error_reporting(E_ALL | E_NOTICE);
 @ini_set('display_errors', defined('PIWIK_DISPLAY_ERRORS') ? PIWIK_DISPLAY_ERRORS : @ini_get('display_errors'));
 @ini_set('xdebug.show_exception_trace', 0);
 @ini_set('magic_quotes_runtime', 0);
+@ini_set('default_charset', 'UTF-8');
 
 if (!defined('PIWIK_VENDOR_PATH')) {
 	if (is_dir(PIWIK_INCLUDE_PATH . '/vendor')) {


### PR DESCRIPTION
To Be Confirmed whether this fixes #4410 
