### PR TITLE
ControllerResolver.php: return HTTP status 404 if action is not found

### DIFF
--- a/core/Http/ControllerResolver.php
+++ b/core/Http/ControllerResolver.php
@@ -63,6 +63,9 @@ class ControllerResolver
             return $controller;
         }
 
+        if (!headers_sent()) {
+            http_response_code(404);
+        }
         throw new Exception(sprintf("Action '%s' not found in the module '%s'", $action, $module));
     }
 


### PR DESCRIPTION
Hopefully fixes #10553 and tells Google to drop error pages from its index.

Feel free to close instead of merge this if it is too crude. I'd love to know if this triggers any failed automated tests.

Background: A previously-valid URL now shows this output on our server:
![image](https://cloud.githubusercontent.com/assets/6819464/19015180/bd6f073e-87ff-11e6-89bb-f764b82bd396.png). 

Google keeps on hitting this page with its Googlebot; PHP writes an entry to the error_log, which our Icinga 2 instance sees.
