### PR TITLE
Fix propagateNewPage does not work when no URL parameters are set

### DIFF
--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -304,6 +304,11 @@ var broadcast = {
         // available in global scope
         var currentSearchStr = window.location.search;
         var currentHashStr = broadcast.getHashFromUrl();
+        
+        if (!currentSearchStr) {
+            currentSearchStr = '?';
+        }
+        
         var oldUrl = currentSearchStr + currentHashStr;
 
         for (var i = 0; i < params_vals.length; i++) {


### PR DESCRIPTION
to reproduce eg go to https://www.example.com  and then execute this method. It would generate a URL like  https://www.example.com/module=Foo&action=bar