### PR TITLE
Fix memory leaks in data table / jqplot

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -91,9 +91,12 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
     _destroy: function() {
       UIControl.prototype._destroy.call(this);
+      // remove handlers to avoid memory leaks
       if (this.windowResizeTableAttached) {
-        // remove resize listener to avoid memory leak
         $(window).off('resize', this._resizeDataTable);
+      }
+      if (this._bodyMouseUp) {
+        $('body').off('mouseup', this._bodyMouseUp);
       }
     },
 
@@ -1188,11 +1191,12 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         });
 
         //close exportToFormat onClickOutside
-        $('body').on('mouseup', function (e) {
+        self._bodyMouseUp = function (e) {
             if (self.exportToFormat) {
                 self.exportToFormatHide(domElem);
             }
-        });
+        };
+        $('body').on('mouseup', self._bodyMouseUp);
 
         $('.exportToFormatItems a', domElem)
             // prevent click jacking attacks by dynamically adding the token auth when the link is clicked

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -89,6 +89,14 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         // initialize your dataTable in your plugin
     },
 
+    _destroy: function() {
+      UIControl.prototype._destroy.call(this);
+      if (this.windowResizeTableAttached) {
+        // remove resize listener to avoid memory leak
+        $(window).off('resize', this._resizeDataTable);
+      }
+    },
+
     //initialisation function
     init: function () {
         var domElem = this.$element;
@@ -577,6 +585,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             }
 
             $(window).on('resize', resizeDataTable);
+            self._resizeDataTable = resizeDataTable;
         }
     },
 

--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -178,12 +178,12 @@
 
             // manage resources
             target.on('piwikDestroyPlot', function () {
-                if (this._resizeListener) {
-                    $(window).off('resize', this._resizeListener);
+                if (self._resizeListener) {
+                    $(window).off('resize', self._resizeListener);
                 }
                 self._plot.destroy();
                 for (var i = 0; i < $.jqplot.visiblePlots.length; i++) {
-                    if ($.jqplot.visiblePlots[i] == self._plot) {
+                    if ($.jqplot.visiblePlots[i] === self) {
                         $.jqplot.visiblePlots[i] = null;
                     }
                 }
@@ -394,14 +394,14 @@
                         if ($.jqplot.visiblePlots[i] == null) {
                             continue;
                         }
-                        $.jqplot.visiblePlots[i].destroy();
+                        $.jqplot.visiblePlots[i].destroyPlot();
                     }
                     $.jqplot.visiblePlots = [];
                 });
             }
 
             if (typeof plot != 'undefined') {
-                $.jqplot.visiblePlots.push(plot);
+                $.jqplot.visiblePlots.push(self);
             }
         },
 


### PR DESCRIPTION
**Overview**:

Prior to these changes, every data table created would remain in memory due to leftover `resize` and `mouseup` handlers on `window`/`document.body` (see individual commit messages for further details).

This PR adds a `_destroy` method to the data table class to appropriately clean up these handlers, and changes jqplot so that it appropriately destroys plot objects when the page changes.

**Prerequisites to reproducing bug**: Have a dashboard configured to show one of these data tables (e.g., the demo works fine for reproducing this bug).

**Reproduce**:

1. Visit the Dashboard.
2. [Take a heap snapshot](https://developer.chrome.com/devtools/docs/heap-profiling#basics_snapshot) using Chrome's development tools.
3. Click on the dashboard link in the left menu.
4. Take another heap snapshot.
5. Compare the number of live instances of `exports.JqplotEvolutionGraphDataTable` between snapshot 1 and 2. 2 will have double the instances of 1.