### PR TITLE
Use widget container to search for sparkline related evolution chart

### DIFF
--- a/plugins/CoreHome/javascripts/sparkline.js
+++ b/plugins/CoreHome/javascripts/sparkline.js
@@ -41,7 +41,7 @@ window.initializeSparklines = function () {
         var graph = $(this);
 
         // we search for .widget to make sure eg in the Dashboard to not update any graph of another report
-        var selectorsToFindParent = ['.widget', '.reporting-page', 'body'];
+        var selectorsToFindParent = ['.widget', '[piwik-widget-container]', '.reporting-page', 'body'];
         var index = 0, selector, parent;
         for (index; index < selectorsToFindParent.length; index++) {
             selector = selectorsToFindParent[index];


### PR DESCRIPTION
Currently it is not possible to use multiple evolution chart / sparklines combinations on one page. As the update triggered by the sparklines doesn't find the correct evolution chart to update.

With this small change it is possible to have multiple reports with evolution chart and sparklines if they are wrapped within a widget container.
