### PR TITLE
Fix icon size for multi row evolution

### DIFF
--- a/plugins/CoreVisualizations/stylesheets/jqplot.css
+++ b/plugins/CoreVisualizations/stylesheets/jqplot.css
@@ -157,6 +157,12 @@ a.rowevolution-startmulti {
     font-weight: bold;
 }
 
+.rowevolution table.metrics td.text img {
+    max-width: 16px;
+    max-height: 16px;
+    vertical-align: bottom;
+}
+
 .multirowevolution table.metrics td.text {
     padding-top: 8px;
 }


### PR DESCRIPTION
When choosing multiple row to compare in rowevolution, the row icons are displayed full size.

See http://demo.piwik.org/index.php?module=CoreHome&action=index&idSite=3&period=day&date=yesterday#?idSite=3&period=day&date=yesterday&category=General_Visitors&subcategory=DevicesDetection_Software&popover=RowAction$3ARowEvolution$3ADevicePlugins.getPlugin$3A$257B$2522action$2522$253A$2522getMultiRowEvolutionPopover$2522$257D$3A$40Flash$2C$40Silverlight$2C$40Gears

This small changes will fix their size.