### PR TITLE
Move method for setting location provider from controller to api

### DIFF
--- a/plugins/UserCountry/API.php
+++ b/plugins/UserCountry/API.php
@@ -198,6 +198,22 @@ class API extends \Piwik\Plugin\API
         return $location;
     }
 
+    /**
+     * Set the location provider
+     *
+     * @param string $providerId  The ID of the provider to use  eg 'default', 'geoip_php', ...
+     * @throws Exception if ID is invalid
+     */
+    public function setLocationProvider($providerId)
+    {
+        Piwik::checkUserHasSuperUserAccess();
+
+        $provider = LocationProvider::setCurrentProvider($providerId);
+        if ($provider === false) {
+            throw new Exception("Invalid provider ID: '$providerId'.");
+        }
+    }
+
     protected function getDataTable($name, $idSite, $period, $date, $segment)
     {
         Piwik::checkUserHasViewAccess($idSite);

--- a/plugins/UserCountry/API.php
+++ b/plugins/UserCountry/API.php
@@ -208,6 +208,10 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasSuperUserAccess();
 
+        if (!UserCountry::isGeoLocationAdminEnabled()) {
+            throw new \Exception('Setting geo location has been disabled in config.');
+        }
+
         $provider = LocationProvider::setCurrentProvider($providerId);
         if ($provider === false) {
             throw new Exception("Invalid provider ID: '$providerId'.");

--- a/plugins/UserCountry/Controller.php
+++ b/plugins/UserCountry/Controller.php
@@ -284,31 +284,6 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     }
 
     /**
-     * Sets the current LocationProvider type.
-     *
-     * Input:
-     *   Requires the 'id' query parameter to be set to the desired LocationProvider's ID.
-     *
-     * Output:
-     *   Nothing.
-     */
-    public function setCurrentLocationProvider()
-    {
-        $this->dieIfGeolocationAdminIsDisabled();
-        Piwik::checkUserHasSuperUserAccess();
-        if ($_SERVER["REQUEST_METHOD"] == "POST") {
-            $this->checkTokenInUrl();
-
-            $providerId = Common::getRequestVar('id');
-            $provider = LocationProvider::setCurrentProvider($providerId);
-            if ($provider === false) {
-                throw new Exception("Invalid provider ID: '$providerId'.");
-            }
-            return 1;
-        }
-    }
-
-    /**
      * Echo's a pretty formatted location using a specific LocationProvider.
      *
      * Input:

--- a/plugins/UserCountry/angularjs/location-provider-selection/location-provider-selection.controller.js
+++ b/plugins/UserCountry/angularjs/location-provider-selection/location-provider-selection.controller.js
@@ -51,9 +51,8 @@
 
             piwikApi.withTokenInUrl();
             piwikApi.fetch({
-                module: 'UserCountry',
-                action: 'setCurrentLocationProvider',
-                id: this.selectedProvider
+                method: 'UserCountry.setLocationProvider',
+                providerId: this.selectedProvider
             }).then(function () {
                 self.isLoading = false;
                 var UI = require('piwik/UI');

--- a/plugins/UserCountry/tests/Integration/APITest.php
+++ b/plugins/UserCountry/tests/Integration/APITest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UserCountry\tests;
+
+use Piwik\Common;
+use Piwik\Plugins\UserCountry\API;
+use Piwik\Plugins\UserCountry\LocationProvider;
+use Piwik\Plugins\UserCountry\LocationProvider\DefaultProvider;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group UserCountryAPI
+ * @group APITest
+ * @group Plugins
+ */
+class APITest extends IntegrationTestCase
+{
+    /**
+     * @var API
+     */
+    private $api;
+    
+    public function setUp()
+    {
+        parent::setUp();
+
+        FakeAccess::$superUser = true;
+
+        $this->api = API::getInstance();
+
+        // reset location providers as they might be manipulated by other tests
+        LocationProvider::$providers = null;
+        LocationProvider::getAllProviders();
+    }
+
+    public function test_setLocationProvider()
+    {
+        $locationProvider = LocationProvider\GeoIp\Php::ID;
+        $this->api->setLocationProvider($locationProvider);
+        $this->assertEquals($locationProvider, Common::getCurrentLocationProviderId());
+
+        $locationProvider = DefaultProvider::ID;
+        $this->api->setLocationProvider($locationProvider);
+        $this->assertEquals($locationProvider, Common::getCurrentLocationProviderId());
+    }
+}

--- a/plugins/UserCountry/tests/Integration/APITest.php
+++ b/plugins/UserCountry/tests/Integration/APITest.php
@@ -8,15 +8,16 @@
 
 namespace Piwik\Plugins\UserCountry\tests;
 
+use Piwik\Access;
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\Plugins\UserCountry\API;
 use Piwik\Plugins\UserCountry\LocationProvider;
 use Piwik\Plugins\UserCountry\LocationProvider\DefaultProvider;
-use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
- * @group UserCountryAPI
+ * @group UserCountry
  * @group APITest
  * @group Plugins
  */
@@ -30,8 +31,6 @@ class APITest extends IntegrationTestCase
     public function setUp()
     {
         parent::setUp();
-
-        FakeAccess::$superUser = true;
 
         $this->api = API::getInstance();
 
@@ -49,5 +48,36 @@ class APITest extends IntegrationTestCase
         $locationProvider = DefaultProvider::ID;
         $this->api->setLocationProvider($locationProvider);
         $this->assertEquals($locationProvider, Common::getCurrentLocationProviderId());
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function test_setLocationProviderInvalid()
+    {
+        $locationProvider = 'invalidProvider';
+        $this->api->setLocationProvider($locationProvider);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function test_setLocationProviderNoSuperUser()
+    {
+        Access::getInstance()->setSuperUserAccess(false);
+
+        $locationProvider = LocationProvider\GeoIp\Php::ID;
+        $this->api->setLocationProvider($locationProvider);
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function test_setLocationProviderDisabledInConfig()
+    {
+        Config::getInstance()->General['enable_geolocation_admin'] = 0;
+
+        $locationProvider = LocationProvider\GeoIp\Php::ID;
+        $this->api->setLocationProvider($locationProvider);
     }
 }

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2864df20d6946a3755878c20f2294f4e6a6c733052e75e92f0ca60b2b1e811ed
-size 4109166
+oid sha256:9ed26d862dbc303fe4b282f4af325cb70d689e115a4487f8dc64882f109b8edf
+size 4115881


### PR DESCRIPTION
Setting the used location provider is currently done in a controller action, which is called from the admin page. 

Moving that method to the API has the advantage that the provider could be set without using the UI. And it will be possible to hook into the API call using the default API events like `API.UserCountry.setLocationProvider.end` to handle something that should be done after the location provider has changed. Might be useful for some plugins.