### PR TITLE
Let plugins customize the system summary widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** l
 
 ### New APIs
 * A new event `Db.getActionReferenceColumnsByTable` has been added in case a plugin defines a custom log table which references data to the log_action table 
+* The event `System.addSystemSummaryItems` and `System.filterSystemSummaryItems` have been added so plugins can add items and filter items of the system summary widget
 * A new JavaScript tracker method `getPiwikUrl` has been added to retrieve the URL of where the Piwik instance is located
 * A new JavaScript tracker method `getCurrentUrl` has been added to retrieve the current URL of the website. 
 * A new JavaScript tracker method `getNumTrackedPageViews` has been added to retrieve the number of tracked page views within the currently loaded page or web application. 

--- a/plugins/CoreHome/SystemSummary/Item.php
+++ b/plugins/CoreHome/SystemSummary/Item.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\CoreHome\SystemSummary;
+
+/**
+ * This class can be used to add a new entry / item to the system summary widget.
+ *
+ * @api
+ */
+class Item
+{
+    private $key;
+    private $label;
+    private $value;
+    private $urlParams;
+    private $icon;
+    private $order;
+
+    /**
+     * Item constructor.
+     * @param string $key  The key or ID for this item. The entry in the widget will have this class so it is possible
+     *                     to style it individually and other plugins can use this key to for example remove this item
+     *                     from the list of system summary items.
+     * @param string $label  The label that will be displayed for this item. The label may already include the value such as "5 segments"
+     * @param string|null $value Optional label. If given, the value will be displayed after the label separated by a colon, eg: "Segments: 5"
+     * @param array|null $urlParams  Optional URL to make the item clickable. Accepts an array of URL parameters that need to be modfified.
+     * @param string $icon  Optional icon css class, eg "icon-user".
+     * @param int $order Optional sort order. The lower the value, the higher up the entry will be shown
+     */
+    public function __construct($key, $label, $value = null, $urlParams = null, $icon = '', $order = 99)
+    {
+        $this->key = $key;
+        $this->label = $label;
+        $this->value = $value;
+        $this->urlParams = $urlParams;
+        $this->icon = $icon;
+        $this->order = $order;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->label;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getUrlParams()
+    {
+        return $this->urlParams;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIcon()
+    {
+        return $this->icon;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+}

--- a/plugins/CoreHome/Widgets/GetSystemSummary.php
+++ b/plugins/CoreHome/Widgets/GetSystemSummary.php
@@ -66,8 +66,8 @@ class GetSystemSummary extends Widget
         Piwik::postEvent('System.addSystemSummaryItems', array(&$systemSummary));
 
         $systemSummary[] = new Item($key = 'piwik-version', Piwik::translate('CoreHome_SystemSummaryPiwikVersion'), Version::VERSION, $url = null, $icon = '', $order = 21);
-        $systemSummary[] = new Item($key = 'php-version', Piwik::translate('CoreHome_SystemSummaryMysqlVersion'), phpversion(), $url = null, $icon = '', $order = 22);
-        $systemSummary[] = new Item($key = 'mysql-version', Piwik::translate('CoreHome_SystemSummaryPhpVersion'), $mysqlVersion, $url = null, $icon = '', $order = 23);
+        $systemSummary[] = new Item($key = 'php-version', Piwik::translate('CoreHome_SystemSummaryMysqlVersion'), $mysqlVersion, $url = null, $icon = '', $order = 22);
+        $systemSummary[] = new Item($key = 'mysql-version', Piwik::translate('CoreHome_SystemSummaryPhpVersion'), phpversion(), $url = null, $icon = '', $order = 23);
 
         $systemSummary = array_filter($systemSummary);
         usort($systemSummary, function ($itemA, $itemB) {

--- a/plugins/CoreHome/templates/getSystemSummary.twig
+++ b/plugins/CoreHome/templates/getSystemSummary.twig
@@ -1,28 +1,26 @@
 <div class="widgetBody systemSummary">
-    <div>
-        <span class="icon icon-user"></span>
-          <a href="{{ linkTo({'module': 'UsersManager', 'action': 'index'}) }}">{{ 'General_NUsers'|translate(numUsers) }}</a>
-    </div>
-    <div>
-        <span><span class="icon icon-segment"></span> {{ 'CoreHome_SystemSummaryNSegments'|translate(numSegments) }}</span>
-    </div>
-    <div>
-        <a href="{{ linkTo({'module': 'SitesManager', 'action': 'index'}) }}">{{ 'CoreHome_SystemSummaryNWebsites'|translate(numWebsites) }}</a>
-    </div>
-    <div>
-        <a href="{{ linkTo({'module': 'CorePluginsAdmin', 'action': 'plugins'}) }}">{{ 'CoreHome_SystemSummaryNActivatedPlugins'|translate(numPlugins) }}</a>
-    </div>
-    <div>
-        <span>{{ 'CoreHome_SystemSummaryPiwikVersion'|translate }}:</span>
-        <span class="piwik-version">{{ piwikVersion }}</span>
-    </div>
-    <div>
-        <span>{{ 'CoreHome_SystemSummaryMysqlVersion'|translate }}:</span>
-        <span>{{ mySqlVersion }}</span>
-    </div>
-    <div>
-        <span>{{ 'CoreHome_SystemSummaryPhpVersion'|translate }}:</span>
-        <span>{{ phpVersion }}</span>
-    </div>
+    {% for item in items %}
+        {% if item is not empty %}
+            <div class="systemSummaryItem {% if item.getKey %}{{ item.getKey }}{% endif %}">
+                {% if item.getIcon %}<span class="icon {{ item.getIcon }}"></span>{% endif %}
+
+                {% if item.getUrlParams -%}
+                    <a href="{{ linkTo(item.getUrlParams) }}" class="itemLabel">
+                {% else -%}
+                    <span class="itemLabel">
+                {% endif -%}
+
+                {{ item.getLabel }}{% if item.getValue %}:{% endif %}
+
+                {%- if item.getUrlParams %}
+                    </a>
+                {%- else %}
+                    </span>
+                {%- endif %}
+
+                {% if item.getValue %}<span class="itemValue">{{ item.getValue }}</span>{% endif %}
+            </div>
+        {% endif %}
+    {% endfor %}
     <br />
 </div>

--- a/plugins/CorePluginsAdmin/CorePluginsAdmin.php
+++ b/plugins/CorePluginsAdmin/CorePluginsAdmin.php
@@ -9,7 +9,9 @@
 namespace Piwik\Plugins\CorePluginsAdmin;
 
 use Piwik\Config;
+use Piwik\Piwik;
 use Piwik\Plugin;
+use Piwik\Plugins\CoreHome\SystemSummary;
 
 class CorePluginsAdmin extends Plugin
 {
@@ -21,8 +23,15 @@ class CorePluginsAdmin extends Plugin
         return array(
             'AssetManager.getJavaScriptFiles'        => 'getJsFiles',
             'AssetManager.getStylesheetFiles'        => 'getStylesheetFiles',
+            'System.addSystemSummaryItems'           => 'addSystemSummaryItems',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys'
         );
+    }
+
+    public function addSystemSummaryItems(&$systemSummary)
+    {
+        $numPlugins = Plugin\Manager::getInstance()->getNumberOfActivatedPluginsExcludingAlwaysActivated();
+        $systemSummary[] = new SystemSummary\Item($key = 'plugins', Piwik::translate('CoreHome_SystemSummaryNActivatedPlugins', $numPlugins), $value = null, $url = array('module' => 'CorePluginsAdmin', 'action' => 'plugins'), $icon = '', $order = 11);
     }
 
     public function getStylesheetFiles(&$stylesheets)

--- a/plugins/SegmentEditor/SegmentEditor.php
+++ b/plugins/SegmentEditor/SegmentEditor.php
@@ -9,7 +9,9 @@
 namespace Piwik\Plugins\SegmentEditor;
 
 use Piwik\Config;
-use Piwik\Db;
+use Piwik\Container\StaticContainer;
+use Piwik\Piwik;
+use Piwik\Plugins\CoreHome\SystemSummary;
 
 /**
  */
@@ -26,8 +28,17 @@ class SegmentEditor extends \Piwik\Plugin
             'AssetManager.getJavaScriptFiles'            => 'getJsFiles',
             'AssetManager.getStylesheetFiles'            => 'getStylesheetFiles',
             'Template.nextToCalendar'                    => 'getSegmentEditorHtml',
+            'System.addSystemSummaryItems'               => 'addSystemSummaryItems',
             'Translate.getClientSideTranslationKeys'     => 'getClientSideTranslationKeys',
         );
+    }
+
+    public function addSystemSummaryItems(&$systemSummary)
+    {
+        $storedSegments = StaticContainer::get('Piwik\Plugins\SegmentEditor\Services\StoredSegmentService');
+        $segments = $storedSegments->getAllSegmentsAndIgnoreVisibility();
+        $numSegments = count($segments);
+        $systemSummary[] = new SystemSummary\Item($key = 'segments', Piwik::translate('CoreHome_SystemSummaryNSegments', $numSegments), $value = null, $url = null, $icon = 'icon-segment', $order = 6);
     }
 
     function getSegmentEditorHtml(&$out)

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -8,12 +8,12 @@
  */
 namespace Piwik\Plugins\SitesManager;
 
+use Piwik\API\Request;
 use Piwik\Common;
-use Piwik\Archive\ArchiveInvalidator;
 use Piwik\Container\StaticContainer;
-use Piwik\Db;
+use Piwik\Piwik;
+use Piwik\Plugins\CoreHome\SystemSummary;
 use Piwik\Plugins\PrivacyManager\PrivacyManager;
-use Piwik\Measurable\Settings\Storage;
 use Piwik\Settings\Storage\Backend\MeasurableSettingsTable;
 use Piwik\Tracker\Cache;
 use Piwik\Tracker\Model as TrackerModel;
@@ -28,7 +28,7 @@ class SitesManager extends \Piwik\Plugin
     const KEEP_URL_FRAGMENT_NO = 2;
 
     /**
-     * @see Piwik\Plugin::registerEvents
+     * @see \Piwik\Plugin::registerEvents
      */
     public function registerEvents()
     {
@@ -38,8 +38,16 @@ class SitesManager extends \Piwik\Plugin
             'Tracker.Cache.getSiteAttributes'        => 'recordWebsiteDataInCache',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
             'SitesManager.deleteSite.end'            => 'onSiteDeleted',
+            'System.addSystemSummaryItems'           => 'addSystemSummaryItems',
             'Request.dispatch'                       => 'redirectDashboardToWelcomePage',
         );
+    }
+
+    public function addSystemSummaryItems(&$systemSummary)
+    {
+        $websites = Request::processRequest('SitesManager.getAllSites', array('filter_limit' => '-1'));
+        $numWebsites = count($websites);
+        $systemSummary[] = new SystemSummary\Item($key = 'websites', Piwik::translate('CoreHome_SystemSummaryNWebsites', $numWebsites), $value = null, $url = array('module' => 'SitesManager', 'action' => 'index'), $icon = '', $order = 10);
     }
 
     public function redirectDashboardToWelcomePage(&$module, &$action)

--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -9,8 +9,10 @@
 namespace Piwik\Plugins\UsersManager;
 
 use Exception;
+use Piwik\API\Request;
 use Piwik\Option;
 use Piwik\Piwik;
+use Piwik\Plugins\CoreHome\SystemSummary;
 use Piwik\SettingsPiwik;
 
 /**
@@ -33,8 +35,21 @@ class UsersManager extends \Piwik\Plugin
             'Tracker.Cache.getSiteAttributes'        => 'recordAdminUsersInCache',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
             'Platform.initialized'                   => 'onPlatformInitialized',
+            'System.addSystemSummaryItems'           => 'addSystemSummaryItems',
             'CronArchive.getTokenAuth'               => 'getCronArchiveTokenAuth'
         );
+    }
+
+    public function addSystemSummaryItems(&$systemSummary)
+    {
+        $userLogins = Request::processRequest('UsersManager.getUsersLogin', array('filter_limit' => '-1'));
+
+        $numUsers = count($userLogins);
+        if (in_array('anonymous', $userLogins)) {
+            $numUsers--;
+        }
+
+        $systemSummary[] = new SystemSummary\Item($key = 'users', Piwik::translate('General_NUsers', $numUsers), $value = null, array('module' => 'UsersManager', 'action' => 'index'), $icon = 'icon-user', $order = 5);
     }
 
     public function onPlatformInitialized()

--- a/tests/resources/screenshot-override/override.css
+++ b/tests/resources/screenshot-override/override.css
@@ -10,6 +10,7 @@
     display:none;
 }
 
+.piwik-version .itemValue,
 span.piwik-version,
 span.plugin-version {
     visibility:hidden;


### PR DESCRIPTION
Plugins can now add more system summary items and filter existing system summary items. 

I'm happy to change namespace if needed. I could have made this a component and pick up classes from an eg "SystemSumary" folder automatically but didn't want to overdo it for now as it is not such an essential feature and it is actually not really a core feature. Can do it though if needed. The events would be still needed even when they are in core so thought to keep it simple for now.