### PR TITLE
Update incorrect translation of "Visit number"

### DIFF
--- a/plugins/VisitorInterest/lang/fr.json
+++ b/plugins/VisitorInterest/lang/fr.json
@@ -8,7 +8,7 @@
         "NPages": "%s pages",
         "OnePage": "1 page",
         "PluginDescription": "Fournit des détails sur les intérêts des visiteurs: nombre de pages vues, temps passé sur le site web, jours depuis la dernière visite et plus.",
-        "VisitNum": "Numéro de la visite",
+        "VisitNum": "Nombre de visites",
         "VisitsByDaysSinceLast": "Visites par jours depuis la dernière visite",
         "visitsByVisitCount": "Visites par nombre de visites",
         "VisitsPerDuration": "Visites par durée de la visite",


### PR DESCRIPTION
The key VisitNum refer to the text "Visit number" in english. The correct translation in french is "Nombre de visites". The actual translation is "Numéro de la visit", which is translated to "Visit ID".
