### PR TITLE
Improves plugin list filters

### DIFF
--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -227,7 +227,7 @@ class Controller extends Plugin\ControllerAdmin
 
             if (isset($plugin['info']) && isset($plugin['info']['authors'])) {
                 foreach ($plugin['info']['authors'] as $author) {
-                    if ($author['name'] == 'Piwik' || $author['name'] == 'InnoCraft') {
+                    if (in_array(strtolower($author['name']), array('piwik', 'innocraft'))) {
                         $plugin['isOfficialPlugin'] = true;
                         break;
                     }

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -223,6 +223,16 @@ class Controller extends Plugin\ControllerAdmin
         foreach ($plugins as $pluginName => &$plugin) {
 
             $plugin['isCorePlugin'] = $this->pluginManager->isPluginBundledWithCore($pluginName);
+            $plugin['isOfficialPlugin'] = false;
+
+            if (isset($plugin['info']) && isset($plugin['info']['authors'])) {
+                foreach ($plugin['info']['authors'] as $author) {
+                    if ($author['name'] == 'Piwik' || $author['name'] == 'InnoCraft') {
+                        $plugin['isOfficialPlugin'] = true;
+                        break;
+                    }
+                }
+            }
 
             if (!empty($plugin['info']['description'])) {
                 $plugin['info']['description'] = $this->translator->translate($plugin['info']['description']);

--- a/plugins/CorePluginsAdmin/angularjs/plugins/plugin-filter.directive.js
+++ b/plugins/CorePluginsAdmin/angularjs/plugins/plugin-filter.directive.js
@@ -48,7 +48,8 @@
 
                         updateNumberOfMatchingPluginsInFilter('[data-filter-origin="all"]', 'all', filterStatus);
                         updateNumberOfMatchingPluginsInFilter('[data-filter-origin="core"]', 'core', filterStatus);
-                        updateNumberOfMatchingPluginsInFilter('[data-filter-origin="noncore"]', 'noncore', filterStatus);
+                        updateNumberOfMatchingPluginsInFilter('[data-filter-origin="official"]', 'official', filterStatus);
+                        updateNumberOfMatchingPluginsInFilter('[data-filter-origin="thirdparty"]', 'thirdparty', filterStatus);
                     }
 
                     function updateNumberOfMatchingPluginsInFilter(selectorFilterToUpdate, filterOrigin, filterStatus)

--- a/plugins/CorePluginsAdmin/lang/en.json
+++ b/plugins/CorePluginsAdmin/lang/en.json
@@ -37,6 +37,7 @@
         "NoPluginSettings": "No plugin settings that can be configured",
         "Origin": "Origin",
         "OriginCore": "Core",
+        "OriginOfficial": "Official",
         "OriginThirdParty": "Third-party",
         "PluginHomepage": "Plugin Homepage",
         "PluginNotCompatibleWith": "%1$s plugin is not compatible with %2$s.",

--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -76,7 +76,8 @@
             <strong>{{ 'CorePluginsAdmin_Origin'|translate }}</strong>
             <a data-filter-origin="all" href="#" class="active">{{ 'General_All'|translate }}<span class="counter"></span></a> |
             <a data-filter-origin="core" href="#">{{ 'CorePluginsAdmin_OriginCore'|translate }}<span class="counter"></span></a> |
-            <a data-filter-origin="noncore" href="#">{{ 'CorePluginsAdmin_OriginThirdParty'|translate }}<span class="counter"></span></a>
+            <a data-filter-origin="official" href="#">{{ 'CorePluginsAdmin_OriginOfficial'|translate }}<span class="counter"></span></a> |
+            <a data-filter-origin="thirdparty" href="#">{{ 'CorePluginsAdmin_OriginThirdParty'|translate }}<span class="counter"></span></a>
         </span>
 
         <span class="status">
@@ -114,7 +115,7 @@
         {% for name,plugin in pluginsInfo %}
             {% set isDefaultTheme = isTheme and name == 'Morpheus' %}
             {% if (plugin.alwaysActivated is defined and not plugin.alwaysActivated) or isTheme %}
-                <tr {% if plugin.activated %}class="active-plugin"{% else %}class="inactive-plugin"{% endif %} data-filter-status="{% if plugin.activated %}active{% else %}inactive{% endif %}" data-filter-origin="{% if plugin.isCorePlugin %}core{% else %}noncore{% endif %}">
+                <tr {% if plugin.activated %}class="active-plugin"{% else %}class="inactive-plugin"{% endif %} data-filter-status="{% if plugin.activated %}active{% else %}inactive{% endif %}" data-filter-origin="{% if plugin.isCorePlugin %}core{% elseif plugin.isOfficialPlugin %}official{% else %}thirdparty{% endif %}">
                     <td class="name">
                         <a name="{{ name|e('html_attr') }}"></a>
                         {% if not plugin.isCorePlugin and name in marketplacePluginNames -%}

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1dfe72aff4ea603f1c3ddfd0cdcfcd3e03d1230713e077054512e3fe2b682ac9
-size 955453
+oid sha256:0cacebc0fa6fa2aec9920c16311d1ea10a0770d787967f0f411d2b3b172c4ed2
+size 956270

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_themes.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_themes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8713d9dca666ac6f2532cc3dee5a4b30bd5e8f3a6fa3181d6b9005c87e2c9b2
-size 80901
+oid sha256:e11b309dbd848688234faa2e2e1e82403035596332128d871b47ec43248cb8bc
+size 81460


### PR DESCRIPTION
As the available filters  (All, Core, Third-Party) were kind of confusing, I tried to improve that by adding a new category 'Official', which will list all plugins that are developed by the Piwik team

![image](https://cloud.githubusercontent.com/assets/1579355/23515628/028c3bba-ff6b-11e6-8bcc-c6a2bc92d9d9.png)

Name of this category is still open for discussion.
Also we might consider to add a new category 'Premium', listing all plugins bought on Marketplace. Any opinions on that?

fixes #11145