### PR TITLE
Use limit selection for limitting exports

### DIFF
--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -121,7 +121,6 @@ class Config
         'show_pagination_control',
         'show_offset_information',
         'hide_annotations_view',
-        'export_limit',
         'columns_to_display'
     );
 
@@ -456,13 +455,6 @@ class Config
     public $hide_annotations_view = true;
 
     /**
-     * The filter_limit query parameter value to use in export links.
-     *
-     * Defaulted to the value of the `[General] API_datatable_default_limit` INI config option.
-     */
-    public $export_limit = '';
-
-    /**
      * Message to show if not data is available for the report
      * Defaults to `CoreHome_ThereIsNoDataForThisReport` if not set
      *
@@ -492,7 +484,6 @@ class Config
      */
     public function __construct()
     {
-        $this->export_limit = \Piwik\Config::getInstance()->General['API_datatable_default_limit'];
         $this->translations = array_merge(
             Metrics::getDefaultMetrics(),
             Metrics::getDefaultProcessedMetrics()

--- a/plugins/CoreHome/templates/_dataTableActions.twig
+++ b/plugins/CoreHome/templates/_dataTableActions.twig
@@ -70,13 +70,13 @@
 
         <ul id='dropdownExport{{ randomIdForDropdown }}' class='dropdown-content exportToFormatItems'>
             {% set requestParams = properties.request_parameters_to_modify|json_encode %}
-            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="CSV" filter_limit="{{ properties.export_limit }}">CSV</a></li>
-            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="TSV" filter_limit="{{ properties.export_limit }}">TSV (Excel)</a></li>
-            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="XML" filter_limit="{{ properties.export_limit }}">XML</a></li>
-            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="JSON" filter_limit="{{ properties.export_limit }}">Json</a></li>
-            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="PHP" filter_limit="{{ properties.export_limit }}">Php</a></li>
+            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="CSV" filter_limit="{{ properties.filter_limit }}">CSV</a></li>
+            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="TSV" filter_limit="{{ properties.filter_limit }}">TSV (Excel)</a></li>
+            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="XML" filter_limit="{{ properties.filter_limit }}">XML</a></li>
+            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="JSON" filter_limit="{{ properties.filter_limit }}">Json</a></li>
+            <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="PHP" filter_limit="{{ properties.filter_limit }}">Php</a></li>
             {% if properties.show_export_as_rss_feed %}
-                <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="RSS" filter_limit="{{ properties.export_limit }}" date="last10">
+                <li><a target="_blank" requestParams="{{ requestParams|e('html_attr') }}" methodToCall="{{ properties.apiMethodToRequestDataTable }}" format="RSS" filter_limit="{{ properties.filter_limit }}" date="last10">
                         <span class="icon-feed"></span> RSS
                     </a>
                 </li>


### PR DESCRIPTION
Currently when clicking a download / export link for an report, the `export_limit` is used for limiting the records. As this value always defaults to `[General] API_datatable_default_limit` INI config option.
As that value isn't overwritten anywhere there was no possibility to change the limits for the export.

This change removes the `export_limit` option for data tables and uses the selected filter limit instead. That way the download will be limitted to the number selected for the datatable.

This is only kind of a quick fix. In the future we should maybe show a limit selection before starting the download instead of using the one for the datatable.
