### PR TITLE
Ensure component updated event is triggered even if there is no update file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Read more about migrating a plugin from Piwik 2.X to Piwik 3 on our [Migration g
  * `Updater.componentUpdated` triggered after core or a plugin has been updated
  * `PluginManager.pluginInstalled` triggered after a plugin was installed
  * `PluginManager.pluginUninstalled` triggered after a plugin was uninstalled
+ * `Updater.componentInstalled` triggered after a component was installed
+ * `Updater.componentUninstalled` triggered after a component was uninstalled
 * New HTTP Tracking API parameter `pv_id` which accepts a six character unique ID that identifies which actions were performed on a specific page view. Read more about it in the [HTTP Tracking API](https://developer.piwik.org/api-reference/tracking-api);
 * New event `Segment.addSegments` that lets you add segments.
 

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1086,7 +1086,7 @@ class Manager
             $pluginsInstalled[] = $pluginName;
             $this->updatePluginsInstalledConfig($pluginsInstalled);
             $updater = new Updater();
-            $updater->markComponentSuccessfullyUpdated($plugin->getPluginName(), $plugin->getVersion());
+            $updater->markComponentSuccessfullyUpdated($plugin->getPluginName(), $plugin->getVersion(), $isNew = true);
             $saveConfig = true;
 
             /**

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -356,6 +356,36 @@ class Updater
                 uasort($componentsWithUpdateFile[$name], "version_compare");
             } else {
                 // there are no update file => nothing to do, update to the new version is successful
+
+                /**
+                 * Event triggered after a component has been updated.
+                 *
+                 * Can be used to handle stuff that should be done after a component was updated
+                 *
+                 * **Example**
+                 *
+                 *     Piwik::addAction('Updater.componentUpdated', function ($componentName, $updatedVersion, $warningMessages) {
+                 *          $mail = new Mail();
+                 *          $mail->setDefaultFromPiwik();
+                 *          $mail->addTo('test@example.org');
+                 *          $mail->setSubject('Component was updated);
+                 *          $message = sprintf(
+                 *              'Component %1$s has been updated to version %2$s',
+                 *              $componentName, $updatedVersion
+                 *          );
+                 *          if (!empty($warningMessages)) {
+                 *              $message .= "Some warnings occured:\n" . implode("\n", $warningMessages);
+                 *          }
+                 *          $mail->setBodyText($message);
+                 *          $mail->send();
+                 *     });
+                 *
+                 * @param string $componentName 'core', or plugin name
+                 * @param string $updatedVersion version updated to
+                 * @param array  $warningMessages warnings occurred during update
+                 */
+                Piwik::postEvent('Updater.componentUpdated', array($name, $newVersion, array()));
+
                 $this->markComponentSuccessfullyUpdated($name, $newVersion);
             }
         }

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -108,7 +108,7 @@ class Updater
         /**
          * Event triggered after a component has been updated.
          *
-         * Can be used to handle stuff that should be done after a component was updated
+         * Can be used to handle logic that should be done after a component was updated
          *
          * **Example**
          *
@@ -125,7 +125,7 @@ class Updater
          *          $mail->send();
          *     });
          *
-         * @param string $componentName 'core', or plugin name
+         * @param string $componentName 'core', plugin name or dimension name
          * @param string $updatedVersion version updated to
          */
         Piwik::postEvent('Updater.componentUpdated', array($name, $version));
@@ -146,9 +146,9 @@ class Updater
         }
 
         /**
-         * Event triggered after a plugin has been uninstalled.
+         * Event triggered after a component has been uninstalled.
          *
-         * @param string $pluginName The plugin that has been uninstalled.
+         * @param string $name The component that has been uninstalled.
          */
         Piwik::postEvent('Updater.componentUninstalled', array($name));
     }


### PR DESCRIPTION
Component update event has only be triggered if an update file was processed.

Shall we backport that for 2.x?
