### PR TITLE
fixed icon size in Row Evolution popup

### DIFF
--- a/plugins/CoreHome/DataTableRowAction/RowEvolution.php
+++ b/plugins/CoreHome/DataTableRowAction/RowEvolution.php
@@ -130,7 +130,7 @@ class RowEvolution
         $metricsText = Piwik::translate('RowEvolution_AvailableMetrics');
         $popoverTitle = '';
         if ($this->rowLabel) {
-            $icon = $this->rowIcon ? '<img src="' . $this->rowIcon . '" alt="">' : '';
+            $icon = $this->rowIcon ? '<img width="16px" height="16px" src="' . $this->rowIcon . '" alt="">' : '';
             $metricsText = sprintf(Piwik::translate('RowEvolution_MetricsFor'), $this->dimension . ': ' . $icon . ' ' . $this->rowLabel);
             $popoverTitle = $icon . ' ' . $this->rowLabel;
         }

--- a/plugins/Morpheus/stylesheets/ui/_popups.less
+++ b/plugins/Morpheus/stylesheets/ui/_popups.less
@@ -1,6 +1,10 @@
 .ui-dialog-title {
     color: @theme-color-text;
     font-weight: normal;
+    img {
+        width: 16px;
+        height: 16px;
+    }
 }
 
 .ui-dialog .ui-widget-header {


### PR DESCRIPTION
fixing large icons in https://demo.piwik.org/index.php?module=CoreHome&action=index&idSite=3&period=day&date=yesterday#?idSite=3&period=day&date=yesterday&category=General_Visitors&subcategory=DevicesDetection_Software&popover=RowAction$3ARowEvolution$3ADevicesDetection.getOsVersions$3A$257B$257D$3A$40Windows$25207

![bildschirmfoto vom 2017-01-21 12-56-42](https://cloud.githubusercontent.com/assets/6266037/22174212/15195e0e-dfd9-11e6-99a0-0a598787a16b.png)
