### PR TITLE
show all websites full width on mobile

### DIFF
--- a/plugins/MultiSites/angularjs/dashboard/dashboard.directive.less
+++ b/plugins/MultiSites/angularjs/dashboard/dashboard.directive.less
@@ -10,7 +10,10 @@
 }
 
 #multisites {
-  width: 80%;
+  > .col {
+    padding-left: 0;
+    padding-right: 0;
+  }
 
   .notification-error {
     margin-top: 15px;

--- a/plugins/MultiSites/templates/getSitesInfo.twig
+++ b/plugins/MultiSites/templates/getSitesInfo.twig
@@ -8,26 +8,26 @@
 {% endblock %}
 
 {% block content %}
-<div class="container" id="multisites">
-
-    {% if isWidgetized %}
-        <div id="main">
-    {% else %}
-        <div id="main" class="card">
-            <div class="card-content">
-    {% endif %}
-            <div piwik-multisites-dashboard
-                 display-revenue-column="{% if displayRevenueColumn %}true{% else %}false{%endif%}"
-                 page-size="{{ limit }}"
-                 show-sparklines="{% if show_sparklines %}true{% else %}false{%endif%}"
-                 date-sparkline="{{ dateSparkline }}"
-                 auto-refresh-today-report="{{ autoRefreshTodayReport }}">
+<div class="row" id="multisites">
+    <div class="col s12 m12 l10 offset-l1">
+        {% if isWidgetized %}
+            <div id="main">
+        {% else %}
+            <div id="main" class="card">
+                <div class="card-content">
+        {% endif %}
+                <div piwik-multisites-dashboard
+                     display-revenue-column="{% if displayRevenueColumn %}true{% else %}false{%endif%}"
+                     page-size="{{ limit }}"
+                     show-sparklines="{% if show_sparklines %}true{% else %}false{%endif%}"
+                     date-sparkline="{{ dateSparkline }}"
+                     auto-refresh-today-report="{{ autoRefreshTodayReport }}">
+                </div>
+        {% if isWidgetized %}
             </div>
-    {% if isWidgetized %}
-        </div>
-    {% else %}
-        </div></div>
-    {% endif %}
+        {% else %}
+            </div></div>
+        {% endif %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
refs #10642 
 It will make the card full width but tables will stand out. Same for eg ScheduledReports etc. 
