### PR TITLE
Fix block quotes are not shown correctly in plugin details

### DIFF
--- a/plugins/Marketplace/stylesheets/plugin-details.less
+++ b/plugins/Marketplace/stylesheets/plugin-details.less
@@ -25,6 +25,12 @@
         background-position: center;
     }
 
+    blockquote {
+        margin: 20px 0;
+        padding-left: 1.5rem;
+        border-left: 5px solid #ee6e73;
+    }
+
     .tab-content ul, .tab-content ol {
         list-style: initial;
         padding-left: 20px;


### PR DESCRIPTION
See Funnels plugin where the first part is a block quote