### PR TITLE
Intl LC_NUMERIC use fallback if locale en_US not installed

### DIFF
--- a/core/Intl/Locale.php
+++ b/core/Intl/Locale.php
@@ -32,7 +32,7 @@ class Locale
         setlocale(LC_ALL, $newLocale);
         setlocale(LC_CTYPE, '');
         // Always use english for numbers. otherwise the decimal separator might get localized when casting a float to string
-        setlocale(LC_NUMERIC, array('en_US.UTF-8', 'en-US'));
+        setlocale(LC_NUMERIC, array('en_US.UTF-8', 'en-US', 'C.UTF-8', 'C'));
     }
 
     public static function setDefaultLocale()


### PR DESCRIPTION
Fixes "Error in the display of localized numbers" #10594 / #10596

Problem: On a few systems, only local locales are installed / enabled. Therefore, setting LC_NUMERIC to "en_US.UTF-8" silently fails and numerics are juggled in local manner (1,0 vs 1.0). This makes the NumberFormatter fail on those numbers.

The locale C/C.UTF-8/POSIX is present on nearly all systems, so we add those to the setlocale fallbacks.