### PR TITLE
Email reports: prevent errors when report is generated in some asian language in some cases

### DIFF
--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -365,7 +365,7 @@ class ProcessedReport
 
 	if (function_exists('mb_substr')) {
             foreach ($columns as &$name) {
-                if (substr($name, 0, 1) === mb_substr($name, 0, 1) {
+                if (substr($name, 0, 1) === mb_substr($name, 0, 1)) {
 		    $name = ucfirst($name);
 		}
             }

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -363,9 +363,13 @@ class ProcessedReport
 
         list($newReport, $columns, $rowsMetadata, $totals) = $this->handleTableReport($idSite, $dataTable, $reportMetadata, $showRawMetrics, $formatMetrics);
 
-        foreach ($columns as &$name) {
-            $name = ucfirst($name);
-        }
+	if (function_exists('mb_substr)) {
+            foreach ($columns as &$name) {
+                if (substr($name, 0, 1) === mb_substr($name, 0, 1) {
+		    $name = ucfirst($name);
+		}
+            }
+	}
         $website = new Site($idSite);
 
         $period = Period\Factory::build($period, $date);

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -363,7 +363,7 @@ class ProcessedReport
 
         list($newReport, $columns, $rowsMetadata, $totals) = $this->handleTableReport($idSite, $dataTable, $reportMetadata, $showRawMetrics, $formatMetrics);
 
-	if (function_exists('mb_substr)) {
+	if (function_exists('mb_substr')) {
             foreach ($columns as &$name) {
                 if (substr($name, 0, 1) === mb_substr($name, 0, 1) {
 		    $name = ucfirst($name);


### PR DESCRIPTION
Update ProcessedReport function
before doing ucfirst, check if it's a multi-byte letter (like asian language).
If it's, then avoid doing ucfirst.