### PR TITLE
fix in General Settings dashboard, getting "Invalid PHP version"

### DIFF
--- a/plugins/CorePluginsAdmin/MarketplaceApiClient.php
+++ b/plugins/CorePluginsAdmin/MarketplaceApiClient.php
@@ -123,9 +123,14 @@ class MarketplaceApiClient
         return array();
     }
 
+    private function getPhpVersion()
+    {
+        return PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
+    }
+
     private function fetch($action, $params)
     {
-        $params['php'] = phpversion();
+        $params['php'] = $this->getPhpVersion();
         $params['piwik'] = Version::VERSION;
         $params['prefer_stable'] = '1';
         ksort($params);


### PR DESCRIPTION
fixes #10560 

should use only "7.0.9"  instead of "PHP 7.0.9-1+deb.sury.org~trusty+1"
