### PR TITLE
Allow plugin to decide about archiving without visits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ If the tracker is not initialised correctly, the browser console will display th
 * The creation of settings has slightly changed to improve performance. It is now possible to create new settings via the method `$this->makeSetting()` see `Piwik\Plugins\ExampleSettingsPlugin\SystemSettings` for an example.
 * It is no longer possible to define an introduction text for settings.
 * If requesting multipe periods for one report, the keys that define the range are no longer translated. For example before 3.0 an API response may contain: `<result date="From 2010-02-01 to 2010-02-07">` which is now `<result date="2010-02-01,2010-02-07">`.
-* The method `Piwik\Plugin\Archiver::shouldRunWithoutVisits()` has been added. It gives plugin archivers the possibility to decide whether to run if there weren't any visits by overwriting this method.
+* The method `Piwik\Plugin\Archiver::shouldRunEvenWhenNoVisits()` has been added. By overwriting this method and returning true, a plugin archiver can force the archiving to run even when there was no visit for the website/date/period/segment combination (by default, archivers are skipped when there is no visit).
 * The following deprecated events have been removed as mentioned.
  * `Tracker.existingVisitInformation` Use [dimensions](http://developer.piwik.org/guides/dimensions) instead of using `Tracker` events.
  * `Tracker.newVisitorInformation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ If the tracker is not initialised correctly, the browser console will display th
 * The creation of settings has slightly changed to improve performance. It is now possible to create new settings via the method `$this->makeSetting()` see `Piwik\Plugins\ExampleSettingsPlugin\SystemSettings` for an example.
 * It is no longer possible to define an introduction text for settings.
 * If requesting multipe periods for one report, the keys that define the range are no longer translated. For example before 3.0 an API response may contain: `<result date="From 2010-02-01 to 2010-02-07">` which is now `<result date="2010-02-01,2010-02-07">`.
+* The method `Piwik\Plugin\Archiver::shouldRunWithoutVisits()` has been added. It gives plugin archivers the possibility to decide whether to run if there weren't any visits by overwriting this method.
 * The following deprecated events have been removed as mentioned.
  * `Tracker.existingVisitInformation` Use [dimensions](http://developer.piwik.org/guides/dimensions) instead of using `Tracker` events.
  * `Tracker.newVisitorInformation`

--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -120,11 +120,8 @@ class Loader
             $visitsConverted = $metrics['nb_visits_converted'];
         }
 
-        if ($this->isThereSomeVisits($visits)
-            || $this->shouldArchiveForSiteEvenWhenNoVisits()
-        ) {
-            $pluginsArchiver->callAggregateAllPlugins($visits, $visitsConverted);
-        }
+        $forceArchivingWithoutVisits = !$this->isThereSomeVisits($visits) && $this->shouldArchiveForSiteEvenWhenNoVisits();
+        $pluginsArchiver->callAggregateAllPlugins($visits, $visitsConverted, $forceArchivingWithoutVisits);
 
         $idArchive = $pluginsArchiver->finalizeArchive();
 

--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -73,7 +73,7 @@ class Loader
         list($visits, $visitsConverted) = $this->prepareCoreMetricsArchive($visits, $visitsConverted);
         list($idArchive, $visits) = $this->prepareAllPluginsArchive($visits, $visitsConverted);
 
-        if ($this->isThereSomeVisits($visits)) {
+        if ($this->isThereSomeVisits($visits) || PluginsArchiver::doesAnyPluginArchiveWithoutVisits()) {
             return $idArchive;
         }
         return false;

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -94,7 +94,7 @@ class PluginsArchiver
      * Instantiates the Archiver class in each plugin that defines it,
      * and triggers Aggregation processing on these plugins.
      */
-    public function callAggregateAllPlugins($visits, $visitsConverted)
+    public function callAggregateAllPlugins($visits, $visitsConverted, $forceArchivingWithoutVisits = false)
     {
         Log::debug("PluginsArchiver::%s: Initializing archiving process for all plugins [visits = %s, visits converted = %s]",
             __FUNCTION__, $visits, $visitsConverted);
@@ -111,7 +111,12 @@ class PluginsArchiver
             $archiver = $this->makeNewArchiverObject($archiverClass, $pluginName);
 
             if (!$archiver->isEnabled()) {
-                Log::debug("PluginsArchiver::%s: Skipping archiving for plugin '%s'.", __FUNCTION__, $pluginName);
+                Log::debug("PluginsArchiver::%s: Skipping archiving for plugin '%s' (disabled).", __FUNCTION__, $pluginName);
+                continue;
+            }
+
+            if (!$forceArchivingWithoutVisits && !$visits && !$archiver->shouldRunWithoutVisits()) {
+                Log::debug("PluginsArchiver::%s: Skipping archiving for plugin '%s' (no visits).", __FUNCTION__, $pluginName);
                 continue;
             }
 

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -101,7 +101,7 @@ class PluginsArchiver
 
         $this->archiveProcessor->setNumberOfVisits($visits, $visitsConverted);
 
-        $archivers = $this->getPluginArchivers();
+        $archivers = static::getPluginArchivers();
 
         foreach ($archivers as $pluginName => $archiverClass) {
             // We clean up below all tables created during this function call (and recursive calls)
@@ -167,11 +167,27 @@ class PluginsArchiver
     }
 
     /**
+     * Returns if any plugin archiver archives without visits
+     */
+    public static function doesAnyPluginArchiveWithoutVisits()
+    {
+        $archivers = static::getPluginArchivers();
+
+        foreach ($archivers as $pluginName => $archiverClass) {
+            if ($archiverClass::shouldRunWithoutVisits()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Loads Archiver class from any plugin that defines one.
      *
      * @return \Piwik\Plugin\Archiver[]
      */
-    protected function getPluginArchivers()
+    protected static function getPluginArchivers()
     {
         if (empty(static::$archivers)) {
             $pluginNames = \Piwik\Plugin\Manager::getInstance()->getActivatedPlugins();

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -115,7 +115,7 @@ class PluginsArchiver
                 continue;
             }
 
-            if (!$forceArchivingWithoutVisits && !$visits && !$archiver->shouldRunWithoutVisits()) {
+            if (!$forceArchivingWithoutVisits && !$visits && !$archiver->shouldRunEvenWhenNoVisits()) {
                 Log::debug("PluginsArchiver::%s: Skipping archiving for plugin '%s' (no visits).", __FUNCTION__, $pluginName);
                 continue;
             }
@@ -174,7 +174,7 @@ class PluginsArchiver
         $archivers = static::getPluginArchivers();
 
         foreach ($archivers as $pluginName => $archiverClass) {
-            if ($archiverClass::shouldRunWithoutVisits()) {
+            if ($archiverClass::shouldRunEvenWhenNoVisits()) {
                 return true;
             }
         }

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\ArchiveProcessor\PluginsArchiver;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Archiver\Request;
 use Piwik\Container\StaticContainer;
@@ -816,9 +817,11 @@ class CronArchive
         $this->requests++;
         $this->processed++;
 
+        $shouldArchiveWithoutVisits = PluginsArchiver::doesAnyPluginArchiveWithoutVisits();
+
         // If there is no visit today and we don't need to process this website, we can skip remaining archives
         if (
-            0 == $visitsToday
+            0 == $visitsToday && !$shouldArchiveWithoutVisits
             && !$shouldArchivePeriods
         ) {
             $this->logger->info("Skipped website id $idSite, no visit today, " . $timerWebsite->__toString());
@@ -827,7 +830,7 @@ class CronArchive
             return false;
         }
 
-        if (0 == $visitsLastDays
+        if (0 == $visitsLastDays && !$shouldArchiveWithoutVisits
             && !$shouldArchivePeriods
             && $this->shouldArchiveAllSites
         ) {

--- a/core/Plugin/Archiver.php
+++ b/core/Plugin/Archiver.php
@@ -141,4 +141,14 @@ abstract class Archiver
     {
         return $this->enabled;
     }
+
+    /**
+     * Whether this Archiver should run even if there aren't any visits.
+     *
+     * @return bool
+     */
+    public function shouldRunWithoutVisits()
+    {
+        return false;
+    }
 }

--- a/core/Plugin/Archiver.php
+++ b/core/Plugin/Archiver.php
@@ -147,7 +147,7 @@ abstract class Archiver
      *
      * @return bool
      */
-    public function shouldRunWithoutVisits()
+    public static function shouldRunWithoutVisits()
     {
         return false;
     }

--- a/core/Plugin/Archiver.php
+++ b/core/Plugin/Archiver.php
@@ -143,11 +143,13 @@ abstract class Archiver
     }
 
     /**
-     * Whether this Archiver should run even if there aren't any visits.
+     * By overwriting this method and returning true, a plugin archiver can force the archiving to run even when there
+     * was no visit for the website/date/period/segment combination
+     * (by default, archivers are skipped when there is no visit).
      *
      * @return bool
      */
-    public static function shouldRunWithoutVisits()
+    public static function shouldRunEvenWhenNoVisits()
     {
         return false;
     }

--- a/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
@@ -37,7 +37,7 @@ class CustomArchiver extends Archiver
 
 class CustomPluginsArchiver extends PluginsArchiver
 {
-    protected function getPluginArchivers()
+    protected static function getPluginArchivers()
     {
         return array(
             'MyPluginName' => 'Piwik\Tests\Integration\Archive\CustomArchiver'

--- a/tests/PHPUnit/Integration/ArchiveWithNoVisitsTest.php
+++ b/tests/PHPUnit/Integration/ArchiveWithNoVisitsTest.php
@@ -20,6 +20,8 @@ class ArchiveWithNoVisitsTest_MockArchiver extends Archiver
 {
     public static $methodsCalled = array();
 
+    public static $runWithoutVisits = false;
+
     public function aggregateDayReport()
     {
         self::$methodsCalled[] = 'aggregateDayReport';
@@ -28,6 +30,11 @@ class ArchiveWithNoVisitsTest_MockArchiver extends Archiver
     public function aggregateMultipleReports()
     {
         self::$methodsCalled[] = 'aggregateMultipleReports';
+    }
+
+    public function shouldRunWithoutVisits()
+    {
+        return self::$runWithoutVisits;
     }
 }
 
@@ -64,6 +71,28 @@ class ArchiveWithNoVisitsTest extends IntegrationTestCase
 
         // initiate archiving and make sure both aggregate methods are called correctly
         VisitsSummaryAPI::getInstance()->get($idSite = 1, 'week', '2012-01-10');
+
+        $expectedMethodCalls = array(
+            'aggregateDayReport',
+            'aggregateDayReport',
+            'aggregateDayReport',
+            'aggregateDayReport',
+            'aggregateDayReport',
+            'aggregateDayReport',
+            'aggregateDayReport',
+            'aggregateMultipleReports',
+        );
+        $this->assertEquals($expectedMethodCalls, ArchiveWithNoVisitsTest_MockArchiver::$methodsCalled);
+    }
+
+    public function test_PluginArchiver_CanBeUsedToTriggerArchiving_EvenIfSiteHasNoVisits()
+    {
+        PluginsArchiver::$archivers['VisitsSummary'] = 'Piwik\Tests\Integration\ArchiveWithNoVisitsTest_MockArchiver';
+
+        ArchiveWithNoVisitsTest_MockArchiver::$runWithoutVisits = true;
+
+        // initiate archiving and make sure methods are called
+        VisitsSummaryAPI::getInstance()->get($idSite = 1, 'week', '2012-01-01');
 
         $expectedMethodCalls = array(
             'aggregateDayReport',

--- a/tests/PHPUnit/Integration/ArchiveWithNoVisitsTest.php
+++ b/tests/PHPUnit/Integration/ArchiveWithNoVisitsTest.php
@@ -32,7 +32,7 @@ class ArchiveWithNoVisitsTest_MockArchiver extends Archiver
         self::$methodsCalled[] = 'aggregateMultipleReports';
     }
 
-    public function shouldRunWithoutVisits()
+    public static function shouldRunWithoutVisits()
     {
         return self::$runWithoutVisits;
     }

--- a/tests/PHPUnit/Integration/ArchiveWithNoVisitsTest.php
+++ b/tests/PHPUnit/Integration/ArchiveWithNoVisitsTest.php
@@ -32,7 +32,7 @@ class ArchiveWithNoVisitsTest_MockArchiver extends Archiver
         self::$methodsCalled[] = 'aggregateMultipleReports';
     }
 
-    public static function shouldRunWithoutVisits()
+    public static function shouldRunEvenWhenNoVisits()
     {
         return self::$runWithoutVisits;
     }


### PR DESCRIPTION
At the moment no plugin archiver will be executed if there are no visits for the archived period.
In some cases it would be useful for plugins to be able to archive data even if there are no visits for the archived period.
(The existing possibility to force all archivers to run for a specific site if there are no visists might be a bit to "much" in some cases.)
