### PR TITLE
Make it possible to customize the `No data available` message shown in reports

### DIFF
--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -463,6 +463,14 @@ class Config
     public $export_limit = '';
 
     /**
+     * Message to show if not data is available for the report
+     * Defaults to `CoreHome_ThereIsNoDataForThisReport` if not set
+     *
+     * @var string
+     */
+    public $no_data_message = '';
+
+    /**
      * @ignore
      */
     public $report_id = '';

--- a/plugins/CoreHome/templates/_dataTable.twig
+++ b/plugins/CoreHome/templates/_dataTable.twig
@@ -53,6 +53,8 @@
                 <div class="pk-emptyDataTable">
                 {% if showReportDataWasPurgedMessage is defined and showReportDataWasPurgedMessage %}
                     {{ 'CoreHome_DataForThisReportHasBeenPurged'|translate(deleteReportsOlderThan) }}
+                {% elseif properties.no_data_message %}
+                    {{ properties.no_data_message|raw }}
                 {% else %}
                     {{ 'CoreHome_ThereIsNoDataForThisReport'|translate }}
                 {% endif %}


### PR DESCRIPTION
For some reports it might make sense to explain why no data is available.
As doing that in the reports footer is not visible good enough it should be done directly in the no data message sometimes.
