### PR TITLE
When calculating report totals make sure to actually work on first level table

### DIFF
--- a/core/API/DataTableManipulator/ReportTotalsCalculator.php
+++ b/core/API/DataTableManipulator/ReportTotalsCalculator.php
@@ -129,6 +129,7 @@ class ReportTotalsCalculator extends DataTableManipulator
         }
 
         $request = $this->request;
+        unset($request['idSubtable']); // to make sure we work on first level table
 
         /** @var \Piwik\Period $period */
         $period = $table->getMetadata('period');


### PR DESCRIPTION
Need to see if some tests fail. It was not working on first level table as the method describes. We need to work on first level table to get proper "total" values of all possible branches / paths to be able to calculate percentages