### PR TITLE
Fix logo images sizes in scheduled reports

### DIFF
--- a/plugins/ImageGraph/StaticGraph/HorizontalBar.php
+++ b/plugins/ImageGraph/StaticGraph/HorizontalBar.php
@@ -24,13 +24,15 @@ class HorizontalBar extends GridGraph
     {
         $verticalLegend = false;
 
-        // determine the maximum logo width & height
-        list($maxLogoWidth, $maxLogoHeight) = self::getMaxLogoSize($this->abscissaLogos);
-
-        foreach ($this->abscissaLogos as $logoPath) {
+        // create resized copies of logo to match maximum width / height
+        foreach ($this->abscissaLogos as &$logoPath) {
+            $logoPath = $this->createResizedImageCopyIfNeeded($logoPath);
             list($logoWidth, $logoHeight) = self::getLogoSize($logoPath);
             $logoPathToHeight[$logoPath] = $logoHeight;
         }
+
+        // determine the maximum logo width & height
+        list($maxLogoWidth, $maxLogoHeight) = self::getMaxLogoSize($this->abscissaLogos);
 
         // truncate report
         $graphHeight = $this->getGraphBottom($horizontalGraph = true) - $this->getGridTopMargin($horizontalGraph = true, $verticalLegend);


### PR DESCRIPTION
As cPchart has not possibility to resize the series logos, I decided to create resized copies in `tmp` directory before adding them.

fixes #11558