### PR TITLE
Make sure to ignore free plugins when checking for license

### DIFF
--- a/plugins/Marketplace/Plugins/InvalidLicenses.php
+++ b/plugins/Marketplace/Plugins/InvalidLicenses.php
@@ -190,7 +190,7 @@ class InvalidLicenses
         if (!empty($paidPlugins)) {
             foreach ($paidPlugins as $plugin) {
                 
-                if (empty($plugin['isPaid'])) {
+                if (!empty($plugin['isFree'])) {
                     continue;
                 }
                 

--- a/plugins/Marketplace/Plugins/InvalidLicenses.php
+++ b/plugins/Marketplace/Plugins/InvalidLicenses.php
@@ -189,6 +189,11 @@ class InvalidLicenses
 
         if (!empty($paidPlugins)) {
             foreach ($paidPlugins as $plugin) {
+                
+                if (empty($plugin['isPaid'])) {
+                    continue;
+                }
+                
                 $pluginName = $plugin['name'];
                 if ($this->isPluginActivated($pluginName)) {
                     if (empty($plugin['consumer']['license'])) {


### PR DESCRIPTION
2.X PR for https://github.com/piwik/piwik/pull/10940 

Some users see a license warning for a free GPL plugin see https://forum.piwik.org/t/license-missing-of-a-free-glp-plugin/21674/6. I have spent hours trying to understand how this could possibly happen over the last weeks but not sure how it happens. It must be some kind of caching issue with a certain PHP version or something. This change might not fix the actual issue but is a good check to have on top to check for invalid licenses only if it is not a free plugin.