### PR TITLE
overwrite Exit page url in log_visit, only when it is valid

### DIFF
--- a/plugins/Actions/Columns/ExitPageUrl.php
+++ b/plugins/Actions/Columns/ExitPageUrl.php
@@ -42,6 +42,7 @@ class ExitPageUrl extends VisitDimension
             $idActionUrl = $action->getIdActionUrlForEntryAndExitIds();
         }
 
+        // set Exit Page Url only when it is a valid url
         if($idActionUrl === false) {
             return false;
         }
@@ -63,11 +64,12 @@ class ExitPageUrl extends VisitDimension
 
         $id = $action->getIdActionUrlForEntryAndExitIds();
 
-        if (!empty($id)) {
-            $id = (int) $id;
+        // set Exit Page Url only when it is a valid url
+        if (empty($id)) {
+            return false;
         }
 
-        return $id;
+        return (int) $id;
     }
 
     public function getName()

--- a/plugins/Actions/Columns/ExitPageUrl.php
+++ b/plugins/Actions/Columns/ExitPageUrl.php
@@ -42,6 +42,10 @@ class ExitPageUrl extends VisitDimension
             $idActionUrl = $action->getIdActionUrlForEntryAndExitIds();
         }
 
+        if($idActionUrl === false) {
+            return false;
+        }
+
         return (int) $idActionUrl;
     }
 


### PR DESCRIPTION
In some cases this may help some of the Transitions API metrics being more accurate

related to https://github.com/piwik/piwik/pull/10510
