### PR TITLE
URL query string parameters to remove from URL are now stored in config file

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -623,6 +623,10 @@ window_look_back_for_visitor = 0
 ; visitors that stay on the website and view only one page will be considered as time on site of 0 second
 default_time_one_page_visit = 0
 
+; Comma separated list of URL query string variable names that will be removed from your tracked URLs
+; By default, Piwik will remove the most common parameters which are known to change often (eg. session ID parameters)
+url_query_parameter_to_exclude_from_url = "gclid,fb_xd_fragment,fb_comment_id,phpsessid,jsessionid,sessionid,aspsessionid,doing_wp_cron,sid"
+
 ; if set to 1, Piwik attempts a "best guess" at the visitor's country of
 ; origin when the preferred language tag omits region information.
 ; The mapping is defined in core/DataFiles/LanguageToCountry.php,

--- a/core/Tracker/PageUrl.php
+++ b/core/Tracker/PageUrl.php
@@ -28,10 +28,6 @@ class PageUrl
         'https://'     => 2
     );
 
-    protected static $queryParametersToExclude = array('gclid', 'fb_xd_fragment', 'fb_comment_id',
-                                                       'phpsessid', 'jsessionid', 'sessionid', 'aspsessionid',
-                                                       'doing_wp_cron', 'sid');
-
     /**
      * Given the Input URL, will exclude all query parameters set for this site
      *
@@ -87,7 +83,7 @@ class PageUrl
         $excludedParameters = self::getExcludedParametersFromWebsite($website);
 
         $parametersToExclude = array_merge($excludedParameters,
-                                           self::$queryParametersToExclude,
+                                           self::getUrlParameterNamesToExcludeFromUrl(),
                                            $campaignTrackingParameters);
 
         /**
@@ -104,6 +100,19 @@ class PageUrl
 
         $parametersToExclude = array_map('strtolower', $parametersToExclude);
         return $parametersToExclude;
+    }
+
+    /**
+     * Returns the list of URL query parameters that should be removed from the tracked URL query string.
+     *
+     * @return array
+     */
+    protected static function getUrlParameterNamesToExcludeFromUrl()
+    {
+        $paramsToExclude = Config::getInstance()->Tracker['url_query_parameter_to_exclude_from_url'];
+        $paramsToExclude = explode(",", $paramsToExclude);
+        $paramsToExclude = array_map('trim', $paramsToExclude);
+        return $paramsToExclude;
     }
 
     /**


### PR DESCRIPTION
follows up https://github.com/piwik/piwik/issues/9789

Since we're adding `sid` to the list of URL params to be removed from all URLs, and since it is a common URL query string, we need to let users customise the list of URL params to exclude. 

in https://github.com/piwik/piwik/issues/9889 we will later move these into the UI.
