### PR TITLE
Remove no longer needed edge case for conversions

### DIFF
--- a/plugins/Goals/Tracker/GoalsRequestProcessor.php
+++ b/plugins/Goals/Tracker/GoalsRequestProcessor.php
@@ -98,25 +98,6 @@ class GoalsRequestProcessor extends RequestProcessor
                 $request->setMetadata('Goals', 'visitIsConverted', true);
             }
         }
-
-        // There is an edge case when:
-        // - two manual goal conversions happen in the same second
-        // - which result in handleExistingVisit throwing the exception
-        //   because the UPDATE didn't affect any rows (one row was found, but not updated since no field changed)
-        // - the exception is caught here and will result in a new visit incorrectly
-        // In this case, we cancel the current conversion to be recorded:
-        $isManualGoalConversion = $this->isManualGoalConversion($request);
-        $requestIsEcommerce = $request->getMetadata('Goals', 'isRequestEcommerce');
-        $visitorNotFoundInDb = $request->getMetadata('CoreHome', 'visitorNotFoundInDb');
-
-        if ($visitorNotFoundInDb
-            && ($isManualGoalConversion
-                || $requestIsEcommerce)
-        ) {
-            $request->setMetadata('Goals', 'goalsConverted', array());
-            $request->setMetadata('Goals', 'visitIsConverted', false);
-        }
-
     }
 
     public function recordLogs(VisitProperties $visitProperties, Request $request)


### PR DESCRIPTION
This code is no longer executed since `visitorNotFoundInDb` is only set after `afterRequestProcessed` is executed and does actually not make much sense to me anyway since conversions shouldn't affect whether log visit will be updated twice or not etc. Also 2 manual conversions shouldn't have any different affect to several automatically detected goals