### PR TITLE
Fix rate metric was not formatted

### DIFF
--- a/core/API/Inconsistencies.php
+++ b/core/API/Inconsistencies.php
@@ -37,7 +37,9 @@ class Inconsistencies
             'bounce_rate_returning',
             'nb_visits_percentage',
             '/.*_evolution/',
-            '/goal_.*_conversion_rate/'
+            '/goal_.*_conversion_rate/',
+            '/form_.*_rate/',
+            '/field_.*_rate/',
         );
     }
 }


### PR DESCRIPTION
Similar to https://github.com/piwik/piwik/pull/10887 makes sure the rate metrics are formatted in mobile app. I wonder if we should maybe simply change it to `'/.*_rate$/'` and then remove several of them? Would simplify it for the future and be faster
