### PR TITLE
Make sure to create a dropdown menu when there are more than 5 entries in a sub-menu

### DIFF
--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -257,6 +257,7 @@ class CoreHome extends \Piwik\Plugin
         $translationKeys[] = 'Intl_Year_Short';
         $translationKeys[] = 'General_MultiSitesSummary';
         $translationKeys[] = 'General_SearchNoResults';
+        $translationKeys[] = 'CoreHome_ChooseX';
         $translationKeys[] = 'CoreHome_YouAreUsingTheLatestVersion';
         $translationKeys[] = 'CoreHome_IncludeRowsWithLowPopulation';
         $translationKeys[] = 'CoreHome_ExcludeRowsWithLowPopulation';

--- a/plugins/CoreHome/angularjs/reporting-menu/reportingmenu-model.js
+++ b/plugins/CoreHome/angularjs/reporting-menu/reportingmenu-model.js
@@ -82,7 +82,7 @@
 
                 category.subcategories = [];
 
-                var goalsGroup = false;
+                var categoryGroups = false;
 
                 angular.forEach(pages, function (page, key) {
                     if (page.category.id === categoryId) {
@@ -92,25 +92,25 @@
                             subcategory.active = true;
                         }
 
-                        if (page.widgets && page.widgets[0] && page.category.id === 'Goals_Goals' && isNumeric(page.subcategory.id)) {
+                        if (page.widgets && page.widgets[0] && isNumeric(page.subcategory.id)) {
                             // we handle a goal
-                            if (!goalsGroup) {
-                                goalsGroup = angular.copy(subcategory);
-                                goalsGroup.name = $filter('translate')('Goals_ChooseGoal');
-                                goalsGroup.isGroup = true;
-                                goalsGroup.subcategories = [];
-                                goalsGroup.order = 10;
+                            if (!categoryGroups) {
+                                categoryGroups = angular.copy(subcategory);
+                                categoryGroups.name = $filter('translate')('CoreHome_ChooseX', [category.name]);
+                                categoryGroups.isGroup = true;
+                                categoryGroups.subcategories = [];
+                                categoryGroups.order = 10;
                             }
 
                             if (subcategory.active) {
-                                goalsGroup.name = subcategory.name;
-                                goalsGroup.active = true;
+                                categoryGroups.name = subcategory.name;
+                                categoryGroups.active = true;
                             }
 
                             var goalId = page.subcategory.id;
                             subcategory.tooltip = subcategory.name + ' (id = ' + goalId + ' )';
 
-                            goalsGroup.subcategories.push(subcategory);
+                            categoryGroups.subcategories.push(subcategory);
                             return;
                         }
 
@@ -118,12 +118,12 @@
                     }
                 });
 
-                if (goalsGroup && goalsGroup.subcategories && goalsGroup.subcategories.length <= 3) {
-                    angular.forEach(goalsGroup.subcategories, function (subcategory) {
+                if (categoryGroups && categoryGroups.subcategories && categoryGroups.subcategories.length <= 5) {
+                    angular.forEach(categoryGroups.subcategories, function (subcategory) {
                         category.subcategories.push(subcategory);
                     });
-                } else if(goalsGroup) {
-                    category.subcategories.push(goalsGroup);
+                } else if(categoryGroups) {
+                    category.subcategories.push(categoryGroups);
                 }
 
                 category.subcategories = sortMenuItems(category.subcategories);

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -315,6 +315,15 @@ var broadcast = {
             }
         }
 
+        var updatedUrl = new RegExp('&updated=([0-9]+)');
+        var updatedCounter = updatedUrl.exec(currentSearchStr);
+        if (!updatedCounter) {
+            currentSearchStr += '&updated=1';
+        } else {
+            updatedCounter = 1 + parseInt(updatedCounter[1]);
+            currentSearchStr = currentSearchStr.replace(new RegExp('(&updated=[0-9]+)'), '&updated=' + updatedCounter);
+        }
+
         if (strHash && currentHashStr.length != 0) {
             var params_hash_vals = strHash.split("&");
             for (var i = 0; i < params_hash_vals.length; i++) {

--- a/plugins/CoreHome/lang/en.json
+++ b/plugins/CoreHome/lang/en.json
@@ -7,6 +7,7 @@
         "ClickToEditX": "Click to edit %s",
         "CloseSearch": "Close search",
         "CloseWidgetDirections": "You can close this widget by clicking on the 'X' icon at the top of the widget.",
+        "ChooseX": "Choose %1$s",
         "DataForThisReportHasBeenPurged": "The data for this report is more than %s months old and has been purged.",
         "DataTableExcludeAggregateRows": "Aggregate rows are shown %s Hide them",
         "DataTableIncludeAggregateRows": "Aggregate rows are hidden %s Show them",

--- a/plugins/CorePluginsAdmin/angularjs/field/field.directive.js
+++ b/plugins/CorePluginsAdmin/angularjs/field/field.directive.js
@@ -134,6 +134,14 @@
                     }
                 });
 
+                if ('undefined' !== typeof $scope.placeholder && $scope.placeholder !== null) {
+                    $scope.$watch('placeholder', function (val, oldVal) {
+                        if (val !== oldVal) {
+                            $scope.field.uiControlAttributes.placeholder = val;
+                        }
+                    });
+                }
+
                 $scope.$watch('disabled', function (val, oldVal) {
                     if (val !== oldVal) {
                         $scope.field.uiControlAttributes.disabled = val;

--- a/plugins/CorePluginsAdmin/angularjs/form-field/field-textarea.html
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/field-textarea.html
@@ -1,6 +1,7 @@
 <div>
     <textarea name="{{ formField.name }}"
               piwik-attributes="{{formField.uiControlAttributes}}"
+              id="{{ formField.name }}"
               ng-model="formField.value"
               class="materialize-textarea"
     ></textarea>

--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -272,6 +272,5 @@ class Goals extends \Piwik\Plugin
         $translationKeys[] = 'Goals_DeleteGoalConfirm';
         $translationKeys[] = 'Goals_Ecommerce';
         $translationKeys[] = 'Goals_Optional';
-        $translationKeys[] = 'Goals_ChooseGoal';
     }
 }

--- a/plugins/Goals/lang/en.json
+++ b/plugins/Goals/lang/en.json
@@ -16,7 +16,6 @@
         "CategoryTextVisitsSummary_VisitsSummary": "User attribute",
         "CategoryTextDevicesDetection_DevicesDetection": "Devices",
         "CategoryTextGeneral_Visit": "engagement",
-        "ChooseGoal": "Choose Goal",
         "ClickOutlink": "Click on a Link to an external website",
         "SendEvent": "Send an event",
         "ColumnAverageOrderRevenueDocumentation": "Average Order Value (AOV) is the total revenue from all Ecommerce Orders divided by the number of orders.",

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -110,6 +110,10 @@ PageRenderer.prototype.evaluate = function (impl, waitTime) {
     this.queuedEvents.push([this._evaluate, waitTime, impl]);
 };
 
+PageRenderer.prototype.execCallback = function (callback, waitTime) {
+    this.queuedEvents.push([this._execCallback, waitTime, callback]);
+};
+
 PageRenderer.prototype.downloadLink = function (selector, waitTime) {
     this.queuedEvents.push([this._downloadLink, waitTime, selector]);
 };
@@ -274,6 +278,11 @@ PageRenderer.prototype._evaluate = function (impl, callback) {
         eval("(" + js + ")();");
     }, impl.toString());
 
+    callback();
+};
+
+PageRenderer.prototype._execCallback = function (actualCallback, callback) {
+    actualCallback();
     callback();
 };
 


### PR DESCRIPTION
When there are more than 5 entries of the same type such as goals or dashboards, we create a dropdown menu and group them together. There used to be an API to do this in Piwik 2 but we have removed the reporting menu API so the API to do this no longer existed. This PR brings this feature back without the developer having to do anything. It now works just automatically.
