### PR TITLE
Slightly improves the visibility of inactive plugins in installed plugin list (3.x)

### DIFF
--- a/plugins/CorePluginsAdmin/stylesheets/plugins_admin.less
+++ b/plugins/CorePluginsAdmin/stylesheets/plugins_admin.less
@@ -80,6 +80,16 @@ table.entityTable tr td a.uninstall {
         }
     }
 
+    .inactive-plugin {
+        td {
+            background-color: rgba(230, 230, 230, 0.3);
+        }
+
+        &:hover td {
+            background-color: #f2f2f2;
+        }
+    }
+
     td.vers {
         white-space: nowrap;
     }

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc9107b10c50ac6c51a12b316cced368329c3bfbacb71c6ca9d4cb4da939cb36
-size 934782
+oid sha256:0b2e471127b89633946ad688be5e6dc030784f9780c541df2379d8c0ce836a8b
+size 933608

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_themes.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_themes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:606e20bb10d36ca8f7cc07f7a106e02f3c19fd2b1ac8191c468d7ffe9fca4a09
-size 75108
+oid sha256:84e59ce08370286d50e24f3446509365786a254846a91affa418566f48d005a9
+size 74942


### PR DESCRIPTION
Currently all plugins have the same appearance, which makes it hard to see which plugins are disabled.
To make that a bit better visible this PR changes the background color of those plugins:

![image](https://cloud.githubusercontent.com/assets/1579355/18616064/a01e4b62-7db5-11e6-9e62-2fe55b267613.png)

Guess it was similar in Piwik 2.
