### PR TITLE
Avoid segment encoding issues

### DIFF
--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -7,15 +7,14 @@
 
 Segmentation = (function($) {
 
-  Mousetrap.bind('s', function(event) {
-    if (event.preventDefault) {
-        event.preventDefault();
-    } else {
-        event.returnValue = false; // IE
-    }
-    $('.segmentListContainer .segmentationContainer .title').trigger('click').focus();
+    Mousetrap.bind('s', function (event) {
+        if (event.preventDefault) {
+            event.preventDefault();
+        } else {
+            event.returnValue = false; // IE
+        }
+        $('.segmentListContainer .segmentationContainer .title').trigger('click').focus();
     });
-
 
     function preselectFirstMetricMatch(rowNode)
     {
@@ -68,16 +67,10 @@ Segmentation = (function($) {
 
         segmentation.prototype.getSegment = function(){
             var self = this;
-            if($.browser.mozilla) {
-                return self.currentSegmentStr;
-            }
-            return decodeURIComponent(self.currentSegmentStr);
+            return self.currentSegmentStr;
         };
 
         segmentation.prototype.setSegment = function(segmentStr){
-            if(!$.browser.mozilla) {
-                segmentStr = encodeURIComponent(segmentStr);
-            }
             this.currentSegmentStr = segmentStr;
         };
 
@@ -87,7 +80,7 @@ Segmentation = (function($) {
             title += ' '+ _pk_translate('SegmentEditor_CurrentlySelectedSegment', [segmentDescription]);
 
             $(this.content).attr('title', title);
-        }
+        };
 
         segmentation.prototype.markCurrentSegment = function(){
             var current = this.getSegment();
@@ -155,8 +148,7 @@ Segmentation = (function($) {
         };
 
         var getMockedInputRowHtml = function(){
-            var mockedInputRow = '<div class="segment-row"><a class="segment-close" href="#"></a><div class="segment-row-inputs">'+getMockedInputSet().html()+'</div></div>';
-            return mockedInputRow;
+            return '<div class="segment-row"><a class="segment-close" href="#"></a><div class="segment-row-inputs">'+getMockedInputSet().html()+'</div></div>';
         };
 
         var getMockedFormRow = function(){
@@ -275,14 +267,8 @@ Segmentation = (function($) {
 
                     injClass = "";
                     var checkSelected = segment.definition;
-                    if(!$.browser.mozilla) {
-                        checkSelected = encodeURIComponent(checkSelected);
-                    }
 
-                    if( checkSelected == self.currentSegmentStr
-                        || checkSelected == decodeURIComponent(self.currentSegmentStr)
-                        || checkSelected == unescape(decodeURIComponent(self.currentSegmentStr))
-                    ) {
+                    if(checkSelected == self.currentSegmentStr) {
                         injClass = 'class="segmentSelected"';
                     }
                     listHtml += '<li data-idsegment="'+segment.idsegment+'" data-definition="'+ (segment.definition).replace(/"/g, '&quot;') +'" '
@@ -352,7 +338,7 @@ Segmentation = (function($) {
         var sanitiseSegmentName = function(segment) {
             segment = piwikHelper.escape(segment);
             return segment;
-        }
+        };
 
         var getFormHtml = function() {
             var html = self.editorTemplate.find("> .segment-element").clone();
@@ -1245,8 +1231,6 @@ Segmentation = (function($) {
                         segment = $search.segment
                     }
 
-                    segment = decodeURIComponent(segment);
-
                     if (self.getSegment() != segment) {
                         self.setSegment(segment);
                         self.initHtml();
@@ -1294,8 +1278,6 @@ $(document).ready(function() {
 
         this.changeSegment = function(segmentDefinition) {
             if (piwikHelper.isAngularRenderingThePage()) {
-                segmentDefinition = this.uriEncodeSegmentDefinition(segmentDefinition);
-
                 angular.element(document).injector().invoke(function ($location, $rootScope) {
                     var $search = $location.search();
 
@@ -1310,7 +1292,6 @@ $(document).ready(function() {
                             } catch (e) {}
                         }, 1);
                     }
-
                 });
                 return false;
             } else {
@@ -1454,9 +1435,7 @@ $(document).ready(function() {
                     || broadcast.getValueFromUrl('segment');
             }
 
-            if ($.browser.mozilla) {
-                segmentFromRequest = decodeURIComponent(segmentFromRequest);
-            }
+            segmentFromRequest = decodeURIComponent(segmentFromRequest);
 
             return segmentFromRequest;
         }

--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -268,7 +268,9 @@ Segmentation = (function($) {
                     injClass = "";
                     var checkSelected = segment.definition;
 
-                    if(checkSelected == self.currentSegmentStr) {
+                    if( checkSelected == self.currentSegmentStr ||
+                        checkSelected == decodeURIComponent(self.currentSegmentStr)
+                    ) {
                         injClass = 'class="segmentSelected"';
                     }
                     listHtml += '<li data-idsegment="'+segment.idsegment+'" data-definition="'+ (segment.definition).replace(/"/g, '&quot;') +'" '

--- a/tests/UI/expected-screenshots/SegmentSelectorEditorTest_saved.png
+++ b/tests/UI/expected-screenshots/SegmentSelectorEditorTest_saved.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2cc95675231eebaa66d97bc5b23cecf8ad6cf688a68b0b4127d82cb3f25a2f46
-size 17406
+oid sha256:4e8587632885c96c3724139138b53c3312b8e88a3c9aa5601adf9f804c43c29d
+size 17711

--- a/tests/UI/expected-screenshots/SegmentSelectorEditorTest_saved_reload.png
+++ b/tests/UI/expected-screenshots/SegmentSelectorEditorTest_saved_reload.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2cc95675231eebaa66d97bc5b23cecf8ad6cf688a68b0b4127d82cb3f25a2f46
-size 17406
+oid sha256:4e8587632885c96c3724139138b53c3312b8e88a3c9aa5601adf9f804c43c29d
+size 17711

--- a/tests/UI/expected-screenshots/SegmentSelectorEditorTest_updated.png
+++ b/tests/UI/expected-screenshots/SegmentSelectorEditorTest_updated.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8c00557145a34fc48374e5315f0e9c42618aaa7266295682f2778897a79c17b
-size 17110
+oid sha256:a0a4c3bd7e42558eaf5ebe40693845d2e3954ab84bc6ce3cce5e3cf6b0e7d326
+size 17801

--- a/tests/UI/expected-screenshots/SegmentSelectorEditorTest_updated_reload.png
+++ b/tests/UI/expected-screenshots/SegmentSelectorEditorTest_updated_reload.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8c00557145a34fc48374e5315f0e9c42618aaa7266295682f2778897a79c17b
-size 17110
+oid sha256:a0a4c3bd7e42558eaf5ebe40693845d2e3954ab84bc6ce3cce5e3cf6b0e7d326
+size 17801


### PR DESCRIPTION
I've removed all encodeURI/decodeURI stuff from the segments. Angular already encodes it in the URL automatically, so it was encoded twice in some cases.
I've currently tested the changes successfully on:

* Internet Explorer 11
* Chrome 56
* Firefox 47
* Vivaldi 1.7

Hope I haven't missed any test case...

Maybe anyone could test it on some other browsers @mattab @tsteur 

_side note: as the double encoded segments worked in many cases before, it might eventually be possible that this changes breaks some bookmarks having double encoded segments in it. But I haven't found any so far_

fixes #11321
maybe refs #10973