### PR TITLE
Improve switching between sites in reporting area when viewing an entity 

### DIFF
--- a/plugins/CoreHome/angularjs/common/services/reporting-pages-model.js
+++ b/plugins/CoreHome/angularjs/common/services/reporting-pages-model.js
@@ -16,18 +16,36 @@
         var model = {
             pages : [],
             findPage: findPage,
+            findPageInCategory: findPageInCategory,
             reloadAllPages : reloadAllPages,
             getAllPages : getAllPages
         };
 
         return model;
 
+        function findPageInCategory(categoryId) {
+            var found = null;
+
+            angular.forEach(model.pages, function (page) {
+                // happens when user switches between sites, in this case check if the same category exists and if so,
+                // select first entry from that category
+                if (!found && page &&
+                    page.category && page.subcategory &&
+                    page.category.id === categoryId && page.subcategory.id) {
+                    found = page;
+                }
+            });
+
+            return found;
+        }
+
         function findPage(categoryId, subcategoryId)
         {
             var found = null;
 
             angular.forEach(model.pages, function (page) {
-                if (page &&
+                if (!found &&
+                    page &&
                     page.category && page.subcategory &&
                     page.category.id === categoryId && ('' + page.subcategory.id) === subcategoryId) {
                     found = page;

--- a/plugins/CoreHome/angularjs/reporting-page/reportingpage.controller.js
+++ b/plugins/CoreHome/angularjs/reporting-page/reportingpage.controller.js
@@ -7,9 +7,9 @@
 (function () {
     angular.module('piwikApp').controller('ReportingPageController', ReportingPageController);
 
-    ReportingPageController.$inject = ['$scope', 'piwik', '$rootScope', '$location', 'reportingPageModel'];
+    ReportingPageController.$inject = ['$scope', 'piwik', '$rootScope', '$location', 'reportingPageModel', 'reportingPagesModel'];
 
-    function ReportingPageController($scope, piwik, $rootScope, $location, pageModel) {
+    function ReportingPageController($scope, piwik, $rootScope, $location, pageModel, pagesModel) {
         pageModel.resetPage();
         $scope.pageModel = pageModel;
 
@@ -53,6 +53,17 @@
             }
 
             pageModel.fetchPage(category, subcategory).then(function () {
+
+                if (!pageModel.page) {
+                    var page = pagesModel.findPageInCategory(category);
+                    if (page && page.subcategory) {
+                        var $search = $location.search();
+                        $search.subcategory = page.subcategory.id;
+                        $location.search($search);
+                        return;
+                    }
+                }
+
                 $scope.hasNoPage = !pageModel.page;
                 $scope.loading = false;
             });


### PR DESCRIPTION
fixes #11721 

To reproduce eg view a goal, then switch website, it should select the first entry from that reporting category.