### PR TITLE
Fix Scheduled Reports sent one hour late in daylight saving timezones

### DIFF
--- a/core/Updates/2.16.3-b3.php
+++ b/core/Updates/2.16.3-b3.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Updates;
+
+use Piwik\Plugins\ScheduledReports\API as ScheduledReportsAPI;
+use Piwik\Plugins\ScheduledReports\Model as ScheduledReportsModel;
+use Piwik\Site;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+
+/**
+ * Update for version 2.16.3-b3.
+ *
+ * Update existing scheduled reports to use UTC timezone for hour setting
+ */
+class Updates_2_16_3_b3 extends PiwikUpdates
+{
+    public function doUpdate(Updater $updater)
+    {
+        $model      = new ScheduledReportsModel();
+        $allReports = ScheduledReportsAPI::getInstance()->getReports();
+        foreach ($allReports as $report) {
+            $report['hour'] = $this->adjustTimezoneBySite($report['hour'], $report['idsite']);
+            $model->updateReport($report['idreport'], $report);
+        }
+    }
+
+    protected function adjustTimezoneBySite($hour, $idSite)
+    {
+        $timezone     = Site::getTimezoneFor($idSite);
+        $dateTimeZone = new \DateTimeZone($timezone);
+        $timeZoneDifference = -ceil($dateTimeZone->getOffset(new \DateTime()) / 3600);
+        return (24 + $hour + $timeZoneDifference) % 24;
+    }
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Piwik version.
      * @var string
      */
-    const VERSION = '2.16.3-b2';
+    const VERSION = '2.16.3-b3';
 
     public function isStableVersion($version)
     {

--- a/plugins/ScheduledReports/Controller.php
+++ b/plugins/ScheduledReports/Controller.php
@@ -26,7 +26,11 @@ class Controller extends \Piwik\Plugin\Controller
         $view = new View('@ScheduledReports/index');
         $this->setGeneralVariablesView($view);
 
-        $view->countWebsites = count(APISitesManager::getInstance()->getSitesIdWithAtLeastViewAccess());
+        $siteTimezone = $this->site->getTimezone();
+        $dateTimeZone = new \DateTimeZone($siteTimezone);
+
+        $view->timeZoneDifference = -$dateTimeZone->getOffset(new \DateTime());
+        $view->countWebsites      = count(APISitesManager::getInstance()->getSitesIdWithAtLeastViewAccess());
 
         // get report types
         $reportTypes = API::getReportTypes();

--- a/plugins/ScheduledReports/Controller.php
+++ b/plugins/ScheduledReports/Controller.php
@@ -29,7 +29,7 @@ class Controller extends \Piwik\Plugin\Controller
         $siteTimezone = $this->site->getTimezone();
         $dateTimeZone = new \DateTimeZone($siteTimezone);
 
-        $view->timeZoneDifference = -$dateTimeZone->getOffset(new \DateTime());
+        $view->timeZoneDifference = $dateTimeZone->getOffset(new \DateTime()) / 3600;
         $view->countWebsites      = count(APISitesManager::getInstance()->getSitesIdWithAtLeastViewAccess());
 
         // get report types

--- a/plugins/ScheduledReports/Tasks.php
+++ b/plugins/ScheduledReports/Tasks.php
@@ -18,11 +18,9 @@ class Tasks extends \Piwik\Plugin\Tasks
         foreach (API::getInstance()->getReports() as $report) {
             if (!$report['deleted'] && $report['period'] != Schedule::PERIOD_NEVER) {
 
-                $timezone = Site::getTimezoneFor($report['idsite']);
-
                 $schedule = Schedule::getScheduledTimeForPeriod($report['period']);
                 $schedule->setHour($report['hour']);
-                $schedule->setTimezone($timezone);
+                $schedule->setTimezone('UTC'); // saved hour is UTC always
 
                 $this->custom(API::getInstance(), 'sendReport', $report['idreport'], $schedule);
             }

--- a/plugins/ScheduledReports/javascripts/pdf.js
+++ b/plugins/ScheduledReports/javascripts/pdf.js
@@ -9,6 +9,10 @@ var getReportParametersFunctions = Object();
 var updateReportParametersFunctions = Object();
 var resetReportParametersFunctions = Object();
 
+function adjustHourToTimezone(hour, difference) {
+    return (24 + parseInt(hour) + difference) % 24;
+}
+
 function formSetEditReport(idReport) {
     var report = {
         'type': ReportPlugin.defaultReportType,
@@ -29,14 +33,14 @@ function formSetEditReport(idReport) {
 
     toggleReportType(report.type);
 
-    var hour = (24 + parseInt(report.hour) - timeZoneDifference) % 24;
+    var hour = adjustHourToTimezone(report.hour, timeZoneDifference);
 
     $('#report_description').html(report.description);
     $('#report_segment').find('option[value=' + report.idsegment + ']').prop('selected', 'selected');
     $('#report_type').find('option[value=' + report.type + ']').prop('selected', 'selected');
     $('#report_period').find('option[value=' + report.period + ']').prop('selected', 'selected');
     $('#report_hour').val(hour).bind('change', function() {
-        $('#hour_utc').text((24 + parseInt($(this).val()) + timeZoneDifference) % 24);
+        $('#hour_utc').text(adjustHourToTimezone($(this).val(), -timeZoneDifference));
     });
     $('#hour_utc').text(report.hour);
     $('[name=report_format].' + report.type + ' option[value=' + report.format + ']').prop('selected', 'selected');
@@ -127,7 +131,7 @@ function initManagePdf() {
 
         apiParameters.parameters = getReportParametersFunctions[apiParameters.reportType]();
 
-        var hour = (24 + parseInt($('#report_hour').val()) + timeZoneDifference) % 24;
+        var hour = adjustHourToTimezone($('#report_hour').val());
 
         var ajaxHandler = new ajaxHelper();
         ajaxHandler.addParams(apiParameters, 'POST');

--- a/plugins/ScheduledReports/javascripts/pdf.js
+++ b/plugins/ScheduledReports/javascripts/pdf.js
@@ -131,7 +131,7 @@ function initManagePdf() {
 
         apiParameters.parameters = getReportParametersFunctions[apiParameters.reportType]();
 
-        var hour = adjustHourToTimezone($('#report_hour').val());
+        var hour = adjustHourToTimezone($('#report_hour').val(), -timeZoneDifference);
 
         var ajaxHandler = new ajaxHelper();
         ajaxHandler.addParams(apiParameters, 'POST');

--- a/plugins/ScheduledReports/javascripts/pdf.js
+++ b/plugins/ScheduledReports/javascripts/pdf.js
@@ -29,11 +29,16 @@ function formSetEditReport(idReport) {
 
     toggleReportType(report.type);
 
+    var hour = (24 + parseInt(report.hour) - timeZoneDifference) % 24;
+
     $('#report_description').html(report.description);
     $('#report_segment').find('option[value=' + report.idsegment + ']').prop('selected', 'selected');
     $('#report_type').find('option[value=' + report.type + ']').prop('selected', 'selected');
     $('#report_period').find('option[value=' + report.period + ']').prop('selected', 'selected');
-    $('#report_hour').val(report.hour);
+    $('#report_hour').val(hour).bind('change', function() {
+        $('#hour_utc').text((24 + parseInt($(this).val()) + timeZoneDifference) % 24);
+    });
+    $('#hour_utc').text(report.hour);
     $('[name=report_format].' + report.type + ' option[value=' + report.format + ']').prop('selected', 'selected');
 
     $('select[name=report_type]').change( toggleDisplayOptionsByFormat );
@@ -122,10 +127,12 @@ function initManagePdf() {
 
         apiParameters.parameters = getReportParametersFunctions[apiParameters.reportType]();
 
+        var hour = (24 + parseInt($('#report_hour').val()) + timeZoneDifference) % 24;
+
         var ajaxHandler = new ajaxHelper();
         ajaxHandler.addParams(apiParameters, 'POST');
         ajaxHandler.addParams({period: $('#report_period').find('option:selected').val()}, 'GET');
-        ajaxHandler.addParams({hour: $('#report_hour').val()}, 'GET');
+        ajaxHandler.addParams({hour: hour}, 'GET');
         ajaxHandler.redirectOnSuccess();
         ajaxHandler.setLoadingElement();
         if (idReport) {

--- a/plugins/ScheduledReports/lang/en.json
+++ b/plugins/ScheduledReports/lang/en.json
@@ -29,6 +29,7 @@
         "PluginDescription": "Create custom reports and schedule them to be emailed daily, weekly or monthly to one or several people. Several report formats are supported (html, pdf, csv, images).",
         "ReportFormat": "Report Format",
         "ReportHour": "Send report at %s o'clock",
+        "ReportHourWithUTC": "Send report at %1$s o'clock (%2$s o'clock UTC)",
         "ReportIncludeNWebsites": "The report will include main metrics for all websites that have at least one visit (from the %s websites currently available).",
         "ReportSent": "Report sent",
         "ReportsIncluded": "Statistics included",

--- a/plugins/ScheduledReports/stylesheets/scheduledreports.less
+++ b/plugins/ScheduledReports/stylesheets/scheduledreports.less
@@ -7,5 +7,6 @@
 #report_hour {
   height: 0.9em;
   padding: 0 0 0 5px;
-  width: 35px;
+  width: 45px;
+  background-position: 25px center;
 }

--- a/plugins/ScheduledReports/templates/_addReport.twig
+++ b/plugins/ScheduledReports/templates/_addReport.twig
@@ -59,7 +59,20 @@
                         <br/>
                         {{ 'ScheduledReports_MonthlyScheduleHelp'|translate }}
                         <br/>
-                        {{ 'ScheduledReports_ReportHour'|translate('<input type="text" id="report_hour" class="inp" size="2">')|raw }}
+
+                        {% set hourInput %}
+                            <select id="report_hour">
+                            {% for i in 0..23 %}
+                                <option value="{{ i }}">{{ i }}</option>
+                            {% endfor %}
+                            </select>
+                        {% endset %}
+
+                        {% if timeZoneDifference != 0 %}
+                            {{ 'ScheduledReports_ReportHourWithUTC'|translate(hourInput, '<span id="hour_utc"></span>')|raw }}
+                        {% else %}
+                            {{ 'ScheduledReports_ReportHour'|translate(hourInput)|raw }}
+                        {% endif %}
                     </div>
                 </td>
             </tr>

--- a/plugins/ScheduledReports/templates/index.twig
+++ b/plugins/ScheduledReports/templates/index.twig
@@ -32,6 +32,7 @@
 </div>
 
 <script type="text/javascript">
+    var timeZoneDifference = {{ timeZoneDifference }} / 3600;
     var ReportPlugin = {};
     ReportPlugin.defaultPeriod = '{{ defaultPeriod }}';
     ReportPlugin.defaultHour = '{{ defaultHour }}';

--- a/plugins/ScheduledReports/templates/index.twig
+++ b/plugins/ScheduledReports/templates/index.twig
@@ -32,7 +32,7 @@
 </div>
 
 <script type="text/javascript">
-    var timeZoneDifference = {{ timeZoneDifference }} / 3600;
+    var timeZoneDifference = {{ timeZoneDifference }};
     var ReportPlugin = {};
     ReportPlugin.defaultPeriod = '{{ defaultPeriod }}';
     ReportPlugin.defaultHour = '{{ defaultHour }}';

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -371,21 +371,22 @@ class ApiTest extends IntegrationTestCase
         ));
 
         // expected tasks
+        // NOTE: scheduled reports are always saved with UTC, to avoid daylight saving issues
         $scheduleTask1 = Schedule::factory('daily');
-        $scheduleTask1->setHour(0); // paris is UTC-1, period ends at 23h UTC
-        $scheduleTask1->setTimezone('Europe/Paris');
+        $scheduleTask1->setHour(0);
+        $scheduleTask1->setTimezone('UTC');
 
         $scheduleTask2 = new Monthly();
-        $scheduleTask2->setHour(0); // site is UTC-6.5, period ends at 6h30 UTC, smallest resolution is hour
-        $scheduleTask2->setTimezone('UTC-6.5');
+        $scheduleTask2->setHour(0);
+        $scheduleTask2->setTimezone('UTC');
 
         $scheduleTask3 = new Monthly();
-        $scheduleTask3->setHour(8); // paris is UTC-1, configured to be sent at 8h
-        $scheduleTask3->setTimezone('Europe/Paris');
+        $scheduleTask3->setHour(8);
+        $scheduleTask3->setTimezone('UTC');
 
         $scheduleTask4 = new Monthly();
-        $scheduleTask4->setHour(8); // site is UTC-6.5, configured to be sent at 8h
-        $scheduleTask4->setTimezone('UTC-6.5');
+        $scheduleTask4->setHour(8);
+        $scheduleTask4->setTimezone('UTC');
 
         $expectedTasks = array(
             new Task(APIScheduledReports::getInstance(), 'sendReport', 1, $scheduleTask1),


### PR DESCRIPTION
[Replaces #10318]

This PR aims to fix the issue, that scheduled reports might be sent one hour to late / to early if the reports are saved for an site having a timezone using daylight savings.

The problem occurs because the "hour" the report should be sent at is currently saved in the timezone of the site. That means a new report with the timezone like e.g. `Europe/Berlin` with the setting to send the report at 8 o'clock would be one hour earlier/later when the daylight saving changes.

Internal Piwik uses UTC for running the tasks, so it tries to adjust the saved hour using the site's timezone difference. At the moment that would be two hours for `Europe/Berlin`, so the report would sent at 6 o'clock UTC. When the daylight saving changes again, the timezone difference will be only an hour. So Piwik will then reduce the saved hour value only by one to get the UTC time, which will be 7 o'clock (which is one hour later).

To avoid this in the future, I changed the current behavior to **not** save the hour value in the site's timezone anymore, but to use the UTC time instead. Doing this, the value can't be affected by daylight saving anymore. I also added an update script to update existing reports to have UTC values.

When creating/editing an report for an site using a timezone with a difference to UTC, Piwik will now should the UTC, aswell:

![image](https://cloud.githubusercontent.com/assets/1579355/16897794/b9d51aa2-4bbc-11e6-91d6-202fa6e4dbab.png)

fixes #7658, refs #5873
