### PR TITLE
Change '//' comment to '/* ... */' to avoid interference with html/js optimisers.

### DIFF
--- a/plugins/Morpheus/templates/javascriptCode.twig
+++ b/plugins/Morpheus/templates/javascriptCode.twig
@@ -1,7 +1,7 @@
 <!-- Piwik -->
 <script type="text/javascript">
   var _paq = _paq || [];
-  // tracker methods like "setCustomDimension" should be called before "trackPageView"
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
 {$options}  _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {

--- a/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
@@ -39,7 +39,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = "&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
-  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
+  /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   _paq.push([\"setCookieDomain\", \"*.localhost\"]);
   _paq.push([\"setDomains\", [\"*.localhost/piwik\",\"*.another-domain/piwik\",\"*.another-domain/piwik\"]]);
@@ -78,7 +78,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = "&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
-  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
+  /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
@@ -116,7 +116,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = "&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
-  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
+  /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   // you can set up to 5 custom variables for each visitor
   _paq.push([\"setCustomVariable\", 1, \"name\", \"value\", \"visit\"]);
@@ -163,7 +163,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = "&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
-  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
+  /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   // you can set up to 5 custom variables for each visitor
   _paq.push([\"setCustomVariable\", 1, \"name\", \"value\", \"visit\"]);
@@ -207,7 +207,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = "&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
-  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
+  /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
@@ -244,7 +244,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
         $expected = '&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
-  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
+  /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
   // you can set up to 5 custom variables for each visitor
   _paq.push(["setCustomVariable", 1, "abc\"def", "abc\"def", "visit"]);

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
@@ -2,7 +2,7 @@
 <result>&lt;!-- Piwik --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
   var _paq = _paq || [];
-  // tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot;
+  /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {


### PR DESCRIPTION
Change '//' comment to '/* ... */' to avoid interference with html/js
optimisers.

Fix #11332