### PR TITLE
When updating the config file failed (or when any other file is not writable...), the Updater (for core or plugins) will now automatically throw an error and cancel the update

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -376,15 +376,18 @@ class Config
      */
     protected function writeConfig($clear = true)
     {
-        if ($this->doNotWriteConfigInTests) {
-            return;
-        }
-
         $output = $this->dumpConfig();
         if ($output !== null
             && $output !== false
         ) {
-            $success = @file_put_contents($this->getLocalPath(), $output);
+
+            if ($this->doNotWriteConfigInTests) {
+                // simulate whether it would be successful
+                $success = is_writable($this->getLocalPath());
+            } else {
+                $success = @file_put_contents($this->getLocalPath(), $output);
+            }
+
             if ($success === false) {
                 throw $this->getConfigNotWritableException();
             }

--- a/core/Config.php
+++ b/core/Config.php
@@ -12,6 +12,7 @@ namespace Piwik;
 use Exception;
 use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Container\StaticContainer;
+use Piwik\Exception\MissingFilePermissionException;
 use Piwik\ProfessionalServices\Advertising;
 
 /**
@@ -411,6 +412,6 @@ class Config
     public function getConfigNotWritableException()
     {
         $path = "config/" . basename($this->getLocalPath());
-        return new Exception(Piwik::translate('General_ConfigFileIsNotWritable', array("(" . $path . ")", "")));
+        return new MissingFilePermissionException(Piwik::translate('General_ConfigFileIsNotWritable', array("(" . $path . ")", "")));
     }
 }

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -10,6 +10,7 @@ namespace Piwik;
 
 use Piwik\Columns\Updater as ColumnUpdater;
 use Piwik\Container\StaticContainer;
+use Piwik\Exception\MissingFilePermissionException;
 use Piwik\Updater\UpdateObserver;
 use Zend_Db_Exception;
 
@@ -257,8 +258,8 @@ class Updater
                 $this->markComponentSuccessfullyUpdated($componentName, $fileVersion);
             } catch (UpdaterErrorException $e) {
                 $this->executeListenerHook('onError', array($componentName, $fileVersion, $e));
-
                 throw $e;
+
             } catch (\Exception $e) {
                 $warningMessages[] = $e->getMessage();
 
@@ -552,7 +553,9 @@ class Updater
             // make sure to check for them here
             if ($e instanceof Zend_Db_Exception) {
                 throw new UpdaterErrorException($e->getMessage(), $e->getCode(), $e);
-            } else {
+            } else if ($e instanceof MissingFilePermissionException) {
+                throw new UpdaterErrorException($e->getMessage(), $e->getCode(), $e);
+            }{
                 throw $e;
             }
         }

--- a/tests/PHPUnit/Integration/UpdaterTest.php
+++ b/tests/PHPUnit/Integration/UpdaterTest.php
@@ -18,6 +18,20 @@ use Piwik\Tests\Framework\Fixture;
  */
 class UpdaterTest extends IntegrationTestCase
 {
+    public function test_doUpdate_reportsAnError_whenMissingFilePermissionException()
+    {
+        $updater = new Updater($pathToCoreUpdates = null, PIWIK_INCLUDE_PATH . '/tests/resources/Updater/%s/');
+        $updater->markComponentSuccessfullyUpdated('testpluginUpdates', '0.4');
+        $componentsWithUpdateFile = $updater->getComponentsWithUpdateFile(array('testpluginUpdates' => '0.5'));
+
+        $this->assertEquals(1, count($componentsWithUpdateFile));
+
+        $result = $updater->updateComponents($componentsWithUpdateFile);
+
+        $this->assertTrue( count ($result['errors']) > 0, 'when an update fails because config file is not writable, we expect the updater to report a critical error');
+    }
+
+
     public function testUpdaterChecksCoreVersionAndDetectsUpdateFile()
     {
         $updater = new Updater(PIWIK_INCLUDE_PATH . '/tests/resources/Updater/core/');

--- a/tests/PHPUnit/Integration/UpdaterTest.php
+++ b/tests/PHPUnit/Integration/UpdaterTest.php
@@ -29,6 +29,7 @@ class UpdaterTest extends IntegrationTestCase
         $result = $updater->updateComponents($componentsWithUpdateFile);
 
         $this->assertTrue( count ($result['errors']) > 0, 'when an update fails because config file is not writable, we expect the updater to report a critical error');
+        $this->assertEquals( 'make sure this exception is thrown', $result['errors'][0]);
     }
 
 

--- a/tests/resources/Updater/testpluginUpdates/0.5.php
+++ b/tests/resources/Updater/testpluginUpdates/0.5.php
@@ -1,0 +1,12 @@
+<?php
+namespace Piwik\Plugins\testpluginUpdates;
+
+use Piwik\Updates as PiwikUpdates;
+
+class Updates_0_5 extends PiwikUpdates
+{
+    function doUpdate(\Piwik\Updater $updater)
+    {
+        throw new \Piwik\Exception\MissingFilePermissionException();
+    }
+}

--- a/tests/resources/Updater/testpluginUpdates/0.5.php
+++ b/tests/resources/Updater/testpluginUpdates/0.5.php
@@ -7,6 +7,6 @@ class Updates_0_5 extends PiwikUpdates
 {
     function doUpdate(\Piwik\Updater $updater)
     {
-        throw new \Piwik\Exception\MissingFilePermissionException();
+        throw new \Piwik\Exception\MissingFilePermissionException('make sure this exception is thrown');
     }
 }


### PR DESCRIPTION
Fixes #9128
