### PR TITLE
when there's an error during Twig template processing, or during LESS css compiling, or a generic PHP error, display the safe mode

### DIFF
--- a/core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php
+++ b/core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php
@@ -13,6 +13,7 @@ use lessc;
 use Piwik\AssetManager\UIAsset;
 use Piwik\AssetManager\UIAssetMerger;
 use Piwik\Common;
+use Piwik\Exception\StylesheetLessCompileException;
 use Piwik\Piwik;
 
 class StylesheetUIAssetMerger extends UIAssetMerger
@@ -41,7 +42,11 @@ class StylesheetUIAssetMerger extends UIAssetMerger
         $concatenatedAssets = $this->getConcatenatedAssets();
 
         $this->lessCompiler->setFormatter('classic');
-        $compiled = $this->lessCompiler->compile($concatenatedAssets);
+        try {
+            $compiled = $this->lessCompiler->compile($concatenatedAssets);
+        } catch(\Exception $e) {
+            throw new StylesheetLessCompileException($e->getMessage());
+        }
 
         foreach ($this->cssAssetsToReplace as $asset) {
             // to fix #10173

--- a/core/Exception/StylesheetLessCompileException.php
+++ b/core/Exception/StylesheetLessCompileException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Exception;
+
+class StylesheetLessCompileException extends Exception
+{
+}

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -15,6 +15,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Exception\AuthenticationFailedException;
 use Piwik\Exception\DatabaseSchemaIsNewerThanCodebaseException;
 use Piwik\Exception\PluginDeactivatedException;
+use Piwik\Exception\StylesheetLessCompileException;
 use Piwik\Http\ControllerResolver;
 use Piwik\Http\Router;
 use Piwik\Plugins\CoreAdminHome\CustomLogo;
@@ -73,11 +74,11 @@ class FrontController extends Singleton
 
     /**
      * @param $lastError
-     * @return mixed|void
+     * @return string
      * @throws AuthenticationFailedException
      * @throws Exception
      */
-    private static function generateSafeModeOutput($lastError)
+    private static function generateSafeModeOutputFromError($lastError)
     {
         Common::sendResponseCode(500);
 
@@ -91,6 +92,20 @@ class FrontController extends Singleton
         }
 
         return $message;
+    }
+
+    /**
+     * @param Exception $e
+     * @return string
+     */
+    private static function generateSafeModeOutputFromException(\Exception $e)
+    {
+        $error = array(
+            'message' => $e->getMessage(),
+            'file' => $e->getFile(),
+            'line' => $e->getLine()
+        );
+        return self::generateSafeModeOutputFromError($error);
     }
 
     /**
@@ -133,6 +148,12 @@ class FrontController extends Singleton
              * @param \Piwik\NoAccessException $exception The exception that was caught.
              */
             Piwik::postEvent('User.isNotAuthorized', array($exception), $pending = true);
+        } catch (\Twig_Error_Runtime $e) {
+            echo $this->generateSafeModeOutputFromException($e);
+            exit;
+        } catch(StylesheetLessCompileException $e) {
+            echo $this->generateSafeModeOutputFromException($e);
+            exit;
         }
     }
 
@@ -202,7 +223,7 @@ class FrontController extends Singleton
     {
         $lastError = error_get_last();
         if (!empty($lastError) && $lastError['type'] == E_ERROR) {
-            $message = self::generateSafeModeOutput($lastError);
+            $message = self::generateSafeModeOutputFromError($lastError);
             echo $message;
         }
     }

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -324,6 +324,10 @@ class Controller extends Plugin\ControllerAdmin
         $view->showVersion     = !Common::getRequestVar('tests_hide_piwik_version', 0);
         $view->pluginCausesIssue = '';
 
+        // When the CSS merger in StylesheetUIAssetMerger throws an exception, safe mode is displayed.
+        // This flag prevents an infinite loop where safemode would try to re-generate the cache buster which requires CSS merger..
+        $view->disableCacheBuster();
+
         if (!empty($lastError['file'])) {
             preg_match('/piwik\/plugins\/(.*)\//', $lastError['file'], $matches);
 


### PR DESCRIPTION
ref https://github.com/piwik/piwik/pull/11082