### PR TITLE
When the core:update command is executed with a user:group different from the user:group that owns the Piwik files, display a message to indicate how to fix file permissions

### DIFF
--- a/core/Filechecks.php
+++ b/core/Filechecks.php
@@ -174,7 +174,7 @@ class Filechecks
     {
         $realpath = Filesystem::realpath(PIWIK_INCLUDE_PATH . '/');
         $message = '';
-        $message .= "<code>chown -R ". self::getUserAndGroup() ." " . $realpath . "</code><br />";
+        $message .= "<code>" . self::getCommandToChangeOwnerOfPiwikFiles() . "</code><br />";
         $message .= "<code>chmod -R 0755 " . $realpath . "</code><br />";
         $message .= 'After you execute these commands (or change permissions via your FTP software), refresh the page and you should be able to use the "Automatic Update" feature.';
         return $message;
@@ -205,7 +205,7 @@ class Filechecks
         return $message;
     }
 
-    private static function getUserAndGroup()
+    public static function getUserAndGroup()
     {
         $user = self::getUser();
         if (!function_exists('shell_exec')) {
@@ -246,5 +246,31 @@ class Filechecks
             return "<code>cacls $realpath /t /g " . self::getUser() . ":f</code><br />\n";
         }
         return "<code>chmod -R 0755 $realpath</code><br />";
+    }
+
+    /**
+     * @return string
+     */
+    public static function getCommandToChangeOwnerOfPiwikFiles()
+    {
+        $realpath = Filesystem::realpath(PIWIK_INCLUDE_PATH . '/');
+        return "chown -R " . self::getUserAndGroup() . " " . $realpath;
+    }
+
+    public static function getOwnerOfPiwikFiles()
+    {
+        $index = Filesystem::realpath(PIWIK_INCLUDE_PATH . '/index.php');
+        $stat = stat($index);
+        if(!$stat) {
+            return '';
+        }
+
+        $group = posix_getgrgid($stat[5]);
+        $group = $group['name'];
+
+        $user = posix_getpwuid($stat[4]);
+        $user = $user['name'];
+
+        return "$user:$group";
     }
 }

--- a/plugins/CoreUpdater/Commands/Update.php
+++ b/plugins/CoreUpdater/Commands/Update.php
@@ -8,6 +8,8 @@
  */
 namespace Piwik\Plugins\CoreUpdater\Commands;
 
+use Piwik\Filechecks;
+use Piwik\SettingsServer;
 use Piwik\Version;
 use Piwik\Config;
 use Piwik\DbHelper;
@@ -67,6 +69,9 @@ class Update extends ConsoleCommand
             } else {
                 $this->writeSuccessMessage($output, array('Database upgrade not executed.'));
             }
+
+            $this->writeAlertMessageWhenCommandExecutedWithUnexpectedUser($output);
+
 
         } catch(NoUpdatesFoundException $e) {
             // Do not fail if no updates were found
@@ -152,6 +157,11 @@ class Update extends ConsoleCommand
     private function doDryRun(Updater $updater, OutputInterface $output)
     {
         $migrationQueries = $this->getMigrationQueriesToExecute($updater);
+
+        if(empty($migrationQueries)) {
+            $output->writeln(array("    *** Note: There are no SQL queries to execute. ***", ""));
+            return;
+        }
 
         $output->writeln(array("    *** Note: this is a Dry Run ***", ""));
 
@@ -333,5 +343,32 @@ class Update extends ConsoleCommand
         $updater->addUpdateObserver(new CliUpdateObserver($output, $migrationQueryCount));
 
         return $updater;
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    protected function writeAlertMessageWhenCommandExecutedWithUnexpectedUser(OutputInterface $output)
+    {
+        if(SettingsServer::isWindows()) {
+            // does not work on windows
+            return;
+        }
+
+        $processUserAndGroup = Filechecks::getUserAndGroup();
+        $fileOwnerUserAndGroup = Filechecks::getOwnerOfPiwikFiles();
+
+        if($processUserAndGroup == $fileOwnerUserAndGroup) {
+            // current process user/group appear to be same as the Piwik filesystem user/group -> OK
+            return;
+        }
+        $output->writeln(
+
+            sprintf("<comment>It appears you have executed this update with user %s, while your Piwik files are owned by %s. \n\nTo ensure that the Piwik files are readable by the correct user, you may need to run the following command (or a similar command depending on your server configuration):\n\n$ %s</comment>",
+                $processUserAndGroup,
+                $fileOwnerUserAndGroup,
+                Filechecks::getCommandToChangeOwnerOfPiwikFiles()
+            )
+        );
     }
 }


### PR DESCRIPTION
- Fixes #10143 
- Message does not display at all on Windows
- Here is screenshot of what the error looks like:

![core update](https://cloud.githubusercontent.com/assets/466765/17879275/be4e7b82-6944-11e6-80bf-e82afa6b3852.png)
