### PR TITLE
Do not issue warning/errors during update, when activating a plugin that is already activated

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -12,13 +12,13 @@ use Exception;
 use Piwik\Access;
 use Piwik\Common;
 use Piwik\DataTable;
+use Piwik\Exception\PluginDeactivatedException;
+use Piwik\Log;
 use Piwik\Piwik;
-use Piwik\PluginDeactivatedException;
+use Piwik\Plugin\Manager as PluginManager;
 use Piwik\SettingsServer;
 use Piwik\Url;
 use Piwik\UrlHelper;
-use Piwik\Log;
-use Piwik\Plugin\Manager as PluginManager;
 
 /**
  * Dispatches API requests to the appropriate API method.

--- a/core/Exception/PluginDeactivatedException.php
+++ b/core/Exception/PluginDeactivatedException.php
@@ -6,7 +6,8 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik;
+namespace Piwik\Exception;
+use Exception;
 
 /**
  * Exception thrown when the requested plugin is not activated in the config file

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -14,6 +14,7 @@ use Piwik\API\Request;
 use Piwik\Container\StaticContainer;
 use Piwik\Exception\AuthenticationFailedException;
 use Piwik\Exception\DatabaseSchemaIsNewerThanCodebaseException;
+use Piwik\Exception\PluginDeactivatedException;
 use Piwik\Http\ControllerResolver;
 use Piwik\Http\Router;
 use Piwik\Plugins\CoreAdminHome\CustomLogo;
@@ -95,7 +96,7 @@ class FrontController extends Singleton
     /**
      * Executes the requested plugin controller method.
      *
-     * @throws Exception|\Piwik\PluginDeactivatedException in case the plugin doesn't exist, the action doesn't exist,
+     * @throws Exception|\Piwik\Exception\PluginDeactivatedException in case the plugin doesn't exist, the action doesn't exist,
      *                                                     there is not enough permission, etc.
      *
      * @param string $module The name of the plugin whose controller to execute, eg, `'UserCountryMap'`.

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -12,26 +12,25 @@ namespace Piwik\Plugin;
 use Piwik\Application\Kernel\PluginList;
 use Piwik\Cache;
 use Piwik\Columns\Dimension;
-use Piwik\Config as PiwikConfig;
 use Piwik\Config;
-use Piwik\Db;
-use Piwik\Settings\Storage as SettingsStorage;
+use Piwik\Config as PiwikConfig;
 use Piwik\Container\StaticContainer;
+use Piwik\Db;
 use Piwik\EventDispatcher;
 use Piwik\Filesystem;
 use Piwik\Log;
 use Piwik\Notification;
 use Piwik\Piwik;
 use Piwik\Plugin;
-use Piwik\PluginDeactivatedException;
+use Piwik\Plugin\Dimension\ActionDimension;
+use Piwik\Plugin\Dimension\ConversionDimension;
+use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Session;
+use Piwik\Settings\Storage as SettingsStorage;
 use Piwik\Theme;
 use Piwik\Tracker;
 use Piwik\Translation\Translator;
 use Piwik\Updater;
-use Piwik\Plugin\Dimension\ActionDimension;
-use Piwik\Plugin\Dimension\ConversionDimension;
-use Piwik\Plugin\Dimension\VisitDimension;
 
 require_once PIWIK_INCLUDE_PATH . '/core/EventDispatcher.php';
 
@@ -468,7 +467,8 @@ class Manager
     {
         $plugins = $this->pluginList->getActivatedPlugins();
         if (in_array($pluginName, $plugins)) {
-            throw new \Exception("Plugin '$pluginName' already activated.");
+            // plugin is already activated
+            return;
         }
 
         if (!$this->isPluginInFilesystem($pluginName)) {


### PR DESCRIPTION
This should fix the build which I broke earlier
- move PluginDeactivatedException into Exception namespace

---> as a result of this change, we could (should?) remove the try/catch blocks around the activatePlugin calls in all Updates files
