### PR TITLE
Trigger JS tracker update when checking for updates

### DIFF
--- a/plugins/CustomPiwikJs/CustomPiwikJs.php
+++ b/plugins/CustomPiwikJs/CustomPiwikJs.php
@@ -23,6 +23,7 @@ class CustomPiwikJs extends Plugin
             'PluginManager.pluginInstalled' => 'updateTracker',
             'PluginManager.pluginUninstalled' => 'updateTracker',
             'Updater.componentUpdated' => 'updateTracker',
+            'Controller.CoreHome.checkForUpdates.end' => 'updateTracker'
         );
     }
 


### PR DESCRIPTION
If for some reason the tracker file does not get updated, we will regenerate it immediately when someone is checking for updates manually. This way we can tell users to perform this action to force regeneration immediately (if there was a change). This way users don't have to log in to their server and force regeneration via a command when it was not updated automatically.