### PR TITLE
Replace archives if they already exists instead of ignoring them

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -304,10 +304,11 @@ class Model
     {
         // duplicate idarchives are Ignored, see https://github.com/piwik/piwik/issues/987
         $query = "INSERT IGNORE INTO " . $tableName . " (" . implode(", ", $fields) . ")
-                  VALUES (?,?,?,?,?,?,?,?)";
+                  VALUES (?,?,?,?,?,?,?,?) ON DUPLICATE KEY UPDATE " . end($fields) . " = ?";
 
         $bindSql   = $record;
         $bindSql[] = $name;
+        $bindSql[] = $value;
         $bindSql[] = $value;
 
         Db::query($query, $bindSql);

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -247,6 +247,8 @@ class ArchiveTest extends IntegrationTestCase
         ));
 
         $this->assertEquals(1, $userLanguageReport->getRowsCount());
+        $this->assertEquals('UserLanguage_LanguageCode fr', $userLanguageReport->getFirstRow()->getColumn('label'));
+        $this->assertEquals('UserLanguage_LanguageCode fr', $userLanguageReport->getLastRow()->getColumn('label'));
 
         $parameters = new Parameters(new Site(1), $period, new Segment('', ''));
         $parameters->setRequestedPlugin('UserLanguage');
@@ -261,8 +263,10 @@ class ArchiveTest extends IntegrationTestCase
         // track a new visits now
         $fixture = self::$fixture;
         $t = $fixture::getTracker(1, $date, $defaultInit = true);
-        $t->setBrowserLanguage('id');
-        $fixture::checkResponse($t->doTrackPageView('http://example.org/index.htm'));
+        $t->setForceVisitDateTime(Date::factory($date)->addHour(1)->getDatetime());
+        $t->setUrl('http://example.org/index.htm');
+        $t->setBrowserLanguage('pt-br');
+        $fixture::checkResponse($t->doTrackPageView('my site'));
 
         $archiveWriter            = new ArchiveWriter($parameters, !!$idArchive);
         $archiveWriter->idArchive = $idArchive;
@@ -284,6 +288,8 @@ class ArchiveTest extends IntegrationTestCase
         ));
 
         $this->assertEquals(2, $userLanguageReport->getRowsCount());
+        $this->assertEquals('UserLanguage_LanguageCode fr', $userLanguageReport->getFirstRow()->getColumn('label'));
+        $this->assertEquals('UserLanguage_LanguageCode pt', $userLanguageReport->getLastRow()->getColumn('label'));
     }
 
 


### PR DESCRIPTION
Whenever the archives tries to insert data for an archives it is done using an `INSERT IGNORE`. While this isn't a problem for normal use-case it might be required for other cases to replace the archive data instead of throwing it away.