### PR TITLE
More generic raw log access

### DIFF
--- a/core/Tracker/LogTable.php
+++ b/core/Tracker/LogTable.php
@@ -21,6 +21,16 @@ abstract class LogTable {
     abstract public function getName();
 
     /**
+     * Get the name of the column that represents the primary key. For example "idvisit" or "idlink_va". If the table
+     * does not have a unique ID for each row, you may choose a column that comes closest to it, for example "idvisit".
+     * @return string
+     */
+    public function getIdColumn()
+    {
+        return '';
+    }
+
+    /**
      * Get the name of the column that can be used to join a visit with another table. This is the name of the column
      * that represents the "idvisit".
      * @return string

--- a/plugins/CoreHome/Tracker/LogTable/Action.php
+++ b/plugins/CoreHome/Tracker/LogTable/Action.php
@@ -17,6 +17,11 @@ class Action extends LogTable
         return 'log_action';
     }
 
+    public function getIdColumn()
+    {
+        return 'idaction';
+    }
+
     public function getColumnToJoinOnIdAction()
     {
         return 'idaction';

--- a/plugins/CoreHome/Tracker/LogTable/Conversion.php
+++ b/plugins/CoreHome/Tracker/LogTable/Conversion.php
@@ -17,6 +17,11 @@ class Conversion extends LogTable
         return 'log_conversion';
     }
 
+    public function getIdColumn()
+    {
+        return 'idvisit';
+    }
+
     public function getColumnToJoinOnIdVisit()
     {
         return 'idvisit';

--- a/plugins/CoreHome/Tracker/LogTable/ConversionItem.php
+++ b/plugins/CoreHome/Tracker/LogTable/ConversionItem.php
@@ -17,6 +17,11 @@ class ConversionItem extends LogTable
         return 'log_conversion_item';
     }
 
+    public function getIdColumn()
+    {
+        return 'idvisit';
+    }
+
     public function getColumnToJoinOnIdVisit()
     {
         return 'idvisit';

--- a/plugins/CoreHome/Tracker/LogTable/LinkVisitAction.php
+++ b/plugins/CoreHome/Tracker/LogTable/LinkVisitAction.php
@@ -17,6 +17,11 @@ class LinkVisitAction extends LogTable
         return 'log_link_visit_action';
     }
 
+    public function getIdColumn()
+    {
+        return 'idlink_va';
+    }
+
     public function getColumnToJoinOnIdAction()
     {
         return 'idaction_url';

--- a/plugins/CoreHome/Tracker/LogTable/Visit.php
+++ b/plugins/CoreHome/Tracker/LogTable/Visit.php
@@ -17,6 +17,11 @@ class Visit extends LogTable
         return 'log_visit';
     }
 
+    public function getIdColumn()
+    {
+        return 'idvisit';
+    }
+
     public function getColumnToJoinOnIdVisit()
     {
         return 'idvisit';

--- a/tests/PHPUnit/System/RawLogDaoTest.php
+++ b/tests/PHPUnit/System/RawLogDaoTest.php
@@ -12,6 +12,24 @@ use Piwik\DataAccess\RawLogDao;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
+class CustomRawLogDao extends RawLogDao {
+
+    public function getTableIdColumns()
+    {
+        return parent::getTableIdColumns();
+    }
+
+    public function getIdFieldForLogTable($logTable)
+    {
+        return parent::getIdFieldForLogTable($logTable);
+    }
+
+    public function getMaxIdsInLogTables()
+    {
+        return parent::getMaxIdsInLogTables();
+    }
+}
+
 /**
  * @group Core
  * @group RawLogDao
@@ -20,7 +38,7 @@ use Piwik\Tests\Framework\TestCase\SystemTestCase;
 class RawLogDaoTest extends SystemTestCase
 {
     /**
-     * @var RawLogDao
+     * @var CustomRawLogDao
      */
     private $dao;
 
@@ -34,7 +52,7 @@ class RawLogDaoTest extends SystemTestCase
             Fixture::createWebsite('2010-00-00 00:00:00');
         }
 
-        $this->dao = new RawLogDao();
+        $this->dao = new CustomRawLogDao();
     }
 
     /**
@@ -46,6 +64,46 @@ class RawLogDaoTest extends SystemTestCase
 
         $hasVisits = $this->dao->hasSiteVisitsBetweenTimeframe($from, $to, $idSite);
         $this->assertSame($expectedHasVisits, $hasVisits);
+    }
+
+    public function test_getIdColumns()
+    {
+        $expected = array(
+            'log_action' => 'idaction',
+            'log_conversion_item' => 'idvisit',
+            'log_conversion' => 'idvisit',
+            'log_link_visit_action' => 'idlink_va',
+            'log_visit' => 'idvisit',
+        );
+        $this->assertSame($expected, $this->dao->getTableIdColumns());
+    }
+
+    public function test_getIdFieldForLogTable()
+    {
+        $this->assertSame('idaction', $this->dao->getIdFieldForLogTable('log_action'));
+        $this->assertSame('idlink_va', $this->dao->getIdFieldForLogTable('log_link_visit_action'));
+        $this->assertSame('idvisit', $this->dao->getIdFieldForLogTable('log_visit'));
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unknown log table 'log_foobarbaz'
+     */
+    public function test_getIdFieldForLogTable_whenUnknownTable()
+    {
+        $this->dao->getIdFieldForLogTable('log_foobarbaz');
+    }
+
+    public function test_getMaxIdsInLogTables()
+    {
+        $expected = array(
+            'log_action' => '2',
+            'log_conversion_item' => null,
+            'log_conversion' => null,
+            'log_link_visit_action' => '11',
+            'log_visit' => '1',
+        );
+        $this->assertSame($expected, $this->dao->getMaxIdsInLogTables());
     }
 
     public function getVisitsInTimeFrameData()


### PR DESCRIPTION
Instead of hard coding the tables, use our existing Log table classes to configure it dynamically. This way it also works for custom plugins etc. No change log is needed as the log tables are not public API yet.