### PR TITLE
Improve referrer type detection for direct entries

### DIFF
--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -288,8 +288,11 @@ abstract class Base extends VisitDimension
             return false;
         }
 
+        $site = Cache::getCacheWebsiteAttributes($this->idsite);
+        $excludeUnknowns = $site['exclude_unknown_urls'];
+
         // fallback logic if the referrer domain is not known to any site to not break BC
-        if (isset($this->currentUrlParse['host'])) {
+        if (!$excludeUnknowns && isset($this->currentUrlParse['host'])) {
             // this might be actually buggy if first thing tracked is eg an outlink and referrer is from that site
             $currentHost = Common::mb_strtolower($this->currentUrlParse['host']);
             if ($currentHost == Common::mb_strtolower($this->referrerHost)) {

--- a/plugins/Referrers/tests/Integration/Columns/ReferrerTypeTest.php
+++ b/plugins/Referrers/tests/Integration/Columns/ReferrerTypeTest.php
@@ -32,6 +32,7 @@ class ReferrerTypeTest extends IntegrationTestCase
     private $idSite1 = 1;
     private $idSite2 = 2;
     private $idSite3 = 3;
+    private $idSite4 = 4;
 
     public function setUp()
     {
@@ -45,6 +46,7 @@ class ReferrerTypeTest extends IntegrationTestCase
         Fixture::createWebsite($date, $ecommerce, $name = 'test1', $url = 'http://piwik.org/foo/bar');
         Fixture::createWebsite($date, $ecommerce, $name = 'test2', $url = 'http://piwik.org/');
         Fixture::createWebsite($date, $ecommerce, $name = 'test3', $url = 'http://piwik.pro/');
+        Fixture::createWebsite($date, $ecommerce, $name = 'test4', $url = 'http://google.com/subdir/', 1, null, null, null, null, $excludeUnknownUrls = 1);
 
         $this->referrerType = new ReferrerType();
     }
@@ -112,6 +114,19 @@ class ReferrerTypeTest extends IntegrationTestCase
 
             // testing case where domain of referrer is not known to any site but neither is the URL, url != urlref
             array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite3, 'http://example.org', 'http://example.com/bar'),
+
+            ####### testing specific case:
+            ## - ignore unknown urls is activated for idSite4
+
+            // referrer comes from another subdir, but same host   => external website
+            array(Common::REFERRER_TYPE_WEBSITE,      $this->idSite4, 'http://google.com/subdir/site', 'http://google.com/base'),
+            // referrer comes from same subdir and host   => direct entry
+            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite4, 'http://google.com/subdir/page', 'http://google.com/subdir/x'),
+            array(Common::REFERRER_TYPE_DIRECT_ENTRY, $this->idSite4, 'http://google.com/subdir/', 'http://google.com/subdir/?q=test'),
+            // referrer comes from another subdir, but same host, query matches search engine definition  => search engine
+            array(Common::REFERRER_TYPE_SEARCH_ENGINE, $this->idSite4, 'http://google.com/subdir/index.html', 'http://google.com/search?q=test'),
+            // referrer comes from search engine not matching site
+            array(Common::REFERRER_TYPE_SEARCH_ENGINE, $this->idSite4, 'http://google.com/subdir/index.html', 'http://google.fr/search?q=test')
         );
     }
 

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -466,11 +466,14 @@ class Fixture extends \PHPUnit_Framework_Assert
      * @param null|string $searchCategoryParameters
      * @param null|string $timezone
      * @param null|string $type eg 'website' or 'mobileapp'
+     * @param null|string $settings eg 'website' or 'mobileapp'
+     * @param int $excludeUnknownUrls
      * @return int    idSite of website created
      */
     public static function createWebsite($dateTime, $ecommerce = 0, $siteName = false, $siteUrl = false,
                                          $siteSearch = 1, $searchKeywordParameters = null,
-                                         $searchCategoryParameters = null, $timezone = null, $type = null)
+                                         $searchCategoryParameters = null, $timezone = null, $type = null,
+                                         $excludeUnknownUrls = 0)
     {
         if($siteName === false) {
             $siteName = self::DEFAULT_SITE_NAME;
@@ -488,7 +491,9 @@ class Fixture extends \PHPUnit_Framework_Assert
             $startDate = null,
             $excludedUserAgents = null,
             $keepURLFragments = null,
-            $type
+            $type,
+            $settings = null,
+            $excludeUnknownUrls
         );
 
         // Manually set the website creation date to a day earlier than the earliest day we record stats for


### PR DESCRIPTION
The detection for direct entries does not always work correctly if there are multiple websites running on the same host (eg in subdirectories).

Sample case:

Website tracked in Piwik has the url `http://www.sample.com/website/`

On `http://www.sample.com/` might run another site, maybe also a social network or search engine, same for any subdirectory of that host.

If we track a visitor on `http://www.sample.com/website/index` coming from `http://www.sample.com/sitexy`, the request will be counted as direct entry, cause of the [fallback logic](https://github.com/piwik/piwik/blob/master/plugins/Referrers/Columns/Base.php#L291-L299) used.

That wouldn't be correct in that specific case, as the referrer should be detected as website (or maybe a search engine).

As Piwik allows to track any url, as long it is not configured otherwise, that fallback logic is required as ongoing tracking requests for the same (not configured) host would all be detected as external website otherwise.

With this change, the fallback logic will be disabled if the tracked website does not allow to track any url (exclude unknown url option). That should not make any difference except for the mentioned case.

As tracking requests for other host will be ignored, the detection for direct entries will only be called with valid hosts. There is no need to check if referring host and tracked host matches, as it would match [before](https://github.com/piwik/piwik/blob/master/plugins/Referrers/Columns/Base.php#L284-L287).

fixes #10121
