### PR TITLE
Fix fatal error exception is already in use

### DIFF
--- a/core/Exception/PluginDeactivatedException.php
+++ b/core/Exception/PluginDeactivatedException.php
@@ -7,7 +7,6 @@
  */
 
 namespace Piwik\Exception;
-use Exception;
 
 /**
  * Exception thrown when the requested plugin is not activated in the config file


### PR DESCRIPTION
Cannot use Exception as Exception because the name is already in use in core/Exception/PluginDeactivatedException.php on line 10

Noticed this error when our docs are generated. 
