### PR TITLE
Do not remove an additional day if current day is selected

### DIFF
--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -482,12 +482,6 @@ class Model
                 }
             } else {
                 $processedDate = Date::factory($date);
-                if ($date == 'today'
-                    || $date == 'now'
-                    || $processedDate->toString() == Date::factory('now', $currentTimezone)->toString()
-                ) {
-                    $processedDate = $processedDate->subDay(1);
-                }
                 $processedPeriod = Period\Factory::build($period, $processedDate);
             }
             $dateStart = $processedPeriod->getDateStart()->setTimezone($currentTimezone);


### PR DESCRIPTION
fixes #9053 

I debugged it locally and it indeed removes a day when eg viewing today with period week.
