### PR TITLE
Remove possibility for synchronous ajax requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ### Breaking Changes
 
 * Deprecated `piwik` font was removed. Use `matomo` font instead
+* The JavaScript AjaxHelper does not longer support synchronous requests. All requests will be sent async instead.
 
 ## Matomo 3.13.1
 

--- a/plugins/Morpheus/javascripts/ajaxHelper.js
+++ b/plugins/Morpheus/javascripts/ajaxHelper.js
@@ -72,12 +72,6 @@ function ajaxHelper() {
     this.format =         'json';
 
     /**
-     * Should ajax request be asynchronous
-     * @type {Boolean}
-     */
-    this.async =          true;
-
-    /**
      * A timeout for the request which will override any global timeout
      * @type {Boolean}
      */
@@ -372,17 +366,9 @@ function ajaxHelper() {
 
     /**
      * Send the request
-     *
-     * Note: Sending synchronous requests will be removed in Matomo 4
-     *
-     * @param {Boolean} [sync]  indicates if the request should be synchronous (defaults to false)
      * @return {void}
      */
-    this.send = function (sync) {
-        if (sync === true) {
-            this.async = false;
-        }
-
+    this.send = function () {
         if ($(this.errorElement).length) {
             $(this.errorElement).hide();
         }
@@ -433,7 +419,7 @@ function ajaxHelper() {
         url += $.param(parameters);
         var ajaxCall = {
             type:     'POST',
-            async:    this.async !== false,
+            async:    true,
             url:      url,
             dataType: this.format || 'json',
             complete: this.completeCallback,


### PR DESCRIPTION
There were still some last synchronous ajax requests in dashboard management. Don't think it should be a problem to have them async as those requests shouldn't take long.

Not sure if we should maybe move that to next major version, as it might break UI for some plugins

fixes #8246