### PR TITLE
Fix empty dashboard notification was shown multiple times under circumstances

### DIFF
--- a/plugins/Dashboard/angularjs/dashboard/dashboard.directive.js
+++ b/plugins/Dashboard/angularjs/dashboard/dashboard.directive.js
@@ -29,6 +29,7 @@
 
             widgetsHelper.getAvailableWidgets();
 
+            $('#dashboardWidgetsArea').off('dashboardempty', showEmptyDashboardNotification);
             $('#dashboardWidgetsArea')
                 .on('dashboardempty', showEmptyDashboardNotification)
                 .dashboard({


### PR DESCRIPTION
Was shown multiple times if switched between multiple dashboards and then opening an empty dashboard
