### PR TITLE
Hide dashboard selection box if no dashboards available for selection

### DIFF
--- a/plugins/Dashboard/templates/index.twig
+++ b/plugins/Dashboard/templates/index.twig
@@ -3,6 +3,7 @@
     {% include "@CoreHome/_periodSelect.twig" %}
     {{ postEvent("Template.nextToCalendar") }}
     {% render dashboardSettingsControl %}
+    {% if dashboards|length %}
     <div id="Dashboard" class="piwikTopControl borderedControl piwikSelector">
         <ul>
             {% for dashboard in dashboards %}
@@ -13,6 +14,7 @@
             {% endfor %}
         </ul>
     </div>
+    {% endif %}
 </div>
 {% import 'ajaxMacros.twig' as ajax %}
 {{ ajax.loadingDiv }}


### PR DESCRIPTION
When viewing a widgetized dashboard as anonymous user the dashboard selection appears empty.

![image](https://cloud.githubusercontent.com/assets/1579355/26669122/e92768a0-46ac-11e7-979e-974900c39de0.png)

As that empty box is useless it should be hidden.