### PR TITLE
fix Deprecated - Non-static method Piwik\Db\Adapter::isRecommendedAdapter() should not be called statically,

### DIFF
--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -125,7 +125,7 @@ class Adapter
      * @param string $adapterName
      * @return bool
      */
-    public function isRecommendedAdapter($adapterName)
+    public static function isRecommendedAdapter($adapterName)
     {
         return strtolower($adapterName) === 'pdo/mysql';
     }


### PR DESCRIPTION
fixes #10463
