### PR TITLE
Piwik.js: trackLink does not invoke callback if request is done via GET

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -3177,7 +3177,9 @@ if (typeof window.Piwik !== 'object') {
                     iterator = 0; // To avoid JSLint warning of empty block
                     if (typeof callback === 'function') { callback(); }
                 };
-                image.src = configTrackerUrl + (configTrackerUrl.indexOf('?') < 0 ? '?' : '&') + request.replace("&send_image=0","");
+                // make sure to actually load an image so callback gets invoked
+                request = request.replace("send_image=0","send_image=1");
+                image.src = configTrackerUrl + (configTrackerUrl.indexOf('?') < 0 ? '?' : '&') + request;
             }
 
             /*

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -3177,7 +3177,7 @@ if (typeof window.Piwik !== 'object') {
                     iterator = 0; // To avoid JSLint warning of empty block
                     if (typeof callback === 'function') { callback(); }
                 };
-                image.src = configTrackerUrl + (configTrackerUrl.indexOf('?') < 0 ? '?' : '&') + request;
+                image.src = configTrackerUrl + (configTrackerUrl.indexOf('?') < 0 ? '?' : '&') + request.replace("&send_image=0","");
             }
 
             /*


### PR DESCRIPTION
This is PR as a result to discussion on issue #10153.

-> I remove "send_image=0" from request parameters, when the call goes through getImage().
-> this allows the PHP tracker to reply to GET requests with a 1x1 image, instead of HTTP 204.

Note : the corresponding code in /core/Tracker/Response.php is : 

```
    private function outputApiResponse(Tracker $tracker)
    {
       [...]
       if (array_key_exists('send_image', $request) && $request['send_image'] === '0') {
            Common::sendResponseCode(204);
            return;
        }
        $this->outputTransparentGif();
    }
}

```
