### PR TITLE
"Send an email when a plugin update is available" is default since Piwik 3.0.0-b1

### DIFF
--- a/plugins/CoreUpdater/SystemSettings.php
+++ b/plugins/CoreUpdater/SystemSettings.php
@@ -100,8 +100,8 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         return $this->makeSetting('enable_plugin_update_communication', $default = true, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
             $field->introduction = Piwik::translate('CoreAdminHome_SendPluginUpdateCommunication');
             $field->uiControl = FieldConfig::UI_CONTROL_RADIO;
-            $field->availableValues = array('1' => Piwik::translate('General_Yes'),
-                                            '0' => sprintf('%s (%s)', Piwik::translate('General_No'), Piwik::translate('General_Default')));
+            $field->availableValues = array('1' => sprintf('%s (%s)', Piwik::translate('General_Yes'), Piwik::translate('General_Default')),
+                                            '0' => Piwik::translate('General_No'));
             $field->inlineHelp = Piwik::translate('CoreAdminHome_SendPluginUpdateCommunicationHelp');
         });
     }

--- a/tests/PHPUnit/System/expected/test_ImportLogs__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__CorePluginsAdmin.getSystemSettings.xml
@@ -35,8 +35,8 @@
 				<uiControlAttributes>
 				</uiControlAttributes>
 				<availableValues>
-					<row key="1">Yes</row>
-					<row key="0">No (Default)</row>
+					<row key="1">Yes (Default)</row>
+					<row key="0">No</row>
 				</availableValues>
 				<description />
 				<inlineHelp>An email will be sent to Super Users when there is a new version available for a plugin.</inlineHelp>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__CorePluginsAdmin.getSystemSettings.xml
@@ -35,8 +35,8 @@
 				<uiControlAttributes>
 				</uiControlAttributes>
 				<availableValues>
-					<row key="1">Yes</row>
-					<row key="0">No (Default)</row>
+					<row key="1">Yes (Default)</row>
+					<row key="0">No</row>
 				</availableValues>
 				<description />
 				<inlineHelp>An email will be sent to Super Users when there is a new version available for a plugin.</inlineHelp>

--- a/tests/PHPUnit/System/expected/test_noVisit_PeriodIsLast__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_noVisit_PeriodIsLast__CorePluginsAdmin.getSystemSettings.xml
@@ -35,8 +35,8 @@
 				<uiControlAttributes>
 				</uiControlAttributes>
 				<availableValues>
-					<row key="1">Yes</row>
-					<row key="0">No (Default)</row>
+					<row key="1">Yes (Default)</row>
+					<row key="0">No</row>
 				</availableValues>
 				<description />
 				<inlineHelp>An email will be sent to Super Users when there is a new version available for a plugin.</inlineHelp>

--- a/tests/PHPUnit/System/expected/test_noVisit__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_noVisit__CorePluginsAdmin.getSystemSettings.xml
@@ -35,8 +35,8 @@
 				<uiControlAttributes>
 				</uiControlAttributes>
 				<availableValues>
-					<row key="1">Yes</row>
-					<row key="0">No (Default)</row>
+					<row key="1">Yes (Default)</row>
+					<row key="0">No</row>
 				</availableValues>
 				<description />
 				<inlineHelp>An email will be sent to Super Users when there is a new version available for a plugin.</inlineHelp>

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_settings_general.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_settings_general.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:127712b381c85f7b7059c74fcb44010591f131ee0ec8eaf0ca9b8e7e2064c770
-size 654055
+oid sha256:c9291466e1d0a7c6779da21f6b5bbf14cb2f8c83c4dc7dc62b3a669c9fe98c14
+size 653985


### PR DESCRIPTION
follows up https://github.com/piwik/piwik/pull/10691

we have been sending plugin updates emails to new users since 3.0.0 release and just need to show the default is Yes in the UI


Edit: CI tests build passes, error is not related