### PR TITLE
Make sure to load Piwik JS tracker synchronously when requested to be loaded sync

### DIFF
--- a/core/View.php
+++ b/core/View.php
@@ -116,6 +116,7 @@ class View implements ViewInterface
     protected $templateVars = array();
     private $contentType = 'text/html; charset=utf-8';
     private $xFrameOptions = null;
+    private $enableCacheBuster = true;
 
     /**
      * Constructor.
@@ -143,6 +144,14 @@ class View implements ViewInterface
         } catch (Exception $ex) {
             // pass (occurs when DB cannot be connected to, perhaps piwik URL cache should be stored in config file...)
         }
+    }
+
+    /**
+     * Disables the cache buster (adding of ?cb=...) to JavaScript and stylesheet files
+     */
+    public function disableCacheBuster()
+    {
+        $this->enableCacheBuster = false;
     }
 
     /**
@@ -237,9 +246,8 @@ class View implements ViewInterface
             } else {
                 $cacheBuster = UIAssetCacheBuster::getInstance()->piwikVersionBasedCacheBuster();
             }
-
             $this->cacheBuster = $cacheBuster;
-            
+
             $this->loginModule = Piwik::getLoginPluginName();
 
             $user = APIUsersManager::getInstance()->getUser($this->userLogin);
@@ -260,6 +268,16 @@ class View implements ViewInterface
         return $this->renderTwigTemplate();
     }
 
+    /**
+     * @internal
+     * @ignore
+     * @return Twig_Environment
+     */
+    public function getTwig()
+    {
+        return $this->twig;
+    }
+
     protected function renderTwigTemplate()
     {
         try {
@@ -272,7 +290,9 @@ class View implements ViewInterface
             throw $ex;
         }
 
-        $output = $this->applyFilter_cacheBuster($output);
+        if ($this->enableCacheBuster) {
+            $output = $this->applyFilter_cacheBuster($output);
+        }
 
         $helper = new Theme;
         $output = $helper->rewriteAssetsPathToTheme($output);

--- a/plugins/Morpheus/templates/javascriptCode.twig
+++ b/plugins/Morpheus/templates/javascriptCode.twig
@@ -7,9 +7,11 @@
     {$setTrackerUrl}
     {$optionsBeforeTrackerUrl}_paq.push(['setTrackerUrl', u+'piwik.php']);
     _paq.push(['setSiteId', '{$idSite}']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async={$loadAsync}; g.defer={$loadAsync}; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    {% if loadAsync %}var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);{% endif %}
   })();
 </script>
+{% if not loadAsync %}<script type='text/javascript' src="{$protocol}{$piwikUrl}/piwik.js">
+{% endif %}
 <noscript><p><img src="{$protocol}{$piwikUrl}/piwik.php?idsite={$idSite}" style="border:0;" alt="" /></p></noscript>
 <!-- End Piwik Code -->

--- a/plugins/Morpheus/templates/javascriptCode.twig
+++ b/plugins/Morpheus/templates/javascriptCode.twig
@@ -9,6 +9,7 @@
     _paq.push(['setSiteId', '{$idSite}']);
     {% if loadAsync %}var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);{% endif %}
+
   })();
 </script>
 {% if not loadAsync %}<script type='text/javascript' src="{$protocol}{$piwikUrl}/piwik.js">

--- a/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
@@ -152,6 +152,41 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $this->assertEquals($expected, $jsTag);
     }
 
+    /**
+     * Tests the generated JS code with options before tracker url
+     */
+    public function testJavascriptTrackingCode_loadSync()
+    {
+        $generator = new TrackerCodeGenerator();
+
+        Piwik::addAction('Piwik.getJavascriptCode', function (&$codeImpl) {
+            $codeImpl['loadAsync'] = false;
+        });
+
+        $jsTag = $generator->generate($idSite = 1, $piwikUrl = 'http://localhost/piwik',
+            $mergeSubdomains = true, $groupPageTitlesByDomain = true, $mergeAliasUrls = true);
+
+        $expected = "&lt;!-- Piwik --&gt;
+&lt;script type=&quot;text/javascript&quot;&gt;
+  var _paq = _paq || [];
+  _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u=&quot;//localhost/piwik/&quot;;
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '1']);
+    
+  })();
+&lt;/script&gt;
+&lt;script type='text/javascript' src=&quot;//localhost/piwik/piwik.js&quot;&gt;
+&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//localhost/piwik/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
+&lt;!-- End Piwik Code --&gt;
+";
+
+        $this->assertEquals($expected, $jsTag);
+    }
+
     public function testStringsAreEscaped()
     {
         $generator = new TrackerCodeGenerator();


### PR DESCRIPTION
In https://github.com/piwik/piwik/pull/10502/files we added a property to load the tracker sync. However, we can only make sure it is actually loaded sync when loading it as a separate `<script>` and not by setting `.defer= false; .async = false`;

Migrated the template partially to twig. First I moved pretty all the jsCodeImpl variables to twig but then I noticed it is way to risky as some `${...}` are defined in the TrackingCode generator class and some in the template, some are escaped while some others are not, the whole template is partially escaped and I don't want to cause any regression here. Therefore for now only partially migrated it to twig.
