### PR TITLE
Fix propagateNewPage might not actually load the page

### DIFF
--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -338,6 +338,15 @@ var broadcast = {
         // Now load the new page.
         var newUrl = currentSearchStr + currentHashStr;
 
+        var $rootScope = piwikHelper.getAngularDependency('$rootScope');
+        if ($rootScope) {
+            $rootScope.$on('$locationChangeStart', function (event) {
+                if (event) {
+                    event.preventDefault();
+                }
+            })
+        }
+
         if (oldUrl == newUrl) {
             window.location.reload();
         } else {


### PR DESCRIPTION
This is because angular might cancel the url change or listen to it themselves and not reload the page entirely.