### PR TITLE
Fix metric was not formatted

### DIFF
--- a/core/API/Inconsistencies.php
+++ b/core/API/Inconsistencies.php
@@ -31,6 +31,7 @@ class Inconsistencies
         return array(
             'bounce_rate',
             'conversion_rate',
+            'abandoned_rate',
             'interaction_rate',
             'exit_rate',
             'bounce_rate_returning',


### PR DESCRIPTION
Will also issue PR for Piwik 3. In this case we had a plugin with conversion rate and abandoned rate. Only conversion rate got formatted (like 45%) when fetching a regular report where abandoned rate remained unformatted (like 0.55).