### PR TITLE
PHP 7: when there is a fatal error in API request processing, display the original error in the api response

### DIFF
--- a/core/API/ApiRenderer.php
+++ b/core/API/ApiRenderer.php
@@ -39,7 +39,12 @@ abstract class ApiRenderer
         return 'Success:' . $message;
     }
 
-    public function renderException($message, \Exception $exception)
+    /**
+     * @param $message
+     * @param Exception|\Throwable $exception
+     * @return mixed
+     */
+    public function renderException($message, $exception)
     {
         return $message;
     }

--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -138,10 +138,10 @@ class ResponseBuilder
     }
 
     /**
-     * @param Exception $e
+     * @param Exception|\Throwable $e
      * @return Exception
      */
-    private function decorateExceptionWithDebugTrace(Exception $e)
+    private function decorateExceptionWithDebugTrace($e)
     {
         // If we are in tests, show full backtrace
         if (defined('PIWIK_PATH_TEST_TO_ROOT')) {
@@ -157,7 +157,11 @@ class ResponseBuilder
         return $e;
     }
 
-    private function formatExceptionMessage(Exception $exception)
+    /**
+     * @param Exception|\Throwable $exception
+     * @return string
+     */
+    private function formatExceptionMessage($exception)
     {
         $message = $exception->getMessage();
         if (\Piwik_ShouldPrintBackTraceWithMessage()) {

--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -175,7 +175,7 @@ class Response
         return $e->getMessage();
     }
 
-    protected function logExceptionToErrorLog(Exception $e)
+    protected function logExceptionToErrorLog($e)
     {
         error_log(sprintf("Error in Piwik (tracker): %s", str_replace("\n", " ", $this->getMessageFromException($e))));
     }

--- a/plugins/API/Renderer/Console.php
+++ b/plugins/API/Renderer/Console.php
@@ -16,7 +16,12 @@ use Piwik\DataTable;
 class Console extends ApiRenderer
 {
 
-    public function renderException($message, \Exception $exception)
+    /**
+     * @param $message
+     * @param Exception|\Throwable $exception
+     * @return string
+     */
+    public function renderException($message, $exception)
     {
         self::sendHeader();
 

--- a/plugins/API/Renderer/Csv.php
+++ b/plugins/API/Renderer/Csv.php
@@ -23,7 +23,12 @@ class Csv extends ApiRenderer
         return "message\n" . $message;
     }
 
-    public function renderException($message, \Exception $exception)
+    /**
+     * @param $message
+     * @param Exception|\Throwable $exception
+     * @return string
+     */
+    public function renderException($message, $exception)
     {
         Common::sendHeader('Content-Type: text/html; charset=utf-8', true);
         return 'Error: ' . $message;

--- a/plugins/API/Renderer/Html.php
+++ b/plugins/API/Renderer/Html.php
@@ -16,7 +16,12 @@ use Piwik\DataTable;
 class Html extends ApiRenderer
 {
 
-    public function renderException($message, \Exception $exception)
+    /**
+     * @param $message
+     * @param Exception|\Throwable $exception
+     * @return string
+     */
+    public function renderException($message, $exception)
     {
         Common::sendHeader('Content-Type: text/plain; charset=utf-8', true);
 

--- a/plugins/API/Renderer/Json.php
+++ b/plugins/API/Renderer/Json.php
@@ -31,7 +31,12 @@ class Json extends ApiRenderer
         return $this->applyJsonpIfNeeded($result);
     }
 
-    public function renderException($message, \Exception $exception)
+    /**
+     * @param $message
+     * @param Exception|\Throwable $exception
+     * @return string
+     */
+    public function renderException($message, $exception)
     {
         $exceptionMessage = str_replace(array("\r\n", "\n"), "", $message);
 

--- a/plugins/API/Renderer/Original.php
+++ b/plugins/API/Renderer/Original.php
@@ -18,7 +18,13 @@ class Original extends ApiRenderer
         return true;
     }
 
-    public function renderException($message, \Exception $exception)
+    /**
+     * @param $message
+     * @param \Exception|\Throwable $exception
+     * @throws \Exception|\Throwable
+     * @return void
+     */
+    public function renderException($message, $exception)
     {
         throw $exception;
     }

--- a/plugins/API/Renderer/Php.php
+++ b/plugins/API/Renderer/Php.php
@@ -23,7 +23,12 @@ class Php extends ApiRenderer
         return $this->serializeIfNeeded($success);
     }
 
-    public function renderException($message, \Exception $exception)
+    /**
+     * @param $message
+     * @param Exception|\Throwable $exception
+     * @return string
+     */
+    public function renderException($message, $exception)
     {
         $message = array('result' => 'error', 'message' => $message);
 

--- a/plugins/API/Renderer/Rss.php
+++ b/plugins/API/Renderer/Rss.php
@@ -16,7 +16,12 @@ use Piwik\DataTable;
 class Rss extends ApiRenderer
 {
 
-    public function renderException($message, \Exception $exception)
+    /**
+     * @param $message
+     * @param \Exception|\Throwable $exception
+     * @return string
+     */
+    public function renderException($message, $exception)
     {
         self::sendHeader('plain');
 

--- a/plugins/API/Renderer/Xml.php
+++ b/plugins/API/Renderer/Xml.php
@@ -24,7 +24,12 @@ class Xml extends ApiRenderer
                "</result>";
     }
 
-    public function renderException($message, \Exception $exception)
+    /**
+     * @param $message
+     * @param \Exception|\Throwable $exception
+     * @return string
+     */
+    public function renderException($message, $exception)
     {
         return '<?xml version="1.0" encoding="utf-8" ?>' . "\n" .
                "<result>\n" .

--- a/plugins/BulkTracking/tests/Framework/Mock/Tracker/Response.php
+++ b/plugins/BulkTracking/tests/Framework/Mock/Tracker/Response.php
@@ -13,7 +13,7 @@ use Exception;
 
 class Response extends \Piwik\Plugins\BulkTracking\Tracker\Response
 {
-    protected function logExceptionToErrorLog(Exception $e)
+    protected function logExceptionToErrorLog($e)
     {
         // prevent from writing to console in tests
     }

--- a/plugins/BulkTracking/tests/Unit/ResponseTest.php
+++ b/plugins/BulkTracking/tests/Unit/ResponseTest.php
@@ -15,7 +15,7 @@ use Exception;
 
 class TestResponse extends Response {
 
-    protected function logExceptionToErrorLog(Exception $e)
+    protected function logExceptionToErrorLog($e)
     {
         // prevent console from outputting the error_log message
     }

--- a/tests/PHPUnit/Unit/Tracker/ResponseTest.php
+++ b/tests/PHPUnit/Unit/Tracker/ResponseTest.php
@@ -16,7 +16,7 @@ use Exception;
 
 class TestResponse extends Response {
 
-    protected function logExceptionToErrorLog(Exception $e)
+    protected function logExceptionToErrorLog($e)
     {
         // prevent console from outputting the error_log message
     }


### PR DESCRIPTION
Some further PHP 7 tweaks to ensure we display the original error when there is a fatal error thrown by PHP engine. 

Same issue as https://github.com/piwik/piwik/commit/60ae66a89b8e4cdca5d7e71bbefb47fd15534eb1

See #10115
