### PR TITLE
Make sure to always trigger site event when creating a new site instance

### DIFF
--- a/core/Site.php
+++ b/core/Site.php
@@ -55,20 +55,33 @@ class Site
      */
     protected static $infoSites = array();
 
+    private $site = array();
+
     /**
      * Constructor.
      *
      * @param int $idsite The ID of the site we want data for.
+     * @throws UnexpectedWebsiteFoundException
      */
     public function __construct($idsite)
     {
-        $this->id = (int)$idsite;
-        if (!isset(self::$infoSites[$this->id])) {
+        $this->id = (int) $idsite;
+
+        if (!empty(self::$infoSites[$this->id])) {
+            $site = self::$infoSites[$this->id];
+        } else {
             $site = API::getInstance()->getSiteFromId($this->id);
-            $sites = array(&$site);
-            self::triggerSetSitesEvent($sites);
-            self::setSiteFromArray($this->id, $site);
+
+            if (empty($site)) {
+                throw new UnexpectedWebsiteFoundException('The requested website id = ' . (int)$this->id . ' couldn\'t be found');
+            }
         }
+
+        $sites = array(&$site);
+        self::triggerSetSitesEvent($sites);
+        self::setSiteFromArray($this->id, $site);
+
+        $this->site = $site;
     }
 
     /**
@@ -251,19 +264,11 @@ class Site
      */
     protected function get($name)
     {
-        if (!isset(self::$infoSites[$this->id])) {
-            $site = API::getInstance()->getSiteFromId($this->id);
-
-            if (empty($site)) {
-                throw new UnexpectedWebsiteFoundException('The requested website id = ' . (int)$this->id . ' couldn\'t be found');
-            }
-
-            self::setSiteFromArray($this->id, $site);
+        if (isset($this->site[$name])) {
+            return $this->site[$name];
         }
-        if (!isset(self::$infoSites[$this->id][$name])) {
-            throw new Exception("The property $name could not be found on the website ID " . (int)$this->id);
-        }
-        return self::$infoSites[$this->id][$name];
+
+        throw new Exception("The property $name could not be found on the website ID " . (int)$this->id);
     }
 
     /**

--- a/tests/PHPUnit/Integration/SiteTest.php
+++ b/tests/PHPUnit/Integration/SiteTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\Integration;
+
+use Piwik\Piwik;
+use Piwik\Plugins\SitesManager\API;
+use Piwik\Site;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Core
+ */
+class SiteTest extends IntegrationTestCase
+{
+    private $idSite;
+
+    public $siteAppendix = ' foo';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->idSite = Fixture::createWebsite('2014-01-02 03:04:05');
+
+        $self = $this;
+
+        Piwik::addAction('Site.setSites', function (&$sites) use ($self) {
+            foreach ($sites as &$site) {
+                if (strpos($site['name'], $self->siteAppendix) !== 0) {
+                    $site['name'] .= $self->siteAppendix;
+                }
+            }
+        });
+    }
+
+    /**
+     * @expectedException \Piwik\Exception\UnexpectedWebsiteFoundException
+     * @expectedExceptionMessage An unexpected website was found in the request
+     */
+    public function test_constructor_throwsException_ifSiteDoesNotExist()
+    {
+        $this->makeSite(9999);
+    }
+
+    public function test_constructor_enrichesSite()
+    {
+        $site = $this->makeSite($this->idSite);
+        $this->assertSame('Piwik test' . $this->siteAppendix, $site->getName());
+    }
+
+    public function test_construct_enrichesSiteEvenIfSiteWasSetToCachePreviously()
+    {
+        $site = API::getInstance()->getSiteFromId($this->idSite);
+        Site::setSiteFromArray($this->idSite, $site);
+
+        $site = $this->makeSite($this->idSite);
+        $this->assertSame('Piwik test' . $this->siteAppendix, $site->getName());
+    }
+
+    public function test_construct_whenRemovingSiteFromGlobalSitesArray_TheObjectItselfStillworks()
+    {
+        $site = $this->makeSite($this->idSite);
+        $this->assertSame('Piwik test' . $this->siteAppendix, $site->getName());
+
+        Site::clearCache();
+
+        $this->assertSame('Piwik test' . $this->siteAppendix, $site->getName());
+        $this->assertSame(array(), Site::getSites()); // make sure data was not fetched again
+    }
+
+    private function makeSite($idSite)
+    {
+        return new Site($idSite);
+    }
+}


### PR DESCRIPTION
In https://github.com/piwik/piwik/pull/10990 I already tried to achieve this but noticed there are still case when this is not working. For example any request to `SitesManager.getSiteFromId` will overwrite any site information in `Site::$infoSites`. 

Meaning a controller might do `new Site()`, then further down an API request, or the archiver does `SitesManager.getSiteFromId` and overwrites a previously enriched site. It is even more messy that at any point the data within `new Site()` might be changed by another API request or method that calls `Sites::set*`.

It is much better to instead keep the site in a non-static property when an instance is created and to always work on that data. This is much more reliable and what consumers expect. In theory, there could be a case that a site is deleted or updated via an API request, and then the data within `Site->site` is not updated automatically but this is not a problem for us.

Having this PR merged will make sure that when you change eg the name of a website with the event `Site.setSites`, it will appear correctly in the website selector and in the mobile app.

There are still more inconsistencies to tackle eventually. Eg all `SitesManager.get*` methods might trigger the `Site.getSites` event letting consumers change the site objects, but none of the APIs actually return the changed value. This is much harder to solve though and therefore not included in this PR