### PR TITLE
Fix Piwik UI becomes very slow when having many rows

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -96,6 +96,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         this.workingDivId = this._createDivId();
         domElem.attr('id', this.workingDivId);
 
+        this.maxNumRowsToHandleEvents = 250;
         this.loadedSubDataTable = {};
         this.isEmpty = $('.pk-emptyDataTable', domElem).length > 0;
         this.bindEventsAndApplyStyle(domElem);
@@ -1543,6 +1544,9 @@ $.extend(DataTable.prototype, UIControl.prototype, {
     },
 
     handleColumnHighlighting: function (domElem) {
+        if (!this.canHandleRowEvents(domElem)) {
+            return;
+        }
 
         var maxWidth = {};
         var currentNthChild = null;
@@ -1715,6 +1719,10 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         });
     },
 
+    canHandleRowEvents: function (domElem) {
+        return domElem.find('table > tbody > tr').size() <= this.maxNumRowsToHandleEvents;
+    },
+
     handleRowActions: function (domElem) {
         this.doHandleRowActions(domElem.find('table > tbody > tr'));
     },
@@ -1859,6 +1867,10 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
     // also used in action data table
     doHandleRowActions: function (trs) {
+        if (!trs || trs.length >= this.maxNumRowsToHandleEvents) {
+            return;
+        }
+
         var self = this;
 
         var merged = $.extend({}, self.param, self.props);

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1867,7 +1867,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
     // also used in action data table
     doHandleRowActions: function (trs) {
-        if (!trs || trs.length >= this.maxNumRowsToHandleEvents) {
+        if (!trs || trs.length > this.maxNumRowsToHandleEvents) {
             return;
         }
 

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -96,7 +96,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         this.workingDivId = this._createDivId();
         domElem.attr('id', this.workingDivId);
 
-        this.maxNumRowsToHandleEvents = 250;
+        this.maxNumRowsToHandleEvents = 255;
         this.loadedSubDataTable = {};
         this.isEmpty = $('.pk-emptyDataTable', domElem).length > 0;
         this.bindEventsAndApplyStyle(domElem);


### PR DESCRIPTION
To reproduce eg go to Actions => Pages for Month, then select flatten and "all" in the limit. If you now see like 700-2000 rows or so Piwik UI will take seconds to render and it will be almost impossible to scroll. Doing some profiling I was able to improve it a little by disabling some features when there are > 250 rows. Ideally we would make those features simply faster (if possible) and enable it for all rows but for now it will be better to disable those features and have at least a usable UI

Performance could be still improved but would need to spend more time.