### PR TITLE
do not start a session during tracker mode or if session is not start…

### DIFF
--- a/core/Notification/Manager.php
+++ b/core/Notification/Manager.php
@@ -129,6 +129,10 @@ class Manager
 
     private static function removeOldestNotificationsIfThereAreTooMany()
     {
+        if (!self::isSessionEnabled()) {
+            return;
+        }
+        
         $maxNotificationsInSession = 30;
 
         $session = static::getSession();


### PR DESCRIPTION
…ed yet

Eg could start a session during tracking if a tracker plugin is not compatible with the current Piwik and it would try to trigger a notification because of this.

It is already fixed in Piwik 3.0
