### PR TITLE
Ensure ui test class is set on all pages

### DIFF
--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -437,6 +437,8 @@ PageRenderer.prototype.capture = function (outputPath, callback, selector) {
         }
 
         var result = page.evaluate(function(selector) {
+            window.jQuery('html').addClass('uiTest');
+
             if ('undefined' === typeof $ && 'undefined' !== typeof window.jQuery) {
                 var $ = window.jQuery;
             }


### PR DESCRIPTION
This may also fix some random tests etc.

The thing is that we only add the `uiTest` class when a page is loaded via `page.load()`. However, when you click somewhere on that page and a new URL or page is loaded, the `uiTest` class won't be set there meaning it doesn't disable animations on that page, it doesn't hide a date etc.