### PR TITLE
Live API when a Segment is used: Select 10 times more rows so that resultset after grouping is more likely to contain enough rows

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1194,7 +1194,7 @@ class CronArchive
      *
      * @return array
      */
-    private function getTimezonesHavingNewDay()
+    private function getTimezonesHavingNewDaySinceLastRun()
     {
         $timestamp = $this->lastSuccessRunTimestamp;
         $uniqueTimezones = APISitesManager::getInstance()->getUniqueSiteTimezones();
@@ -1235,7 +1235,7 @@ class CronArchive
      */
     private function findWebsiteIdsInTimezoneWithNewDay($websiteIds)
     {
-        $timezones = $this->getTimezonesHavingNewDay();
+        $timezones = $this->getTimezonesHavingNewDaySinceLastRun();
         $websiteDayHasFinishedSinceLastRun = APISitesManager::getInstance()->getSitesIdFromTimezones($timezones);
         $websiteDayHasFinishedSinceLastRun = array_intersect($websiteDayHasFinishedSinceLastRun, $websiteIds);
         $this->websiteDayHasFinishedSinceLastRun = $websiteDayHasFinishedSinceLastRun;

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -408,6 +408,10 @@ class Model
         $orderBy .= "visit_last_action_time " . $filterSortOrder;
         $orderByParent = "sub.visit_last_action_time " . $filterSortOrder;
 
+        if (!$segment->isEmpty()) {
+            $limit = $limit * 10;
+        }
+
         $subQuery = $segment->getSelectQuery($select, $from, $where, $whereBind, $orderBy, $groupBy, $limit, $offset);
 
         $bind = $subQuery['bind'];

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -408,21 +408,28 @@ class Model
         $orderBy .= "visit_last_action_time " . $filterSortOrder;
         $orderByParent = "sub.visit_last_action_time " . $filterSortOrder;
 
+        // this $innerLimit is a workaround (see https://github.com/piwik/piwik/issues/9200#issuecomment-183641293)
+        $innerLimit = $limit;
         if (!$segment->isEmpty()) {
-            $limit = $limit * 10;
+            $innerLimit = $limit * 10;
         }
 
-        $subQuery = $segment->getSelectQuery($select, $from, $where, $whereBind, $orderBy, $groupBy, $limit, $offset);
+        $innerQuery = $segment->getSelectQuery($select, $from, $where, $whereBind, $orderBy, $groupBy, $innerLimit, $offset);
 
-        $bind = $subQuery['bind'];
-        // Group by idvisit so that a visitor converting 2 goals only appears once
+        $bind = $innerQuery['bind'];
+        // Group by idvisit so that a given visit appears only once, useful when for example:
+        // 1) when a visitor converts 2 goals
+        // 2) when an Action Segment is used, the inner query will return one row per action, but we want one row per visit
         $sql = "
 			SELECT sub.* FROM (
-				" . $subQuery['sql'] . "
+				" . $innerQuery['sql'] . "
 			) AS sub
 			GROUP BY sub.idvisit
 			ORDER BY $orderByParent
 		";
+        if($limit) {
+            $sql .= sprintf("LIMIT %d \n", $limit);
+        }
         return array($sql, $bind);
     }
 

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -57,6 +57,7 @@ class ModelTest extends IntegrationTestCase
                  ) AS sub
                  GROUP BY sub.idvisit
                  ORDER BY sub.visit_last_action_time DESC
+                 LIMIT 100
         ';
         $expectedBind = array(
             '1',
@@ -97,6 +98,7 @@ class ModelTest extends IntegrationTestCase
                  ) AS sub
                  GROUP BY sub.idvisit
                  ORDER BY sub.visit_last_action_time DESC
+                 LIMIT 100
         ';
         $expectedBind = array(
             '2',
@@ -135,6 +137,7 @@ class ModelTest extends IntegrationTestCase
                  ) AS sub
                  GROUP BY sub.idvisit
                  ORDER BY sub.visit_last_action_time DESC
+                 LIMIT 100
         ';
         $expectedBind = array(
             '1',
@@ -175,12 +178,13 @@ class ModelTest extends IntegrationTestCase
                           AND log_visit.visit_last_action_time <= ? )
                           AND ( log_link_visit_action.custom_var_k1 = ? )
                         ORDER BY idsite, visit_last_action_time DESC
-                        LIMIT 10, 100
+                        LIMIT 10, 1000
                         ) AS log_inner
                     ORDER BY idsite, visit_last_action_time DESC
                  ) AS sub
                  GROUP BY sub.idvisit
                  ORDER BY sub.visit_last_action_time DESC
+                 LIMIT 100
         ';
         $expectedBind = array(
             '1',


### PR DESCRIPTION
refs https://github.com/piwik/piwik/issues/9200

If the build passes, this may be worth to merge to help with #9200 
