### PR TITLE
Rename Null class to NullBackend for PHP7 compatibility (where Null is reserved class name in PHP7)

### DIFF
--- a/core/Settings/Storage/Backend/NullBackend.php
+++ b/core/Settings/Storage/Backend/NullBackend.php
@@ -15,7 +15,7 @@ use Piwik\Settings\Storage;
  * Static / temporary storage where a value shall never be persisted. Meaning it will use the default value
  * for each request until configured differently. Useful for tests etc.
  */
-class Null implements BackendInterface
+class NullBackend implements BackendInterface
 {
     private $storageId;
 

--- a/core/Settings/Storage/Factory.php
+++ b/core/Settings/Storage/Factory.php
@@ -122,7 +122,7 @@ class Factory
      */
     public function getNonPersistentStorage($key)
     {
-        return new Storage(new Backend\Null($key));
+        return new Storage(new Backend\NullBackend($key));
     }
 
     private function makeStorage(BackendInterface $backend)

--- a/tests/PHPUnit/Integration/Settings/SettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/SettingTest.php
@@ -216,7 +216,7 @@ class SettingTest extends IntegrationTestCase
         }
 
         $setting = new Setting($name, $default, $type, 'MyPluginName');
-        $setting->setStorage(new Storage(new Backend\Null('myId')));
+        $setting->setStorage(new Storage(new Backend\NullBackend('myId')));
         $setting->setIsWritableByCurrentUser(true);
 
         if (isset($configure)) {

--- a/tests/PHPUnit/Integration/Settings/Storage/Backend/NullTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/Backend/NullTest.php
@@ -10,7 +10,7 @@ namespace Piwik\Tests\Integration\Settings\Storage\Backend;
 
 use Piwik\Config;
 use Piwik\Db;
-use Piwik\Settings\Storage\Backend\Null;
+use Piwik\Settings\Storage\Backend\NullBackend;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
@@ -30,7 +30,7 @@ class NullTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->backend = new Null('storageId1FooBar');
+        $this->backend = new NullBackend('storageId1FooBar');
     }
 
     public function test_getStorageId_shouldReturnStorageId()

--- a/tests/PHPUnit/Integration/Settings/Storage/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/FactoryTest.php
@@ -10,7 +10,7 @@ namespace Piwik\Tests\Integration\Settings\Storage;
 
 use Piwik\Settings\FieldConfig;
 use Piwik\Settings\Storage\Backend\Cache;
-use Piwik\Settings\Storage\Backend\Null;
+use Piwik\Settings\Storage\Backend\NullBackend;
 use Piwik\Settings\Storage\Backend\SitesTable;
 use Piwik\Settings\Storage\Backend\MeasurableSettingsTable;
 use Piwik\Settings\Storage\Backend\PluginSettingsTable;
@@ -83,7 +83,7 @@ class FactoryTest extends IntegrationTestCase
         $this->assertTrue($storage instanceof Storage);
 
         $backend = $storage->getBackend();
-        $this->assertTrue($backend instanceof Null);
+        $this->assertTrue($backend instanceof NullBackend);
         $this->assertSame('measurableSettings0#PluginNameFoo#nonpersistent', $backend->getStorageId());
     }
 
@@ -112,7 +112,7 @@ class FactoryTest extends IntegrationTestCase
         $this->assertTrue($storage instanceof Storage);
 
         $backend = $storage->getBackend();
-        $this->assertTrue($backend instanceof Null);
+        $this->assertTrue($backend instanceof NullBackend);
         $this->assertSame('sitesTable#0#nonpersistent', $backend->getStorageId());
     }
 
@@ -122,7 +122,7 @@ class FactoryTest extends IntegrationTestCase
         $this->assertTrue($storage instanceof Storage);
 
         $backend = $storage->getBackend();
-        $this->assertTrue($backend instanceof Null);
+        $this->assertTrue($backend instanceof NullBackend);
         $this->assertSame('myKey', $backend->getStorageId());
     }
 
@@ -132,7 +132,7 @@ class FactoryTest extends IntegrationTestCase
         $storage = $this->factory->getNonPersistentStorage('anykey');
         SettingsServer::setIsNotTrackerApiRequest();
 
-        $this->assertTrue($storage->getBackend() instanceof Null);
+        $this->assertTrue($storage->getBackend() instanceof NullBackend);
     }
 
     public function test_getNonPersistentStorage_shouldNotUseCache()


### PR DESCRIPTION
so we can run our automated tests on PHP7 
