### PR TITLE
Activating a plugin should fail when the plugin has missing dependencies

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -414,14 +414,40 @@ class Plugin
             return array();
         }
 
-        $dependency = new Dependency();
-
-        if (!is_null($piwikVersion)) {
-            $dependency->setPiwikVersion($piwikVersion);
-        }
-
+        $dependency = $this->makeDependency($piwikVersion);
         return $dependency->getMissingDependencies($this->pluginInformation['require']);
     }
+
+    /**
+     * Returns a string (translated) describing the missing requirements for this plugin and the given Piwik version
+     *
+     * @param string $piwikVersion
+     * @return string "AnonymousPiwikUsageMeasurement requires PIWIK >=3.0.0"
+     */
+    public function getMissingDependenciesAsString($piwikVersion = null)
+    {
+        if (empty($this->pluginInformation['require'])) {
+            return '';
+        }
+        $dependency = $this->makeDependency($piwikVersion);
+
+        $missingDependencies = $dependency->getMissingDependencies($this->pluginInformation['require']);
+
+        if(empty($missingDependencies)) {
+            return '';
+        }
+
+        $causedBy = array();
+        foreach ($missingDependencies as $dependency) {
+            $causedBy[] = ucfirst($dependency['requirement']) . ' ' . $dependency['causedBy'];
+        }
+
+        return Piwik::translate("CorePluginsAdmin_PluginRequirement", array(
+            $this->getPluginName(),
+            implode(', ', $causedBy)
+        ));
+    }
+
 
     /**
      * Extracts the plugin name from a backtrace array. Returns `false` if we can't find one.
@@ -526,5 +552,19 @@ class Plugin
             include_once $file;
         }
         return true;
+    }
+
+    /**
+     * @param $piwikVersion
+     * @return Dependency
+     */
+    private function makeDependency($piwikVersion)
+    {
+        $dependency = new Dependency();
+
+        if (!is_null($piwikVersion)) {
+            $dependency->setPiwikVersion($piwikVersion);
+        }
+        return $dependency;
     }
 }

--- a/core/Plugin/Dependency.php
+++ b/core/Plugin/Dependency.php
@@ -103,4 +103,6 @@ class Dependency
 
         return '';
     }
+
+
 }

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -12,7 +12,6 @@ namespace Piwik\Plugin;
 use Piwik\Application\Kernel\PluginList;
 use Piwik\Cache;
 use Piwik\Columns\Dimension;
-use Piwik\Common;
 use Piwik\Config as PiwikConfig;
 use Piwik\Config;
 use Piwik\Db;
@@ -631,7 +630,7 @@ class Manager
                 'info' => $oPlugin->getInformation(),
                 'activated'       => $this->isPluginActivated($pluginName),
                 'alwaysActivated' => $this->isPluginAlwaysActivated($pluginName),
-                'missingRequirements' => $oPlugin->getMissingDependencies(),
+                'missingRequirements' => $oPlugin->getMissingDependenciesAsString(),
                 'uninstallable' => $this->isPluginUninstallable($pluginName),
             );
             $plugins[$pluginName] = $info;
@@ -843,10 +842,11 @@ class Manager
                 if ($newPlugin->hasMissingDependencies()) {
                     $this->deactivatePlugin($pluginName);
 
-                    // add this state we do not know yet whether current user has super user access. We do not even know
+                    // at this state we do not know yet whether current user has super user access. We do not even know
                     // if someone is actually logged in.
-                    $message  = sprintf('We disabled the plugin %s as it has missing dependencies.', $pluginName);
-                    $message .= ' Please contact your Piwik administrator.';
+                    $message  = Piwik::translate('CorePluginsAdmin_WeDeactivatedThePluginAsItHasMissingDependencies', array($pluginName, $newPlugin->getMissingDependenciesAsString()));
+                    $message .= ' ';
+                    $message .= Piwik::translate('General_PleaseContactYourPiwikAdministrator');
 
                     $notification = new Notification($message);
                     $notification->context = Notification::CONTEXT_ERROR;

--- a/lang/en.json
+++ b/lang/en.json
@@ -291,6 +291,7 @@
         "PiwikIsACollaborativeProjectYouCanContributeAndDonate": "%1$sPiwik%2$s is a collaborative project brought to you by the %7$sPiwik team%8$s members as well as many other contributors around the globe. <br/> If you're a fan of Piwik, you can help: find out %3$sHow to participate in Piwik%4$s, or %5$sdonate now%6$s to help fund Piwik 3.0!",
         "PiwikXIsAvailablePleaseNotifyPiwikAdmin": "%1$s is available. Please notify the %2$sPiwik administrator%3$s.",
         "PiwikXIsAvailablePleaseUpdateNow": "Piwik %1$s is available. %2$sPlease update now!%3$s (see %4$schanges%5$s).",
+        "PleaseContactYourPiwikAdministrator": "Please contact your Piwik administrator.",
         "PleaseSpecifyValue": "Please specify a value for '%s'.",
         "PleaseUpdatePiwik": "Please update your Piwik",
         "Plugin": "Plugin",

--- a/plugins/CorePluginsAdmin/Commands/ActivatePlugin.php
+++ b/plugins/CorePluginsAdmin/Commands/ActivatePlugin.php
@@ -37,6 +37,11 @@ class ActivatePlugin extends ConsoleCommand
             return;
         }
 
+        if ($dependencies = $pluginManager->loadPlugin($plugin)->getMissingDependenciesAsString()) {
+            $output->writeln("<error>$dependencies</error>");
+            return;
+        }
+
         $pluginManager->activatePlugin($plugin);
 
         $output->writeln("Activated plugin <info>$plugin</info>");

--- a/plugins/CoreUpdater/templates/newVersionAvailable.twig
+++ b/plugins/CoreUpdater/templates/newVersionAvailable.twig
@@ -35,7 +35,7 @@
 
             <ul>
                 {% for plugin in incompatiblePlugins %}
-                    <li>{{ pluginsMacro.missingRequirementsInfo(plugin.getPluginName, plugin.getInformation, plugin.getMissingDependencies(piwik_new_version), marketplacePlugins) }}</li>
+                    <li>{{ pluginsMacro.missingRequirementsInfo(plugin.getPluginName, plugin.getInformation, plugin.getMissingDependenciesAsString(piwik_new_version), marketplacePlugins) }}</li>
                 {% endfor %}
             </ul>
         {% endif %}


### PR DESCRIPTION
- when using `plugin:activate` console command: before it looked like the `plugin:activate` command worked but it actually didn't work. Now we output a clear error message.
- also added the text to the notification: ![reuse](https://cloud.githubusercontent.com/assets/466765/17720336/2b18bb80-6475-11e6-8e60-59b691763eea.png)

Replaces #10401 
