### PR TITLE
Fix metadata problem for goal reports

### DIFF
--- a/core/API/DataTableManipulator.php
+++ b/core/API/DataTableManipulator.php
@@ -162,6 +162,11 @@ abstract class DataTableManipulator
 
             $meta = API::getInstance()->getMetadata($idSite, $this->apiModule, $this->apiMethod, $apiParameters);
 
+            if (empty($meta) && array_key_exists('idGoal', $apiParameters)) {
+                unset($apiParameters['idGoal']);
+                $meta = API::getInstance()->getMetadata($idSite, $this->apiModule, $this->apiMethod, $apiParameters);
+            }
+
             if (empty($meta)) {
                 throw new Exception(sprintf(
                     "The DataTable cannot be manipulated: Metadata for report %s.%s could not be found. You can define the metadata in a hook, see example at: http://developer.piwik.org/api-reference/events#apigetreportmetadata",


### PR DESCRIPTION
Tried to fix #9697.
I don't think that it is the best solution, but I guess it shouldn't have any side effects this way.

Note regarding: https://github.com/piwik/piwik/issues/9697#issuecomment-179637988
Removing [lines 159-161](https://github.com/piwik/piwik/blob/master/core/API/DataTableManipulator.php#L159-L161) completely would fix this issue aswell, but that might create problems for other goal reports where the `idGoal` is part of the metadata

fixes #9697
