### PR TITLE
Improve message in plugin admin if a plugin is not found in filesystem

### DIFF
--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -247,10 +247,19 @@ class Controller extends Plugin\ControllerAdmin
                     $suffix = "You may uninstall the plugin or manually delete the files in piwik/plugins/$pluginName/";
                 }
 
-                $description = '<strong>'
-                    . $this->translator->translate('CorePluginsAdmin_PluginNotCompatibleWith', array($pluginName, self::getPiwikVersion()))
-                    . '</strong><br/>'
-                    . $suffix;
+                if (is_dir(PIWIK_INCLUDE_PATH . '/plugins/' . $pluginName)) {
+                    $description = '<strong>'
+                        . $this->translator->translate('CorePluginsAdmin_PluginNotCompatibleWith',
+                            array($pluginName, self::getPiwikVersion()))
+                        . '</strong><br/>'
+                        . $suffix;
+                } else {
+                    $description = '<strong>'
+                        . $this->translator->translate('CorePluginsAdmin_PluginNotFound',
+                            array($pluginName))
+                        . '</strong><br/>'
+                        . $this->translator->translate('CorePluginsAdmin_PluginNotFoundAlternative');
+                }
                 $plugin['info'] = array(
                     'description' => $description,
                     'version'     => $this->translator->translate('General_Unknown'),

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -247,7 +247,7 @@ class Controller extends Plugin\ControllerAdmin
                     $suffix = "You may uninstall the plugin or manually delete the files in piwik/plugins/$pluginName/";
                 }
 
-                if (is_dir(PIWIK_INCLUDE_PATH . '/plugins/' . $pluginName)) {
+                if ($this->pluginManager->isPluginInFilesystem($pluginName)) {
                     $description = '<strong>'
                         . $this->translator->translate('CorePluginsAdmin_PluginNotCompatibleWith',
                             array($pluginName, self::getPiwikVersion()))

--- a/plugins/CorePluginsAdmin/lang/en.json
+++ b/plugins/CorePluginsAdmin/lang/en.json
@@ -41,6 +41,8 @@
         "OriginThirdParty": "Third-party",
         "PluginHomepage": "Plugin Homepage",
         "PluginNotCompatibleWith": "%1$s plugin is not compatible with %2$s.",
+        "PluginNotFound": "Plugin %1$s not found on filesystem.",
+        "PluginNotFoundAlternative": "If you've been using this plugin, try reuploading or reinstalling it from the marketplace. If not, click uninstall to remove it from the list.",
         "PluginNotWorkingAlternative": "If you've been using this plugin, maybe you can find a more recent version in the Marketplace. If not, you may want to uninstall it.",
         "PluginRequirement": "%1$s requires %2$s.",
         "PluginsManagement": "Manage Plugins",


### PR DESCRIPTION
Currently if a plugin does not exist on the filesystem the plugin shows "Plugin not compatible with Piwik X".
As mentioned in https://github.com/piwik/plugin-MarketingCampaignsReporting/issues/10#issuecomment-295145594 this might be a bit missleading if the plugin is simply missing on filesystem.

With this PR plugin that are not found will have this message:

![image](https://cloud.githubusercontent.com/assets/1579355/25169635/fed69086-24e7-11e7-9c18-afff9a586a52.png)

