### PR TITLE
Make sure required plugins are loaded in correct order

### DIFF
--- a/core/Application/Kernel/PluginList.php
+++ b/core/Application/Kernel/PluginList.php
@@ -8,6 +8,8 @@
 
 namespace Piwik\Application\Kernel;
 
+use Piwik\Plugin\MetadataLoader;
+
 /**
  * Lists the currently activated plugins. Used when setting up Piwik's environment before
  * initializing the DI container.
@@ -111,7 +113,15 @@ class PluginList
         $otherPluginsToLoadAfterDefaultPlugins = array_diff($plugins, $defaultPluginsLoadedFirst);
 
         // sort by name to have a predictable order for those extra plugins
-        sort($otherPluginsToLoadAfterDefaultPlugins);
+        $self = $this;
+        usort($otherPluginsToLoadAfterDefaultPlugins, function ($a, $b) use ($self) {
+            $pluginJson = MetadataLoader::loadPluginInfoJson($a);
+            if (empty($pluginJson['require'][$b])) {
+                return 1;
+            }
+
+            return -1;
+        });
 
         $sorted = array_merge($defaultPluginsLoadedFirst, $otherPluginsToLoadAfterDefaultPlugins);
 

--- a/core/Application/Kernel/PluginList.php
+++ b/core/Application/Kernel/PluginList.php
@@ -114,15 +114,27 @@ class PluginList
 
         // sort by name to have a predictable order for those extra plugins
         $self = $this;
-        usort($otherPluginsToLoadAfterDefaultPlugins, function ($a, $b) use ($self) {
-            $pluginJson = MetadataLoader::loadPluginInfoJson($a);
-            if (empty($pluginJson['require'][$b])) {
+        $pluginJsonCache = array();
+        usort($otherPluginsToLoadAfterDefaultPlugins, function ($a, $b) use ($self, &$pluginJsonCache) {
+            if (!isset($pluginJsonCache[$a])) {
+                $pluginJsonCache[$a] = MetadataLoader::loadPluginInfoJson($a);
+            }
+
+            if (!empty($pluginJsonCache[$a]['require'][$b])) {
                 return 1;
             }
 
-            return -1;
-        });
+            if (!isset($pluginJsonCache[$b])) {
+                $pluginJsonCache[$b] = MetadataLoader::loadPluginInfoJson($b);
+            }
 
+            if (!empty($pluginJsonCache[$b]['require'][$a])) {
+                return -1;
+            }
+
+            return 0;
+        });
+        
         $sorted = array_merge($defaultPluginsLoadedFirst, $otherPluginsToLoadAfterDefaultPlugins);
 
         return $sorted;

--- a/core/Plugin/MetadataLoader.php
+++ b/core/Plugin/MetadataLoader.php
@@ -50,7 +50,7 @@ class MetadataLoader
     public function load()
     {
         $defaults = $this->getDefaultPluginInformation();
-        $plugin   = $this->loadPluginInfoJson();
+        $plugin   = self::loadPluginInfoJson($this->pluginName);
 
         // use translated plugin description if available
         if ($defaults['description'] != Piwik::translate($defaults['description'])) {
@@ -71,7 +71,7 @@ class MetadataLoader
 
     public function hasPluginJson()
     {
-        $hasJson = $this->loadPluginInfoJson();
+        $hasJson = $this->loadPluginInfoJson($this->pluginName);
 
         return !empty($hasJson);
     }
@@ -90,13 +90,13 @@ class MetadataLoader
         );
     }
 
-    private function loadPluginInfoJson()
+    public static function loadPluginInfoJson($pluginName)
     {
-        $path = $this->getPathToPluginFolder() . '/' . self::PLUGIN_JSON_FILENAME;
-        return $this->loadJsonMetadata($path);
+        $path = \Piwik\Plugin\Manager::getPluginsDirectory() . $pluginName . '/' . self::PLUGIN_JSON_FILENAME;
+        return self::loadJsonMetadata($path);
     }
 
-    private function loadJsonMetadata($path)
+    private static function loadJsonMetadata($path)
     {
         if (!file_exists($path)) {
             return array();


### PR DESCRIPTION
I noticed a bug when requiring a plugin.

If eg a plugin named `Acc` requires a plugin named `Cli`, plugin `Acc` will be not activated because `Acc` will be always loaded before `Cli`. See the diff changes, so far we always sort custom plugins alphabetically. However, it should respect a required plugin and make sure to load a required plugin first. In this case `Cli` before `Acc`.

While this PR should work, it is maybe a bit slow to load the `plugin.json` of each custom plugin each time for each request additionally (we load it again later in Metadata loader where it is cached). In tracker we would under circumstances not need to load it at all.

@sgiehl @mattab maybe you guys have a better idea on how to fix it? AFAIK the DI container and environment is not set up at this time and caching this information is likely not really possible. Also we can often not write it directly into plugin.json as we may not have file permissions etc.