### PR TITLE
Make sure required plugins are loaded in correct order

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -15,7 +15,6 @@ use Piwik\Columns\Dimension;
 use Piwik\Config;
 use Piwik\Config as PiwikConfig;
 use Piwik\Container\StaticContainer;
-use Piwik\Db;
 use Piwik\EventDispatcher;
 use Piwik\Exception\PluginDeactivatedException;
 use Piwik\Filesystem;
@@ -26,10 +25,8 @@ use Piwik\Plugin;
 use Piwik\Plugin\Dimension\ActionDimension;
 use Piwik\Plugin\Dimension\ConversionDimension;
 use Piwik\Plugin\Dimension\VisitDimension;
-use Piwik\Session;
 use Piwik\Settings\Storage as SettingsStorage;
 use Piwik\Theme;
-use Piwik\Tracker;
 use Piwik\Translation\Translator;
 use Piwik\Updater;
 
@@ -838,37 +835,56 @@ class Manager
     {
         $pluginsToPostPendingEventsTo = array();
         foreach ($this->pluginsToLoad as $pluginName) {
-            if (!$this->isPluginLoaded($pluginName)
-                && !$this->isPluginThirdPartyAndBogus($pluginName)
-            ) {
-                $newPlugin = $this->loadPlugin($pluginName);
-                if ($newPlugin === null) {
-                    continue;
-                }
-
-                if ($newPlugin->hasMissingDependencies()) {
-                    $this->deactivatePlugin($pluginName);
-
-                    // at this state we do not know yet whether current user has super user access. We do not even know
-                    // if someone is actually logged in.
-                    $message  = Piwik::translate('CorePluginsAdmin_WeDeactivatedThePluginAsItHasMissingDependencies', array($pluginName, $newPlugin->getMissingDependenciesAsString()));
-                    $message .= ' ';
-                    $message .= Piwik::translate('General_PleaseContactYourPiwikAdministrator');
-
-                    $notification = new Notification($message);
-                    $notification->context = Notification::CONTEXT_ERROR;
-                    Notification\Manager::notify('PluginManager_PluginDeactivated', $notification);
-                    continue;
-                }
-
-                $pluginsToPostPendingEventsTo[] = $newPlugin;
-            }
+            $pluginsToPostPendingEventsTo = $this->reloadActivatedPlugin($pluginName, $pluginsToPostPendingEventsTo);
         }
 
         // post pending events after all plugins are successfully loaded
         foreach ($pluginsToPostPendingEventsTo as $plugin) {
             EventDispatcher::getInstance()->postPendingEventsTo($plugin);
         }
+    }
+
+    private function reloadActivatedPlugin($pluginName, $pluginsToPostPendingEventsTo)
+    {
+        if ($this->isPluginLoaded($pluginName) || $this->isPluginThirdPartyAndBogus($pluginName)) {
+            return $pluginsToPostPendingEventsTo;
+        }
+
+        $newPlugin = $this->loadPlugin($pluginName);
+
+        if ($newPlugin === null) {
+            return $pluginsToPostPendingEventsTo;
+        }
+
+        $requirements = $newPlugin->getMissingDependencies();
+
+        if (!empty($requirements)) {
+            foreach ($requirements as $requirement) {
+                $possiblePluginName = $requirement['requirement'];
+                if (in_array($possiblePluginName, $this->pluginsToLoad, $strict = true)) {
+                    $pluginsToPostPendingEventsTo = $this->reloadActivatedPlugin($possiblePluginName, $pluginsToPostPendingEventsTo);
+                }
+            }
+        }
+
+        if ($newPlugin->hasMissingDependencies()) {
+            $this->deactivatePlugin($pluginName);
+
+            // at this state we do not know yet whether current user has super user access. We do not even know
+            // if someone is actually logged in.
+            $message  = Piwik::translate('CorePluginsAdmin_WeDeactivatedThePluginAsItHasMissingDependencies', array($pluginName, $newPlugin->getMissingDependenciesAsString()));
+            $message .= ' ';
+            $message .= Piwik::translate('General_PleaseContactYourPiwikAdministrator');
+
+            $notification = new Notification($message);
+            $notification->context = Notification::CONTEXT_ERROR;
+            Notification\Manager::notify('PluginManager_PluginDeactivated', $notification);
+            return $pluginsToPostPendingEventsTo;
+        }
+
+        $pluginsToPostPendingEventsTo[] = $newPlugin;
+
+        return $pluginsToPostPendingEventsTo;
     }
 
     public function getIgnoredBogusPlugins()


### PR DESCRIPTION
I noticed a bug when a plugin requires another plugin.

If eg a plugin named `Acc` requires a plugin named `Cli`, plugin `Acc` will be not activated because `Acc` will be always loaded before `Cli`. See https://github.com/piwik/piwik/blob/3.0.4-b2/core/Application/Kernel/PluginList.php#L113-L114 we always sort custom plugins alphabetically. However, it should respect a required plugin and make sure to load a required plugin first. In this case `Cli` before `Acc`.

In #11676 I implemented similar solution but is slower I would say. This solution should be quite a bit faster when having a few plugins installed. Also this plugin should make sure to load plugins alphabetically if no plugin requires anything which means the tests won't randomly fail.

@sgiehl @mattab maybe you guys have a better idea on how to fix it?

There is still an issue that `plugins/$pluginName/config/config.php` in each plugin is loaded alphabetically. It is to be discussed if a `config.php` of a required plugin should have less of a priority so that a plugin that requires another plugin, can overwrite a DI setting of the required plugin. Meaning ideally, the config for `Cli` would be loaded first, then `Acc` because `Acc` requires `Cli`. This way `Acc` could overwrite any DI setting from `Cli`. Currently, `config.php` files are loaded as they are defined in `config.ini.php` which is usually alphabetically because of https://github.com/piwik/piwik/blob/3.0.4-b2/core/Plugin/Manager.php#L209-L212 (if config file is writable and not changed manually).
