### PR TITLE
Fix word-breaking for long menu items (Firefox)

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -173,6 +173,7 @@ nav {
           padding: 12px 21px 12px 19px;
           color: @theme-color-menu-contrast-text;
           decoration: none !important;
+          word-wrap: break-word;
           word-break: break-word;
 
           &:hover, &:focus {

--- a/plugins/Goals/Widgets/AddNewGoal.php
+++ b/plugins/Goals/Widgets/AddNewGoal.php
@@ -34,7 +34,7 @@ class AddNewGoal extends \Piwik\Widget\Widget
         if (Piwik::isUserHasAdminAccess($idSite)) {
             $config->setName('Goals_AddNewGoal');
         } else {
-            $config->setName('Goals_CreateNewGOal');
+            $config->setName('Goals_CreateNewGoal');
         }
 
         if (count($goals) !== 0) {


### PR DESCRIPTION
`word-wrap: break-word;` works in Firefox. So all browsers should then have the same behavior. 

fixes #10614