### PR TITLE
Tracking API: when overriding the request datetime with an invalid token_auth, don't track the request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,6 +178,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,6 +174,10 @@ cache:
 
 
 
+
+
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,6 +180,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -182,6 +182,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -186,6 +186,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,6 +172,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,12 +103,13 @@ Read more about migrating a plugin from Piwik 2.X to Piwik 3 on our [Migration g
 * New event `Segment.addSegments` that lets you add segments.
 * New Piwik JavaScript Tracker method `disableHeartBeatTimer()` to disable the heartbeat timer if it was previously enabled. 
 
-### New features
-* New "Sparklines" visualization that lets you create a widget showing multiple sparklines.
-
 ### Changes
 * New now accept tracking requests for up to 1 day in the past instead of only 4 hours
 * If a tracking request has a custom timestamp that is older than one day and the tracking request is not authenticated, we ignore the whole tracking request instead of ignoring the custom timestamp and still tracking the request with the current timestamp
+
+### New features
+* New "Sparklines" visualization that lets you create a widget showing multiple sparklines.
+* New config.ini.php setting: `tracking_requests_require_authentication_when_custom_timestamp_newer_than` to change how far back Piwik will track your requests without authentication. By default, value is set to 86400 (one day). The configured value is in seconds.
 
 ### Library updates
 * Updated AngularJS from 1.2.28 to 1.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,10 @@ Read more about migrating a plugin from Piwik 2.X to Piwik 3 on our [Migration g
 ### New features
 * New "Sparklines" visualization that lets you create a widget showing multiple sparklines.
 
+### Changes
+* New now accept tracking requests for up to 1 day in the past instead of only 4 hours
+* If a tracking request has a custom timestamp that is older than one day and the tracking request is not authenticated, we ignore the whole tracking request instead of ignoring the custom timestamp and still tracking the request with the current timestamp
+
 ### Library updates
 * Updated AngularJS from 1.2.28 to 1.4.3
 * Updated several backend libraries to their latest version: doctrine/cache, php-di.

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -697,6 +697,11 @@ bulk_requests_use_transaction = 1
 ; DO NOT USE THIS SETTING ON PUBLIC PIWIK SERVERS
 tracking_requests_require_authentication = 1
 
+; By default, Piwik accepts only tracking requests for up to 1 day in the past. For tracking requests with a custom date
+; date is older than 1 day, Piwik requires an authenticated tracking requests. By setting this config to another value
+; You can change how far back Piwik will track your requests without authentication. The configured value is in seconds.
+tracking_requests_require_authentication_when_custom_timestamp_newer_than = 86400;
+
 [Segments]
 ; Reports with segmentation in API requests are processed in real time.
 ; On high traffic websites it is recommended to pre-process the data

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -54,7 +54,7 @@ class Request
 
     const UNKNOWN_RESOLUTION = 'unknown';
 
-    const CUSTOM_TIMESTAMP_DOES_NOT_REQUIRE_TOKENAUTH_WHEN_NEWER_THAN = 14400; // 4 hours
+    private $customTimestampDoesNotRequireTokenauthWhenNewerThan;
 
     /**
      * @param $params
@@ -70,6 +70,7 @@ class Request
         $this->tokenAuth = $tokenAuth;
         $this->timestamp = time();
         $this->isEmptyRequest = empty($params);
+        $this->customTimestampDoesNotRequireTokenauthWhenNewerThan = (int) TrackerConfig::getConfigValue('tracking_requests_require_authentication_when_custom_timestamp_newer_than');
 
         // When the 'url' and referrer url parameter are not given, we might be in the 'Simple Image Tracker' mode.
         // The URL can default to the Referrer, which will be in this case
@@ -465,13 +466,14 @@ class Request
 
         // If timestamp in the past, token_auth is required
         $timeFromNow = $this->timestamp - $cdt;
-        $isTimestampRecent = $timeFromNow < self::CUSTOM_TIMESTAMP_DOES_NOT_REQUIRE_TOKENAUTH_WHEN_NEWER_THAN;
+        $isTimestampRecent = $timeFromNow < $this->customTimestampDoesNotRequireTokenauthWhenNewerThan;
 
         if (!$isTimestampRecent) {
             if (!$this->isAuthenticated()) {
-                Common::printDebug(sprintf("Custom timestamp is %s seconds old, requires &token_auth...", $timeFromNow));
+                $message = sprintf("Custom timestamp is %s seconds old, requires &token_auth...", $timeFromNow);
+                Common::printDebug($message);
                 Common::printDebug("WARN: Tracker API 'cdt' was used with invalid token_auth");
-                return false;
+                throw new Exception($message);
             }
         }
 

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -473,7 +473,7 @@ class Request
                 $message = sprintf("Custom timestamp is %s seconds old, requires &token_auth...", $timeFromNow);
                 Common::printDebug($message);
                 Common::printDebug("WARN: Tracker API 'cdt' was used with invalid token_auth");
-                throw new Exception($message);
+                throw new InvalidRequestParameterException($message);
             }
         }
 

--- a/tests/PHPUnit/Fixtures/ManySitesImportedLogs.php
+++ b/tests/PHPUnit/Fixtures/ManySitesImportedLogs.php
@@ -41,6 +41,8 @@ class ManySitesImportedLogs extends Fixture
         GeoIp::$geoIPDatabaseDir = 'tests/lib/geoip-files';
         LocationProvider::setCurrentProvider('geoip_php');
 
+        self::createSuperUser();
+
         $this->trackVisits();
         $this->setupSegments();
     }

--- a/tests/PHPUnit/Fixtures/OneVisitorTwoVisits.php
+++ b/tests/PHPUnit/Fixtures/OneVisitorTwoVisits.php
@@ -13,6 +13,7 @@ use Piwik\Db;
 use Piwik\Plugins\Goals\API as APIGoals;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Tests\Framework\Fixture;
+use Piwik\Tracker\Cache;
 
 /**
  * This fixture adds one website and tracks two visits by one visitor.
@@ -84,7 +85,11 @@ class OneVisitorTwoVisits extends Fixture
             APISitesManager::getInstance()->setSiteSpecificUserAgentExcludeEnabled(false);
         }
 
+        self::createSuperUser();
         $t = self::getTracker($idSite, $dateTime, $defaultInit = true);
+
+        Cache::clearCacheGeneral();
+        Cache::regenerateCacheWebsiteAttributes(array($idSite));
 
         if ($this->useThirdPartyCookies) {
             $t->DEBUG_APPEND_URL = '&forceUseThirdPartyCookie=1';

--- a/tests/PHPUnit/Unit/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestTest.php
@@ -49,9 +49,13 @@ class RequestTest extends UnitTestCase
         $this->assertSame($this->time, $request->getCurrentTimestamp());
     }
 
-    public function test_cdt_ShouldReturnTheCurrentTimestamp_IfNotAuthenticatedAndTimestampIsNotRecent()
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Custom timestamp is 86500 seconds old
+     */
+    public function test_cdt_ShouldNotTrackTheRequest_IfNotAuthenticatedAndTimestampIsNotRecent()
     {
-        $request = $this->buildRequest(array('cdt' => '' . $this->time - 28800));
+        $request = $this->buildRequest(array('cdt' => '' . $this->time - 86500));
         $this->assertSame($this->time, $request->getCurrentTimestamp());
     }
 
@@ -64,9 +68,9 @@ class RequestTest extends UnitTestCase
 
     public function test_cdt_ShouldReturnTheCustomTimestamp_IfAuthenticatedAndValid()
     {
-        $request = $this->buildRequest(array('cdt' => '' . ($this->time - 28800)));
+        $request = $this->buildRequest(array('cdt' => '' . ($this->time - 86500)));
         $request->setIsAuthenticated();
-        $this->assertSame('' . ($this->time - 28800), $request->getCurrentTimestamp());
+        $this->assertSame('' . ($this->time - 86500), $request->getCurrentTimestamp());
     }
 
     public function test_cdt_ShouldReturnTheCustomTimestamp_IfTimestampIsInFuture()


### PR DESCRIPTION
fix #10890 