### PR TITLE
Only set X-Frame-Options when not empty + Do not set "X-Frame-Options: sameorigin" when embedding dashboards in iframe

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -708,7 +708,8 @@ abstract class Controller
         $general = PiwikConfig::getInstance()->General;
         $view->enableFrames = $general['enable_framed_pages']
                 || (isset($general['enable_framed_logins']) && $general['enable_framed_logins']);
-        if (!$view->enableFrames) {
+        $embeddedAsIframe = (Common::getRequestVar('module') == 'Widgetize');
+        if (!$view->enableFrames && !$embeddedAsIframe) {
             $view->setXFrameOptions('sameorigin');
         }
 

--- a/core/View.php
+++ b/core/View.php
@@ -265,7 +265,9 @@ class View implements ViewInterface
         Common::sendHeader('Content-Type: ' . $this->contentType);
         // always sending this header, sometimes empty, to ensure that Dashboard embed loads
         // - when calling sendHeader() multiple times, the last one prevails
-        Common::sendHeader('X-Frame-Options: ' . (string)$this->xFrameOptions);
+        if(!empty($this->xFrameOptions)) {
+            Common::sendHeader('X-Frame-Options: ' . (string)$this->xFrameOptions);
+        }
 
         return $this->renderTwigTemplate();
     }
@@ -356,6 +358,7 @@ class View implements ViewInterface
      */
     public function setXFrameOptions($option = 'deny')
     {
+
         if ($option === 'deny' || $option === 'sameorigin') {
             $this->xFrameOptions = $option;
         }


### PR DESCRIPTION
fixes #10167