### PR TITLE
Make LogAggregator::getWhereStatement public

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -473,7 +473,7 @@ class LogAggregator
         return in_array($metricId, $metricsRequested);
     }
 
-    protected function getWhereStatement($tableName, $datetimeField, $extraWhere = false)
+    public function getWhereStatement($tableName, $datetimeField, $extraWhere = false)
     {
         $where = "$tableName.$datetimeField >= ?
 				AND $tableName.$datetimeField <= ?


### PR DESCRIPTION
When using `generateQuery()` in to archive reports it will automatically bind parameters from `getGeneralQueryBindParams()`. This works only when also applying the matching where statement that is generated by `getWhereStatement()`. Therefore the method needs to be public, otherwise `generateQuery()` is not really useful and may invalidate many plugins over time.