### PR TITLE
Named parameters in generic proxy API events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Read more about migrating a plugin from Piwik 2.X to Piwik 3 in [our Migration g
  * `Login.authenticate`  Create a custom SessionInitializer instead of using `Login` events
  * `Login.initSession.end`
  * `Login.authenticate.successful`
+* When posting one of the events `API.Request.dispatch`, `API.Request.dispatch.end`, `API.$plugin.$apiAction`, or `API.$plugin.$apiAction.end` the `$finalParameters` parameter is indexed in Piwik 2 (eg `array(1, 6)`), and named in Piwik 3 (eg `array('idSite' => 1, 'idGoal' => 6)`)
  
 Read more about migrating a plugin from Piwik 2.X to Piwik 3 on our [Migration guide](https://developer.piwik.org/guides/migrate-piwik-2-to-3).
 

--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -204,8 +204,16 @@ class Proxy extends Singleton
              */
             Piwik::postEvent(sprintf('API.%s.%s', $pluginName, $methodName), array(&$finalParameters));
 
+            $apiParametersInCorrectOrder = array();
+
+            foreach ($parameterNamesDefaultValues as $name => $defaultValue) {
+                if (isset($finalParameters[$name]) || array_key_exists($name, $finalParameters)) {
+                    $apiParametersInCorrectOrder[] = $finalParameters[$name];
+                }
+            }
+
             // call the method
-            $returnedValue = call_user_func_array(array($object, $methodName), $finalParameters);
+            $returnedValue = call_user_func_array(array($object, $methodName), $apiParametersInCorrectOrder);
 
             $endHookParams = array(
                 &$returnedValue,

--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -405,7 +405,7 @@ class Proxy extends Singleton
             } catch (Exception $e) {
                 throw new Exception(Piwik::translate('General_PleaseSpecifyValue', array($name)));
             }
-            $finalParameters[] = $requestValue;
+            $finalParameters[$name] = $requestValue;
         }
         return $finalParameters;
     }

--- a/plugins/VisitsSummary/VisitsSummary.php
+++ b/plugins/VisitsSummary/VisitsSummary.php
@@ -38,16 +38,16 @@ class VisitsSummary extends \Piwik\Plugin
 
     public function enrichProcessedReportIfVisitsSummaryGet(&$response, $infos)
     {
-        if (empty($infos['parameters'][4]) || empty($response['reportData'])) {
+        if (empty($infos['parameters']['apiAction']) || empty($response['reportData'])) {
             return;
         }
 
         $params  = $infos['parameters'];
-        $idSites = array($params[0]);
-        $period  = $params[1];
-        $date    = $params[2];
-        $module  = $params[3];
-        $method  = $params[4];
+        $idSites = array($params['idSite']);
+        $period  = $params['period'];
+        $date    = $params['date'];
+        $module  = $params['apiModule'];
+        $method  = $params['apiAction'];
 
         if (!$this->isRequestingVisitsSummaryGet($module, $method)) {
             return;


### PR DESCRIPTION
When an API method is called, we post some generic events: `API.Request.dispatch`, `API.Request.dispatch.end`, `API.$plugin.$apiAction`, and `API.$plugin.$apiAction.end` see 
https://developer.piwik.org/api-reference/events#apipluginnamemethodname

Those events are meant to change API parameters, the response and to perform other logic when any API method is called. As an argument they post a parameter `$finalParameters = array(5, 10, 'foo', 'bar')` meaning a plugin needs to access those parameters like `$finalParameters[0]`. 

This is quite fragile if the order of an API method ever changes and it is very hard to read the code as it is not clear which value is behind that key. Therefore we will now pass named parameters there and it will now look like: `$finalParameters = array('idSite' => 5, 'idGoal' => 10, 'name' => 'foo', 'attribute' => 'bar')`. 

This way it is better to read and easier to access parameters and less fragile as the order of parameters in our API methods could always change. 
