### PR TITLE
Fix a visualization of a title might not be shown in the dashboard

### DIFF
--- a/plugins/CoreHome/angularjs/widget-container/widgetcontainer.directive.js
+++ b/plugins/CoreHome/angularjs/widget-container/widgetcontainer.directive.js
@@ -32,12 +32,13 @@
                 return function (scope, element, attrs, ngModel) {
                     scope.$watch('container', function (container) {
                         if (container && container.widgets && container.widgets[0] && container.widgets[0].parameters) {
-                            var isWidgetized = container.widgets[0].parameters.widget == '1';
+                            var widget = container.widgets[0];
+                            var isWidgetized = widget.parameters.widget == '1';
 
-                            if (isWidgetized) {
-                                container.widgets[0].parameters.showtitle = '0';
+                            if (isWidgetized && widget.viewDataTable && widget.viewDataTable == 'graphEvolution') {
+                                // we hide the first title for Visits Overview with Graph and Goal Overview
+                                widget.parameters.showtitle = '0';
                             }
-
                         }
                     });
                 }


### PR DESCRIPTION
The logic below was needed to hide the title in "Visits Overview with graph" and "Goals Overview" to not show a headline above the evolution graph. However, we should only disable the title when it is an evolution graph, in all cases we should show it. We had a problem where the first title was not visible in the dashboard. In that case, there was no evolution graph in the beginning and it should show the title.