### PR TITLE
Fix no required Piwik version was defined

### DIFF
--- a/plugins/ExamplePlugin/plugin.json
+++ b/plugins/ExamplePlugin/plugin.json
@@ -4,7 +4,7 @@
   "description": "Piwik Platform showcase: how to create widgets, menus, scheduled tasks, a custom archiver, plugin tests, and a AngularJS component.",
   "theme": false,
   "require": {
-    "piwik": ">=PIWIK_VERSION"
+    "piwik": ">=PIWIK_VERSION,<3.0.0-b1"
   },
   "authors": [
     {

--- a/plugins/ExampleTheme/plugin.json
+++ b/plugins/ExampleTheme/plugin.json
@@ -3,6 +3,9 @@
     "description": "Piwik Platform showcase: example of how to create a simple Theme.",
     "version": "0.1.0",
     "theme": true,
+    "require": {
+       "piwik": ">=PIWIK_VERSION,<3.0.0-b1"
+    },
     "stylesheet": "stylesheets/theme.less",
     "homepage": "",
     "license": "GPL v3+",


### PR DESCRIPTION
Themes should specify a required Piwik version just like other plugins. Now we also recommend to specify an upper version constraint for the Piwik version so it is clear whether it is compatible with Piwik 3 or not.
