### PR TITLE
Improved plugins update API and how plugins define and reuse schema migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
 * The creation of settings has slightly changed to improve performance. It is now possible to create new settings via the method `$this->makeSetting()` see `Piwik\Plugins\ExampleSettingsPlugin\SystemSettings` for an example.
 * It is no possible to define an introduction text for settings.
 
+### Deprecations
+* The method `Piwik\Updates::getMigrationQueries()` has been deprecated and renamed to `getMigrations()`. It is still supported to use the method, but the method will be removed in Piwik 4.0.0
+* The method `Piwik\Updater::executeMigrationQueries()` has been deprecated and renamed to `executeMigrations`. It is still supported to use the method, but the method will be removed in Piwik 4.0.0.
+
 ### New APIs
 * Multiple widgets for one report can now be created via the `Report::configureWidgets()` method via the new classes `Piwik\Widget\ReportWidgetFactory` and `Piwik\Widget\ReportWidgetConfig`
 * There is a new property `Report::$subCategory` that let's you add a report to the reporting UI. If a page having that name does not exist yet, it will be created automatically. The newly added method `Report::getSubCategory()` let's you get this value.
@@ -34,6 +38,8 @@ This is a changelog for Piwik platform developers. All changes for our HTTP API'
 * New HTTP API method `API.getReportPagesMetadata` to get a list of all available pages that exist including the widgets they include
 * New HTTP API method `SitesManager.getSiteSettings` to get a list of all available settings for a specific site
 * The JavaScript AjaxHelper has a new method `ajaxHelper.withTokenInUrl()` to easily send a token along a XHR. Within the Controller the existence of this token can be checked via `$this->checkTokenInUrl();` to prevent CSRF attacks.
+* The new class `Piwik\Updater\Migration\Factory` lets you easily create migrations that can be executed during an update. For example database or plugin related migrations. To generate a new update with migrations execute `./console generate:update`.
+* The new method `Piwik\Updater::executeMigration` lets you execute a single migration.
 
 ### New features
 * New "Sparklines" visualization that let's you create a widget showing multiple sparklines

--- a/core/Columns/Updater.php
+++ b/core/Columns/Updater.php
@@ -17,6 +17,7 @@ use Piwik\Db;
 use Piwik\Updater as PiwikUpdater;
 use Piwik\Filesystem;
 use Piwik\Cache as PiwikCache;
+use Piwik\Updater\Migration;
 
 /**
  * Class that handles dimension updates
@@ -52,18 +53,27 @@ class Updater extends \Piwik\Updates
         $this->conversionDimensions = $conversionDimensions;
     }
 
+    /**
+     * @param PiwikUpdater $updater
+     * @return Migration\Db[]
+     */
     public function getMigrationQueries(PiwikUpdater $updater)
     {
         $sqls = array();
 
         $changingColumns = $this->getUpdates($updater);
+        $errorCodes = array(
+            Migration\Db\Sql::ERROR_CODE_COLUMN_NOT_EXISTS,
+            Migration\Db\Sql::ERROR_CODE_DUPLICATE_COLUMN
+        );
 
         foreach ($changingColumns as $table => $columns) {
             if (empty($columns) || !is_array($columns)) {
                 continue;
             }
 
-            $sqls["ALTER TABLE `" . Common::prefixTable($table) . "` " . implode(', ', $columns)] = array('1091', '1060');
+            $sql = "ALTER TABLE `" . Common::prefixTable($table) . "` " . implode(', ', $columns);
+            $sqls[] = new Migration\Db\Sql($sql, $errorCodes);
         }
 
         return $sqls;

--- a/core/Db/BatchInsert.php
+++ b/core/Db/BatchInsert.php
@@ -13,7 +13,6 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Db;
-use Piwik\DbHelper;
 use Piwik\Log;
 use Piwik\SettingsServer;
 

--- a/core/Plugin/SettingsProvider.php
+++ b/core/Plugin/SettingsProvider.php
@@ -24,8 +24,6 @@ use \Piwik\Settings\Plugin\SystemSettings;
  * {@link addSetting()} method for each of the plugin's settings.
  *
  * For an example, see the {@link Piwik\Plugins\ExampleSettingsPlugin\ExampleSettingsPlugin} plugin.
- *
- * @api
  */
 class SettingsProvider
 {

--- a/core/Plugin/SettingsProvider.php
+++ b/core/Plugin/SettingsProvider.php
@@ -24,6 +24,8 @@ use \Piwik\Settings\Plugin\SystemSettings;
  * {@link addSetting()} method for each of the plugin's settings.
  *
  * For an example, see the {@link Piwik\Plugins\ExampleSettingsPlugin\ExampleSettingsPlugin} plugin.
+ *
+ * @api
  */
 class SettingsProvider
 {

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -10,6 +10,8 @@ namespace Piwik;
 
 use Piwik\Columns\Updater as ColumnUpdater;
 use Piwik\Container\StaticContainer;
+use Piwik\Updater\Migration;
+use Piwik\Updater\Migration\Db\Sql;
 use Piwik\Updater\UpdateObserver;
 use Zend_Db_Exception;
 
@@ -172,7 +174,7 @@ class Updater
     /**
      * Returns the list of SQL queries that would be executed during the update
      *
-     * @return array of SQL queries
+     * @return Sql[] of SQL queries
      * @throws \Exception
      */
     public function getSqlQueriesToExecute()
@@ -195,10 +197,15 @@ class Updater
 
                 $classNames[] = $className;
 
+                /** @var Updates $update */
                 $update = StaticContainer::getContainer()->make($className);
-                $queriesForComponent = call_user_func(array($update, 'getMigrationQueries'), $this);
-                foreach ($queriesForComponent as $query => $error) {
-                    $queries[] = $query . ';';
+                $migrationsForComponent = $update->getMigrations($this);
+                foreach ($migrationsForComponent as $index => $migration) {
+                    $migration = $this->keepBcForOldMigrationQueryFormat($index, $migration);
+
+                    if ($migration instanceof Migration\Db) {
+                        $queries[] = $migration;
+                    }
                 }
                 $this->hasMajorDbUpdate = $this->hasMajorDbUpdate || call_user_func(array($className, 'isMajorUpdate'));
             }
@@ -484,55 +491,50 @@ class Updater
     }
 
     /**
-     * Execute multiple migration queries from a single Update file.
-     *
-     * @param string $file The path to the Updates file.
-     * @param array $migrationQueries An array mapping SQL queries w/ one or more MySQL errors to ignore.
+     * @deprecated since Piwik 3.0.0, use {@link executeMigrations()} instead.
      */
     public function executeMigrationQueries($file, $migrationQueries)
     {
-        foreach ($migrationQueries as $update => $ignoreError) {
-            $this->executeSingleMigrationQuery($update, $ignoreError, $file);
+        $this->executeMigrations($file, $migrationQueries);
+    }
+
+    /**
+     * Execute multiple migration queries from a single Update file.
+     *
+     * @param string $file The path to the Updates file.
+     * @param Migration[] $migrations An array of migrations
+     * @api
+     */
+    public function executeMigrations($file, $migrations)
+    {
+        foreach ($migrations as $index => $migration) {
+            $migration = $this->keepBcForOldMigrationQueryFormat($index, $migration);
+            $this->executeMigration($file, $migration);
         }
     }
 
     /**
-     * Execute a single migration query from an update file.
-     *
-     * @param string $migrationQuerySql The SQL to execute.
-     * @param int|int[]|null An optional error code or list of error codes to ignore.
-     * @param string $file The path to the Updates file.
+     * @param $file
+     * @param Migration $migration
+     * @throws UpdaterErrorException
+     * @api
      */
-    public function executeSingleMigrationQuery($migrationQuerySql, $errorToIgnore, $file)
+    public function executeMigration($file, Migration $migration)
     {
         try {
-            $this->executeListenerHook('onStartExecutingMigrationQuery', array($file, $migrationQuerySql));
+            $this->executeListenerHook('onStartExecutingMigration', array($file, $migration));
 
-            Db::exec($migrationQuerySql);
+            $migration->exec();
+
         } catch (\Exception $e) {
-            $this->handleUpdateQueryError($e, $migrationQuerySql, $errorToIgnore, $file);
+            if (!$migration->shouldIgnoreError($e)) {
+                $message = sprintf("%s:\nError trying to execute the migration '%s'.\nThe error was: %s",
+                                   $file, $migration->__toString(), $e->getMessage());
+                throw new UpdaterErrorException($message);
+            }
         }
 
-        $this->executeListenerHook('onFinishedExecutingMigrationQuery', array($file, $migrationQuerySql));
-    }
-
-    /**
-     * Handle an update query error.
-     *
-     * @param \Exception $e The error that occurred.
-     * @param string $updateSql The SQL that was executed.
-     * @param int|int[]|null An optional error code or list of error codes to ignore.
-     * @param string $file The path to the Updates file.
-     * @throws \Exception
-     */
-    public function handleUpdateQueryError(\Exception $e, $updateSql, $errorToIgnore, $file)
-    {
-        if (($errorToIgnore === false)
-            || !self::isDbErrorOneOf($e, $errorToIgnore)
-        ) {
-            $message = $file . ":\nError trying to execute the query '" . $updateSql . "'.\nThe error was: " . $e->getMessage();
-            throw new UpdaterErrorException($message);
-        }
+        $this->executeListenerHook('onFinishedExecutingMigration', array($file, $migration));
     }
 
     private function executeListenerHook($hookName, $arguments)
@@ -558,42 +560,28 @@ class Updater
         }
     }
 
+    private function keepBcForOldMigrationQueryFormat($index, $migration)
+    {
+        if (!is_object($migration)) {
+            // keep BC for old format (pre 3.0): array($sqlQuery => $errorCodeToIgnore)
+            $migrationFactory = StaticContainer::get('Piwik\Updater\Migration\Factory');
+            $migration = $migrationFactory->db->sql($index, $migration);
+        }
+
+        return $migration;
+    }
+
     /**
      * Performs database update(s)
      *
      * @param string $file Update script filename
      * @param array $sqlarray An array of SQL queries to be executed
      * @throws UpdaterErrorException
+     * @deprecated
      */
     public static function updateDatabase($file, $sqlarray)
     {
         self::$activeInstance->executeMigrationQueries($file, $sqlarray);
-    }
-
-    /**
-     * Executes a database update query.
-     *
-     * @param string $updateSql Update SQL query.
-     * @param int|false $errorToIgnore A MySQL error code to ignore.
-     * @param string $file The Update file that's calling this method.
-     */
-    public static function executeMigrationQuery($updateSql, $errorToIgnore, $file)
-    {
-        self::$activeInstance->executeSingleMigrationQuery($updateSql, $errorToIgnore, $file);
-    }
-
-    /**
-     * Handle an error that is thrown from a database query.
-     *
-     * @param \Exception $e the exception thrown.
-     * @param string $updateSql Update SQL query.
-     * @param int|false $errorToIgnore A MySQL error code to ignore.
-     * @param string $file The Update file that's calling this method.
-     * @throws UpdaterErrorException
-     */
-    public static function handleQueryError($e, $updateSql, $errorToIgnore, $file)
-    {
-        self::$activeInstance->handleQueryError($e, $updateSql, $errorToIgnore, $file);
     }
 
     /**
@@ -605,35 +593,6 @@ class Updater
     public static function recordComponentSuccessfullyUpdated($name, $version)
     {
         self::$activeInstance->markComponentSuccessfullyUpdated($name, $version);
-    }
-
-    /**
-     * Retrieve the current version of a recorded component
-     * @param string $name
-     * @return false|string
-     * @throws \Exception
-     */
-    public static function getCurrentRecordedComponentVersion($name)
-    {
-        return self::$activeInstance->getCurrentComponentVersion($name);
-    }
-
-    /**
-     * Returns whether an exception is a DB error with a code in the $errorCodesToIgnore list.
-     *
-     * @param int $error
-     * @param int|int[] $errorCodesToIgnore
-     * @return boolean
-     */
-    public static function isDbErrorOneOf($error, $errorCodesToIgnore)
-    {
-        $errorCodesToIgnore = is_array($errorCodesToIgnore) ? $errorCodesToIgnore : array($errorCodesToIgnore);
-        foreach ($errorCodesToIgnore as $code) {
-            if (Db::get()->isErrNo($error, $code)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/core/Updater/Migration.php
+++ b/core/Updater/Migration.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater;
+
+use Piwik\Db;
+use Exception;
+
+/**
+ * Base class for migrations. Any migration must extend this class.
+ *
+ * @api
+ */
+abstract class Migration
+{
+    /**
+     * Executes the migration.
+     * @return void
+     */
+    abstract public function exec();
+
+    /**
+     * Get a description of what the migration actually does. For example "Activate plugin $plugin" or
+     * "SELECT * FROM table".
+     *
+     * @return string
+     */
+    abstract public function __toString();
+
+    /**
+     * Decides whether an error should be ignored or not.
+     * @param Exception $exception
+     * @return bool
+     */
+    public function shouldIgnoreError($exception)
+    {
+        return false;
+    }
+}

--- a/core/Updater/Migration/Db.php
+++ b/core/Updater/Migration/Db.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration;
+
+use Piwik\Updater\Migration;
+
+/**
+ * Base class for a single database migration. Any database migration must extend this class.
+ *
+ * @api
+ */
+abstract class Db extends Migration
+{
+
+    /**
+     * Table '%s' already exists
+     */
+    const ERROR_CODE_TABLE_EXISTS = 1050;
+
+    /**
+     *  Unknown table '%s'
+     */
+    const ERROR_CODE_UNKNOWN_TABLE = 1051;
+
+    /**
+     *  Unknown column '%s' in '%s'
+     */
+    const ERROR_CODE_UNKNOWN_COLUMN = 1054;
+
+    /**
+     * Duplicate column name '%s'
+     */
+    const ERROR_CODE_DUPLICATE_COLUMN = 1060;
+
+    /**
+     * Duplicate key name '%s'
+     */
+    const ERROR_CODE_DUPLICATE_KEY = 1061;
+
+    /**
+     * Duplicate entry '%s' for key %d
+     */
+    const ERROR_CODE_DUPLICATE_ENTRY = 1062;
+
+    /**
+     * Key column '%s' doesn't exist in table
+     */
+    const ERROR_CODE_KEY_COLUMN_NOT_EXISTS = 1072;
+
+    /**
+     * Can't DROP '%s'; check that column/key exists
+     */
+    const ERROR_CODE_COLUMN_NOT_EXISTS = 1091;
+
+    /**
+     * Table '%s.%s' doesn't exist
+     */
+    const ERROR_CODE_TABLE_NOT_EXISTS = 1146;
+
+}

--- a/core/Updater/Migration/Db/AddColumn.php
+++ b/core/Updater/Migration/Db/AddColumn.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+/**
+ * @see Factory::addColumn()
+ * @ignore
+ */
+class AddColumn extends Sql
+{
+    public function __construct($table, $columnName, $columnType, $placeColumnAfter)
+    {
+        $sql = sprintf("ALTER TABLE `%s` ADD COLUMN `%s` %s", $table, $columnName, $columnType);
+
+        if (!empty($placeColumnAfter)) {
+            $sql .= sprintf(' AFTER `%s`', $placeColumnAfter);
+        }
+
+        parent::__construct($sql, static::ERROR_CODE_DUPLICATE_COLUMN);
+    }
+
+}

--- a/core/Updater/Migration/Db/AddColumns.php
+++ b/core/Updater/Migration/Db/AddColumns.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+/**
+ * @see Factory::addColumns()
+ * @ignore
+ */
+class AddColumns extends Sql
+{
+    public function __construct($table, $columns, $placeColumnAfter)
+    {
+        $changes = array();
+        foreach ($columns as $columnName => $columnType) {
+            $part = sprintf("ADD COLUMN `%s` %s", $columnName, $columnType);
+
+            if (!empty($placeColumnAfter)) {
+                $part .= sprintf(' AFTER `%s`', $placeColumnAfter);
+                $placeColumnAfter = $columnName;
+            }
+
+            $changes[] = $part;
+        }
+
+        $sql = sprintf("ALTER TABLE `%s` %s", $table, implode(', ', $changes));
+
+        parent::__construct($sql, static::ERROR_CODE_DUPLICATE_COLUMN);
+    }
+
+}

--- a/core/Updater/Migration/Db/AddIndex.php
+++ b/core/Updater/Migration/Db/AddIndex.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+/**
+ * @see Factory::addIndex()
+ * @ignore
+ */
+class AddIndex extends Sql
+{
+    protected $indexType = 'INDEX';
+    protected $indexNamePrefix = 'index';
+
+    /**
+     * AddIndex constructor.
+     * @param string $table
+     * @param array $columnNames
+     * @param string $indexName
+     */
+    public function __construct($table, $columnNames, $indexName)
+    {
+        $columns = array();
+        $columnNamesOnly = array();
+        foreach ($columnNames as $columnName) {
+            $columnName = str_replace(' ', '', $columnName); // eg "column_name (10)" => "column_name(10)"
+            preg_match('/^([\w]+)(\(?\d*\)?)$/', $columnName, $matches); // match "column_name" and "column_name(10)"
+
+            $nameOnly = $matches[1]; // eg "column_name"
+            $columnNamesOnly[] = $nameOnly;
+            $column = "`$nameOnly`";
+            if (!empty($matches[2])) {
+                $column .= ' ' . $matches[2]; // eg "(10)"
+            }
+
+            $columns[] = $column;
+        }
+
+        if (empty($indexName)) {
+            $indexName = $this->indexNamePrefix . '_' . implode('_', $columnNamesOnly);
+        }
+
+        $sql = sprintf("ALTER TABLE `%s` ADD %s %s (%s)", $table, $this->indexType, $indexName, implode(', ', $columns));
+
+        parent::__construct($sql, array(static::ERROR_CODE_DUPLICATE_KEY, static::ERROR_CODE_KEY_COLUMN_NOT_EXISTS));
+    }
+
+}

--- a/core/Updater/Migration/Db/AddPrimaryKey.php
+++ b/core/Updater/Migration/Db/AddPrimaryKey.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+/**
+ * @see Factory::addPrimaryKey()
+ * @ignore
+ */
+class AddPrimaryKey extends Sql
+{
+    /**
+     * AddPrimaryKey constructor.
+     * @param string $table
+     * @param array $columnNames
+     */
+    public function __construct($table, $columnNames)
+    {
+        $sql = sprintf("ALTER TABLE `%s` ADD PRIMARY KEY(`%s`)", $table, implode('`, `', $columnNames));
+
+        parent::__construct($sql, array(static::ERROR_CODE_DUPLICATE_KEY, static::ERROR_CODE_KEY_COLUMN_NOT_EXISTS));
+    }
+
+}

--- a/core/Updater/Migration/Db/AddUniqueKey.php
+++ b/core/Updater/Migration/Db/AddUniqueKey.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+/**
+ * @see Factory::addUniqueKey()
+ * @ignore
+ */
+class AddUniqueKey extends AddIndex
+{
+    protected $indexType = 'UNIQUE KEY';
+    protected $indexNamePrefix = 'unique';
+
+    /**
+     * AddUniqueKey constructor.
+     * @param string $table
+     * @param array $columnNames
+     * @param string $indexName
+     */
+    public function __construct($table, $columnNames, $indexName)
+    {
+        parent::__construct($table, $columnNames, $indexName);
+    }
+
+}

--- a/core/Updater/Migration/Db/BatchInsert.php
+++ b/core/Updater/Migration/Db/BatchInsert.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+use Piwik\Db;
+use Piwik\Updater\Migration;
+
+/**
+ * Inserts a new record into an existing table.
+ *
+ * @see Factory::batchInsert()
+ * @see Db\BatchInsert::tableInsertBatch()
+ * @ignore
+ *
+ * We do not extend Migration\Db as it should be not printed to the users in queries preview when updating.
+ */
+class BatchInsert extends Migration
+{
+    private $table;
+    private $columnNames;
+    private $values;
+    private $throwException;
+    private $charset;
+
+    /**
+     * @param string $table
+     * @param array $columnNames
+     * @param array $values
+     * @param bool $throwException
+     * @param string $charset
+     * @throws \Exception
+     */
+    public function __construct($table, $columnNames, $values, $throwException, $charset)
+    {
+        $this->table = $table;
+        $this->columnNames = $columnNames;
+        $this->values = $values;
+        $this->throwException = (bool) $throwException;
+        $this->charset = $charset;
+    }
+
+    public function shouldIgnoreError($exception)
+    {
+        return false;
+    }
+
+    public function __toString()
+    {
+        return '<batch insert>';
+    }
+
+    public function exec()
+    {
+        Db\BatchInsert::tableInsertBatch($this->table, $this->columnNames, $this->values, $this->throwException, $this->charset);
+    }
+
+    public function getColumnNames()
+    {
+        return $this->columnNames;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTable()
+    {
+        return $this->table;
+    }
+
+    /**
+     * @return array
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function doesThrowException()
+    {
+        return $this->throwException;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCharset()
+    {
+        return $this->charset;
+    }
+}

--- a/core/Updater/Migration/Db/BoundSql.php
+++ b/core/Updater/Migration/Db/BoundSql.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+use Piwik\Db;
+
+/**
+ * @see Factory::boundSql()
+ * @ignore
+ */
+class BoundSql extends Sql
+{
+    /**
+     * @var array
+     */
+    private $bind;
+
+    /**
+     * BoundSql constructor.
+     * @param string $sql
+     * @param array $bind
+     * @param int|int[] $errorCodesToIgnore
+     */
+    public function __construct($sql, $bind, $errorCodesToIgnore)
+    {
+        parent::__construct($sql, $errorCodesToIgnore);
+        $this->bind = (array) $bind;
+    }
+
+    public function __toString()
+    {
+        $sql = parent::__toString();
+
+        foreach ($this->bind as $value) {
+            if (!is_int($value) && !is_float($value)) {
+                $value = "'" . addcslashes($value, "\000\n\r\\'\"\032") . "'";
+            }
+            $sql = substr_replace($sql, $value, $pos = strpos($sql, '?'), $len = 1);
+        }
+
+        return $sql;
+    }
+
+    public function exec()
+    {
+        Db::query($this->sql, $this->bind);
+    }
+}

--- a/core/Updater/Migration/Db/ChangeColumn.php
+++ b/core/Updater/Migration/Db/ChangeColumn.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+/**
+ * @see Factory::changeColumn()
+ * @ignore
+ */
+class ChangeColumn extends Sql
+{
+    public function __construct($table, $oldColumnName, $newColumnName, $columnType)
+    {
+        $sql = sprintf("ALTER TABLE `%s` CHANGE `%s` `%s` %s", $table, $oldColumnName, $newColumnName, $columnType);
+        parent::__construct($sql, array(static::ERROR_CODE_DUPLICATE_COLUMN,
+                                        static::ERROR_CODE_UNKNOWN_COLUMN));
+    }
+
+}

--- a/core/Updater/Migration/Db/ChangeColumnType.php
+++ b/core/Updater/Migration/Db/ChangeColumnType.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+/**
+ * @see Factory::changeColumnType()
+ * @ignore
+ */
+class ChangeColumnType extends ChangeColumn
+{
+    public function __construct($table, $columnName, $columnType)
+    {
+        parent::__construct($table, $columnName, $columnName, $columnType);
+    }
+
+}

--- a/core/Updater/Migration/Db/ChangeColumnTypes.php
+++ b/core/Updater/Migration/Db/ChangeColumnTypes.php
@@ -22,7 +22,7 @@ class ChangeColumnTypes extends Sql
 
         $sql = sprintf("ALTER TABLE `%s` %s", $table, implode(', ', $changes));
 
-        parent::__construct($sql, static::ERROR_CODE_DUPLICATE_COLUMN);
+        parent::__construct($sql, static::ERROR_CODE_UNKNOWN_COLUMN);
     }
 
 }

--- a/core/Updater/Migration/Db/ChangeColumnTypes.php
+++ b/core/Updater/Migration/Db/ChangeColumnTypes.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+/**
+ * @see Factory::changeColumnTypes()
+ * @ignore
+ */
+class ChangeColumnTypes extends Sql
+{
+    public function __construct($table, $columns)
+    {
+        $changes = array();
+        foreach ($columns as $columnName => $columnType) {
+            $changes[] = sprintf("CHANGE `%s` `%s` %s", $columnName, $columnName, $columnType);
+        }
+
+        $sql = sprintf("ALTER TABLE `%s` %s", $table, implode(', ', $changes));
+
+        parent::__construct($sql, static::ERROR_CODE_DUPLICATE_COLUMN);
+    }
+
+}

--- a/core/Updater/Migration/Db/CreateTable.php
+++ b/core/Updater/Migration/Db/CreateTable.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+use Piwik\Db;
+
+/**
+ * @see Factory::createTable()
+ * @ignore
+ */
+class CreateTable extends Sql
+{
+    /**
+     * Constructor.
+     * @param Db\Settings $dbSettings
+     * @param string $table Prefixed table name
+     * @param string|string[] $columnNames array(columnName => columnValue)
+     * @param string|string[] $primaryKey one or multiple columns that define the primary key
+     */
+    public function __construct(Db\Settings $dbSettings, $table, $columnNames, $primaryKey)
+    {
+        $columns = array();
+        foreach ($columnNames as $column => $type) {
+            $columns[] = sprintf('`%s` %s', $column, $type);
+        }
+
+        if (!empty($primaryKey)) {
+            $columns[] = sprintf('PRIMARY KEY ( `%s` )', implode('`, `', $primaryKey));
+        }
+
+        $sql = sprintf('CREATE TABLE `%s` (%s) ENGINE=%s DEFAULT CHARSET=utf8',
+                       $table, implode(', ' , $columns), $dbSettings->getEngine());
+
+        parent::__construct($sql, static::ERROR_CODE_TABLE_EXISTS);
+    }
+
+}

--- a/core/Updater/Migration/Db/DropColumn.php
+++ b/core/Updater/Migration/Db/DropColumn.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+/**
+ * @see Factory::dropColumn()
+ * @ignore
+ */
+class DropColumn extends Sql
+{
+    public function __construct($table, $columnName)
+    {
+        $sql = sprintf("ALTER TABLE `%s` DROP COLUMN `%s`", $table, $columnName);
+
+        if (!empty($placeColumnAfter)) {
+            $sql .= sprintf(' AFTER `%s`', $placeColumnAfter);
+        }
+
+        parent::__construct($sql, static::ERROR_CODE_COLUMN_NOT_EXISTS);
+    }
+
+}

--- a/core/Updater/Migration/Db/DropIndex.php
+++ b/core/Updater/Migration/Db/DropIndex.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+use Piwik\Db;
+
+/**
+ * @see Factory::dropIndex()
+ * @ignore
+ */
+class DropIndex extends Sql
+{
+    /**
+     * @param string $table Prefixed table name
+     * @param string $indexName name of the index
+     */
+    public function __construct($table, $indexName)
+    {
+        $sql = sprintf('ALTER TABLE `%s` DROP INDEX `%s`', $table, $indexName);
+
+        parent::__construct($sql, array(static::ERROR_CODE_COLUMN_NOT_EXISTS));
+    }
+
+}

--- a/core/Updater/Migration/Db/DropTable.php
+++ b/core/Updater/Migration/Db/DropTable.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+use Piwik\Db;
+
+/**
+ * @see Factory::dropTable()
+ * @ignore
+ */
+class DropTable extends Sql
+{
+    /**
+     * @param string $table Prefixed table name
+     */
+    public function __construct($table)
+    {
+        $sql = sprintf('DROP TABLE IF EXISTS `%s`', $table);
+
+        parent::__construct($sql, array(static::ERROR_CODE_TABLE_NOT_EXISTS, static::ERROR_CODE_UNKNOWN_TABLE));
+    }
+
+}

--- a/core/Updater/Migration/Db/Factory.php
+++ b/core/Updater/Migration/Db/Factory.php
@@ -1,0 +1,383 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+use Piwik\Common;
+use Piwik\Container\StaticContainer;
+
+/**
+ * Provides database migrations.
+ *
+ * @api
+ */
+class Factory
+{
+    /**
+     * @var \DI\Container
+     */
+    private $container;
+
+    /**
+     * @ignore
+     */
+    public function __construct()
+    {
+        $this->container = StaticContainer::getContainer();
+    }
+
+    /**
+     * Performs a custom SQL query during the update.
+     *
+     * Example:
+     * $factory->sql("DELETE * FROM table_name WHERE plugin_name = 'MyPluginName'");
+     *
+     * @param string $sql  The SQL query that should be executed. Make sure to prefix a table name via
+     *                     {@link Piwik\Commin::prefixTable()}.
+     * @param int|int[]    $errorCodesToIgnore Any given MySQL server error code will be ignored. For a list of all
+     *                                         possible error codes have a look at {@link \Piwik\Updater\Migration\Db}.
+     *                                         If no error should be ignored use an empty array or `false`.
+     * @return Sql
+     */
+    public function sql($sql, $errorCodesToIgnore = array())
+    {
+        if ($errorCodesToIgnore === false) {
+            $errorCodesToIgnore = array();
+        }
+
+        return $this->container->make('Piwik\Updater\Migration\Db\Sql', array(
+            'sql' => $sql, 'errorCodesToIgnore' => $errorCodesToIgnore
+        ));
+    }
+
+    /**
+     * Performs a custom SQL query that uses bound parameters during the update.
+     *
+     * You can replace values with a question mark and then pass the actual value via `$bind` for better security.
+     *
+     * Example:
+     * $factory->boundSql('DELETE * FROM table_name WHERE idsite = ?, array($idSite = 1));
+     *
+     * @param string $sql  The SQL query that should be executed. Make sure to prefix a table name via
+     *                     {@link Piwik\Commin::prefixTable()}.
+     * @param array $bind  An array of values that need to be replaced with the question marks in the SQL query.
+     * @param int|int[] $errorCodesToIgnore Any given MySQL server error code will be ignored. For a list of all
+     *                                            possible error codes have a look at {@link \Piwik\Updater\Migration\Db}.
+     *                                            If no error should be ignored use `false`.
+     * @return BoundSql
+     */
+    public function boundSql($sql, $bind, $errorCodesToIgnore = array())
+    {
+        if ($errorCodesToIgnore === false) {
+            $errorCodesToIgnore = array();
+        }
+
+        return $this->container->make('Piwik\Updater\Migration\Db\BoundSql', array(
+            'sql' => $sql, 'errorCodesToIgnore' => $errorCodesToIgnore, 'bind' => $bind
+        ));
+    }
+
+    /**
+     * Creates a new database table.
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param array $columnNames  An array of column names and their type they should use. For example:
+     *                            array('column_name_1' => 'VARCHAR(200) NOT NULL', 'column_name_2' => 'INT(10) DEFAULT 0')
+     * @param string|string[] $primaryKey Optional. One or multiple columns that shall define the primary key.
+     * @return CreateTable
+     */
+    public function createTable($table, $columnNames, $primaryKey = array())
+    {
+        $table = $this->prefixTable($table);
+
+        if (!empty($primaryKey) && !is_array($primaryKey)) {
+            $primaryKey = array($primaryKey);
+        }
+
+        return $this->container->make('Piwik\Updater\Migration\Db\CreateTable', array(
+            'table' => $table, 'columnNames' => $columnNames, 'primaryKey' => $primaryKey
+        ));
+    }
+
+    /**
+     * Drops an existing database table.
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @return DropTable
+     */
+    public function dropTable($table)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\DropTable', array(
+            'table' => $table
+        ));
+    }
+
+    /**
+     * Adds a new database table column to an existing table.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param string $columnName  The name of the column that shall be added, eg 'my_column_name'.
+     * @param string $columnType  The column type it should have, eg 'VARCHAR(200) NOT NULL'.
+     * @param string|null $placeColumnAfter  If specified, the added column will be added after this specified column
+     *                                       name. If you specify a column be sure it actually exists and can be added
+     *                                       after this column.
+     * @return AddColumn
+     */
+    public function addColumn($table, $columnName, $columnType, $placeColumnAfter = null)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\AddColumn', array(
+            'table' => $table, 'columnName' => $columnName, 'columnType' => $columnType, 'placeColumnAfter' => $placeColumnAfter
+        ));
+    }
+
+    /**
+     * Adds multiple new database table columns to an existing table at once.
+     *
+     * Adding multiple columns at the same time can lead to performance improvements compared to adding each new column
+     * separately.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param array $columns An array of column name to column type pairs,
+     *                       eg array('my_column_name' => 'VARCHAR(200) NOT NULL', 'column2' => '...')
+     * @param string|null $placeColumnAfter  If specified, the first added column will be added after this specified column
+     *                                       name. All following columns will be added after the previous specified in
+     *                                       $columns. If you specify a column be sure it actually exists and can be added
+     *                                       after this column.
+     * @return AddColumns
+     */
+    public function addColumns($table, $columns, $placeColumnAfter = null)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\AddColumns', array(
+            'table' => $table, 'columns' => $columns, 'placeColumnAfter' => $placeColumnAfter
+        ));
+    }
+
+    /**
+     * Drops an existing database table column.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param string $columnName  The name of the column that shall be dropped, eg 'my_column_name'.
+     * @return DropColumn
+     */
+    public function dropColumn($table, $columnName)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\DropColumn', array(
+            'table' => $table, 'columnName' => $columnName
+        ));
+    }
+
+    /**
+     * Changes the column name and column type of an existing database table column.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param string $oldColumnName  The current name of the column that shall be renamed/changed, eg 'column_name'.
+     * @param string $newColumnName  The new name of the column, eg 'new_column_name'.
+     * @param string $columnType  The updated type the new column should have, eg 'VARCHAR(200) NOT NULL'.
+     *
+     * @return ChangeColumn
+     */
+    public function changeColumn($table, $oldColumnName, $newColumnName, $columnType)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\ChangeColumn', array(
+            'table' => $table, 'oldColumnName' => $oldColumnName,
+            'newColumnName' => $newColumnName, 'columnType' => $columnType
+        ));
+    }
+
+    /**
+     * Changes the type of an existing database table column.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param string $columnName  The name of the column that shall be changed, eg 'my_column_name'.
+     * @param string $columnType  The updated type the column should have, eg 'VARCHAR(200) NOT NULL'.
+     *
+     * @return ChangeColumnType
+     */
+    public function changeColumnType($table, $columnName, $columnType)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\ChangeColumnType', array(
+            'table' => $table, 'columnName' => $columnName, 'columnType' => $columnType
+        ));
+    }
+
+    /**
+     * Changes the type of multiple existing database table columns at the same time.
+     *
+     * Changing multiple columns at the same time can lead to performance improvements compared to changing the type
+     * of each column separately.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param array $columns An array of column name to column type pairs,
+     *                       eg array('my_column_name' => 'VARCHAR(200) NOT NULL', 'column2' => '...')
+     *
+     * @return ChangeColumnTypes
+     */
+    public function changeColumnTypes($table, $columns)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\ChangeColumnTypes', array(
+            'table' => $table, 'columns' => $columns
+        ));
+    }
+
+    /**
+     * Adds an index to an existing database table.
+     *
+     * This is equivalent to an `ADD INDEX indexname (column_name_1, column_name_2)` in SQL.
+     * It adds a normal index, no unique index.
+     *
+     * Note: If no indexName is specified, it will automatically generate a name for this index if which is basically:
+     * `'index_' . implode('_', $columnNames)`. If a column name is eg `column1(10)` then only the first part (`column1`)
+     * will be used. For example when using columns `array('column1', 'column2(10)')` then the index name will be
+     * `index_column1_column2`.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param string[]|string $columnNames Either one or multiple column names, eg array('column_name_1', 'column_name_2').
+     *                                     A column name can be appended by a number bracket eg "column_name_1(10)".
+     * @param string $indexName If specified, the given index name will be used instead of the automatically generated one.
+     * @return AddIndex
+     */
+    public function addIndex($table, $columnNames, $indexName = '')
+    {
+        $table = $this->prefixTable($table);
+
+        if (!is_array($columnNames)) {
+            $columnNames = array($columnNames);
+        }
+
+        return $this->container->make('Piwik\Updater\Migration\Db\AddIndex', array(
+            'table' => $table, 'columnNames' => $columnNames, 'indexName' => $indexName
+        ));
+    }
+
+    /**
+     * Adds a unique key to an existing database table.
+     *
+     * This is equivalent to an `ADD UNIQUE KEY indexname (column_name_1, column_name_2)` in SQL.
+     *
+     * Note: If no indexName is specified, it will automatically generate a name for this index if which is basically:
+     * `'index_' . implode('_', $columnNames)`. If a column name is eg `column1(10)` then only the first part (`column1`)
+     * will be used. For example when using columns `array('column1', 'column2(10)')` then the index name will be
+     * `index_column1_column2`.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param string[]|string $columnNames Either one or multiple column names, eg array('column_name_1', 'column_name_2').
+     *                                     A column name can be appended by a number bracket eg "column_name_1(10)".
+     * @param string $indexName If specified, the given unique key name will be used instead of the automatically generated one.
+     * @return AddIndex
+     */
+    public function addUniqueKey($table, $columnNames, $indexName = '')
+    {
+        $table = $this->prefixTable($table);
+
+        if (!is_array($columnNames)) {
+            $columnNames = array($columnNames);
+        }
+
+        return $this->container->make('Piwik\Updater\Migration\Db\AddUniqueKey', array(
+            'table' => $table, 'columnNames' => $columnNames, 'indexName' => $indexName
+        ));
+    }
+
+    /**
+     * Drops an existing index from a database table.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param string $indexName The name of the index that shall be dropped.
+     * @return DropIndex
+     */
+    public function dropIndex($table, $indexName)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\DropIndex', array(
+            'table' => $table, 'indexName' => $indexName
+        ));
+    }
+
+    /**
+     * Adds a primary key to an existing database table.
+     *
+     * This is equivalent to an `ADD PRIMARY KEY(column_name_1, column_name_2)` in SQL.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param string[]|string $columnNames Either one or multiple column names, eg array('column_name_1', 'column_name_2')
+     * @return AddPrimaryKey
+     */
+    public function addPrimaryKey($table, $columnNames)
+    {
+        $table = $this->prefixTable($table);
+        if (!is_array($columnNames)) {
+            $columnNames = array($columnNames);
+        }
+
+        return $this->container->make('Piwik\Updater\Migration\Db\AddPrimaryKey', array(
+            'table' => $table, 'columnNames' => $columnNames
+        ));
+    }
+
+    /**
+     * Inserts a new record / row into an existing database table.
+     *
+     * Make sure to specify all columns that need to be defined in order to insert a value successfully. There could
+     * be for example columns that are not nullable and therefore need a value.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param array $columnValuePairs An array containing column => value pairs. For example:
+     *                                array('column_name_1' => 'value1', 'column_name_2' => 'value2')
+     * @return Insert
+     */
+    public function insert($table, $columnValuePairs)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\Insert', array(
+            'table' => $table, 'columnValuePairs' => $columnValuePairs
+        ));
+    }
+
+    /**
+     * Performs a batch insert into a specific table using either LOAD DATA INFILE or plain INSERTs,
+     * as a fallback. On MySQL, LOAD DATA INFILE is 20x faster than a series of plain INSERTs.
+     *
+     * Please note that queries for batch inserts are currently not shown to an end user and should therefore not be
+     * returned in an `Updates::getMigrations` method. Instead it needs to be execute directly in `Updates::doUpdate`
+     * via `$updater->executeMigration($factory->dbBatchInsert(...));`
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param string[] $columnNames An array of unquoted column names, eg array('column_name1', 'column_name_2')
+     * @param array $values An array of data to be inserted, eg array(array('row1column1', 'row1column2'),array('row2column1', 'row2column2'))
+     * @param bool $throwException Whether to throw an exception that was caught while trying LOAD DATA INFILE, or not.
+     * @param string $charset The charset to use, defaults to utf8
+     * @return BatchInsert
+     */
+    public function batchInsert($table, $columnNames, $values, $throwException = false, $charset = 'utf8')
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\BatchInsert', array(
+            'table' => $table, 'columnNames' => $columnNames, 'values' => $values,
+            'throwException' => $throwException, 'charset' => $charset
+        ));
+    }
+
+    private function prefixTable($table)
+    {
+        return Common::prefixTable($table);
+    }
+}

--- a/core/Updater/Migration/Db/Insert.php
+++ b/core/Updater/Migration/Db/Insert.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+use Piwik\Common;
+use Piwik\Db;
+
+/**
+ * @see Factory::insert()
+ * @ignore
+ */
+class Insert extends BoundSql
+{
+    /**
+     * Insert constructor.
+     * @param string $table
+     * @param array $columnValuePairs array(columnName => columnValue)
+     */
+    public function __construct($table, $columnValuePairs)
+    {
+        $columns = implode('`, `', array_keys($columnValuePairs));
+        $bind = array_values($columnValuePairs);
+
+        $sql = sprintf('INSERT INTO `%s` (`%s`) VALUES (%s)', $table, $columns, Common::getSqlStringFieldsArray($columnValuePairs));
+
+        parent::__construct($sql, $bind, static::ERROR_CODE_DUPLICATE_ENTRY);
+    }
+
+}

--- a/core/Updater/Migration/Db/Sql.php
+++ b/core/Updater/Migration/Db/Sql.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Updater\Migration as MigrationInterface;
+use Piwik\Updater\Migration\Db as DbMigration;
+
+/**
+ * Executes a given SQL query.
+ *
+ * @see Factory::sql()
+ * @ignore
+ */
+class Sql extends DbMigration
+{
+
+    /**
+     * @var string
+     */
+    protected $sql;
+
+    /**
+     * @var false|int|array
+     */
+    private $errorCodesToIgnore;
+
+    /**
+     * Sql constructor.
+     * @param string $sql
+     * @param int|int[] $errorCodesToIgnore  If no error should be ignored use an empty array.
+     */
+    public function __construct($sql, $errorCodesToIgnore)
+    {
+        if (!is_array($errorCodesToIgnore)) {
+            $errorCodesToIgnore = array($errorCodesToIgnore);
+        }
+
+        $this->sql = $sql;
+        $this->errorCodesToIgnore = $errorCodesToIgnore;
+    }
+
+    public function shouldIgnoreError($exception)
+    {
+        if (empty($this->errorCodesToIgnore)) {
+            return false;
+        }
+
+        foreach ($this->errorCodesToIgnore as $code) {
+            if (Db::get()->isErrNo($exception, $code)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @internal
+     * @param int $errorCode
+     * @return $this
+     */
+    public function addErrorCodeToIgnore($errorCode)
+    {
+        $this->errorCodesToIgnore[] = $errorCode;
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     */
+    public function getErrorCodesToIgnore()
+    {
+        return $this->errorCodesToIgnore;
+    }
+
+    public function __toString()
+    {
+        $sql = $this->sql;
+
+        if (!Common::stringEndsWith($sql, ';')) {
+            $sql .= ';';
+        }
+
+        return $sql;
+    }
+
+    public function exec()
+    {
+        Db::exec($this->sql);
+    }
+}

--- a/core/Updater/Migration/Factory.php
+++ b/core/Updater/Migration/Factory.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration;
+
+use Interop\Container\ContainerInterface;
+use Piwik\Common;
+use Piwik\Updater\Migration\Db\Factory as DbFactory;
+use Piwik\Updater\Migration\Plugin\Factory as PluginFactory;
+
+/**
+ * Migration factory to create various migrations that implement the Migration interface.
+ *
+ * @api
+ */
+class Factory
+{
+    /**
+     * @var DbFactory
+     */
+    public $db;
+
+    /**
+     * @var PluginFactory
+     */
+    public $plugin;
+
+    /**
+     * @ignore
+     */
+    public function __construct(DbFactory $dbFactory, PluginFactory $pluginFactory)
+    {
+        $this->db = $dbFactory;
+        $this->plugin = $pluginFactory;
+    }
+}

--- a/core/Updater/Migration/Plugin/Activate.php
+++ b/core/Updater/Migration/Plugin/Activate.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Plugin;
+
+use Piwik\Plugin;
+use Piwik\Updater\Migration;
+
+/**
+ * Activates the given plugin during the update
+ */
+class Activate extends Migration
+{
+    /**
+     * @var string
+     */
+    private $pluginName;
+
+    /**
+     * @var Plugin\Manager
+     */
+    private $pluginManager;
+
+    public function __construct(Plugin\Manager $pluginManager, $pluginName)
+    {
+        $this->pluginManager = $pluginManager;
+        $this->pluginName = $pluginName;
+    }
+
+    public function __toString()
+    {
+        return sprintf('Activating plugin "%s"', $this->pluginName);
+    }
+
+    public function shouldIgnoreError($exception)
+    {
+        return true;
+    }
+
+    public function exec()
+    {
+        if (!$this->pluginManager->isPluginActivated($this->pluginName)) {
+            $this->pluginManager->activatePlugin($this->pluginName);
+        }
+    }
+
+}

--- a/core/Updater/Migration/Plugin/Factory.php
+++ b/core/Updater/Migration/Plugin/Factory.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Plugin;
+
+use Piwik\Container\StaticContainer;
+
+/**
+ * Provides plugin migrations.
+ *
+ * @api
+ */
+class Factory
+{
+    /**
+     * @var \DI\Container
+     */
+    private $container;
+
+    /**
+     * @ignore
+     */
+    public function __construct()
+    {
+        $this->container = StaticContainer::getContainer();
+    }
+
+    /**
+     * Activates the given plugin during an update.
+     *
+     * If the plugin is already activated or if any other error occurs it will be ignored.
+     *
+     * @param string $pluginName
+     * @return Activate
+     */
+    public function activate($pluginName)
+    {
+        return $this->container->make('Piwik\Updater\Migration\Plugin\Activate', array(
+            'pluginName' => $pluginName
+        ));
+    }
+}

--- a/core/Updater/UpdateObserver.php
+++ b/core/Updater/UpdateObserver.php
@@ -65,23 +65,23 @@ abstract class UpdateObserver
     }
 
     /**
-     * Executed before a migration query is executed.
+     * Executed before a migration is executed.
      *
      * @param string $updateFile The path to the Updates file being executed.
-     * @param string $sql The SQL query that is about to be executed.
+     * @param Migration $migration The migration that is about to be executed.
      */
-    public function onStartExecutingMigrationQuery($updateFile, $sql)
+    public function onStartExecutingMigration($updateFile, Migration $migration)
     {
         // empty
     }
 
     /**
-     * Executed after a migration query is executed.
+     * Executed after a migration is executed.
      *
      * @param string $updateFile The path to the Updates file being executed.
-     * @param string $sql The SQL query that has finished executing.
+     * @param Migration $migration The migration that is about to be executed.
      */
-    public function onFinishedExecutingMigrationQuery($updateFile, $sql)
+    public function onFinishedExecutingMigration($updateFile, Migration $migration)
     {
         // empty
     }

--- a/core/Updates.php
+++ b/core/Updates.php
@@ -7,6 +7,7 @@
  *
  */
 namespace Piwik;
+use Piwik\Updater\Migration;
 
 /**
  * Base class for update scripts.
@@ -32,7 +33,7 @@ namespace Piwik;
 abstract class Updates
 {
     /**
-     * @deprecated since v2.12.0 use getMigrationQueries() instead
+     * @deprecated since v2.12.0 use getMigrationQueries() instead. Will be removed in Piwik 4.0.0
      */
     public static function getSql()
     {
@@ -40,28 +41,34 @@ abstract class Updates
     }
 
     /**
-     * @deprecated since v2.12.0 use doUpdate() instead
+     * @deprecated since v2.12.0 use doUpdate() instead. Will be removed in Piwik 4.0.0
      */
     public static function update()
     {
     }
 
     /**
-     * Return SQL to be executed in this update.
+     * Return migrations to be executed in this update.
      *
-     * SQL queries should be defined here, instead of in `doUpdate()`, since this method is used
-     * in the `core:update` command when displaying the queries an update will run. If you execute
-     * queries directly in `doUpdate()`, they won't be displayed to the user.
+     * Migrations should be defined here, instead of in `doUpdate()`, since this method is used to display a preview
+     * of which migrations and database queries an update will run. If you execute migrations directly in `doUpdate()`,
+     * they won't be displayed to the user.
      *
      * @param Updater $updater
-     * @return array ```
-     *               array(
-     *                   'ALTER .... ' => '1234', // if the query fails, it will be ignored if the error code is 1234
-     *                   'ALTER .... ' => false,  // if an error occurs, the update will stop and fail
-     *                                            // and user will have to manually run the query
-     *               )
-     *               ```
+     * @return Migration[]
      * @api
+     */
+    public function getMigrations(Updater $updater)
+    {
+        return $this->getMigrationQueries($updater);
+    }
+
+    /**
+     * Return SQL to be executed in this update.
+     *
+     * @param Updater $updater
+     * @return array
+     * @deprecated since Piwik 3.0.0, implement {@link getMigrations()} instead. Will be removed in Piwik 4.0.0
      */
     public function getMigrationQueries(Updater $updater)
     {
@@ -71,10 +78,10 @@ abstract class Updates
     /**
      * Perform the incremental version update.
      *
-     * This method should preform all updating logic. If you define queries in an overridden `getMigrationQueries()`
-     * method, you must call {@link Updater::executeMigrationQueries()} here.
+     * This method should preform all updating logic. If you define migrations in an overridden `getMigrations()`
+     * method, you must call {@link Updater::executeMigrations()} here.
      *
-     * See {@link Updates} for an example.
+     * See {@link \Piwik\Plugins\ExamplePlugin\Updates\Updates_0_0_2} for an example.
      *
      * @param Updater $updater
      * @api

--- a/core/Updates/0.2.12.php
+++ b/core/Updates/0.2.12.php
@@ -9,30 +9,38 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_2_12 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('site') . '`
-				CHANGE `ts_created` `ts_created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL'              => false,
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				DROP `config_color_depth`'                                                                  => 1091,
+            $this->migration->db->changeColumnType('site', 'ts_created', 'TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL'),
+            $this->migration->db->dropColumn('log_visit', 'config_color_depth'),
 
             // 0.2.12 [673]
             // Note: requires INDEX privilege
-            'DROP INDEX index_idaction ON `' . Common::prefixTable('log_action') . '`'                      => 1091,
+            $this->migration->db->dropIndex('log_action', 'index_idaction')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.2.13.php
+++ b/core/Updates/0.2.13.php
@@ -9,30 +9,39 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_2_13 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'DROP TABLE IF EXISTS `' . Common::prefixTable('option') . '`'    => false,
-
-            'CREATE TABLE `' . Common::prefixTable('option') . "` (
-				option_name VARCHAR( 64 ) NOT NULL ,
-				option_value LONGTEXT NOT NULL ,
-				autoload TINYINT NOT NULL DEFAULT '1',
-				PRIMARY KEY ( option_name )
-			)" => 1050,
+            $this->migration->db->dropTable('option'),
+            $this->migration->db->createTable('option', array(
+                'option_name'  => 'VARCHAR( 64 ) NOT NULL' ,
+                'option_value' => 'LONGTEXT NOT NULL' ,
+                'autoload' => "TINYINT NOT NULL DEFAULT '1'",
+            )),
+            $this->migration->db->addPrimaryKey('option', 'option_name')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.2.24.php
+++ b/core/Updates/0.2.24.php
@@ -9,28 +9,36 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_2_24 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'CREATE INDEX index_type_name
-                ON ' . Common::prefixTable('log_action') . ' (type, name(15))'                       => 1072,
-            'CREATE INDEX index_idsite_date
-                ON ' . Common::prefixTable('log_visit') . ' (idsite, visit_server_date)'             => 1072,
-            'DROP INDEX index_idsite ON ' . Common::prefixTable('log_visit')                         => 1091,
-            'DROP INDEX index_visit_server_date ON ' . Common::prefixTable('log_visit')              => 1091,
+            $this->migration->db->addIndex('log_action', array('type', 'name(15)'), 'index_type_name'),
+            $this->migration->db->addIndex('log_visit', array('idsite', 'visit_server_date'), 'index_idsite_date'),
+            $this->migration->db->dropIndex('log_visit', 'index_idsite'),
+            $this->migration->db->dropIndex('log_visit', 'index_visit_server_date'),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.2.27.php
+++ b/core/Updates/0.2.27.php
@@ -13,68 +13,76 @@ use Piwik\Common;
 use Piwik\DbHelper;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_2_27 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
-        $sqlarray = array(
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				ADD `visit_goal_converted` VARCHAR( 1 ) NOT NULL AFTER `visit_total_time`'           => 1060,
-            // 0.2.27 [826]
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				CHANGE `visit_goal_converted` `visit_goal_converted` TINYINT(1) NOT NULL'            => 1060,
+        $this->migration = $factory;
+    }
 
-            'CREATE TABLE `' . Common::prefixTable('goal') . "` (
-				`idsite` int(11) NOT NULL,
-				`idgoal` int(11) NOT NULL,
-				`name` varchar(50) NOT NULL,
-				`match_attribute` varchar(20) NOT NULL,
-				`pattern` varchar(255) NOT NULL,
-				`pattern_type` varchar(10) NOT NULL,
-				`case_sensitive` tinyint(4) NOT NULL,
-				`revenue` float NOT NULL,
-				`deleted` tinyint(4) NOT NULL default '0',
-				PRIMARY KEY  (`idsite`,`idgoal`)
-			)"                                                                                       => 1050,
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = array(
+            $this->migration->db->addColumn('log_visit', 'visit_goal_converted', 'TINYINT( 1 ) NOT NULL', 'visit_total_time'),
+            $this->migration->db->sql('CREATE TABLE `' . Common::prefixTable('goal') . "` (
+                `idsite` int(11) NOT NULL,
+                `idgoal` int(11) NOT NULL,
+                `name` varchar(50) NOT NULL,
+                `match_attribute` varchar(20) NOT NULL,
+                `pattern` varchar(255) NOT NULL,
+                `pattern_type` varchar(10) NOT NULL,
+                `case_sensitive` tinyint(4) NOT NULL,
+                `revenue` float NOT NULL,
+                `deleted` tinyint(4) NOT NULL default '0',
+                PRIMARY KEY  (`idsite`,`idgoal`)
+            )", Updater\Migration\Db::ERROR_CODE_TABLE_EXISTS),
 
-            'CREATE TABLE `' . Common::prefixTable('log_conversion') . '` (
-				`idvisit` int(10) unsigned NOT NULL,
-				`idsite` int(10) unsigned NOT NULL,
-				`visitor_idcookie` char(32) NOT NULL,
-				`server_time` datetime NOT NULL,
-				`visit_server_date` date NOT NULL,
-				`idaction` int(11) NOT NULL,
-				`idlink_va` int(11) NOT NULL,
-				`referer_idvisit` int(10) unsigned default NULL,
-				`referer_type` int(10) unsigned default NULL,
-				`referer_name` varchar(70) default NULL,
-				`referer_keyword` varchar(255) default NULL,
-				`visitor_returning` tinyint(1) NOT NULL,
-				`location_country` char(3) NOT NULL,
-				`location_continent` char(3) NOT NULL,
-				`url` text NOT NULL,
-				`idgoal` int(10) unsigned NOT NULL,
-				`revenue` float default NULL,
-				PRIMARY KEY  (`idvisit`,`idgoal`),
-				KEY `index_idsite_date` (`idsite`,`visit_server_date`)
-			)'                                                                                       => 1050,
+            $this->migration->db->sql('CREATE TABLE `' . Common::prefixTable('log_conversion') . '` (
+                `idvisit` int(10) unsigned NOT NULL,
+                `idsite` int(10) unsigned NOT NULL,
+                `visitor_idcookie` char(32) NOT NULL,
+                `server_time` datetime NOT NULL,
+                `visit_server_date` date NOT NULL,
+                `idaction` int(11) NOT NULL,
+                `idlink_va` int(11) NOT NULL,
+                `referer_idvisit` int(10) unsigned default NULL,
+                `referer_type` int(10) unsigned default NULL,
+                `referer_name` varchar(70) default NULL,
+                `referer_keyword` varchar(255) default NULL,
+                `visitor_returning` tinyint(1) NOT NULL,
+                `location_country` char(3) NOT NULL,
+                `location_continent` char(3) NOT NULL,
+                `url` text NOT NULL,
+                `idgoal` int(10) unsigned NOT NULL,
+                `revenue` float default NULL,
+                PRIMARY KEY  (`idvisit`,`idgoal`),
+                KEY `index_idsite_date` (`idsite`,`visit_server_date`)
+            )', Updater\Migration\Db::ERROR_CODE_TABLE_EXISTS),
         );
 
         $tables = DbHelper::getTablesInstalled();
         foreach ($tables as $tableName) {
             if (preg_match('/archive_/', $tableName) == 1) {
-                $sqlarray['CREATE INDEX index_all ON ' . $tableName . ' (`idsite`,`date1`,`date2`,`name`,`ts_archived`)'] = 1072;
+                $columns = array('idsite','date1','date2','name','ts_archived');
+                $tableNameUnprefixed = Common::unprefixTable($tableName);
+                $migrations[] = $this->migration->db->addIndex($tableNameUnprefixed, $columns, 'index_all');
             }
         }
 
-        return $sqlarray;
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.2.32.php
+++ b/core/Updates/0.2.32.php
@@ -9,31 +9,37 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_2_32 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
             // 0.2.32 [941]
-            'ALTER TABLE `' . Common::prefixTable('access') . '`
-				CHANGE `login` `login` VARCHAR( 100 ) NOT NULL'                                                                       => false,
-            'ALTER TABLE `' . Common::prefixTable('user') . '`
-				CHANGE `login` `login` VARCHAR( 100 ) NOT NULL'           => false,
-            'ALTER TABLE `' . Common::prefixTable('user_dashboard') . '`
-				CHANGE `login` `login` VARCHAR( 100 ) NOT NULL' => '1146',
-            'ALTER TABLE `' . Common::prefixTable('user_language') . '`
-				CHANGE `login` `login` VARCHAR( 100 ) NOT NULL'  => '1146',
+            $this->migration->db->changeColumnType('access', 'login', 'VARCHAR( 100 ) NOT NULL'),
+            $this->migration->db->changeColumnType('user', 'login', 'VARCHAR( 100 ) NOT NULL'),
+            $this->migration->db->changeColumnType('user_dashboard', 'login', 'VARCHAR( 100 ) NOT NULL'),
+            $this->migration->db->changeColumnType('user_language', 'login', 'VARCHAR( 100 ) NOT NULL'),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.2.35.php
+++ b/core/Updates/0.2.35.php
@@ -9,24 +9,33 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_2_35 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('user_dashboard') . '`
-				CHANGE `layout` `layout` TEXT NOT NULL' => false,
+            $this->migration->db->changeColumnType('user_dashboard', 'layout', 'TEXT NOT NULL')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.2.37.php
+++ b/core/Updates/0.2.37.php
@@ -12,22 +12,33 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_2_37 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'DELETE FROM `' . Common::prefixTable('user_dashboard') . "`
-				WHERE layout LIKE '%.getLastVisitsGraph%'
-				OR layout LIKE '%.getLastVisitsReturningGraph%'" => false,
+            $this->migration->db->sql('DELETE FROM `' . Common::prefixTable('user_dashboard') . "`
+                                       WHERE layout LIKE '%.getLastVisitsGraph%'
+                                       OR layout LIKE '%.getLastVisitsReturningGraph%'"),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.4.1.php
+++ b/core/Updates/0.4.1.php
@@ -9,26 +9,34 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_4_1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-				CHANGE `idlink_va` `idlink_va` INT(11) DEFAULT NULL'                                                                     => false,
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-				CHANGE `idaction` `idaction` INT(11) DEFAULT NULL' => '1054',
+            $this->migration->db->changeColumnType('log_conversion', 'idlink_va', 'INT(11) DEFAULT NULL'),
+            $this->migration->db->changeColumnType('log_conversion', 'idaction', 'INT(11) DEFAULT NULL'),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.4.2.php
+++ b/core/Updates/0.4.2.php
@@ -9,30 +9,37 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_4_2 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				ADD `config_java` TINYINT(1) NOT NULL AFTER `config_flash`'         => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				ADD `config_quicktime` TINYINT(1) NOT NULL AFTER `config_director`' => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				ADD `config_gears` TINYINT(1) NOT NULL AFTER  `config_windowsmedia`,
-				ADD `config_silverlight` TINYINT(1) NOT NULL AFTER `config_gears`'  => 1060,
+            $this->migration->db->addColumn('log_visit', 'config_java', 'TINYINT(1) NOT NULL', 'config_flash'),
+            $this->migration->db->addColumn('log_visit', 'config_quicktime', 'TINYINT(1) NOT NULL', 'config_director'),
+            $this->migration->db->addColumn('log_visit', 'config_gears', 'TINYINT(1) NOT NULL', 'config_windowsmedia'),
+            $this->migration->db->addColumn('log_visit', 'config_silverlight', 'TINYINT(1) NOT NULL', 'config_gears'),
         );
     }
 
     // when restoring (possibly) previousy dropped columns, ignore mysql code error 1060: duplicate column
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.4.php
+++ b/core/Updates/0.4.php
@@ -12,28 +12,37 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_4 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
             // 0.4 [1140]
-            'UPDATE `' . Common::prefixTable('log_visit') . '`
-				SET location_ip=location_ip+CAST(POW(2,32) AS UNSIGNED) WHERE location_ip < 0'    => false,
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				CHANGE `location_ip` `location_ip` BIGINT UNSIGNED NOT NULL'                      => 1054,
-            'UPDATE `' . Common::prefixTable('logger_api_call') . '`
-				SET caller_ip=caller_ip+CAST(POW(2,32) AS UNSIGNED) WHERE caller_ip < 0'          => 1146,
-            'ALTER TABLE `' . Common::prefixTable('logger_api_call') . '`
-				CHANGE `caller_ip` `caller_ip` BIGINT UNSIGNED'                                   => 1146,
+            $this->migration->db->sql('UPDATE `' . Common::prefixTable('log_visit') . '`
+                SET location_ip=location_ip+CAST(POW(2,32) AS UNSIGNED) WHERE location_ip < 0'),
+            $this->migration->db->changeColumnType('log_visit', 'location_ip', 'BIGINT UNSIGNED NOT NULL'),
+            $this->migration->db->sql('UPDATE `' . Common::prefixTable('logger_api_call') . '`
+                SET caller_ip=caller_ip+CAST(POW(2,32) AS UNSIGNED) WHERE caller_ip < 0', Updater\Migration\Db::ERROR_CODE_TABLE_NOT_EXISTS),
+            $this->migration->db->changeColumnType('logger_api_call', 'caller_ip', 'BIGINT UNSIGNED')->addErrorCodeToIgnore(Updater\Migration\Db::ERROR_CODE_TABLE_NOT_EXISTS),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.5.4.php
+++ b/core/Updates/0.5.4.php
@@ -13,16 +13,26 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_5_4 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_action') . '`
-				 CHANGE `name` `name` TEXT' => false,
+            $this->migration->db->changeColumnType('log_action', 'name', 'TEXT'),
         );
     }
 
@@ -60,6 +70,6 @@ class Updates_0_5_4 extends Updates
             }
         }
 
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.5.5.php
+++ b/core/Updates/0.5.5.php
@@ -13,33 +13,46 @@ use Piwik\Common;
 use Piwik\DbHelper;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_5_5 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
-        $sqlarray = array(
-            'DROP INDEX index_idsite_date ON ' . Common::prefixTable('log_visit')                                                                => 1091,
-            'CREATE INDEX index_idsite_date_config ON ' . Common::prefixTable('log_visit') . ' (idsite, visit_server_date, config_md5config(8))' => array(1061,1072),
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = array(
+            $this->migration->db->dropIndex('log_visit', 'index_idsite_date'),
+            $this->migration->db->addIndex('log_visit', array('idsite', 'visit_server_date', 'config_md5config(8)'), 'index_idsite_date_config'),
         );
 
         $tables = DbHelper::getTablesInstalled();
         foreach ($tables as $tableName) {
+            $unprefixedTable = Common::unprefixTable($tableName);
             if (preg_match('/archive_/', $tableName) == 1) {
-                $sqlarray['DROP INDEX index_all ON ' . $tableName] = 1091;
+                $migrations[] = $this->migration->db->dropIndex($unprefixedTable, 'index_all');
             }
             if (preg_match('/archive_numeric_/', $tableName) == 1) {
-                $sqlarray['CREATE INDEX index_idsite_dates_period ON ' . $tableName . ' (idsite, date1, date2, period)'] = 1061;
+                $columns = array('idsite', 'date1', 'date2', 'period');
+                $migrations[] = $this->migration->db->addIndex($unprefixedTable, $columns, 'index_idsite_dates_period');
             }
         }
 
-        return $sqlarray;
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.6-rc1.php
+++ b/core/Updates/0.6-rc1.php
@@ -12,29 +12,42 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+use Piwik\Updater\Migration;
 
 /**
  */
 class Updates_0_6_rc1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         $defaultTimezone = 'UTC';
         $defaultCurrency = 'USD';
+
         return array(
-            'ALTER TABLE ' . Common::prefixTable('user') . ' CHANGE date_registered date_registered TIMESTAMP NULL'                                                                => 1054,
-            'ALTER TABLE ' . Common::prefixTable('site') . ' CHANGE ts_created ts_created TIMESTAMP NULL'                                                                          => 1054,
-            'ALTER TABLE ' . Common::prefixTable('site') . ' ADD `timezone` VARCHAR( 50 ) NOT NULL AFTER `ts_created` ;'                                                           => 1060,
-            'UPDATE ' . Common::prefixTable('site') . ' SET `timezone` = "' . $defaultTimezone . '";'                                                                              => 1060,
-            'ALTER TABLE ' . Common::prefixTable('site') . ' ADD currency CHAR( 3 ) NOT NULL AFTER `timezone` ;'                                                                   => 1060,
-            'UPDATE ' . Common::prefixTable('site') . ' SET `currency` = "' . $defaultCurrency . '";'                                                                              => 1060,
-            'ALTER TABLE ' . Common::prefixTable('site') . ' ADD `excluded_ips` TEXT NOT NULL AFTER `currency` ;'                                                                  => 1060,
-            'ALTER TABLE ' . Common::prefixTable('site') . ' ADD excluded_parameters VARCHAR( 255 ) NOT NULL AFTER `excluded_ips` ;'                                               => 1060,
-            'ALTER TABLE ' . Common::prefixTable('log_visit') . ' ADD INDEX `index_idsite_datetime_config`  ( `idsite` , `visit_last_action_time`  , `config_md5config` ( 8 ) ) ;' => array(1061, 1072),
-            'ALTER TABLE ' . Common::prefixTable('log_visit') . ' ADD INDEX index_idsite_idvisit (idsite, idvisit) ;'                                                              => array(1061, 1072),
-            'ALTER TABLE ' . Common::prefixTable('log_conversion') . ' DROP INDEX index_idsite_date'                                                                               => 1091,
-            'ALTER TABLE ' . Common::prefixTable('log_conversion') . ' DROP visit_server_date;'                                                                                    => 1091,
-            'ALTER TABLE ' . Common::prefixTable('log_conversion') . ' ADD INDEX index_idsite_datetime ( `idsite` , `server_time` )'                                               => array(1072, 1061),
+            $this->migration->db->changeColumnType('user', 'date_registered', 'TIMESTAMP NULL'),
+            $this->migration->db->changeColumnType('site', 'ts_created', 'TIMESTAMP NULL'),
+            $this->migration->db->addColumn('site', 'timezone', 'VARCHAR( 50 ) NOT NULL', 'ts_created'),
+            $this->migration->db->sql('UPDATE ' . Common::prefixTable('site') . ' SET `timezone` = "' . $defaultTimezone . '";', Migration\Db::ERROR_CODE_DUPLICATE_COLUMN),
+            $this->migration->db->addColumn('site', 'currency', 'CHAR( 3 ) NOT NULL', 'timezone'),
+            $this->migration->db->sql('UPDATE ' . Common::prefixTable('site') . ' SET `currency` = "' . $defaultCurrency . '";', Migration\Db::ERROR_CODE_DUPLICATE_COLUMN),
+            $this->migration->db->addColumn('site', 'excluded_ips', 'TEXT NOT NULL', 'currency'),
+            $this->migration->db->addColumn('site', 'excluded_parameters', 'VARCHAR( 255 ) NOT NULL', 'excluded_ips'),
+            $this->migration->db->addIndex('log_visit', array('idsite', 'visit_last_action_time', 'config_md5config(8)'), 'index_idsite_datetime_config'),
+            $this->migration->db->addIndex('log_visit', array('idsite', 'idvisit')),
+            $this->migration->db->dropIndex('log_conversion', 'index_idsite_date'),
+            $this->migration->db->dropColumn('log_conversion', 'visit_server_date'),
+            $this->migration->db->addIndex('log_conversion', array('idsite', 'server_time'), 'index_idsite_datetime'),
         );
     }
 
@@ -54,7 +67,7 @@ class Updates_0_6_rc1 extends Updates
         }
 
         // Run the SQL
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
 
         // Outputs warning message, pointing users to the plugin download page
         if (!empty($disabledPlugins)) {

--- a/core/Updates/0.6.3.php
+++ b/core/Updates/0.6.3.php
@@ -9,22 +9,30 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Config;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_6_3 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				CHANGE `location_ip` `location_ip` INT UNSIGNED NOT NULL'                   => 1054,
-            'ALTER TABLE `' . Common::prefixTable('logger_api_call') . '`
-				CHANGE `caller_ip` `caller_ip` INT UNSIGNED'                                => array(1054, 1146),
+            $this->migration->db->changeColumnType('log_visit', 'location_ip', 'INT UNSIGNED NOT NULL'),
+            $this->migration->db->changeColumnType('logger_api_call', 'caller_ip', 'INT UNSIGNED')->addErrorCodeToIgnore(Updater\Migration\Db::ERROR_CODE_TABLE_NOT_EXISTS),
         );
     }
 
@@ -44,6 +52,6 @@ class Updates_0_6_3 extends Updates
             }
         }
 
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/0.7.php
+++ b/core/Updates/0.7.php
@@ -9,24 +9,33 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_0_7 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('option') . '`
-				CHANGE `option_name` `option_name` VARCHAR(255) NOT NULL' => false,
+            $this->migration->db->changeColumnType('option', 'option_name', 'VARCHAR(255) NOT NULL'),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.10.2-b1.php
+++ b/core/Updates/1.10.2-b1.php
@@ -9,25 +9,33 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_10_2_b1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            // ignore existing column name error (1060)
-            'ALTER TABLE ' . Common::prefixTable('report')
-            . " ADD COLUMN hour tinyint NOT NULL default 0 AFTER period" => 1060,
+            $this->migration->db->addColumn('report', 'hour', 'TINYINT NOT NULL DEFAULT 0', 'period')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.10.2-b2.php
+++ b/core/Updates/1.10.2-b2.php
@@ -9,25 +9,33 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_10_2_b2 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            // ignore existing column name error (1060)
-            'ALTER TABLE ' . Common::prefixTable('site')
-            . " ADD COLUMN `keep_url_fragment` TINYINT NOT NULL DEFAULT 0 AFTER `group`" => 1060,
+            $this->migration->db->addColumn('site', 'keep_url_fragment', 'TINYINT NOT NULL DEFAULT 0', 'group')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.12-b1.php
+++ b/core/Updates/1.12-b1.php
@@ -9,29 +9,38 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_12_b1 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
     public static function isMajorUpdate()
     {
         return true;
     }
 
-    public function getMigrationQueries(Updater $updater)
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_link_visit_action') . '`
-			 ADD `custom_float` FLOAT NULL DEFAULT NULL' => 1060
+            $this->migration->db->addColumn('log_link_visit_action', 'custom_float', 'FLOAT NULL DEFAULT NULL')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.12-b16.php
+++ b/core/Updates/1.12-b16.php
@@ -9,25 +9,33 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_12_b16 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            // ignore existing column name error (1060)
-            'ALTER TABLE ' . Common::prefixTable('report')
-            . " ADD COLUMN idsegment INT(11) AFTER description" => 1060,
+            $this->migration->db->addColumn('report', 'idsegment', 'INT(11)', 'description')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.2-rc1.php
+++ b/core/Updates/1.2-rc1.php
@@ -12,116 +12,116 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_2_rc1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $customVarType = 'VARCHAR(100) DEFAULT NULL';
+        $customVarColumns = array(
+            'custom_var_k1' => $customVarType,
+            'custom_var_v1' => $customVarType,
+            'custom_var_k2' => $customVarType,
+            'custom_var_v2' => $customVarType,
+            'custom_var_k3' => $customVarType,
+            'custom_var_v3' => $customVarType,
+            'custom_var_k4' => $customVarType,
+            'custom_var_v4' => $customVarType,
+            'custom_var_k5' => $customVarType,
+            'custom_var_v5' => $customVarType,
+        );
+
         return array(
             // Various performance improvements schema updates
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-			    DROP `visit_server_date`,
-			    DROP INDEX `index_idsite_date_config`,
-			    DROP INDEX `index_idsite_datetime_config`,
-			    ADD `idvisitor` BINARY(8) NOT NULL AFTER `idsite`,
-			    ADD `config_id` BINARY(8) NOT NULL AFTER `config_md5config`
-			   ' => array(1054, 1091),
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-		    	ADD `visit_entry_idaction_name` INT UNSIGNED NOT NULL AFTER `visit_entry_idaction_url`,
-			    ADD `visit_exit_idaction_name` INT UNSIGNED NOT NULL AFTER `visit_exit_idaction_url`,
-			    CHANGE `visit_exit_idaction_url` `visit_exit_idaction_url` INT UNSIGNED NOT NULL,
-			    CHANGE `visit_entry_idaction_url` `visit_entry_idaction_url` INT UNSIGNED NOT NULL,
-			    CHANGE `referer_type` `referer_type` TINYINT UNSIGNED NULL DEFAULT NULL,
-			    ADD visitor_count_visits SMALLINT(5) UNSIGNED NOT NULL AFTER `visitor_returning`,
-			    ADD visitor_days_since_last SMALLINT(5) UNSIGNED NOT NULL,
-			    ADD visitor_days_since_first SMALLINT(5) UNSIGNED NOT NULL
-			   ' => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-			    ADD custom_var_k1 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v1 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_k2 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v2 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_k3 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v3 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_k4 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v4 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_k5 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v5 VARCHAR(100) DEFAULT NULL
-			   ' => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_link_visit_action') . '`
-				ADD `idsite` INT( 10 ) UNSIGNED NOT NULL AFTER `idlink_va` ,
-				ADD `idvisitor` BINARY(8) NOT NULL AFTER `idsite`,
-				ADD `idaction_name_ref` INT UNSIGNED NOT NULL AFTER `idaction_name`
-			   ' => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_link_visit_action') . '`
-				ADD `server_time` DATETIME AFTER `idsite`,
-				ADD INDEX `index_idsite_servertime` ( `idsite` , `server_time` )
-			   ' => 1060,
+            $this->migration->db->sql('ALTER TABLE `' . Common::prefixTable('log_visit') . '`
+                DROP `visit_server_date`,
+                DROP INDEX `index_idsite_date_config`,
+                DROP INDEX `index_idsite_datetime_config`,
+                ADD `idvisitor` BINARY(8) NOT NULL AFTER `idsite`,
+                ADD `config_id` BINARY(8) NOT NULL AFTER `config_md5config`
+               ', array(Updater\Migration\Db::ERROR_CODE_UNKNOWN_COLUMN, Updater\Migration\Db::ERROR_CODE_COLUMN_NOT_EXISTS)),
+            $this->migration->db->sql('ALTER TABLE `' . Common::prefixTable('log_visit') . '`
+                ADD `visit_entry_idaction_name` INT UNSIGNED NOT NULL AFTER `visit_entry_idaction_url`,
+                ADD `visit_exit_idaction_name` INT UNSIGNED NOT NULL AFTER `visit_exit_idaction_url`,
+                CHANGE `visit_exit_idaction_url` `visit_exit_idaction_url` INT UNSIGNED NOT NULL,
+                CHANGE `visit_entry_idaction_url` `visit_entry_idaction_url` INT UNSIGNED NOT NULL,
+                CHANGE `referer_type` `referer_type` TINYINT UNSIGNED NULL DEFAULT NULL,
+                ADD visitor_count_visits SMALLINT(5) UNSIGNED NOT NULL AFTER `visitor_returning`,
+                ADD visitor_days_since_last SMALLINT(5) UNSIGNED NOT NULL,
+                ADD visitor_days_since_first SMALLINT(5) UNSIGNED NOT NULL
+               ', Updater\Migration\Db::ERROR_CODE_DUPLICATE_COLUMN),
 
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-			    DROP `referer_idvisit`,
-			    ADD `idvisitor` BINARY(8) NOT NULL AFTER `idsite`
-			   ' => array(1060, 1091),
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-			    ADD visitor_count_visits SMALLINT(5) UNSIGNED NOT NULL,
-			    ADD visitor_days_since_first SMALLINT(5) UNSIGNED NOT NULL
-			   ' => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-			    ADD custom_var_k1 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v1 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_k2 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v2 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_k3 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v3 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_k4 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v4 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_k5 VARCHAR(100) DEFAULT NULL,
-    			ADD custom_var_v5 VARCHAR(100) DEFAULT NULL
-			   ' => array(1060, 1061),
+            $this->migration->db->addColumns('log_visit', $customVarColumns),
+
+            $this->migration->db->addColumns('log_link_visit_action', array(
+                'idsite' => 'INT( 10 ) UNSIGNED NOT NULL',
+                'idvisitor' => 'BINARY(8) NOT NULL',
+                'idaction_name_ref' => 'INT UNSIGNED NOT NULL'
+            ), 'idlink_va'),
+
+            $this->migration->db->addColumn('log_link_visit_action', 'server_time', 'DATETIME', 'idsite'),
+            $this->migration->db->addIndex('log_link_visit_action', array('idsite', 'server_time'), 'index_idsite_servertime'),
+            
+            $this->migration->db->sql('ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
+                DROP `referer_idvisit`,
+                ADD `idvisitor` BINARY(8) NOT NULL AFTER `idsite`
+               ', array(Updater\Migration\Db::ERROR_CODE_DUPLICATE_COLUMN, Updater\Migration\Db::ERROR_CODE_COLUMN_NOT_EXISTS)),
+            $this->migration->db->addColumns('log_conversion', array(
+                'visitor_count_visits' => 'SMALLINT(5) UNSIGNED NOT NULL',
+                'visitor_days_since_first' => 'SMALLINT(5) UNSIGNED NOT NULL',
+            )),
+            $this->migration->db->addColumns('log_conversion', $customVarColumns),
 
             // Migrate 128bits IDs inefficiently stored as 8bytes (256 bits) into 64bits
-            'UPDATE ' . Common::prefixTable('log_visit') . '
-    			SET idvisitor = binary(unhex(substring(visitor_idcookie,1,16))),
-    				config_id = binary(unhex(substring(config_md5config,1,16)))
-	   			' => 1054,
-            'UPDATE ' . Common::prefixTable('log_conversion') . '
-    			SET idvisitor = binary(unhex(substring(visitor_idcookie,1,16)))
-	   			' => 1054,
+            $this->migration->db->sql('UPDATE ' . Common::prefixTable('log_visit') . '
+                SET idvisitor = binary(unhex(substring(visitor_idcookie,1,16))),
+                    config_id = binary(unhex(substring(config_md5config,1,16)))
+                   ', Updater\Migration\Db::ERROR_CODE_UNKNOWN_COLUMN),
+            $this->migration->db->sql('UPDATE ' . Common::prefixTable('log_conversion') . '
+                SET idvisitor = binary(unhex(substring(visitor_idcookie,1,16)))
+                   ', Updater\Migration\Db::ERROR_CODE_UNKNOWN_COLUMN),
 
             // Drop migrated fields
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-		    	DROP visitor_idcookie,
-		    	DROP config_md5config
-		    	' => 1091,
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-		    	DROP visitor_idcookie
-		    	' => 1091,
+            $this->migration->db->sql('ALTER TABLE `' . Common::prefixTable('log_visit') . '`
+                DROP visitor_idcookie,
+                DROP config_md5config
+                ', Updater\Migration\Db::ERROR_CODE_COLUMN_NOT_EXISTS),
+            $this->migration->db->sql('ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
+                DROP visitor_idcookie
+                ', Updater\Migration\Db::ERROR_CODE_COLUMN_NOT_EXISTS),
 
             // Recreate INDEX on new field
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-		    	ADD INDEX `index_idsite_datetime_config` (idsite, visit_last_action_time, config_id)
-		    	' => 1061,
+            $this->migration->db->addIndex('log_visit', array('idsite', 'visit_last_action_time', 'config_id'), 'index_idsite_datetime_config'),
 
             // Backfill action logs as best as we can
-            'UPDATE ' . Common::prefixTable('log_link_visit_action') . ' as action,
-				  	' . Common::prefixTable('log_visit') . '  as visit
+            $this->migration->db->sql('UPDATE ' . Common::prefixTable('log_link_visit_action') . ' as action,
+                      ' . Common::prefixTable('log_visit') . '  as visit
                 SET action.idsite = visit.idsite,
-                	action.server_time = visit.visit_last_action_time,
-                	action.idvisitor = visit.idvisitor
+                    action.server_time = visit.visit_last_action_time,
+                    action.idvisitor = visit.idvisitor
                 WHERE action.idvisit=visit.idvisit
-                ' => false,
+                '),
 
-            'ALTER TABLE `' . Common::prefixTable('log_link_visit_action') . '`
-				CHANGE `server_time` `server_time` DATETIME NOT NULL
-			   ' => false,
+            $this->migration->db->changeColumnType('log_link_visit_action', 'server_time', 'DATETIME NOT NULL'),
 
             // New index used max once per request, in case this table grows significantly in the future
-            'ALTER TABLE `' . Common::prefixTable('option') . '` ADD INDEX ( `autoload` ) ' => 1061,
+            $this->migration->db->addIndex('option', 'autoload', 'autoload'),
 
             // new field for websites
-            'ALTER TABLE `' . Common::prefixTable('site') . '` ADD `group` VARCHAR( 250 ) NOT NULL' => 1060,
+            $this->migration->db->addColumn('site', 'group', 'VARCHAR( 250 ) NOT NULL'),
         );
     }
 
@@ -141,7 +141,7 @@ class Updates_1_2_rc1 extends Updates
         }
 
         // Run the SQL
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
 
         // Outputs warning message, pointing users to the plugin download page
         if (!empty($disabledPlugins)) {

--- a/core/Updates/1.2-rc2.php
+++ b/core/Updates/1.2-rc2.php
@@ -16,6 +16,7 @@ use Piwik\Updater;
  */
 class Updates_1_2_rc2 extends Updates
 {
+
     public function doUpdate(Updater $updater)
     {
         try {

--- a/core/Updates/1.2.3.php
+++ b/core/Updates/1.2.3.php
@@ -13,28 +13,45 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_2_3 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $dbName = Config::getInstance()->database['dbname'];
+
         return array(
+
             // LOAD DATA INFILE uses the database's charset
-            'ALTER DATABASE `' . Config::getInstance()->database['dbname'] . '` DEFAULT CHARACTER SET utf8' => false,
+            $this->migration->db->sql('ALTER DATABASE `' . $dbName . '` DEFAULT CHARACTER SET utf8'),
 
             // Various performance improvements schema updates
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				DROP INDEX index_idsite_datetime_config,
-				DROP INDEX index_idsite_idvisit,
-				ADD INDEX index_idsite_config_datetime (idsite, config_id, visit_last_action_time),
-				ADD INDEX index_idsite_datetime (idsite, visit_last_action_time)' => array(1061, 1091),
+            $this->migration->db->sql(
+               'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
+                DROP INDEX index_idsite_datetime_config,
+                DROP INDEX index_idsite_idvisit,
+                ADD INDEX index_idsite_config_datetime (idsite, config_id, visit_last_action_time),
+                ADD INDEX index_idsite_datetime (idsite, visit_last_action_time)',
+                array(Updater\Migration\Db::ERROR_CODE_DUPLICATE_KEY, Updater\Migration\Db::ERROR_CODE_COLUMN_NOT_EXISTS)
+            ),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.2.5-rc1.php
+++ b/core/Updates/1.2.5-rc1.php
@@ -12,25 +12,36 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_2_5_rc1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('goal') . '`
-		    	ADD `allow_multiple` tinyint(4) NOT NULL AFTER case_sensitive' => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-				ADD buster int unsigned NOT NULL AFTER revenue,
-				DROP PRIMARY KEY,
-		    	ADD PRIMARY KEY (idvisit, idgoal, buster)' => 1060,
+            $this->migration->db->addColumn('goal', 'allow_multiple', 'TINYINT(4) NOT NULL', 'case_sensitive'),
+            $this->migration->db->sql(
+                'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
+                    ADD buster int unsigned NOT NULL AFTER revenue,
+                    DROP PRIMARY KEY,
+                    ADD PRIMARY KEY (idvisit, idgoal, buster)', Updater\Migration\Db::ERROR_CODE_DUPLICATE_COLUMN),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.2.5-rc7.php
+++ b/core/Updates/1.2.5-rc7.php
@@ -9,24 +9,33 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_2_5_rc7 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-		    	ADD INDEX index_idsite_idvisitor (idsite, idvisitor)' => 1061,
+            $this->migration->db->addIndex('log_visit', array('idsite', 'idvisitor')),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.4-rc1.php
+++ b/core/Updates/1.4-rc1.php
@@ -12,25 +12,34 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_4_rc1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'UPDATE `' . Common::prefixTable('pdf') . '`
-		    	SET format = "pdf"'              => '42S22',
-            'ALTER TABLE `' . Common::prefixTable('pdf') . '`
-		    	ADD COLUMN `format` VARCHAR(10)' => '42S22',
+            $this->migration->db->sql('UPDATE `' . Common::prefixTable('pdf') . '` SET format = "pdf"', '42S22'),
+            $this->migration->db->addColumn('pdf', 'format', 'VARCHAR(10)')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
         try {
-            $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+            $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
         } catch (\Exception $e) {
         }
     }

--- a/core/Updates/1.4-rc2.php
+++ b/core/Updates/1.4-rc2.php
@@ -12,33 +12,44 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_4_rc2 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $errorCodeDbNotExists = Updater\Migration\Db::ERROR_CODE_TABLE_NOT_EXISTS;
+
         return array(
-            "SET sql_mode=''"                                                            => false,
+            $this->migration->db->sql("SET sql_mode=''"),
             // this converts the 32-bit UNSIGNED INT column to a 16 byte VARBINARY;
             // _but_ MySQL does string conversion! (e.g., integer 1 is converted to 49 -- the ASCII code for "1")
-            'ALTER TABLE ' . Common::prefixTable('log_visit') . '
-				MODIFY location_ip VARBINARY(16) NOT NULL'                               => false,
-            'ALTER TABLE ' . Common::prefixTable('logger_api_call') . '
-				MODIFY caller_ip VARBINARY(16) NOT NULL'                                 => 1146,
+            $this->migration->db->sql('ALTER TABLE ' . Common::prefixTable('log_visit') . ' MODIFY location_ip VARBINARY(16) NOT NULL'),
+            $this->migration->db->sql('ALTER TABLE ' . Common::prefixTable('logger_api_call') . ' MODIFY caller_ip VARBINARY(16) NOT NULL', $errorCodeDbNotExists),
 
             // fortunately, 2^32 is 10 digits long and fits in the VARBINARY(16) without truncation;
             // to fix this, we cast to an integer, convert to hex, pad out leading zeros, and unhex it
-            'UPDATE ' . Common::prefixTable('log_visit') . "
-				SET location_ip = UNHEX(LPAD(HEX(CONVERT(location_ip, UNSIGNED)), 8, '0'))"   => false,
-            'UPDATE ' . Common::prefixTable('logger_api_call') . "
-				SET caller_ip = UNHEX(LPAD(HEX(CONVERT(caller_ip, UNSIGNED)), 8, '0'))" => 1146,
+            $this->migration->db->sql('UPDATE ' . Common::prefixTable('log_visit') . "
+                SET location_ip = UNHEX(LPAD(HEX(CONVERT(location_ip, UNSIGNED)), 8, '0'))"),
+            $this->migration->db->sql('UPDATE ' . Common::prefixTable('logger_api_call') . "
+                SET caller_ip = UNHEX(LPAD(HEX(CONVERT(caller_ip, UNSIGNED)), 8, '0'))", $errorCodeDbNotExists),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.5-b2.php
+++ b/core/Updates/1.5-b2.php
@@ -9,33 +9,48 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_5_b2 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $customVarType = 'VARCHAR(100) DEFAULT NULL';
+
+        $customVarColumns = array(
+            'custom_var_k1' => $customVarType,
+            'custom_var_v1' => $customVarType,
+            'custom_var_k2' => $customVarType,
+            'custom_var_v2' => $customVarType,
+            'custom_var_k3' => $customVarType,
+            'custom_var_v3' => $customVarType,
+            'custom_var_k4' => $customVarType,
+            'custom_var_v4' => $customVarType,
+            'custom_var_k5' => $customVarType,
+            'custom_var_v5' => $customVarType,
+        );
+
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_link_visit_action') . '`
-				 ADD  custom_var_k1 VARCHAR(100) DEFAULT NULL AFTER time_spent_ref_action,
-				 ADD  custom_var_v1 VARCHAR(100) DEFAULT NULL,
-				 ADD  custom_var_k2 VARCHAR(100) DEFAULT NULL,
-				 ADD  custom_var_v2 VARCHAR(100) DEFAULT NULL,
-				 ADD  custom_var_k3 VARCHAR(100) DEFAULT NULL,
-				 ADD  custom_var_v3 VARCHAR(100) DEFAULT NULL,
-				 ADD  custom_var_k4 VARCHAR(100) DEFAULT NULL,
-				 ADD  custom_var_v4 VARCHAR(100) DEFAULT NULL,
-				 ADD  custom_var_k5 VARCHAR(100) DEFAULT NULL,
-				 ADD  custom_var_v5 VARCHAR(100) DEFAULT NULL' => 1060,
+            $this->migration->db->addColumns('log_link_visit_action', $customVarColumns, 'time_spent_ref_action')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.5-b3.php
+++ b/core/Updates/1.5-b3.php
@@ -9,55 +9,50 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_5_b3 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $customVarType = 'VARCHAR(100) DEFAULT NULL';
+
+        $customVarColumns = array(
+            'custom_var_k1' => $customVarType,
+            'custom_var_v1' => $customVarType,
+            'custom_var_k2' => $customVarType,
+            'custom_var_v2' => $customVarType,
+            'custom_var_k3' => $customVarType,
+            'custom_var_v3' => $customVarType,
+            'custom_var_k4' => $customVarType,
+            'custom_var_v4' => $customVarType,
+            'custom_var_k5' => $customVarType,
+            'custom_var_v5' => $customVarType,
+        );
+
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				 CHANGE custom_var_k1 custom_var_k1 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v1 custom_var_v1 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k2 custom_var_k2 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v2 custom_var_v2 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k3 custom_var_k3 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v3 custom_var_v3 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k4 custom_var_k4 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v4 custom_var_v4 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k5 custom_var_k5 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v5 custom_var_v5 VARCHAR(100) DEFAULT NULL'                                                                              => false,
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-				 CHANGE custom_var_k1 custom_var_k1 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v1 custom_var_v1 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k2 custom_var_k2 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v2 custom_var_v2 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k3 custom_var_k3 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v3 custom_var_v3 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k4 custom_var_k4 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v4 custom_var_v4 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k5 custom_var_k5 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v5 custom_var_v5 VARCHAR(100) DEFAULT NULL'        => false,
-            'ALTER TABLE `' . Common::prefixTable('log_link_visit_action') . '`
-				 CHANGE custom_var_k1 custom_var_k1 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v1 custom_var_v1 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k2 custom_var_k2 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v2 custom_var_v2 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k3 custom_var_k3 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v3 custom_var_v3 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k4 custom_var_k4 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v4 custom_var_v4 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_k5 custom_var_k5 VARCHAR(100) DEFAULT NULL,
-				 CHANGE custom_var_v5 custom_var_v5 VARCHAR(100) DEFAULT NULL' => false,
+            $this->migration->db->changeColumnTypes('log_visit', $customVarColumns),
+            $this->migration->db->changeColumnTypes('log_conversion', $customVarColumns),
+            $this->migration->db->changeColumnTypes('log_link_visit_action', $customVarColumns),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.5-b4.php
+++ b/core/Updates/1.5-b4.php
@@ -9,24 +9,33 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_5_b4 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('site') . '`
-				 ADD ecommerce TINYINT DEFAULT 0' => 1060,
+            $this->migration->db->addColumn('site', 'ecommerce', 'TINYINT DEFAULT 0')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.5-b5.php
+++ b/core/Updates/1.5-b5.php
@@ -9,29 +9,38 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_5_b5 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'CREATE TABLE `' . Common::prefixTable('session') . '` (
-								id CHAR(32) NOT NULL,
-								modified INTEGER,
-								lifetime INTEGER,
-								data TEXT,
-								PRIMARY KEY ( id )
-								)  DEFAULT CHARSET=utf8' => 1050,
+            $this->migration->db->createTable('session', array(
+                'id' => 'CHAR(32) NOT NULL',
+                'modified' => 'INTEGER',
+                'lifetime' => 'INTEGER',
+                'data' => 'TEXT',
+            ), $primary = 'id')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.6-b1.php
+++ b/core/Updates/1.6-b1.php
@@ -9,60 +9,57 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_6_b1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $idActionType = 'INTEGER(10) UNSIGNED NOT NULL';
+        $customVarType = 'VARCHAR(200) DEFAULT NULL';
+
+        $customVarColumns = array(
+            'custom_var_k1' => $customVarType,
+            'custom_var_v1' => $customVarType,
+            'custom_var_k2' => $customVarType,
+            'custom_var_v2' => $customVarType,
+            'custom_var_k3' => $customVarType,
+            'custom_var_v3' => $customVarType,
+            'custom_var_k4' => $customVarType,
+            'custom_var_v4' => $customVarType,
+            'custom_var_k5' => $customVarType,
+            'custom_var_v5' => $customVarType,
+        );
+
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_conversion_item') . '`
-				 ADD idaction_category2 INTEGER(10) UNSIGNED NOT NULL AFTER idaction_category,
-				 ADD idaction_category3 INTEGER(10) UNSIGNED NOT NULL,
-				 ADD idaction_category4 INTEGER(10) UNSIGNED NOT NULL,
-				 ADD idaction_category5 INTEGER(10) UNSIGNED NOT NULL'         => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				 CHANGE custom_var_k1 custom_var_k1 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v1 custom_var_v1 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k2 custom_var_k2 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v2 custom_var_v2 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k3 custom_var_k3 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v3 custom_var_v3 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k4 custom_var_k4 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v4 custom_var_v4 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k5 custom_var_k5 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v5 custom_var_v5 VARCHAR(200) DEFAULT NULL' => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_conversion') . '`
-				 CHANGE custom_var_k1 custom_var_k1 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v1 custom_var_v1 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k2 custom_var_k2 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v2 custom_var_v2 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k3 custom_var_k3 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v3 custom_var_v3 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k4 custom_var_k4 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v4 custom_var_v4 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k5 custom_var_k5 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v5 custom_var_v5 VARCHAR(200) DEFAULT NULL' => 1060,
-            'ALTER TABLE `' . Common::prefixTable('log_link_visit_action') . '`
-				 CHANGE custom_var_k1 custom_var_k1 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v1 custom_var_v1 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k2 custom_var_k2 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v2 custom_var_v2 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k3 custom_var_k3 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v3 custom_var_v3 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k4 custom_var_k4 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v4 custom_var_v4 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_k5 custom_var_k5 VARCHAR(200) DEFAULT NULL,
-				 CHANGE custom_var_v5 custom_var_v5 VARCHAR(200) DEFAULT NULL' => 1060,
+            $this->migration->db->addColumns('log_conversion_item', array(
+                'idaction_category2' => $idActionType,
+                'idaction_category3' => $idActionType,
+                'idaction_category4' => $idActionType,
+                'idaction_category5' => $idActionType,
+            ), 'idaction_category'),
+            $this->migration->db->changeColumnTypes('log_visit', $customVarColumns),
+            $this->migration->db->changeColumnTypes('log_conversion', $customVarColumns),
+            $this->migration->db->changeColumnTypes('log_link_visit_action', $customVarColumns),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.7-b1.php
+++ b/core/Updates/1.7-b1.php
@@ -12,25 +12,34 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_7_b1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('pdf') . '`
-		    	ADD COLUMN `aggregate_reports_format` TINYINT(1) NOT NULL AFTER `reports`'                => 1060,
-            'UPDATE `' . Common::prefixTable('pdf') . '`
-		    	SET `aggregate_reports_format` = 1' => false,
+            $this->migration->db->addColumn('pdf', 'aggregate_reports_format', 'TINYINT(1) NOT NULL', 'reports'),
+            $this->migration->db->sql('UPDATE `' . Common::prefixTable('pdf') . '` SET `aggregate_reports_format` = 1')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
         try {
-            $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+            $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
         } catch (\Exception $e) {
         }
     }

--- a/core/Updates/1.7.2-rc5.php
+++ b/core/Updates/1.7.2-rc5.php
@@ -9,26 +9,35 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_7_2_rc5 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('pdf') . '`
-		    	CHANGE `aggregate_reports_format` `display_format` TINYINT(1) NOT NULL' => false
+            $this->migration->db->changeColumn('pdf', 'aggregate_reports_format', 'display_format', 'TINYINT(1) NOT NULL')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
         try {
-            $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+            $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
         } catch (\Exception $e) {
         }
     }

--- a/core/Updates/1.7.2-rc7.php
+++ b/core/Updates/1.7.2-rc7.php
@@ -13,32 +13,51 @@ use Piwik\Common;
 use Piwik\Db;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_7_2_rc7 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('user_dashboard') . '`
-		        ADD `name` VARCHAR( 100 ) NULL DEFAULT NULL AFTER  `iddashboard`' => 1060,
+            $this->migration->db->addColumn('user_dashboard', 'name', 'VARCHAR( 100 ) NULL DEFAULT NULL', 'iddashboard')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
         try {
-            $dashboards = Db::fetchAll('SELECT * FROM `' . Common::prefixTable('user_dashboard') . '`');
+            $migrations = array();
+
+            $table = Common::prefixTable('user_dashboard');
+            $dashboards = Db::fetchAll('SELECT iddashboard, login, layout FROM `' . $table . '`');
+
+            $updateQuery = 'UPDATE `' . $table . '` SET layout = ? WHERE iddashboard = ? AND login = ?';
+
             foreach ($dashboards as $dashboard) {
                 $idDashboard = $dashboard['iddashboard'];
                 $login = $dashboard['login'];
                 $layout = $dashboard['layout'];
                 $layout = html_entity_decode($layout);
                 $layout = str_replace("\\\"", "\"", $layout);
-                Db::query('UPDATE `' . Common::prefixTable('user_dashboard') . '` SET layout = ? WHERE iddashboard = ? AND login = ?', array($layout, $idDashboard, $login));
+
+                $migrations[] = $this->migration->db->boundSql($updateQuery, array($layout, $idDashboard, $login));
             }
-            $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+
+            $updater->executeMigrations(__FILE__, $migrations);
+            $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
         } catch (\Exception $e) {
         }
     }

--- a/core/Updates/1.8.3-b1.php
+++ b/core/Updates/1.8.3-b1.php
@@ -14,39 +14,48 @@ use Piwik\Db;
 use Piwik\Plugins\ScheduledReports\ScheduledReports;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_8_3_b1 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
 
-    public function getMigrationQueries(Updater $updater)
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('site') . '`
-				CHANGE `excluded_parameters` `excluded_parameters` TEXT NOT NULL'                      => false,
+            $this->migration->db->changeColumnType('site', 'excluded_parameters', 'TEXT NOT NULL'),
 
-            'CREATE TABLE `' . Common::prefixTable('report') . '` (
-					`idreport` INT(11) NOT NULL AUTO_INCREMENT,
-					`idsite` INTEGER(11) NOT NULL,
-					`login` VARCHAR(100) NOT NULL,
-					`description` VARCHAR(255) NOT NULL,
-					`period` VARCHAR(10) NOT NULL,
-					`type` VARCHAR(10) NOT NULL,
-					`format` VARCHAR(10) NOT NULL,
-					`reports` TEXT NOT NULL,
-					`parameters` TEXT NULL,
-					`ts_created` TIMESTAMP NULL,
-					`ts_last_sent` TIMESTAMP NULL,
-					`deleted` tinyint(4) NOT NULL default 0,
-					PRIMARY KEY (`idreport`)
-				) DEFAULT CHARSET=utf8' => 1050,
+            $this->migration->db->createTable('report', array(
+                'idreport' => 'INT(11) NOT NULL AUTO_INCREMENT',
+                'idsite' => 'INTEGER(11) NOT NULL',
+                'login' => 'VARCHAR(100) NOT NULL',
+                'description' => 'VARCHAR(255) NOT NULL',
+                'period' => 'VARCHAR(10) NOT NULL',
+                'type' => 'VARCHAR(10) NOT NULL',
+                'format' => 'VARCHAR(10) NOT NULL',
+                'reports' => 'TEXT NOT NULL',
+                'parameters' => 'TEXT NULL',
+                'ts_created' => 'TIMESTAMP NULL',
+                'ts_last_sent' => 'TIMESTAMP NULL',
+                'deleted' => 'tinyint(4) NOT NULL default 0',
+            ), $primaryKey = 'idreport'),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
         if (!\Piwik\Plugin\Manager::getInstance()->isPluginLoaded('ScheduledReports')) {
             return;
         }
@@ -86,9 +95,9 @@ class Updates_1_8_3_b1 extends Updates
 
                 Db::query(
                     'INSERT INTO `' . Common::prefixTable('report') . '` SET
-					idreport = ?, idsite = ?, login = ?, description = ?, period = ?,
-					type = ?, format = ?, reports = ?, parameters = ?, ts_created = ?,
-					ts_last_sent = ?, deleted = ?',
+                    idreport = ?, idsite = ?, login = ?, description = ?, period = ?,
+                    type = ?, format = ?, reports = ?, parameters = ?, ts_created = ?,
+                    ts_last_sent = ?, deleted = ?',
                     array(
                          $idreport,
                          $idsite,
@@ -106,7 +115,8 @@ class Updates_1_8_3_b1 extends Updates
                 );
             }
 
-            Db::query('DROP TABLE `' . Common::prefixTable('pdf') . '`');
+            $updater->executeMigration(__FILE__, $this->migration->db->dropTable('pdf'));
+
         } catch (\Exception $e) {
         }
     }

--- a/core/Updates/1.8.4-b1.php
+++ b/core/Updates/1.8.4-b1.php
@@ -12,18 +12,28 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_8_4_b1 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
 
     public static function isMajorUpdate()
     {
         return true;
     }
 
-    public function getMigrationQueries(Updater $updater)
+    public function getMigrations(Updater $updater)
     {
         $action = Common::prefixTable('log_action');
         $duplicates = Common::prefixTable('log_action_duplicates');
@@ -33,146 +43,146 @@ class Updates_1_8_4_b1 extends Updates
 
         return array(
 
-            // add url_prefix column
-            "   ALTER TABLE `$action`
-		    	ADD `url_prefix` TINYINT(2) NULL AFTER `type`;
-		    "                                                                                                     => 1060, // ignore error 1060 Duplicate column name 'url_prefix'
+            $this->migration->db->addColumn('log_action', 'url_prefix', 'TINYINT(2) NULL', 'type'),
 
             // remove protocol and www and store information in url_prefix
+            $this->migration->db->sql(
             "   UPDATE `$action`
-				SET
-				  url_prefix = IF (
-					LEFT(name, 11) = 'http://www.', 1, IF (
-					  LEFT(name, 7) = 'http://', 0, IF (
-						LEFT(name, 12) = 'https://www.', 3, IF (
-						  LEFT(name, 8) = 'https://', 2, NULL
-						)
-					  )
-					)
-				  ),
-				  name = IF (
-					url_prefix = 0, SUBSTRING(name, 8), IF (
-					  url_prefix = 1, SUBSTRING(name, 12), IF (
-						url_prefix = 2, SUBSTRING(name, 9), IF (
-						  url_prefix = 3, SUBSTRING(name, 13), name
-						)
-					  )
-					)
-				  ),
-				  hash = CRC32(name)
-				WHERE
-				  type = 1 AND
-				  url_prefix IS NULL;
-			"                                                                      => false,
-
-            // find duplicates
-            "   DROP TABLE IF EXISTS `$duplicates`;
-			"                                                    => false,
-            "   CREATE TABLE `$duplicates` (
-				 `before` int(10) unsigned NOT NULL,
-				 `after` int(10) unsigned NOT NULL,
-				 KEY `mainkey` (`before`)
-				) ENGINE=InnoDB;
-			"                                                            => false,
+                SET
+                  url_prefix = IF (
+                    LEFT(name, 11) = 'http://www.', 1, IF (
+                      LEFT(name, 7) = 'http://', 0, IF (
+                        LEFT(name, 12) = 'https://www.', 3, IF (
+                          LEFT(name, 8) = 'https://', 2, NULL
+                        )
+                      )
+                    )
+                  ),
+                  name = IF (
+                    url_prefix = 0, SUBSTRING(name, 8), IF (
+                      url_prefix = 1, SUBSTRING(name, 12), IF (
+                        url_prefix = 2, SUBSTRING(name, 9), IF (
+                          url_prefix = 3, SUBSTRING(name, 13), name
+                        )
+                      )
+                    )
+                  ),
+                  hash = CRC32(name)
+                WHERE
+                  type = 1 AND
+                  url_prefix IS NULL;
+            "),
+            $this->migration->db->dropTable('log_action_duplicates'),
+            $this->migration->db->createTable('log_action_duplicates', array(
+                'before' => 'int(10) unsigned NOT NULL',
+                'after' => 'int(10) unsigned NOT NULL',
+            )),
+            $this->migration->db->sql("ALTER TABLE $duplicates ADD KEY `mainkey` (`before`)"),
 
             // grouping by name only would be case-insensitive, so we GROUP BY name,hash
             // ON (action.type = 1 AND canonical.hash = action.hash) will use index (type, hash)
+            $this->migration->db->sql(
             "   INSERT INTO `$duplicates` (
-				  SELECT
-					action.idaction AS `before`,
-					canonical.idaction AS `after`
-				  FROM
-					(
-					  SELECT
-						name,
-						hash,
-						MIN(idaction) AS idaction
-					  FROM
-						`$action` AS action_canonical_base
-					  WHERE
-						type = 1 AND
-						url_prefix IS NOT NULL
-					  GROUP BY name, hash
-					  HAVING COUNT(idaction) > 1
-					)
-					AS canonical
-				  LEFT JOIN
-					`$action` AS action
-					ON (action.type = 1 AND canonical.hash = action.hash)
-					AND canonical.name = action.name
-					AND canonical.idaction != action.idaction
-				);
-			" => false,
+                  SELECT
+                    action.idaction AS `before`,
+                    canonical.idaction AS `after`
+                  FROM
+                    (
+                      SELECT
+                        name,
+                        hash,
+                        MIN(idaction) AS idaction
+                      FROM
+                        `$action` AS action_canonical_base
+                      WHERE
+                        type = 1 AND
+                        url_prefix IS NOT NULL
+                      GROUP BY name, hash
+                      HAVING COUNT(idaction) > 1
+                    )
+                    AS canonical
+                  LEFT JOIN
+                    `$action` AS action
+                    ON (action.type = 1 AND canonical.hash = action.hash)
+                    AND canonical.name = action.name
+                    AND canonical.idaction != action.idaction
+                );
+            "),
 
             // replace idaction in log_link_visit_action
+            $this->migration->db->sql(
             "   UPDATE
-				  `$visitAction` AS link
-				LEFT JOIN
-				  `$duplicates` AS duplicates_idaction_url
-				  ON link.idaction_url = duplicates_idaction_url.before
-				SET
-				  link.idaction_url = duplicates_idaction_url.after
-				WHERE
-				  duplicates_idaction_url.after IS NOT NULL;
-			"                           => false,
+                  `$visitAction` AS link
+                LEFT JOIN
+                  `$duplicates` AS duplicates_idaction_url
+                  ON link.idaction_url = duplicates_idaction_url.before
+                SET
+                  link.idaction_url = duplicates_idaction_url.after
+                WHERE
+                  duplicates_idaction_url.after IS NOT NULL;
+            "),
+            $this->migration->db->sql(
             "   UPDATE
-				  `$visitAction` AS link
-				LEFT JOIN
-				  `$duplicates` AS duplicates_idaction_url_ref
-				  ON link.idaction_url_ref = duplicates_idaction_url_ref.before
-				SET
-				  link.idaction_url_ref = duplicates_idaction_url_ref.after
-				WHERE
-				  duplicates_idaction_url_ref.after IS NOT NULL;
-			"                           => false,
+                  `$visitAction` AS link
+                LEFT JOIN
+                  `$duplicates` AS duplicates_idaction_url_ref
+                  ON link.idaction_url_ref = duplicates_idaction_url_ref.before
+                SET
+                  link.idaction_url_ref = duplicates_idaction_url_ref.after
+                WHERE
+                  duplicates_idaction_url_ref.after IS NOT NULL;
+            "),
 
             // replace idaction in log_conversion
+            $this->migration->db->sql(
             "   UPDATE
-				  `$conversion` AS conversion
-				LEFT JOIN
-				  `$duplicates` AS duplicates
-				  ON conversion.idaction_url = duplicates.before
-				SET
-				  conversion.idaction_url = duplicates.after
-				WHERE
-				  duplicates.after IS NOT NULL;
-			"                            => false,
+                  `$conversion` AS conversion
+                LEFT JOIN
+                  `$duplicates` AS duplicates
+                  ON conversion.idaction_url = duplicates.before
+                SET
+                  conversion.idaction_url = duplicates.after
+                WHERE
+                  duplicates.after IS NOT NULL;
+            "),
 
             // replace idaction in log_visit
+            $this->migration->db->sql(
             "   UPDATE
-				  `$visit` AS visit
-				LEFT JOIN
-				  `$duplicates` AS duplicates_entry
-				  ON visit.visit_entry_idaction_url = duplicates_entry.before
-				SET
-				  visit.visit_entry_idaction_url = duplicates_entry.after
-				WHERE
-				  duplicates_entry.after IS NOT NULL;
-			"                                 => false,
+                  `$visit` AS visit
+                LEFT JOIN
+                  `$duplicates` AS duplicates_entry
+                  ON visit.visit_entry_idaction_url = duplicates_entry.before
+                SET
+                  visit.visit_entry_idaction_url = duplicates_entry.after
+                WHERE
+                  duplicates_entry.after IS NOT NULL;
+            "),
+            $this->migration->db->sql(
             "   UPDATE
-				  `$visit` AS visit
-				LEFT JOIN
-				  `$duplicates` AS duplicates_exit
-				  ON visit.visit_exit_idaction_url = duplicates_exit.before
-				SET
-				  visit.visit_exit_idaction_url = duplicates_exit.after
-				WHERE
-				  duplicates_exit.after IS NOT NULL;
-			"                                 => false,
+                  `$visit` AS visit
+                LEFT JOIN
+                  `$duplicates` AS duplicates_exit
+                  ON visit.visit_exit_idaction_url = duplicates_exit.before
+                SET
+                  visit.visit_exit_idaction_url = duplicates_exit.after
+                WHERE
+                  duplicates_exit.after IS NOT NULL;
+            "),
 
             // remove duplicates from log_action
+            $this->migration->db->sql(
             "   DELETE action FROM
-				  `$action` AS action
-				LEFT JOIN
-				  `$duplicates` AS duplicates
-				  ON action.idaction = duplicates.before
-				WHERE
-				  duplicates.after IS NOT NULL;
-			"                                => false,
+                  `$action` AS action
+                LEFT JOIN
+                  `$duplicates` AS duplicates
+                  ON action.idaction = duplicates.before
+                WHERE
+                  duplicates.after IS NOT NULL;
+            "),
 
             // remove the duplicates table
-            "   DROP TABLE `$duplicates`;
-			"                                                              => false
+            $this->migration->db->dropTable('log_action_duplicates')
         );
     }
 
@@ -180,7 +190,7 @@ class Updates_1_8_4_b1 extends Updates
     {
         try {
             self::enableMaintenanceMode();
-            $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+            $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
             self::disableMaintenanceMode();
         } catch (\Exception $e) {
             self::disableMaintenanceMode();

--- a/core/Updates/1.9-b16.php
+++ b/core/Updates/1.9-b16.php
@@ -12,41 +12,45 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_9_b16 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
     public static function isMajorUpdate()
     {
         return true;
     }
 
-    public function getMigrationQueries(Updater $updater)
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE  `' . Common::prefixTable('log_link_visit_action') . '`
-			CHANGE `idaction_url` `idaction_url` INT( 10 ) UNSIGNED NULL DEFAULT NULL'
-            => false,
-
-            'ALTER TABLE  `' . Common::prefixTable('log_visit') . '`
-			ADD visit_total_searches SMALLINT(5) UNSIGNED NOT NULL AFTER `visit_total_actions`'
-            => 1060,
-
-            'ALTER TABLE  `' . Common::prefixTable('site') . '`
-			ADD sitesearch TINYINT DEFAULT 1 AFTER `excluded_parameters`,
-            ADD sitesearch_keyword_parameters TEXT NOT NULL AFTER `sitesearch`,
-            ADD sitesearch_category_parameters TEXT NOT NULL AFTER `sitesearch_keyword_parameters`'
-                                                                                             => 1060,
+            $this->migration->db->changeColumnType('log_link_visit_action', 'idaction_url', 'INT( 10 ) UNSIGNED NULL DEFAULT NULL'),
+            $this->migration->db->addColumn('log_visit', 'visit_total_searches', 'SMALLINT(5) UNSIGNED NOT NULL', 'visit_total_actions'),
+            $this->migration->db->addColumns('site', array(
+                'sitesearch' => 'TINYINT DEFAULT 1',
+                'sitesearch_keyword_parameters' => 'TEXT NOT NULL',
+                'sitesearch_category_parameters' => 'TEXT NOT NULL',
+            ), 'excluded_parameters'),
 
             // enable Site Search for all websites, users can manually disable the setting
-            'UPDATE `' . Common::prefixTable('site') . '`
-		    	SET `sitesearch` = 1' => false,
+            $this->migration->db->sql('UPDATE `' . Common::prefixTable('site') . '` SET `sitesearch` = 1')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.9-b19.php
+++ b/core/Updates/1.9-b19.php
@@ -9,33 +9,35 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_9_b19 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE  `' . Common::prefixTable('log_link_visit_action') . '`
-			CHANGE `idaction_url_ref` `idaction_url_ref` INT( 10 ) UNSIGNED NULL DEFAULT 0'
-            => false,
-            'ALTER TABLE  `' . Common::prefixTable('log_visit') . '`
-			CHANGE `visit_exit_idaction_url` `visit_exit_idaction_url` INT( 10 ) UNSIGNED NULL DEFAULT 0'
-            => false
+            $this->migration->db->changeColumnType('log_link_visit_action', 'idaction_url_ref', 'INT( 10 ) UNSIGNED NULL DEFAULT 0'),
+            $this->migration->db->changeColumnType('log_visit', 'visit_exit_idaction_url', 'INT( 10 ) UNSIGNED NULL DEFAULT 0'),
+            $this->migration->plugin->activate('Transitions'),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
-
-        try {
-            \Piwik\Plugin\Manager::getInstance()->activatePlugin('Transitions');
-        } catch (\Exception $e) {
-        }
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/1.9.1-b2.php
+++ b/core/Updates/1.9.1-b2.php
@@ -9,25 +9,35 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_9_1_b2 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE ' . Common::prefixTable('site') . " DROP `feedburnerName`" => 1091
+            $this->migration->db->dropColumn('site', 'feedburnerName')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
         // manually remove ExampleFeedburner column
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
 
         // remove ExampleFeedburner plugin
         $pluginToDelete = 'ExampleFeedburner';

--- a/core/Updates/1.9.3-b8.php
+++ b/core/Updates/1.9.3-b8.php
@@ -9,26 +9,34 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_1_9_3_b8 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            // ignore existing column name error (1060)
-            'ALTER TABLE ' . Common::prefixTable('site')
-            . " ADD COLUMN excluded_user_agents TEXT NOT NULL AFTER excluded_parameters" => 1060,
+            $this->migration->db->addColumn('site', 'excluded_user_agents', 'TEXT NOT NULL', 'excluded_parameters')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
         // add excluded_user_agents column to site table
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.0-a12.php
+++ b/core/Updates/2.0-a12.php
@@ -12,15 +12,26 @@ use Piwik\Common;
 use Piwik\Db;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_2_0_a12 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         $result = array(
-            'ALTER TABLE ' . Common::prefixTable('logger_message') . ' MODIFY level VARCHAR(16) NULL' => false
+            $this->migration->db->sql('ALTER TABLE ' . Common::prefixTable('logger_message') . ' MODIFY level VARCHAR(16) NULL')
         );
 
         $unneededLogTables = array('logger_exception', 'logger_error', 'logger_api_call');
@@ -30,7 +41,7 @@ class Updates_2_0_a12 extends Updates
             try {
                 $rows = Db::fetchOne("SELECT COUNT(*) FROM $tableName");
                 if ($rows == 0) {
-                    $result["DROP TABLE $tableName"] = false;
+                    $result[] = $this->migration->db->dropTable($table);
                 }
             } catch (\Exception $ex) {
                 // ignore
@@ -43,6 +54,6 @@ class Updates_2_0_a12 extends Updates
     public function doUpdate(Updater $updater)
     {
         // change level column in logger_message table to string & remove other logging tables if empty
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.0-a13.php
+++ b/core/Updates/2.0-a13.php
@@ -12,35 +12,52 @@ use Piwik\Common;
 use Piwik\Option;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_2_0_a13 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         // Renaming old archived records now that the plugin is called Referrers
-        $sql = array();
+        $migrations = array();
         $tables = \Piwik\DbHelper::getTablesInstalled();
         foreach ($tables as $tableName) {
             if (strpos($tableName, 'archive_') !== false) {
-                $sql['UPDATE `' . $tableName . '` SET `name`=REPLACE(`name`, \'Referers_\', \'Referrers_\') WHERE `name` LIKE \'Referers_%\''] = false;
+                $migrations[] = $this->migration->db->sql('UPDATE `' . $tableName . '` SET `name`=REPLACE(`name`, \'Referers_\', \'Referrers_\') WHERE `name` LIKE \'Referers_%\'');
             }
         }
         $errorCodeTableNotFound = '1146';
 
         // Rename custom segments containing Referers segments
-        $sql['UPDATE `' . Common::prefixTable('segment') . '` SET `definition`=REPLACE(`definition`, \'referer\', \'referrer\') WHERE `definition` LIKE \'%referer%\''] = $errorCodeTableNotFound;
+        $migrations[] = $this->migration->db->sql('UPDATE `' . Common::prefixTable('segment') . '` SET `definition`=REPLACE(`definition`, \'referer\', \'referrer\') WHERE `definition` LIKE \'%referer%\'', $errorCodeTableNotFound);
 
         // Rename Referrers reports within scheduled reports
-        $sql['UPDATE `' . Common::prefixTable('report') . '` SET `reports`=REPLACE(`reports`, \'Referer\', \'Referrer\') WHERE `reports` LIKE \'%Referer%\''] = $errorCodeTableNotFound;
+        $query = 'UPDATE `' . Common::prefixTable('report') . '` SET `reports`=REPLACE(`reports`, \'Referer\', \'Referrer\') WHERE `reports` LIKE \'%Referer%\'';
+        $migrations[] = $this->migration->db->sql($query, $errorCodeTableNotFound);
 
         // Rename Referrers widgets in custom dashboards
-        $sql['UPDATE `' . Common::prefixTable('user_dashboard') . '` SET `layout`=REPLACE(`layout`, \'Referer\', \'Referrer\') WHERE `layout` LIKE \'%Referer%\''] = $errorCodeTableNotFound;
+        $query = 'UPDATE `' . Common::prefixTable('user_dashboard') . '` SET `layout`=REPLACE(`layout`, \'Referer\', \'Referrer\') WHERE `layout` LIKE \'%Referer%\'';
+        $migrations[] = $this->migration->db->sql($query, $errorCodeTableNotFound);
 
-        $sql['UPDATE `' . Common::prefixTable('option') . '` SET `option_name` = \'version_ScheduledReports\' WHERE `option_name` = \'version_PDFReports\' '] = '1062'; // http://forum.piwik.org/read.php?2,106895
+        $query = 'UPDATE `' . Common::prefixTable('option') . '` SET `option_name` = \'version_ScheduledReports\' WHERE `option_name` = \'version_PDFReports\' ';
+        $migrations[] = $this->migration->db->sql($query, Updater\Migration\Db::ERROR_CODE_DUPLICATE_ENTRY); // http://forum.piwik.org/read.php?2,106895
 
-        return $sql;
+        $migrations[] = $this->migration->plugin->activate('Referrers');
+        $migrations[] = $this->migration->plugin->activate('ScheduledReports');
+
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
@@ -48,17 +65,9 @@ class Updates_2_0_a13 extends Updates
         // delete schema version_
         Option::delete('version_Referers');
 
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
 
         // old plugins deleted in 2.0-a17 update file
 
-        try {
-            \Piwik\Plugin\Manager::getInstance()->activatePlugin('Referrers');
-        } catch (\Exception $e) {
-        }
-        try {
-            \Piwik\Plugin\Manager::getInstance()->activatePlugin('ScheduledReports');
-        } catch (\Exception $e) {
-        }
     }
 }

--- a/core/Updates/2.0-a7.php
+++ b/core/Updates/2.0-a7.php
@@ -9,29 +9,35 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_2_0_a7 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            // ignore existing column name error (1060)
-            'ALTER TABLE ' . Common::prefixTable('logger_message')
-            . " ADD COLUMN tag VARCHAR(50) NULL AFTER idlogger_message" => 1060,
-
-            'ALTER TABLE ' . Common::prefixTable('logger_message')
-            . " ADD COLUMN level TINYINT AFTER timestamp"               => 1060,
+            $this->migration->db->addColumn('logger_message', 'tag', 'VARCHAR(50) NULL', 'idlogger_message'),
+            $this->migration->db->addColumn('logger_message', 'level', 'TINYINT', 'timestamp'),
         );
     }
 
     public function doUpdate(Updater $updater)
     {
         // add tag & level columns to logger_message table
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.0-b3.php
+++ b/core/Updates/2.0-b3.php
@@ -9,34 +9,43 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_2_0_b3 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
     public static function isMajorUpdate()
     {
         return true;
     }
 
-    public function getMigrationQueries(Updater $updater)
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE ' . Common::prefixTable('log_visit')
-            . " ADD COLUMN  visit_total_events SMALLINT(5) UNSIGNED NOT NULL AFTER visit_total_searches" => 1060,
-
-            'ALTER TABLE ' . Common::prefixTable('log_link_visit_action')
-            . " ADD COLUMN  idaction_event_category INTEGER(10) UNSIGNED AFTER idaction_name_ref,
-	            ADD COLUMN  idaction_event_action INTEGER(10) UNSIGNED AFTER idaction_event_category" => 1060,
+            $this->migration->db->addColumn('log_visit', 'visit_total_events', 'SMALLINT(5) UNSIGNED NOT NULL', 'visit_total_searches'),
+            $this->migration->db->addColumns('log_link_visit_action', array(
+                'idaction_event_category' => 'INTEGER(10) UNSIGNED',
+                'idaction_event_action' => 'INTEGER(10) UNSIGNED'
+            ), $placeAfter = 'idaction_name_ref')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
 
         try {
             \Piwik\Plugin\Manager::getInstance()->activatePlugin('Events');

--- a/core/Updates/2.0-b9.php
+++ b/core/Updates/2.0-b9.php
@@ -9,25 +9,36 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Site;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_2_0_b9 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $type = "VARCHAR(255) NOT NULL DEFAULT '" . Site::DEFAULT_SITE_TYPE . "'";
+
         return array(
-            "ALTER TABLE `" . Common::prefixTable('site')
-                . "` ADD `type` VARCHAR(255) NOT NULL DEFAULT '". Site::DEFAULT_SITE_TYPE ."' AFTER `group` " => 1060,
+            $this->migration->db->addColumn('site', 'type', $type, 'group')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.0.4-b5.php
+++ b/core/Updates/2.0.4-b5.php
@@ -17,23 +17,32 @@ use Piwik\Plugins\UsersManager\API as UsersManagerApi;
 use Piwik\Updater;
 use Piwik\UpdaterErrorException;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_2_0_4_b5 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            // ignore existing column name error (1060)
-            'ALTER TABLE ' . Common::prefixTable('user')
-            . " ADD COLUMN `superuser_access` tinyint(2) unsigned NOT NULL DEFAULT '0' AFTER token_auth" => 1060,
+            $this->migration->db->addColumn('user', 'superuser_access', "TINYINT(2) UNSIGNED NOT NULL DEFAULT '0'", 'token_auth')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
 
         try {
             self::migrateConfigSuperUserToDb();

--- a/core/Updates/2.0.4-b7.php
+++ b/core/Updates/2.0.4-b7.php
@@ -20,10 +20,6 @@ use Piwik\Updater;
  */
 class Updates_2_0_4_b7 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
-    {
-        return array();
-    }
 
     public function doUpdate(Updater $updater)
     {

--- a/core/Updates/2.0.4-b8.php
+++ b/core/Updates/2.0.4-b8.php
@@ -20,11 +20,6 @@ use Piwik\Updater;
  */
 class Updates_2_0_4_b8 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
-    {
-        return array();
-    }
-
     public function doUpdate(Updater $updater)
     {
         try {

--- a/core/Updates/2.1.1-b11.php
+++ b/core/Updates/2.1.1-b11.php
@@ -8,11 +8,12 @@
 namespace Piwik\Updates;
 
 use Piwik\ArchiveProcessor\Rules;
+use Piwik\Common;
 use Piwik\DataAccess\ArchiveWriter;
 use Piwik\Date;
-use Piwik\Db\BatchInsert;
 use Piwik\Db;
 use Piwik\Plugins\VisitFrequency\API as VisitFrequencyApi;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 use Piwik\Segment;
 use Piwik\Updater;
 use Piwik\Updates;
@@ -21,6 +22,16 @@ use Piwik\Updates;
  */
 class Updates_2_1_1_b11 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
     public function doUpdate(Updater $updater)
     {
         $returningMetrics = array(
@@ -89,15 +100,14 @@ class Updates_2_1_1_b11 extends Updates
                 }
 
                 // add missing archives
-                try {
-                    $params = array();
-                    foreach ($missingIdArchives as $missingIdArchive) {
-                        $params[] = array_values($missingIdArchive);
-                    }
-                    BatchInsert::tableInsertBatch($table, array_keys(reset($missingIdArchives)), $params, $throwException = false, $charset = 'latin1');
-                } catch (\Exception $ex) {
-                    Updater::handleQueryError($ex, "<batch insert>", false, __FILE__);
+                $params = array();
+                foreach ($missingIdArchives as $missingIdArchive) {
+                    $params[] = array_values($missingIdArchive);
                 }
+                $fields = array_keys(reset($missingIdArchives));
+                $tableUnprefixed = Common::unprefixTable($table);
+                $migration = $this->migration->db->batchInsert($tableUnprefixed, $fields, $params, $throwException = false, $charset = 'latin1');
+                $updater->executeMigration(__FILE__, $migration);
             }
 
             // update idarchive & name columns in rows with *._returning metrics
@@ -123,7 +133,7 @@ class Updates_2_1_1_b11 extends Updates
                 }
                 $updateSql .= sprintf($updateSqlSuffix, implode(',', $idArchives));
 
-                Updater::executeMigrationQuery($updateSql, false, __FILE__);
+                $updater->executeMigration(__FILE__, $this->migration->db->sql($updateSql));
             }
         }
     }

--- a/core/Updates/2.10.0-b10.php
+++ b/core/Updates/2.10.0-b10.php
@@ -12,13 +12,23 @@ namespace Piwik\Updates;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_10_0_b10 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
 
-    public function getMigrationQueries(Updater $updater)
+    public function __construct(MigrationFactory $factory)
     {
-        $sqls = array();
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = array();
 
         $archiveTables = ArchiveTableCreator::getTablesArchivesInstalled();
 
@@ -27,10 +37,10 @@ class Updates_2_10_0_b10 extends Updates
         });
 
         foreach ($archiveBlobTables as $table) {
-            $sqls["UPDATE " . $table . " SET name = 'DevicePlugins_plugin' WHERE name = 'UserSettings_plugin'"] = false;
+            $migrations[] = $this->migration->db->sql("UPDATE $table SET name = 'DevicePlugins_plugin' WHERE name = 'UserSettings_plugin'");
         }
 
-        return $sqls;
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
@@ -42,6 +52,6 @@ class Updates_2_10_0_b10 extends Updates
         } catch (\Exception $e) {
         }
 
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.10.0-b5.php
+++ b/core/Updates/2.10.0-b5.php
@@ -16,6 +16,7 @@ use Piwik\Db;
 use Piwik\Updater;
 use Piwik\Updates;
 use Piwik\Plugins\Dashboard\Model as DashboardModel;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  * This Update script will update all browser and os archives of UserSettings and DevicesDetection plugin
@@ -43,9 +44,19 @@ class Updates_2_10_0_b5 extends Updates
 {
     public static $archiveBlobTables;
 
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
-        $sqls = array('# ATTENTION: This update script will execute some more SQL queries than that below as it is necessary to rebuilt some archives #' => false);
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = array('# ATTENTION: This update script will execute some more SQL queries than that below as it is necessary to rebuilt some archives #' => false);
 
         // update scheduled reports to use new plugin
         $reportsToReplace = array(
@@ -58,8 +69,9 @@ class Updates_2_10_0_b5 extends Updates
             'UserSettings_getWideScreen' => 'UserSettings_getScreenType',
         );
 
+        $reportTable = Common::prefixTable('report');
         foreach ($reportsToReplace as $old => $new) {
-            $sqls["UPDATE " . Common::prefixTable('report') . " SET reports = REPLACE(reports, '".$old."', '".$new."')"] = false;
+            $migrations[] = $this->migration->db->sql("UPDATE $reportTable SET reports = REPLACE(reports, '".$old."', '".$new."')");
         }
 
         // update dashboard to use new widgets
@@ -85,6 +97,9 @@ class Updates_2_10_0_b5 extends Updates
 
         $allDashboards = Db::get()->fetchAll(sprintf("SELECT * FROM %s", Common::prefixTable('user_dashboard')));
 
+        $dashboardTable = Common::prefixTable('user_dashboard');
+        $dashboardQuery = "UPDATE $dashboardTable SET layout = ? WHERE iddashboard = ?";
+
         foreach ($allDashboards as $dashboard) {
             $dashboardLayout = json_decode($dashboard['layout']);
 
@@ -92,16 +107,16 @@ class Updates_2_10_0_b5 extends Updates
 
             $newLayout = json_encode($dashboardLayout);
             if ($newLayout != $dashboard['layout']) {
-                $sqls["UPDATE " . Common::prefixTable('user_dashboard') . " SET layout = '".addslashes($newLayout)."' WHERE iddashboard = ".$dashboard['iddashboard']] = false;
+                $migrations[] = $this->migration->db->boundSql($dashboardQuery, array($newLayout, $dashboard['iddashboard']));
             }
         }
 
-        return $sqls;
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
 
         // DeviceDetection upgrade in beta1 timed out on demo #6750
         $archiveBlobTables = self::getAllArchiveBlobTables();

--- a/core/Updates/2.10.0-b7.php
+++ b/core/Updates/2.10.0-b7.php
@@ -12,13 +12,23 @@ namespace Piwik\Updates;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_10_0_b7 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
 
-    public function getMigrationQueries(Updater $updater)
+    public function __construct(MigrationFactory $factory)
     {
-        $sqls = array();
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = array();
 
         $archiveTables = ArchiveTableCreator::getTablesArchivesInstalled();
 
@@ -27,15 +37,15 @@ class Updates_2_10_0_b7 extends Updates
         });
 
         foreach ($archiveBlobTables as $table) {
-            $sqls["UPDATE " . $table . " SET name = 'Resolution_resolution' WHERE name = 'UserSettings_resolution'"] = false;
-            $sqls["UPDATE " . $table . " SET name = 'Resolution_configuration' WHERE name = 'UserSettings_configuration'"] = false;
+            $migrations[] = $this->migration->db->sql("UPDATE $table SET name = 'Resolution_resolution' WHERE name = 'UserSettings_resolution'");
+            $migrations[] = $this->migration->db->sql("UPDATE $table SET name = 'Resolution_configuration' WHERE name = 'UserSettings_configuration'");
         }
 
-        return $sqls;
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.11.0-b4.php
+++ b/core/Updates/2.11.0-b4.php
@@ -12,13 +12,23 @@ namespace Piwik\Updates;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_11_0_b4 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
 
-    public function getMigrationQueries(Updater $updater)
+    public function __construct(MigrationFactory $factory)
     {
-        $sqls = array();
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = array();
 
         $archiveTables = ArchiveTableCreator::getTablesArchivesInstalled();
 
@@ -27,10 +37,10 @@ class Updates_2_11_0_b4 extends Updates
         });
 
         foreach ($archiveBlobTables as $table) {
-            $sqls["UPDATE " . $table . " SET name = 'UserLanguage_language' WHERE name = 'UserSettings_language'"] = false;
+            $migrations[] = $this->migration->db->sql("UPDATE $table SET name = 'UserLanguage_language' WHERE name = 'UserSettings_language'");
         }
 
-        return $sqls;
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
@@ -42,6 +52,6 @@ class Updates_2_11_0_b4 extends Updates
         } catch (\Exception $e) {
         }
 
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.11.0-b5.php
+++ b/core/Updates/2.11.0-b5.php
@@ -8,17 +8,31 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Plugin\Manager;
 use Piwik\Updates;
 use Piwik\Updater;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_11_0_b5 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        return array(
+            $this->migration->plugin->activate('Monolog')
+        );
+    }
+
     public function doUpdate(Updater $updater)
     {
-        try {
-            Manager::getInstance()->activatePlugin('Monolog');
-        } catch (\Exception $e) {
-        }
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.13.0-b3.php
+++ b/core/Updates/2.13.0-b3.php
@@ -11,16 +11,29 @@ namespace Piwik\Updates;
 
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_13_0_b3 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        return array(
+            $this->migration->plugin->activate('Diagnostics')
+        );
+    }
+
     public function doUpdate(Updater $updater)
     {
-        $pluginManager = \Piwik\Plugin\Manager::getInstance();
-
-        try {
-            $pluginManager->activatePlugin('Diagnostics');
-        } catch (\Exception $e) {
-        }
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.13.1.php
+++ b/core/Updates/2.13.1.php
@@ -12,6 +12,7 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  * Update for version 2.13.1.
@@ -19,16 +20,26 @@ use Piwik\Updates;
 class Updates_2_13_1 extends Updates
 {
     /**
-     * Here you can define one or multiple SQL statements that should be executed during the update.
-     * @return array
+     * @var MigrationFactory
      */
-    public function getMigrationQueries(Updater $updater)
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    /**
+     * Here you can define one or multiple SQL statements that should be executed during the update.
+     * @return Updater\Migration[]
+     */
+    public function getMigrations(Updater $updater)
     {
         $optionTable = Common::prefixTable('option');
         $removeEmptyDefaultReportsSql = "delete from `$optionTable` where option_name like '%defaultReport%' and option_value=''";
 
         return array(
-            $removeEmptyDefaultReportsSql => false
+            $this->migration->db->sql($removeEmptyDefaultReportsSql)
         );
     }
 
@@ -38,6 +49,6 @@ class Updates_2_13_1 extends Updates
      */
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.14.0-b2.php
+++ b/core/Updates/2.14.0-b2.php
@@ -9,35 +9,39 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
 use Piwik\Db;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_14_0_b2 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
-        $dbSettings = new Db\Settings();
-        $engine = $dbSettings->getEngine();
+        $this->migration = $factory;
+    }
 
-        $table = Common::prefixTable('site_setting');
+    public function getMigrations(Updater $updater)
+    {
+        $table = 'site_setting';
 
-        $sqlarray = array(
-            "DROP TABLE IF EXISTS `$table`" => false,
-            "CREATE TABLE `$table` (
-                  idsite INTEGER(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-                  `setting_name` VARCHAR(255) NOT NULL,
-                  `setting_value` LONGTEXT NOT NULL,
-                      PRIMARY KEY(idsite, setting_name)
-                    ) ENGINE=$engine DEFAULT CHARSET=utf8" => 1050,
+        return array(
+            $this->migration->db->dropTable($table),
+            $this->migration->db->createTable($table, array(
+                'idsite' => 'INTEGER(10) UNSIGNED NOT NULL AUTO_INCREMENT',
+                'setting_name' => 'VARCHAR(255) NOT NULL',
+                'setting_value' => 'LONGTEXT NOT NULL',
+            ), $primaryKey = array('idsite', 'setting_name')),
         );
-
-        return $sqlarray;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.15.0-b3.php
+++ b/core/Updates/2.15.0-b3.php
@@ -9,24 +9,32 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 
 class Updates_2_15_0_b3 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
-        $updateSql = array(
-            'ALTER TABLE `' . Common::prefixTable('site')
-                . '` ADD COLUMN `exclude_unknown_urls` TINYINT(1) DEFAULT 0 AFTER `currency`' => array(1060)
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        return array(
+            $this->migration->db->addColumn('site', 'exclude_unknown_urls', 'TINYINT(1) DEFAULT 0', 'currency')
         );
-        return $updateSql;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.15.0.php
+++ b/core/Updates/2.15.0.php
@@ -10,16 +10,30 @@ namespace Piwik\Updates;
 
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_15_0 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        return array(
+            $this->migration->plugin->activate('Heartbeat')
+        );
+    }
+
     public function doUpdate(Updater $updater)
     {
-        $pluginManager = \Piwik\Plugin\Manager::getInstance();
-
-        try {
-            $pluginManager->activatePlugin('Heartbeat');
-        } catch (\Exception $e) {
-        }
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
+
 }

--- a/core/Updates/2.16.0-rc2.php
+++ b/core/Updates/2.16.0-rc2.php
@@ -10,19 +10,29 @@ namespace Piwik\Updates;
 
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_16_0_rc2 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        return array(
+            $this->migration->plugin->activate('PiwikPro')
+        );
+    }
+
     public function doUpdate(Updater $updater)
     {
-        $pluginManager = \Piwik\Plugin\Manager::getInstance();
-        $pluginName = 'PiwikPro';
-
-        try {
-            if (!$pluginManager->isPluginActivated($pluginName)) {
-                $pluginManager->activatePlugin($pluginName);
-            }
-        } catch (\Exception $e) {
-        }
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.4.0-b8.php
+++ b/core/Updates/2.4.0-b8.php
@@ -8,22 +8,31 @@
  */
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_4_0_b8 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            "ALTER TABLE `" . Common::prefixTable('session')
-            . "` CHANGE `id` `id` VARCHAR( 255 ) NOT NULL " => false,
+            $this->migration->db->changeColumnType('session', 'id', 'VARCHAR( 255 ) NOT NULL')
         );
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.7.0-b2.php
+++ b/core/Updates/2.7.0-b2.php
@@ -11,18 +11,31 @@ namespace Piwik\Updates;
 
 use Piwik\Updates;
 use Piwik\Updater;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 /**
  */
 class Updates_2_7_0_b2 extends Updates
 {
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrationss(Updater $updater)
+    {
+        return array(
+            $this->migration->plugin->activate('Contents')
+        );
+    }
+
     public function doUpdate(Updater $updater)
     {
-        $pluginManager = \Piwik\Plugin\Manager::getInstance();
-
-        try {
-            $pluginManager->activatePlugin('Contents');
-        } catch (\Exception $e) {
-        }
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/core/Updates/2.9.0-b1.php
+++ b/core/Updates/2.9.0-b1.php
@@ -11,35 +11,41 @@ namespace Piwik\Updates;
 use Piwik\Common;
 use Piwik\Db;
 use Piwik\Option;
-use Piwik\Plugin\Manager;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_9_0_b1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
-    {
-        $sql = array();
-        $sql = self::updateBrowserEngine($sql);
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
 
-        return $sql;
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = array();
+        $migrations = $this->updateBrowserEngine($migrations);
+        $migrations[] = $this->migration->plugin->activate('TestRunner');
+
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
 
         self::updateIPAnonymizationSettings();
-
-        try {
-            Manager::getInstance()->activatePlugin('TestRunner');
-        } catch (\Exception $e) {
-        }
     }
 
-    private static function updateBrowserEngine($sql)
+    private function updateBrowserEngine($sql)
     {
-        $sql[sprintf("ALTER TABLE `%s` ADD COLUMN `config_browser_engine` VARCHAR(10) NOT NULL", Common::prefixTable('log_visit'))] = 1060;
+        $sql[] = $this->migration->db->addColumn('log_visit', 'config_browser_engine', 'VARCHAR(10) NOT NULL');
 
         $browserEngineMatch = array(
             'Trident' => array('IE'),
@@ -58,7 +64,7 @@ class Updates_2_9_0_b1 extends Updates
         }
 
         $engineUpdate = sprintf("UPDATE %s SET `config_browser_engine` = %s", Common::prefixTable('log_visit'), $engineUpdate);
-        $sql[$engineUpdate] = false;
+        $sql[] = $this->migration->db->sql($engineUpdate);
 
         $archiveBlobTables = Db::get()->fetchCol("SHOW TABLES LIKE '%archive_blob%'");
 
@@ -66,7 +72,8 @@ class Updates_2_9_0_b1 extends Updates
         foreach ($archiveBlobTables as $table) {
 
             // try to rename old archives
-            $sql[sprintf("UPDATE IGNORE %s SET name='DevicesDetection_browserEngines' WHERE name = 'UserSettings_browserType'", $table)] = false;
+            $query = sprintf("UPDATE IGNORE %s SET name='DevicesDetection_browserEngines' WHERE name = 'UserSettings_browserType'", $table);
+            $sql[] = $this->migration->db->sql($query);
         }
 
         return $sql;

--- a/core/Updates/2.9.0-b7.php
+++ b/core/Updates/2.9.0-b7.php
@@ -8,29 +8,41 @@
 
 namespace Piwik\Updates;
 
-use Piwik\Common;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Db;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_9_0_b7 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
-    {
-        $sql = array();
-        $sql = self::addCreateSequenceTableQuery($sql);
-        $sql = self::addArchivingIdMigrationQueries($sql);
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
 
-        return $sql;
+    private $sequenceTable = 'sequence';
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = array();
+        $migrations = $this->addCreateSequenceTableQuery($migrations);
+        $migrations = $this->addArchivingIdMigrationQueries($migrations);
+
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 
-    private static function addArchivingIdMigrationQueries($sql)
+    private function addArchivingIdMigrationQueries($sql)
     {
         $tables = ArchiveTableCreator::getTablesArchivesInstalled();
 
@@ -46,45 +58,23 @@ class Updates_2_9_0_b7 extends Updates
                     $maxId = 1;
                 }
 
-                $query = self::getQueryToCreateSequence($table, $maxId);
-                // refs  #6696, ignores  Integrity constraint violation: 1062 Duplicate entry 'piwik_archive_numeric_2010_01' for key 'PRIMARY'
-                $sql[$query] = '1062';
+                $sql[] = $this->migration->db->insert($this->sequenceTable, array('name' => $table, 'value' => $maxId));
             }
         }
 
         return $sql;
     }
 
-    private static function getQueryToCreateSequence($name, $initialValue)
-    {
-        $table = self::getSequenceTableName();
-        $query = sprintf("INSERT INTO %s (name, value) VALUES ('%s', %d)", $table, $name, $initialValue);
-
-        return $query;
-    }
-
     /**
      * @return string
      */
-    private static function addCreateSequenceTableQuery($sql)
+    private function addCreateSequenceTableQuery($sql)
     {
-        $dbSettings = new Db\Settings();
-        $engine = $dbSettings->getEngine();
-        $table  = self::getSequenceTableName();
-
-        $query = "CREATE TABLE `$table` (
-                `name` VARCHAR(120) NOT NULL,
-                `value` BIGINT(20) UNSIGNED NOT NULL,
-                PRIMARY KEY(`name`)
-        ) ENGINE=$engine DEFAULT CHARSET=utf8";
-
-        $sql[$query] = 1050;
+        $sql[] = $this->migration->db->createTable($this->sequenceTable, array(
+           'name' => 'VARCHAR(120) NOT NULL',
+           'value' => 'BIGINT(20) UNSIGNED NOT NULL',
+        ), $primary = 'name');
 
         return $sql;
-    }
-
-    private static function getSequenceTableName()
-    {
-        return Common::prefixTable('sequence');
     }
 }

--- a/core/Updates/3.0.0-b1.php
+++ b/core/Updates/3.0.0-b1.php
@@ -11,8 +11,9 @@ namespace Piwik\Updates;
 
 use Piwik\Common;
 use Piwik\Db;
-use Piwik\DbHelper;
 use Piwik\Updater;
+use Piwik\Updater\Migration;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 use Piwik\Updates;
 use Piwik\Plugins\Dashboard;
 
@@ -22,47 +23,54 @@ use Piwik\Plugins\Dashboard;
 class Updates_3_0_0_b1 extends Updates
 {
     /**
-     * Here you can define one or multiple SQL statements that should be executed during the update.
-     * @return array
+     * @var MigrationFactory
      */
-    public function getMigrationQueries(Updater $updater)
+    private $migration;
+
+    private $pluginSettingsTable = 'plugin_setting';
+    private $siteSettingsTable = 'site_setting';
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    /**
+     * Here you can define one or multiple SQL statements that should be executed during the update.
+     * @param Updater $updater
+     * @return Migration[]
+     */
+    public function getMigrations(Updater $updater)
     {
         $db = Db::get();
         $allGoals = $db->fetchAll(sprintf("SELECT DISTINCT idgoal FROM %s", Common::prefixTable('goal')));
         $allDashboards = $db->fetchAll(sprintf("SELECT * FROM %s", Common::prefixTable('user_dashboard')));
 
-        $queries = $this->getDashboardMigrationSqls($allDashboards, $allGoals);
-        $queries = $this->getPluginSettingsMigrationQueries($queries, $db);
-        $queries = $this->getSiteSettingsMigrationQueries($queries);
+        $migrations = $this->getDashboardMigrations($allDashboards, $allGoals);
+        $migrations = $this->getPluginSettingsMigrations($migrations);
+        $migrations = $this->getSiteSettingsMigrations($migrations);
 
-        return $queries;
+        return $migrations;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 
     /**
-     * @param $queries
-     * @param Db $db
-     * @return mixed
+     * @param Migration[] $queries
+     * @return Migration[]
      */
-    private function getPluginSettingsMigrationQueries($queries, $db)
+    private function getPluginSettingsMigrations($queries)
     {
-        $pluginSettingsTableName = $this->getPluginSettingsTableName();
-        $dbSettings = new Db\Settings();
-        $engine = $dbSettings->getEngine();
-
-        $pluginSettingsTable = "CREATE TABLE $pluginSettingsTableName (
-                          `plugin_name` VARCHAR(60) NOT NULL,
-                          `setting_name` VARCHAR(255) NOT NULL,
-                          `setting_value` LONGTEXT NOT NULL,
-                          `user_login` VARCHAR(100) NOT NULL DEFAULT '',
-                              INDEX(plugin_name, user_login)
-                            ) ENGINE=$engine DEFAULT CHARSET=utf8
-            ";
-        $queries[$pluginSettingsTable] = 1050;
+        $queries[] = $this->migration->db->createTable($this->pluginSettingsTable, array(
+            'plugin_name' => 'VARCHAR(60) NOT NULL',
+            'setting_name' => 'VARCHAR(255) NOT NULL',
+            'setting_value' => 'LONGTEXT NOT NULL',
+            'user_login' => "VARCHAR(100) NOT NULL DEFAULT ''",
+        ));
+        $queries[] = $this->migration->db->addIndex($this->pluginSettingsTable, array('plugin_name', 'user_login'));
 
         $optionTable = Common::prefixTable('option');
         $query = 'SELECT `option_name`, `option_value` FROM `' . $optionTable . '` WHERE `option_name` LIKE "Plugin_%_Settings"';
@@ -83,61 +91,54 @@ class Updates_3_0_0_b1 extends Updates
                 }
 
                 foreach ($settingValue as $val) {
-                    $queries[$this->createPluginSettingQuery($pluginName, $settingName, $val)] = 1062;
+                    $queries[] = $this->createPluginSettingQuery($pluginName, $settingName, $val);
                 }
             }
         }
 
-        $queries[$query = sprintf('DELETE FROM `%s` WHERE `option_name` like "Plugin_%%_Settings"', $optionTable)] = false;
+        $queries[] = $this->migration->db->sql(sprintf('DELETE FROM `%s` WHERE `option_name` like "Plugin_%%_Settings"', $optionTable));
 
         return $queries;
     }
 
     /**
-     * @param $queries
-     * @param Db $db
-     * @return mixed
+     * @param Migration[] $queries
+     * @return Migration[]
      */
-    private function getSiteSettingsMigrationQueries($queries)
+    private function getSiteSettingsMigrations($queries)
     {
-        $table = Common::prefixTable('site_setting');
+        $table = $this->siteSettingsTable;
+        $queries[] = $this->migration->db->addColumn($table, 'plugin_name', 'VARCHAR(60) NOT NULL', $afer = 'idsite');
 
-        $pluginSettingsTable = "ALTER TABLE $table ADD COLUMN `plugin_name` VARCHAR(60) NOT NULL AFTER `idsite`";
-        $queries[$pluginSettingsTable] = 1060;
-        $queries["ALTER TABLE $table DROP PRIMARY KEY, ADD INDEX(idsite, plugin_name);"] = false;
+        $table = Common::prefixTable($table);
+        $queries[] = $this->migration->db->sql("ALTER TABLE `$table` DROP PRIMARY KEY, ADD INDEX(idsite, plugin_name);",
+                                               Migration\Db::ERROR_CODE_COLUMN_NOT_EXISTS);
 
         // we cannot migrate existing settings as we do not know the related plugin name, but this feature
         // (measurablesettings) was not really used anyway. If a migration is somewhere really needed it has to be
         // handled in the plugin
-        $queries[sprintf('DELETE FROM `%s`', $table)] = false;
+        $queries[] = $this->migration->db->sql(sprintf('DELETE FROM `%s`', $table));
 
         return $queries;
     }
 
     private function createPluginSettingQuery($pluginName, $settingName, $settingValue)
     {
-        $table = $this->getPluginSettingsTableName();
-
         $login = '';
         if (preg_match('/^.+#(.+)#$/', $settingName, $matches)) {
             $login = $matches[1];
             $settingName = str_replace('#' . $login . '#', '', $settingName);
         }
 
-        $db = Db::get();
-
-        $query  = sprintf("INSERT INTO %s (plugin_name, setting_name, setting_value, user_login) VALUES ", $table);
-        $query .= sprintf("(%s, %s, %s, %s)", $db->quote($pluginName), $db->quote($settingName), $db->quote($settingValue), $db->quote($login));
-
-        return $query;
+        return $this->migration->db->insert($this->pluginSettingsTable, array(
+            'plugin_name' => $pluginName,
+            'setting_name' => $settingName,
+            'setting_value' => $settingValue,
+            'user_login' => $login
+        ));
     }
 
-    private function getPluginSettingsTableName()
-    {
-        return Common::prefixTable('plugin_setting');
-    }
-
-    private function getDashboardMigrationSqls($allDashboards, $allGoals)
+    private function getDashboardMigrations($allDashboards, $allGoals)
     {
         $sqls = array();
 
@@ -433,6 +434,9 @@ class Updates_3_0_0_b1 extends Updates
                     ));
         }
 
+        $table = Common::prefixTable('user_dashboard');
+        $sql = sprintf('UPDATE %s SET layout = ? WHERE iddashboard = ?', $table);
+
         foreach ($allDashboards as $dashboard) {
             $dashboardLayout = json_decode($dashboard['layout']);
 
@@ -440,7 +444,7 @@ class Updates_3_0_0_b1 extends Updates
 
             $newLayout = json_encode($dashboardLayout);
             if ($newLayout != $dashboard['layout']) {
-                $sqls["UPDATE " . Common::prefixTable('user_dashboard') . " SET layout = '".addslashes($newLayout)."' WHERE iddashboard = ".$dashboard['iddashboard']] = false;
+                $sqls[] = $this->migration->db->boundSql($sql, array($newLayout, $dashboard['iddashboard']));
             }
         }
 

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -432,6 +432,7 @@ class Controller extends Plugin\ControllerAdmin
             }
 
             $message = $this->translator->translate('CorePluginsAdmin_SuccessfullyActicated', array($pluginName));
+
             if ($this->settingsProvider->getSystemSettings($pluginName)) {
                 $target   = sprintf('<a href="index.php%s#%s">',
                     Url::getCurrentQueryStringWithParametersModified(array('module' => 'CoreAdminHome', 'action' => 'generalSettings')),

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -432,7 +432,7 @@ class Controller extends Plugin\ControllerAdmin
             }
 
             $message = $this->translator->translate('CorePluginsAdmin_SuccessfullyActicated', array($pluginName));
-
+            
             if ($this->settingsProvider->getSystemSettings($pluginName)) {
                 $target   = sprintf('<a href="index.php%s#%s">',
                     Url::getCurrentQueryStringWithParametersModified(array('module' => 'CoreAdminHome', 'action' => 'generalSettings')),

--- a/plugins/CoreUpdater/Commands/Update.php
+++ b/plugins/CoreUpdater/Commands/Update.php
@@ -156,7 +156,7 @@ class Update extends ConsoleCommand
         $output->writeln(array("    *** Note: this is a Dry Run ***", ""));
 
         foreach ($migrationQueries as $query) {
-            $output->writeln("    " . $query);
+            $output->writeln("    " . $query->__toString());
         }
 
         $output->writeln(array("", "    *** End of Dry Run ***", ""));

--- a/plugins/CoreUpdater/Commands/Update/CliUpdateObserver.php
+++ b/plugins/CoreUpdater/Commands/Update/CliUpdateObserver.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\CoreUpdater\Commands\Update;
 
+use Piwik\Updater\Migration;
 use Piwik\Updater\UpdateObserver;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -40,14 +41,15 @@ class CliUpdateObserver extends UpdateObserver
         $this->totalMigrationQueryCount = $totalMigrationQueryCount;
     }
 
-    public function onStartExecutingMigrationQuery($updateFile, $sql)
+    public function onStartExecutingMigration($updateFile, Migration $migration)
     {
-        $this->output->write("  Executing <comment>$sql</comment>... ");
+        $string = $migration->__toString();
+        $this->output->write("  Executing <comment>$string</comment>... ");
 
         ++$this->currentMigrationQueryExecutionCount;
     }
 
-    public function onFinishedExecutingMigrationQuery($updateFile, $sql)
+    public function onFinishedExecutingMigration($updateFile, Migration $migration)
     {
         $this->output->writeln("Done. <info>[{$this->currentMigrationQueryExecutionCount} / {$this->totalMigrationQueryCount}]</info>");
     }

--- a/plugins/DevicesDetection/Updates/1.14.php
+++ b/plugins/DevicesDetection/Updates/1.14.php
@@ -12,15 +12,27 @@ namespace Piwik\Plugins\DevicesDetection;
 use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_1_14 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
     {
         return array(
-            'ALTER TABLE `' . Common::prefixTable('log_visit') . '`
-				CHANGE `config_os_version` `config_os_version`  VARCHAR( 100 ) DEFAULT NULL,
-				CHANGE `config_device_type` `config_device_type`  VARCHAR( 100 ) DEFAULT NULL' => false,
+            $this->migration->db->changeColumnTypes('log_visit', array(
+                'config_os_version' => 'VARCHAR( 100 ) DEFAULT NULL',
+                'config_device_type' => 'VARCHAR( 100 ) DEFAULT NULL'
+            ))
         );
     }
 
@@ -31,7 +43,7 @@ class Updates_1_14 extends Updates
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 
 }

--- a/plugins/LanguagesManager/Updates/2.15.1-b1.php
+++ b/plugins/LanguagesManager/Updates/2.15.1-b1.php
@@ -9,24 +9,31 @@
 
 namespace Piwik\Plugins\LanguagesManager;
 
-use Piwik\Common;
 use Piwik\Updater;
 use Piwik\Updates;
-
+use Piwik\Updater\Migration\Factory as MigrationFactory;
 
 class Updates_2_15_1_b1 extends Updates
 {
-    public function getMigrationQueries(Updater $updater)
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
     {
-        $updateSql = array(
-            'ALTER TABLE `' . Common::prefixTable('user_language')
-                . '` ADD COLUMN `use_12_hour_clock` TINYINT(1) NOT NULL DEFAULT 0 AFTER `language`' => array(1060)
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        return array(
+            $this->migration->db->addColumn('user_language', 'use_12_hour_clock', 'TINYINT(1) NOT NULL DEFAULT 0', 'language')
         );
-        return $updateSql;
     }
 
     public function doUpdate(Updater $updater)
     {
-        $updater->executeMigrationQueries(__FILE__, $this->getMigrationQueries($updater));
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
     }
 }

--- a/tests/PHPUnit/Integration/Columns/UpdaterTest.php
+++ b/tests/PHPUnit/Integration/Columns/UpdaterTest.php
@@ -16,6 +16,7 @@ use Piwik\Plugin\Dimension\ConversionDimension;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Updater;
+use Piwik\Updater\Migration;
 
 // NOTE: we can't use PHPUnit mock framework since we have to set columnName/columnType. reflection will set it, but
 // for some reason, methods of base type don't see the set value.
@@ -97,11 +98,11 @@ class UpdaterTest extends IntegrationTestCase
         $actualMigrationQueries = $this->columnsUpdater->getMigrationQueries($updater);
 
         $expectedMigrationQueries = array(
-            'ALTER TABLE `log_visit` ADD COLUMN `test_visit_col_1` INTEGER(10) UNSIGNED NOT NULL, ADD COLUMN `test_visit_col_2` VARCHAR(32) NOT NULL' => array('1091', '1060'),
-            'ALTER TABLE `log_link_visit_action` ADD COLUMN `test_action_col_1` VARCHAR(32) NOT NULL, ADD COLUMN `test_action_col_2` INTEGER(10) UNSIGNED DEFAULT NULL' => array('1091', '1060'),
-            'ALTER TABLE `log_conversion` ADD COLUMN `test_conv_col_1` FLOAT DEFAULT NULL, ADD COLUMN `test_conv_col_2` VARCHAR(32) NOT NULL' => array('1091', '1060'),
+            'ALTER TABLE `log_visit` ADD COLUMN `test_visit_col_1` INTEGER(10) UNSIGNED NOT NULL, ADD COLUMN `test_visit_col_2` VARCHAR(32) NOT NULL;' => array('1091', '1060'),
+            'ALTER TABLE `log_link_visit_action` ADD COLUMN `test_action_col_1` VARCHAR(32) NOT NULL, ADD COLUMN `test_action_col_2` INTEGER(10) UNSIGNED DEFAULT NULL;' => array('1091', '1060'),
+            'ALTER TABLE `log_conversion` ADD COLUMN `test_conv_col_1` FLOAT DEFAULT NULL, ADD COLUMN `test_conv_col_2` VARCHAR(32) NOT NULL;' => array('1091', '1060'),
         );
-        $this->assertEquals($expectedMigrationQueries, $actualMigrationQueries);
+        $this->assertEquals($expectedMigrationQueries, $this->flattenQueries($actualMigrationQueries));
     }
 
     public function test_getMigrationQueries_ReturnsCorrectQueries_IfDimensionIsInTable_ButHasNewVersion()
@@ -112,11 +113,24 @@ class UpdaterTest extends IntegrationTestCase
         $actualMigrationQueries = $this->columnsUpdater->getMigrationQueries($updater);
 
         $expectedMigrationQueries = array(
-            'ALTER TABLE `log_visit` MODIFY COLUMN `test_visit_col_1` INTEGER(10) UNSIGNED NOT NULL, MODIFY COLUMN `test_visit_col_2` VARCHAR(32) NOT NULL' => array('1091', '1060'),
-            'ALTER TABLE `log_link_visit_action` MODIFY COLUMN `test_action_col_1` VARCHAR(32) NOT NULL, MODIFY COLUMN `test_action_col_2` INTEGER(10) UNSIGNED DEFAULT NULL' => array('1091', '1060'),
-            'ALTER TABLE `log_conversion` MODIFY COLUMN `test_conv_col_1` FLOAT DEFAULT NULL, MODIFY COLUMN `test_conv_col_2` VARCHAR(32) NOT NULL' => array('1091', '1060')
+            'ALTER TABLE `log_visit` MODIFY COLUMN `test_visit_col_1` INTEGER(10) UNSIGNED NOT NULL, MODIFY COLUMN `test_visit_col_2` VARCHAR(32) NOT NULL;' => array('1091', '1060'),
+            'ALTER TABLE `log_link_visit_action` MODIFY COLUMN `test_action_col_1` VARCHAR(32) NOT NULL, MODIFY COLUMN `test_action_col_2` INTEGER(10) UNSIGNED DEFAULT NULL;' => array('1091', '1060'),
+            'ALTER TABLE `log_conversion` MODIFY COLUMN `test_conv_col_1` FLOAT DEFAULT NULL, MODIFY COLUMN `test_conv_col_2` VARCHAR(32) NOT NULL;' => array('1091', '1060')
         );
-        $this->assertEquals($expectedMigrationQueries, $actualMigrationQueries);
+        $this->assertEquals($expectedMigrationQueries, $this->flattenQueries($actualMigrationQueries));
+    }
+
+    /**
+     * @param Migration\Db\Sql[] $queries
+     * @return array
+     */
+    private function flattenQueries($queries)
+    {
+        $response = array();
+        foreach ($queries as $query) {
+            $response[$query->__toString()] = $query->getErrorCodesToIgnore();
+        }
+        return $response;
     }
 
     public function test_getMigrationQueries_ReturnsNoQueries_IfDimensionsAreInTable_ButHaveNoNewVersions()

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/BoundSqlTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/BoundSqlTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Updater\Migration\Db;
+
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Updater\Migration\Db\BoundSql;
+
+/**
+ * @group Core
+ * @group Updater
+ * @group Migration
+ * @group BoundSql
+ * @group BoundSqlTest
+ */
+class BoundSqlTest extends IntegrationTestCase
+{
+    private $testQuery = 'ALTER TABLE foobar ADD COLUMN barbaz VARCHAR(1)';
+
+    public function test_toString_shouldAppendSemicolonIfNeeded()
+    {
+        $sql = $this->boundSql($this->testQuery, array());
+
+        $this->assertSame($this->testQuery . ';', '' . $sql);
+    }
+
+    public function test_toString_shouldNotAppendSemicolonIfNotNeeded()
+    {
+        $sql = $this->boundSql($this->testQuery . ';');
+
+        $this->assertSame($this->testQuery . ';', '' . $sql);
+    }
+
+    public function test_toString_shouldReplacePlaceHolders()
+    {
+        $sql = $this->boundSql('DELETE FROM table WHERE x=?, foobar = ?, xyz = ?', array(
+            'my value 1', 5, 'test\' val\ue"'
+        ));
+
+        $this->assertSame("DELETE FROM table WHERE x='my value 1', foobar = 5, xyz = 'test\' val\\\\ue\\\"';", '' . $sql);
+    }
+
+    public function test_constructor_shouldConvertErrorCodeToArray_IfNeeded()
+    {
+        $sql = $this->boundSql($this->testQuery, array(), 1091);
+        $this->assertSame(array(1091), $sql->getErrorCodesToIgnore());
+    }
+
+    public function test_constructor_shouldNotConvertErrorCodeToArray_IfNotNeeded()
+    {
+        $sql = $this->boundSql($this->testQuery, array(), array(1091, 1061));
+        $this->assertSame(array(1091, 1061), $sql->getErrorCodesToIgnore());
+    }
+
+    private function boundSql($query, $bind = array(), $errorCode = array())
+    {
+        return new BoundSql($query, $bind, $errorCode);
+    }
+
+
+}

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/FactoryTest.php
@@ -1,0 +1,420 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Updater\Migration\Db;
+
+use Piwik\Common;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Updater\Migration\Db\AddColumn;
+use Piwik\Updater\Migration\Db\AddColumns;
+use Piwik\Updater\Migration\Db\AddIndex;
+use Piwik\Updater\Migration\Db\AddPrimaryKey;
+use Piwik\Updater\Migration\Db\AddUniqueKey;
+use Piwik\Updater\Migration\Db\BatchInsert;
+use Piwik\Updater\Migration\Db\BoundSql;
+use Piwik\Updater\Migration\Db\ChangeColumn;
+use Piwik\Updater\Migration\Db\ChangeColumnType;
+use Piwik\Updater\Migration\Db\ChangeColumnTypes;
+use Piwik\Updater\Migration\Db\CreateTable;
+use Piwik\Updater\Migration\Db\DropColumn;
+use Piwik\Updater\Migration\Db\DropIndex;
+use Piwik\Updater\Migration\Db\DropTable;
+use Piwik\Updater\Migration\Db\Factory;
+use Piwik\Updater\Migration\Db\Insert;
+use Piwik\Updater\Migration\Db\Sql;
+
+/**
+ * @group Core
+ * @group Updater
+ * @group Migration
+ */
+class FactoryTest extends IntegrationTestCase
+{
+    /**
+     * @var Factory
+     */
+    private $factory;
+
+    private $testTable = 'tablename';
+    private $testTablePrefixed = '';
+
+    public function setUp()
+    {
+        parent::setUp();
+        
+        $this->testTablePrefixed = Common::prefixTable($this->testTable);
+        $this->factory = new Factory();
+    }
+
+    public function test_sql_returnsSqlInstance()
+    {
+        $migration = $this->sql();
+
+        $this->assertTrue($migration instanceof Sql);
+    }
+
+    public function test_sql_forwardsQueryAndErrorCode()
+    {
+        $migration = $this->sql();
+
+        $this->assertSame('SELECT 1;', '' . $migration);
+        $this->assertSame(array(5), $migration->getErrorCodesToIgnore());
+    }
+
+    public function test_boundSql_returnsSqlInstance()
+    {
+        $migration = $this->boundSql();
+
+        $this->assertTrue($migration instanceof BoundSql);
+    }
+
+    public function test_boundSql_forwardsParameters()
+    {
+        $migration = $this->boundSql();
+
+        $this->assertSame("SELECT 2 WHERE 'query';", '' . $migration);
+        $this->assertSame(array(8), $migration->getErrorCodesToIgnore());
+    }
+
+    public function test_createTable_returnsCreateTableInstance()
+    {
+        $migration = $this->createTable();
+
+        $this->assertTrue($migration instanceof CreateTable);
+    }
+
+    public function test_createTable_forwardsParameters()
+    {
+        $migration = $this->createTable();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("CREATE TABLE `$table` (`column` INT(10) DEFAULT 0, `column2` VARCHAR(255)) ENGINE=InnoDB DEFAULT CHARSET=utf8;", ''. $migration);
+    }
+
+    public function test_createTable_withPrimaryKey()
+    {
+        $migration = $this->createTable('column2');
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("CREATE TABLE `$table` (`column` INT(10) DEFAULT 0, `column2` VARCHAR(255), PRIMARY KEY ( `column2` )) ENGINE=InnoDB DEFAULT CHARSET=utf8;", ''. $migration);
+    }
+
+    public function test_dropTable_returnsDropTableInstance()
+    {
+        $migration = $this->factory->dropTable($this->testTable);
+
+        $this->assertTrue($migration instanceof DropTable);
+    }
+
+    public function test_dropTable_forwardsParameters()
+    {
+        $migration = $this->factory->dropTable($this->testTable);
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("DROP TABLE IF EXISTS `$table`;", ''. $migration);
+    }
+
+    public function test_dropColumn_returnsDropColumnInstance()
+    {
+        $migration = $this->dropColumn();
+
+        $this->assertTrue($migration instanceof DropColumn);
+    }
+
+    public function test_dropColumn_forwardsParameters()
+    {
+        $migration = $this->dropColumn();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` DROP COLUMN `column1`;", '' . $migration);
+    }
+
+    public function test_addColumn_forwardsParameters_withLastColumn()
+    {
+        $migration = $this->addColumn('lastcolumn');
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` ADD COLUMN `column` INT(10) DEFAULT 0 AFTER `lastcolumn`;", '' . $migration);
+    }
+
+    public function test_addColumn_returnsAddColumnInstance()
+    {
+        $migration = $this->addColumn(null);
+
+        $this->assertTrue($migration instanceof AddColumn);
+    }
+
+    public function test_addColumn_forwardsParameters_noLastColumn()
+    {
+        $migration = $this->addColumn(null);
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` ADD COLUMN `column` INT(10) DEFAULT 0;", '' . $migration);
+    }
+
+    public function test_addColumns_returnsAddColumnsInstance()
+    {
+        $migration = $this->addColumns(null);
+
+        $this->assertTrue($migration instanceof AddColumns);
+    }
+
+    public function test_addColumns_forwardsParameters()
+    {
+        $migration = $this->addColumns('columnafter');
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` ADD COLUMN `column1` INT(10) DEFAULT 0 AFTER `columnafter`, ADD COLUMN `column2` VARCHAR(10) DEFAULT \"\" AFTER `column1`;", '' . $migration);
+    }
+
+    public function test_addColumns_NoAfterColumn()
+    {
+        $migration = $this->addColumns(null);
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` ADD COLUMN `column1` INT(10) DEFAULT 0, ADD COLUMN `column2` VARCHAR(10) DEFAULT \"\";", '' . $migration);
+    }
+
+    public function test_changeColumn_returnsChangeColumnInstance()
+    {
+        $migration = $this->changeColumn();
+
+        $this->assertTrue($migration instanceof ChangeColumn);
+    }
+
+    public function test_changeColumn_forwardsParameters()
+    {
+        $migration = $this->changeColumn();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` CHANGE `column_old` `column_new` INT(10) DEFAULT 0;", '' . $migration);
+    }
+
+    public function test_changeColumnType_returnsChangeColumnTypeInstance()
+    {
+        $migration = $this->changeColumnType();
+
+        $this->assertTrue($migration instanceof ChangeColumnType);
+    }
+
+    public function test_changeColumnType_forwardsParameters()
+    {
+        $migration = $this->changeColumnType();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` CHANGE `column` `column` INT(10) DEFAULT 0;", '' . $migration);
+    }
+
+    public function test_changeColumnTypes_returnsChangeColumnTypesInstance()
+    {
+        $migration = $this->changeColumnTypes();
+
+        $this->assertTrue($migration instanceof ChangeColumnTypes);
+    }
+
+    public function test_changeColumnTypes_forwardsParameters()
+    {
+        $migration = $this->changeColumnTypes();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` CHANGE `column1` `column1` INT(10) DEFAULT 0, CHANGE `column2` `column2` VARCHAR(10) DEFAULT \"\";", '' . $migration);
+    }
+
+    public function test_addIndex_returnsAddIndexInstance()
+    {
+        $migration = $this->addIndex();
+
+        $this->assertTrue($migration instanceof AddIndex);
+    }
+
+    public function test_addIndex_forwardsParameters_generatesIndexNameAutomatically()
+    {
+        $migration = $this->addIndex();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` ADD INDEX index_column1_column3 (`column1`, `column3` (10));", '' . $migration);
+    }
+
+    public function test_addIndex_customIndexName()
+    {
+        $migration = $this->addIndex('myCustomIndex');
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` ADD INDEX myCustomIndex (`column1`, `column3` (10));", '' . $migration);
+    }
+
+    public function test_addUniqueKey_returnsAddUniqueKeyInstance()
+    {
+        $migration = $this->addUniqueKey();
+
+        $this->assertTrue($migration instanceof AddUniqueKey);
+    }
+
+    public function test_addUniqueKey_forwardsParameters_generatesIndexNameAutomatically()
+    {
+        $migration = $this->addUniqueKey();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` ADD UNIQUE KEY unique_column1_column3 (`column1`, `column3` (10));", '' . $migration);
+    }
+
+    public function test_addUniqueKey_customIndexName()
+    {
+        $migration = $this->addUniqueKey('myCustomIndex');
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` ADD UNIQUE KEY myCustomIndex (`column1`, `column3` (10));", '' . $migration);
+    }
+
+    public function test_dropIndex_returnsAddIndexInstance()
+    {
+        $migration = $this->dropIndex();
+
+        $this->assertTrue($migration instanceof DropIndex);
+    }
+
+    public function test_addIndex_forwardsParameters()
+    {
+        $migration = $this->dropIndex();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` DROP INDEX `index_column1_column5`;", '' . $migration);
+    }
+
+    public function test_addPrimaryKey()
+    {
+        $migration = $this->addPrimaryKey();
+
+        $this->assertTrue($migration instanceof AddPrimaryKey);
+    }
+
+    public function test_addPrimaryKey_forwardsParameters()
+    {
+        $migration = $this->addPrimaryKey();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("ALTER TABLE `$table` ADD PRIMARY KEY(`column1`, `column2`);", '' . $migration);
+    }
+
+    public function test_insert_returnsInsertInstance()
+    {
+        $migration = $this->insert();
+
+        $this->assertTrue($migration instanceof Insert);
+    }
+
+    public function test_insert_forwardsParameters()
+    {
+        $migration = $this->insert();
+
+        $table = $this->testTablePrefixed;
+        $this->assertSame("INSERT INTO `$table` (`column1`, `column3`) VALUES ('val1',5);", ''. $migration);
+    }
+
+    public function test_batchInsert_returnsBatchInsertInstance()
+    {
+        $migration = $this->batchInsert();
+        $this->assertTrue($migration instanceof BatchInsert);
+    }
+
+    public function test_batchInsert_forwardsParameters()
+    {
+        $migration = $this->batchInsert();
+        $this->assertSame('<batch insert>', '' . $migration);
+        $this->assertSame($this->testTablePrefixed, $migration->getTable());
+        $this->assertSame(array('col1'), $migration->getColumnNames());
+        $this->assertSame(array(array('val1')), $migration->getValues());
+        $this->assertSame('utf8', $migration->getCharset());
+        $this->assertTrue($migration->doesThrowException());
+    }
+
+    private function sql()
+    {
+        return $this->factory->sql('SELECT 1;', 5);
+    }
+
+    private function boundSql()
+    {
+        return $this->factory->boundSql('SELECT 2 WHERE ?;', array('column' => 'query'), array(8));
+    }
+
+    private function createTable($primaryKey = array())
+    {
+        return $this->factory->createTable($this->testTable, array('column' => 'INT(10) DEFAULT 0', 'column2' => 'VARCHAR(255)'), $primaryKey);
+    }
+
+    private function addColumn($placeAfterColumn)
+    {
+        return $this->factory->addColumn($this->testTable, 'column', 'INT(10) DEFAULT 0', $placeAfterColumn);
+    }
+
+    private function dropColumn()
+    {
+        return $this->factory->dropColumn($this->testTable, 'column1');
+    }
+
+    private function addColumns($placeAfterColumn)
+    {
+        return $this->factory->addColumns($this->testTable, array(
+            'column1' => 'INT(10) DEFAULT 0',
+            'column2' => 'VARCHAR(10) DEFAULT ""',
+        ), $placeAfterColumn);
+    }
+
+    private function changeColumn()
+    {
+        return $this->factory->changeColumn($this->testTable, 'column_old', 'column_new', 'INT(10) DEFAULT 0');
+    }
+
+    private function changeColumnType()
+    {
+        return $this->factory->changeColumnType($this->testTable, 'column', 'INT(10) DEFAULT 0');
+    }
+
+    private function changeColumnTypes()
+    {
+        return $this->factory->changeColumnTypes($this->testTable, array(
+            'column1' => 'INT(10) DEFAULT 0',
+            'column2' => 'VARCHAR(10) DEFAULT ""',
+        ));
+    }
+
+    private function addIndex($customIndex = '')
+    {
+        return $this->factory->addIndex($this->testTable, array('column1', 'column3 (10)'), $customIndex);
+    }
+
+    private function addUniqueKey($customIndex = '')
+    {
+        return $this->factory->addUniqueKey($this->testTable, array('column1', 'column3 (10)'), $customIndex);
+    }
+
+    private function dropIndex()
+    {
+        return $this->factory->dropIndex($this->testTable, 'index_column1_column5');
+    }
+
+    private function addPrimaryKey()
+    {
+        return $this->factory->addPrimaryKey($this->testTable, array('column1', 'column2'));
+    }
+
+    private function insert()
+    {
+        return $this->factory->insert($this->testTable, array('column1' => 'val1', 'column3' => 5));
+    }
+
+    private function batchInsert()
+    {
+        $columns = array('col1');
+        $values = array(array('val1'));
+        return $this->factory->batchInsert($this->testTable, $columns, $values, $throwException = true, $charset = 'utf8');
+    }
+
+
+}

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Updater\Migration\Db;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\DbHelper;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Updater\Migration\Db\Factory;
+
+/**
+ * Test where migrations are actually executed.
+ *
+ * @group Core
+ * @group Updater
+ * @group Migration
+ * @group SqlTest
+ */
+class MigrationsTest extends IntegrationTestCase
+{
+    /**
+     * @var Factory
+     */
+    private $factory;
+
+    private $testTable = 'tablename';
+    private $testTablePrefixed = '';
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        self::dropTestTableIfNeeded();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::dropTestTableIfNeeded();
+
+        parent::tearDownAfterClass();
+    }
+
+    private static function dropTestTableIfNeeded()
+    {
+        $table = Common::prefixTable('tablename');
+        Db::exec("DROP TABLE IF EXISTS `$table`");
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->testTablePrefixed = Common::prefixTable($this->testTable);
+        $this->factory = new Factory();
+    }
+
+    public function test_createTable()
+    {
+        $columns = array('column1' => 'VARCHAR(200) DEFAULT ""', 'column2' => 'INT(11) NOT NULL');
+        $this->factory->createTable($this->testTable, $columns)->exec();
+
+        $this->assertTableIsInstalled();
+        $this->assertSame(array('column1', 'column2'), $this->getInstalledColumnNames());
+    }
+
+    /**
+     * @depends test_createTable
+     */
+    public function test_addColumn()
+    {
+        $this->factory->addColumn($this->testTable, 'column3', 'SMALLINT(1)')->exec();
+
+        $this->assertSame(array('column1', 'column2', 'column3'), $this->getInstalledColumnNames());
+    }
+
+    /**
+     * @depends test_addColumn
+     */
+    public function test_addIndex()
+    {
+        $this->factory->addIndex($this->testTable, array('column1', 'column3'))->exec();
+
+        $index = $this->getIndexesDefinedOnTable();
+
+        $this->assertCount(2, $index);
+        $this->assertSame('column1', $index[0]['Column_name']);
+        $this->assertSame('index_column1_column3', $index[0]['Key_name']);
+        $this->assertSame('column3', $index[1]['Column_name']);
+        $this->assertSame('index_column1_column3', $index[1]['Key_name']);
+    }
+
+    /**
+     * @depends test_addIndex
+     */
+    public function test_dropIndex()
+    {
+        $this->factory->dropIndex($this->testTable, 'index_column1_column3')->exec();
+
+        $index = $this->getIndexesDefinedOnTable();
+
+        $this->assertSame(array(), $index);
+    }
+
+    /**
+     * @depends test_dropIndex
+     */
+    public function test_addUniqueKey()
+    {
+        $this->factory->addUniqueKey($this->testTable, array('column1', 'column3'), 'custom_name')->exec();
+
+        $index = $this->getIndexesDefinedOnTable();
+
+        $this->assertCount(2, $index);
+        $this->assertSame('column1', $index[0]['Column_name']);
+        $this->assertSame('custom_name', $index[0]['Key_name']);
+        $this->assertSame('column3', $index[1]['Column_name']);
+        $this->assertSame('custom_name', $index[1]['Key_name']);
+    }
+
+    /**
+     * @depends test_addUniqueKey
+     */
+    public function test_addPrimaryIndex()
+    {
+        $this->factory->addPrimaryKey($this->testTable, array('column3'))->exec();
+
+        $index = Db::fetchAll("SHOW INDEX FROM {$this->testTablePrefixed} WHERE Key_name = 'PRIMARY'");
+
+        $this->assertCount(1, $index);
+        $this->assertSame('column3', $index[0]['Column_name']);
+    }
+
+    /**
+     * @depends test_addPrimaryIndex
+     */
+    public function test_changeColumnType()
+    {
+        $this->factory->changeColumnType($this->testTable, 'column2', 'SMALLINT(4) NOT NULL')->exec();
+    }
+
+    /**
+     * @depends test_changeColumnType
+     */
+    public function test_insert()
+    {
+        $values = array(
+            'column1' => 'my text',
+            'column2' => '554934',
+            'column3' => '1'
+        );
+        $this->factory->insert($this->testTable, $values)->exec();
+
+        $row = $this->fetchRow();
+
+        $values['column2'] = 32767; // because we changed type to smallint before
+        $this->assertEquals($values, $row);
+    }
+
+    /**
+     * @depends test_insert
+     */
+    public function test_sql()
+    {
+        $this->factory->sql("ALTER TABLE {$this->testTablePrefixed} CHANGE COLUMN `column2` `column5` SMALLINT(4) NOT NULL")->exec();
+
+        $this->assertSame(array('column1', 'column5', 'column3'), $this->getInstalledColumnNames());
+    }
+
+    /**
+     * @depends test_sql
+     */
+    public function test_addColumns()
+    {
+        $this->factory->addColumns($this->testTable, array(
+            'column10' => 'VARCHAR(255) DEFAULT ""',
+            'column11' => 'VARCHAR(55) DEFAULT ""',
+        ))->exec();
+
+        $this->assertSame(array('column1', 'column5', 'column3', 'column10', 'column11'), $this->getInstalledColumnNames());
+    }
+
+    /**
+     * @depends test_addColumns
+     */
+    public function test_changeColumnTypes()
+    {
+        $this->factory->changeColumnTypes($this->testTable, array(
+            'column5' => 'VARCHAR(10) DEFAULT ""',
+            'column11' => 'VARCHAR(255) DEFAULT "test"',
+        ))->exec();
+    }
+
+    /**
+     * @depends test_changeColumnTypes
+     */
+    public function test_dropColumn()
+    {
+        $this->factory->dropColumn($this->testTable, 'column10')->exec();
+
+        $this->assertSame(array('column1', 'column5', 'column3', 'column11'), $this->getInstalledColumnNames());
+    }
+
+    /**
+     * @depends test_dropColumn
+     */
+    public function test_changeColumn()
+    {
+        $this->factory->changeColumn($this->testTable, 'column11', 'column12', 'VARCHAR(255)')->exec();
+
+        $this->assertSame(array('column1', 'column5', 'column3', 'column12'), $this->getInstalledColumnNames());
+    }
+
+    /**
+     * @depends test_changeColumn
+     */
+    public function test_dropTable()
+    {
+        $this->factory->dropTable($this->testTable)->exec();
+
+        $this->assertTableIsNotInstalled();
+    }
+
+    private function fetchRow()
+    {
+        return Db::fetchRow("SELECT * FROM {$this->testTablePrefixed}");
+    }
+
+    private function assertTableIsInstalled()
+    {
+        $this->assertNotEmpty($this->getInstalledTable());
+    }
+
+    private function assertTableIsNotInstalled()
+    {
+        $this->assertEmpty($this->getInstalledTable());
+    }
+
+    private function getInstalledTable()
+    {
+        return Db::fetchAll("SHOW TABLES LIKE '{$this->testTablePrefixed}'");
+    }
+
+    private function getInstalledColumnNames()
+    {
+        $columns = DbHelper::getTableColumns($this->testTablePrefixed);
+        return array_keys($columns);
+    }
+
+    private function getIndexesDefinedOnTable()
+    {
+        return Db::fetchAll("SHOW INDEX FROM {$this->testTablePrefixed}");
+    }
+}

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/SqlTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/SqlTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Updater\Migration\Db;
+
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Updater\Migration\Db\Sql;
+
+/**
+ * @group Core
+ * @group Updater
+ * @group Migration
+ * @group SqlTest
+ */
+class SqlTest extends IntegrationTestCase
+{
+    private $testQuery = 'ALTER TABLE foobar ADD COLUMN barbaz VARCHAR(1)';
+
+    public function test_toString_shouldAppendSemicolonIfNeeded()
+    {
+        $sql = $this->sql($this->testQuery);
+
+        $this->assertSame($this->testQuery . ';', '' . $sql);
+    }
+
+    public function test_toString_shouldNotAppendSemicolonIfNotNeeded()
+    {
+        $sql = $this->sql($this->testQuery . ';');
+
+        $this->assertSame($this->testQuery . ';', '' . $sql);
+    }
+
+    public function test_constructor_shouldConvertErrorCodeToArray_IfNeeded()
+    {
+        $sql = $this->sql($this->testQuery, 1091);
+        $this->assertSame(array(1091), $sql->getErrorCodesToIgnore());
+    }
+
+    public function test_constructor_shouldNotConvertErrorCodeToArray_IfNotNeeded()
+    {
+        $sql = $this->sql($this->testQuery, array(1091, 1061));
+        $this->assertSame(array(1091, 1061), $sql->getErrorCodesToIgnore());
+    }
+
+    public function test_addErrorCodeToIgnore_addsOneErrorCode()
+    {
+        $sql = $this->sql($this->testQuery, array(1091, 1061));
+        $sql->addErrorCodeToIgnore(1049);
+        $this->assertSame(array(1091, 1061, 1049), $sql->getErrorCodesToIgnore());
+    }
+
+    private function sql($query, $errorCode = false)
+    {
+        return new Sql($query, $errorCode);
+    }
+
+
+}

--- a/tests/PHPUnit/Integration/Updater/Migration/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/FactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Updater\Migration;
+
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Updater\Migration;
+use Piwik\Updater\Migration\Db\Factory as DbFactory;
+use Piwik\Updater\Migration\Plugin\Factory as PluginFactory;
+
+/**
+ * @group Core
+ * @group Updater
+ * @group Migration
+ */
+class FactoryTest extends IntegrationTestCase
+{
+    /**
+     * @var Migration\Factory
+     */
+    private $factory;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->factory = new Migration\Factory(new DbFactory(), new PluginFactory());
+    }
+
+    public function test_db_holdsDatabaseFactory()
+    {
+        $this->assertTrue($this->factory->db instanceof DbFactory);
+    }
+
+    public function test_plugin_holdsPluginFactory()
+    {
+        $this->assertTrue($this->factory->plugin instanceof PluginFactory);
+    }
+
+}

--- a/tests/PHPUnit/Integration/Updater/Migration/Plugin/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Plugin/FactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Updater\Migration\Plugin;
+
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Updater\Migration\Plugin\Activate;
+use Piwik\Updater\Migration\Plugin\Factory;
+
+/**
+ * @group Core
+ * @group Updater
+ * @group Migration
+ */
+class FactoryTest extends IntegrationTestCase
+{
+    /**
+     * @var Factory
+     */
+    private $factory;
+
+    private $pluginName = 'MyTestPluginName';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->factory = new Factory();
+    }
+
+    public function test_activate_returnsActivateInstance()
+    {
+        $migration = $this->factory->activate($this->pluginName);
+
+        $this->assertTrue($migration instanceof Activate);
+    }
+
+    public function test_sql_forwardsQueryAndErrorCode()
+    {
+        $migration = $this->factory->activate($this->pluginName);
+
+        $this->assertSame('Activating plugin "MyTestPluginName"', '' . $migration);
+    }
+
+}

--- a/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
+++ b/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
@@ -80,6 +80,11 @@ class DeprecatedMethodsTest extends \PHPUnit_Framework_TestCase
         $this->assertDeprecatedMethodIsRemovedInPiwik3('Piwik\Plugins\Resolution\Resolution', 'renameUserSettingsModuleAndAction');
         $this->assertDeprecatedMethodIsRemovedInPiwik3('Piwik\Plugins\DevicePlugins\DevicePlugins', 'renameUserSettingsModuleAndAction');
         $this->assertDeprecatedMethodIsRemovedInPiwik3('Piwik\Plugins\UserLanguage\UserLanguage', 'renameUserSettingsModuleAndAction');
+
+        $this->assertDeprecatedMethodIsRemovedInPiwik4('Piwik\Updates', 'getSql');
+        $this->assertDeprecatedMethodIsRemovedInPiwik4('Piwik\Updates', 'update');
+        $this->assertDeprecatedMethodIsRemovedInPiwik4('Piwik\Updates', 'getMigrationQueries');
+        $this->assertDeprecatedMethodIsRemovedInPiwik4('Piwik\Updater', 'executeMigrationQueries');
     }
 
     private function assertDeprecatedMethodIsRemoved($className, $method, $removalDate)
@@ -126,14 +131,24 @@ class DeprecatedMethodsTest extends \PHPUnit_Framework_TestCase
 
     private function assertDeprecatedMethodIsRemovedInPiwik3($className, $method)
     {
+        $this->assertDeprecatedMethodIsRemovedInPiwikVersion('3.0.0', $className, $method);
+    }
+
+    private function assertDeprecatedMethodIsRemovedInPiwik4($className, $method)
+    {
+        $this->assertDeprecatedMethodIsRemovedInPiwikVersion('4.0.0', $className, $method);
+    }
+
+    private function assertDeprecatedMethodIsRemovedInPiwikVersion($piwikVersion, $className, $method)
+    {
         $version = Version::VERSION;
 
         $class        = new ReflectionClass($className);
         $methodExists = $class->hasMethod($method);
 
-        if (-1 === version_compare($version, '3.0.0')) {
+        if (-1 === version_compare($version, $piwikVersion)) {
 
-            $errorMessage = $className . '::' . $method . ' should still exists until 3.0 although it is deprecated.';
+            $errorMessage = $className . '::' . $method . ' should still exists until ' . $piwikVersion . ' although it is deprecated.';
             $this->assertTrue($methodExists, $errorMessage);
             return;
         }


### PR DESCRIPTION
Plugins can now more easily define updates by reusing some existing migrations. So far a couple of database migrations and one plugin migration exists. In the future we can add many more migrations.

I also renamed some existing API methods but kept BC even though it is for 3.0 as I don't want to break updates when it's easy to keep BC for a while.

In an update one can now implement `getMigrations()` method and generate migrations via the migrations factory instead of specifying SQL queries manually via `return array('SELECT ... => errorCodesToIgnore)`. While we still can define custom SQL queries we can often reuse existing migrations and this way we don't have to check for correct error codes all the time etc.

For example:

``` php
public function getMigrations(Updater $updater)
    {
        // many different migrations are available to be used via $this->migration factory
        $migration1 = $this->migration->db->changeColumnType('log_visit', 'example', 'BOOLEAN NOT NULL');
        // you can also define custom SQL migrations. If you need to bind parameters, use `->boundSql()`
        $migration2 = $this->migration->db->sql($sqlQuery = 'SELECT 1');

        return array(
            // $migration1,
            // $migration2
        );
    }
```

It is easy for us to add new migrations. In the future we could add more features:
- eg also define `undo()` methods for some migrations although this will very likely not happen in the next years.
- The migrations could automatically detect whether an update is a major update or not. 
- Migrations could in the future provide a method like `checkPrecondition` to eg check whether all required conditions are met. Say there is an UpdateConfig migration and this migration could check whether the config file is actually writable before the update is performed. 
- At some point we could "merge" `alter table` statements across multiple updates. For example if multiple updates define a migration for `log_visit` we could automatically combine them in one big alter update for faster performance etc.
- For eg plugin changes we could print commands to execute on the console such as `./console plugin:activate $pluginName` and not only print SQL updates
- ...

Currently, the following DB migrations are available:
- AddColumn
- AddColumns
- AddIndex
- AddPrimaryKey
- BatchInsert
- BoundSql
- ChangeColumn
- ChangeColumnType
- ChangeColumnTypes
- CreateTable
- DropColumn
- DropIndex
- DropTable
- Sql

For an example see https://github.com/piwik/piwik/blob/update_migrations_2/plugins/ExamplePlugin/Updates/0.0.2.php

To add a new migration create a new class in `Piwik\Updater\Migration`. Eg in the `Db` or `Plugin` directory. I can imagine there will be in the future also a `Config` directory etc. Then add a method to the `Factory` in within that directory. By using the factory everything will go through DI. Then a method should be added eg to `tests/PHPUnit/Integration/Updater/Migration/Db/FactoryTest.php` (here we test whether factory returns correct instance and we check eg if correct SQL is generated) and `MigrationsTest.php` (here we actually test whether the migration works) .

All the classes under `core/Updater/Migration` are not API apart from the `Factories` and a `Db` class containing constants for error codes. Only the factories are API which allows us to change code for the migrations in the future.
