### PR TITLE
Twig:  "Variable "topMenu" does not exist." may occur

### DIFF
--- a/plugins/CoreHome/templates/_topBar.twig
+++ b/plugins/CoreHome/templates/_topBar.twig
@@ -26,13 +26,13 @@
     {% endif %}
 
     {% spaceless %}
-        {% for label,menu in topMenu %}
+        {% for label,menu in topMenu|default(false) %}
             <li role="menuitem" class="{{ _self.isActiveItem(menu, topMenuModule, topMenuAction) }}">{{ _self.topMenuItem(label, menu._icon, menu) }}</li>
         {% endfor %}
     {% endspaceless %}
 </ul>
 <ul class="side-nav" id="mobile-top-menu">
-    {% for label,menu in topMenu %}
+    {% for label,menu in topMenu|default(false) %}
         <li role="menuitem" class="{{ _self.isActiveItem(menu, topMenuModule, topMenuAction) }}"
             >{{ _self.topMenuItem(label, '', menu) }}</li>
     {% endfor %}

--- a/plugins/CoreHome/templates/_topBar.twig
+++ b/plugins/CoreHome/templates/_topBar.twig
@@ -1,4 +1,4 @@
-{{ postEvent("Template.beforeTopBar", userAlias, userLogin, topMenu) }}
+{{ postEvent("Template.beforeTopBar", userAlias, userLogin, topMenu|default(false) ) }}
 <ul class="right hide-on-med-and-down">
     {% macro menuItemLabel(label, icon) %}
         {% if icon is defined and icon and icon starts with 'icon-' %}


### PR DESCRIPTION
in some edge cases this could be triggered:
```
The following error just broke Piwik (v3.0.4):
Variable "topMenu" does not exist.
in
/var/www/piwik/plugins/CoreHome/templates/_topBar.twig line 1
```
