### PR TITLE
fix  Warning - Invalid argument supplied for foreach() in plugins/Referrers/Controller.php(422)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -289,7 +289,7 @@
         "Password": "Password",
         "Period": "Period",
         "Piechart": "Piechart",
-        "PiwikIsACollaborativeProjectYouCanContributeAndDonate": "%1$sPiwik%2$s is a collaborative project brought to you by the %7$sPiwik team%8$s members as well as many other contributors around the globe. <br/> If you're a fan of Piwik, you can help: find out %3$sHow to participate in Piwik%4$s, or %5$sdonate now%6$s to help fund Piwik 3.0!",
+        "PiwikIsACollaborativeProjectYouCanContributeAndDonateNextRelease": "%1$sPiwik%2$s is a collaborative project brought to you by the %7$sPiwik team%8$s members as well as many other contributors around the globe. <br/> If you're a fan of Piwik, you can help: find out %3$sHow to participate in Piwik%4$s, or %5$sdonate now%6$s to help fund the next great Piwik release-!",
         "PiwikXIsAvailablePleaseNotifyPiwikAdmin": "%1$s is available. Please notify the %2$sPiwik administrator%3$s.",
         "PiwikXIsAvailablePleaseUpdateNow": "Piwik %1$s is available. %2$sPlease update now!%3$s (see %4$schanges%5$s).",
         "PleaseContactYourPiwikAdministrator": "Please contact your Piwik administrator.",

--- a/plugins/CoreHome/lang/en.json
+++ b/plugins/CoreHome/lang/en.json
@@ -30,7 +30,6 @@
         "InjectedHostWarningIntro": "You are now accessing Piwik from %1$s, but Piwik has been configured to run at this address: %2$s.",
         "JavascriptDisabled": "JavaScript must be enabled in order for you to use Piwik in standard view.<br \/>However, it seems JavaScript is either disabled or not supported by your browser.<br \/>To use standard view, enable JavaScript by changing your browser options, then %1$stry again%2$s.<br \/>",
         "MainNavigation": "Main navigation",
-        "MakeADifference": "Make a difference: %1$sDonate now%2$s to fund Piwik 3.0!",
         "MakeOneTimeDonation": "Make a one time donation, instead.",
         "Menu": "Menu",
         "NoPrivilegesAskPiwikAdmin": "You are logged in as '%1$s' but it seems you don't have any permission set in Piwik. %2$s Ask your Piwik administrator (click to email)%3$s to give you 'view' access to a website.",

--- a/plugins/Feedback/templates/index.twig
+++ b/plugins/Feedback/templates/index.twig
@@ -11,7 +11,7 @@
         <div piwik-content-block
              content-title="{{ headline|e('html_attr') }}"
              feature="{{ 'General_Help'|translate|e('html_attr') }}">
-            <p>{{ 'General_PiwikIsACollaborativeProjectYouCanContributeAndDonate'|translate(
+            <p>{{ 'General_PiwikIsACollaborativeProjectYouCanContributeAndDonateNextRelease'|translate(
                 "<a href='?module=Proxy&action=redirect&url=http://piwik.org' target='_blank'>",
                 "</a>",
                 "<a target='_blank' href='?module=Proxy&action=redirect&url=http://piwik.org/get-involved/'>",

--- a/plugins/Referrers/Controller.php
+++ b/plugins/Referrers/Controller.php
@@ -410,7 +410,7 @@ function DisplayTopKeywords($url = "")
             $api = $api . "&url=" . urlencode($url);
             $keywords = @json_decode(file_get_contents($api), $assoc = true);
             Common::sendHeader('Content-Type: text/html; charset=utf-8', true);
-            if ($keywords === false || isset($keywords["result"])) {
+            if ($keywords === false || isset($keywords["result"]) || !is_array($keywords)) {
                 // DEBUG ONLY: uncomment for troubleshooting an empty output (the URL output reveals the token_auth)
                 //echo "Error while fetching the <a href=\'".$api."\'>Top Keywords from Piwik</a>";
                 return;


### PR DESCRIPTION
fix WARNING: /home/piwik/htdocs/plugins/Referrers/Controller.php(422) Warning - Invalid argument supplied for foreach()

Reported in https://forum.piwik.org/t/warning-message-plugins-referrers-controller-php-422-warning/22314