### PR TITLE
When tracker is in maintenande mode return HTTP status code 503 (instead of the current 200 and 400 http status cods)

### DIFF
--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -264,6 +264,11 @@ class Tracker
             TrackerConfig::setConfigValue('enable_fingerprinting_across_websites', 1);
         }
 
+        // Tests can simulate the tracker API maintenance mode
+        if (Common::getRequestVar('forceEnableTrackerMaintenanceMode', false, null, $args) == 1) {
+            TrackerConfig::setConfigValue('record_statistics', 0);
+        }
+
         // Tests can force the use of 3rd party cookie for ID visitor
         if (Common::getRequestVar('forceUseThirdPartyCookie', false, null, $args) == 1) {
             TrackerConfig::setConfigValue('use_third_party_id_cookie', 1);

--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -71,6 +71,7 @@ class Response
     public function outputResponse(Tracker $tracker)
     {
         if (!$tracker->shouldRecordStatistics()) {
+            Common::sendResponseCode(503);
             $this->outputApiResponse($tracker);
             Common::printDebug("Logging disabled, display transparent logo");
         } elseif (!$tracker->hasLoggedRequests()) {

--- a/tests/PHPUnit/System/TrackerResponseTest.php
+++ b/tests/PHPUnit/System/TrackerResponseTest.php
@@ -7,8 +7,10 @@
  */
 namespace Piwik\Tests\System;
 
+use Piwik\SettingsPiwik;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
+use Piwik\Tracker\TrackerConfig;
 
 /**
  * @group TrackerTest
@@ -112,6 +114,16 @@ class TrackerResponseTest extends SystemTestCase
 
         $expected = "This resource is part of Piwik. Keep full control of your data with the leading free and open source <a href='https://piwik.org' target='_blank'>digital analytics platform</a> for web and mobile.";
         $this->assertHttpResponseText($expected, $url);
+    }
+
+
+    public function test_response_ShouldReturnPiwikMessageWithHttp503_InCaseOfMaintenanceMode()
+    {
+        $url = $this->tracker->getUrlTrackPageView('Test');
+        $this->assertResponseCode(200, $url);
+
+        $url = $url . "&forceEnableTrackerMaintenanceMode=1";
+        $this->assertResponseCode(503, $url);
     }
 
 }

--- a/tests/PHPUnit/System/TrackerResponseTest.php
+++ b/tests/PHPUnit/System/TrackerResponseTest.php
@@ -7,7 +7,7 @@
  */
 namespace Piwik\Tests\System;
 
-use Piwik\SettingsPiwik;
+use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
 /**

--- a/tests/PHPUnit/System/TrackerResponseTest.php
+++ b/tests/PHPUnit/System/TrackerResponseTest.php
@@ -8,9 +8,7 @@
 namespace Piwik\Tests\System;
 
 use Piwik\SettingsPiwik;
-use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
-use Piwik\Tracker\TrackerConfig;
 
 /**
  * @group TrackerTest


### PR DESCRIPTION

This will make our return code consistent with the UI which also returns 503 while in maintenance mode

 Learn more about starting a maintenance window: https://piwik.org/faq/how-to/faq_111/
