### PR TITLE
Make sure evolution select field in multi sites is visible in firefox

### DIFF
--- a/plugins/MultiSites/angularjs/dashboard/dashboard.directive.less
+++ b/plugins/MultiSites/angularjs/dashboard/dashboard.directive.less
@@ -177,9 +177,9 @@
   }
 
   #evolution_selector {
-    margin: -6px 0 0 5px;
-    height: 20px;
-    width: 70px;
+    height: 28px;
+    margin: -9px 0 0 5px;
+    width: 80px;
     display: inline-block;
   }
 


### PR DESCRIPTION
fixes #10559 

Not using material design there is on purpose as there is not much space in the headline and it wouldn't look as nice etc. It is specifically set to not use it there
