### PR TITLE
Added goals event as it is needed for custom dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@ The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** l
  * `Menu.Top.addItems`
  * `ViewDataTable.addViewDataTable` Create a [Visualization](http://developer.piwik.org/guides/visualizing-report-data) instead
  * `ViewDataTable.getDefaultType` Specify the default type in a [Report](http://developer.piwik.org/guides/custom-reports) instead
- * `Goals.getReportsWithGoalMetrics` Specify a report has goal metrics in a [Report](http://developer.piwik.org/guides/custom-reports) instead
  * `Login.authenticate`  Create a custom SessionInitializer instead of using `Login` events
  * `Login.initSession.end`
  * `Login.authenticate.successful`

--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -8,9 +8,7 @@
  */
 namespace Piwik\Plugins\Goals;
 
-use Piwik\ArchiveProcessor;
 use Piwik\Common;
-use Piwik\Db;
 use Piwik\Piwik;
 use Piwik\Plugin\ReportsProvider;
 use Piwik\Tracker\GoalManager;
@@ -198,21 +196,50 @@ class Goals extends \Piwik\Plugin
             }
         }
 
-        $reportWithGoalMetrics = array(
-            array('category' => 'General_Visit',
-                'name'     => Piwik::translate('Goals_VisitsUntilConv'),
-                'module'   => 'Goals',
-                'action'   => 'getVisitsUntilConversion',
-                'viewDataTable' => 'table',
-            ),
-            array('category' => 'General_Visit',
-                'name'     => Piwik::translate('Goals_DaysToConv'),
-                'module'   => 'Goals',
-                'action'   => 'getDaysToConversion',
-                'viewDataTable' => 'table',
-            )
+        $reportsWithGoals[] = array('category' => 'General_Visit',
+            'name'     => Piwik::translate('Goals_VisitsUntilConv'),
+            'module'   => 'Goals',
+            'action'   => 'getVisitsUntilConversion',
+            'viewDataTable' => 'table',
         );
-        $reportsWithGoals = array_merge($reportsWithGoals, $reportWithGoalMetrics);
+        $reportsWithGoals[] = array('category' => 'General_Visit',
+            'name'     => Piwik::translate('Goals_DaysToConv'),
+            'module'   => 'Goals',
+            'action'   => 'getDaysToConversion',
+            'viewDataTable' => 'table',
+        );
+
+        /**
+         * Triggered when gathering all reports that contain Goal metrics. The list of reports
+         * will be displayed on the left column of the bottom of every _Goals_ page.
+         *
+         * If plugins define reports that contain goal metrics (such as **conversions** or **revenue**),
+         * they can use this event to make sure their reports can be viewed on Goals pages.
+         *
+         * **Example**
+         *
+         *     public function getReportsWithGoalMetrics(&$reports)
+         *     {
+         *         $reports[] = array(
+         *             'category' => Piwik::translate('MyPlugin_myReportCategory'),
+         *             'name' => Piwik::translate('MyPlugin_myReportDimension'),
+         *             'module' => 'MyPlugin',
+         *             'action' => 'getMyReport'
+         *         );
+         *     }
+         *
+         * @param array &$reportsWithGoals The list of arrays describing reports that have Goal metrics.
+         *                                 Each element of this array must be an array with the following
+         *                                 properties:
+         *
+         *                                 - **category**: The report category. This should be a translated string.
+         *                                 - **name**: The report's translated name.
+         *                                 - **module**: The plugin the report is in, eg, `'UserCountry'`.
+         *                                 - **action**: The API method of the report, eg, `'getCountry'`.
+         * @ignore
+         * @deprecated since 2.5.0
+         */
+        Piwik::postEvent('Goals.getReportsWithGoalMetrics', array(&$reportsWithGoals));
 
         return $reportsWithGoals;
     }

--- a/plugins/Goals/Pages.php
+++ b/plugins/Goals/Pages.php
@@ -296,6 +296,9 @@ class Pages
                 }
 
                 $widget = $this->createWidgetForReport($report['module'], $report['action']);
+                if (!empty($report['name'])) {
+                    $widget->setName($report['name']);
+                }
                 $widget->setParameters($params);
                 $widget->setCategoryId($categoryText);
                 $widget->setSubcategoryId($categoryText);


### PR DESCRIPTION
Turns out `Goals.getReportsWithGoalMetrics` was actually needed for custom dimensions. I noticed removing it broke a feature where it shows the custom dimensions there.
