### PR TITLE
always unescape escaped % symbols in translations

### DIFF
--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -84,7 +84,7 @@ class Translator
         }
 
         if (count($args) == 0) {
-            return $translationId;
+            return str_replace('%%', '%', $translationId);
         }
         return vsprintf($translationId, $args);
     }

--- a/lang/en.json
+++ b/lang/en.json
@@ -70,7 +70,7 @@
         "ColumnPageBounceRateDocumentation": "The percentage of visits that started on this page and left the website straight away.",
         "ColumnPageviews": "Pageviews",
         "ColumnPageviewsDocumentation": "The number of times this page was visited.",
-        "ColumnPercentageVisits": "% Visits",
+        "ColumnPercentageVisits": "%% Visits",
         "ColumnRevenue": "Revenue",
         "ColumnSumVisitLength": "Total time spent by visitors (in seconds)",
         "ColumnTotalPageviews": "Total Pageviews",

--- a/plugins/Actions/lang/en.json
+++ b/plugins/Actions/lang/en.json
@@ -18,7 +18,7 @@
         "ColumnSearchCategory": "Search Category",
         "ColumnSearches": "Searches",
         "ColumnSearchesDocumentation": "The number of visits that searched for this keyword on your website's search engine.",
-        "ColumnSearchExits": "% Search Exits",
+        "ColumnSearchExits": "%% Search Exits",
         "ColumnSearchExitsDocumentation": "The percentage of visits that left the website after searching for this Keyword on your Site Search engine.",
         "ColumnSearchResultsCount": "Search Results Count",
         "ColumnSiteSearchKeywords": "Unique Keywords",

--- a/plugins/LanguagesManager/Test/Integration/LanguagesManagerTest.php
+++ b/plugins/LanguagesManager/Test/Integration/LanguagesManagerTest.php
@@ -156,6 +156,32 @@ class LanguagesManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * check all english translations do not contain unescaped % symbols
+     *
+     * @group Plugins
+     * @group numbered2
+     */
+    function testTranslationsUseEscapedPercentSigns()
+    {
+        Cache::flushAll();
+        $translator = StaticContainer::get('Piwik\Translation\Translator');
+        $translator->reset();
+        Translate::loadAllTranslations();
+        $translations = $translator->getAllTranslations();
+        foreach ($translations AS $plugin => $pluginTranslations) {
+            if ($plugin == 'Intl') {
+                continue; // skip generated stuff
+            }
+            foreach ($pluginTranslations as $key => $pluginTranslation) {
+                $pluginTranslation = preg_replace('/(%(?:[1-9]\$)?[a-z])/', '', $pluginTranslation); // remove placeholders
+                $pluginTranslation = str_replace('%%', '', $pluginTranslation); // remove already escaped symbols
+                $this->assertEquals(0, substr_count($pluginTranslation, '%'),
+                    sprintf('%s.%s must use escaped %% symbols', $plugin, $key));
+            }
+        }
+    }
+
+    /**
      * test English short name for language
      *
      * @group Plugins


### PR DESCRIPTION
Using unescaped % symbols in translations can cause problems on transifex: see #10877

Currently escaped % weren't always unescaped.

fixes #10877