### PR TITLE
Make the updates generated by generate:update command work

### DIFF
--- a/plugins/CoreConsole/Commands/GenerateUpdate.php
+++ b/plugins/CoreConsole/Commands/GenerateUpdate.php
@@ -82,10 +82,6 @@ class GenerateUpdate extends GeneratePluginBase
         $className = str_replace('Updates_xx', '', $className);
         $className = trim($className, '\\');
 
-        if ($component !== 'core') {
-            $className .= '\Updates';
-        }
-
         return $className;
     }
 


### PR DESCRIPTION
Fix generated plugin updates did not work because the namespace had `Updates` appended.

replaces #10409
