### PR TITLE
After Updating/Deleting/Adding a segment, force a refresh of the dashboard

### DIFF
--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -1278,28 +1278,7 @@ $(document).ready(function() {
             segmentDefinition = cleanupSegmentDefinition(segmentDefinition);
             segmentDefinition = encodeURIComponent(segmentDefinition);
 
-            if (piwikHelper.isAngularRenderingThePage()) {
-
-                angular.element(document).injector().invoke(function ($location, $rootScope) {
-                    var $search = $location.search();
-
-                    if (segmentDefinition !== $search.segment) {
-                        // eg when using back button the date might be actually already changed in the URL and we do not
-                        // want to change the URL again
-                        $search.segment = segmentDefinition.replace(/%$/, '%25').replace(/%([^\d].)/g, "%25$1");
-                        $location.search($search);
-                        setTimeout(function () {
-                            try {
-                                $rootScope.$apply();
-                            } catch (e) {}
-                        }, 1);
-                    }
-
-                });
-                return false;
-            } else {
-                return broadcast.propagateNewPage('segment=' + segmentDefinition, true);
-            }
+            return broadcast.propagateNewPage('segment=' + segmentDefinition, true);
         };
 
         this.changeSegmentList = function () {};


### PR DESCRIPTION
the refresh is  currently needed for not only this one bug, but other bugs as well. The Segmentation editor JS was not implemented in a modern way and segment listing is buggy without the page reload after a change to segments. 

Later sometime we'll rewrite the Segment Editor in AngularJS later so this reload will not be needed and the segment editor will be responsive and easy to use on mobile.

fixes https://github.com/piwik/piwik/issues/10626
Reverting https://github.com/piwik/piwik/commit/5daf6c2388693746f2a47a9e6c31276d0b423a4f
part of https://github.com/piwik/piwik/commit/0c9c30b731ccbacf47e154b9f7a590af49e3d799