### PR TITLE
Make row evolution and segmented visitor log work for plugins that define entities

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable_rowactions.js
+++ b/plugins/CoreHome/javascripts/dataTable_rowactions.js
@@ -288,6 +288,13 @@ DataTable_RowActions_RowEvolution.prototype.performAction = function (label, tr,
         label = this.multiEvolutionRows.join(',');
     }
 
+    $.each(this.dataTable.param, function (index, value) {
+        // we automatically add fields like idDimension, idGoal etc.
+        if (index !== 'idSite' && index.indexOf('id') === 0 && $.isNumeric(value)) {
+            extraParams[index] = value;
+        }
+    });
+
     // check if abandonedCarts is in the dataTable params and if so, propagate to row evolution request
     if (this.dataTable.param.abandonedCarts !== undefined) {
         extraParams['abandonedCarts'] = this.dataTable.param.abandonedCarts;

--- a/plugins/Live/javascripts/rowaction.js
+++ b/plugins/Live/javascripts/rowaction.js
@@ -79,6 +79,13 @@
             extraParams = {date: this.dataTable.param.date, period: this.dataTable.param.period};
         }
 
+        $.each(this.dataTable.param, function (index, value) {
+            // we automatically add fields like idDimension, idGoal etc.
+            if (index !== 'idSite' && index.indexOf('id') === 0 && $.isNumeric(value)) {
+                extraParams[index] = value;
+            }
+        });
+
         this.openPopover(apiMethod, segment, extraParams);
     };
 


### PR DESCRIPTION
As per title. Otherwise it would not forward parameters like idGoal, idDimension, ... and row evolution wouldn't work for plugins that are based on IDs like custom dimensions and goals etc.