### PR TITLE
Make sure to format percentages in Scheduled Reports

### DIFF
--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -879,7 +879,7 @@ class ProcessedReport
         // Add % symbol to rates
         if (strpos($columnName, '_rate') !== false) {
             if (strpos($value, "%") === false) {
-                return $value . "%";
+                return (100 * $value) . "%";
             }
         }
 


### PR DESCRIPTION
If a report defines processed metrics containing percentages, they will be printed as eg `0.34%` instead of `34%` unless the metric is specified here which is not possible eg for plugins: https://github.com/piwik/piwik/blob/2.x-dev/core/API/Inconsistencies.php#L31
