### PR TITLE
Websites manager: Add possibility to exclude URL parameters matching a regular expressions

### DIFF
--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -17,6 +17,32 @@ use Piwik\Intl\Data\Provider\RegionDataProvider;
  */
 class UrlHelper
 {
+    
+    /**
+    * Checks if a string matches/is equal to one of the patterns/strings.
+    *
+    * @static
+    * @param $test String to test.
+    * @param $patterns Array of strings or regexs.
+    *
+    * @return true if $test matches or is equal to one of the regex/string in $patterns, false otherwise.
+    */
+    protected static function in_array_reg($test, $patterns)
+    {
+        foreach($patterns as $val) {
+            if(@preg_match($val, null) === false) {
+                if( $val==$test ) {
+                    return true;
+                }
+            } else {
+                if( preg_match($val, $test) === 1 ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
     /**
      * Converts an array of query parameter name/value mappings into a query string.
      * Parameters that are in `$parametersToExclude` will not appear in the result.
@@ -36,7 +62,7 @@ class UrlHelper
             // decode encoded square brackets
             $name = str_replace(array('%5B', '%5D'), array('[', ']'), $name);
 
-            if (!in_array(strtolower($name), $parametersToExclude)) {
+            if (!self::in_array_reg(strtolower($name), $parametersToExclude)) {
                 if (is_array($value)) {
                     foreach ($value as $param) {
                         if ($param === false) {

--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -31,7 +31,7 @@ class UrlHelper
     {
         foreach($patterns as $val) {
             if(@preg_match($val, null) === false) {
-                if( $val==$test ) {
+                if( strcasecmp($val, $test) === 0 ) {
                     return true;
                 }
             } else {

--- a/plugins/SitesManager/lang/en.json
+++ b/plugins/SitesManager/lang/en.json
@@ -43,7 +43,7 @@
         "KeepURLFragmentsLong": "Keep Page URL fragments when tracking Page URLs",
         "ListOfIpsToBeExcludedOnAllWebsites": "The IPs below will be excluded from being tracked on all websites.",
         "ListOfQueryParametersToBeExcludedOnAllWebsites": "The Query URLs parameters below will be excluded from URLs on all websites.",
-        "ListOfQueryParametersToExclude": "Enter the list of URL Query Parameters, one per line, to exclude from the Page URLs reports.",
+        "ListOfQueryParametersToExclude": "Enter the list of URL Query Parameters, one per line, to exclude from the Page URLs reports. Regular expressions such as /^sess.*|.*[dD]ate$/ are suported.",
         "MainDescription": "Your Web Analytics reports need Websites! Add, update, delete Websites, and show the JavaScript to insert in your pages.",
         "MenuManage": "Manage",
         "NotAnEcommerceSite": "Not an Ecommerce site",

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
@@ -96,7 +96,7 @@
 				</uiControlAttributes>
 				<availableValues />
 				<description />
-				<inlineHelp>Enter the list of URL Query Parameters, one per line, to exclude from the Page URLs reports.&lt;br /&gt;&lt;br /&gt;Piwik will automatically exclude the common session parameters (phpsessid, sessionid, ...).</inlineHelp>
+				<inlineHelp>Enter the list of URL Query Parameters, one per line, to exclude from the Page URLs reports. Regular expressions such as /^sess.*|.*[dD]ate$/ are suported.&lt;br /&gt;&lt;br /&gt;Piwik will automatically exclude the common session parameters (phpsessid, sessionid, ...).</inlineHelp>
 				<introduction />
 				<condition />
 			</row>

--- a/tests/PHPUnit/Integration/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ActionTest.php
@@ -174,6 +174,21 @@ class ActionTest extends IntegrationTestCase
     }
 
     /**
+     * Testing with some website specific parameters excluded using regular expressions
+     * @dataProvider getTestUrls
+     */
+    public function testExcludeQueryParametersRegExSiteExcluded($url, $filteredUrl)
+    {
+        $excludedQueryParameters = '/p[4|2]/, /^var.*/';
+        $this->setUpRootAccess();
+        $idSite = API::getInstance()->addSite("site1", array('http://example.org'), $ecommerce = 0,
+            $siteSearch = 1, $searchKeywordParameters = null, $searchCategoryParameters = null,
+            $excludedIps = '', $excludedQueryParameters, $timezone = null, $currency = null,
+            $group = null, $startDate = null, $excludedUserAgents = null, $keepURLFragments = 1);
+        $this->assertEquals($filteredUrl[1], PageUrl::excludeQueryParametersFromUrl($url, $idSite));
+    }
+
+    /**
      * Testing with some website specific and some global excluded query parameters
      * @dataProvider getTestUrls
      */

--- a/tests/PHPUnit/Unit/UrlHelperTest.php
+++ b/tests/PHPUnit/Unit/UrlHelperTest.php
@@ -234,4 +234,64 @@ class UrlHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('add=foo', UrlHelper::getQueryFromUrl('/', array('add' => 'foo')));
         $this->assertEquals('add[]=foo&add[]=test', UrlHelper::getQueryFromUrl('/', array('add' => array('foo', 'test'))));
     }
+    
+    
+    /**
+     * Dataprovider for testGetQueryStringWithExcludedParameters
+     */
+    public function getQueryParameters()
+    {
+        return array(
+            array(
+                'p1=v1&p2=v2',                      //expected
+                array('p1'=>'v1', 'p2'=>'v2'),      //queryParameters
+                array()                             //parametersToExclude
+            ),
+            array(
+                'p2=v2', 
+                array('p1'=>'v1', 'p2'=>'v2'),
+                array('p1')
+            ),
+            array(
+                'p1=v1&p2=v2', 
+                array('p1'=>'v1', 'p2'=>'v2', 'sessionId'=>'HHSJHERTG'),
+                array('sessionId')
+            ),
+            array(
+                'p1=v1&p2=v2', 
+                array('p1'=>'v1', 'p2'=>'v2', 'sessionId'=>'HHSJHERTG'),
+                array('/session/')
+            ),
+            array(
+                'p1=v1&p2=v2', 
+                array('p1'=>'v1', 'sessionId'=>'HHSJHERTG', 'p2'=>'v2', 'token'=>'RYUN36HSAO'),
+                array('/[session|token]/')
+            ),
+            array(
+                '', 
+                array('p1'=>'v1', 'p2'=>'v2', 'sessionId'=>'HHSJHERTG', 'token'=>'RYUN36HSAO'),
+                array('/.*/')
+            ),
+            array(
+                'p2=v2&p4=v4', 
+                array('p1'=>'v1', 'p2'=>'v2', 'p3'=>'v3', 'p4'=>'v4'),
+                array('/p[1|3]/')
+            ),
+            array(
+                'p2=v2&p4=v4', 
+                array('p1'=>'v1', 'p2'=>'v2', 'p3'=>'v3', 'p4'=>'v4', 'utm_source'=>'gekko', 'utm_medium'=>'email', 'utm_campaign'=>'daily'),
+                array('/p[1|3]/', '/utm_/')
+            )
+        );
+    }
+    
+    /**
+     * @dataProvider getQueryParameters
+     * @group Core
+     */
+    public function testGetQueryStringWithExcludedParameters($expected, $queryParameters, $parametersToExclude)
+    {
+        $this->assertEquals($expected, UrlHelper::getQueryStringWithExcludedParameters($queryParameters, $parametersToExclude));
+    }
+    
 }


### PR DESCRIPTION
Allows to use regular expressions in the exclude parameters option.
Doesn't break compatibility if the parameter is not a regular expression, doing a strict compare.
"/.*/" can be used to exclude all parameters.