### PR TITLE
When generating a component, require correct Piwik version

### DIFF
--- a/plugins/CoreConsole/Commands/GeneratePluginBase.php
+++ b/plugins/CoreConsole/Commands/GeneratePluginBase.php
@@ -133,7 +133,7 @@ abstract class GeneratePluginBase extends ConsoleCommand
             $piwikVersion.= '-stable';
         }
 
-        $newRequiredVersion = sprintf('>=%s,<%d.0.0', $piwikVersion, $nextMajorVersion);
+        $newRequiredVersion = sprintf('>=%s,<%d.0.0-b1', $piwikVersion, $nextMajorVersion);
 
 
         if (!empty($pluginJson['require']['piwik'])) {


### PR DESCRIPTION
It was generating a required Piwik version like `>=3.0.2,<4.0.0` but should be `>=3.0.2,<4.0.0-b1`
