### PR TITLE
Fixes displayed month name in period selector (3.x)

### DIFF
--- a/plugins/CoreHome/javascripts/calendar.js
+++ b/plugins/CoreHome/javascripts/calendar.js
@@ -79,7 +79,7 @@
 
         var displayDate = dateText;
         if (selectedPeriod === 'month') {
-            displayDate = _pk_translate('Intl_Month_Long_StandAlone_' + currentMonth) + ' ' + currentYear;
+            displayDate = _pk_translate('Intl_Month_Long_StandAlone_' + (currentMonth+1)) + ' ' + currentYear;
         } else if (selectedPeriod === 'year') {
             displayDate = currentYear;
         } else if (selectedPeriod === 'range' || selectedPeriod === 'week') {


### PR DESCRIPTION
The displayed month name was always one month prior the selected month and for January there was an error string displayed in date selector.
