### PR TITLE
Fix modal confirms for 3.x

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -195,7 +195,7 @@ var piwikHelper = {
             options = {};
         }
 
-        var domElem = $(domSelector);
+        var domElem = $(domSelector).clone();
         var buttons = [];
 
         var content = '<div class="modal"><div class="modal-content"></div>';


### PR DESCRIPTION
When opening a modal confirm for a specific element, the element is currently moved into the modal box. Closing the box, doesn't move it back, so recreating won't work, as the content can't be found anymore.

With this small change the content is cloned before using it for modal confirm.

To reproduce the failure, simply try to remove a segment, click no, and try it again.

Note: Maybe we should refactor the modal confirm later. As closing modals doesn't remove the modal from dom.
