### PR TITLE
shorten getController function

### DIFF
--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -40,30 +40,18 @@ class ControllerResolver
      */
     public function getController($module, $action, array &$parameters)
     {
-        $controller = $this->createPluginController($module, $action);
-        if ($controller) {
-            return $controller;
-        }
-
-        $controller = $this->createWidgetController($module, $action, $parameters);
-        if ($controller) {
-            return $controller;
-        }
-
-        $controller = $this->createReportController($module, $action, $parameters);
-        if ($controller) {
-            return $controller;
-        }
-
-        $controller = $this->createReportMenuController($module, $action, $parameters);
-        if ($controller) {
-            return $controller;
+        foreach(['Plugin', 'Widget', 'Report', 'ReportMenu'] as $controler) {
+            $controller = "create$controller" . 'Controller';
+            $controller = $this->$controller($module, $action, $parameters);
+            if ($controller) {
+                return $controller;
+            }
         }
 
         throw new Exception(sprintf("Action '%s' not found in the module '%s'", $action, $module));
     }
 
-    private function createPluginController($module, $action)
+    private function createPluginController($module, $action, array &$parameters)
     {
         $controllerClass = "Piwik\\Plugins\\$module\\Controller";
         if (!class_exists($controllerClass)) {


### PR DESCRIPTION
Please issue pull request against the `3.x-dev` branch as the `master` branch currently represents our `2.X` version which is in LTS mode. 

Important fixes will be merged into `master` if needed after it was merged to `3.x-dev`.

shorten getController function before it gets out of hand
