### PR TITLE
On mobile, in website selector, display the arrow to the right

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -121,6 +121,10 @@ nav {
       }
 
       .piwikSelector {
+        > a.title {
+            max-width: none;
+        }
+
         display: block;
       }
 


### PR DESCRIPTION
Check if this fixes the issue #10641 . If not I'd likely move it out of 3.0
