### PR TITLE
Add unifont.ttf to file integrity whitelist

### DIFF
--- a/core/FileIntegrity.php
+++ b/core/FileIntegrity.php
@@ -74,6 +74,7 @@ class FileIntegrity
             'misc/package',
             'misc/package/WebAppGallery/*.xml',
             'misc/package/WebAppGallery/install.sql',
+            'plugins/ImageGraph/fonts/unifont.ttf',
             'vendor/autoload.php',
             'vendor/composer/autoload_real.php',
             'tmp/*',


### PR DESCRIPTION
Add the file "plugins/ImageGraph/fonts/unifont.ttf" to the file integrity check ignore list. Fixes #11454.