### PR TITLE
Make goal title in report clickable

### DIFF
--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -275,6 +275,14 @@ class Config
     public $title = '';
 
     /**
+     * If a URL is set, the title of the report will be clickable. Is supposed to be set for entities that can be
+     * configured (edited) such as goal. Eg when there is a goal report, and someone is allowed to edit the goal entity,
+     * a link is supposed to be with a URL to the edit goal form.
+     * @var string
+     */
+    public $title_edit_entity_url = '';
+
+    /**
      * The report description. eg like a goal description
      */
     public $description = '';

--- a/plugins/CoreHome/angularjs/reporting-menu/reportingmenu.controller.js
+++ b/plugins/CoreHome/angularjs/reporting-menu/reportingmenu.controller.js
@@ -63,6 +63,7 @@
             subcategory.active = true;
 
             if (subsubcategory) {
+                subcategory.name = subsubcategory.name;
                 subsubcategory.active = true;
             }
         };
@@ -120,8 +121,9 @@
         });
 
         $rootScope.$on('$locationChangeSuccess', function () {
-            var category    = $location.search().category;
-            var subcategory = $location.search().subcategory;
+            var $search = $location.search();
+            var category    = $search.category;
+            var subcategory = $search.subcategory;
 
             period = getUrlParam('period');
             date   = getUrlParam('date');

--- a/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.js
+++ b/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.js
@@ -129,6 +129,7 @@
                             currentElement = contentNode.html(response).children();
 
                             if (scope.widgetName) {
+                                // we need to respect the widget title, which overwrites a possibly set report title
                                 var $title = currentElement.find('> .card-content .card-title');
                                 if ($title.size()) {
                                     $title.text(scope.widgetName);

--- a/plugins/CoreHome/templates/_dataTable.twig
+++ b/plugins/CoreHome/templates/_dataTable.twig
@@ -12,6 +12,7 @@
 <div class="card-content">
     {% if properties.title %}
         <h2 class="card-title"
+            {% if properties.title_edit_entity_url %}edit-url="{{ properties.title_edit_entity_url }}"{% endif %}
               piwik-enriched-headline
         >{{ properties.title }}</h2>
     {% endif %}

--- a/plugins/CoreVisualizations/Visualizations/Sparklines.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines.php
@@ -72,6 +72,7 @@ class Sparklines extends ViewDataTable
 
         $view->sparklines = $this->config->getSortedSparklines();
         $view->isWidget = Common::getRequestVar('widget', 0, 'int');
+        $view->titleAttributes = $this->config->title_attributes;
 
         $view->title = '';
         if ($this->config->show_title) {

--- a/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines/Config.php
@@ -33,6 +33,13 @@ class Config extends \Piwik\ViewDataTable\Config
      */
     private $sparklines = array();
 
+    /**
+     * Adds possibility to set html attributes on the sparklines title / headline. For example can be used
+     * to set an angular directive
+     * @var string
+     */
+    public $title_attributes = array();
+
     public function __construct()
     {
         parent::__construct();

--- a/plugins/CoreVisualizations/templates/_dataTableViz_sparklines.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_sparklines.twig
@@ -3,8 +3,9 @@
 {% if not isWidget %}
     <div class="card"><div class="card-content">
 {% endif %}
-    {% if title is not empty %}<h2 class="card-title">{{ title }}</h2>{% endif %}
-
+    {% if title is not empty %}<h2 class="card-title"
+                                    {% if titleAttributes is not empty %}{% for attribute, value in titleAttributes %}{{ attribute }}="{{ value }}"{% endfor %}{% endif %}
+                                >{{ title }}</h2>{% endif %}
     {% if not isWidget %}
     <div class="row">
         <div class="col m6">

--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -246,6 +246,7 @@ class Goals extends \Piwik\Plugin
 
     public function getJsFiles(&$jsFiles)
     {
+        $jsFiles[] = "plugins/Goals/angularjs/common/directives/goal-page-link.js";
         $jsFiles[] = "plugins/Goals/angularjs/manage-goals/manage-goals.controller.js";
         $jsFiles[] = "plugins/Goals/angularjs/manage-goals/manage-goals.directive.js";
     }

--- a/plugins/Goals/Reports/Get.php
+++ b/plugins/Goals/Reports/Get.php
@@ -111,6 +111,10 @@ class Get extends Base
             $onlySummary = Common::getRequestVar('only_summary', 0, 'int');
 
             if ($onlySummary && !empty($idGoal)) {
+                if (is_numeric($idGoal)) {
+                    $view->config->title_attributes = array('piwik-goal-page-link' => $idGoal);
+                }
+
                 // in Goals overview summary we show proper title for a goal
                 $goal = $this->getGoal($idGoal);
                 if (!empty($goal['name'])) {

--- a/plugins/Goals/Reports/Get.php
+++ b/plugins/Goals/Reports/Get.php
@@ -23,6 +23,7 @@ use Piwik\Plugins\Goals\Pages;
 use Piwik\Report\ReportWidgetFactory;
 use Piwik\Site;
 use Piwik\Tracker\GoalManager;
+use Piwik\Url;
 use Piwik\Widget\WidgetsList;
 
 class Get extends Base
@@ -101,9 +102,10 @@ class Get extends Base
     {
         $idGoal = Common::getRequestVar('idGoal', 0, 'string');
 
+        $idSite = $this->getIdSite();
+
         if ($view->isViewDataTableId(Sparklines::ID)) {
             /** @var Sparklines $view */
-            $idSite = $this->getIdSite();
             $isEcommerceEnabled = $this->isEcommerceEnabled($idSite);
 
             $onlySummary = Common::getRequestVar('only_summary', 0, 'int');
@@ -182,6 +184,17 @@ class Get extends Base
                 }
             }
         } else if ($view->isViewDataTableId(Evolution::ID)) {
+            if (!empty($idSite) && Piwik::isUserHasAdminAccess($idSite)) {
+                $view->config->title_edit_entity_url = 'index.php' . Url::getCurrentQueryStringWithParametersModified(array(
+                    'module' => 'Goals',
+                    'action' => 'manage',
+                    'forceView' => null,
+                    'viewDataTable' => null,
+                    'showtitle' => null,
+                    'random' => null
+                ));
+            }
+
             $goal = $this->getGoal($idGoal);
             if (!empty($goal['name'])) {
                 $view->config->title = Piwik::translate('Goals_GoalX', "'" . $goal['name'] . "'");

--- a/plugins/Goals/angularjs/common/directives/goal-page-link.js
+++ b/plugins/Goals/angularjs/common/directives/goal-page-link.js
@@ -1,0 +1,44 @@
+/*!
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+/**
+ *
+ * Usage:
+ * <div piwik-goal-page-link="idGoal">
+ */
+(function () {
+    angular.module('piwikApp.directive').directive('piwikGoalPageLink', piwikGoalPageLink);
+
+    piwikGoalPageLink.$inject = ['$location', 'piwik'];
+
+    function piwikGoalPageLink($location, piwik){
+
+        return {
+            restrict: 'A',
+            compile: function (element, attrs) {
+
+                if (attrs.piwikGoalPageLink && piwik.helper.isAngularRenderingThePage()) {
+                    var title = element.text();
+                    element.html('<a></a>');
+                    var link =  element.find('a');
+                    link.text(title);
+                    link.attr('href', 'javascript:void(0)');
+                    link.bind('click', function () {
+                        var $search = $location.search();
+                        $search.category = 'Goals_Goals';
+                        $search.subcategory = encodeURIComponent(attrs.piwikGoalPageLink);
+                        $location.search($search);
+                    });
+                }
+
+                return function (scope, element, attrs) {
+
+                };
+            }
+        };
+    }
+})();


### PR DESCRIPTION
fixes #10554 

Please note that the title shows an underline when hovered so the link is more visible. This is default behaviour that can be changed but will be more useable with underline
