### PR TITLE
Disable pivotBy for Insights visualization

### DIFF
--- a/plugins/Insights/Visualizations/Insight.php
+++ b/plugins/Insights/Visualizations/Insight.php
@@ -10,7 +10,6 @@
 namespace Piwik\Plugins\Insights\Visualizations;
 
 use Piwik\Common;
-use Piwik\DataTable;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugin\Visualization;
 use Piwik\Plugins\Insights\API;
@@ -53,6 +52,8 @@ class Insight extends Visualization
             'comparedToXPeriods' => $this->requestConfig->compared_to_x_periods_ago,
             'orderBy'  => $this->requestConfig->order_by,
             'filterBy' => $this->requestConfig->filter_by,
+            'pivotBy' => false,
+            'pivotByColumn' => false,
             'limitIncreaser' => $this->getLimitIncrease(),
             'limitDecreaser' => $this->getLimitDecrease(),
         );
@@ -94,6 +95,7 @@ class Insight extends Visualization
     {
         $this->config->datatable_js_type = 'InsightsDataTable';
         $this->config->show_limit_control = true;
+        $this->config->show_pivot_by_subtable = false;
         $this->config->show_pagination_control = false;
         $this->config->show_offset_information = false;
         $this->config->show_search = false;

--- a/plugins/Insights/Visualizations/Insight/RequestConfig.php
+++ b/plugins/Insights/Visualizations/Insight/RequestConfig.php
@@ -26,6 +26,8 @@ class RequestConfig extends VisualizationRequestConfig
     public function __construct()
     {
         $this->disable_generic_filters = true;
+        $this->pivotBy = false;
+        $this->pivotByColumn = false;
 
         $properties = array(
             'min_growth_percent',


### PR DESCRIPTION
Insights cannot be shown for a pivoted table. Therefor pivotBy settings will now be ignored when showing an Insights visualization

fixes #11489