### PR TITLE
Cells in email reports should reuse same font size and family

### DIFF
--- a/plugins/CoreHome/templates/ReportRenderer/_htmlReportBody.twig
+++ b/plugins/CoreHome/templates/ReportRenderer/_htmlReportBody.twig
@@ -46,10 +46,10 @@
                 {% else %}
                     {% set rowMetadata=null %}
                 {% endif %}
-                <tr style="{{ cycle(cycleValues, cycleIndex) }};{{styleTableCell}}">
+                <tr style="{{ cycle(cycleValues, cycleIndex) }};">
                     {% set cycleIndex=cycleIndex+1 %}
                     {% for columnId, columnName in reportColumns %}
-                        <td style="padding:17px 15px;{% if columnId == 'label' %}{%  else %} text-align:right;{% endif %}">
+                        <td style="padding:17px 15px;{% if columnId == 'label' %}{%  else %} text-align:right;{% endif %};{{styleTableCell}}">
                             {% if columnId == 'label' %}
                                 {% if rowMetrics[columnId] is defined %}
                                     {% if rowMetadata.logo is defined %}

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_month.original.html
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_month.original.html
@@ -395,54 +395,54 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Site 1                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 43
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 43
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Site 2                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -470,58 +470,58 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique visitors                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Actions                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 43
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Maximum actions in one visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Actions per Visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.9
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Avg. Visit Duration (in seconds)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:10:55
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bounce Rate                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 27%
                                                                                     </td>
                                     </tr>
@@ -576,52 +576,52 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/screens/unknown.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/screens/normal.png'>
                                         &nbsp;
                                                                                                             Desktop                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -664,25 +664,25 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 43
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:10:55
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 27%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -725,27 +725,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/brand/Unknown.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 43
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:10:55
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 27%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -788,48 +788,48 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         800x300                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 41
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4.6
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:13:21
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1024x768                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -872,52 +872,52 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/UNK.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/WIN.png'>
                                         &nbsp;
                                                                                                             Windows XP                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -960,77 +960,77 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/UNK.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/FF.png'>
                                         &nbsp;
                                                                                                             Firefox                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/OP.png'>
                                         &nbsp;
                                                                                                             Opera                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -1073,77 +1073,77 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/UNK.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/FF.png'>
                                         &nbsp;
                                                                                                             Firefox 3.6                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/OP.png'>
                                         &nbsp;
                                                                                                             Opera 9.63                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -1186,71 +1186,71 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unknown / Unknown / 800x300                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Windows / Firefox / 1024x768                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Windows / Opera / 800x300                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -1293,52 +1293,52 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/UNK.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/WIN.png'>
                                         &nbsp;
                                                                                                             Windows                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -1381,71 +1381,71 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Gecko (Firefox)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Presto (Opera)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -1476,132 +1476,132 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/cookie.png'>
                                         &nbsp;
                                                                                                             Cookie                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/flash.png'>
                                         &nbsp;
                                                                                                             Flash                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/java.png'>
                                         &nbsp;
                                                                                                             Java                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/director.png'>
                                         &nbsp;
                                                                                                             Director                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/gears.png'>
                                         &nbsp;
                                                                                                             Gears                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/pdf.png'>
                                         &nbsp;
                                                                                                             Pdf                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/quicktime.png'>
                                         &nbsp;
                                                                                                             Quicktime                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/realplayer.png'>
                                         &nbsp;
                                                                                                             Realplayer                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/silverlight.png'>
                                         &nbsp;
                                                                                                             Silverlight                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/windowsmedia.png'>
                                         &nbsp;
                                                                                                             Windowsmedia                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -1644,52 +1644,52 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/fr.png'>
                                         &nbsp;
                                                                                                             France                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -1732,48 +1732,48 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Europe                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -1816,27 +1816,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 43
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:10:55
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 27%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -1879,48 +1879,48 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         French                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -1963,27 +1963,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 43
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:10:55
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 27%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -2026,48 +2026,48 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unknown (xx)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         French (fr)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -2095,82 +2095,82 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0-10s                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         11-30s                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         31-60s                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1-2 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2-4 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4-7 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7-10 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         10-15 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-30 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         30+ min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -2198,82 +2198,82 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 page                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6-7 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8-10 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         11-14 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-20 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         21+ pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -2304,156 +2304,156 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 27%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 73%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9-14 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-25 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         26-50 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         51-100 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         101-200 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         201+ visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -2481,122 +2481,122 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         New visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 day                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8-14 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-30 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         31-60 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         61-120 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         121-364 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         365+ days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -2624,66 +2624,66 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique returning visitors                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Returning Users                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Returning Visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 9
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Actions by Returning Visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 41
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Maximum actions in one returning visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bounce Rate for Returning Visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Avg. Actions per Returning Visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4.6
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Avg. Duration of a Returning Visit (in sec)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:13:21
                                                                                     </td>
                                     </tr>
@@ -2726,554 +2726,554 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         10h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         11h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         12h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 43
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:10:55
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 27%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         13h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         14h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         16h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         17h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         18h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         19h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         20h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         21h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         22h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         23h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -3316,554 +3316,554 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         10h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         11h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         12h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         13h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         14h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         16h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         17h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         18h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         19h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         20h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         21h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         22h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         23h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -3906,163 +3906,163 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Monday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 6
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:07:31
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 50%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Tuesday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 10
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Wednesday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Thursday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Friday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Saturday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Sunday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 7
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2.3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:05:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 67%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -4090,74 +4090,74 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Pageviews                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 43
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique Pageviews                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 27
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Downloads                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique Downloads                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Outlinks                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique Outlinks                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Searches                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique Keywords                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Avg. generation time                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.3s
                                                                                     </td>
                                     </tr>
@@ -4185,26 +4185,26 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bytes transferred overall                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bytes transferred pageviews                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bytes transferred downloads                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -4247,102 +4247,102 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/index.htm'>
                                                                         index.htm                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:05:20
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.3s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://'>
                                                                         Page URL not defined                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 17
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.22s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/thankyou'>
                                                                         thankyou                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:04:30
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.31s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/products'>
                                                                         products                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.15s
                                                                                     </td>
                                     </tr>
@@ -4379,40 +4379,40 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/index.htm'>
                                                                         index.htm                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.3s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/products'>
                                                                         products                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.15s
                                                                                     </td>
                                     </tr>
@@ -4449,36 +4449,36 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         second visitor/two days later/a new visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.32s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         first page view                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.14s
                                                                                     </td>
                                     </tr>
@@ -4515,59 +4515,59 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/index.htm'>
                                                                         index.htm                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 11%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.3s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/thankyou'>
                                                                         thankyou                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.31s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/products'>
                                                                         products                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.15s
                                                                                     </td>
                                     </tr>
@@ -4604,36 +4604,36 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Checkout/Purchasing...                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.45s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         first page view                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.14s
                                                                                     </td>
                                     </tr>
@@ -4676,117 +4676,117 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Checkout/Purchasing...                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.45s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         second visitor/two days later/a new visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:06:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.32s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         second visitor/two days later/second page view                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 8
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:09:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.17s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         first page view                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.14s
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Page Name not defined                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0.22s
                                                                                     </td>
                                     </tr>
@@ -4901,71 +4901,71 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Websites                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 6
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 22
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.7
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:10:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 33%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Campaigns                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Direct Entry                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -5008,48 +5008,48 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         referrer.com                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 6
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 22
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.7
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:10:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 33%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         goal-matching-url-parameter                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -5104,77 +5104,77 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://referrer.com/Other_Page.htm'>
                                                                         referrer.com/Other_Page.htm                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 10
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='https://referrer.com/Other_Page.htm'>
                                                                         referrer.com/Other_Page.htm                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 10
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://referrer.com/page.htm?param=valuewith some spaces'>
                                                                         referrer.com/page.htm?param=valuewith some spaces                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -5223,25 +5223,25 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         goal-matching-url-parameter - referrer.com                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:15:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -5269,34 +5269,34 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Conversions                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Visits with Conversions                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Revenue                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Conversion Rate                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>

--- a/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_week.original.html
+++ b/tests/PHPUnit/System/expected/test_ecommerceOrderWithItems_scheduled_report_in_html_tables_only__ScheduledReports.generateReport_week.original.html
@@ -455,54 +455,54 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Piwik test                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13351.11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Piwik test                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 250
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -530,58 +530,58 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique visitors                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Actions                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Maximum actions in one visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 6
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Actions per Visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Avg. Visit Duration (in seconds)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bounce Rate                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
                                     </tr>
@@ -630,71 +630,71 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         ValueIsZero - Custom Variable value not defined                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         VisitorType - NewLoggedOut                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         VisitorName - Great name!                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 12
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:25:32
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 25%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13351.11
                                                                                     </td>
                                     </tr>
@@ -737,27 +737,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/screens/normal.png'>
                                         &nbsp;
                                                                                                             Desktop                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
@@ -800,25 +800,25 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
@@ -861,27 +861,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/brand/Unknown.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
@@ -924,25 +924,25 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1024x768                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 80%
                                                                                     </td>
                                     </tr>
@@ -985,27 +985,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/WIN.png'>
                                         &nbsp;
                                                                                                             Windows XP                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 80%
                                                                                     </td>
                                     </tr>
@@ -1048,27 +1048,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/FF.png'>
                                         &nbsp;
                                                                                                             Firefox                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 80%
                                                                                     </td>
                                     </tr>
@@ -1111,27 +1111,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/browsers/FF.png'>
                                         &nbsp;
                                                                                                             Firefox 3.6                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 80%
                                                                                     </td>
                                     </tr>
@@ -1174,25 +1174,25 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Windows / Firefox / 1024x768                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 80%
                                                                                     </td>
                                     </tr>
@@ -1235,27 +1235,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicesDetection/images/os/WIN.png'>
                                         &nbsp;
                                                                                                             Windows                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 80%
                                                                                     </td>
                                     </tr>
@@ -1298,25 +1298,25 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Gecko (Firefox)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 80%
                                                                                     </td>
                                     </tr>
@@ -1347,132 +1347,132 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/cookie.png'>
                                         &nbsp;
                                                                                                             Cookie                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/flash.png'>
                                         &nbsp;
                                                                                                             Flash                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/java.png'>
                                         &nbsp;
                                                                                                             Java                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/director.png'>
                                         &nbsp;
                                                                                                             Director                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/gears.png'>
                                         &nbsp;
                                                                                                             Gears                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/pdf.png'>
                                         &nbsp;
                                                                                                             Pdf                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/quicktime.png'>
                                         &nbsp;
                                                                                                             Quicktime                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/realplayer.png'>
                                         &nbsp;
                                                                                                             Realplayer                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/silverlight.png'>
                                         &nbsp;
                                                                                                             Silverlight                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/DevicePlugins/images/plugins/windowsmedia.png'>
                                         &nbsp;
                                                                                                             Windowsmedia                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -1515,52 +1515,52 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/pl.png'>
                                         &nbsp;
                                                                                                             Poland                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 12
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:25:32
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 25%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13351.11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/fr.png'>
                                         &nbsp;
                                                                                                             France                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:12:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 10
                                                                                     </td>
                                     </tr>
@@ -1603,25 +1603,25 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Europe                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
@@ -1664,27 +1664,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
@@ -1727,48 +1727,48 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Polish                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 12
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:25:32
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 25%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 75%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         French                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:12:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
@@ -1811,27 +1811,27 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                         <img width="16px" height="16px" src='http://example.com/piwik/tests/PHPUnit/proxy/plugins/UserCountry/images/flags/xx.png'>
                                         &nbsp;
                                                                                                             Unknown                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
@@ -1874,48 +1874,48 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Polish (pl)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 12
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:25:32
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 25%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 75%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         French (fr)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:12:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
@@ -1943,82 +1943,82 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0-10s                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         11-30s                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         31-60s                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1-2 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2-4 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4-7 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7-10 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         10-15 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-30 min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         30+ min                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
@@ -2046,82 +2046,82 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 page                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6-7 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8-10 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         11-14 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-20 pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         21+ pages                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -2152,156 +2152,156 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 60%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9-14 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-25 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         26-50 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         51-100 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         101-200 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         201+ visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -2329,122 +2329,122 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         New visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 day                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8-14 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-30 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         31-60 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         61-120 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         121-364 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         365+ days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -2472,66 +2472,66 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique returning visitors                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Returning Users                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Returning Visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Actions by Returning Visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 12
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Maximum actions in one returning visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 6
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bounce Rate for Returning Visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 25%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Avg. Actions per Returning Visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Avg. Duration of a Returning Visit (in sec)                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:25:32
                                                                                     </td>
                                     </tr>
@@ -2574,554 +2574,554 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         10h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         11h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         12h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 80%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         13h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         14h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         16h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         17h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         18h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         19h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         20h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         21h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         22h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         23h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -3164,554 +3164,554 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:12:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 10
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4.5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:42:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 3111.11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:06:03
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 10240
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:12:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         10h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         11h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         12h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         13h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         14h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         16h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         17h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         18h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         19h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         20h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         21h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         22h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         23h                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -3754,163 +3754,163 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Monday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Tuesday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 13
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4.3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:30:01
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 66.67%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Wednesday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1.5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:12:02
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 50%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Thursday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Friday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Saturday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Sunday                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -3938,66 +3938,66 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Pageviews                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique Pageviews                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Downloads                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique Downloads                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Outlinks                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique Outlinks                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Searches                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Unique Keywords                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -4025,26 +4025,26 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bytes transferred overall                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bytes transferred pageviews                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Bytes transferred downloads                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -4084,24 +4084,24 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/index.htm'>
                                                                         index.htm                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:03:23
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
@@ -4135,18 +4135,18 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/index.htm'>
                                                                         index.htm                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -4180,44 +4180,44 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         View product left in cart                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         incredible title!                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Looking at Electronics &amp; Cameras page with a page level custom variable                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -4251,18 +4251,18 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                             <a style="color: rgb(13,13,13);" href='http://example.org/index.htm'>
                                                                         index.htm                                                                            </a>
                                                                                                                         </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
@@ -4296,30 +4296,30 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         View product left in cart                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Another Product page with multiple categories                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
@@ -4359,162 +4359,162 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         View product left in cart                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 9
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:02:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Another Product page                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:06:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Another Product page with multiple categories                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Another Product page with no category                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:00:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         incredible title!                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:06:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Looking at Electronics &amp; Cameras page again                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:06:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Looking at Electronics &amp; Cameras page with a page level custom variable                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:06:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Looking at product page                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:12:00
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -4629,25 +4629,25 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Direct Entry                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 16
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 00:22:49
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
@@ -4711,82 +4711,82 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Ecommerce Orders                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Visits with Conversions                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Revenue                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13351.11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Subtotal                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 2700
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Tax                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 531
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Shipping                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 120.11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Discount                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 686
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Purchased Products                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 12
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Average Order Value                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 3337.78
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Conversion Rate                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 40%
                                                                                     </td>
                                     </tr>
@@ -4814,106 +4814,106 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9-14 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-25 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         26-50 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         51-100 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         101+ visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -4941,114 +4941,114 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 day                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8-14 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-30 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         31-60 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         61-120 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         121-364 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         365+ days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -5076,42 +5076,42 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Abandoned Carts                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Revenue left in cart                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 7530.33
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Products left in cart                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 12
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Average Order Value                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 2510.11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Conversion Rate                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 60%
                                                                                     </td>
                                     </tr>
@@ -5139,106 +5139,106 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9-14 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-25 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         26-50 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         51-100 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         101+ visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -5266,114 +5266,114 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 day                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8-14 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-30 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         31-60 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         61-120 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         121-364 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         365+ days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -5419,132 +5419,132 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         SKU2                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1500
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1500
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         SKU VERY nice indeed                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1011.22
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 255.61
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1.5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 50%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         ANOTHER SKU HERE                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 600
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 6
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 100
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 6
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         TRIPOD SKU                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 200
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 100
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         SKU IN ABANDONED CART TWO                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -5590,158 +5590,158 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Canon SLR                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1500
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1500
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         PRODUCT name                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1011.22
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 255.61
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1.5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         PRODUCT name BIS                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 600
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 6
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 100
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 6
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         TRIPOD - bought day after                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 200
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 100
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         PRODUCT TWO LEFT in cart                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         PRODUCT THREE LEFT in cart                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1332
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -5787,210 +5787,210 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Electronics &amp; Cameras                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 2500
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1000
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1.5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 66.67%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Multiple Category 1                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1000
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 500
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Multiple Category 2                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1000
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 500
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Multiple Category 4                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1000
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 500
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Multiple Category 5                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 1000
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 500
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 100%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Product Category not defined                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 611.22
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 7
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 55.61
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3.5
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 50%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Tools                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 200
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 100
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 2
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Category TWO LEFT in cart                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 3
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0%
                                                                                     </td>
                                     </tr>
@@ -6018,34 +6018,34 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Conversions                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 5
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Visits with Conversions                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 4
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Revenue                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 13361.11
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Conversion Rate                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 80%
                                                                                     </td>
                                     </tr>
@@ -6076,145 +6076,145 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9-14 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-25 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         26-50 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         51-100 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         101+ visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -6245,156 +6245,156 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 day                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8-14 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-30 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         31-60 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         61-120 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         121-364 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         365+ days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 0
                                                                                     </td>
                                     </tr>
@@ -6422,34 +6422,34 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Conversions                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Visits with Conversions                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Revenue                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 $ 10
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         Conversion Rate                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 20%
                                                                                     </td>
                                     </tr>
@@ -6477,106 +6477,106 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 visit                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         9-14 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-25 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         26-50 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         51-100 visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         101+ visits                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
@@ -6604,114 +6604,114 @@
                         </thead>
             <tbody>
                                                     
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         0 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 1
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         1 day                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         2 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         3 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         4 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         5 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         6 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         7 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         8-14 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         15-30 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         31-60 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         61-120 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style=";border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style=";">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         121-364 days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>
                             
-                                                                    <tr style="background-color: rgb(242,242,242);border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
-                                                                <td style="padding:17px 15px;">
+                                                                    <tr style="background-color: rgb(242,242,242);">
+                                                                <td style="padding:17px 15px;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                                                                                         365+ days                                                                                                                        </td>
-                                            <td style="padding:17px 15px; text-align:right;">
+                                            <td style="padding:17px 15px; text-align:right;;border-bottom:1px solid rgb(231,231,231);font-size: 15px;padding:17px 15px;color:#0d0d0d;font-family:-apple-system, BlinkMacSystemFont, &#039;Segoe UI&#039;, Roboto, Oxygen-Sans, Cantarell, &#039;Helvetica Neue&#039;, sans-serif;">
                                                                                                 0
                                                                                     </td>
                                     </tr>


### PR DESCRIPTION
Issue was visible in some webmail like gmail - but was working in thunderbird