### PR TITLE
wrap commands during install

### DIFF
--- a/plugins/Morpheus/stylesheets/simple_structure.css
+++ b/plugins/Morpheus/stylesheets/simple_structure.css
@@ -16,7 +16,7 @@ body#simple  {
 	text-decoration: none;
 }
 #simple .box {
-    border-radius: 2px;	
+    border-radius: 2px;
     border: solid 1px #ccc;
     max-width: 780px;
     margin: 30px auto 60px auto;
@@ -74,6 +74,10 @@ body#simple  {
 }
 #simple .box .content h2:first-child {
 	margin-top: 0;
+}
+
+#simple .box .content blockquote {
+	word-wrap: break-word;
 }
 
 #simple .box .footer {


### PR DESCRIPTION
fixes #11122

`word-wrap: break-word` wraps the commands, while only breaking if necessary. 

![bildschirmfoto vom 2017-01-02 10-52-32](https://cloud.githubusercontent.com/assets/6266037/21587191/b6aab43e-d0d9-11e6-9c9e-52402e8aed89.png)

Firefox even breakes on `/`
![bildschirmfoto vom 2017-01-02 10-59-33](https://cloud.githubusercontent.com/assets/6266037/21587281/a0e60b84-d0da-11e6-9392-a9ecaf8140a4.png)

The text is still copyable without a newline.