### PR TITLE
Added a new method that allows plugins to define metrics we expect to see percentage values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** l
 ## Piwik 3.0.2
 
 ### New APIs
-* The JavaScript Tracker now supports CrossDomain tracking. The following tracker methods were added for this: `enableCrossDomainLinking`, `disableCrossDomainLinking`, `isCrossDomainLinkingEnabled` 
+* The JavaScript Tracker now supports CrossDomain tracking. The following tracker methods were added for this: `enableCrossDomainLinking`, `disableCrossDomainLinking`, `isCrossDomainLinkingEnabled`
+* Added a new method `Piwik\Plugin\Report::getMetricNamesToProcessReportTotals()` that lets you define which metrics should show percentages in the table report visualization on hover. If defined, these percentages will be automatically calculated.
 
 ## Piwik 3.0.1
 

--- a/core/API/DataTableManipulator/ReportTotalsCalculator.php
+++ b/core/API/DataTableManipulator/ReportTotalsCalculator.php
@@ -92,6 +92,13 @@ class ReportTotalsCalculator extends DataTableManipulator
             $metricNames[$metricId] = Metrics::getReadableColumnName($metricId);
         }
 
+        if (!empty($this->report)) {
+            $reportMetrics = $this->report->getMetricNamesToProcessReportTotals();
+            foreach ($reportMetrics as $metricId => $metricName) {
+                $metricNames[$metricId] = $metricName;
+            }
+        }
+
         foreach ($firstLevelTable->getRows() as $row) {
             $columns = $row->getColumns();
             foreach ($metricNames as $metricId => $metricName) {

--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -429,6 +429,20 @@ class Report
     }
 
     /**
+     * Use this method to register metrics to process report totals.
+     *
+     * When a metric is registered, it will process the report total values and as a result show percentage values
+     * in the HTML Table reporting visualization.
+     *
+     * @return string[]  metricId => metricColumn, if the report has only column names and no IDs, it should return
+     *                   metricColumn => metricColumn, eg array('13' => 'nb_pageviews') or array('mymetric' => 'mymetric')
+     */
+    public function getMetricNamesToProcessReportTotals()
+    {
+        return array();
+    }
+
+    /**
      * Returns an array of metric documentations and their corresponding translations. Eg
      * `array('nb_visits' => 'If a visitor comes to your website for the first time or if they visit a page more than 30 minutes after...')`.
      * By default the given {@link $metrics} are used and their corresponding translations are looked up automatically.


### PR DESCRIPTION
I first used an event in `Metrics::getMetricIdsToProcessReportTotal`  but this makes all reports quite a bit slower as you can see it iterates a lot over all the metrics and all rows and all columns in `sumColumnValueToTotal`. Therefore it is much better to add a method to report class so we iterate over metrics only when needed.

I tried to add a test but couldn't really manage to write one.