### PR TITLE
JavaScript Tracker: new option "Track users with JavaScript disabled" and the  <noscript> tag is not included by default anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,6 +174,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -178,6 +178,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -176,6 +176,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,6 +180,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -182,6 +182,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,6 +172,8 @@ cache:
 
 
 
+
+
 notifications:
   slack:
     rooms:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,8 @@ Read more about migrating a plugin from Piwik 2.X to Piwik 3 on our [Migration g
  * `Updater.componentUninstalled` triggered after a component was uninstalled
 * New HTTP Tracking API parameter `pv_id` which accepts a six character unique ID that identifies which actions were performed on a specific page view. Read more about it in the [HTTP Tracking API](https://developer.piwik.org/api-reference/tracking-api);
 * New event `Segment.addSegments` that lets you add segments.
-* New Piwik JavaScript Tracker method `disableHeartBeatTimer()` to disable the heartbeat timer if it was previously enabled. 
+* New Piwik JavaScript Tracker method `disableHeartBeatTimer()` to disable the heartbeat timer if it was previously enabled.
+* The `SitesManager.getJavascriptTag` has a new option `getJavascriptTag` to enable the tracking of users that have JavaScript disabled
 
 ### New features
 * New "Sparklines" visualization that lets you create a widget showing multiple sparklines.

--- a/core/Tracker/TrackerCodeGenerator.php
+++ b/core/Tracker/TrackerCodeGenerator.php
@@ -31,6 +31,7 @@ class TrackerCodeGenerator
      * @param string $customCampaignKeywordParam
      * @param bool $doNotTrack
      * @param bool $disableCookies
+     * @param bool $trackNoScript
      * @return string Javascript code.
      */
     public function generate(
@@ -44,7 +45,8 @@ class TrackerCodeGenerator
         $customCampaignNameQueryParam = null,
         $customCampaignKeywordParam = null,
         $doNotTrack = false,
-        $disableCookies = false
+        $disableCookies = false,
+        $trackNoScript = false
     ) {
         // changes made to this code should be mirrored in plugins/CoreAdminHome/javascripts/jsTrackingGenerator.js var generateJsCode
 
@@ -120,7 +122,8 @@ class TrackerCodeGenerator
             'options'                 => $options,
             'optionsBeforeTrackerUrl' => $optionsBeforeTrackerUrl,
             'protocol'                => '//',
-            'loadAsync'               => true
+            'loadAsync'               => true,
+            'trackNoScript'           => $trackNoScript
         );
         $parameters = compact('mergeSubdomains', 'groupPageTitlesByDomain', 'mergeAliasUrls', 'visitorCustomVariables',
             'pageCustomVariables', 'customCampaignNameQueryParam', 'customCampaignKeywordParam',
@@ -161,6 +164,7 @@ class TrackerCodeGenerator
         $view = new View('@Morpheus/javascriptCode');
         $view->disableCacheBuster();
         $view->loadAsync = $codeImpl['loadAsync'];
+        $view->trackNoScript = $codeImpl['trackNoScript'];
         $jsCode = $view->render();
         $jsCode = htmlentities($jsCode);
 

--- a/plugins/CoreAdminHome/angularjs/trackingcode/jstrackingcode.controller.js
+++ b/plugins/CoreAdminHome/angularjs/trackingcode/jstrackingcode.controller.js
@@ -84,7 +84,8 @@
                 customCampaignNameQueryParam: null,
                 customCampaignKeywordParam: null,
                 doNotTrack: self.doNotTrack ? 1 : 0,
-                disableCookies: self.disableCookies ? 1 : 0
+                disableCookies: self.disableCookies ? 1 : 0,
+                trackNoScript: self.trackNoScript ? 1: 0
             };
 
             if (self.useCustomCampaignParams) {

--- a/plugins/CoreAdminHome/angularjs/trackingcode/jstrackingcode.controller.js
+++ b/plugins/CoreAdminHome/angularjs/trackingcode/jstrackingcode.controller.js
@@ -80,7 +80,7 @@
                 groupPageTitlesByDomain: self.groupByDomain ? 1 : 0,
                 mergeSubdomains: self.trackAllSubdomains ? 1 : 0,
                 mergeAliasUrls: self.trackAllAliases ? 1 : 0,
-                visitorCustomVariables: getCustomVariables(self.customVars),
+                visitorCustomVariables: self.trackCustomVars ? getCustomVariables(self.customVars) : 0,
                 customCampaignNameQueryParam: null,
                 customCampaignKeywordParam: null,
                 doNotTrack: self.doNotTrack ? 1 : 0,

--- a/plugins/CoreAdminHome/lang/en.json
+++ b/plugins/CoreAdminHome/lang/en.json
@@ -40,6 +40,7 @@
         "JSTracking_MergeSubdomainsDesc": "So if one visitor visits %1$s and %2$s, they will be counted as a unique visitor.",
         "JSTracking_PageCustomVars": "Track a custom variable for each page view",
         "JSTracking_PageCustomVarsDesc": "For example, with variable name \"Category\" and value \"White Papers\".",
+        "JSTracking_TrackNoScript": "Track users with JavaScript disabled",
         "JSTracking_VisitorCustomVars": "Track custom variables for this visitor",
         "JSTracking_VisitorCustomVarsDesc": "For example, with variable name \"Type\" and value \"Customer\".",
         "JSTrackingIntro1": "You can track visitors to your website many different ways. The recommended way to do it is through JavaScript. To use this method you must make sure every webpage of your website has some JavaScript code, which you can generate here.",

--- a/plugins/CoreAdminHome/templates/trackingCodeGenerator.twig
+++ b/plugins/CoreAdminHome/templates/trackingCodeGenerator.twig
@@ -80,6 +80,14 @@
                  value="" inline-help="#jsTrackAllAliasesInlineHelp">
             </div>
 
+            <div piwik-field uicontrol="checkbox" name="javascript-tracking-noscript"
+                 ng-model="jsTrackingCode.trackNoScript"
+                 ng-change="jsTrackingCode.updateTrackingCode()"
+                 disabled="jsTrackingCode.isLoading"
+                 title="{{ 'CoreAdminHome_JSTracking_TrackNoScript'|translate|e('html_attr') }}"
+                 value="" inline-help="">
+            </div>
+
             <h3>{{ 'Mobile_Advanced'|translate }}</h3>
 
             <p>

--- a/plugins/CoreAdminHome/templates/trackingCodeGenerator.twig
+++ b/plugins/CoreAdminHome/templates/trackingCodeGenerator.twig
@@ -103,7 +103,6 @@
 
                 {# visitor custom variable #}
                 <div piwik-field uicontrol="checkbox" name="javascript-tracking-visitor-cv-check"
-                     class="section-toggler-link"
                      ng-model="jsTrackingCode.trackCustomVars"
                      ng-change="jsTrackingCode.updateTrackingCode()"
                      disabled="jsTrackingCode.isLoading"

--- a/plugins/Morpheus/templates/javascriptCode.twig
+++ b/plugins/Morpheus/templates/javascriptCode.twig
@@ -1,6 +1,7 @@
 <!-- Piwik -->
 <script type="text/javascript">
   var _paq = _paq || [];
+  // tracker methods like "setCustomDimension" should be called before "trackPageView"
 {$options}  _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
@@ -14,5 +15,6 @@
 </script>
 {% if not loadAsync %}<script type='text/javascript' src="{$protocol}{$piwikUrl}/piwik.js"></script>
 {% endif %}
-<noscript><p><img src="{$protocol}{$piwikUrl}/piwik.php?idsite={$idSite}" style="border:0;" alt="" /></p></noscript>
+{% if trackNoScript %}<noscript><p><img src="{$protocol}{$piwikUrl}/piwik.php?idsite={$idSite}&rec=1" style="border:0;" alt="" /></p></noscript>
+{% endif %}
 <!-- End Piwik Code -->

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -101,7 +101,7 @@ class API extends \Piwik\Plugin\API
     public function getJavascriptTag($idSite, $piwikUrl = '', $mergeSubdomains = false, $groupPageTitlesByDomain = false,
                                      $mergeAliasUrls = false, $visitorCustomVariables = false, $pageCustomVariables = false,
                                      $customCampaignNameQueryParam = false, $customCampaignKeywordParam = false,
-                                     $doNotTrack = false, $disableCookies = false, $`` = false)
+                                     $doNotTrack = false, $disableCookies = false, $trackNoScript = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -95,12 +95,13 @@ class API extends \Piwik\Plugin\API
      * @param bool $customCampaignKeywordParam
      * @param bool $doNotTrack
      * @param bool $disableCookies
+     * @param bool $trackNoScript
      * @return string The Javascript tag ready to be included on the HTML pages
      */
     public function getJavascriptTag($idSite, $piwikUrl = '', $mergeSubdomains = false, $groupPageTitlesByDomain = false,
                                      $mergeAliasUrls = false, $visitorCustomVariables = false, $pageCustomVariables = false,
                                      $customCampaignNameQueryParam = false, $customCampaignKeywordParam = false,
-                                     $doNotTrack = false, $disableCookies = false)
+                                     $doNotTrack = false, $disableCookies = false, $`` = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
@@ -120,7 +121,7 @@ class API extends \Piwik\Plugin\API
         $code = $generator->generate($idSite, $piwikUrl, $mergeSubdomains, $groupPageTitlesByDomain,
                                      $mergeAliasUrls, $visitorCustomVariables, $pageCustomVariables,
                                      $customCampaignNameQueryParam, $customCampaignKeywordParam,
-                                     $doNotTrack, $disableCookies);
+                                     $doNotTrack, $disableCookies, $trackNoScript);
         $code = str_replace(array('<br>', '<br />', '<br/>'), '', $code);
         return $code;
     }

--- a/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
@@ -26,11 +26,12 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
             $visitorCustomVariables = array(array("name", "value"), array("name 2", "value 2")),
             $pageCustomVariables = array(array("page cvar", "page cvar value")),
             $customCampaignNameQueryParam = "campaignKey", $customCampaignKeywordParam = "keywordKey",
-            $doNotTrack = true);
+            $doNotTrack = true, $disableCookies = false, $trackNoScript = true);
 
         $expected = "&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
+  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   // you can set up to 5 custom variables for each visitor
   _paq.push([\"setCustomVariable\", 1, \"name\", \"value\", \"visit\"]);
@@ -50,7 +51,33 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
-&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//localhost/piwik/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
+&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//localhost/piwik/piwik.php?idsite=1&amp;rec=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
+&lt;!-- End Piwik Code --&gt;
+";
+
+        $this->assertEquals($expected, $jsTag);
+    }
+
+    public function testJavascriptTrackingCode_noScriptTrackingDisabled_defaultTrackingCode()
+    {
+        $generator = new TrackerCodeGenerator();
+
+        $jsTag = $generator->generate($idSite = 1, $piwikUrl = 'http://localhost/piwik');
+
+        $expected = "&lt;!-- Piwik --&gt;
+&lt;script type=&quot;text/javascript&quot;&gt;
+  var _paq = _paq || [];
+  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u=&quot;//localhost/piwik/&quot;;
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+&lt;/script&gt;
 &lt;!-- End Piwik Code --&gt;
 ";
 
@@ -78,6 +105,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = "&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
+  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   // you can set up to 5 custom variables for each visitor
   _paq.push([\"setCustomVariable\", 1, \"name\", \"value\", \"visit\"]);
@@ -97,7 +125,6 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
-&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;https://localhost/piwik/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
 &lt;!-- End Piwik Code --&gt;
 ";
 
@@ -125,6 +152,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = "&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
+  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   // you can set up to 5 custom variables for each visitor
   _paq.push([\"setCustomVariable\", 1, \"name\", \"value\", \"visit\"]);
@@ -145,7 +173,6 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
-&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//localhost/piwik/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
 &lt;!-- End Piwik Code --&gt;
 ";
 
@@ -169,6 +196,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = "&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
+  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
@@ -180,7 +208,6 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
   })();
 &lt;/script&gt;
 &lt;script type='text/javascript' src=&quot;//localhost/piwik/piwik.js&quot;&gt;&lt;/script&gt;
-&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//localhost/piwik/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
 &lt;!-- End Piwik Code --&gt;
 ";
 
@@ -206,6 +233,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = '&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
+  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
   _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
   // you can set up to 5 custom variables for each visitor
   _paq.push(["setCustomVariable", 1, "abc\"def", "abc\"def", "visit"]);
@@ -223,7 +251,6 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src=u+\'piwik.js\'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
-&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//abc&quot;def/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
 &lt;!-- End Piwik Code --&gt;
 ';
 

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
@@ -2,6 +2,7 @@
 <result>&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
+  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
@@ -12,6 +13,5 @@
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
-&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//example.org/piwik/piwik.php?idsite=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
 &lt;!-- End Piwik Code --&gt;
 </result>

--- a/tests/UI/expected-screenshots/Installation_js_tracking.png
+++ b/tests/UI/expected-screenshots/Installation_js_tracking.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7abe83847ecf91c2c210116a8f3125276ca2eccf08ac9344fc31737f8c18bf9
-size 190033
+oid sha256:05078353764c65c355af7f3b96a2948be8a89f75d1ffe508209354b50b095b7d
+size 188228

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_manage_tracking_code.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_manage_tracking_code.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:231f951986687e6a47c094ac6b9fa2635a9a95758a819bd228c9ae97601c0c25
-size 304254
+oid sha256:bb4d3d2f549fe303574fd4c0df7c332f49e74701ec9211d4b39dc307ad9692fd
+size 306805


### PR DESCRIPTION
fix #10797

Removing noscript by default does not break API as it was not working before anyway because we did not set `&rec=1`. If we enabled noScript by default we would break API as we would suddenly record that data.