### PR TITLE
Improve updater to remove old files

### DIFF
--- a/plugins/CoreUpdater/Model.php
+++ b/plugins/CoreUpdater/Model.php
@@ -26,6 +26,8 @@ class Model
     public function removeGoneFiles($source, $target)
     {
         Filesystem::unlinkTargetFilesNotPresentInSource($source . '/core', $target . '/core');
+        Filesystem::unlinkTargetFilesNotPresentInSource($source . '/libs', $target . '/libs');
+        Filesystem::unlinkTargetFilesNotPresentInSource($source . '/vendor', $target . '/vendor');
 
         foreach ($this->getPluginsFromDirectoy($source) as $pluginDir) {
             Filesystem::unlinkTargetFilesNotPresentInSource($source . $pluginDir, $target . $pluginDir);


### PR DESCRIPTION
Seems our update currently only checks the `core` directory, as well as all plugin directories. Thus changes in other directories like `libs` or `vendor` won't be checked.

fixes #11446