### PR TITLE
Add LoginLdap plugin as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,6 +46,10 @@
 	path = plugins/Bandwidth
 	url = https://github.com/piwik/plugin-Bandwidth.git
     branch = master
+[submodule "plugins/LoginLdap"]
+	path = plugins/LoginLdap
+	url = https://github.com/piwik/plugin-LoginLdap.git
+    branch = master
 
 
 # Add new Plugin submodule above this line ^^

--- a/tests/PHPUnit/Framework/TestingEnvironmentVariables.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentVariables.php
@@ -104,6 +104,7 @@ class TestingEnvironmentVariables
 
         $disabledPlugins = $pluginList->getCorePluginsDisabledByDefault();
         $disabledPlugins[] = 'LoginHttpAuth';
+        $disabledPlugins[] = 'LoginLdap';
         $disabledPlugins[] = 'ExampleVisualization';
 
         $disabledPlugins = array_diff($disabledPlugins, array(

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0cacebc0fa6fa2aec9920c16311d1ea10a0770d787967f0f411d2b3b172c4ed2
-size 956270
+oid sha256:b87d0f7d76690c781b1523647632c90cffa2b7bd75af2c9c63e0ccb849db695e
+size 973500

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e89dec188dfd22ab45968c14547eaa831fb78d0621fff7807d423fab6bf0894f
-size 4193113
+oid sha256:64daa79a981cc4fa26baa2b88a4883bcc23a28e291bfaa14855b1c075a0888e6
+size 4233315

--- a/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ead27f2a738167a13047f24e34ed56914b3aee1dd0ca473e635d25e6a3af1e38
-size 193129
+oid sha256:ce4997e90ad02cac0b258440b26181a3dab713c9fbabfab71156d37c1ac69d3b
+size 196162


### PR DESCRIPTION
Thanks to @sgiehl for making LoginLdap compatible with Piwik 3, we can now add the plugin as a submodule. This refs https://github.com/piwik/piwik/issues/10625 and may even fix the issue, as this should be the last plugin to add as submodule :+1: 