### PR TITLE
Introduces new config setting to enabled plugin upload 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This is the Developer Changelog for Piwik platform developers. All changes in ou
 
 The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** lets you see more details about any Piwik release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Piwik 3.0.3
+
+### Breaking Changes
+* New config setting `enable_plugin_upload` let's you enable plugin upload. This used to work without any changes before, but is disabled by default now for security reasons.
+
 ## Piwik 3.0.2
 
 ### New Features

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -539,6 +539,10 @@ enable_load_data_infile = 1
 ; - links to Uninstall themes will be disabled (but user can still enable/disable themes)
 enable_plugins_admin = 1
 
+; By setting this option to 1, it will be possible to upload plugin archives directly in Piwik
+; Enabling this opens a remote code execution vulnarability, which yould be used by attackers gaining access to Piwik admin
+enable_plugin_upload = 0
+
 ; By setting this option to 0, you can prevent Super User from editing the Geolocation settings.
 enable_geolocation_admin = 1
 

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -88,6 +88,10 @@ class Controller extends Plugin\ControllerAdmin
         static::dieIfPluginsAdminIsDisabled();
         Piwik::checkUserHasSuperUserAccess();
 
+        if (!CorePluginsAdmin::isPluginUploadEnabled()) {
+            throw new \Exception('Plugin upload disabled by config');
+        }
+
         $nonce = Common::getRequestVar('nonce', null, 'string');
 
         if (!Nonce::verifyNonce(MarketplaceController::INSTALL_NONCE, $nonce)) {

--- a/plugins/CorePluginsAdmin/CorePluginsAdmin.php
+++ b/plugins/CorePluginsAdmin/CorePluginsAdmin.php
@@ -36,6 +36,11 @@ class CorePluginsAdmin extends Plugin
         return (bool) Config::getInstance()->General['enable_plugins_admin'];
     }
 
+    public static function isPluginUploadEnabled()
+    {
+        return (bool) Config::getInstance()->General['enable_plugin_upload'];
+    }
+
     public function getJsFiles(&$jsFiles)
     {
         $jsFiles[] = "libs/bower_components/jQuery.dotdotdot/src/js/jquery.dotdotdot.min.js";

--- a/plugins/Marketplace/Controller.php
+++ b/plugins/Marketplace/Controller.php
@@ -271,6 +271,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $view->isPluginsAdminEnabled = CorePluginsAdmin::isPluginsAdminEnabled();
         $view->isAutoUpdatePossible = SettingsPiwik::isAutoUpdatePossible();
         $view->isAutoUpdateEnabled = SettingsPiwik::isAutoUpdateEnabled();
+        $view->isPluginUploadEnabled = CorePluginsAdmin::isPluginUploadEnabled();
 
         return $view->render();
     }

--- a/plugins/Marketplace/lang/en.json
+++ b/plugins/Marketplace/lang/en.json
@@ -103,6 +103,7 @@
     "Updated": "Updated",
     "UpdatingPlugin": "Updating %1$s",
     "UploadZipFile": "Upload ZIP file",
+    "PluginUploadDisabled": "Plugin upload is disabled in config file. In order to enable this feature please update your configuration or contact your administrator",
     "LicenseKeyExpiresSoon": "Your license key expires soon, please contact %1$s.",
     "LicenseKeyIsExpired": "Your license key is expired, please contact %1$s.",
     "MultiServerEnvironmentWarning": "You cannot install or update the plugin directly as you are using Piwik on multiple servers. The plugin would be only installed on one server. Instead download the plugin and deploy it manually to all your servers.",

--- a/plugins/Marketplace/templates/overview.twig
+++ b/plugins/Marketplace/templates/overview.twig
@@ -42,6 +42,8 @@
                 </form>
                 {% else %}
                     <p class="description"> {{ 'Marketplace_PluginUploadDisabled'|translate|raw }} </p>
+                    <pre>[General]
+enable_plugin_upload = 1</pre>
                     <input role="yes" type="button" value="{{ 'General_Ok'|translate }}"/>
                 {% endif %}
             </div>

--- a/plugins/Marketplace/templates/overview.twig
+++ b/plugins/Marketplace/templates/overview.twig
@@ -31,6 +31,7 @@
             <div class="ui-confirm" id="installPluginByUpload">
                 <h2>{{ 'Marketplace_TeaserExtendPiwikByUpload'|translate }}</h2>
 
+                {% if isPluginUploadEnabled %}
                 <p class="description"> {{ 'Marketplace_AllowedUploadFormats'|translate }} </p>
 
                 <form enctype="multipart/form-data" method="post" id="uploadPluginForm"
@@ -39,6 +40,10 @@
                     <br />
                     <input class="startUpload btn" type="submit" value="{{ 'Marketplace_UploadZipFile'|translate }}">
                 </form>
+                {% else %}
+                    <p class="description"> {{ 'Marketplace_PluginUploadDisabled'|translate|raw }} </p>
+                    <input role="yes" type="button" value="{{ 'General_Ok'|translate }}"/>
+                {% endif %}
             </div>
 
             <div class="row marketplaceActions" ng-controller="PiwikMarketplaceController as marketplace">

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a90487bbaaae92569b8ddc2c3fa0ffd19b973ae7cd771efdea6b11199efdd7b5
-size 3532421
+oid sha256:2e96b498dcfca1d95472396dff36c50890e8fba6d72bef83327982125a5964e4
+size 3552812


### PR DESCRIPTION
Links for plugin upload will still be visible as before, but they will show a message instead. 

Wasn't sure if we simply should remove the links when upload is disabled, but that would hide the feature completely, so I decided to show a message instead.

NOTE: Upload will be disabled by default

fixes #11329