### PR TITLE
Make sure to trigger Sites.getSites event when a new Site instance is created

### DIFF
--- a/core/Site.php
+++ b/core/Site.php
@@ -65,6 +65,8 @@ class Site
         $this->id = (int)$idsite;
         if (!isset(self::$infoSites[$this->id])) {
             $site = API::getInstance()->getSiteFromId($this->id);
+            $sites = array(&$site);
+            self::triggerSetSitesEvent($sites);
             self::setSiteFromArray($this->id, $site);
         }
     }


### PR DESCRIPTION
Background: In Piwik 2.13 we removed the `Site.setSite` event because it is slow. So in some cases it may not actually trigger a `Sites.setSites` event when a site is loaded. For example when doing `new Site()`. I think in this case we should still trigger that event if the site did not exist yet because we do not call it very often and not in a loop for all sites etc. This is useful since `new Site` is used eg in `Controller` and for such cases we should trigger this event.