### PR TITLE
Automatically update all marketplace plugins when updating Piwik

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -137,14 +137,19 @@ class Plugin
         if ($cache->contains($cacheId)) {
             $this->pluginInformation = $cache->fetch($cacheId);
         } else {
-            $metadataLoader = new MetadataLoader($pluginName);
-            $this->pluginInformation = $metadataLoader->load();
-
-            if ($this->hasDefinedPluginInformationInPluginClass() && $metadataLoader->hasPluginJson()) {
-                throw new \Exception('Plugin ' . $pluginName . ' has defined the method getInformation() and as well as having a plugin.json file. Please delete the getInformation() method from the plugin class. Alternatively, you may delete the plugin directory from plugins/' . $pluginName);
-            }
+            $this->reloadPluginInformation();
 
             $cache->save($cacheId, $this->pluginInformation);
+        }
+    }
+
+    public function reloadPluginInformation()
+    {
+        $metadataLoader = new MetadataLoader($this->pluginName);
+        $this->pluginInformation = $metadataLoader->load();
+
+        if ($this->hasDefinedPluginInformationInPluginClass() && $metadataLoader->hasPluginJson()) {
+            throw new \Exception('Plugin ' . $this->pluginName . ' has defined the method getInformation() and as well as having a plugin.json file. Please delete the getInformation() method from the plugin class. Alternatively, you may delete the plugin directory from plugins/' . $this->pluginName);
         }
     }
 

--- a/plugins/CorePluginsAdmin/MarketplaceApiClient.php
+++ b/plugins/CorePluginsAdmin/MarketplaceApiClient.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\CorePluginsAdmin;
 
 use Piwik\Cache;
+use Piwik\Container\StaticContainer;
 use Piwik\Http;
 use Piwik\Version;
 
@@ -126,6 +127,8 @@ class MarketplaceApiClient
     private function fetch($action, $params)
     {
         ksort($params);
+        $params['piwik'] = StaticContainer::get('marketplacePiwikVersion');
+        $params['php'] = phpversion();
         $query = http_build_query($params);
 
         $cacheId = $this->getCacheKey($action, $query);

--- a/plugins/CorePluginsAdmin/MarketplaceApiClient.php
+++ b/plugins/CorePluginsAdmin/MarketplaceApiClient.php
@@ -133,7 +133,7 @@ class MarketplaceApiClient
     {
         ksort($params);
         $params['piwik'] = self::getPiwikVersion();
-        $params['php'] = phpversion();
+        $params['php'] = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
         $query = http_build_query($params);
 
         $cacheId = $this->getCacheKey($action, $query);

--- a/plugins/CorePluginsAdmin/MarketplaceApiClient.php
+++ b/plugins/CorePluginsAdmin/MarketplaceApiClient.php
@@ -124,10 +124,15 @@ class MarketplaceApiClient
         return array();
     }
 
+    public static function getPiwikVersion()
+    {
+        return StaticContainer::get('marketplacePiwikVersion');
+    }
+
     private function fetch($action, $params)
     {
         ksort($params);
-        $params['piwik'] = StaticContainer::get('marketplacePiwikVersion');
+        $params['piwik'] = self::getPiwikVersion();
         $params['php'] = phpversion();
         $query = http_build_query($params);
 
@@ -183,7 +188,7 @@ class MarketplaceApiClient
         $latestVersion = array_pop($plugin['versions']);
         $downloadUrl = $latestVersion['download'];
 
-        return $this->domain . $downloadUrl . '?coreVersion=' . Version::VERSION;
+        return $this->domain . $downloadUrl . '?coreVersion=' . self::getPiwikVersion();
     }
 
 }

--- a/plugins/CorePluginsAdmin/PluginInstaller.php
+++ b/plugins/CorePluginsAdmin/PluginInstaller.php
@@ -12,6 +12,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Filechecks;
 use Piwik\Filesystem;
 use Piwik\Piwik;
+use Piwik\Plugin\Manager as PluginManager;
 use Piwik\Plugin\Dependency as PluginDependency;
 use Piwik\Unzip;
 
@@ -48,6 +49,11 @@ class PluginInstaller
             $this->copyPluginToDestination($tmpPluginFolder);
 
             Filesystem::deleteAllCacheOnUpdate($this->pluginName);
+
+            $plugin = PluginManager::getInstance()->getLoadedPlugin($this->pluginName);
+            if (!empty($plugin)) {
+                $plugin->reloadPluginInformation();
+            }
 
         } catch (\Exception $e) {
 

--- a/plugins/CorePluginsAdmin/PluginInstaller.php
+++ b/plugins/CorePluginsAdmin/PluginInstaller.php
@@ -160,7 +160,10 @@ class PluginInstaller
             $requires = (array) $metadata->require;
         }
 
+        $piwikVersion = MarketplaceApiClient::getPiwikVersion();
+
         $dependency = new PluginDependency();
+        $dependency->setPiwikVersion($piwikVersion);
         $missingDependencies = $dependency->getMissingDependencies($requires);
 
         if (!empty($missingDependencies)) {

--- a/plugins/CorePluginsAdmin/config/config.php
+++ b/plugins/CorePluginsAdmin/config/config.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+    'marketplacePiwikVersion' => function () {
+        return \Piwik\Version::VERSION;
+    }
+);

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -98,6 +98,8 @@ class Controller extends \Piwik\Plugin\Controller
             $messages = $e->getUpdateLogMessages();
         }
 
+        Filesystem::deleteAllCacheOnUpdate();
+
         $view->feedbackMessages = $messages;
         $this->addCustomLogoInfo($view);
         return $view->render();

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -20,6 +20,7 @@ use Piwik\Plugin\Manager as PluginManager;
 use Piwik\Plugin\ReleaseChannels;
 use Piwik\Plugins\CorePluginsAdmin\CorePluginsAdmin;
 use Piwik\Plugins\CorePluginsAdmin\MarketplaceApiClient;
+use Piwik\Plugins\CorePluginsAdmin\MarketplaceApiException;
 use Piwik\Plugins\CorePluginsAdmin\PluginInstaller;
 use Piwik\SettingsServer;
 use Piwik\Translation\Translator;
@@ -119,10 +120,18 @@ class Updater
             // we need to load the marketplace already here, otherwise it will use the new, updated file in Piwik 3
             $marketplace = new MarketplaceApiClient();
             require_once PIWIK_DOCUMENT_ROOT . '/plugins/CorePluginsAdmin/PluginInstaller.php';
+            require_once PIWIK_DOCUMENT_ROOT . '/plugins/CorePluginsAdmin/MarketplaceApiException.php';
 
             $this->installNewFiles($extractedArchiveDirectory);
             $messages[] = $this->translator->translate('CoreUpdater_InstallingTheLatestVersion');
 
+        } catch (ArchiveDownloadException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            throw new UpdaterException($e, $messages);
+        }
+
+        try {
             if (CorePluginsAdmin::isMarketplaceEnabled()) {
                 $messages[] = $this->translator->translate('CoreUpdater_CheckingForPluginUpdates');
 
@@ -136,20 +145,26 @@ class Updater
                 $pluginsWithUpdate = $marketplace->checkUpdates($loadedPlugins);
 
                 foreach ($pluginsWithUpdate as $pluginWithUpdate) {
-                    $messages[] = $this->translator->translate('CoreUpdater_UpdatingPluginXToVersionY', array($pluginWithUpdate['name'], $pluginWithUpdate['version']));
+                    $pluginName = $pluginWithUpdate['name'];
 
-                    $pluginInstaller = new PluginInstaller($pluginWithUpdate['name']);
+                    $messages[] = $this->translator->translate('CoreUpdater_UpdatingPluginXToVersionY',
+                                                               array($pluginName, $pluginWithUpdate['version']));
+
+                    $pluginInstaller = new PluginInstaller($pluginName);
                     $pluginInstaller->installOrUpdatePluginFromMarketplace();
                 }
             }
+        } catch (MarketplaceApiException $e) {
+            // there is a problem with the connection to the server, ignore for now
+        } catch (Exception $e) {
+            throw new UpdaterException($e, $messages);
+        }
 
+        try {
             $disabledPluginNames = $this->disableIncompatiblePlugins($newVersion);
             if (!empty($disabledPluginNames)) {
                 $messages[] = $this->translator->translate('CoreUpdater_DisablingIncompatiblePlugins', implode(', ', $disabledPluginNames));
             }
-
-        } catch (ArchiveDownloadException $e) {
-            throw $e;
         } catch (Exception $e) {
             throw new UpdaterException($e, $messages);
         }

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -143,20 +143,17 @@ class Updater
                 }
             }
 
+            $disabledPluginNames = $this->disableIncompatiblePlugins($newVersion);
+            if (!empty($disabledPluginNames)) {
+                $messages[] = $this->translator->translate('CoreUpdater_DisablingIncompatiblePlugins', implode(', ', $disabledPluginNames));
+            }
+
         } catch (ArchiveDownloadException $e) {
             throw $e;
         } catch (Exception $e) {
             throw new UpdaterException($e, $messages);
         }
 
-        try {
-            $disabledPluginNames = $this->disableIncompatiblePlugins($newVersion);
-            if (!empty($disabledPluginNames)) {
-                $messages[] = $this->translator->translate('CoreUpdater_DisablingIncompatiblePlugins', implode(', ', $disabledPluginNames));
-            }
-        } catch (Exception $e) {
-            throw new UpdaterException($e, $messages);
-        }
         return $messages;
     }
 

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -10,7 +10,6 @@ namespace Piwik\Plugins\CoreUpdater;
 
 use Exception;
 use Piwik\ArchiveProcessor\Rules;
-use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Filechecks;
 use Piwik\Filesystem;
@@ -25,7 +24,6 @@ use Piwik\Plugins\CorePluginsAdmin\PluginInstaller;
 use Piwik\SettingsServer;
 use Piwik\Translation\Translator;
 use Piwik\Unzip;
-use Piwik\UpdateCheck;
 use Piwik\Version;
 
 class Updater
@@ -135,7 +133,7 @@ class Updater
             if (CorePluginsAdmin::isMarketplaceEnabled()) {
                 $messages[] = $this->translator->translate('CoreUpdater_CheckingForPluginUpdates');
 
-                $pluginManager = \Piwik\Plugin\Manager::getInstance();
+                $pluginManager = PluginManager::getInstance();
                 $pluginManager->loadAllPluginsAndGetTheirInfo();
                 $loadedPlugins = $pluginManager->getLoadedPlugins();
 

--- a/plugins/CoreUpdater/lang/en.json
+++ b/plugins/CoreUpdater/lang/en.json
@@ -24,7 +24,7 @@
         "HelpMessageIntroductionWhenError": "The above is the core error message. It should help explain the cause, but if you require further help please:",
         "HelpMessageIntroductionWhenWarning": "The update completed successfuly, however there were issues during the process. Please read the above descriptions for details. For further help:",
         "HighTrafficPiwikServerEnableMaintenance": "If you manage a high traffic Piwik server, we recommend to %1$smomentarily disable visitor Tracking and put the Piwik User Interface in maintenance mode%2$s.",
-        "IncompatbilePluginsWillBeDisabledInfo": "Note: some plugins are not compatible with Piwik %s. They will be disabled when you upgrade:",
+        "IncompatbilePluginsWillBeDisabledInfo": "Note: some plugins are not compatible with Piwik %s. We will update them if there is an update on the Marketplace, otherwise we will be disable them when you upgrade:",
         "InstallingTheLatestVersion": "Installing the latest version",
         "LatestBetaRelease": "Latest beta release",
         "LatestStableRelease": "Latest stable release",

--- a/plugins/CoreUpdater/lang/en.json
+++ b/plugins/CoreUpdater/lang/en.json
@@ -1,5 +1,6 @@
 {
     "CoreUpdater": {
+        "CheckingForPluginUpdates": "Checking for new plugin updates",
         "ClickHereToViewSqlQueries": "Click here to view and copy the list of SQL queries that will get executed",
         "CriticalErrorDuringTheUpgradeProcess": "Critical Error during the update process:",
         "DatabaseUpgradeRequired": "Database Upgrade Required",
@@ -52,6 +53,7 @@
         "UpdateAutomatically": "Update Automatically",
         "UpdateHasBeenCancelledExplanation": "Piwik One Click Update has been cancelled. If you can't fix the above error message, it is recommended that you manually update Piwik. %1$s Please check out the %2$sUpdate documentation%3$s to get started!",
         "UpdateTitle": "Update",
+        "UpdatingPluginXToVersionY": "Updating plugin %1$s to version %2$s",
         "UpdateSuccessTitle": "Piwik has been successfully updated!",
         "UpdateErrorTitle": "Update error",
         "ThankYouUpdatePiwik": "Thank you for using Piwik and keeping it up to date!",

--- a/tests/UI/expected-screenshots/CoreUpdaterCode_newVersion.png
+++ b/tests/UI/expected-screenshots/CoreUpdaterCode_newVersion.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dcbcc69e9e1fee906e196cfdfcbd622c24a5c042caca5c790b491e24959360fa
-size 70744
+oid sha256:0ccb9b1ad53b1b53a4b525618d414ac4dece5231df2ab478c7e5c1dd7596fc62
+size 73430


### PR DESCRIPTION
Needed for Piwik 3. 

Otherwise user would update from Piwik 2 to Piwik 3, the plugins would not be compatible anymore and we would disable the plugins that are not compatible. Instead we update first Piwik, then update all the Marketplace plugins.

I have tested it (all day) and it worked for me.
