### PR TITLE
Make it possible to disable Flatten feature for a given report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** l
 
 ### Breaking Changes
 * New config setting `enable_plugin_upload` lets you enable uploading and installing a Piwik plugin ZIP file by a Super User. This used to be enabled by default, but it is now disabled by default now for security reasons.
-* New property `Report::$supportsFlattening` lets you define if a report supports flattening (d)efaults to `true`). If set to `false` it will also set `ViewDataTable\Config::$show_flatten_table` to `false`
+* New Report class property `Report::$supportsFlatten` lets you define if a report supports flattening (defaults to `true`). If set to `false` it will also set `ViewDataTable\Config::$show_flatten_table` to `false`
 
 ### New APIs
 * A new event `Controller.triggerAdminNotifications` has been added to let plugins know when they are supposed to trigger notifications in the admin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** l
 
 ### Breaking Changes
 * New config setting `enable_plugin_upload` lets you enable uploading and installing a Piwik plugin ZIP file by a Super User. This used to be enabled by default, but it is now disabled by default now for security reasons.
+* New property `Report::$supportsFlattening` lets you define if a report supports flattening (d)efaults to `true`). If set to `false` it will also set `ViewDataTable\Config::$show_flatten_table` to `false`
 
 ### New APIs
 * A new event `Controller.triggerAdminNotifications` has been added to let plugins know when they are supposed to trigger notifications in the admin.

--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -171,7 +171,7 @@ class DataTablePostProcessor
     {
         if (Common::getRequestVar('flat', '0', 'string', $this->request) == '1') {
             // skip flattening if not supported by report and remove subtables only
-            if ($this->report && !$this->report->supportsFlattening()) {
+            if ($this->report && !$this->report->supportsFlatten()) {
                 $dataTable->filter('RemoveSubtables');
                 return $dataTable;
             }

--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -170,6 +170,12 @@ class DataTablePostProcessor
     public function applyFlattener($dataTable)
     {
         if (Common::getRequestVar('flat', '0', 'string', $this->request) == '1') {
+            // skip flattening if not supported by report and remove subtables only
+            if ($this->report && !$this->report->supportsFlattening()) {
+                $dataTable->filter('RemoveSubtables');
+                return $dataTable;
+            }
+
             $flattener = new Flattener($this->apiModule, $this->apiMethod, $this->request);
             if (Common::getRequestVar('include_aggregate_rows', '0', 'string', $this->request) == '1') {
                 $flattener->includeAggregateRows();

--- a/core/DataTable/Filter/RemoveSubtables.php
+++ b/core/DataTable/Filter/RemoveSubtables.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\DataTable\Filter;
+
+use Piwik\DataTable;
+use Piwik\DataTable\BaseFilter;
+
+/**
+ * Delete all existing subtables from rows.
+ *
+ * **Basic example usage**
+ *
+ *     $dataTable->filter('RemoveSubtables');
+ *
+ * @api
+ */
+class RemoveSubtables extends BaseFilter
+{
+    /**
+     * Constructor.
+     *
+     * @param DataTable $table The DataTable that will be filtered eventually.
+     */
+    public function __construct($table)
+    {
+        parent::__construct($table);
+    }
+
+    /**
+     * See {@link Limit}.
+     *
+     * @param DataTable $table
+     */
+    public function filter($table)
+    {
+        $rows = $table->getRows();
+        foreach ($rows as $row) {
+            $row->removeSubtable();
+        }
+    }
+}

--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -125,7 +125,7 @@ class Report
      * @var bool
      * @api
      */
-    protected $supportsFlattening = true;
+    protected $supportsFlatten = true;
 
     /**
      * Set it to boolean `true` if your report always returns a constant count of rows, for instance always 24 rows
@@ -505,9 +505,9 @@ class Report
      * @return bool
      * @ignore
      */
-    public function supportsFlattening()
+    public function supportsFlatten()
     {
-        return $this->supportsFlattening;
+        return $this->supportsFlatten;
     }
 
     /**

--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -120,6 +120,14 @@ class Report
     protected $hasGoalMetrics = false;
 
     /**
+     * Set this property to false in case your report can't/shouldn't be flattened.
+     * In this case, flattener won't be applied even if parameter is provided in a request
+     * @var bool
+     * @api
+     */
+    protected $supportsFlattening = true;
+
+    /**
      * Set it to boolean `true` if your report always returns a constant count of rows, for instance always 24 rows
      * for 1-24 hours.
      * @var bool
@@ -491,6 +499,15 @@ class Report
     public function hasGoalMetrics()
     {
         return $this->hasGoalMetrics;
+    }
+
+    /**
+     * @return bool
+     * @ignore
+     */
+    public function supportsFlattening()
+    {
+        return $this->supportsFlattening;
     }
 
     /**

--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -502,6 +502,7 @@ class Config
 
         $this->loadDocumentation();
         $this->setShouldShowPivotBySubtable();
+        $this->setShouldShowFlattener();
     }
 
     /** Load documentation from the API */
@@ -752,6 +753,15 @@ class Config
                 $this->pivot_by_dimension = $subtableDimension->getId();
                 $this->pivot_dimension_name = $subtableDimension->getName();
             }
+        }
+    }
+
+    private function setShouldShowFlattener()
+    {
+        $report = ReportsProvider::factory($this->controllerName, $this->controllerAction);
+
+        if ($report && !$report->supportsFlattening()) {
+            $this->show_flatten_table = false;
         }
     }
 

--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -760,7 +760,7 @@ class Config
     {
         $report = ReportsProvider::factory($this->controllerName, $this->controllerAction);
 
-        if ($report && !$report->supportsFlattening()) {
+        if ($report && !$report->supportsFlatten()) {
             $this->show_flatten_table = false;
         }
     }

--- a/plugins/Referrers/Reports/GetReferrerType.php
+++ b/plugins/Referrers/Reports/GetReferrerType.php
@@ -37,6 +37,7 @@ class GetReferrerType extends Base
         $this->hasGoalMetrics = true;
         $this->order = 1;
         $this->subcategoryId = 'Referrers_WidgetGetAll';
+        $this->supportsFlattening = false;
     }
 
     public function getDefaultTypeViewDataTable()

--- a/plugins/Referrers/Reports/GetReferrerType.php
+++ b/plugins/Referrers/Reports/GetReferrerType.php
@@ -37,7 +37,7 @@ class GetReferrerType extends Base
         $this->hasGoalMetrics = true;
         $this->order = 1;
         $this->subcategoryId = 'Referrers_WidgetGetAll';
-        $this->supportsFlattening = false;
+        $this->supportsFlatten = false;
     }
 
     public function getDefaultTypeViewDataTable()

--- a/plugins/UserId/Reports/GetUsers.php
+++ b/plugins/UserId/Reports/GetUsers.php
@@ -25,12 +25,12 @@ class GetUsers extends Base
     {
         parent::init();
 
-        $this->name = Piwik::translate('UserId_UserReportTitle');
-        $this->subcategoryId = 'UserId_UserReportTitle';
-        $this->documentation = '';
-        $this->dimension = new UserId();
-        $this->metrics = array('label', 'nb_visits', 'nb_actions', 'nb_visits_converted');
-        $this->supportsFlattening = false;
+        $this->name            = Piwik::translate('UserId_UserReportTitle');
+        $this->subcategoryId   = 'UserId_UserReportTitle';
+        $this->documentation   = '';
+        $this->dimension       = new UserId();
+        $this->metrics         = array('label', 'nb_visits', 'nb_actions', 'nb_visits_converted');
+        $this->supportsFlatten = false;
 
         // This defines in which order your report appears in the mobile app, in the menu and in the list of widgets
         $this->order = 9;

--- a/plugins/UserId/Reports/GetUsers.php
+++ b/plugins/UserId/Reports/GetUsers.php
@@ -30,6 +30,7 @@ class GetUsers extends Base
         $this->documentation = '';
         $this->dimension = new UserId();
         $this->metrics = array('label', 'nb_visits', 'nb_actions', 'nb_visits_converted');
+        $this->supportsFlattening = false;
 
         // This defines in which order your report appears in the mobile app, in the menu and in the list of widgets
         $this->order = 9;
@@ -60,7 +61,6 @@ class GetUsers extends Base
         $view->config->show_related_reports = false;
         $view->config->show_insights = false;
         $view->config->show_pivot_by_subtable = false;
-        $view->config->show_flatten_table = false;
 
         if ($view->isViewDataTableId(HtmlTable::ID)) {
             $view->config->disable_row_evolution = false;

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Referrers.getReferrerType_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__Referrers.getReferrerType_day.xml
@@ -14,68 +14,26 @@
 	</row>
 	<row>
 		<label>Search Engines</label>
+		<nb_uniq_visitors>12</nb_uniq_visitors>
+		<nb_visits>12</nb_visits>
+		<nb_actions>12</nb_actions>
+		<nb_users>0</nb_users>
+		<max_actions>1</max_actions>
+		<sum_visit_length>0</sum_visit_length>
+		<bounce_count>12</bounce_count>
+		<nb_visits_converted>0</nb_visits_converted>
+		<segment>referrerType==search</segment>
+	</row>
+	<row>
+		<label>Websites</label>
 		<nb_uniq_visitors>7</nb_uniq_visitors>
-		<nb_visits>7</nb_visits>
-		<nb_actions>7</nb_actions>
+		<nb_visits>8</nb_visits>
+		<nb_actions>8</nb_actions>
 		<nb_users>0</nb_users>
 		<max_actions>1</max_actions>
 		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>7</bounce_count>
+		<bounce_count>8</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
-	</row>
-	<row>
-		<label>Websites</label>
-		<nb_uniq_visitors>3</nb_uniq_visitors>
-		<nb_visits>4</nb_visits>
-		<nb_actions>4</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>4</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-	</row>
-	<row>
-		<label>Search Engines</label>
-		<nb_uniq_visitors>3</nb_uniq_visitors>
-		<nb_visits>3</nb_visits>
-		<nb_actions>3</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>3</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-	</row>
-	<row>
-		<label>Search Engines</label>
-		<nb_uniq_visitors>2</nb_uniq_visitors>
-		<nb_visits>2</nb_visits>
-		<nb_actions>2</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>2</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-	</row>
-	<row>
-		<label>Websites</label>
-		<nb_uniq_visitors>2</nb_uniq_visitors>
-		<nb_visits>2</nb_visits>
-		<nb_actions>2</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>2</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
-	</row>
-	<row>
-		<label>Websites</label>
-		<nb_uniq_visitors>2</nb_uniq_visitors>
-		<nb_visits>2</nb_visits>
-		<nb_actions>2</nb_actions>
-		<nb_users>0</nb_users>
-		<max_actions>1</max_actions>
-		<sum_visit_length>0</sum_visit_length>
-		<bounce_count>2</bounce_count>
-		<nb_visits_converted>0</nb_visits_converted>
+		<segment>referrerType==website</segment>
 	</row>
 </result>

--- a/tests/UI/expected-screenshots/UIIntegrationTest_metric_tooltip.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_metric_tooltip.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c133c0a47fe8139277d12e0fd82a5145d84a22d6bfeeff18b4cde7a0e8316b04
-size 168821
+oid sha256:d8ff715f995e7e109653c1c2a774d1ffd0219c5db50c8ac797fac07383c756d6
+size 168384


### PR DESCRIPTION
Currently datatables are automatically flattened if the `flat` parameter is given in the request. This cannot be prevented.
It is now possible to set for a report if it supports flattening or not. This will also automatically be set to the view, so it's not required to set if for report and view as well. 

This PR also disables the flattening for the referrer type report, as it doesn't work for that report.

fixes #11323
