### PR TITLE
API.getReportMetadata should only work with one idSite 

### DIFF
--- a/core/API/ApiRenderer.php
+++ b/core/API/ApiRenderer.php
@@ -91,8 +91,15 @@ abstract class ApiRenderer
             $format = 'json';
         }
 
+        $idSite = Common::getRequestVar('idSite', 0, 'int', $this->request);
+
+        if (empty($idSite)) {
+            $idSite = 'all';
+        }
+
         $renderer = Renderer::factory($format);
         $renderer->setTable($dataTable);
+        $renderer->setIdSite($idSite);
         $renderer->setRenderSubTables(Common::getRequestVar('expanded', false, 'int', $this->request));
         $renderer->setHideIdSubDatableFromResponse(Common::getRequestVar('hideIdSubDatable', false, 'int', $this->request));
 

--- a/core/BaseFactory.php
+++ b/core/BaseFactory.php
@@ -26,7 +26,7 @@ abstract class BaseFactory
      * Creates a new instance of a class using a string ID.
      *
      * @param string $classId The ID of the class.
-     * @return BaseFactory
+     * @return \Piwik\DataTable\Renderer
      * @throws Exception if $classId is invalid.
      */
     public static function factory($classId)

--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -12,7 +12,6 @@ use Piwik\Common;
 use Piwik\DataTable\Renderer;
 use Piwik\DataTable\Simple;
 use Piwik\DataTable;
-use Piwik\Date;
 use Piwik\Period;
 use Piwik\Period\Range;
 use Piwik\Piwik;

--- a/core/ReportRenderer.php
+++ b/core/ReportRenderer.php
@@ -35,11 +35,23 @@ abstract class ReportRenderer extends BaseFactory
     const PDF_FORMAT = 'pdf';
     const CSV_FORMAT = 'csv';
 
+    protected $idSite = 'all';
+
     private static $availableReportRenderers = array(
         self::PDF_FORMAT,
         self::HTML_FORMAT,
         self::CSV_FORMAT,
     );
+
+    /**
+     * Sets the site id
+     *
+     * @param int $idSite
+     */
+    public function setIdSite($idSite)
+    {
+        $this->idSite = $idSite;
+    }
 
     protected static function getClassNameFromClassId($rendererType)
     {

--- a/core/ReportRenderer/Csv.php
+++ b/core/ReportRenderer/Csv.php
@@ -141,6 +141,7 @@ class Csv extends ReportRenderer
     protected function getRenderer(DataTableInterface $table, $uniqueId)
     {
         $csvRenderer = new CsvDataTableRenderer();
+        $csvRenderer->setIdSite($this->idSite);
         $csvRenderer->setTable($table);
         $csvRenderer->setConvertToUnicode(false);
         $csvRenderer->setApiMethod(

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -264,19 +264,26 @@ class API extends \Piwik\Plugin\API
      * Triggers a hook to ask plugins for available Reports.
      * Returns metadata information about each report (category, name, dimension, metrics, etc.)
      *
-     * @param string $idSites Comma separated list of website Ids
+     * @param string $idSites THIS PARAMETER IS DEPRECATED AND WILL BE REMOVED IN PIWIK 4
      * @param bool|string $period
      * @param bool|Date $date
      * @param bool $hideMetricsDoc
      * @param bool $showSubtableReports
+     * @param int $idSite
      * @return array
      */
     public function getReportMetadata($idSites = '', $period = false, $date = false, $hideMetricsDoc = false,
-                                      $showSubtableReports = false)
+                                      $showSubtableReports = false, $idSite = false)
     {
+        if (empty($idSite) && !empty($idSites)) {
+            $idSite = array_shift($idSites);
+        } elseif (empty($idSites)) {
+            throw new \Exception('Calling API.getReportMetadata without any idSite is no longer supported since Piwik 3.0.0. Please specifiy at least one idSite via the "idSite" parameter.');
+        }
+
         Piwik::checkUserHasViewAccess($idSites);
 
-        $metadata = $this->processedReport->getReportMetadata($idSites, $period, $date, $hideMetricsDoc, $showSubtableReports);
+        $metadata = $this->processedReport->getReportMetadata($idSite, $period, $date, $hideMetricsDoc, $showSubtableReports);
         return $metadata;
     }
 

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -281,11 +281,11 @@ class API extends \Piwik\Plugin\API
             } else {
                 $idSite = $idSites;
             }
-        } elseif (empty($idSites)) {
+        } elseif (empty($idSite) && empty($idSites)) {
             throw new \Exception('Calling API.getReportMetadata without any idSite is no longer supported since Piwik 3.0.0. Please specifiy at least one idSite via the "idSite" parameter.');
         }
 
-        Piwik::checkUserHasViewAccess($idSites);
+        Piwik::checkUserHasViewAccess($idSite);
 
         $metadata = $this->processedReport->getReportMetadata($idSite, $period, $date, $hideMetricsDoc, $showSubtableReports);
         return $metadata;

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -276,7 +276,11 @@ class API extends \Piwik\Plugin\API
                                       $showSubtableReports = false, $idSite = false)
     {
         if (empty($idSite) && !empty($idSites)) {
-            $idSite = array_shift($idSites);
+            if (is_array($idSites)) {
+                $idSite = array_shift($idSites);
+            } else {
+                $idSite = $idSites;
+            }
         } elseif (empty($idSites)) {
             throw new \Exception('Calling API.getReportMetadata without any idSite is no longer supported since Piwik 3.0.0. Please specifiy at least one idSite via the "idSite" parameter.');
         }

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -109,7 +109,7 @@ class ProcessedReport
 
     public function getReportMetadataByUniqueId($idSite, $apiMethodUniqueId)
     {
-        $metadata = $this->getReportMetadata(array($idSite));
+        $metadata = $this->getReportMetadata($idSite);
 
         foreach ($metadata as $report) {
             if ($report['uniqueId'] == $apiMethodUniqueId) {
@@ -148,23 +148,20 @@ class ProcessedReport
      * Triggers a hook to ask plugins for available Reports.
      * Returns metadata information about each report (category, name, dimension, metrics, etc.)
      *
-     * @param string $idSites Comma separated list of website Ids
+     * @param int $idSite
      * @param bool|string $period
      * @param bool|Date $date
      * @param bool $hideMetricsDoc
      * @param bool $showSubtableReports
      * @return array
      */
-    public function getReportMetadata($idSites, $period = false, $date = false, $hideMetricsDoc = false, $showSubtableReports = false)
+    public function getReportMetadata($idSite, $period = false, $date = false, $hideMetricsDoc = false, $showSubtableReports = false)
     {
-        $idSites = Site::getIdSitesFromIdSitesString($idSites);
-        if (!empty($idSites)) {
-            Piwik::checkUserHasViewAccess($idSites);
-        }
+        Piwik::checkUserHasViewAccess($idSite);
 
         // as they cache key contains a lot of information there would be an even better cache result by caching parts of
         // this huge method separately but that makes it also more complicated. leaving it like this for now.
-        $key   = $this->buildReportMetadataCacheKey($idSites, $period, $date, $hideMetricsDoc, $showSubtableReports);
+        $key   = $this->buildReportMetadataCacheKey($idSite, $period, $date, $hideMetricsDoc, $showSubtableReports);
         $key   = CacheId::pluginAware($key);
         $cache = PiwikCache::getTransientCache();
 
@@ -172,7 +169,7 @@ class ProcessedReport
             return $cache->fetch($key);
         }
 
-        $parameters = array('idSites' => $idSites, 'period' => $period, 'date' => $date);
+        $parameters = array('idSite' => $idSite, 'period' => $period, 'date' => $date);
 
         $availableReports = array();
 
@@ -721,7 +718,7 @@ class ProcessedReport
         return null;
     }
 
-    private function buildReportMetadataCacheKey($idSites, $period, $date, $hideMetricsDoc, $showSubtableReports)
+    private function buildReportMetadataCacheKey($idSite, $period, $date, $hideMetricsDoc, $showSubtableReports)
     {
         if (isset($_GET) && isset($_POST) && is_array($_GET) && is_array($_POST)) {
             $request = $_GET + $_POST;
@@ -742,7 +739,7 @@ class ProcessedReport
             }
         }
 
-        $key .= implode(',', $idSites) . ($period === false ? 0 : $period) . ($date === false ? 0 : $date);
+        $key .= $idSite . 'x' . ($period === false ? 0 : $period) . 'x' . ($date === false ? 0 : $date);
         $key .= (int)$hideMetricsDoc . (int)$showSubtableReports . Piwik::getCurrentUserLogin();
         return 'reportMetadata' . md5($key);
     }

--- a/plugins/API/Renderer/Console.php
+++ b/plugins/API/Renderer/Console.php
@@ -10,8 +10,6 @@ namespace Piwik\Plugins\API\Renderer;
 
 use Piwik\API\ApiRenderer;
 use Piwik\Common;
-use Piwik\DataTable\Renderer;
-use Piwik\DataTable;
 
 class Console extends ApiRenderer
 {

--- a/plugins/API/Renderer/Csv.php
+++ b/plugins/API/Renderer/Csv.php
@@ -10,8 +10,6 @@ namespace Piwik\Plugins\API\Renderer;
 
 use Piwik\API\ApiRenderer;
 use Piwik\Common;
-use Piwik\DataTable\Renderer;
-use Piwik\DataTable;
 use Piwik\ProxyHttp;
 
 class Csv extends ApiRenderer

--- a/plugins/API/Renderer/Html.php
+++ b/plugins/API/Renderer/Html.php
@@ -10,8 +10,6 @@ namespace Piwik\Plugins\API\Renderer;
 
 use Piwik\API\ApiRenderer;
 use Piwik\Common;
-use Piwik\DataTable\Renderer;
-use Piwik\DataTable;
 
 class Html extends ApiRenderer
 {

--- a/plugins/API/Renderer/Json.php
+++ b/plugins/API/Renderer/Json.php
@@ -11,7 +11,6 @@ namespace Piwik\Plugins\API\Renderer;
 use Piwik\API\ApiRenderer;
 use Piwik\Common;
 use Piwik\DataTable\Renderer;
-use Piwik\DataTable;
 use Piwik\Piwik;
 use Piwik\ProxyHttp;
 
@@ -34,6 +33,7 @@ class Json extends ApiRenderer
     /**
      * @param $message
      * @param Exception|\Throwable $exception
+     * @param \Exception|\Throwable $exception
      * @return string
      */
     public function renderException($message, $exception)

--- a/plugins/API/Renderer/Php.php
+++ b/plugins/API/Renderer/Php.php
@@ -10,8 +10,6 @@ namespace Piwik\Plugins\API\Renderer;
 
 use Piwik\API\ApiRenderer;
 use Piwik\Common;
-use Piwik\DataTable\Renderer;
-use Piwik\DataTable;
 use Piwik\Piwik;
 
 class Php extends ApiRenderer
@@ -25,7 +23,7 @@ class Php extends ApiRenderer
 
     /**
      * @param $message
-     * @param Exception|\Throwable $exception
+     * @param \Exception|\Throwable $exception
      * @return string
      */
     public function renderException($message, $exception)

--- a/plugins/API/Renderer/Rss.php
+++ b/plugins/API/Renderer/Rss.php
@@ -10,8 +10,6 @@ namespace Piwik\Plugins\API\Renderer;
 
 use Piwik\API\ApiRenderer;
 use Piwik\Common;
-use Piwik\DataTable\Renderer;
-use Piwik\DataTable;
 
 class Rss extends ApiRenderer
 {

--- a/plugins/API/Renderer/Tsv.php
+++ b/plugins/API/Renderer/Tsv.php
@@ -9,8 +9,6 @@
 namespace Piwik\Plugins\API\Renderer;
 
 use Piwik\Common;
-use Piwik\DataTable\Renderer;
-use Piwik\DataTable;
 
 class Tsv extends Csv
 {

--- a/plugins/API/Renderer/Xml.php
+++ b/plugins/API/Renderer/Xml.php
@@ -10,8 +10,6 @@ namespace Piwik\Plugins\API\Renderer;
 
 use Piwik\API\ApiRenderer;
 use Piwik\Common;
-use Piwik\DataTable\Renderer;
-use Piwik\DataTable;
 
 class Xml extends ApiRenderer
 {

--- a/plugins/Actions/Reports/SiteSearchBase.php
+++ b/plugins/Actions/Reports/SiteSearchBase.php
@@ -37,9 +37,9 @@ abstract class SiteSearchBase extends Base
 
     public function configureReportMetadata(&$availableReports, $infos)
     {
-        $idSites = !empty($infos['idSites']) ? $infos['idSites'] : array();
+        $idSite = array($infos['idSite']);
 
-        if (!$this->isEnabledForIdSites($idSites, Common::getRequestVar('idSite', 0, 'int'))) {
+        if (!$this->isEnabledForIdSites($idSite, Common::getRequestVar('idSite', 0, 'int'))) {
             return;
         }
 

--- a/plugins/CoreHome/angularjs/common/services/report-metadata-model.js
+++ b/plugins/CoreHome/angularjs/common/services/report-metadata-model.js
@@ -39,8 +39,8 @@
             if (!reportsPromise) {
                 reportsPromise = piwikApi.fetch({
                     method: 'API.getReportMetadata',
-                    idSites: piwik.idSite || piwik.broadcast.getValueFromUrl('idSite'),
-                    filter_limit: '-1'
+                    filter_limit: '-1',
+                    idSite: piwik.idSite || piwik.broadcast.getValueFromUrl('idSite')
                 }).then(function (response) {
                     model.reports = response;
                     return response;

--- a/plugins/Ecommerce/Reports/Base.php
+++ b/plugins/Ecommerce/Reports/Base.php
@@ -54,13 +54,11 @@ abstract class Base extends Report
 
     private function isEcommerceEnabledByInfos($infos)
     {
-        $idSites = $infos['idSites'];
+        $idSite = $infos['idSite'];
 
-        if (count($idSites) != 1) {
+        if (empty($idSite)) {
             return false;
         }
-
-        $idSite = reset($idSites);
 
         return $this->isEcommerceEnabled($idSite);
     }

--- a/plugins/Goals/Reports/Base.php
+++ b/plugins/Goals/Reports/Base.php
@@ -41,13 +41,11 @@ abstract class Base extends \Piwik\Plugin\Report
 
     protected function getIdSiteFromInfos($infos)
     {
-        $idSites = $infos['idSites'];
+        $idSite = $infos['idSite'];
 
-        if (count($idSites) != 1) {
+        if (empty($idSite)) {
             return null;
         }
-
-        $idSite = reset($idSites);
 
         return $idSite;
     }

--- a/plugins/ImageGraph/ImageGraph.php
+++ b/plugins/ImageGraph/ImageGraph.php
@@ -52,14 +52,13 @@ class ImageGraph extends \Piwik\Plugin
      */
     public function getReportMetadata(&$reports, $info)
     {
-        $idSites = $info['idSites'];
+        $idSite = $info['idSite'];
 
         // If only one website is selected, we add the Graph URL
-        if (count($idSites) != 1) {
+        if (empty($idSite)) {
             return;
         }
-        $idSite = reset($idSites);
-
+        
         // in case API.getReportMetadata was not called with date/period we use sane defaults
         if (empty($info['period'])) {
             $info['period'] = 'day';

--- a/plugins/SEO/Widgets/GetRank.php
+++ b/plugins/SEO/Widgets/GetRank.php
@@ -14,7 +14,6 @@ use Piwik\Widget\WidgetConfig;
 use Piwik\Site;
 use Piwik\Url;
 use Piwik\UrlHelper;
-use Piwik\View;
 use Piwik\Plugins\SEO\API;
 
 class GetRank extends \Piwik\Widget\Widget

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -469,6 +469,7 @@ class API extends \Piwik\Plugin\API
         }
 
         // init report renderer
+        $reportRenderer->setIdSite($idSite);
         $reportRenderer->setLocale($language);
 
         // render report


### PR DESCRIPTION
refs #7834 

As mentioned in https://github.com/piwik/piwik/issues/7834#issuecomment-238130825 to fix `API.getSegmentsMetadata` we should create a new issue and fix eg in Piwik 4 or something.

Failing tests should not be related to this change
