### PR TITLE
Make sure safemode is shown in case of fatal error while rendering <head>

### DIFF
--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -371,6 +371,8 @@ class Controller extends Plugin\ControllerAdmin
 
     public function safemode($lastError = array())
     {
+        ob_clean();
+        
         $this->tryToRepairPiwik();
 
         if (empty($lastError)) {


### PR DESCRIPTION
Eg if AnonymousPiwikUserManagement triggers an error while <head> is being rendered, the safemode page was not visible. We omit all previously rendered content to make sure the safemode page will be always visible. Otherwise we end up something like this:

``` html
<html>
  <head>... <html><head></head><body></body></html>
  </head>
```

fixes https://github.com/piwik/piwik/issues/10693
