### PR TITLE
When generating a new plugin component, make sure to generate correct piwik version require

### DIFF
--- a/plugins/CoreConsole/Commands/GeneratePluginBase.php
+++ b/plugins/CoreConsole/Commands/GeneratePluginBase.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\CoreConsole\Commands;
 
+use Piwik\Common;
 use Piwik\Development;
 use Piwik\Filesystem;
 use Piwik\Plugin\ConsoleCommand;
@@ -123,14 +124,50 @@ abstract class GeneratePluginBase extends ConsoleCommand
         }
 
         $piwikVersion       = Version::VERSION;
-        $newRequiredVersion = '>=' . $piwikVersion;
+        $nextMajorVersion = (int) $piwikVersion + 1;
+        $secondPartPiwikVersionRequire = ',<' . $nextMajorVersion . '.0.0-b1';
+        $newRequiredVersion = '>=' . $piwikVersion .  $secondPartPiwikVersionRequire;
 
         if (!empty($pluginJson['require']['piwik'])) {
-            $requiredVersion = $pluginJson['require']['piwik'];
+            $requiredVersion = trim($pluginJson['require']['piwik']);
 
             if ($requiredVersion === $newRequiredVersion) {
+                // there is nothing to updated
                 return;
             }
+
+            // our generated versions look like ">=2.25.4,<3.0.0-b1".
+            // We only updated the Piwik version in the first part if the piwik version looks like that or if it has only
+            // one piwik version defined. In all other cases, eg user uses || etc we do not update it as user has customized
+            // the piwik version.
+
+            foreach (['<>','!=', '<=','==', '^'] as $comparison) {
+                if (strpos($requiredVersion, $comparison) === 0) {
+                    // user is using custom piwik version require, we do not overwrite anything.
+                    return;
+                }
+            }
+
+            if (strpos($requiredVersion, '||') !== false || strpos($requiredVersion, ' ') !== false) {
+                // user is using custom piwik version require, we do not overwrite anything.
+                return;
+            }
+
+            $requiredPiwikVersions = explode(',', (string) $requiredVersion);
+            $numRequiredPiwikVersions = count($requiredPiwikVersions);
+
+            if ($numRequiredPiwikVersions > 2) {
+                // user is using custom piwik version require, we do not overwrite anything.
+                return;
+            }
+
+            if ($numRequiredPiwikVersions === 2 &&
+                !Common::stringEndsWith($requiredVersion, $secondPartPiwikVersionRequire)) {
+                // user is using custom piwik version require, we do not overwrite anything
+                return;
+            }
+
+            // if only one piwik version is defined we update it to make sure it does now specify an upper version limit
 
             $dependency     = new Dependency();
             $missingVersion = $dependency->getMissingVersions($piwikVersion, $requiredVersion);


### PR DESCRIPTION
In plugin.json we used to generate piwik require only ">=3.0.0-b1" but now we require eg ">=3.0.0-b1,<4.0.0-b1" when generating a plugin. Meaning we make sure to specify an upper limit.

When generating any plugin component we update the required piwik version in plugin.json automatically and set it to the current used Piwik version as users likely don't test it with older Piwik versions. We now generate a version constraint like ">=3.0.0-b1,<4.0.0-b1" as well and we only update it, if the developer is actually using that version format and not if a developer has defined a custom version constraint.
