### PR TITLE
Accessility: set a title attribute on Main menu item for better experience on screen readers

### DIFF
--- a/plugins/CoreHome/templates/_topBar.twig
+++ b/plugins/CoreHome/templates/_topBar.twig
@@ -3,7 +3,7 @@
 
     {% macro menuItemLabel(label, icon) %}
         {% if icon is defined and icon and icon starts with 'icon-' %}
-            <span class="{{ icon|striptags }}"></span>
+            <span class="{{ icon|striptags }}" aria-label="{{ label|translate }}"></span>
         {% else %}
             {{ label|translate }}
         {% endif %}

--- a/plugins/CoreHome/templates/_topBar.twig
+++ b/plugins/CoreHome/templates/_topBar.twig
@@ -3,7 +3,7 @@
 
     {% macro menuItemLabel(label, icon) %}
         {% if icon is defined and icon and icon starts with 'icon-' %}
-            <span class="{{ icon|striptags }}" aria-label="{{ label|translate }}"></span>
+            <span class="{{ icon|striptags }}" aria-label="{{ label|translate|e('html_attr') }}"></span>
         {% else %}
             {{ label|translate }}
         {% endif %}


### PR DESCRIPTION
This pull request fixesan accessibility issue in the main menu with items having only an icon. The title attribute is not enough to provide full accessibility, for example NVDA does not show it when navigating using arrow keys or in the elements list. So this change adds an aria-label to the icon when it exists ant therefore the label is not displayed as the link's child.
