### PR TITLE
Pre-process even "real time" segments, when archiving of segment is enforced via browser_archiving_disabled_enforce=1

### DIFF
--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -163,6 +163,12 @@ class Rules
         return Config::getInstance()->General['time_before_today_archive_considered_outdated'];
     }
 
+    public static function isBrowserArchivingAvailableForSegments()
+    {
+        $generalConfig = Config::getInstance()->General;
+        return (self::isRequestAuthorizedToArchive() && !$generalConfig['browser_archiving_disabled_enforce']);
+    }
+
     public static function isArchivingDisabledFor(array $idSites, Segment $segment, $periodLabel)
     {
         $generalConfig = Config::getInstance()->General;

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1722,7 +1722,11 @@ class CronArchive
             return true;
         }
 
-        return !empty($this->segmentsToForce) && !in_array($segment, $this->segmentsToForce);
+        if(empty($this->segmentsToForce)) {
+            return false;
+        }
+
+        return !in_array($segment, $this->segmentsToForce);
     }
 
     private function logForcedSegmentInfo()


### PR DESCRIPTION
To do:
- [ ]  fix this PR (the logic is broken)
- [ ] write test
- [ ] announce in CHANGELOG.md as it may create extra `core:archive` load after upgrade

Fixes #10307
