### PR TITLE
Fix missing whitespace between parameters in help text when using archive.php on cli

### DIFF
--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -22,18 +22,15 @@ define('PIWIK_ENABLE_SESSION_START', false);
 
 require_once PIWIK_INCLUDE_PATH . '/core/Common.php';
 
-if (!empty($_SERVER['argv'][0])) {
-    $callee = $_SERVER['argv'][0];
-} else {
-    $callee = '';
-}
+if (Piwik\Common::isPhpCliMode()) {
+    $script = array_shift($_SERVER['argv']);
+    $args   = implode(' ', $_SERVER['argv']);
 
-if (false !== strpos($callee, 'archive.php')) {
     $piwikHome = PIWIK_INCLUDE_PATH;
     echo "
 -------------------------------------------------------
 Using this 'archive.php' script is no longer recommended.
-Please use '/path/to/php $piwikHome/console core:archive " . implode('', array_slice($_SERVER['argv'], 1)) . "' instead.
+Please use '/path/to/php $piwikHome/console core:archive " . $args . "' instead.
 To get help use '/path/to/php $piwikHome/console core:archive --help'
 See also: http://piwik.org/docs/setup-auto-archiving/
 
@@ -41,16 +38,12 @@ If you cannot use the console because it requires CLI
 try 'php archive.php --url=http://your.piwik/path'
 -------------------------------------------------------
 \n\n";
-}
 
-
-if (Piwik\Common::isPhpCliMode()) {
     require_once PIWIK_INCLUDE_PATH . "/core/bootstrap.php";
 
     $console = new Piwik\Console();
 
     // manipulate command line arguments so CoreArchiver command will be executed
-    $script = array_shift($_SERVER['argv']);
     array_unshift($_SERVER['argv'], 'core:archive');
     array_unshift($_SERVER['argv'], $script);
 

--- a/misc/cron/archive.php
+++ b/misc/cron/archive.php
@@ -23,14 +23,18 @@ define('PIWIK_ENABLE_SESSION_START', false);
 require_once PIWIK_INCLUDE_PATH . '/core/Common.php';
 
 if (Piwik\Common::isPhpCliMode()) {
-    $script = array_shift($_SERVER['argv']);
-    $args   = implode(' ', $_SERVER['argv']);
+    require_once PIWIK_INCLUDE_PATH . "/core/bootstrap.php";
 
+    $console = new Piwik\Console();
+
+    // manipulate command line arguments so CoreArchiver command will be executed
+    $script = array_shift($_SERVER['argv']);
     $piwikHome = PIWIK_INCLUDE_PATH;
+
     echo "
 -------------------------------------------------------
 Using this 'archive.php' script is no longer recommended.
-Please use '/path/to/php $piwikHome/console core:archive " . $args . "' instead.
+Please use '/path/to/php $piwikHome/console core:archive " . implode(' ', $_SERVER['argv']) . "' instead.
 To get help use '/path/to/php $piwikHome/console core:archive --help'
 See also: http://piwik.org/docs/setup-auto-archiving/
 
@@ -39,11 +43,6 @@ try 'php archive.php --url=http://your.piwik/path'
 -------------------------------------------------------
 \n\n";
 
-    require_once PIWIK_INCLUDE_PATH . "/core/bootstrap.php";
-
-    $console = new Piwik\Console();
-
-    // manipulate command line arguments so CoreArchiver command will be executed
     array_unshift($_SERVER['argv'], 'core:archive');
     array_unshift($_SERVER['argv'], $script);
 


### PR DESCRIPTION
I noticed in the deprecated help text it would print used arguments without a whitespace separation eg `php archive.php test --test` it would print `test--test`. Also refactored code to have it cleaner.
