### PR TITLE
Do not throw an exception when logging debug info in tracker 

### DIFF
--- a/core/Tracker/Action.php
+++ b/core/Tracker/Action.php
@@ -283,7 +283,7 @@ abstract class Action
         $typeId = array_search($type, $constants);
 
         if (false === $typeId) {
-            throw new Exception("Unexpected action type " . $type);
+            return $type;
         }
 
         return str_replace('TYPE_', '', $typeId);


### PR DESCRIPTION
This method is only called when Tracker debugging is enabled. It may cause problems if an unknown type is used and then the tracking completely fails which also stops tracking. Debugging info should not really throw exceptions, at least not in this case.
