### PR TITLE
Unload plugin instead of deactivating it when a plugin has a missing dependency

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -868,17 +868,17 @@ class Manager
         }
 
         if ($newPlugin->hasMissingDependencies()) {
-            $this->deactivatePlugin($pluginName);
+            $this->unloadPluginFromMemory($pluginName);
 
             // at this state we do not know yet whether current user has super user access. We do not even know
             // if someone is actually logged in.
-            $message  = Piwik::translate('CorePluginsAdmin_WeDeactivatedThePluginAsItHasMissingDependencies', array($pluginName, $newPlugin->getMissingDependenciesAsString()));
+            $message  = Piwik::translate('CorePluginsAdmin_WeCouldNotLoadThePluginAsItHasMissingDependencies', array($pluginName, $newPlugin->getMissingDependenciesAsString()));
             $message .= ' ';
             $message .= Piwik::translate('General_PleaseContactYourPiwikAdministrator');
 
             $notification = new Notification($message);
             $notification->context = Notification::CONTEXT_ERROR;
-            Notification\Manager::notify('PluginManager_PluginDeactivated', $notification);
+            Notification\Manager::notify('PluginManager_PluginUnloaded', $notification);
             return $pluginsToPostPendingEventsTo;
         }
 

--- a/plugins/CorePluginsAdmin/lang/en.json
+++ b/plugins/CorePluginsAdmin/lang/en.json
@@ -63,7 +63,7 @@
         "UninstallConfirm": "You are about to uninstall a plugin %s. The plugin will be completely removed from your platform and it won't be recoverable. Are you sure you want to do this?",
         "Version": "Version",
         "ViewAllMarketplacePlugins": "View all Marketplace plugins",
-        "WeDeactivatedThePluginAsItHasMissingDependencies": "We disabled the plugin %s as it has missing dependencies:",
+        "WeCouldNotLoadThePluginAsItHasMissingDependencies": "The plugin %s could not be loaded as it has missing dependencies: %s",
         "Websites": "Websites"
     }
 }


### PR DESCRIPTION
Deactivating a plugin in case of a missing dependency is a bit risky. If just once a dependency is missing it would be directly deactivated. For example during an update we may run into an issue where a plugin dependency might be missing just for a short time frame. There may be also other edge cases where this might be the case. It would be better to instead trigger a notification only. I would show this notification only to super users but we do not have anything loaded at this time.

It also fixes an issue that the missing dependency was never shown in the notification because there was a `%s` missing.

Any other ideas?