### PR TITLE
Fix giving a user access to a site is not possible when login is numeric

### DIFF
--- a/plugins/UsersManager/angularjs/manage-user-access/manage-user-access.controller.js
+++ b/plugins/UsersManager/angularjs/manage-user-access/manage-user-access.controller.js
@@ -42,7 +42,7 @@
             }
         };
 
-        this.setAccess = function (login, access) 
+        this.setAccess = function (login, access) {
           login = String(login);
           login=piwik.helper.escape(piwik.helper.htmlEntities(login));
             if ( $('[data-login="' + login + '"]').find("#"+access).has('.accessGranted').length ){

--- a/plugins/UsersManager/angularjs/manage-user-access/manage-user-access.controller.js
+++ b/plugins/UsersManager/angularjs/manage-user-access/manage-user-access.controller.js
@@ -42,7 +42,8 @@
             }
         };
 
-        this.setAccess = function (login, access) {
+        this.setAccess = function (login, access) 
+          login = String(login);
           login=piwik.helper.escape(piwik.helper.htmlEntities(login));
             if ( $('[data-login="' + login + '"]').find("#"+access).has('.accessGranted').length ){
                 return;


### PR DESCRIPTION
Eg when login is 1234, the `login` var may actually be a number and then `.replace` won't work.

fixes #11680

I had a rough look for the other JS files there and should work for all other cases.