### PR TITLE
Add config setting to allow 777 file and directory permissions if needed, disabled by default

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -312,6 +312,11 @@ minimum_memory_limit = 128
 ; Set to "-1" to always use the configured memory_limit value in php.ini file.
 minimum_memory_limit_when_archiving = 768
 
+; If set to 1, Piwik will enable a fallback to file permissions "0777" if a file or directory cannot be made writable
+; via "0755" or "0775". Enable this setting only if you cannot fix file permission problems otherwise as files may be
+; made world writable. This means files will be readable by all users on your server.
+allow_world_writable_file_permissions = 0;
+
 ; Piwik will check that usernames and password have a minimum length, and will check that characters are "allowed"
 ; This can be disabled, if for example you wish to import an existing User database in Piwik and your rules are less restrictive
 disable_checks_usernames_attributes = 0

--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -91,11 +91,21 @@ class Filesystem
             @chmod($path, 0755);
             if (!is_writable($path)) {
                 @chmod($path, 0775);
-                // enough! we're not going to make the directory world-writeable
+                // enough! we're not going to make the directory world-writeable, unless specifically allowed in config
+
+                if (!is_writable($path) && self::allowWorldWritableFilePermissions()) {
+                    @chmod($path, 0777);
+                }
             }
         }
 
         self::createIndexFilesToPreventDirectoryListing($path);
+    }
+
+    private function allowWorldWritableFilePermissions()
+    {
+        $allowWorldWritable = Config::getInstance()->General['allow_world_writable_file_permissions'];
+        return !empty($allowWorldWritable);
     }
 
     /**
@@ -493,9 +503,18 @@ class Filesystem
         if (!@copy($source, $dest)) {
             @chmod($dest, 0755);
             if (!@copy($source, $dest)) {
+
                 $message = "Error while creating/copying file to <code>$dest</code>. <br />"
                     . Filechecks::getErrorMessageMissingPermissions(self::getPathToPiwikRoot());
-                throw new Exception($message);
+
+                if (self::allowWorldWritableFilePermissions()) {
+                    @chmod($dest, 0777);
+                    if (!@copy($source, $dest)) {
+                        throw new Exception($message);
+                    }
+                } else {
+                    throw new Exception($message);
+                }
             }
         }
 


### PR DESCRIPTION
fix #10789 
@mattab would that be something that we merge?

It's not good for security to have 777 file permissions but users find ways anyway see https://github.com/piwik/piwik/issues/10789#issuecomment-256595387 . Would make it work for more users and of course disabled by default.

I tried to add a test but can't really think of a way to do this.