### PR TITLE
Make interaction_position and visit_total_interactions MEDIUMINT to prevent  Numeric value out of range: 1264 Out of range value for column interaction_position / visit_total_interactions

### DIFF
--- a/plugins/Actions/Columns/InteractionPosition.php
+++ b/plugins/Actions/Columns/InteractionPosition.php
@@ -18,7 +18,7 @@ use Piwik\Plugin\Dimension\ActionDimension;
 class InteractionPosition extends ActionDimension
 {
     protected $columnName = 'interaction_position';
-    protected $columnType = 'SMALLINT UNSIGNED DEFAULT NULL';
+    protected $columnType = 'MEDIUMINT UNSIGNED DEFAULT NULL';
     protected $nameSingular = 'Actions_ColumnInteractionPosition';
     protected $type = self::TYPE_NUMBER;
 

--- a/plugins/Actions/Columns/VisitTotalInteractions.php
+++ b/plugins/Actions/Columns/VisitTotalInteractions.php
@@ -17,7 +17,7 @@ use Piwik\Tracker\Visitor;
 class VisitTotalInteractions extends VisitDimension
 {
     protected $columnName = 'visit_total_interactions';
-    protected $columnType = 'SMALLINT UNSIGNED DEFAULT 0';
+    protected $columnType = 'MEDIUMINT UNSIGNED DEFAULT 0';
     protected $type = self::TYPE_NUMBER;
     protected $segmentName = 'interactions';
     protected $nameSingular = 'General_NbInteractions';


### PR DESCRIPTION
fixes #11058 correctly

For existing installations, these two fields must be manually updated to MEDIUMINT (because we are not allowed to make huge schema changes in a minor version)