### PR TITLE
Fix possible twig error in updater if support is defined but no email

### DIFF
--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -120,6 +120,7 @@
 
     {% if metadata is defined
         and metadata.support is defined
+        and metadata.support.email is defined
         and metadata.support.email
         and pluginName not in marketplacePluginNames %}
         {{ 'CorePluginsAdmin_EmailToEnquireUpdatedVersion'|translate('<a href="mailto:' ~ metadata.support.email|e('html_attr') ~'">' ~ metadata.support.email ~ '</a>', pluginName)|raw }}


### PR DESCRIPTION
See eg http://builds-artifacts.piwik.org/piwik/piwik/10380/19911/ errors. If a plugin defines in `plugin.json` eg 

``` json
support: {"issues": "..."}
```

it will fail because support is defined but no email. This can break the updater.
