### PR TITLE
 Button to add a segment is missing some text in French language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,6 +172,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/plugins/SegmentEditor/stylesheets/segmentation.less
+++ b/plugins/SegmentEditor/stylesheets/segmentation.less
@@ -531,6 +531,8 @@ div.scrollable {
 .segmentEditorPanel.expanded .add_new_segment {
     width: 100%;
     margin: 16px 0 8px 0;
+    height: auto;
+    min-height: 36px;
 }
 
 .segmentationContainer > ul.submenu > li {


### PR DESCRIPTION
fixes #10656

It will look like this:

![image](https://cloud.githubusercontent.com/assets/273120/20549939/8f2adef6-b195-11e6-88ec-830284f8b049.png)

It is not ideal but I cannot lower the line-height because otherwise the button would not look nice when english language is used (or in general when button shows text in one line).

Maybe the button text could be on top changed to only say like "new segment"?