### PR TITLE
Added new events for scheduled tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This is the Developer Changelog for Piwik platform developers. All changes in ou
 
 The Product Changelog at **[piwik.org/changelog](http://piwik.org/changelog)** lets you see more details about any Piwik release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Piwik 3.0.5
+
+### New APIs
+* The events `ScheduledTasks.shouldExecuteTask`, `ScheduledTasks.execute`, `ScheduledTasks.execute.end` have been added to customize the behaviour of scheduled tasks.
+
 ## Piwik 3.0.4
 
 ### New APIs


### PR DESCRIPTION
Added new events so other plugins can disable tasks or customize behaviour.

The execute events are similar to our `Request.dispatch` and `Request.dispatch.end` event / `API.Request.dispatch` and `API.Request.dispatch.end` events.