### PR TITLE
Drop temporary table when no longer needed

### DIFF
--- a/core/DataAccess/RawLogDao.php
+++ b/core/DataAccess/RawLogDao.php
@@ -173,10 +173,12 @@ class RawLogDao
         // delete before unlocking tables so there's no chance a new log row that references an
         // unused action will be inserted.
         $this->deleteUnusedActions();
+
         Db::unlockAllTables();
+
+        $this->dropTempTableForStoringUsedActions();
     }
-
-
+    
     /**
      * Returns the list of the website IDs that received some visits between the specified timestamp.
      *
@@ -310,6 +312,12 @@ class RawLogDao
 					idaction INT(11),
 					PRIMARY KEY (idaction)
 				)";
+        Db::query($sql);
+    }
+
+    private function dropTempTableForStoringUsedActions()
+    {
+        $sql = "DROP TABLE " . Common::prefixTable(self::DELETE_UNUSED_ACTIONS_TEMP_TABLE_NAME);
         Db::query($sql);
     }
 


### PR DESCRIPTION
I know the temporary table only exists during session, but problem is a possible error `PDOException: SQLSTATE[42S01]: Base table or view already exists: 1050 Table 'tmp_log_actions_to_keep' already exists` when logs are purged twice during a session. 

We could use `if not exists` when creating the table but then we would still have the entries from a previous "delete logs run" in there.

I noticed this error in tests but it may also occur in a regular task schedule that purge logs is called twice if eg implemented by a plugin and by privacy manager etc.