### PR TITLE
Define icon size for plugin icon in popup in visitor log

### DIFF
--- a/plugins/Live/templates/_dataTableViz_visitorLog.twig
+++ b/plugins/Live/templates/_dataTableViz_visitorLog.twig
@@ -19,7 +19,7 @@
                         <li>
                             {{ 'General_Plugins'|translate }}:
                             {% for pluginIcon in visitor.getColumn('pluginsIcons') %}
-                                <img src="{{ pluginIcon.pluginIcon }}" alt="{{ pluginIcon.pluginName|capitalize(true) }}"/>
+                                <img width="16px" height="16px" src="{{ pluginIcon.pluginIcon }}" alt="{{ pluginIcon.pluginName|capitalize(true) }}"/>
                             {% endfor %}
                         </li>
                     {% endif %}


### PR DESCRIPTION
Another place where the icon size is not defined:
![bildschirmfoto von 2017-01-23 22-05-14](https://cloud.githubusercontent.com/assets/6266037/22239727/26ef783e-e218-11e6-93ab-1347cb5c6f28.png)

Unfortunately this shows a mistake I made when generating the new icons:
I replaced the white background with transparency to replicate the look of the old icons. But this also replaced white parts of the logos, which isn't visible normally but looks ugly on non-white backgrounds:
![bildschirmfoto von 2017-01-24 09-36-38](https://cloud.githubusercontent.com/assets/6266037/22239923/d2a76d62-e218-11e6-9238-e865a20ef8f9.png)

To fix it I would need to regenerate all icons and replace them either with non-transparent ones or use floodfill from one corner (which may create new issues if  the background is not one connected background. 

Of course there is also the "hack" of adding `background: white;` to the icons.