### PR TITLE
Changing date by clicking chart causes segment to be disabled in background

### DIFF
--- a/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
+++ b/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
@@ -98,9 +98,10 @@
                             var idSite = broadcast.getValueFromUrl('idSite', url);
                             var period = broadcast.getValueFromUrl('period', url);
                             var date   = broadcast.getValueFromUrl('date', url);
+                            var segment = broadcast.getValueFromUrl('segment');
 
                             if (module && action) {
-                                url += '#module=' + module + '&action=' + action;
+                                url += '#?module=' + module + '&action=' + action;
 
                                 if (idSite) {
                                     url += '&idSite=' + idSite;
@@ -120,6 +121,10 @@
 
                                 if (period) {
                                     url += '&date=' + date;
+                                }
+
+                                if (segment) {
+                                    url += '&segment=' + encodeURI(decodeURI(segment)); // ensure segment is encoded only once
                                 }
                             }
                         }

--- a/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
+++ b/plugins/CoreVisualizations/javascripts/jqplotEvolutionGraph.js
@@ -98,7 +98,7 @@
                             var idSite = broadcast.getValueFromUrl('idSite', url);
                             var period = broadcast.getValueFromUrl('period', url);
                             var date   = broadcast.getValueFromUrl('date', url);
-                            var segment = broadcast.getValueFromUrl('segment');
+                            var segment = broadcast.getValueFromUrl('segment', url);
 
                             if (module && action) {
                                 url += '#?module=' + module + '&action=' + action;
@@ -124,7 +124,7 @@
                                 }
 
                                 if (segment) {
-                                    url += '&segment=' + encodeURI(decodeURI(segment)); // ensure segment is encoded only once
+                                    url += '&segment=' + encodeURIComponent(decodeURIComponent(segment)); // ensure segment is encoded once
                                 }
                             }
                         }


### PR DESCRIPTION
Evolution charts allow to change the date by clicking on a point within it. The urls redirected to did not include the segment if one was choosen before.

This PR is issued for Piwik 2.16.x LTS as it is already fixed in 3.x-dev branch by some other refactorings.
