### PR TITLE
Adds proxy method to call API using session

### DIFF
--- a/plugins/CoreHome/Controller.php
+++ b/plugins/CoreHome/Controller.php
@@ -111,7 +111,7 @@ class Controller extends \Piwik\Plugin\Controller
         $controllerName = Common::getRequestVar('moduleToLoad');
         $actionName     = Common::getRequestVar('actionToLoad', 'index');
 
-        if($controllerName == 'API') {
+        if($controllerName == 'API' || ($controllerName == 'Proxy' && $actionName == 'callApi')) {
             throw new Exception("Showing API requests in context is not supported for security reasons. Please change query parameter 'moduleToLoad'.");
         }
         if ($actionName == 'showInContext') {

--- a/plugins/CoreHome/Controller.php
+++ b/plugins/CoreHome/Controller.php
@@ -111,7 +111,7 @@ class Controller extends \Piwik\Plugin\Controller
         $controllerName = Common::getRequestVar('moduleToLoad');
         $actionName     = Common::getRequestVar('actionToLoad', 'index');
 
-        if($controllerName == 'API' || ($controllerName == 'Proxy' && $actionName == 'callApi')) {
+        if(!$this->isAllowedContextRequest($controllerName, $actionName)) {
             throw new Exception("Showing API requests in context is not supported for security reasons. Please change query parameter 'moduleToLoad'.");
         }
         if ($actionName == 'showInContext') {
@@ -121,6 +121,11 @@ class Controller extends \Piwik\Plugin\Controller
         $view = $this->getDefaultIndexView();
         $view->content = FrontController::getInstance()->fetchDispatch($controllerName, $actionName);
         return $view->render();
+    }
+
+    protected function isAllowedContextRequest($controller, $action)
+    {
+        return $controller != 'API' && ($controller != 'Proxy' || $action != 'callApiWithCurrentSession');
     }
 
     public function markNotificationAsRead()

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -433,7 +433,7 @@ var broadcast = {
             });
         }
 
-        if(broadcast.getParamValue('module', urlAjax) == 'API') {
+        if(broadcast.getParamValue('module', urlAjax) == 'API' || broadcast.getParamValue('module', urlAjax) == 'Proxy' && broadcast.getParamValue('action', urlAjax) == 'callApi') {
             broadcast.lastUrlRequested = null;
             $('#content').html("Loading content from the API and displaying it within Piwik is not allowed.");
             piwikHelper.hideAjaxLoading();

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -404,6 +404,19 @@ var broadcast = {
     },
 
     /**
+     * Checks if the given url is being allowed to be loaded using ajax
+     *
+     * @param {string} url
+     * @returns {boolean}
+     * @private
+     */
+    _isAllowedAjaxUrl: function (url) {
+        var module = broadcast.getParamValue('module', url);
+        var action = broadcast.getParamValue('action', url);
+        return !(module == 'API' || (module == 'Proxy' && action == 'callApiWithCurrentSession'));
+    },
+
+    /**
      * Loads the given url with ajax and replaces the content
      *
      * Note: the method is replaced in Overlay/javascripts/Piwik_Overlay.js - keep this in mind when making changes.
@@ -433,7 +446,7 @@ var broadcast = {
             });
         }
 
-        if(broadcast.getParamValue('module', urlAjax) == 'API' || broadcast.getParamValue('module', urlAjax) == 'Proxy' && broadcast.getParamValue('action', urlAjax) == 'callApi') {
+        if(!broadcast._isAllowedAjaxUrl(urlAjax)) {
             broadcast.lastUrlRequested = null;
             $('#content').html("Loading content from the API and displaying it within Piwik is not allowed.");
             piwikHelper.hideAjaxLoading();

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1050,7 +1050,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             // prevent click jacking attacks by dynamically adding the token auth when the link is clicked
             .click(function () {
                 $(this).attr('href', function () {
-                    var url = $(this).attr('href') + '&token_auth=' + piwik.token_auth;
+                    var url = $(this).attr('href');
 
                     var limit = $('.limitSelection>div>span', domElem).attr('value');
                     var defaultLimit = $(this).attr('filter_limit');
@@ -1099,7 +1099,8 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                     period = 'day';
                 }
 
-                var str = 'index.php?module=API'
+                var str = 'index.php?module=Proxy'
+                    + '&action=callApi'
                     + '&method=' + method
                     + '&format=' + format
                     + '&idSite=' + self.param.idSite

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1100,7 +1100,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                 }
 
                 var str = 'index.php?module=Proxy'
-                    + '&action=callApi'
+                    + '&action=callApiWithCurrentSession'
                     + '&method=' + method
                     + '&format=' + format
                     + '&idSite=' + self.param.idSite

--- a/plugins/Proxy/Controller.php
+++ b/plugins/Proxy/Controller.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\Proxy;
 use Piwik\AssetManager;
 use Piwik\AssetManager\UIAsset;
 use Piwik\Common;
+use Piwik\FrontController;
 use Piwik\Piwik;
 use Piwik\ProxyHttp;
 use Piwik\Url;
@@ -24,6 +25,15 @@ class Controller extends \Piwik\Plugin\Controller
 {
     const TRANSPARENT_PNG_PIXEL = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=';
     const JS_MIME_TYPE = "application/javascript; charset=UTF-8";
+
+    /**
+     * Proxy method to call API methods using current session for authentication
+     */
+    public function callApi()
+    {
+        echo FrontController::getInstance()->dispatch('API', 'index');
+        exit;
+    }
 
     /**
      * Output the merged CSS file.

--- a/plugins/Proxy/Controller.php
+++ b/plugins/Proxy/Controller.php
@@ -29,7 +29,7 @@ class Controller extends \Piwik\Plugin\Controller
     /**
      * Proxy method to call API methods using current session for authentication
      */
-    public function callApi()
+    public function callApiWithCurrentSession()
     {
         echo FrontController::getInstance()->dispatch('API', 'index');
         exit;

--- a/plugins/ScheduledReports/templates/_listReports.twig
+++ b/plugins/ScheduledReports/templates/_listReports.twig
@@ -66,7 +66,7 @@
             </td>
             <td>
                 {# download link #}
-                <a href="{{ linkTo({'module':'API', 'segment': null, 'token_auth':token_auth,
+                <a href="{{ linkTo({'module':'Proxy', 'action': 'callApi', 'segment': null,
                             'method':'ScheduledReports.generateReport', 'idReport':report.idreport,
                             'outputType':downloadOutputType, 'language':language,
                             'format': (report.format in ['html', 'csv']) ? report.format : false

--- a/plugins/ScheduledReports/templates/_listReports.twig
+++ b/plugins/ScheduledReports/templates/_listReports.twig
@@ -66,7 +66,7 @@
             </td>
             <td>
                 {# download link #}
-                <a href="{{ linkTo({'module':'Proxy', 'action': 'callApi', 'segment': null,
+                <a href="{{ linkTo({'module':'Proxy', 'action': 'callApiWithCurrentSession', 'segment': null,
                             'method':'ScheduledReports.generateReport', 'idReport':report.idreport,
                             'outputType':downloadOutputType, 'language':language,
                             'format': (report.format in ['html', 'csv']) ? report.format : false

--- a/plugins/Widgetize/Controller.php
+++ b/plugins/Widgetize/Controller.php
@@ -35,7 +35,7 @@ class Controller extends \Piwik\Plugin\Controller
         $controllerName = Common::getRequestVar('moduleToWidgetize');
         $actionName     = Common::getRequestVar('actionToWidgetize');
 
-        if($controllerName == 'API') {
+        if($controllerName == 'API' || $controllerName == 'Proxy') {
             throw new \Exception("Widgetizing API requests is not supported for security reasons. Please change query parameter 'moduleToWidgetize'.");
         }
 


### PR DESCRIPTION
New proxy method is used for download links in email reports and datatables, to avoid exposing the token_auth in direct API urls.

fixes #10185 
fixes #10147
