### PR TITLE
if assume_secure_protocol is enabled make sure to use https in CORS

### DIFF
--- a/core/API/CORSHandler.php
+++ b/core/API/CORSHandler.php
@@ -10,6 +10,7 @@ namespace Piwik\API;
 
 use Piwik\Common;
 use Piwik\Url;
+use Piwik\ProxyHttp;
 
 class CORSHandler
 {
@@ -35,7 +36,11 @@ class CORSHandler
         if (!empty($_SERVER['HTTP_ORIGIN'])) {
             $origin = $_SERVER['HTTP_ORIGIN'];
             if (in_array($origin, $this->domains, true)) {
-                Common::sendHeader('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+                $domain = $_SERVER['HTTP_ORIGIN'];
+                if (ProxyHttp::isHttps()) {
+                    $domain = str_replace('http://', 'https://', $domain);
+                }
+                Common::sendHeader('Access-Control-Allow-Origin: ' . $domain);
             }
         }
     }


### PR DESCRIPTION
I have actually not tested this but seen it as a potential problem in a case where CORS is needed.
