### PR TITLE
Load marketplace client in updater only when marketplace is enabled

### DIFF
--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -118,14 +118,17 @@ class Updater
 
             // we also need to make sure to create a new instance here as otherwise we would change the "global"
             // environment, but we only want to change piwik version temporarily for this task here
-            $environment = StaticContainer::getContainer()->make('Piwik\Plugins\Marketplace\Environment');
-            $environment->setPiwikVersion($newVersion);
-            /** @var \Piwik\Plugins\Marketplace\Api\Client $marketplaceClient */
-            $marketplaceClient = StaticContainer::getContainer()->make('Piwik\Plugins\Marketplace\Api\Client', array(
-                'environment' => $environment
-            ));
-            require_once PIWIK_DOCUMENT_ROOT . '/plugins/CorePluginsAdmin/PluginInstaller.php';
-            require_once PIWIK_DOCUMENT_ROOT . '/plugins/Marketplace/Api/Exception.php';
+
+            if (Marketplace::isMarketplaceEnabled()) {
+                $environment = StaticContainer::getContainer()->make('Piwik\Plugins\Marketplace\Environment');
+                $environment->setPiwikVersion($newVersion);
+                /** @var \Piwik\Plugins\Marketplace\Api\Client $marketplaceClient */
+                $marketplaceClient = StaticContainer::getContainer()->make('Piwik\Plugins\Marketplace\Api\Client', array(
+                    'environment' => $environment
+                ));
+                require_once PIWIK_DOCUMENT_ROOT . '/plugins/CorePluginsAdmin/PluginInstaller.php';
+                require_once PIWIK_DOCUMENT_ROOT . '/plugins/Marketplace/Api/Exception.php';
+            }
 
             $this->installNewFiles($extractedArchiveDirectory);
             $messages[] = $this->translator->translate('CoreUpdater_InstallingTheLatestVersion');
@@ -138,7 +141,7 @@ class Updater
 
         try {
 
-            if (Marketplace::isMarketplaceEnabled()) {
+            if (Marketplace::isMarketplaceEnabled() && !empty($marketplaceClient)) {
                 $messages[] = $this->translator->translate('CoreUpdater_CheckingForPluginUpdates');
                 $pluginManager = PluginManager::getInstance();
                 $pluginManager->loadAllPluginsAndGetTheirInfo();


### PR DESCRIPTION
When the Marketplace plugin is disabled, `StaticContainer::getContainer()->make('Piwik\Plugins\Marketplace\Environment')` may return `null` I believe. Therefore we should only load it when the Marketplace is actually enabled. 

Thix fix is already included in the Marketplace PR for 3.x