### PR TITLE
Fix Clicking on the "Dashboard" top link hides all dashboard content

### DIFF
--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -25,7 +25,7 @@
                                     <li {% if urlParameters._url.module is defined and urlParameters._url.module == currentModule and urlParameters._url.action is defined and urlParameters._url.action == currentAction %}class="active"{% endif %}
                                         role="menuitem"
                                     >
-                                        <a class="item" tabindex="5"
+                                        <a class="item" tabindex="5" target="_self"
                                            title="{{ urlParameters._tooltip|default('')|translate|e('html_attr') }}"
                                            href="index.php?{{ urlParameters._url|urlRewriteWithParameters|slice(1) }}">
                                             {{ name|translate }}
@@ -58,7 +58,7 @@
                                 {% for name,urlParameters in level2 %}
                                     {% if name|slice(0,1) != '_' %}
                                         <li>
-                                            <a title="{{ urlParameters._tooltip|default('')|translate|e('html_attr') }}"
+                                            <a title="{{ urlParameters._tooltip|default('')|translate|e('html_attr') }}" target="_self"
                                                href="index.php?{{ urlParameters._url|urlRewriteWithParameters|slice(1) }}">{{ name|translate }}</a>
                                         </li>
                                     {% endif %}

--- a/plugins/CoreHome/templates/_topBar.twig
+++ b/plugins/CoreHome/templates/_topBar.twig
@@ -13,7 +13,7 @@
             {{ menu._html|raw }}
         {% else %}
             <a {% if menu._tooltip is defined %}title="{{ menu._tooltip }}"{% endif %}
-               id="topmenu-{{ menu._url.module|lower }}"
+               id="topmenu-{{ menu._url.module|lower }}" target="_self"
                href="index.php{{ menu._url|urlRewriteWithParameters }}" tabindex="3">{{ _self.menuItemLabel(label, icon) }}</a>
         {% endif %}
     {% endmacro %}


### PR DESCRIPTION
fixes #11386
