### PR TITLE
Fix a bug where Piwik returns wrong rows by label

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -247,8 +247,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      *
      * @var bool
      */
-    protected $
-        dexContinuously = false;
+    protected $rebuildIndexContinuously = false;
 
     /**
      * Column name of last time the table was sorted

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -247,7 +247,8 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      *
      * @var bool
      */
-    protected $rebuildIndexContinuously = false;
+    protected $
+        dexContinuously = false;
 
     /**
      * Column name of last time the table was sorted
@@ -698,6 +699,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function rebuildIndex()
     {
+        $this->rowsIndexByLabel = array();
         $this->rebuildIndexContinuously = true;
 
         foreach ($this->rows as $id => $row) {

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -107,6 +107,35 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($table2->getRowFromIdSubDataTable($idTable3), $table2->getLastRow());
     }
 
+    public function test_rebuildIndex()
+    {
+        $labels = array(0 => 'abc', 1 => 'def', 2 => 'ghi', 3 => 'jkl', 4 => 'mno');
+        $table = new DataTable();
+
+        $rows = array();
+        foreach ($labels as $label) {
+            $row = new Row(array(Row::COLUMNS => array('label' => $label)));
+            $table->addRow($row);
+            $rows[] = $row;
+        }
+
+        foreach ($labels as $label) {
+            $rowVerify1 = $table->getRowFromLabel($label);
+            $this->assertSame($label, $rowVerify1->getColumn('label'));
+        }
+
+        $table->setRows(array($rows[2], $rows[3], $rows[4]));
+        $table->rebuildIndex();// rebuildindex would be called anyway but we force rebuilding the index just to make sure
+
+        // verify still accessible
+        $rowVerify1 = $table->getRowFromLabel('ghi');
+        $this->assertSame('ghi', $rowVerify1->getColumn('label'));
+
+        // verify no longer accessible
+        $rowVerify3 = $table->getRowFromLabel('abc');
+        $this->assertFalse($rowVerify3);
+    }
+
     public function test_clone_shouldIncreasesTableId()
     {
         $table = new DataTable;


### PR DESCRIPTION
I have just spent a couple of hours remote debugging a bug that I couldn't reproduce. Imaging you limit a data table and remove some rows.

Later you call `$table->getRowFromLabel('foobar');` then it might still have the id mapped in `$this->rowsIndexByLabel` even though the actual column was removed. Ideally, when a row is deleted, we would also delete the map from `$this->rowsIndexByLabel` directly. Naturally you would think a `$table->setLabelsHaveChanged()`would fix this but I noticed it does actually not unset all previously stored links so under circumstances `$table->getRowFromLabel('foobar');` might actually return a row with a completely different label. This is especially problematic when eg trying to rename something like `Archiver::LABEL_NOT_DEFINED`. In this case a completely different row was renamed to "Not defined"

This could actually explain a couple of odd issues and may be worth merging into Piwik 2 as well.