### PR TITLE
Fix frameElement access for IE

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2706,13 +2706,24 @@ if (typeof window.Piwik !== 'object') {
         }
 
         function isInsideAnIframe () {
-            if (isDefined(windowAlias.frameElement)) {
-                return (windowAlias.frameElement && String(windowAlias.frameElement.nodeName).toLowerCase() === 'iframe');
+            var frameElement;
+
+            try {
+                // If the parent window has another origin, then accessing frameElement
+                // throws an Error in IE. Compare issue #10105.
+                frameElement = windowAlias.frameElement;
+            } catch (e1) {
+                // When there was an Error, then we know we are inside an iframe.
+                return true;
+            }
+
+            if (isDefined(frameElement)) {
+                return (frameElement && String(frameElement.nodeName).toLowerCase() === 'iframe');
             }
 
             try {
                 return windowAlias.self !== windowAlias.top;
-            } catch (e) {
+            } catch (e2) {
                 return true;
             }
         }


### PR DESCRIPTION
Accessing `window.frameElement` throws an Error in IE if the iframe has
another origin than its parent. If there is an error on accessing
`window.frameElement`, then we know that we are inside an iframe.

Closes #10105.
