### PR TITLE
Plugin updates are located within the \Updates namespace

### DIFF
--- a/core/Updater.php
+++ b/core/Updater.php
@@ -226,6 +226,14 @@ class Updater
             return '\\Piwik\\Columns\\Updater';
         }
 
+        $backwardCompatibleClass = '\\Piwik\\Plugins\\' . $componentName . '\\' . $className;
+
+        // as of Piwik 3.0.0, we expect plugin updates within an Updates\ namespace
+        // this could be @deprecated in Piwik 4.0.0
+        if(class_exists($backwardCompatibleClass, false)) {
+            return $backwardCompatibleClass;
+        }
+
         return '\\Piwik\\Plugins\\' . $componentName . '\\Updates\\' . $className;
     }
 

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -226,7 +226,7 @@ class Updater
             return '\\Piwik\\Columns\\Updater';
         }
 
-        return '\\Piwik\\Plugins\\' . $componentName . '\\' . $className;
+        return '\\Piwik\\Plugins\\' . $componentName . '\\Updates\\' . $className;
     }
 
     /**

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -229,6 +229,7 @@ class Updater
         $backwardCompatibleClass = '\\Piwik\\Plugins\\' . $componentName . '\\' . $className;
 
         // as of Piwik 3.0.0, we expect plugin updates within an Updates\ namespace
+        // but in Piwik 3.0.0 we stay backward compatible
         // this could be @deprecated in Piwik 4.0.0
         if(class_exists($backwardCompatibleClass, false)) {
             return $backwardCompatibleClass;

--- a/plugins/CoreConsole/Commands/GenerateUpdate.php
+++ b/plugins/CoreConsole/Commands/GenerateUpdate.php
@@ -81,11 +81,6 @@ class GenerateUpdate extends GeneratePluginBase
         $className = $updater->getUpdateClassName($component, 'xx');
         $className = str_replace('Updates_xx', '', $className);
         $className = trim($className, '\\');
-
-        if ($component !== 'core') {
-            $className .= '\Updates';
-        }
-
         return $className;
     }
 


### PR DESCRIPTION
- in Piwik 2.x the `generate:update` does not work (as Piwik core will try to load the wrong class name ie. without `Updates\` namespace)
- in Piwik 3.x the `generate:update` command works with this pull request. plugin updates are located in the Updates\ namespace within the plugin namespace, so we read the correct namespace.

follows up commit: https://github.com/piwik/piwik/commit/fda46f16327d2af89b7450c729dbbcf7d0c322f0

refs https://github.com/piwik/developer-documentation/pull/139

Notes:
- [ ] we should note in the developer changelog that plugin updates are now documented and available, so everyone knows about them.
- [ ] this PR breaks backward compatibility in case some plugins were defining their updates without the `Updates\` namespace. We should mark this in the developer changelog?
- [ ]  double check that all our own plugins define their updates in this correct namespace
