### PR TITLE
Add possibility to reload the reporting menu on demand

### DIFF
--- a/plugins/CoreHome/angularjs/reporting-menu/reportingmenu-model.js
+++ b/plugins/CoreHome/angularjs/reporting-menu/reportingmenu-model.js
@@ -147,6 +147,7 @@
             var pagesPromise = reportingPagesModel.reloadAllPages();
             return pagesPromise.then(function (pages) {
                 model.menu = buildMenuFromPages(pages);
+                return model.menu;
             });
         }
 

--- a/plugins/CoreHome/angularjs/reporting-menu/reportingmenu.controller.js
+++ b/plugins/CoreHome/angularjs/reporting-menu/reportingmenu.controller.js
@@ -120,6 +120,21 @@
             }
         });
 
+        $rootScope.$on('updateReportingMenu', function () {
+            menuModel.reloadMenuItems().then(function (menu) {
+                var $search = $location.search();
+                var category    = $search.category;
+                var subcategory = $search.subcategory;
+                // we need to make sure to select same categories again
+                if (category && subcategory) {
+                    var found = menuModel.findSubcategory(category, subcategory);
+                    if (found) {
+                        enterSubcategory(found.category, found.subcategory, found.subsubcategory);
+                    }
+                }
+            });
+        });
+
         $rootScope.$on('$locationChangeSuccess', function () {
             var $search = $location.search();
             var category    = $search.category;


### PR DESCRIPTION
without a page reload. This is useful when eg a dashboard is added, a goal is added, etc. 

Instead of doing a page reload to update the menu we only fetch the menu items.

Not a public API so no changelog etc needed.