### PR TITLE
Added missing method rowCount to db classes

### DIFF
--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -95,6 +95,17 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
     }
 
     /**
+     * Return number of affected rows in last query
+     *
+     * @param mixed $queryResult Result from query()
+     * @return int
+     */
+    public function rowCount($queryResult)
+    {
+        return mysqli_affected_rows($this->_connection);
+    }
+
+    /**
      * Returns true if this adapter's required extensions are enabled
      *
      * @return bool

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -194,6 +194,17 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
     }
 
     /**
+     * Return number of affected rows in last query
+     *
+     * @param mixed $queryResult Result from query()
+     * @return int
+     */
+    public function rowCount($queryResult)
+    {
+        return $queryResult->rowCount();
+    }
+
+    /**
      * Retrieve client version in PHP style
      *
      * @return string

--- a/tests/PHPUnit/Integration/DbTest.php
+++ b/tests/PHPUnit/Integration/DbTest.php
@@ -85,6 +85,21 @@ class DbTest extends IntegrationTestCase
         Db::destroyDatabaseObject();
     }
 
+    /**
+     * @dataProvider getDbAdapter
+     */
+    public function test_getRowCount($adapter, $expectedClass)
+    {
+        Db::destroyDatabaseObject();
+        Config::getInstance()->database['adapter'] = $adapter;
+        $db = Db::get();
+        // make sure test is useful and setting adapter works
+        $this->assertInstanceOf($expectedClass, $db);
+
+        $result = $db->query('select 21');
+        $this->assertEquals(1, $db->rowCount($result));
+    }
+
     public function getDbAdapter()
     {
         return array(


### PR DESCRIPTION
I just ran into an issue where I used the `Db::rowCount` method. This works fine when being in tracker mode and code works as the Db tracker has this method. However, when writing tests for it, it may use the regular Db during the tests which means the test fails. Therefore I added the missing methods to make the tests work.

Not sure if this is considered a bug, an enhancement, whether we should mention it in changelog or not.