### PR TITLE
piwik.js: In addTracker do not explicitely allow to set piwikUrl to null since it may not work

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -5638,9 +5638,8 @@ if (typeof window.Piwik !== 'object') {
 
             /**
              * Adds a new tracker. All sent requests will be also sent to the given siteId and piwikUrl.
-             * If piwikUrl is not set, current url will be used.
              *
-             * @param null|string piwikUrl  If null, will reuse the same tracker URL of the current tracker instance
+             * @param string piwikUrl  The tracker URL of the current tracker instance
              * @param int|string siteId
              * @return Tracker
              */


### PR DESCRIPTION

fixes #11340