### PR TITLE
Add possibility to set (overwrite) the widgets in a container

### DIFF
--- a/core/Widget/WidgetContainerConfig.php
+++ b/core/Widget/WidgetContainerConfig.php
@@ -98,6 +98,16 @@ class WidgetContainerConfig extends WidgetConfig
     /**
      * Get all added widget configs.
      *
+     * @param WidgetConfig[] $configs
+     */
+    public function setWidgetConfigs($configs)
+    {
+        $this->widgets = $configs;
+    }
+
+    /**
+     * Get all added widget configs.
+     *
      * @return WidgetConfig[]
      */
     public function getWidgetConfigs()

--- a/core/Widget/WidgetContainerConfig.php
+++ b/core/Widget/WidgetContainerConfig.php
@@ -96,7 +96,7 @@ class WidgetContainerConfig extends WidgetConfig
     }
 
     /**
-     * Get all added widget configs.
+     * Set (overwrite) widget configs.
      *
      * @param WidgetConfig[] $configs
      */

--- a/tests/PHPUnit/Unit/Widget/WidgetContainerConfigTest.php
+++ b/tests/PHPUnit/Unit/Widget/WidgetContainerConfigTest.php
@@ -270,6 +270,24 @@ class WidgetContainerConfigTest extends \PHPUnit_Framework_TestCase
         ), $this->config->getWidgetConfigs());
     }
 
+    public function test_setWidgetConfigs_canOverwriteWidgets()
+    {
+        $this->assertSame(array(), $this->config->getWidgetConfigs());
+
+        $this->config->addWidgetConfig($widget1 = $this->createWidgetConfig('widget1'));
+        $this->config->addWidgetConfig($widget2 = $this->createWidgetConfig('widget2'));
+        $this->assertSame(array($widget1,$widget2), $this->config->getWidgetConfigs());
+
+        $widget3 = $this->createWidgetConfig('widget3');
+        $widget4 = new WidgetContainerConfig();
+        $this->config->setWidgetConfigs(array($widget2, $widget3, $widget4));
+        $this->assertSame(array(
+            $widget2,
+            $widget3,
+            $widget4
+        ), $this->config->getWidgetConfigs());
+    }
+
     private function createWidgetConfig($widgetName)
     {
         $config = new WidgetConfig();


### PR DESCRIPTION
This can be useful when filtering widgets and you want to remove some widgets that are defined within a container.