### PR TITLE
Add a system test reproducing #10857 

### DIFF
--- a/tests/PHPUnit/Fixtures/TwoSitesTwoVisitorsDifferentDays.php
+++ b/tests/PHPUnit/Fixtures/TwoSitesTwoVisitorsDifferentDays.php
@@ -135,7 +135,8 @@ class TwoSitesTwoVisitorsDifferentDays extends Fixture
             // Temporary, until we implement 1st party cookies in PiwikTracker
             $visitorB->DEBUG_APPEND_URL .= '&_idvc=2&_viewts=' . Date::factory($dateTime)->getTimestamp();
 
-            $visitorB->setUrlReferrer('http://referrer.com/Other_Page.htm');
+            $protocol = (0 === $days % 2) ? 'http' : 'https';
+            $visitorB->setUrlReferrer($protocol . '://referrer.com/Other_Page.htm');
             if( in_array($days, array(2,3,4,$daysToGenerateVisitsFor-1)) ) {
                 $visitorB->setUrl( self::URL_IS_GOAL_WITH_CAMPAIGN_PARAMETERS );
             } else {

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Referrers.getWebsites_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Referrers.getWebsites_day.xml
@@ -72,7 +72,7 @@
 				<segment>referrerName==referrer.com</segment>
 				<subtable>
 					<row>
-						<label>http://referrer.com/Other_Page.htm</label>
+						<label>https://referrer.com/Other_Page.htm</label>
 						<nb_uniq_visitors>1</nb_uniq_visitors>
 						<nb_visits>1</nb_visits>
 						<nb_actions>5</nb_actions>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Referrers.getWebsites_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Referrers.getWebsites_month.xml
@@ -16,13 +16,13 @@
 				<subtable>
 					<row>
 						<label>http://referrer.com/Other_Page.htm</label>
-						<nb_visits>4</nb_visits>
-						<nb_actions>20</nb_actions>
+						<nb_visits>2</nb_visits>
+						<nb_actions>10</nb_actions>
 						<max_actions>5</max_actions>
-						<sum_visit_length>3604</sum_visit_length>
+						<sum_visit_length>1802</sum_visit_length>
 						<bounce_count>0</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
-						<sum_daily_nb_uniq_visitors>4</sum_daily_nb_uniq_visitors>
+						<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 						<sum_daily_nb_users>0</sum_daily_nb_users>
 					</row>
 					<row>
@@ -32,6 +32,17 @@
 						<max_actions>1</max_actions>
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>2</bounce_count>
+						<nb_visits_converted>0</nb_visits_converted>
+						<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+						<sum_daily_nb_users>0</sum_daily_nb_users>
+					</row>
+					<row>
+						<label>https://referrer.com/Other_Page.htm</label>
+						<nb_visits>2</nb_visits>
+						<nb_actions>10</nb_actions>
+						<max_actions>5</max_actions>
+						<sum_visit_length>1802</sum_visit_length>
+						<bounce_count>0</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
 						<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 						<sum_daily_nb_users>0</sum_daily_nb_users>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Referrers.getWebsites_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Referrers.getWebsites_week.xml
@@ -42,14 +42,25 @@
 				<segment>referrerName==referrer.com</segment>
 				<subtable>
 					<row>
-						<label>http://referrer.com/Other_Page.htm</label>
-						<nb_visits>3</nb_visits>
-						<nb_actions>15</nb_actions>
+						<label>https://referrer.com/Other_Page.htm</label>
+						<nb_visits>2</nb_visits>
+						<nb_actions>10</nb_actions>
 						<max_actions>5</max_actions>
-						<sum_visit_length>2703</sum_visit_length>
+						<sum_visit_length>1802</sum_visit_length>
 						<bounce_count>0</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
-						<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
+						<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+						<sum_daily_nb_users>0</sum_daily_nb_users>
+					</row>
+					<row>
+						<label>http://referrer.com/Other_Page.htm</label>
+						<nb_visits>1</nb_visits>
+						<nb_actions>5</nb_actions>
+						<max_actions>5</max_actions>
+						<sum_visit_length>901</sum_visit_length>
+						<bounce_count>0</bounce_count>
+						<nb_visits_converted>0</nb_visits_converted>
+						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 						<sum_daily_nb_users>0</sum_daily_nb_users>
 					</row>
 					<row>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Referrers.getWebsites_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays__Referrers.getWebsites_year.xml
@@ -16,13 +16,13 @@
 				<subtable>
 					<row>
 						<label>http://referrer.com/Other_Page.htm</label>
-						<nb_visits>4</nb_visits>
-						<nb_actions>20</nb_actions>
+						<nb_visits>2</nb_visits>
+						<nb_actions>10</nb_actions>
 						<max_actions>5</max_actions>
-						<sum_visit_length>3604</sum_visit_length>
+						<sum_visit_length>1802</sum_visit_length>
 						<bounce_count>0</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
-						<sum_daily_nb_uniq_visitors>4</sum_daily_nb_uniq_visitors>
+						<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 						<sum_daily_nb_users>0</sum_daily_nb_users>
 					</row>
 					<row>
@@ -32,6 +32,17 @@
 						<max_actions>1</max_actions>
 						<sum_visit_length>0</sum_visit_length>
 						<bounce_count>2</bounce_count>
+						<nb_visits_converted>0</nb_visits_converted>
+						<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+						<sum_daily_nb_users>0</sum_daily_nb_users>
+					</row>
+					<row>
+						<label>https://referrer.com/Other_Page.htm</label>
+						<nb_visits>2</nb_visits>
+						<nb_actions>10</nb_actions>
+						<max_actions>5</max_actions>
+						<sum_visit_length>1802</sum_visit_length>
+						<bounce_count>0</bounce_count>
 						<nb_visits_converted>0</nb_visits_converted>
 						<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 						<sum_daily_nb_users>0</sum_daily_nb_users>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Referrers.getWebsites_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Referrers.getWebsites_day.xml
@@ -71,7 +71,7 @@
 			<segment>referrerName==referrer.com</segment>
 			<subtable>
 				<row>
-					<label>http://referrer.com/Other_Page.htm</label>
+					<label>https://referrer.com/Other_Page.htm</label>
 					<nb_uniq_visitors>1</nb_uniq_visitors>
 					<nb_visits>1</nb_visits>
 					<nb_actions>5</nb_actions>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Referrers.getWebsites_month.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Referrers.getWebsites_month.xml
@@ -15,13 +15,13 @@
 			<subtable>
 				<row>
 					<label>http://referrer.com/Other_Page.htm</label>
-					<nb_visits>4</nb_visits>
-					<nb_actions>20</nb_actions>
+					<nb_visits>2</nb_visits>
+					<nb_actions>10</nb_actions>
 					<max_actions>5</max_actions>
-					<sum_visit_length>3604</sum_visit_length>
+					<sum_visit_length>1802</sum_visit_length>
 					<bounce_count>0</bounce_count>
 					<nb_visits_converted>0</nb_visits_converted>
-					<sum_daily_nb_uniq_visitors>4</sum_daily_nb_uniq_visitors>
+					<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 					<sum_daily_nb_users>0</sum_daily_nb_users>
 				</row>
 				<row>
@@ -31,6 +31,17 @@
 					<max_actions>1</max_actions>
 					<sum_visit_length>0</sum_visit_length>
 					<bounce_count>2</bounce_count>
+					<nb_visits_converted>0</nb_visits_converted>
+					<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+					<sum_daily_nb_users>0</sum_daily_nb_users>
+				</row>
+				<row>
+					<label>https://referrer.com/Other_Page.htm</label>
+					<nb_visits>2</nb_visits>
+					<nb_actions>10</nb_actions>
+					<max_actions>5</max_actions>
+					<sum_visit_length>1802</sum_visit_length>
+					<bounce_count>0</bounce_count>
 					<nb_visits_converted>0</nb_visits_converted>
 					<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 					<sum_daily_nb_users>0</sum_daily_nb_users>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Referrers.getWebsites_week.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Referrers.getWebsites_week.xml
@@ -41,14 +41,25 @@
 			<segment>referrerName==referrer.com</segment>
 			<subtable>
 				<row>
-					<label>http://referrer.com/Other_Page.htm</label>
-					<nb_visits>3</nb_visits>
-					<nb_actions>15</nb_actions>
+					<label>https://referrer.com/Other_Page.htm</label>
+					<nb_visits>2</nb_visits>
+					<nb_actions>10</nb_actions>
 					<max_actions>5</max_actions>
-					<sum_visit_length>2703</sum_visit_length>
+					<sum_visit_length>1802</sum_visit_length>
 					<bounce_count>0</bounce_count>
 					<nb_visits_converted>0</nb_visits_converted>
-					<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
+					<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+					<sum_daily_nb_users>0</sum_daily_nb_users>
+				</row>
+				<row>
+					<label>http://referrer.com/Other_Page.htm</label>
+					<nb_visits>1</nb_visits>
+					<nb_actions>5</nb_actions>
+					<max_actions>5</max_actions>
+					<sum_visit_length>901</sum_visit_length>
+					<bounce_count>0</bounce_count>
+					<nb_visits_converted>0</nb_visits_converted>
+					<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 					<sum_daily_nb_users>0</sum_daily_nb_users>
 				</row>
 				<row>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Referrers.getWebsites_year.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_idSiteOne___Referrers.getWebsites_year.xml
@@ -15,13 +15,13 @@
 			<subtable>
 				<row>
 					<label>http://referrer.com/Other_Page.htm</label>
-					<nb_visits>4</nb_visits>
-					<nb_actions>20</nb_actions>
+					<nb_visits>2</nb_visits>
+					<nb_actions>10</nb_actions>
 					<max_actions>5</max_actions>
-					<sum_visit_length>3604</sum_visit_length>
+					<sum_visit_length>1802</sum_visit_length>
 					<bounce_count>0</bounce_count>
 					<nb_visits_converted>0</nb_visits_converted>
-					<sum_daily_nb_uniq_visitors>4</sum_daily_nb_uniq_visitors>
+					<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 					<sum_daily_nb_users>0</sum_daily_nb_users>
 				</row>
 				<row>
@@ -31,6 +31,17 @@
 					<max_actions>1</max_actions>
 					<sum_visit_length>0</sum_visit_length>
 					<bounce_count>2</bounce_count>
+					<nb_visits_converted>0</nb_visits_converted>
+					<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+					<sum_daily_nb_users>0</sum_daily_nb_users>
+				</row>
+				<row>
+					<label>https://referrer.com/Other_Page.htm</label>
+					<nb_visits>2</nb_visits>
+					<nb_actions>10</nb_actions>
+					<max_actions>5</max_actions>
+					<sum_visit_length>1802</sum_visit_length>
+					<bounce_count>0</bounce_count>
 					<nb_visits_converted>0</nb_visits_converted>
 					<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 					<sum_daily_nb_users>0</sum_daily_nb_users>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_csv__ScheduledReports.generateReport_month.original.csv
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_csv__ScheduledReports.generateReport_month.original.csv
@@ -334,7 +334,8 @@ No data available
 
 Websites
 label,nb_visits,nb_actions,nb_actions_per_visit,avg_time_on_site,bounce_rate,revenue
-referrer.com/Other_Page.htm,4,20,5,00:15:01,0%,$ 0
+referrer.com/Other_Page.htm,2,10,5,00:15:01,0%,$ 0
+referrer.com/Other_Page.htm,2,10,5,00:15:01,0%,$ 0
 referrer.com/page.htm?param=valuewith some spaces,2,2,1,00:00:00,100%,$ 0
 
 Social Networks

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_month.original.html
@@ -5033,10 +5033,10 @@
                                                                         referrer.com/Other_Page.htm                                                                            </a>
                                                                                                                         </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                4
+                                                                                                2
                                                                                     </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
-                                                                                                20
+                                                                                                10
                                                                                     </td>
                                             <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
                                                                                                 5
@@ -5053,6 +5053,31 @@
                                     </tr>
                             
                                                                     <tr style=";line-height: 22px;">
+                                                                <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
+                                                                                                                                                                            <a style="color: rgb(13,13,13);" href='https://referrer.com/Other_Page.htm'>
+                                                                        referrer.com/Other_Page.htm                                                                            </a>
+                                                                                                                        </td>
+                                            <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
+                                                                                                2
+                                                                                    </td>
+                                            <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
+                                                                                                10
+                                                                                    </td>
+                                            <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
+                                                                                                5
+                                                                                    </td>
+                                            <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
+                                                                                                00:15:01
+                                                                                    </td>
+                                            <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
+                                                                                                0%
+                                                                                    </td>
+                                            <td style="font-size: 13px; border-left: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
+                                                                                                $ 0
+                                                                                    </td>
+                                    </tr>
+                            
+                                                                    <tr style="background-color: rgb(242,242,242);line-height: 22px;">
                                                                 <td style="font-size: 13px; border-right: 1px solid rgb(217,217,217);  padding: 5px 0 5px 5px;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://referrer.com/page.htm?param=valuewith some spaces'>
                                                                         referrer.com/page.htm?param=valuewith some spaces                                                                            </a>


### PR DESCRIPTION
Add a system test reproducing #10857 -> confirmed that Piwik will track referrers from the same HTTP and HTTPS page as different entries.

