### PR TITLE
Automatically load required plugins during test

### DIFF
--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -228,12 +228,15 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
     private function getPluginAndRequiredPlugins($pluginName, $plugins)
     {
         $pluginJsonPath = $this->makePathToPluginJson($pluginName);
-        $pluginJson = json_decode(trim(file_get_contents($pluginJsonPath)), true);
 
-        if (!empty($pluginJson['require'])) {
-            foreach ($pluginJson['require'] as $possiblePluginName => $requiredVersion) {
-                if (file_exists($this->makePathToPluginJson($possiblePluginName))) {
-                    $plugins = $this->getPluginAndRequiredPlugins($possiblePluginName, $plugins);
+        if (file_exists($pluginJsonPath)) {
+            $pluginJson = json_decode(trim(file_get_contents($pluginJsonPath)), true);
+
+            if (!empty($pluginJson['require'])) {
+                foreach ($pluginJson['require'] as $possiblePluginName => $requiredVersion) {
+                    if (file_exists($this->makePathToPluginJson($possiblePluginName))) {
+                        $plugins = $this->getPluginAndRequiredPlugins($possiblePluginName, $plugins);
+                    }
                 }
             }
         }

--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -227,21 +227,27 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
 
     private function getPluginAndRequiredPlugins($pluginName, $plugins)
     {
-        if (!in_array($pluginName, $plugins)) {
-            $plugins[] = $pluginName;
-        }
+        $pluginJsonPath = $this->makePathToPluginJson($pluginName);
+        $pluginJson = json_decode(trim(file_get_contents($pluginJsonPath)), true);
 
-        $pluginMetadataLoader = new Plugin\MetadataLoader($pluginName);
-        $pluginInfo = $pluginMetadataLoader->load();
-
-        if (!empty($pluginInfo['require'])) {
-            foreach ($pluginInfo['require'] as $possiblePluginName => $requiredVersion) {
-                if (file_exists(Plugin\Manager::getPluginsDirectory() . $possiblePluginName . '/plugin.json')) {
+        if (!empty($pluginJson['require'])) {
+            foreach ($pluginJson['require'] as $possiblePluginName => $requiredVersion) {
+                if (file_exists($this->makePathToPluginJson($possiblePluginName))) {
                     $plugins = $this->getPluginAndRequiredPlugins($possiblePluginName, $plugins);
                 }
             }
         }
+
+        if (!in_array($pluginName, $plugins)) {
+            $plugins[] = $pluginName;
+        }
+
         return $plugins;
+    }
+
+    private function makePathToPluginJson($pluginName)
+    {
+        return Plugin\Manager::getPluginsDirectory() . $pluginName . '/' . Plugin\MetadataLoader::PLUGIN_JSON_FILENAME;
     }
 
     private function classExists($klass)


### PR DESCRIPTION
When a plugin requires another plugin in `plugin.json`, this will make sure to load the required plugin as well (if it exists in filesystem) when running the tests.

Please note that while this works, there are other bugs in Piwik re requiring plugins and will likely issue PR for it.

FYI: I wanted to use the metadata loader but it this stage DI is not set up yet and it fails when calling eg Piwik::Translate