### PR TITLE
Enabling WOFF files under Windows IIS 

### DIFF
--- a/core/Updates/3.0.1.php
+++ b/core/Updates/3.0.1.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Plugins\Installation\ServerFilesGenerator;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+
+class Updates_3_0_1 extends PiwikUpdates
+{
+    public function doUpdate(Updater $updater)
+    {
+        // Allow IIS to serve .woff files (https://github.com/piwik/piwik/pull/11091).
+        ServerFilesGenerator::createFilesForSecurity();
+    }
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Piwik version.
      * @var string
      */
-    const VERSION = '3.0.0';
+    const VERSION = '3.0.1';
 
     public function isStableVersion($version)
     {

--- a/plugins/Installation/ServerFilesGenerator.php
+++ b/plugins/Installation/ServerFilesGenerator.php
@@ -143,6 +143,8 @@ class ServerFilesGenerator
     <staticContent>
       <remove fileExtension=".svg" />
       <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+      <remove fileExtension=".woff" />
+      <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
     </staticContent>
   </system.webServer>
 </configuration>');


### PR DESCRIPTION
Hi,
After upgrading to Piwik 3 on Windows IIS, I encountered a 404 error on the icon file (/plugins/Morpheus/fonts/piwik.woff) because the type for WOFF files (application/font-woff) isn't included by default in the IIS server configuration (similar issues has been reported previously on IIS (#5255) but also on Apache (#8691, #9967)).  

To fix this, I suggest to add the appropriate mime type in the IIS configuration file.

(Off-topic) By the way, in the ServerFilesGenerator class, why the createWebConfigFiles method is protected whereas the deleteWebConfigFiles and createHtAccessFiles (and others) methods are public ? This seems inconsistent and forces me to use the createFilesForSecurity method, which will also recreate the Apache files.