### PR TITLE
Let plugins provide custom piwik.js tracker tests

### DIFF
--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -4159,6 +4159,14 @@ function customAddEventListener(element, eventType, eventHandler, useCapture) {
     }
 })(PiwikTest);
  </script>
+ 
+<?php
+    include_once $root . '/core/Filesystem.php';
+    $files = \Piwik\Filesystem::globr($root . '/plugins/*/tests/javascript', 'index.php');
+    foreach ($files as $file) {
+        include_once $file;
+    }
+?>
 
  <div id="jashDiv">
  <a href="#" onclick="javascript:loadJash();" title="Open JavaScript Shell"><img id="title" src="gnome-terminal.png" border="0" width="24" height="24" /></a>


### PR DESCRIPTION
Plugins could provide custom tracker tests by creating a file 'tests/javascript/index.php' within the plugin.

Won't be a documented feature for now but could add it to dev changelog if needed.

Content within the test file could be eg 

``` html
<script type="text/javascript">
test("MyPiwikTest", function() {
    expect(1);

    var tracker = Piwik.getTracker();

    equal(typeof tracker.trackGoal, 'function', 'trackGoal' );
});
</script>
```

ping @mattab 
