### PR TITLE
When safe mode is displayed, and Super User was not logged in already, let Super User display the full safe mode to troubleshoot further

### DIFF
--- a/core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php
+++ b/core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php
@@ -13,6 +13,7 @@ use lessc;
 use Piwik\AssetManager\UIAsset;
 use Piwik\AssetManager\UIAssetMerger;
 use Piwik\Common;
+use Piwik\Exception\StylesheetLessCompileException;
 use Piwik\Piwik;
 
 class StylesheetUIAssetMerger extends UIAssetMerger
@@ -41,7 +42,11 @@ class StylesheetUIAssetMerger extends UIAssetMerger
         $concatenatedAssets = $this->getConcatenatedAssets();
 
         $this->lessCompiler->setFormatter('classic');
-        $compiled = $this->lessCompiler->compile($concatenatedAssets);
+        try {
+            $compiled = $this->lessCompiler->compile($concatenatedAssets);
+        } catch(\Exception $e) {
+            throw new StylesheetLessCompileException($e->getMessage());
+        }
 
         foreach ($this->cssAssetsToReplace as $asset) {
             // to fix #10173

--- a/core/Exception/StylesheetLessCompileException.php
+++ b/core/Exception/StylesheetLessCompileException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Exception;
+
+class StylesheetLessCompileException extends Exception
+{
+}

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -98,7 +98,7 @@ class FrontController extends Singleton
      * @param Exception $e
      * @return string
      */
-    private static function generateSafeModeOutputFromException(\Exception $e)
+    private static function generateSafeModeOutputFromException($e)
     {
         $error = array(
             'message' => $e->getMessage(),
@@ -152,6 +152,9 @@ class FrontController extends Singleton
             echo $this->generateSafeModeOutputFromException($e);
             exit;
         } catch(StylesheetLessCompileException $e) {
+            echo $this->generateSafeModeOutputFromException($e);
+            exit;
+        } catch(\Error $e) {
             echo $this->generateSafeModeOutputFromException($e);
             exit;
         }

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -15,6 +15,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Exception\AuthenticationFailedException;
 use Piwik\Exception\DatabaseSchemaIsNewerThanCodebaseException;
 use Piwik\Exception\PluginDeactivatedException;
+use Piwik\Exception\StylesheetLessCompileException;
 use Piwik\Http\ControllerResolver;
 use Piwik\Http\Router;
 use Piwik\Plugins\CoreAdminHome\CustomLogo;
@@ -73,11 +74,11 @@ class FrontController extends Singleton
 
     /**
      * @param $lastError
-     * @return mixed|void
+     * @return string
      * @throws AuthenticationFailedException
      * @throws Exception
      */
-    private static function generateSafeModeOutput($lastError)
+    private static function generateSafeModeOutputFromError($lastError)
     {
         Common::sendResponseCode(500);
 
@@ -91,6 +92,20 @@ class FrontController extends Singleton
         }
 
         return $message;
+    }
+
+    /**
+     * @param Exception $e
+     * @return string
+     */
+    private static function generateSafeModeOutputFromException(\Exception $e)
+    {
+        $error = array(
+            'message' => $e->getMessage(),
+            'file' => $e->getFile(),
+            'line' => $e->getLine()
+        );
+        return self::generateSafeModeOutputFromError($error);
     }
 
     /**
@@ -133,6 +148,12 @@ class FrontController extends Singleton
              * @param \Piwik\NoAccessException $exception The exception that was caught.
              */
             Piwik::postEvent('User.isNotAuthorized', array($exception), $pending = true);
+        } catch (\Twig_Error_Runtime $e) {
+            echo $this->generateSafeModeOutputFromException($e);
+            exit;
+        } catch(StylesheetLessCompileException $e) {
+            echo $this->generateSafeModeOutputFromException($e);
+            exit;
         }
     }
 
@@ -202,7 +223,7 @@ class FrontController extends Singleton
     {
         $lastError = error_get_last();
         if (!empty($lastError) && $lastError['type'] == E_ERROR) {
-            $message = self::generateSafeModeOutput($lastError);
+            $message = self::generateSafeModeOutputFromError($lastError);
             echo $message;
         }
     }

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -20,7 +20,9 @@ class SettingsPiwik
     const OPTION_PIWIK_URL = 'piwikUrl';
 
     /**
-     * Get salt from [General] section
+     * Get salt from [General] section. Should ONLY be used as a seed to create hashes
+     *
+     * NOTE: Keep this salt secret! Never output anywhere or share it etc.
      *
      * @return string
      */

--- a/libs/upgradephp/upgrade.php
+++ b/libs/upgradephp/upgrade.php
@@ -702,3 +702,12 @@ if (!function_exists('dump')) {
 
     }
 }
+
+/**
+ * Need to catch that PHP7 error object on php5
+ */
+if( !class_exists('\Error')) {
+	class Error {
+
+	}
+}

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -477,7 +477,6 @@ class Controller extends Plugin\ControllerAdmin
         if (!empty($salt)) {
             $saltFromRequest = Common::getRequestVar('i_am_super_user', '', 'string');
             $isAllowedToTroubleshootAsSuperUser = ($salt == $saltFromRequest);
-            return $isAllowedToTroubleshootAsSuperUser;
         }
         return $isAllowedToTroubleshootAsSuperUser;
     }

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -324,10 +324,6 @@ class Controller extends Plugin\ControllerAdmin
         $view->showVersion     = !Common::getRequestVar('tests_hide_piwik_version', 0);
         $view->pluginCausesIssue = '';
 
-        // When the CSS merger in StylesheetUIAssetMerger throws an exception, safe mode is displayed.
-        // This flag prevents an infinite loop where safemode would try to re-generate the cache buster which requires CSS merger..
-        $view->disableCacheBuster();
-
         if (!empty($lastError['file'])) {
             preg_match('/piwik\/plugins\/(.*)\//', $lastError['file'], $matches);
 

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -324,6 +324,10 @@ class Controller extends Plugin\ControllerAdmin
         $view->showVersion     = !Common::getRequestVar('tests_hide_piwik_version', 0);
         $view->pluginCausesIssue = '';
 
+        // When the CSS merger in StylesheetUIAssetMerger throws an exception, safe mode is displayed.
+        // This flag prevents an infinite loop where safemode would try to re-generate the cache buster which requires CSS merger..
+        $view->disableCacheBuster();
+
         if (!empty($lastError['file'])) {
             preg_match('/piwik\/plugins\/(.*)\//', $lastError['file'], $matches);
 

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -297,17 +297,17 @@ class Controller extends Plugin\ControllerAdmin
             return $message;
         }
 
-        if (Common::isPhpCliMode()) { // TODO: I can't find how this will ever get called / safeMode is never set for Console
+        if (Common::isPhpCliMode()) {
             throw new Exception("Error: " . var_export($lastError, true));
         }
         $view = new View('@CorePluginsAdmin/safemode');
         $view->lastError   = $lastError;
-
         $view->isAllowedToTroubleshootAsSuperUser = $this->isAllowedToTroubleshootAsSuperUser();
         $view->isSuperUser = Piwik::hasUserSuperUserAccess();
         $view->isAnonymousUser = Piwik::isUserIsAnonymous();
         $view->plugins         = $this->pluginManager->loadAllPluginsAndGetTheirInfo();
         $view->deactivateNonce = Nonce::getNonce(static::DEACTIVATE_NONCE);
+        $view->deactivateIAmSuperUserSalt = Common::getRequestVar('i_am_super_user', '', 'string');
         $view->uninstallNonce  = Nonce::getNonce(static::UNINSTALL_NONCE);
         $view->emailSuperUser  = implode(',', Piwik::getAllSuperUserAccessEmailAddresses());
         $view->piwikVersion    = Version::VERSION;
@@ -471,7 +471,6 @@ class Controller extends Plugin\ControllerAdmin
      */
     protected function isAllowedToTroubleshootAsSuperUser()
     {
-
         $isAllowedToTroubleshootAsSuperUser = false;
         $salt = Config::getInstance()->General['salt'];
         if (!empty($salt)) {

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -23,6 +23,7 @@ use Piwik\Plugin;
 use Piwik\Plugins\Marketplace\Marketplace;
 use Piwik\Plugins\Marketplace\Controller as MarketplaceController;
 use Piwik\Plugins\Marketplace\Plugins;
+use Piwik\SettingsPiwik;
 use Piwik\Translation\Translator;
 use Piwik\Url;
 use Piwik\Version;
@@ -472,7 +473,7 @@ class Controller extends Plugin\ControllerAdmin
     protected function isAllowedToTroubleshootAsSuperUser()
     {
         $isAllowedToTroubleshootAsSuperUser = false;
-        $salt = Config::getInstance()->General['salt'];
+        $salt = SettingsPiwik::getSalt();
         if (!empty($salt)) {
             $saltFromRequest = Common::getRequestVar('i_am_super_user', '', 'string');
             $isAllowedToTroubleshootAsSuperUser = ($salt == $saltFromRequest);

--- a/plugins/CorePluginsAdmin/templates/safemode.twig
+++ b/plugins/CorePluginsAdmin/templates/safemode.twig
@@ -79,7 +79,7 @@
                             {{ pluginName }}
                         </td>
                         <td>
-                            <a href="index.php?module=CorePluginsAdmin&action=deactivate&pluginName={{ pluginName }}&nonce={{ deactivateNonce }}"
+                            <a href="index.php?module=CorePluginsAdmin&action=deactivate&pluginName={{ pluginName }}&nonce={{ deactivateNonce }}{% if deactivateIAmSuperUserSalt is not empty %}&i_am_super_user={{ deactivateIAmSuperUserSalt }}{% endif %}"
                                target="_blank">deactivate</a>
                         </td>
                     </tr>

--- a/plugins/CorePluginsAdmin/templates/safemode.twig
+++ b/plugins/CorePluginsAdmin/templates/safemode.twig
@@ -28,7 +28,7 @@
 
         <div style="width: 640px">
 
-        {% if not isAnonymousUser %}
+        {% if isAllowedToTroubleshootAsSuperUser or not isAnonymousUser %}
             <p>
                 The following error just broke Piwik{% if showVersion %} (v{{ piwikVersion }}){%  endif %}:
                 <pre>{{ lastError.message }}</pre>
@@ -58,7 +58,7 @@
 
         {% endif %}
 
-        {% if isSuperUser %}
+        {% if isAllowedToTroubleshootAsSuperUser or isSuperUser %}
 
             <h3>Further troubleshooting</h3>
             <p>
@@ -115,7 +115,7 @@
 
         {% elseif isAnonymousUser %}
 
-            <p>Please contact the system administrator, or login to Piwik to learn more.</p>
+            <p>Please contact the system administrator, or <a href="?module={{ loginModule }}">login to Piwik</a> to learn more.</p>
 
         {% else %}
             <p>
@@ -124,6 +124,16 @@
                 to your system administrator.
             </p>
         {% endif %}
+
+
+        {% if not isAllowedToTroubleshootAsSuperUser and not isSuperUser %}
+            <p>If you are Super User, but cannot login because of this error, you can still troubleshoot further. Follow these steps:
+                <br/>1) open the config/config.ini.php file and look for the <code>salt</code> value under <code>[General]</code>.
+                <br/>2) edit this current URL you are viewing and add the following text (replacing <code>salt_value_from_config</code> by the <code>salt</code> value from the config file):
+                <br/><br/><code>index.php?i_am_super_user=salt_value_from_config&....</code>
+            </p>
+        {% endif %}
+
 
         </div>
 

--- a/plugins/CorePluginsAdmin/templates/safemode.twig
+++ b/plugins/CorePluginsAdmin/templates/safemode.twig
@@ -79,6 +79,9 @@
                             {{ pluginName }}
                         </td>
                         <td>
+                            {{ plugin.info.version|default('') }}
+                        </td>
+                        <td>
                             <a href="index.php?module=CorePluginsAdmin&action=deactivate&pluginName={{ pluginName }}&nonce={{ deactivateNonce }}{% if deactivateIAmSuperUserSalt is not empty %}&i_am_super_user={{ deactivateIAmSuperUserSalt }}{% endif %}"
                                target="_blank">deactivate</a>
                         </td>

--- a/plugins/CorePluginsAdmin/templates/safemode.twig
+++ b/plugins/CorePluginsAdmin/templates/safemode.twig
@@ -63,7 +63,8 @@
             <h3>Further troubleshooting</h3>
             <p>
                 If this error continues to happen, you may be able to fix this issue by disabling one or more of
-                the Third-Party plugins. You can enable them again in the
+                the Third-Party plugins. If you don't know which plugin is causing this error, we recommend to first disable any plugin not created by "Piwik" and not created by "InnoCraft".
+                You can enable plugin again afterwards in the
                 <a rel="noreferrer" target="_blank" href="index.php?module=CorePluginsAdmin&action=plugins">Plugins</a>
                 or <a target="_blank" href="index.php?module=CorePluginsAdmin&action=themes">Themes</a> page under
                 settings at any time.

--- a/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bbdb204e2710005e18b099ebaf78bc716ee1c80959dd8c3f57092669fd7f2c0
-size 169132
+oid sha256:5eaade9619d4cbad93e0731456fdcbb46b3d3c17494d1bfc718b7e8e2ce36256
+size 193496


### PR DESCRIPTION
* Allow not-logged in users, if they can prove they are super users, to view the full safe mode, and to deactivate plugins
* Add a link to Login form 
* Display plugin versions in the safe mode
* Added a text to indicate users to first disable third party plugins (`If you don't know which plugin is causing this error, we recommend to first disable any plugin not created by "Piwik" and not created by "InnoCraft".`)
