### PR TITLE
Replace prefilled values in Name & SiteUrl with placeholders.

### DIFF
--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
@@ -171,7 +171,6 @@
 
         var initNewSite = function() {
             $scope.site.editMode = true;
-            $scope.site.name = "Name";
             $scope.site.timezone = $scope.globalSettings.defaultTimezone;
             $scope.site.currency = $scope.globalSettings.defaultCurrency;
 

--- a/plugins/SitesManager/templates/sites-list/site-fields.html
+++ b/plugins/SitesManager/templates/sites-list/site-fields.html
@@ -71,7 +71,7 @@
 
         <div class="form-group row">
             <div class="col s12 m6 input-field">
-                <input type="text" ng-model="site.name" maxlength="90" />
+                <input type="text" ng-model="site.name" maxlength="90" placeholder="{{ 'General_Name'|translate }}" />
                 <label>{{ 'General_Name'|translate }}</label>
             </div>
             <div class="col s12 m6"></div>
@@ -84,7 +84,7 @@
                 <div piwik-form-field="setting" all-settings="settingsPerPlugin.settings"></div>
             </div>
         </div>
-        
+
         <div piwik-field uicontrol="select" name="currency"
              ng-model="site.currency"
              title="{{ 'SitesManager_Currency'|translate }}"

--- a/plugins/WebsiteMeasurable/MeasurableSettings.php
+++ b/plugins/WebsiteMeasurable/MeasurableSettings.php
@@ -180,7 +180,11 @@ class MeasurableSettings extends \Piwik\Settings\Measurable\MeasurableSettings
                 . '<br /><br />'
                 . Piwik::translate('SitesManager_YourCurrentIpAddressIs', array('<i>' . $ip . '</i>'));
             $field->uiControl = FieldConfig::UI_CONTROL_TEXTAREA;
-            $field->uiControlAttributes = array('cols' => '20', 'rows' => '4');
+            $field->uiControlAttributes = array(
+              'cols' => '20',
+              'rows' => '4',
+              'placeholder' => $ip,
+            );
 
             $field->validate = function ($value) {
                 if (!empty($value)) {

--- a/plugins/WebsiteMeasurable/Settings/Urls.php
+++ b/plugins/WebsiteMeasurable/Settings/Urls.php
@@ -22,7 +22,6 @@ class Urls extends \Piwik\Settings\Measurable\MeasurableProperty
     {
         $name = 'urls';
         $pluginName = 'WebsiteMeasurable';
-        $defaultValue = array('http://siteUrl.com/', 'http://siteUrl2.com/');
         $type = FieldConfig::TYPE_ARRAY;
 
         parent::__construct($name, $defaultValue, $type, $pluginName, $idSite);
@@ -38,7 +37,11 @@ class Urls extends \Piwik\Settings\Measurable\MeasurableProperty
         $config->title = Piwik::translate('SitesManager_Urls');
         $config->inlineHelp = Piwik::translate('SitesManager_AliasUrlHelp');
         $config->uiControl = FieldConfig::UI_CONTROL_TEXTAREA;
-        $config->uiControlAttributes = array('cols' => '25', 'rows' => '3');
+        $config->uiControlAttributes = array(
+          'cols' => '25',
+          'rows' => '3',
+          'placeholder' => "https://siteUrl.com/                                                 https://siteUrl2.com/",
+        );
 
         $self = $this;
         $config->validate = function ($urls) use ($self) {


### PR DESCRIPTION
The add site form has prefilled values for both Name (Name) and SiteUrl (http://siteUrl.com/\nhttp://siteUrl2.com/). 
This is annoying because you then have to remove the existing content when filling in the form.
Hence I suggest using those values as placeholders instead of default values. 