### PR TITLE
Some characters in titles appear encoded

### DIFF
--- a/plugins/API/templates/listAllAPI.twig
+++ b/plugins/API/templates/listAllAPI.twig
@@ -10,7 +10,7 @@
 {% block content %}
 
 <div class="api-list">
-    <div piwik-content-block content-title="{{ title|e('html_attr') }}" rate="true">
+    <div piwik-content-block content-title="{{ title }}" rate="true">
         <p>{{ 'API_PluginDescription'|translate }}</p>
 
         <p>


### PR DESCRIPTION
fixes #10663

`e('html_attr')` is not needed as it is a plain translation anyway