### PR TITLE
Add pull request template mentioning PRs should be made against 3.x-dev

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,3 @@
+Please issue pull request against the `3.x-dev` branch as the `master` branch currently represents our `2.X` version which is in LTS mode. 
+
+Important fixes will be merged into `master` if needed after it was merged to `3.x-dev`.


### PR DESCRIPTION
As we have released Piwik 2.16.1 today it is now time to point new pull requests against 3.x-dev. We will then cherry pick fixed that need to be in 2.16.X. 

I want to merge this as soon as I've made `3.x-dev` branch green. Any opinions on this?
