### PR TITLE
When forcing archiving on multiple sites, it silently fails when a given site does not exist

### DIFF
--- a/core/CronArchive/FixedSiteIds.php
+++ b/core/CronArchive/FixedSiteIds.php
@@ -17,7 +17,7 @@ class FixedSiteIds
     public function __construct($websiteIds)
     {
         if (!empty($websiteIds)) {
-            $this->siteIds = $websiteIds;
+            $this->siteIds = array_values($websiteIds);
         }
     }
 

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -140,6 +140,34 @@ LOG;
         $this->assertStringMatchesFormat($expected, $logger->output);
     }
 
+    public function test_shouldNotStopProcessingWhenOneSiteIsInvalid()
+    {
+        \Piwik\Tests\Framework\Mock\FakeCliMulti::$specifiedResults = array(
+            '/method=API.get/' => serialize(array(array('nb_visits' => 1)))
+        );
+
+        Fixture::createWebsite('2014-12-12 00:01:02');
+
+        $logger = new FakeLogger();
+
+        $archiver = new CronArchive(null, $logger);
+        $archiver->shouldArchiveSpecifiedSites = array(99999, 1);
+        $archiver->init();
+        $archiver->run();
+
+        $expected = <<<LOG
+- Will process 2 websites (--force-idsites)
+Will ignore websites and help finish a previous started queue instead. IDs: 1
+---------------------------
+START
+Starting Piwik reports archiving...
+Will pre-process for website id = 1, period = day, date = last52
+- pre-processing all visits
+LOG;
+
+        $this->assertContains($expected, $logger->output);
+    }
+
     public function provideContainerConfig()
     {
         return array(


### PR DESCRIPTION
fix #10005 
