### PR TITLE
Improve all websites dashboard performance when using range date

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -646,7 +646,7 @@ class Archive
         $doneFlags     = array();
         $archiveGroups = array();
         foreach ($plugins as $plugin) {
-            $doneFlag = $this->getDoneStringForPlugin($plugin);
+            $doneFlag = $this->getDoneStringForPlugin($plugin, $this->params->getIdSites());
 
             $doneFlags[$doneFlag] = true;
             if (!isset($this->idarchives[$doneFlag])) {
@@ -731,7 +731,7 @@ class Archive
 
         // initialize archive ID cache for each report
         foreach ($plugins as $plugin) {
-            $doneFlag = $this->getDoneStringForPlugin($plugin);
+            $doneFlag = $this->getDoneStringForPlugin($plugin, $this->params->getIdSites());
             $this->initializeArchiveIdCache($doneFlag);
         }
 
@@ -749,10 +749,10 @@ class Archive
      * @param string $plugin
      * @return string
      */
-    private function getDoneStringForPlugin($plugin)
+    private function getDoneStringForPlugin($plugin, $idSites)
     {
         return Rules::getDoneStringFlagFor(
-                    $this->params->getIdSites(),
+                    $idSites,
                     $this->params->getSegment(),
                     $this->getPeriodLabel(),
                     $plugin
@@ -893,9 +893,11 @@ class Archive
 
         $periodString = $period->getRangeString();
 
+        $idSites = array($site->getId());
+        
         // process for each plugin as well
         foreach ($archiveGroups as $plugin) {
-            $doneFlag = $this->getDoneStringForPlugin($plugin);
+            $doneFlag = $this->getDoneStringForPlugin($plugin, $idSites);
             $this->initializeArchiveIdCache($doneFlag);
 
             $idArchive = $archiveLoader->prepareArchive($plugin);

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -172,20 +172,21 @@ class Rules
                 || $generalConfig['archiving_range_force_on_browser_request'] != false
             ) {
                 return false;
-            } else {
-                Log::debug("Not forcing archiving for range period.");
             }
+
+            Log::debug("Not forcing archiving for range period.");
+            $processOneReportOnly = false;
+
+        } else {
+            $processOneReportOnly = !self::shouldProcessReportsAllPlugins($idSites, $segment, $periodLabel);
         }
 
-        $processOneReportOnly = !self::shouldProcessReportsAllPlugins($idSites, $segment, $periodLabel);
-        $isArchivingDisabled = !self::isRequestAuthorizedToArchive() || self::$archivingDisabledByTests;
+        $isArchivingEnabled = self::isRequestAuthorizedToArchive() && !self::$archivingDisabledByTests;
 
-        if ($processOneReportOnly
-            && $periodLabel != 'range'
-        ) {
+        if ($processOneReportOnly)  {
             // When there is a segment, we disable archiving when browser_archiving_disabled_enforce applies
             if (!$segment->isEmpty()
-                && $isArchivingDisabled
+                && !$isArchivingEnabled
                 && $generalConfig['browser_archiving_disabled_enforce']
                 && !SettingsServer::isArchivePhpTriggered() // Only applies when we are not running core:archive command
             ) {
@@ -196,7 +197,8 @@ class Rules
             // Always allow processing one report
             return false;
         }
-        return $isArchivingDisabled;
+
+        return !$isArchivingEnabled;
     }
 
     public static function isRequestAuthorizedToArchive()


### PR DESCRIPTION
fix #9662 

Tested it locally with 1000 sites and reduced time to generate report from 60 seconds to about 4 seconds (with profiling enabled). Problem was it called millions of times (3 periods \* 1000 sites \* 1000 sites) all segments etc. as there was a bug when getting the string for the done flag.

For each of those 1000 sites we called again 1000 times getDoneString... which results in 1mio calls for each period. When user has 2000 sites it was likely 12 mio calls. Now it should call it only a few thousand times.  
