### PR TITLE
Always send token_auth for POST requests done in widgetize mode

### DIFF
--- a/plugins/CoreHome/angularjs/common/services/piwik-api.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik-api.js
@@ -47,6 +47,10 @@ var hasBlockedContent = false;
             return getParams && getParams['module'] === 'API' && getParams['method'];
         }
 
+        function isWidgetizedRequest() {
+            return (broadcast.getValueFromUrl('module') == 'Widgetize');
+        }
+
         function reset () {
             getParams  = {};
             postParams = {};
@@ -176,7 +180,7 @@ var hasBlockedContent = false;
          * @private
          */
         function getPostParams (params) {
-            if (isRequestToApiMethod()) {
+            if (isRequestToApiMethod() || isWidgetizedRequest()) {
                 params.token_auth = piwik.token_auth;
             }
 

--- a/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.js
+++ b/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.js
@@ -96,6 +96,10 @@
                             url += '&showtitle=1';
                         }
 
+                        if (broadcast.getValueFromUrl('module') == 'Widgetize' && broadcast.getValueFromUrl('token_auth')) {
+                            url += '&token_auth=' + broadcast.getValueFromUrl('token_auth');
+                        }
+
                         url += '&random=' + parseInt(Math.random() * 10000);
 
                         return '?' + url;

--- a/plugins/Morpheus/javascripts/ajaxHelper.js
+++ b/plugins/Morpheus/javascripts/ajaxHelper.js
@@ -481,8 +481,12 @@ function ajaxHelper() {
                (this.postParams && this.postParams['module'] === 'API' && this.postParams['method']);
     };
 
+    this._isWidgetizedRequest = function () {
+        return (broadcast.getValueFromUrl('module') == 'Widgetize');
+    };
+
     this._getDefaultPostParams = function () {
-        if (this.withToken || this._isRequestToApiMethod()) {
+        if (this.withToken || this._isRequestToApiMethod() || this._isWidgetizedRequest()) {
             return {
                 token_auth: piwik.token_auth
             };

--- a/tests/UI/expected-screenshots/Dashboard_invalid_token_auth.png
+++ b/tests/UI/expected-screenshots/Dashboard_invalid_token_auth.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e8135200b8d1c3efb7f298e770f053970918284b9fc9cdc2196bd4f199a77f9
+size 33186

--- a/tests/UI/expected-screenshots/Dashboard_loaded_token_auth.png
+++ b/tests/UI/expected-screenshots/Dashboard_loaded_token_auth.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad27d14793efb8735da99c610041c7ad27df565ac18a8e993b4cf74bb0e40a40
+size 534693

--- a/tests/UI/specs/Dashboard_spec.js
+++ b/tests/UI/specs/Dashboard_spec.js
@@ -233,4 +233,14 @@ describe("Dashboard", function () {
         }, done);
     });
 
+    it("should fail to load with invalid token_auth", function (done) {
+        testEnvironment.testUseMockAuth = 0;
+        testEnvironment.save();
+
+        expect.screenshot("invalid_token_auth").to.be.capture(function (page) {
+            var tokenAuth = "anyInvalidToken";
+            page.load(url.replace("idDashboard=5", "idDashboard=1") + '&token_auth=' + tokenAuth, 5000);
+        }, done);
+    });
+
 });

--- a/tests/UI/specs/Dashboard_spec.js
+++ b/tests/UI/specs/Dashboard_spec.js
@@ -223,4 +223,14 @@ describe("Dashboard", function () {
         }, done);
     });
 
+    it("should load correctly with token_auth", function (done) {
+        testEnvironment.testUseMockAuth = 0;
+        testEnvironment.save();
+
+        expect.screenshot("loaded_token_auth").to.be.capture(function (page) {
+            var tokenAuth = "9ad1de7f8b329ab919d854c556f860c1";
+            page.load(url.replace("idDashboard=5", "idDashboard=1") + '&token_auth=' + tokenAuth, 5000);
+        }, done);
+    });
+
 });


### PR DESCRIPTION
refs #11055 

This might be the simplest solution to fix the stuff in widgetize mode that uses POST. Otherwise we would need to check every ajax request if it needs to call `withTokenInUrl`.
But I'm curious how we could fix that for the stuff that is loaded using GET (as we never send token_auth with GET).

@tsteur @mattab  Any thoughts?