### PR TITLE
Use PIWIK_DOCUMENT_ROOT instead of PIWIK_USER_PATH

### DIFF
--- a/core/AssetManager/UIAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher.php
@@ -106,7 +106,7 @@ abstract class UIAssetFetcher
     private function getBaseDirectory()
     {
         // served by web server directly, so must be a public path
-        return PIWIK_USER_PATH;
+        return PIWIK_DOCUMENT_ROOT;
     }
 
     /**

--- a/core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php
+++ b/core/AssetManager/UIAssetMerger/StylesheetUIAssetMerger.php
@@ -38,7 +38,7 @@ class StylesheetUIAssetMerger extends UIAssetMerger
     protected function getMergedAssets()
     {
         // note: we're using setImportDir on purpose (not addImportDir)
-        $this->lessCompiler->setImportDir(PIWIK_USER_PATH);
+        $this->lessCompiler->setImportDir(PIWIK_DOCUMENT_ROOT);
         $concatenatedAssets = $this->getConcatenatedAssets();
 
         $this->lessCompiler->setFormatter('classic');
@@ -183,7 +183,7 @@ class StylesheetUIAssetMerger extends UIAssetMerger
         $baseDirectory = dirname($uiAsset->getRelativeLocation());
 
         return function ($matches) use ($baseDirectory) {
-            $absolutePath = PIWIK_USER_PATH . "/$baseDirectory/" . $matches[2];
+            $absolutePath = PIWIK_DOCUMENT_ROOT . "/$baseDirectory/" . $matches[2];
 
             // Allow to import extension less file
             if (strpos($matches[2], '.') === false) {


### PR DESCRIPTION
in UIAssetFetcher and StylesheetUIAssetMerger.
Resolves #11654, makes PIWIK_USER_PATH work again.
Presumably. the paths were just mixed up.