### PR TITLE
Pass instance of both row objects to aggregate callback when aggregating them

### DIFF
--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -477,7 +477,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
                 throw new Exception("Unknown aggregation operation for column $columnToSumName.");
             }
 
-            $newValue = $this->getColumnValuesMerged($operation, $thisColumnValue, $columnToSumValue);
+            $newValue = $this->getColumnValuesMerged($operation, $thisColumnValue, $columnToSumValue, $this, $rowToSum);
 
             $this->setColumn($columnToSumName, $newValue);
         }
@@ -489,7 +489,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
 
     /**
      */
-    private function getColumnValuesMerged($operation, $thisColumnValue, $columnToSumValue)
+    private function getColumnValuesMerged($operation, $thisColumnValue, $columnToSumValue, $thisRow, $rowToSum)
     {
         switch ($operation) {
             case 'skip':
@@ -525,7 +525,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
                 break;
             default:
                 if (is_callable($operation)) {
-                    return call_user_func($operation, $thisColumnValue, $columnToSumValue);
+                    return call_user_func($operation, $thisColumnValue, $columnToSumValue, $thisRow, $rowToSum);
                 }
 
                 throw new Exception("Unknown operation '$operation'.");
@@ -556,7 +556,7 @@ class Row implements \ArrayAccess, \IteratorAggregate
                         continue;
                     }
 
-                    $aggregatedMetadata[$columnn] = $this->getColumnValuesMerged($operation, $thisMetadata, $sumMetadata);
+                    $aggregatedMetadata[$columnn] = $this->getColumnValuesMerged($operation, $thisMetadata, $sumMetadata, $this, $rowToSum);
                 }
             }
 

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -313,9 +313,15 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
         $metadata1 = array('mytest' => 'value1');
         $metadata2 = array('mytest' => 'value2');
 
+        $self = $this;
         $row1 = new Row(array(Row::COLUMNS => array('test_int' => 145), Row::METADATA => $metadata1));
         $finalRow = new Row(array(Row::COLUMNS => array('test_int' => 5), Row::METADATA => $metadata2));
-        $finalRow->sumRowMetadata($row1, array('mytest' => function ($thisValue, $otherValue) {
+        $finalRow->sumRowMetadata($row1, array('mytest' => function ($thisValue, $otherValue, $thisRow, $otherRow) use ($self, $row1, $finalRow) {
+            $self->assertEquals('value2', $thisValue);
+            $self->assertEquals('value1', $otherValue);
+            $self->assertSame($thisRow, $finalRow);
+            $self->assertSame($otherRow, $row1);
+
             if (!is_array($thisValue)) {
                 $thisValue = array($thisValue);
             }
@@ -335,7 +341,16 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
 
         $columns2 = array('test_int' => 5);
         $finalRow = new Row(array(Row::COLUMNS => $columns2));
-        $finalRow->sumRow($row1, $copyMetadata = true, $operation = array('test_int' => function ($thisValue, $otherValue) {
+
+
+        $self = $this;
+
+        $finalRow->sumRow($row1, $copyMetadata = true, $operation = array('test_int' => function ($thisValue, $otherValue, $thisRow, $otherRow) use ($self, $row1, $finalRow) {
+            $self->assertEquals(5, $thisValue);
+            $self->assertEquals(145, $otherValue);
+            $self->assertSame($thisRow, $finalRow);
+            $self->assertSame($otherRow, $row1);
+
             if (!is_array($thisValue)) {
                 $thisValue = array($thisValue);
             }


### PR DESCRIPTION
This allows more flexible aggregation or value replacement operations based on various values of the row object. For example processed metrics could be aggregated during archiving etc.
