### PR TITLE
Improve `menu_apidisallowed` UI test

### DIFF
--- a/tests/UI/expected-screenshots/UIIntegrationTest_menu_apidisallowed.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_menu_apidisallowed.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de19092a7c1e4b1a2be299462df1b50c87fce71a87276fe63440dd11210acae2
-size 494117

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -399,9 +399,10 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         }, done);
     });
 
-    it('should not display API response in the content', function (done) {
-        expect.screenshot('menu_apidisallowed').to.be.captureSelector('#content', function (page) {
-            page.load("?" + urlBase + "#?" + generalParams + "&module=API&action=SitesManager.getImageTrackingCode");
+    it('should not display API response in the content and redirect to dashboard instead', function (done) {
+        expect.page().contains('#dashboardWidgetsArea', /*'menu_apidisallowed',*/ function (page) {
+            var url = "?" + urlBase + "#?" + generalParams + "&module=API&action=SitesManager.getImageTrackingCode";
+            page.load(url, 2000);
         }, done);
     });
 


### PR DESCRIPTION
I've changed the UI test to simply check if the Dashboard is displayed, as actually this should be the case if an invalid page request is made.

fixes #11549 