### PR TITLE
Use typeof(console) to prevent IE 7 error

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -6767,7 +6767,7 @@ if (typeof window.Piwik !== 'object') {
                 var contentNodes = content.findContentNodes();
                 var contents = content.collectContent(contentNodes);
 
-                if (console !== undefined && console && console.log) {
+                if (typeof console !== 'undefined' && console && console.log) {
                     console.log(contents);
                 }
             };
@@ -7277,7 +7277,7 @@ if (typeof window.Piwik !== 'object') {
             window.Piwik.addTracker();
         } else {
             _paq = {push: function (args) {
-                if (console !== undefined && console && console.error) {
+                if (typeof console !== 'undefined' && console && console.error) {
                     console.error('_paq.push() was used but Piwik tracker was not initialized before the piwik.js file was loaded. Make sure to configure the tracker via _paq.push before loading piwik.js. Alternatively, you can create a tracker via Piwik.addTracker() manually and then use _paq.push but it may not fully work as tracker methods may not be executed in the correct order.', args);
                 }
             }};

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -1168,7 +1168,7 @@ if (typeof window.Piwik !== 'object') {
          * @param message
          */
         function logConsoleError(message) {
-            if (console !== undefined && console && console.error) {
+            if (typeof console !== 'undefined' && console && console.error) {
                 console.error(message);
             }
         }


### PR DESCRIPTION
When using directly console !== undefined, older IE versions
throw an error as they're actually tring to access an undefined
value. Use globally supported typeof(console) !== 'undefined'.

Changed typeof(<var>) to typeof <var> as it's not a function

Thanks @sgiehl

Please issue pull request against the `3.x-dev` branch only.

Piwik 2 is in LTS mode. This means we do not accept any pull request for 2.x except critical security bugs and major data loss bugs. 

If you need to create a pull request for 2.x, then please also create the pull request against the `3.x-dev` so we can merge both.

Happy hacking!
