### PR TITLE
always use window.jQuery instead of $ in ui tests

### DIFF
--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -437,12 +437,8 @@ PageRenderer.prototype.capture = function (outputPath, callback, selector) {
         }
 
         var result = page.evaluate(function(selector) {
-            if ('undefined' === typeof $ && 'undefined' !== typeof window.jQuery) {
-                var $ = window.jQuery;
-            }
-
-            var docWidth = $(document).width(),
-                docHeight = $(document).height();
+            var docWidth = window.jQuery(document).width(),
+                docHeight = window.jQuery(document).height();
 
             function isInvalidBoundingRect (rect) {
                 return !rect.width || !rect.height


### PR DESCRIPTION
This is actually better this way instead of assigning $

Please issue pull request against the `3.x-dev` branch only.

Piwik 2 is in LTS mode. This means we do not accept any pull request for 2.x except critical security bugs and major data loss bugs. 

If you need to create a pull request for 2.x, then please also create the pull request against the `3.x-dev` so we can merge both.

Happy hacking!
