### PR TITLE
Remove on pixel overlapping boxshadow on the corners

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -317,7 +317,8 @@ nav {
         border: 0;
         margin: 0;
         box-sizing: border-box;
-        border-radius: 2px !important
+        border-radius: 2px !important;
+        box-shadow: none!important;
       }
     }
 


### PR DESCRIPTION
Remove on pixel overlapping boxshadow on the corners of the quick-access input field in the header.

