### PR TITLE
Remove deprecated events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,25 @@ The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** l
 * The creation of settings has slightly changed to improve performance. It is now possible to create new settings via the method `$this->makeSetting()` see `Piwik\Plugins\ExampleSettingsPlugin\SystemSettings` for an example.
 * It is no possible to define an introduction text for settings.
 * If requesting multipe periods for one report, the keys that define the range are no longer translated. For example before 3.0 an API response may contain: `<result date="From 2010-02-01 to 2010-02-07">` which is now `<result date="2010-02-01,2010-02-07">`.
-
+* The following deprecated events have been removed as mentioned.
+ * `Tracker.existingVisitInformation` Use [dimensions](http://developer.piwik.org/guides/dimensions) instead of using `Tracker` events.
+ * `Tracker.getVisitFieldsToPersist`
+ * `Tracker.newConversionInformation`
+ * `Tracker.newVisitorInformation`
+ * `Tracker.recordAction`
+ * `Tracker.recordEcommerceGoal`
+ * `Tracker.recordStandardGoals`
+ * `API.getSegmentDimensionMetadata` Define segments in [Dimension](http://developer.piwik.org/guides/dimensions) instead
+ * `Menu.Admin.addItems` Create a [Menu](http://developer.piwik.org/guides/menus) instead of using `Menu` events
+ * `Menu.Reporting.addItems`
+ * `Menu.Top.addItems`
+ * `ViewDataTable.addViewDataTable` Create a [Visualization](http://developer.piwik.org/guides/visualizing-report-data) instead
+ * `ViewDataTable.getDefaultType` Specify the default type in a [Report](http://developer.piwik.org/guides/custom-reports) instead
+ * `Goals.getReportsWithGoalMetrics` Specify a report has goal metrics in a [Report](http://developer.piwik.org/guides/custom-reports) instead
+ * `Login.authenticate`  Create a custom SessionInitializer instead of using `Login` events
+ * `Login.initSession.end`
+ * `Login.authenticate.successful`
+ 
 Read more about migrating a plugin from Piwik 2.X to Piwik 3 on our [Migration guide](https://developer.piwik.org/guides/migrate-piwik-2-to-3).
 
 ### Deprecations
@@ -67,6 +85,7 @@ Read more about migrating a plugin from Piwik 2.X to Piwik 3 on our [Migration g
 * The JavaScript AjaxHelper has a new method `ajaxHelper.withTokenInUrl()` to easily send a token along a XHR. Within the Controller the existence of this token can be checked via `$this->checkTokenInUrl();` to prevent CSRF attacks.
 * The new class `Piwik\Updater\Migration\Factory` lets you easily create migrations that can be executed during an update. For example database or plugin related migrations. To generate a new update with migrations execute `./console generate:update`.
 * The new method `Piwik\Updater::executeMigration` lets you execute a single migration.
+* New event `ViewDataTable.filterViewDataTable` let's you filter available visualizations
 
 ### New features
 * New "Sparklines" visualization that let's you create a widget showing multiple sparklines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,6 @@ The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** l
 * If requesting multipe periods for one report, the keys that define the range are no longer translated. For example before 3.0 an API response may contain: `<result date="From 2010-02-01 to 2010-02-07">` which is now `<result date="2010-02-01,2010-02-07">`.
 * The following deprecated events have been removed as mentioned.
  * `Tracker.existingVisitInformation` Use [dimensions](http://developer.piwik.org/guides/dimensions) instead of using `Tracker` events.
- * `Tracker.getVisitFieldsToPersist`
- * `Tracker.newConversionInformation`
  * `Tracker.newVisitorInformation`
  * `Tracker.recordAction`
  * `Tracker.recordEcommerceGoal`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,12 @@ Read more about migrating a plugin from Piwik 2.X to Piwik 3 on our [Migration g
 * The JavaScript AjaxHelper has a new method `ajaxHelper.withTokenInUrl()` to easily send a token along a XHR. Within the Controller the existence of this token can be checked via `$this->checkTokenInUrl();` to prevent CSRF attacks.
 * The new class `Piwik\Updater\Migration\Factory` lets you easily create migrations that can be executed during an update. For example database or plugin related migrations. To generate a new update with migrations execute `./console generate:update`.
 * The new method `Piwik\Updater::executeMigration` lets you execute a single migration.
-* New event `ViewDataTable.filterViewDataTable` let's you filter available visualizations
+* The following events have been added:
+ * `ViewDataTable.filterViewDataTable` let's you filter available visualizations
+ * `Dimension.addDimension` let's you add custom dimensions
+ * `Dimension.filterDimension` let's you filter any dimensions
+ * `Report.addReports` let's you add dynamically created reports
+ * `Report.filterReports` let's you filter any report
 
 ### New features
 * New "Sparklines" visualization that let's you create a widget showing multiple sparklines

--- a/core/Menu/MenuAdmin.php
+++ b/core/Menu/MenuAdmin.php
@@ -128,12 +128,6 @@ class MenuAdmin extends MenuAbstract
     {
         if (!$this->menu) {
 
-            /**
-             * @ignore
-             * @deprecated
-             */
-            Piwik::postEvent('Menu.Admin.addItems', array());
-
             foreach ($this->getAllMenus() as $menu) {
                 $menu->configureAdminMenu($this);
             }

--- a/core/Menu/MenuTop.php
+++ b/core/Menu/MenuTop.php
@@ -66,12 +66,6 @@ class MenuTop extends MenuAbstract
     {
         if (!$this->menu) {
 
-            /**
-             * @ignore
-             * @deprecated
-             */
-            Piwik::postEvent('Menu.Top.addItems', array());
-
             foreach ($this->getAllMenus() as $menu) {
                 $menu->configureTopMenu($this);
             }

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -21,10 +21,6 @@ use Piwik\Segment\SegmentExpression;
  * select visits that have a specific browser or come from a specific
  * country, or both.
  *
- * Individual segment dimensions (such as `browserCode` and `countryCode`)
- * are defined by plugins. Read about the {@hook API.getSegmentDimensionMetadata}
- * event to learn more.
- *
  * Plugins that aggregate data stored in Piwik can support segments by
  * using this class when generating aggregation SQL queries.
  *

--- a/core/Tracker/Action.php
+++ b/core/Tracker/Action.php
@@ -400,18 +400,6 @@ abstract class Action
         $visitActionDebug = $visitAction;
         $visitActionDebug['idvisitor'] = bin2hex($visitActionDebug['idvisitor']);
         Common::printDebug($visitActionDebug);
-
-        /**
-         * Triggered after successfully persisting a [visit action entity](/guides/persistence-and-the-mysql-backend#visit-actions).
-         *
-         * This event is deprecated, use [Dimensions](http://developer.piwik.org/guides/dimensions) instead.
-         *
-         * @param Action $tracker Action The Action tracker instance.
-         * @param array $visitAction The visit action entity that was persisted. Read
-         *                           [this](/guides/persistence-and-the-mysql-backend#visit-actions) to see what it contains.
-         * @deprecated
-         */
-        Piwik::postEvent('Tracker.recordAction', array($trackerAction = $this, $visitAction));
     }
 
     public function writeDebugInfo()

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -342,22 +342,6 @@ class GoalManager
         if ($recorded) {
             $this->recordEcommerceItems($conversion, $items);
         }
-
-        /**
-         * Triggered after successfully persisting an ecommerce conversion.
-         *
-         * _Note: Subscribers should be wary of doing any expensive computation here as it may slow
-         * the tracker down._
-         *
-         * This event is deprecated, use [Dimensions](http://developer.piwik.org/guides/dimensions) instead.
-         *
-         * @param array $conversion The conversion entity that was just persisted. See what information
-         *                          it contains [here](/guides/persistence-and-the-mysql-backend#conversions).
-         * @param array $visitInformation The visit entity that we are tracking a conversion for. See what
-         *                                information it contains [here](/guides/persistence-and-the-mysql-backend#visits).
-         * @deprecated
-         */
-        Piwik::postEvent('Tracker.recordEcommerceGoal', array($conversion, $visitProperties->getProperties()));
     }
 
     /**
@@ -693,20 +677,6 @@ class GoalManager
             $conversion = $this->triggerHookOnDimensions($request, $conversionDimensions, 'onGoalConversion', $visitor, $action, $conversion);
 
             $this->insertNewConversion($conversion, $visitProperties->getProperties(), $request);
-
-            /**
-             * Triggered after successfully recording a non-ecommerce conversion.
-             *
-             * _Note: Subscribers should be wary of doing any expensive computation here as it may slow
-             * the tracker down._
-             *
-             * This event is deprecated, use [Dimensions](http://developer.piwik.org/guides/dimensions) instead.
-             *
-             * @param array $conversion The conversion entity that was just persisted. See what information
-             *                          it contains [here](/guides/persistence-and-the-mysql-backend#conversions).
-             * @deprecated
-             */
-            Piwik::postEvent('Tracker.recordStandardGoals', array($conversion));
         }
     }
 
@@ -719,22 +689,6 @@ class GoalManager
      */
     protected function insertNewConversion($conversion, $visitInformation, Request $request)
     {
-        /**
-         * Triggered before persisting a new [conversion entity](/guides/persistence-and-the-mysql-backend#conversions).
-         *
-         * This event can be used to modify conversion information or to add new information to be persisted.
-         *
-         * This event is deprecated, use [Dimensions](http://developer.piwik.org/guides/dimensions) instead.
-         *
-         * @param array $conversion The conversion entity. Read [this](/guides/persistence-and-the-mysql-backend#conversions)
-         *                          to see what it contains.
-         * @param array $visitInformation The visit entity that we are tracking a conversion for. See what
-         *                                information it contains [here](/guides/persistence-and-the-mysql-backend#visits).
-         * @param \Piwik\Tracker\Request $request An object describing the tracking request being processed.
-         * @deprecated
-         */
-        Piwik::postEvent('Tracker.newConversionInformation', array(&$conversion, $visitInformation, $request));
-
         $newGoalDebug = $conversion;
         $newGoalDebug['idvisitor'] = bin2hex($newGoalDebug['idvisitor']);
         Common::printDebug($newGoalDebug);

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -689,6 +689,23 @@ class GoalManager
      */
     protected function insertNewConversion($conversion, $visitInformation, Request $request)
     {
+        /**
+         * Triggered before persisting a new [conversion entity](/guides/persistence-and-the-mysql-backend#conversions).
+         *
+         * This event can be used to modify conversion information or to add new information to be persisted.
+         *
+         * This event is deprecated, use [Dimensions](http://developer.piwik.org/guides/dimensions) instead.
+         *
+         * @param array $conversion The conversion entity. Read [this](/guides/persistence-and-the-mysql-backend#conversions)
+         *                          to see what it contains.
+         * @param array $visitInformation The visit entity that we are tracking a conversion for. See what
+         *                                information it contains [here](/guides/persistence-and-the-mysql-backend#visits).
+         * @param \Piwik\Tracker\Request $request An object describing the tracking request being processed.
+         * @deprecated
+         * @ignore
+         */
+        Piwik::postEvent('Tracker.newConversionInformation', array(&$conversion, $visitInformation, $request));
+
         $newGoalDebug = $conversion;
         $newGoalDebug['idvisitor'] = bin2hex($newGoalDebug['idvisitor']);
         Common::printDebug($newGoalDebug);

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -211,22 +211,6 @@ class Visit implements VisitInterface
             $this->visitProperties->setProperty($name, $value);
         }
 
-        /**
-         * Triggered before a [visit entity](/guides/persistence-and-the-mysql-backend#visits) is updated when
-         * tracking an action for an existing visit.
-         *
-         * This event can be used to modify the visit properties that will be updated before the changes
-         * are persisted.
-         *
-         * This event is deprecated, use [Dimensions](http://developer.piwik.org/guides/dimensions) instead.
-         *
-         * @param array &$valuesToUpdate Visit entity properties that will be updated.
-         * @param array $visit The entire visit entity. Read [this](/guides/persistence-and-the-mysql-backend#visits)
-         *                     to see what it contains.
-         * @deprecated
-         */
-        Piwik::postEvent('Tracker.existingVisitInformation', array(&$valuesToUpdate, $this->visitProperties->getProperties()));
-
         foreach ($this->requestProcessors as $processor) {
             $processor->onExistingVisit($valuesToUpdate, $this->visitProperties, $this->request);
         }
@@ -277,24 +261,6 @@ class Visit implements VisitInterface
         if ($visitIsConverted) {
             $this->triggerHookOnDimensions($dimensions, 'onConvertedVisit');
         }
-
-        $properties = &$this->visitProperties->getProperties();
-
-        /**
-         * Triggered before a new [visit entity](/guides/persistence-and-the-mysql-backend#visits) is persisted.
-         *
-         * This event can be used to modify the visit entity or add new information to it before it is persisted.
-         * The UserCountry plugin, for example, uses this event to add location information for each visit.
-         *
-         * This event is deprecated, use [Dimensions](http://developer.piwik.org/guides/dimensions) instead.
-         *
-         * @param array &$visit The visit entity. Read [this](/guides/persistence-and-the-mysql-backend#visits) to see
-         *                      what information it contains.
-         * @param \Piwik\Tracker\Request $request An object describing the tracking request being processed.
-         *
-         * @deprecated
-         */
-        Piwik::postEvent('Tracker.newVisitorInformation', array(&$properties, $this->request));
 
         foreach ($this->requestProcessors as $processor) {
             $processor->onNewVisit($this->visitProperties, $this->request);

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -240,19 +240,6 @@ class VisitorRecognizer
                 }
             }
 
-            /**
-             * This event collects a list of [visit entity](/guides/persistence-and-the-mysql-backend#visits) properties that should be loaded when reading
-             * the existing visit. Properties that appear in this list will be available in other tracking
-             * events such as 'onExistingVisit'.
-             *
-             * Plugins can use this event to load additional visit entity properties for later use during tracking.
-             *
-             * This event is deprecated, use [Dimensions](http://developer.piwik.org/guides/dimensions) instead.
-             *
-             * @deprecated 
-             */
-            $this->eventDispatcher->postEvent('Tracker.getVisitFieldsToPersist', array(&$fields));
-
             array_unshift($fields, 'visit_first_action_time');
             array_unshift($fields, 'visit_last_action_time');
 

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -240,6 +240,19 @@ class VisitorRecognizer
                 }
             }
 
+            /**
+             * This event collects a list of [visit entity](/guides/persistence-and-the-mysql-backend#visits) properties that should be loaded when reading
+             * the existing visit. Properties that appear in this list will be available in other tracking
+             * events such as 'onExistingVisit'.
+             *
+             * Plugins can use this event to load additional visit entity properties for later use during tracking.
+             *
+             * This event is deprecated, use [Dimensions](http://developer.piwik.org/guides/dimensions) instead.
+             *
+             * @deprecated
+             */
+            $this->eventDispatcher->postEvent('Tracker.getVisitFieldsToPersist', array(&$fields));
+
             array_unshift($fields, 'visit_first_action_time');
             array_unshift($fields, 'visit_last_action_time');
 

--- a/core/ViewDataTable/Factory.php
+++ b/core/ViewDataTable/Factory.php
@@ -190,8 +190,7 @@ class Factory
             return $report->getDefaultTypeViewDataTable();
         }
 
-        $defaultViewTypes = self::getDefaultTypeViewDataTable();
-        return isset($defaultViewTypes[$apiAction]) ? $defaultViewTypes[$apiAction] : false;
+        return false;
     }
 
     /**
@@ -207,23 +206,6 @@ class Factory
         }
 
         return false;
-    }
-
-    /**
-     * Returns a list of default viewDataTables ID to use when determining which visualization to use for multiple
-     * reports.
-     */
-    private static function getDefaultTypeViewDataTable()
-    {
-        if (null === self::$defaultViewTypes) {
-            self::$defaultViewTypes = array();
-            /**
-             * @ignore
-             */
-            Piwik::postEvent('ViewDataTable.getDefaultType', array(&self::$defaultViewTypes));
-        }
-
-        return self::$defaultViewTypes;
     }
 
     /**

--- a/core/ViewDataTable/Manager.php
+++ b/core/ViewDataTable/Manager.php
@@ -78,25 +78,6 @@ class Manager
         /** @var string[] $visualizations */
         $visualizations = PluginManager::getInstance()->findMultipleComponents('Visualizations', $klassToExtend);
 
-        /**
-         * Triggered when gathering all available DataTable visualizations.
-         *
-         * Plugins that want to expose new DataTable visualizations should subscribe to
-         * this event and add visualization class names to the incoming array.
-         *
-         * **Example**
-         *
-         *     public function addViewDataTable(&$visualizations)
-         *     {
-         *         $visualizations[] = 'Piwik\\Plugins\\MyPlugin\\MyVisualization';
-         *     }
-         *
-         * @param array &$visualizations The array of all available visualizations.
-         * @ignore
-         * @deprecated since 2.5.0 Place visualization in a "Visualizations" directory instead.
-         */
-        Piwik::postEvent('ViewDataTable.addViewDataTable', array(&$visualizations));
-
         $result = array();
 
         foreach ($visualizations as $viz) {
@@ -116,6 +97,24 @@ class Manager
 
             $result[$vizId] = $viz;
         }
+
+        /**
+         * Triggered to filter available DataTable visualizations.
+         *
+         * Plugins that want to disable certain visualizations should subscribe to
+         * this event and remove visualizations from the incoming array.
+         *
+         * **Example**
+         *
+         *     public function filterViewDataTable(&$visualizations)
+         *     {
+         *         unset($visualizations[HtmlTable::ID]);
+         *     }
+         *
+         * @param array &$visualizations An array of all available visualizations indexed by visualization ID.
+         * @since Piwik 3.0.0
+         */
+        Piwik::postEvent('ViewDataTable.filterViewDataTable', array(&$result));
 
         $cache->save($cacheId, $result);
 

--- a/plugins/API/SegmentMetadata.php
+++ b/plugins/API/SegmentMetadata.php
@@ -27,54 +27,6 @@ class SegmentMetadata
             }
         }
 
-        /**
-         * Triggered when gathering all available segment dimensions.
-         *
-         * This event can be used to make new segment dimensions available.
-         *
-         * **Example**
-         *
-         *     public function getSegmentsMetadata(&$segments, $idSites)
-         *     {
-         *         $segments[] = array(
-         *             'type'           => 'dimension',
-         *             'category'       => Piwik::translate('General_Visit'),
-         *             'name'           => 'General_VisitorIP',
-         *             'segment'        => 'visitIp',
-         *             'acceptedValues' => '13.54.122.1, etc.',
-         *             'sqlSegment'     => 'log_visit.location_ip',
-         *             'sqlFilter'      => array('Piwik\IP', 'P2N'),
-         *             'permission'     => $isAuthenticatedWithViewAccess,
-         *         );
-         *     }
-         *
-         * @param array &$dimensions The list of available segment dimensions. Append to this list to add
-         *                           new segments. Each element in this list must contain the
-         *                           following information:
-         *
-         *                           - **type**: Either `'metric'` or `'dimension'`. `'metric'` means
-         *                                       the value is a numeric and `'dimension'` means it is
-         *                                       a string. Also, `'metric'` values will be displayed
-         *                                       under **Visit (metrics)** in the Segment Editor.
-         *                           - **category**: The segment category name. This can be an existing
-         *                                           segment category visible in the segment editor.
-         *                           - **name**: The pretty name of the segment. Can be a translation token.
-         *                           - **segment**: The segment name, eg, `'visitIp'` or `'searches'`.
-         *                           - **acceptedValues**: A string describing one or two exacmple values, eg
-         *                                                 `'13.54.122.1, etc.'`.
-         *                           - **sqlSegment**: The table column this segment will segment by.
-         *                                             For example, `'log_visit.location_ip'` for the
-         *                                             **visitIp** segment.
-         *                           - **sqlFilter**: A PHP callback to apply to segment values before
-         *                                            they are used in SQL.
-         *                           - **permission**: True if the current user has view access to this
-         *                                             segment, false if otherwise.
-         * @param array $idSites The list of site IDs we're getting the available segments
-         *                       for. Some segments (such as Goal segments) depend on the
-         *                       site.
-         */
-        Piwik::postEvent('API.getSegmentDimensionMetadata', array(&$segments, $idSites));
-
         $segments[] = array(
             'type'           => 'dimension',
             'category'       => Piwik::translate('General_Visit'),

--- a/plugins/CoreVisualizations/CoreVisualizations.php
+++ b/plugins/CoreVisualizations/CoreVisualizations.php
@@ -9,7 +9,6 @@
 
 namespace Piwik\Plugins\CoreVisualizations;
 
-use Piwik\Common;
 use Piwik\ViewDataTable\Manager as ViewDataTableManager;
 
 require_once PIWIK_INCLUDE_PATH . '/plugins/CoreVisualizations/JqplotDataGenerator.php';
@@ -21,7 +20,7 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/CoreVisualizations/JqplotDataGenerat
 class CoreVisualizations extends \Piwik\Plugin
 {
     /**
-     * @see Piwik\Plugin::registerEvents
+     * @see \Piwik\Plugin::registerEvents
      */
     public function registerEvents()
     {
@@ -29,7 +28,7 @@ class CoreVisualizations extends \Piwik\Plugin
             'AssetManager.getStylesheetFiles'        => 'getStylesheetFiles',
             'AssetManager.getJavaScriptFiles'        => 'getJsFiles',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
-            'UsersManager.deleteUser'                => 'deleteUser'
+            'UsersManager.deleteUser'                => 'deleteUser',
         );
     }
 

--- a/plugins/CoreVisualizations/Visualizations/HtmlTable.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable.php
@@ -70,6 +70,10 @@ class HtmlTable extends Visualization
             $dataTable = $request->process();
             $this->assignTemplateVar('siteSummary', $dataTable);
         }
+
+        if ($this->isPivoted()) {
+            $this->config->columns_to_display = $this->dataTable->getColumns();
+        }
     }
 
     public function beforeGenericFiltersAreAppliedToLoadedDataTable()

--- a/plugins/CoreVisualizations/Visualizations/HtmlTable.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable.php
@@ -26,6 +26,17 @@ class HtmlTable extends Visualization
     const FOOTER_ICON       = 'icon-table';
     const FOOTER_ICON_TITLE = 'General_DisplaySimpleTable';
 
+    public function beforeGenericFiltersAreAppliedToLoadedDataTable()
+    {
+        if (Common::getRequestVar('pivotBy', '')) {
+            $this->config->columns_to_display = $this->dataTable->getColumns();
+
+            $this->dataTable->applyQueuedFilters();
+        }
+
+        parent::beforeGenericFiltersAreAppliedToLoadedDataTable();
+    }
+
     public static function getDefaultConfig()
     {
         return new HtmlTable\Config();
@@ -70,21 +81,6 @@ class HtmlTable extends Visualization
             $dataTable = $request->process();
             $this->assignTemplateVar('siteSummary', $dataTable);
         }
-
-        if ($this->isPivoted()) {
-            $this->config->columns_to_display = $this->dataTable->getColumns();
-        }
-    }
-
-    public function beforeGenericFiltersAreAppliedToLoadedDataTable()
-    {
-        if ($this->isPivoted()) {
-            $this->config->columns_to_display = $this->dataTable->getColumns();
-
-            $this->dataTable->applyQueuedFilters();
-        }
-
-        parent::beforeGenericFiltersAreAppliedToLoadedDataTable();
     }
 
     protected function isPivoted()

--- a/plugins/CoreVisualizations/Visualizations/HtmlTable.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable.php
@@ -26,17 +26,6 @@ class HtmlTable extends Visualization
     const FOOTER_ICON       = 'icon-table';
     const FOOTER_ICON_TITLE = 'General_DisplaySimpleTable';
 
-    public function beforeGenericFiltersAreAppliedToLoadedDataTable()
-    {
-        if (Common::getRequestVar('pivotBy', '')) {
-            $this->config->columns_to_display = $this->dataTable->getColumns();
-
-            $this->dataTable->applyQueuedFilters();
-        }
-
-        parent::beforeGenericFiltersAreAppliedToLoadedDataTable();
-    }
-
     public static function getDefaultConfig()
     {
         return new HtmlTable\Config();
@@ -81,6 +70,17 @@ class HtmlTable extends Visualization
             $dataTable = $request->process();
             $this->assignTemplateVar('siteSummary', $dataTable);
         }
+    }
+
+    public function beforeGenericFiltersAreAppliedToLoadedDataTable()
+    {
+        if ($this->isPivoted()) {
+            $this->config->columns_to_display = $this->dataTable->getColumns();
+
+            $this->dataTable->applyQueuedFilters();
+        }
+
+        parent::beforeGenericFiltersAreAppliedToLoadedDataTable();
     }
 
     protected function isPivoted()

--- a/plugins/CustomVariables/Columns/Base.php
+++ b/plugins/CustomVariables/Columns/Base.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Plugins\CustomVariables\Columns;
 
-use Piwik\DataTable;
 use Piwik\Piwik;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugin\Segment;
@@ -35,6 +34,27 @@ class Base extends VisitDimension
         $segment->setCategory('CustomVariables_CustomVariables');
         $segment->setUnionOfSegments($this->getSegmentColumns('customVariablePage' . $segmentNameSuffix, $numCustomVariables));
         $this->addSegment($segment);
+
+        $segmentSuffix = 'v';
+        if (strtolower($segmentNameSuffix) === 'name') {
+            $segmentSuffix = 'k';
+        }
+
+        for ($i = 1; $i <= $numCustomVariables; $i++) {
+            $segment = new Segment();
+            $segment->setSegment('customVariable' . $segmentNameSuffix . $i);
+            $segment->setSqlSegment('log_visit.custom_var_' . $segmentSuffix . $i);
+            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariable' . $segmentNameSuffix) . ' ' . $i
+                    . ' (' . Piwik::translate('CustomVariables_ScopeVisit') . ')');
+            $this->addSegment($segment);
+
+            $segment = new Segment();
+            $segment->setSegment('customVariablePage' . $segmentNameSuffix . $i);
+            $segment->setSqlSegment('log_link_visit_action.custom_var_' . $segmentSuffix . $i);
+            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariable' . $segmentNameSuffix) . ' ' . $i
+                    . ' (' . Piwik::translate('CustomVariables_ScopePage') . ')');
+            $this->addSegment($segment);
+        }
     }
 
     private function getSegmentColumns($column, $numCustomVariables)

--- a/plugins/CustomVariables/Columns/Base.php
+++ b/plugins/CustomVariables/Columns/Base.php
@@ -10,7 +10,7 @@ namespace Piwik\Plugins\CustomVariables\Columns;
 
 use Piwik\Piwik;
 use Piwik\Plugin\Dimension\VisitDimension;
-use Piwik\Plugin\Segment;
+use Piwik\Plugins\CustomVariables\Segment;
 use Piwik\Plugins\CustomVariables\CustomVariables;
 
 class Base extends VisitDimension
@@ -23,7 +23,6 @@ class Base extends VisitDimension
         $segment->setType('dimension');
         $segment->setSegment('customVariable' . $segmentNameSuffix);
         $segment->setName($this->getName() . ' (' . Piwik::translate('CustomVariables_ScopeVisit') . ')');
-        $segment->setCategory('CustomVariables_CustomVariables');
         $segment->setUnionOfSegments($this->getSegmentColumns('customVariable' . $segmentNameSuffix, $numCustomVariables));
         $this->addSegment($segment);
 
@@ -31,7 +30,6 @@ class Base extends VisitDimension
         $segment->setType('dimension');
         $segment->setSegment('customVariablePage' . $segmentNameSuffix);
         $segment->setName($this->getName() . ' (' . Piwik::translate('CustomVariables_ScopePage') . ')');
-        $segment->setCategory('CustomVariables_CustomVariables');
         $segment->setUnionOfSegments($this->getSegmentColumns('customVariablePage' . $segmentNameSuffix, $numCustomVariables));
         $this->addSegment($segment);
 

--- a/plugins/CustomVariables/Columns/CustomVariableName.php
+++ b/plugins/CustomVariables/Columns/CustomVariableName.php
@@ -9,8 +9,6 @@
 namespace Piwik\Plugins\CustomVariables\Columns;
 
 use Piwik\Piwik;
-use Piwik\Plugins\CustomVariables\CustomVariables;
-use Piwik\Plugins\CustomVariables\Segment;
 
 class CustomVariableName extends Base
 {
@@ -24,25 +22,4 @@ class CustomVariableName extends Base
         return Piwik::translate('CustomVariables_ColumnCustomVariableName');
     }
 
-    protected function configureSegments()
-    {
-        $maxCustomVariables = CustomVariables::getMaxCustomVariables();
-
-        for ($i = 1; $i <= $maxCustomVariables; $i++) {
-
-            $segment = new Segment();
-            $segment->setSegment('customVariableName' . $i);
-            $segment->setSqlSegment('log_visit.custom_var_k' . $i);
-            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariableName') . ' ' . $i
-                . ' (' . Piwik::translate('CustomVariables_ScopeVisit') . ')');
-            $this->addSegment($segment);
-
-            $segment = new Segment();
-            $segment->setSegment('customVariablePageName' . $i);
-            $segment->setSqlSegment('log_link_visit_action.custom_var_k' . $i);
-            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariableName') . ' ' . $i
-                . ' (' . Piwik::translate('CustomVariables_ScopePage') . ')');
-            $this->addSegment($segment);
-        }
-    }
 }

--- a/plugins/CustomVariables/Columns/CustomVariableName.php
+++ b/plugins/CustomVariables/Columns/CustomVariableName.php
@@ -9,6 +9,8 @@
 namespace Piwik\Plugins\CustomVariables\Columns;
 
 use Piwik\Piwik;
+use Piwik\Plugins\CustomVariables\CustomVariables;
+use Piwik\Plugins\CustomVariables\Segment;
 
 class CustomVariableName extends Base
 {
@@ -20,5 +22,27 @@ class CustomVariableName extends Base
     public function getName()
     {
         return Piwik::translate('CustomVariables_ColumnCustomVariableName');
+    }
+
+    protected function configureSegments()
+    {
+        $maxCustomVariables = CustomVariables::getMaxCustomVariables();
+
+        for ($i = 1; $i <= $maxCustomVariables; $i++) {
+
+            $segment = new Segment();
+            $segment->setSegment('customVariableName' . $i);
+            $segment->setSqlSegment('log_visit.custom_var_k' . $i);
+            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariableName') . ' ' . $i
+                . ' (' . Piwik::translate('CustomVariables_ScopeVisit') . ')');
+            $this->addSegment($segment);
+
+            $segment = new Segment();
+            $segment->setSegment('customVariablePageName' . $i);
+            $segment->setSqlSegment('log_link_visit_action.custom_var_k' . $i);
+            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariableName') . ' ' . $i
+                . ' (' . Piwik::translate('CustomVariables_ScopePage') . ')');
+            $this->addSegment($segment);
+        }
     }
 }

--- a/plugins/CustomVariables/Columns/CustomVariableValue.php
+++ b/plugins/CustomVariables/Columns/CustomVariableValue.php
@@ -9,6 +9,8 @@
 namespace Piwik\Plugins\CustomVariables\Columns;
 
 use Piwik\Piwik;
+use Piwik\Plugins\CustomVariables\CustomVariables;
+use Piwik\Plugins\CustomVariables\Segment;
 
 class CustomVariableValue extends Base
 {
@@ -20,5 +22,26 @@ class CustomVariableValue extends Base
     public function getName()
     {
         return Piwik::translate('CustomVariables_ColumnCustomVariableValue');
+    }
+
+    protected function configureSegments()
+    {
+        $maxCustomVariables = CustomVariables::getMaxCustomVariables();
+
+        for ($i = 1; $i <= $maxCustomVariables; $i++) {
+            $segment = new Segment();
+            $segment->setSegment('customVariableValue' . $i);
+            $segment->setSqlSegment('log_visit.custom_var_v' . $i);
+            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariableValue') . ' ' . $i
+                . ' (' . Piwik::translate('CustomVariables_ScopeVisit') . ')');
+            $this->addSegment($segment);
+
+            $segment = new Segment();
+            $segment->setSegment('customVariablePageValue' . $i);
+            $segment->setSqlSegment('log_link_visit_action.custom_var_v' . $i);
+            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariableValue') . ' ' . $i
+                . ' (' . Piwik::translate('CustomVariables_ScopePage') . ')');
+            $this->addSegment($segment);
+        }
     }
 }

--- a/plugins/CustomVariables/Columns/CustomVariableValue.php
+++ b/plugins/CustomVariables/Columns/CustomVariableValue.php
@@ -9,8 +9,6 @@
 namespace Piwik\Plugins\CustomVariables\Columns;
 
 use Piwik\Piwik;
-use Piwik\Plugins\CustomVariables\CustomVariables;
-use Piwik\Plugins\CustomVariables\Segment;
 
 class CustomVariableValue extends Base
 {
@@ -24,24 +22,4 @@ class CustomVariableValue extends Base
         return Piwik::translate('CustomVariables_ColumnCustomVariableValue');
     }
 
-    protected function configureSegments()
-    {
-        $maxCustomVariables = CustomVariables::getMaxCustomVariables();
-
-        for ($i = 1; $i <= $maxCustomVariables; $i++) {
-            $segment = new Segment();
-            $segment->setSegment('customVariableValue' . $i);
-            $segment->setSqlSegment('log_visit.custom_var_v' . $i);
-            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariableValue') . ' ' . $i
-                . ' (' . Piwik::translate('CustomVariables_ScopeVisit') . ')');
-            $this->addSegment($segment);
-
-            $segment = new Segment();
-            $segment->setSegment('customVariablePageValue' . $i);
-            $segment->setSqlSegment('log_link_visit_action.custom_var_v' . $i);
-            $segment->setName(Piwik::translate('CustomVariables_ColumnCustomVariableValue') . ' ' . $i
-                . ' (' . Piwik::translate('CustomVariables_ScopePage') . ')');
-            $this->addSegment($segment);
-        }
-    }
 }

--- a/plugins/CustomVariables/CustomVariables.php
+++ b/plugins/CustomVariables/CustomVariables.php
@@ -8,24 +8,20 @@
  */
 namespace Piwik\Plugins\CustomVariables;
 
-use Piwik\ArchiveProcessor;
-use Piwik\Piwik;
 use Piwik\Tracker\Cache;
-use Piwik\Tracker;
 
 class CustomVariables extends \Piwik\Plugin
 {
     /**
-     * @see Piwik\Plugin::registerEvents
+     * @see \Piwik\Plugin::registerEvents
      */
     public function registerEvents()
     {
         return array(
-            'API.getSegmentDimensionMetadata' => 'getSegmentsMetadata',
             'Live.getAllVisitorDetails'       => 'extendVisitorDetails',
             'AssetManager.getJavaScriptFiles' => 'getJsFiles',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
-            'AssetManager.getStylesheetFiles'        => 'getStylesheetFiles',
+            'AssetManager.getStylesheetFiles'  => 'getStylesheetFiles',
         );
     }
 
@@ -105,46 +101,6 @@ class CustomVariables extends \Piwik\Plugin
         }
 
         return $cache[$cacheKey];
-    }
-
-    public function getSegmentsMetadata(&$segments)
-    {
-        $maxCustomVariables = self::getNumUsableCustomVariables();
-
-        for ($i = 1; $i <= $maxCustomVariables; $i++) {
-            $segments[] = array(
-                'type'       => 'dimension',
-                'category'   => 'CustomVariables_CustomVariables',
-                'name'       => Piwik::translate('CustomVariables_ColumnCustomVariableName') . ' ' . $i
-                    . ' (' . Piwik::translate('CustomVariables_ScopeVisit') . ')',
-                'segment'    => 'customVariableName' . $i,
-                'sqlSegment' => 'log_visit.custom_var_k' . $i,
-            );
-            $segments[] = array(
-                'type'       => 'dimension',
-                'category'   => 'CustomVariables_CustomVariables',
-                'name'       => Piwik::translate('CustomVariables_ColumnCustomVariableValue') . ' ' . $i
-                    . ' (' . Piwik::translate('CustomVariables_ScopeVisit') . ')',
-                'segment'    => 'customVariableValue' . $i,
-                'sqlSegment' => 'log_visit.custom_var_v' . $i,
-            );
-            $segments[] = array(
-                'type'       => 'dimension',
-                'category'   => 'CustomVariables_CustomVariables',
-                'name'       => Piwik::translate('CustomVariables_ColumnCustomVariableName') . ' ' . $i
-                    . ' (' . Piwik::translate('CustomVariables_ScopePage') . ')',
-                'segment'    => 'customVariablePageName' . $i,
-                'sqlSegment' => 'log_link_visit_action.custom_var_k' . $i,
-            );
-            $segments[] = array(
-                'type'       => 'dimension',
-                'category'   => 'CustomVariables_CustomVariables',
-                'name'       => Piwik::translate('CustomVariables_ColumnCustomVariableValue') . ' ' . $i
-                    . ' (' . Piwik::translate('CustomVariables_ScopePage') . ')',
-                'segment'    => 'customVariablePageValue' . $i,
-                'sqlSegment' => 'log_link_visit_action.custom_var_v' . $i,
-            );
-        }
     }
 
     public function getClientSideTranslationKeys(&$translationKeys)

--- a/plugins/CustomVariables/CustomVariables.php
+++ b/plugins/CustomVariables/CustomVariables.php
@@ -12,6 +12,8 @@ use Piwik\Tracker\Cache;
 
 class CustomVariables extends \Piwik\Plugin
 {
+    const MAX_NUM_CUSTOMVARS_CACHEKEY = 'CustomVariables.MaxNumCustomVariables';
+
     /**
      * @see \Piwik\Plugin::registerEvents
      */
@@ -73,7 +75,7 @@ class CustomVariables extends \Piwik\Plugin
     public static function getNumUsableCustomVariables()
     {
         $cache    = Cache::getCacheGeneral();
-        $cacheKey = 'CustomVariables.NumUsableCustomVariables';
+        $cacheKey = self::MAX_NUM_CUSTOMVARS_CACHEKEY;
 
         if (!array_key_exists($cacheKey, $cache)) {
 

--- a/plugins/CustomVariables/Segment.php
+++ b/plugins/CustomVariables/Segment.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\CustomVariables;
+
+/**
+ * CustomVariables segment base class
+ */
+class Segment extends \Piwik\Plugin\Segment
+{
+    protected  function init()
+    {
+        $this->setCategory('CustomVariables_CustomVariables');
+    }
+}
+

--- a/plugins/CustomVariables/tests/Integration/CustomVariablesTest.php
+++ b/plugins/CustomVariables/tests/Integration/CustomVariablesTest.php
@@ -6,7 +6,8 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\CustomVariables\tests;
+namespace Piwik\Plugins\CustomVariables\tests\Integration;
+
 use Piwik\Plugins\CustomVariables\CustomVariables;
 use Piwik\Plugins\CustomVariables\Model;
 use Piwik\Tracker\Cache;
@@ -30,13 +31,13 @@ class CustomVariablesTest extends IntegrationTestCase
         CustomVariables::getNumUsableCustomVariables();
         $cache = Cache::getCacheGeneral();
 
-        $this->assertSame(5, $cache['CustomVariables.NumUsableCustomVariables']);
+        $this->assertSame(5, $cache[CustomVariables::MAX_NUM_CUSTOMVARS_CACHEKEY]);
     }
 
     public function test_getNumUsableCustomVariables_ShouldReadFromCacheIfPossible()
     {
         $cache = Cache::getCacheGeneral();
-        $cache['CustomVariables.NumUsableCustomVariables'] = 10;
+        $cache[CustomVariables::MAX_NUM_CUSTOMVARS_CACHEKEY] = 10;
         Cache::setCacheGeneral($cache);
 
         $this->assertSame(10, CustomVariables::getNumUsableCustomVariables());

--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -67,7 +67,7 @@ class Goals extends \Piwik\Plugin
     }
 
     /**
-     * @see Piwik\Plugin::registerEvents
+     * @see \Piwik\Plugin::registerEvents
      */
     public function registerEvents()
     {
@@ -77,7 +77,6 @@ class Goals extends \Piwik\Plugin
             'Tracker.Cache.getSiteAttributes'        => 'fetchGoalsFromDb',
             'API.getReportMetadata.end'              => 'getReportMetadataEnd',
             'SitesManager.deleteSite.end'            => 'deleteSiteGoals',
-            'Goals.getReportsWithGoalMetrics'        => 'getActualReportsWithGoalMetrics',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
             'Metrics.getDefaultMetricTranslations'   => 'addMetricTranslations',
             'Category.addSubcategories' => 'addSubcategories'
@@ -194,67 +193,28 @@ class Goals extends \Piwik\Plugin
                     'name'     => $report->getName(),
                     'module'   => $report->getModule(),
                     'action'   => $report->getAction(),
+                    'parameters' => $report->getParameters()
                 );
             }
         }
 
-        /**
-         * Triggered when gathering all reports that contain Goal metrics. The list of reports
-         * will be displayed on the left column of the bottom of every _Goals_ page.
-         *
-         * If plugins define reports that contain goal metrics (such as **conversions** or **revenue**),
-         * they can use this event to make sure their reports can be viewed on Goals pages.
-         *
-         * **Example**
-         *
-         *     public function getReportsWithGoalMetrics(&$reports)
-         *     {
-         *         $reports[] = array(
-         *             'category' => Piwik::translate('MyPlugin_myReportCategory'),
-         *             'name' => Piwik::translate('MyPlugin_myReportDimension'),
-         *             'module' => 'MyPlugin',
-         *             'action' => 'getMyReport'
-         *         );
-         *     }
-         *
-         * @param array &$reportsWithGoals The list of arrays describing reports that have Goal metrics.
-         *                                 Each element of this array must be an array with the following
-         *                                 properties:
-         *
-         *                                 - **category**: The report category. This should be a translated string.
-         *                                 - **name**: The report's translated name.
-         *                                 - **module**: The plugin the report is in, eg, `'UserCountry'`.
-         *                                 - **action**: The API method of the report, eg, `'getCountry'`.
-         * @ignore
-         * @deprecated since 2.5.0
-         */
-        Piwik::postEvent('Goals.getReportsWithGoalMetrics', array(&$reportsWithGoals));
-
-        return $reportsWithGoals;
-    }
-
-    /**
-     * This function executes when the 'Goals.getReportsWithGoalMetrics' event fires. It
-     * adds the 'visits to conversion' report metadata to the list of goal reports so
-     * this report will be displayed.
-     */
-    public function getActualReportsWithGoalMetrics(&$dimensions)
-    {
         $reportWithGoalMetrics = array(
             array('category' => 'General_Visit',
-                  'name'     => Piwik::translate('Goals_VisitsUntilConv'),
-                  'module'   => 'Goals',
-                  'action'   => 'getVisitsUntilConversion',
-                  'viewDataTable' => 'table',
+                'name'     => Piwik::translate('Goals_VisitsUntilConv'),
+                'module'   => 'Goals',
+                'action'   => 'getVisitsUntilConversion',
+                'viewDataTable' => 'table',
             ),
             array('category' => 'General_Visit',
-                  'name'     => Piwik::translate('Goals_DaysToConv'),
-                  'module'   => 'Goals',
-                  'action'   => 'getDaysToConversion',
-                  'viewDataTable' => 'table',
+                'name'     => Piwik::translate('Goals_DaysToConv'),
+                'module'   => 'Goals',
+                'action'   => 'getDaysToConversion',
+                'viewDataTable' => 'table',
             )
         );
-        $dimensions = array_merge($dimensions, $reportWithGoalMetrics);
+        $reportsWithGoals = array_merge($reportsWithGoals, $reportWithGoalMetrics);
+
+        return $reportsWithGoals;
     }
 
     public function getJsFiles(&$jsFiles)

--- a/plugins/Login/SessionInitializer.php
+++ b/plugins/Login/SessionInitializer.php
@@ -118,11 +118,6 @@ class SessionInitializer
         } else {
             $this->processSuccessfulSession($authResult, $rememberMe);
         }
-
-        /**
-         * @deprecated Create a custom SessionInitializer instead.
-         */
-        Piwik::postEvent('Login.initSession.end');
     }
 
     /**
@@ -136,29 +131,6 @@ class SessionInitializer
      */
     protected function doAuthenticateSession(AuthInterface $auth)
     {
-        $login = $auth->getLogin();
-        $tokenAuthSecret = null;
-
-        try {
-            $tokenAuthSecret = $auth->getTokenAuthSecret();
-        } catch (Exception $ex) {
-            Log::debug("SessionInitializer::doAuthenticateSession: token_auth secret for %s not available before user"
-                     . " is authenticated.", $login);
-        }
-
-        $tokenAuth = empty($tokenAuthSecret) ? null : $this->usersManagerAPI->getTokenAuth($login, $tokenAuthSecret);
-
-        /**
-         * @deprecated Create a custom SessionInitializer instead.
-         */
-        Piwik::postEvent(
-            'Login.authenticate',
-            array(
-                $auth->getLogin(),
-                $tokenAuth
-            )
-        );
-
         return $auth->authenticate();
     }
 
@@ -201,17 +173,6 @@ class SessionInitializer
      */
     protected function processSuccessfulSession(AuthResult $authResult, $rememberMe)
     {
-        /**
-         * @deprecated Create a custom SessionInitializer instead.
-         */
-        Piwik::postEvent(
-            'Login.authenticate.successful',
-            array(
-                $authResult->getIdentity(),
-                $authResult->getTokenAuth()
-            )
-        );
-
         $cookie = $this->getAuthCookie($rememberMe);
         $cookie->set('login', $authResult->getIdentity());
         $cookie->set('token_auth', $this->getHashTokenAuth($authResult->getIdentity(), $authResult->getTokenAuth()));

--- a/tests/PHPUnit/Integration/Columns/DimensionTest.php
+++ b/tests/PHPUnit/Integration/Columns/DimensionTest.php
@@ -102,9 +102,9 @@ namespace Piwik\Tests\Integration\Columns
             $this->assertSame('', $this->dimension->getName());
         }
 
-        public function test_getAllDimensions_shouldReturnActionVisitAndConversionDimensions()
+        public function test_getAllDimensions_shouldReturnAllKindOfDimensions()
         {
-            Manager::getInstance()->loadPlugins(array('Actions', 'Events', 'DevicesDetector', 'Goals'));
+            Manager::getInstance()->loadPlugins(array('Actions', 'Events', 'DevicesDetector', 'Goals', 'CustomVariables'));
 
             $dimensions = Dimension::getAllDimensions();
 
@@ -113,6 +113,7 @@ namespace Piwik\Tests\Integration\Columns
             $foundConversion = false;
             $foundVisit      = false;
             $foundAction     = false;
+            $foundNormal     = false;
 
             foreach ($dimensions as $dimension) {
                 if ($dimension instanceof ConversionDimension) {
@@ -121,16 +122,19 @@ namespace Piwik\Tests\Integration\Columns
                     $foundAction = true;
                 } else if ($dimension instanceof VisitDimension) {
                     $foundVisit = true;
+                } else if ($dimension instanceof Dimension) {
+                    $foundNormal = true;
                 } else {
                     $this->fail('Unexpected dimension class found');
                 }
 
-                $this->assertRegExp('/Piwik.Plugins.(Actions|Events|DevicesDetector|Goals).Columns/', get_class($dimension));
+                $this->assertRegExp('/Piwik.Plugins.(Actions|Events|DevicesDetector|Goals|CustomVariables).Columns/', get_class($dimension));
             }
 
             $this->assertTrue($foundConversion);
             $this->assertTrue($foundAction);
             $this->assertTrue($foundVisit);
+            $this->assertTrue($foundNormal);
         }
 
         public function test_getDimensions_shouldReturnAllKindOfDimensionsThatBelongToASpecificPlugin()

--- a/tests/PHPUnit/Integration/DataTable/Filter/PivotByDimensionTest.php
+++ b/tests/PHPUnit/Integration/DataTable/Filter/PivotByDimensionTest.php
@@ -8,6 +8,8 @@
 namespace Piwik\Tests\Core\DataTable\Filter;
 
 use Piwik\API\Proxy;
+use Piwik\Plugins\CustomVariables\CustomVariables;
+use Piwik\Tracker\Cache;
 use Piwik\Config;
 use Piwik\DataTable;
 use Piwik\DataTable\Filter\PivotByDimension;
@@ -223,6 +225,8 @@ class PivotByDimensionTest extends IntegrationTestCase
 
     public function test_filter_CorrectlyCreatesPivotTable_WhenSubtablesHaveNoRows()
     {
+        Cache::setCacheGeneral(array(CustomVariables::MAX_NUM_CUSTOMVARS_CACHEKEY => 5));
+
         $this->loadPlugins('Referrers', 'UserCountry', 'CustomVariables');
 
         $table = $this->getTableToFilter(false);
@@ -236,6 +240,8 @@ class PivotByDimensionTest extends IntegrationTestCase
             array('label' => 'row 2'),
             array('label' => 'row 3')
         );
+
+        Cache::clearCacheGeneral();
         $this->assertTableRowsEquals($expectedRows, $table);
     }
 

--- a/tests/resources/screenshot-override/override.css
+++ b/tests/resources/screenshot-override/override.css
@@ -37,12 +37,16 @@ body > .widget {
     border-style: solid;
 }
 
+.loadingPiwik {
+    display: none !important;
+}
+
 /* do not display RSS feed widget's contents */
 #widgetExampleRssWidgetrssPiwik .rss {
     display:none;
 }
 
-body * {
+html body div *, body * {
     -webkit-transition: none !important;
     transition: none !important;
     -webkit-animation: none !important;


### PR DESCRIPTION
fixes #8503
replaces #8620

The 2 failing UI tests are rather random build errors: http://builds-artifacts.piwik.org/piwik/piwik/8503/14940/ We might have to update those screenshots after merging.

It was not as easy as simply removing all events as some were still in use. I already adjusted treemap plugin to be compatible with 2.X and 3.X
