### PR TITLE
Add possibility to specify a custom row aggregation operation

### DIFF
--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -461,7 +461,11 @@ class Row implements \ArrayAccess, \IteratorAggregate
 
             $operation = 'sum';
             if (is_array($aggregationOperations) && isset($aggregationOperations[$columnToSumName])) {
-                $operation = strtolower($aggregationOperations[$columnToSumName]);
+                if (is_string($aggregationOperations[$columnToSumName])) {
+                    $operation = strtolower($aggregationOperations[$columnToSumName]);
+                } elseif (is_callable($aggregationOperations[$columnToSumName])) {
+                    $operation = $aggregationOperations[$columnToSumName];
+                }
             }
 
             // max_actions is a core metric that is generated in ArchiveProcess_Day. Therefore, it can be
@@ -520,6 +524,10 @@ class Row implements \ArrayAccess, \IteratorAggregate
                 $newValue = $thisColumnValue;
                 break;
             default:
+                if (is_callable($operation)) {
+                    return call_user_func($operation, $thisColumnValue, $columnToSumValue);
+                }
+
                 throw new Exception("Unknown operation '$operation'.");
         }
         return $newValue;

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -308,6 +308,25 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($subtable, $row1->getIdSubDataTable());
     }
 
+    public function testSumRowMetadata_CustomAggregationOperation()
+    {
+        $metadata1 = array('mytest' => 'value1');
+        $metadata2 = array('mytest' => 'value2');
+
+        $row1 = new Row(array(Row::COLUMNS => array('test_int' => 145), Row::METADATA => $metadata1));
+        $finalRow = new Row(array(Row::COLUMNS => array('test_int' => 5), Row::METADATA => $metadata2));
+        $finalRow->sumRowMetadata($row1, array('mytest' => function ($thisValue, $otherValue) {
+            if (!is_array($thisValue)) {
+                $thisValue = array($thisValue);
+            }
+
+            $thisValue[] = $otherValue;
+            return $thisValue;
+        }));
+
+        $this->assertEquals(array('value2', 'value1'), $finalRow->getMetadata('mytest'));
+    }
+
     public function testSumRow_CustomAggregationOperation()
     {
         $columns = array('test_int' => 145, 'test_float' => 145.5);

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -308,6 +308,39 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($subtable, $row1->getIdSubDataTable());
     }
 
+    public function testSumRow_CustomAggregationOperation()
+    {
+        $columns = array('test_int' => 145, 'test_float' => 145.5);
+
+        $row1 = new Row(array(Row::COLUMNS => $columns));
+
+        $columns2 = array('test_int' => 5);
+        $finalRow = new Row(array(Row::COLUMNS => $columns2));
+        $finalRow->sumRow($row1, $copyMetadata = true, $operation = array('test_int' => function ($thisValue, $otherValue) {
+            if (!is_array($thisValue)) {
+                $thisValue = array($thisValue);
+            }
+
+            $thisValue[] = $otherValue;
+            return $thisValue;
+        }));
+
+        $this->assertEquals(array(5, 145), $finalRow->getColumn('test_int'));
+    }
+
+    /**
+     * @expectedException  \Exception
+     * @expectedExceptionMessage Unknown operation 'foobarinvalid'
+     */
+    public function testSumRow_ShouldThrowExceptionIfInvalidOperationIsGiven()
+    {
+        $row1 = new Row(array(Row::COLUMNS => array('test_int' => 145)));
+        $finalRow = new Row(array(Row::COLUMNS => array('test_int' => 5)));
+        $finalRow->sumRow($row1, $copyMetadata = true, $operation = array('test_int' => 'fooBarInvalid'));
+
+        $this->assertEquals(array(5, 145), $finalRow->getColumn('test_int'));
+    }
+
     public function unserializeTestsDataProvider()
     {
         return array(


### PR DESCRIPTION
When summing rows eg because of archiver this allows us to aggregate rows based on a custom operation and not just based on the ones provided by core (like `sum`, `max`, `skip`, ...).

ping @mattab 
