### PR TITLE
Revert "Buttons should display whole text when text is more than one line"

### DIFF
--- a/plugins/Morpheus/stylesheets/ui/_buttons.less
+++ b/plugins/Morpheus/stylesheets/ui/_buttons.less
@@ -39,7 +39,7 @@ button.btn,input[type="submit"].btn, .btn {
 
 // Bootstrap classes (can be removed in the future)
 .btn {
-    display: table;
+    display: inline-block;
 }
 .btn-block {
     width: 100%;


### PR DESCRIPTION
Reverts piwik/piwik#10657

Merged it by mistake/  mis-click
