### PR TITLE
Put idSite into single quote for support custom string id

### DIFF
--- a/plugins/Morpheus/templates/javascriptCode.tpl
+++ b/plugins/Morpheus/templates/javascriptCode.tpl
@@ -6,7 +6,7 @@
   (function() {
     {$setTrackerUrl}
     {$optionsBeforeTrackerUrl}_paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', {$idSite}]);
+    _paq.push(['setSiteId', '{$idSite}']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();

--- a/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
@@ -45,7 +45,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
   (function() {
     var u=&quot;//localhost/piwik/&quot;;
     _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', 1]);
+    _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
@@ -92,7 +92,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
   (function() {
     var u=&quot;https://localhost/piwik/&quot;;
     _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', 1]);
+    _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
@@ -140,7 +140,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     var u=&quot;//localhost/piwik/&quot;;
     _paq.push(['setAPIUrl', 'http://localhost/statistics']);
     _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', 1]);
+    _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
@@ -183,7 +183,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
   (function() {
     var u=&quot;//abc&quot;def/&quot;;
     _paq.push([\'setTrackerUrl\', u+\'piwik.php\']);
-    _paq.push([\'setSiteId\', 1]);
+    _paq.push([\'setSiteId\', \'1\']);
     var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
     g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src=u+\'piwik.js\'; s.parentNode.insertBefore(g,s);
   })();

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
@@ -7,7 +7,7 @@
   (function() {
     var u=&quot;//example.org/piwik/&quot;;
     _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', 1]);
+    _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();


### PR DESCRIPTION
This is small change, but is necessary for https://github.com/piwik/piwik/issues/9975, https://github.com/piwik/piwik/issues/4920 and others. On my tests, even with single quote, numeric idSite works fine for simple pageview track.
