### PR TITLE
Add possibility to ignore "no data recorded" screen for one hour

### DIFF
--- a/plugins/SitesManager/Controller.php
+++ b/plugins/SitesManager/Controller.php
@@ -13,6 +13,7 @@ use Piwik\API\ResponseBuilder;
 use Piwik\Common;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Piwik;
+use Piwik\Session;
 use Piwik\Settings\Measurable\MeasurableSettings;
 use Piwik\SettingsPiwik;
 use Piwik\Site;
@@ -128,6 +129,18 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         Common::sendHeader('Content-type: text/php');
         Common::sendHeader('Content-Disposition: attachment; filename="' . $filename . '"');
         return file_get_contents($path . $filename);
+    }
+
+    public function ignoreNoDataMessage()
+    {
+        Piwik::checkUserHasSomeViewAccess();
+
+        $session = new Session\SessionNamespace('siteWithoutData');
+        $session->ignoreMessage = true;
+        $session->setExpirationSeconds($oneHour = 60 * 60);
+
+        $url = Url::getCurrentUrlWithoutQueryString() . Url::getCurrentQueryStringWithParametersModified(array('module' => 'CoreHome', 'action' => 'index'));
+        Url::redirectToUrl($url);
     }
 
     public function siteWithoutData()

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -17,6 +17,7 @@ use Piwik\Measurable\Settings\Storage;
 use Piwik\Settings\Storage\Backend\MeasurableSettingsTable;
 use Piwik\Tracker\Cache;
 use Piwik\Tracker\Model as TrackerModel;
+use Piwik\Session\SessionNamespace;
 
 /**
  *
@@ -61,6 +62,11 @@ class SitesManager extends \Piwik\Plugin
 
         $trackerModel = new TrackerModel();
         if ($trackerModel->isSiteEmpty($siteId)) {
+            $session = new SessionNamespace('siteWithoutData');
+            if (!empty($session->ignoreMessage)) {
+                return;
+            }
+
             $module = 'SitesManager';
             $action = 'siteWithoutData';
         }

--- a/plugins/SitesManager/lang/en.json
+++ b/plugins/SitesManager/lang/en.json
@@ -76,6 +76,7 @@
         "SiteWithoutDataSetupTracking": "Please set up the %1$stracking code%2$s below into your website or mobile app if you haven't done already.",
         "SiteWithoutDataMessageDisappears": "This message will disappear as soon as some data was tracked for this website.",
         "SiteWithoutDataSetupGoals": "In the meantime, maybe you would like to %1$sset up some goals%2$s or learn more about the %3$sfeatures%4$s of Piwik in one of our %5$sguides%6$s or %7$sFAQs%8$s.",
+        "SiteWithoutDataIgnoreMessage": "Ignore this message for the next hour",
         "SuperUserAccessCan": "A user with Super User access can also %1$s specify global settings%2$s for new websites.",
         "Timezone": "Time zone",
         "TrackingSiteSearch": "Tracking Internal Site Search",

--- a/plugins/SitesManager/lang/en.json
+++ b/plugins/SitesManager/lang/en.json
@@ -76,7 +76,7 @@
         "SiteWithoutDataSetupTracking": "Please set up the %1$stracking code%2$s below into your website or mobile app if you haven't done already.",
         "SiteWithoutDataMessageDisappears": "This message will disappear as soon as some data was tracked for this website.",
         "SiteWithoutDataSetupGoals": "In the meantime, maybe you would like to %1$sset up some goals%2$s or learn more about the %3$sfeatures%4$s of Piwik in one of our %5$sguides%6$s or %7$sFAQs%8$s.",
-        "SiteWithoutDataIgnoreMessage": "Ignore this message for the next hour",
+        "SiteWithoutDataIgnoreMessage": "Don't show this message for the next hour",
         "SuperUserAccessCan": "A user with Super User access can also %1$s specify global settings%2$s for new websites.",
         "Timezone": "Time zone",
         "TrackingSiteSearch": "Tracking Internal Site Search",

--- a/plugins/SitesManager/templates/siteWithoutData.twig
+++ b/plugins/SitesManager/templates/siteWithoutData.twig
@@ -45,6 +45,11 @@
             '<a href="https://piwik.org/features/" rel="noreferrer" target="_blank">', "</a>",
             '<a href="https://piwik.org/docs/" rel="noreferrer" target="_blank">', "</a>",
             '<a href="https://piwik.org/faq/" rel="noreferrer" target="_blank">', "</a>")|raw }}
+
+            <br />
+            <br />
+            <a href="{{ linkTo({module: 'SitesManager', action: 'ignoreNoDataMessage'}) }}"
+               class="btn ignoreSitesWithoutData">{{ 'SitesManager_SiteWithoutDataIgnoreMessage'|translate }}</a>
         </p>
 
         {{ trackingHelp|raw }}

--- a/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard.png
+++ b/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:726a13568beb3a0c5026f45be288ef814d74c779afcd6d5d39f608094ee979e7
-size 223386
+oid sha256:0723f3a7503a471b5432f8b72f0b9fd3f5ceef2ff9e5b3f87175ac2150465ed3
+size 222863

--- a/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard.png
+++ b/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2c131f981a3d5ac09c7f035a3f855bc35f4e7ec9bf3083c475df5a770ce90f5
-size 217051
+oid sha256:726a13568beb3a0c5026f45be288ef814d74c779afcd6d5d39f608094ee979e7
+size 223386

--- a/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard_ignored.png
+++ b/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard_ignored.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e383cb11f0b52e871c8ae76626f296196fb6133e03aba39bb92e05ab770a42b7
+size 284829

--- a/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard_ignored.png
+++ b/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard_ignored.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e383cb11f0b52e871c8ae76626f296196fb6133e03aba39bb92e05ab770a42b7
-size 284829
+oid sha256:c8b3052ed220a9ae9e545542b63266be0dd46d5a8b1038c41a64f9a5b2006dff
+size 285366

--- a/tests/UI/specs/EmptySite_spec.js
+++ b/tests/UI/specs/EmptySite_spec.js
@@ -19,4 +19,11 @@ describe("EmptySite", function () {
             page.load(urlToTest);
         }, done);
     });
+
+    it('should be possible to ignore this screen for one hour', function (done) {
+        expect.screenshot('emptySiteDashboard_ignored').to.be.captureSelector('.page', function (page) {
+            page.click('.ignoreSitesWithoutData');
+            page.wait(1000)
+        }, done);
+    });
 });


### PR DESCRIPTION
I think it would be useful to ignore the "No data recorded" message at least for an hour. 

When users install Piwik or want to try it, then they might not be able to track data immediately making it hard for them to get an idea what Piwik is or can do. By being able to ignore this message a user can "click around" and explore Piwik even when not having any data tracked.

It may also help in the future for cases like https://github.com/piwik/piwik/issues/11568 in case we decide to show the no data message even though log data purging is enabled. Then even though there is currently no data recorded, the user would be still able to access previously generated reports. 

Feel free to suggest different wording.