### PR TITLE
Changed empty tracker response message

### DIFF
--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -78,7 +78,7 @@ class Response
                 Common::sendResponseCode(400);
             }
             Common::printDebug("Empty request => Piwik page");
-            echo "<a href='/'>Piwik</a> is a free/libre web <a href='http://piwik.org'>analytics</a> that lets you keep control of your data.";
+            echo 'This resource is part of <a href="https://piwik.org/" rel="nofollow">Piwik</a>, a free/libre web analytics tool that lets you keep control of your data.';
         } else {
             $this->outputApiResponse($tracker);
             Common::printDebug("Nothing to notice => default behaviour");

--- a/tests/PHPUnit/Integration/TrackerTest.php
+++ b/tests/PHPUnit/Integration/TrackerTest.php
@@ -251,7 +251,7 @@ class TrackerTest extends IntegrationTestCase
 
         $response = $this->tracker->main($this->getDefaultHandler(), $requestSet);
 
-        $expected = "<a href='/'>Piwik</a> is a free/libre web <a href='http://piwik.org'>analytics</a> that lets you keep control of your data.";
+        $expected = 'This resource is part of <a href="https://piwik.org/" rel="nofollow">Piwik</a>, a free/libre web analytics tool that lets you keep control of your data.';
         $this->assertEquals($expected, $response);
     }
 

--- a/tests/PHPUnit/System/TrackerResponseTest.php
+++ b/tests/PHPUnit/System/TrackerResponseTest.php
@@ -101,7 +101,7 @@ class TrackerResponseTest extends SystemTestCase
         $url = Fixture::getTrackerUrl();
         $this->assertResponseCode(200, $url);
 
-        $expected = "<a href='/'>Piwik</a> is a free/libre web <a href='http://piwik.org'>analytics</a> that lets you keep control of your data.";
+        $expected = 'This resource is part of <a href="https://piwik.org/" rel="nofollow">Piwik</a>, a free/libre web analytics tool that lets you keep control of your data.';
         $this->assertHttpResponseText($expected, $url);
     }
 
@@ -110,7 +110,7 @@ class TrackerResponseTest extends SystemTestCase
         $url = Fixture::getTrackerUrl();
         $this->assertResponseCode(400, $url . '?rec=1');
 
-        $expected = "<a href='/'>Piwik</a> is a free/libre web <a href='http://piwik.org'>analytics</a> that lets you keep control of your data.";
+        $expected = 'This resource is part of <a href="https://piwik.org/" rel="nofollow">Piwik</a>, a free/libre web analytics tool that lets you keep control of your data.';
         $this->assertHttpResponseText($expected, $url);
     }
 

--- a/tests/PHPUnit/Unit/Tracker/ResponseTest.php
+++ b/tests/PHPUnit/Unit/Tracker/ResponseTest.php
@@ -127,7 +127,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $tracker->setCountOfLoggedRequests(0);
         $this->response->outputResponse($tracker);
 
-        $this->assertEquals("<a href='/'>Piwik</a> is a free/libre web <a href='http://piwik.org'>analytics</a> that lets you keep control of your data.",
+        $this->assertEquals('This resource is part of <a href="https://piwik.org/" rel="nofollow">Piwik</a>, a free/libre web analytics tool that lets you keep control of your data.',
             $this->response->getOutput());
     }
 


### PR DESCRIPTION
Google don’t like the [link scheme](https://support.google.com/webmasters/answer/66356?hl=en) currently deployed by Piwik. It’s considered quite spammy. It doesn’t help that there are two links, one of which is broken.

This patch adds a slightly more meaningful error response message, and adds HTTPS and a nofollow attribute to the link.
