### PR TITLE
Allow custom form types for user, system and measurable settings

### DIFF
--- a/core/Settings/FieldConfig.php
+++ b/core/Settings/FieldConfig.php
@@ -92,6 +92,14 @@ class FieldConfig
     public $uiControl = null;
 
     /**
+     * Defines a custom template file for a UI control. This file should render a UI control and expose the value in a
+     * "formField.value" angular model. For an example see "plugins/CorePluginsAdmin/angularjs/form-field/field-text.html"
+     *
+     * @var string
+     */
+    public $customUiControlTemplateFile = '';
+
+    /**
      * Name-value mapping of HTML attributes that will be added HTML form control, eg,
      * `array('size' => 3)`. Attributes will be escaped before outputting.
      *

--- a/plugins/CorePluginsAdmin/SettingsMetadata.php
+++ b/plugins/CorePluginsAdmin/SettingsMetadata.php
@@ -120,6 +120,7 @@ class SettingsMetadata
             'availableValues' => $availableValues,
             'description' => $config->description,
             'inlineHelp' => $config->inlineHelp,
+            'templateFile' => $config->customUiControlTemplateFile,
             'introduction' => $config->introduction,
             'condition' => $config->condition,
         );

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
@@ -23,6 +23,7 @@
 				<availableValues />
 				<description />
 				<inlineHelp>It is recommended, but not required, to specify the various URLs, one per line, that your visitors use to access this website. Alias URLs for a website will not appear in the Referrers &gt; Websites report. Note that it is not necessary to specify the URLs with and without 'www' as Piwik automatically considers both.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -38,6 +39,7 @@
 				<availableValues />
 				<description />
 				<inlineHelp>When enabled, Piwik will only track internal actions when the Page URL is one of the known URLs for your website. This prevents people from spamming your analytics with URLs for other websites.&lt;br /&gt;The domain and the path has to be an exact match and each valid subdomain has to be specified separately. For example when the known URLs are 'http://example.com/path' and 'http://good.example.com', tracking requests for 'http://example.com/otherpath' or 'http://bad.example.com' are ignored.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -57,6 +59,7 @@
 				</availableValues>
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -77,6 +80,7 @@
 				<availableValues />
 				<description />
 				<inlineHelp>Enter the list of IPs, one per line, that you wish to exclude from being tracked by Piwik. You can use wildcards, eg. 1.2.3.* or 1.2.*.*&lt;br /&gt;&lt;br /&gt;Your current IP address is &lt;i&gt;127.0.0.1&lt;/i&gt;</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -97,6 +101,7 @@
 				<availableValues />
 				<description />
 				<inlineHelp>Enter the list of URL Query Parameters, one per line, to exclude from the Page URLs reports. Regular expressions such as /^sess.*|.*[dD]ate$/ are suported.&lt;br /&gt;&lt;br /&gt;Piwik will automatically exclude the common session parameters (phpsessid, sessionid, ...).</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -117,6 +122,7 @@
 				<availableValues />
 				<description />
 				<inlineHelp>Enter the list of user agents to exclude from being tracked by Piwik.&lt;br /&gt;&lt;br /&gt;If the visitor's user agent string contains any of the strings you specify, the visitor will be excluded from Piwik.&lt;br /&gt;You can use this to exclude some bots from being tracked.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -135,6 +141,7 @@
 				</availableValues>
 				<description />
 				<inlineHelp>You can use Piwik to track and report what visitors are searching in your website's internal search engine.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -150,6 +157,7 @@
 				<availableValues />
 				<description>Query parameter (Default): q,query,s,search,searchword,k,keyword &amp; Category parameter: </description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition>1 &amp;&amp; sitesearch</condition>
 			</row>
@@ -168,6 +176,7 @@
 				<availableValues />
 				<description />
 				<inlineHelp>Enter a comma separated list of all query parameter names containing the site search keyword.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition>sitesearch &amp;&amp; !use_default_site_search_params</condition>
 			</row>
@@ -186,6 +195,7 @@
 				<availableValues />
 				<description />
 				<inlineHelp>(optional)&lt;br /&gt;&lt;br /&gt;You may enter a comma-separated list of query parameters specifying the search category.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition>1 &amp;&amp; sitesearch &amp;&amp; !use_default_site_search_params</condition>
 			</row>
@@ -204,6 +214,7 @@
 				</availableValues>
 				<description />
 				<inlineHelp>When enabled, the &quot;Goals&quot; report will have a new &quot;Ecommerce&quot; section.&lt;br /&gt;Piwik allows for advanced Ecommerce Analytics tracking &amp; reporting. Learn more about &lt;a href='http://piwik.org/docs/ecommerce-analytics/' target='_blank'&gt; Ecommerce Analytics&lt;/a&gt;.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -227,6 +238,7 @@
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__CorePluginsAdmin.getSystemSettings.xml
@@ -21,6 +21,7 @@
 				</availableValues>
 				<description />
 				<inlineHelp>While our &lt;a href='?module=Proxy&amp;action=redirect&amp;url=http://piwik.org/participate/development-process/' target='_blank'&gt;development process&lt;/a&gt; includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Piwik.&lt;br/&gt;If Piwik is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a href='?module=Proxy&amp;action=redirect&amp;url=http%3A%2F%2Fdeveloper.piwik.org%2Fguides%2Fcore-team-workflow%23influencing-piwik-development' target='_blank'&gt;see here&lt;/a&gt;.&lt;br /&gt;LTS (Long Term Support) versions receive only security and bug fixes.</inlineHelp>
+				<templateFile />
 				<introduction>Release channel</introduction>
 				<condition />
 			</row>
@@ -39,6 +40,7 @@
 				</availableValues>
 				<description />
 				<inlineHelp>An email will be sent to Super Users when there is a new version available for a plugin.</inlineHelp>
+				<templateFile />
 				<introduction>Send an email when a plugin update is available</introduction>
 				<condition />
 			</row>
@@ -64,6 +66,7 @@
 				</availableValues>
 				<description>Choose the metric that should be displayed in the browser tab</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -91,6 +94,7 @@
 				</availableValues>
 				<description>The value will be only displayed in the following browsers</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -108,6 +112,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>This description will be displayed next to the value</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -123,6 +128,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>Password for the 3rd API where we fetch the value</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -144,6 +150,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If enabled, logged in users can opt out in their plugin settings. Anonymous users cannot opt out.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -159,6 +166,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If enabled, anonymized usage data will be sent to demo-anonymous.piwik.org and the tracked data can be viewed there (the data is public). The collected data is used to improve Piwik. Thank you for making Piwik better!</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction>Send anonmyized usage data to the creators of Piwik</introduction>
 				<condition />
 			</row>
@@ -174,6 +182,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If specified, anonymized usage data will be sent to the specified site in this Piwik.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction>Send anonymize usage data to this Piwik</introduction>
 				<condition />
 			</row>
@@ -189,6 +198,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -205,6 +215,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction>Send anonymize usage data to a custom Piwik</introduction>
 				<condition />
 			</row>
@@ -221,6 +232,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If a URL and Site Id is specified, usage data will be sent to the custom Piwik instance.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -236,6 +248,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -258,6 +271,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>If enabled, the Redis Sentinel feature will be used. Make sure to update host and port if needed. Once you have enabled and saved the change, you will be able to specify multiple hosts and ports comma separated.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -274,6 +288,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>The sentinel master name only needs to be configured if Sentinel is enabled.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -290,6 +305,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Remote host or unix socket of the Redis server. Max 500 characters are allowed.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -306,6 +322,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Port the Redis server is running on. Value should be between 1 and 65535. Use 0 if you are using unix socket to connect to Redis server.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -322,6 +339,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>In case you are using Redis for caching make sure to use a different database.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -338,6 +356,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Password set on the Redis server, if any. Redis can be instructed to require a password before allowing clients to execute commands.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -353,6 +372,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>If enabled, all tracking requests will be written into a queue instead of the directly into the database. Requires a Redis server and phpredis PHP extension.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -369,6 +389,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Number of allowed maximum queue workers. Accepts a number between 1 and 16. Best practice is to set the number of CPUs you want to make available for queue processing. Be aware you need to make sure to start the workers manually. We recommend to not use 9-15 workers, rather use 8 or 16 as the queue might not be distributed evenly into different queues. DO NOT USE more than 1 worker if you make use the UserId feature when tracking see https://github.com/piwik/piwik/issues/7691</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -385,6 +406,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Defines how many requests will be picked out of the queue and processed at once. Enter a number which is &gt;= 1.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -400,6 +422,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>If enabled, we will process all requests within a queue during a normal tracking request once there are enough requests in the queue. This will not slow down the tracking request. If disabled, you have to setup a cronjob that executes the &quot;./console queuedtracking:process&quot; console command eg every minute to process the queue.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__CorePluginsAdmin.getUserSettings.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__CorePluginsAdmin.getUserSettings.xml
@@ -16,6 +16,7 @@
 				<availableValues />
 				<description>If enabled, the value will be automatically refreshed depending on the specified interval</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -32,6 +33,7 @@
 				<availableValues />
 				<description>Defines how often the value should be updated</description>
 				<inlineHelp>Enter a number which is &gt;= 15</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -51,6 +53,7 @@
 				</availableValues>
 				<description>Pick your favourite color</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -72,6 +75,7 @@
 				<availableValues />
 				<description>If enabled, anonymous usage data will be tracked. For example which pages are viewed and which reports are used most often. For more information contact your system administrator.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
@@ -30,6 +30,7 @@
 						<availableValues />
 						<description />
 						<inlineHelp>It is recommended, but not required, to specify the various URLs, one per line, that your visitors use to access this website. Alias URLs for a website will not appear in the Referrers &gt; Websites report. Note that it is not necessary to specify the URLs with and without 'www' as Piwik automatically considers both.</inlineHelp>
+						<templateFile />
 						<introduction />
 						<condition />
 					</row>
@@ -45,6 +46,7 @@
 						<availableValues />
 						<description />
 						<inlineHelp>When enabled, Piwik will only track internal actions when the Page URL is one of the known URLs for your website. This prevents people from spamming your analytics with URLs for other websites.&lt;br /&gt;The domain and the path has to be an exact match and each valid subdomain has to be specified separately. For example when the known URLs are 'http://example.com/path' and 'http://good.example.com', tracking requests for 'http://example.com/otherpath' or 'http://bad.example.com' are ignored.</inlineHelp>
+						<templateFile />
 						<introduction />
 						<condition />
 					</row>
@@ -64,6 +66,7 @@
 						</availableValues>
 						<description />
 						<inlineHelp />
+						<templateFile />
 						<introduction />
 						<condition />
 					</row>
@@ -82,7 +85,8 @@
 						</uiControlAttributes>
 						<availableValues />
 						<description />
-						<inlineHelp>Enter the list of IPs, one per line, that you wish to exclude from being tracked by Piwik. You can use wildcards, eg. 1.2.3.* or 1.2.*.*&lt;br /&gt;&lt;br /&gt;Your current IP address is &lt;i&gt;127.0.0.1&lt;/i&gt;</inlineHelp>
+						<inlineHelp>Enter the list of IPs, one per line, that you wish to exclude from being tracked by Piwik. You can use wildcards, eg. 1.2.3.* or 1.2.*.*&lt;br /&gt;&lt;br /&gt;Your current IP address is &lt;i&gt;192.168.33.11&lt;/i&gt;</inlineHelp>
+						<templateFile />
 						<introduction />
 						<condition />
 					</row>
@@ -102,6 +106,7 @@
 						<availableValues />
 						<description />
 						<inlineHelp>Enter the list of URL Query Parameters, one per line, to exclude from the Page URLs reports. Regular expressions such as /^sess.*|.*[dD]ate$/ are suported.&lt;br /&gt;&lt;br /&gt;Piwik will automatically exclude the common session parameters (phpsessid, sessionid, ...).</inlineHelp>
+						<templateFile />
 						<introduction />
 						<condition />
 					</row>
@@ -121,6 +126,7 @@
 						<availableValues />
 						<description />
 						<inlineHelp>Enter the list of user agents to exclude from being tracked by Piwik.&lt;br /&gt;&lt;br /&gt;If the visitor's user agent string contains any of the strings you specify, the visitor will be excluded from Piwik.&lt;br /&gt;You can use this to exclude some bots from being tracked.</inlineHelp>
+						<templateFile />
 						<introduction />
 						<condition />
 					</row>
@@ -139,6 +145,7 @@
 						</availableValues>
 						<description />
 						<inlineHelp>You can use Piwik to track and report what visitors are searching in your website's internal search engine.</inlineHelp>
+						<templateFile />
 						<introduction />
 						<condition />
 					</row>
@@ -154,6 +161,7 @@
 						<availableValues />
 						<description>Query parameter (Default): q,query,s,search,searchword,k,keyword &amp; Category parameter: </description>
 						<inlineHelp />
+						<templateFile />
 						<introduction />
 						<condition>1 &amp;&amp; sitesearch</condition>
 					</row>
@@ -171,6 +179,7 @@
 						<availableValues />
 						<description />
 						<inlineHelp>Enter a comma separated list of all query parameter names containing the site search keyword.</inlineHelp>
+						<templateFile />
 						<introduction />
 						<condition>sitesearch &amp;&amp; !use_default_site_search_params</condition>
 					</row>
@@ -188,6 +197,7 @@
 						<availableValues />
 						<description />
 						<inlineHelp>(optional)&lt;br /&gt;&lt;br /&gt;You may enter a comma-separated list of query parameters specifying the search category.</inlineHelp>
+						<templateFile />
 						<introduction />
 						<condition>1 &amp;&amp; sitesearch &amp;&amp; !use_default_site_search_params</condition>
 					</row>
@@ -206,6 +216,7 @@
 						</availableValues>
 						<description />
 						<inlineHelp>When enabled, the &quot;Goals&quot; report will have a new &quot;Ecommerce&quot; section.&lt;br /&gt;Piwik allows for advanced Ecommerce Analytics tracking &amp; reporting. Learn more about &lt;a href='http://piwik.org/docs/ecommerce-analytics/' target='_blank'&gt; Ecommerce Analytics&lt;/a&gt;.</inlineHelp>
+						<templateFile />
 						<introduction />
 						<condition />
 					</row>
@@ -229,6 +240,7 @@
 						<availableValues />
 						<description />
 						<inlineHelp />
+						<templateFile />
 						<introduction />
 						<condition />
 					</row>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
@@ -85,7 +85,7 @@
 						</uiControlAttributes>
 						<availableValues />
 						<description />
-						<inlineHelp>Enter the list of IPs, one per line, that you wish to exclude from being tracked by Piwik. You can use wildcards, eg. 1.2.3.* or 1.2.*.*&lt;br /&gt;&lt;br /&gt;Your current IP address is &lt;i&gt;192.168.33.11&lt;/i&gt;</inlineHelp>
+						<inlineHelp>Enter the list of IPs, one per line, that you wish to exclude from being tracked by Piwik. You can use wildcards, eg. 1.2.3.* or 1.2.*.*&lt;br /&gt;&lt;br /&gt;Your current IP address is &lt;i&gt;127.0.0.1&lt;/i&gt;</inlineHelp>
 						<templateFile />
 						<introduction />
 						<condition />

--- a/tests/PHPUnit/System/expected/test_noVisit_PeriodIsLast__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_noVisit_PeriodIsLast__CorePluginsAdmin.getSystemSettings.xml
@@ -21,6 +21,7 @@
 				</availableValues>
 				<description />
 				<inlineHelp>While our &lt;a href='?module=Proxy&amp;action=redirect&amp;url=http://piwik.org/participate/development-process/' target='_blank'&gt;development process&lt;/a&gt; includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Piwik.&lt;br/&gt;If Piwik is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a href='?module=Proxy&amp;action=redirect&amp;url=http%3A%2F%2Fdeveloper.piwik.org%2Fguides%2Fcore-team-workflow%23influencing-piwik-development' target='_blank'&gt;see here&lt;/a&gt;.&lt;br /&gt;LTS (Long Term Support) versions receive only security and bug fixes.</inlineHelp>
+				<templateFile />
 				<introduction>Release channel</introduction>
 				<condition />
 			</row>
@@ -39,6 +40,7 @@
 				</availableValues>
 				<description />
 				<inlineHelp>An email will be sent to Super Users when there is a new version available for a plugin.</inlineHelp>
+				<templateFile />
 				<introduction>Send an email when a plugin update is available</introduction>
 				<condition />
 			</row>
@@ -64,6 +66,7 @@
 				</availableValues>
 				<description>Choose the metric that should be displayed in the browser tab</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -91,6 +94,7 @@
 				</availableValues>
 				<description>The value will be only displayed in the following browsers</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -108,6 +112,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>This description will be displayed next to the value</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -123,6 +128,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>Password for the 3rd API where we fetch the value</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -144,6 +150,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If enabled, logged in users can opt out in their plugin settings. Anonymous users cannot opt out.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -159,6 +166,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If enabled, anonymized usage data will be sent to demo-anonymous.piwik.org and the tracked data can be viewed there (the data is public). The collected data is used to improve Piwik. Thank you for making Piwik better!</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction>Send anonmyized usage data to the creators of Piwik</introduction>
 				<condition />
 			</row>
@@ -174,6 +182,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If specified, anonymized usage data will be sent to the specified site in this Piwik.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction>Send anonymize usage data to this Piwik</introduction>
 				<condition />
 			</row>
@@ -189,6 +198,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -205,6 +215,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction>Send anonymize usage data to a custom Piwik</introduction>
 				<condition />
 			</row>
@@ -221,6 +232,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If a URL and Site Id is specified, usage data will be sent to the custom Piwik instance.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -236,6 +248,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -258,6 +271,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>If enabled, the Redis Sentinel feature will be used. Make sure to update host and port if needed. Once you have enabled and saved the change, you will be able to specify multiple hosts and ports comma separated.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -274,6 +288,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>The sentinel master name only needs to be configured if Sentinel is enabled.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -290,6 +305,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Remote host or unix socket of the Redis server. Max 500 characters are allowed.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -306,6 +322,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Port the Redis server is running on. Value should be between 1 and 65535. Use 0 if you are using unix socket to connect to Redis server.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -322,6 +339,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>In case you are using Redis for caching make sure to use a different database.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -338,6 +356,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Password set on the Redis server, if any. Redis can be instructed to require a password before allowing clients to execute commands.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -353,6 +372,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>If enabled, all tracking requests will be written into a queue instead of the directly into the database. Requires a Redis server and phpredis PHP extension.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -369,6 +389,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Number of allowed maximum queue workers. Accepts a number between 1 and 16. Best practice is to set the number of CPUs you want to make available for queue processing. Be aware you need to make sure to start the workers manually. We recommend to not use 9-15 workers, rather use 8 or 16 as the queue might not be distributed evenly into different queues. DO NOT USE more than 1 worker if you make use the UserId feature when tracking see https://github.com/piwik/piwik/issues/7691</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -385,6 +406,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Defines how many requests will be picked out of the queue and processed at once. Enter a number which is &gt;= 1.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -400,6 +422,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>If enabled, we will process all requests within a queue during a normal tracking request once there are enough requests in the queue. This will not slow down the tracking request. If disabled, you have to setup a cronjob that executes the &quot;./console queuedtracking:process&quot; console command eg every minute to process the queue.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>

--- a/tests/PHPUnit/System/expected/test_noVisit_PeriodIsLast__CorePluginsAdmin.getUserSettings.xml
+++ b/tests/PHPUnit/System/expected/test_noVisit_PeriodIsLast__CorePluginsAdmin.getUserSettings.xml
@@ -16,6 +16,7 @@
 				<availableValues />
 				<description>If enabled, the value will be automatically refreshed depending on the specified interval</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -32,6 +33,7 @@
 				<availableValues />
 				<description>Defines how often the value should be updated</description>
 				<inlineHelp>Enter a number which is &gt;= 15</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -51,6 +53,7 @@
 				</availableValues>
 				<description>Pick your favourite color</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -72,6 +75,7 @@
 				<availableValues />
 				<description>If enabled, anonymous usage data will be tracked. For example which pages are viewed and which reports are used most often. For more information contact your system administrator.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>

--- a/tests/PHPUnit/System/expected/test_noVisit__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_noVisit__CorePluginsAdmin.getSystemSettings.xml
@@ -21,6 +21,7 @@
 				</availableValues>
 				<description />
 				<inlineHelp>While our &lt;a href='?module=Proxy&amp;action=redirect&amp;url=http://piwik.org/participate/development-process/' target='_blank'&gt;development process&lt;/a&gt; includes thousands of automated tests, Beta Testers play a key role in achieving the &quot;No bug policy&quot; in Piwik.&lt;br/&gt;If Piwik is a critical part of your business, we recommend you use the latest stable release. If you use the latest beta and you find a bug or have a suggestion, please &lt;a href='?module=Proxy&amp;action=redirect&amp;url=http%3A%2F%2Fdeveloper.piwik.org%2Fguides%2Fcore-team-workflow%23influencing-piwik-development' target='_blank'&gt;see here&lt;/a&gt;.&lt;br /&gt;LTS (Long Term Support) versions receive only security and bug fixes.</inlineHelp>
+				<templateFile />
 				<introduction>Release channel</introduction>
 				<condition />
 			</row>
@@ -39,6 +40,7 @@
 				</availableValues>
 				<description />
 				<inlineHelp>An email will be sent to Super Users when there is a new version available for a plugin.</inlineHelp>
+				<templateFile />
 				<introduction>Send an email when a plugin update is available</introduction>
 				<condition />
 			</row>
@@ -64,6 +66,7 @@
 				</availableValues>
 				<description>Choose the metric that should be displayed in the browser tab</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -91,6 +94,7 @@
 				</availableValues>
 				<description>The value will be only displayed in the following browsers</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -108,6 +112,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>This description will be displayed next to the value</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -123,6 +128,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>Password for the 3rd API where we fetch the value</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -144,6 +150,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If enabled, logged in users can opt out in their plugin settings. Anonymous users cannot opt out.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -159,6 +166,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If enabled, anonymized usage data will be sent to demo-anonymous.piwik.org and the tracked data can be viewed there (the data is public). The collected data is used to improve Piwik. Thank you for making Piwik better!</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction>Send anonmyized usage data to the creators of Piwik</introduction>
 				<condition />
 			</row>
@@ -174,6 +182,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If specified, anonymized usage data will be sent to the specified site in this Piwik.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction>Send anonymize usage data to this Piwik</introduction>
 				<condition />
 			</row>
@@ -189,6 +198,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -205,6 +215,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction>Send anonymize usage data to a custom Piwik</introduction>
 				<condition />
 			</row>
@@ -221,6 +232,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description>If a URL and Site Id is specified, usage data will be sent to the custom Piwik instance.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -236,6 +248,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -258,6 +271,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>If enabled, the Redis Sentinel feature will be used. Make sure to update host and port if needed. Once you have enabled and saved the change, you will be able to specify multiple hosts and ports comma separated.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -274,6 +288,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>The sentinel master name only needs to be configured if Sentinel is enabled.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -290,6 +305,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Remote host or unix socket of the Redis server. Max 500 characters are allowed.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -306,6 +322,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Port the Redis server is running on. Value should be between 1 and 65535. Use 0 if you are using unix socket to connect to Redis server.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -322,6 +339,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>In case you are using Redis for caching make sure to use a different database.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -338,6 +356,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Password set on the Redis server, if any. Redis can be instructed to require a password before allowing clients to execute commands.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -353,6 +372,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>If enabled, all tracking requests will be written into a queue instead of the directly into the database. Requires a Redis server and phpredis PHP extension.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -369,6 +389,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Number of allowed maximum queue workers. Accepts a number between 1 and 16. Best practice is to set the number of CPUs you want to make available for queue processing. Be aware you need to make sure to start the workers manually. We recommend to not use 9-15 workers, rather use 8 or 16 as the queue might not be distributed evenly into different queues. DO NOT USE more than 1 worker if you make use the UserId feature when tracking see https://github.com/piwik/piwik/issues/7691</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -385,6 +406,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>Defines how many requests will be picked out of the queue and processed at once. Enter a number which is &gt;= 1.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -400,6 +422,7 @@ Another line</defaultValue>
 				<availableValues />
 				<description />
 				<inlineHelp>If enabled, we will process all requests within a queue during a normal tracking request once there are enough requests in the queue. This will not slow down the tracking request. If disabled, you have to setup a cronjob that executes the &quot;./console queuedtracking:process&quot; console command eg every minute to process the queue.</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>

--- a/tests/PHPUnit/System/expected/test_noVisit__CorePluginsAdmin.getUserSettings.xml
+++ b/tests/PHPUnit/System/expected/test_noVisit__CorePluginsAdmin.getUserSettings.xml
@@ -16,6 +16,7 @@
 				<availableValues />
 				<description>If enabled, the value will be automatically refreshed depending on the specified interval</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -32,6 +33,7 @@
 				<availableValues />
 				<description>Defines how often the value should be updated</description>
 				<inlineHelp>Enter a number which is &gt;= 15</inlineHelp>
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -51,6 +53,7 @@
 				</availableValues>
 				<description>Pick your favourite color</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>
@@ -72,6 +75,7 @@
 				<availableValues />
 				<description>If enabled, anonymous usage data will be tracked. For example which pages are viewed and which reports are used most often. For more information contact your system administrator.</description>
 				<inlineHelp />
+				<templateFile />
 				<introduction />
 				<condition />
 			</row>


### PR DESCRIPTION
This PR allows us to show custom field types in User-, System- and Measurable-Settings. No longer limited to text, textarea, select, ...

Defining a new field is as easy as eg https://github.com/piwik/piwik/blob/3.x-dev/plugins/CorePluginsAdmin/angularjs/form-field/field-text.html

This is really useful since we were often not able to define settings eg as System Settings because one setting was a bit more complicated and could not be visualized with our default UI settings control but now we can wrap pretty much anything with it.

By default the values for it will be stored along a site, measurable, plugin settings but with just a very few lines and by implementing it is super easy to store settings for a field in a different backend see this interface:
https://github.com/piwik/piwik/blob/3.x-dev/core/Settings/Storage/Backend/BackendInterface.php

Say you have a custom setting for trusted hosts or something else and want to keep the existing place for storing that information then you just wrap the calls to save that method in such an interface. 

Needs to be documented eventually.