### PR TITLE
Add support for email and url form fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** l
 * A new JavaScript tracker method `getCurrentUrl` has been added to retrieve the current URL of the website. 
 * A new JavaScript tracker method `getNumTrackedPageViews` has been added to retrieve the number of tracked page views within the currently loaded page or web application. 
 * New JavaScript tracker methods `setSessionCookie`, `getCookie`, `hasCookies`, `getCookieDomain`, `getCookiePath`, and `getSessionCookieTimeout` have been added for better cookie support in plugins. 
+* `email` and `url` form fields can now be used in settings.
 
 ## Piwik 3.0.3
 

--- a/core/Settings/FieldConfig.php
+++ b/core/Settings/FieldConfig.php
@@ -27,6 +27,16 @@ class FieldConfig
     const UI_CONTROL_TEXT = 'text';
 
     /**
+     * Shows an email text field. To use this field assign it to the `$uiControl` property.
+     */
+    const UI_CONTROL_EMAIL = 'email';
+
+    /**
+     * Shows a URL text field. To use this field assign it to the `$uiControl` property.
+     */
+    const UI_CONTROL_URL = 'url';
+
+    /**
      * Shows a text area. To use this field assign it to the `$uiControl` property.
      */
     const UI_CONTROL_TEXTAREA = 'textarea';

--- a/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
@@ -148,7 +148,7 @@
 
         function getTemplate(field) {
             var control = field.uiControl;
-            if (control === 'password') {
+            if (control === 'password' || control === 'url' || control === 'search' || control === 'email') {
                 control = 'text'; // we use same template for text and password both
             }
 

--- a/plugins/Morpheus/templates/demo.twig
+++ b/plugins/Morpheus/templates/demo.twig
@@ -274,7 +274,7 @@
                      placeholder="Some text here">
                 </div>
 
-                <div piwik-field uicontrol="text" name="email"
+                <div piwik-field uicontrol="email" name="email"
                      title="Email"
                      inline-help="This is the inline help which provides more information.">
                 </div>
@@ -312,6 +312,9 @@
                      title="Form fields can be made full witdth"
                      full-width="true"
                      placeholder="Some text here...">
+                </div>
+
+                <div piwik-field uicontrol="url" name="urlText" title="URL" inline-help="URL field">
                 </div>
 
                 <div piwik-field uicontrol="textarea" name="description"
@@ -375,7 +378,7 @@
           placeholder=&quot;Some text here&quot;&gt;
     &lt;/div&gt;
 
-    &lt;div piwik-field uicontrol=&quot;text&quot; name=&quot;email&quot;
+    &lt;div piwik-field uicontrol=&quot;email&quot; name=&quot;email&quot;
          title=&quot;Email&quot;
          inline-help=&quot;This is the inline help which provides more information.&quot;&gt;
     &lt;/div&gt;
@@ -413,6 +416,9 @@
          title=&quot;Form fields can be made full witdth&quot;
          full-width=&quot;true&quot;
          placeholder=&quot;Some text here...&quot;&gt;
+    &lt;/div&gt;
+
+    &lt;div piwik-field uicontrol=&quot;url&quot; name=&quot;urlText&quot; title=&quot;URL&quot; inline-help=&quot;URL field&quot;&gt;
     &lt;/div&gt;
 
     &lt;div piwik-field uicontrol=&quot;textarea&quot; name=&quot;description&quot;

--- a/tests/UI/expected-screenshots/Morpheus_load.png
+++ b/tests/UI/expected-screenshots/Morpheus_load.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73c4779f2af6eef0ddc37badcb41bf484d9e3fb056acacbbb78317d23759116f
-size 1186022
+oid sha256:b22962c13f73dafd96f26d588529445ec295c3b37010b24fe81e4b7c860969c9
+size 1196468


### PR DESCRIPTION
email and url form fields can now be used in settings or as regular form fields (I'm not sure if they are actually API)