### PR TITLE
Added support for a fiscal year

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -197,8 +197,10 @@ class ArchiveInvalidator
                 $periodsToInvalidate = array_merge($periodsToInvalidate, $period->getAllOverlappingChildPeriods());
             }
 
+// todomc : Ajuster l'invalidation des rapports et des périodes au fisyear. Présentement pas traiter correctement'
             if ($periodType != 'year'
                 && $periodType != 'range'
+                && $periodType != 'fisyear'
             ) {
                 $periodsToInvalidate[] = Period\Factory::build('year', $date);
             }

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -197,7 +197,6 @@ class ArchiveInvalidator
                 $periodsToInvalidate = array_merge($periodsToInvalidate, $period->getAllOverlappingChildPeriods());
             }
 
-// todomc : Ajuster l'invalidation des rapports et des périodes au fisyear. Présentement pas traiter correctement'
             if ($periodType != 'year'
                 && $periodType != 'range'
                 && $periodType != 'fisyear'

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1500,12 +1500,10 @@ class CronArchive
     private function getDateLastN($idSite, $period, $lastTimestampWebsiteProcessed)
     {
         $dateLastMax = self::DEFAULT_DATE_LAST;
-        if ($period == 'year') {
+        if ($period == 'year' || $period == 'fisyear') {
             $dateLastMax = self::DEFAULT_DATE_LAST_YEARS;
         } elseif ($period == 'week') {
             $dateLastMax = self::DEFAULT_DATE_LAST_WEEKS;
-        } elseif ($period == 'fisyear') {
-            $dateLastMax = self::DEFAULT_DATE_LAST_YEARS;
         }
         if (empty($lastTimestampWebsiteProcessed)) {
             $creationDateFor = \Piwik\Site::getCreationDateFor($idSite);

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -686,7 +686,14 @@ class CronArchive
     {
         $success = true;
 
-        foreach (array('week', 'month', 'year') as $period) {
+        $periodList = array('week', 'month', 'year');
+
+        //Add fiscal year to pre-processed archive if present in config
+        if (in_array('fisyear', PeriodFactory::getPeriodsEnabledForAPI())) {
+            array_push($periodList, 'fisyear');
+        }
+
+        foreach ($periodList as $period) {
             if (!$this->shouldProcessPeriod($period)) {
                 // if any period was skipped, we do not mark the Periods archiving as successful
                 $success = false;
@@ -1434,7 +1441,7 @@ class CronArchive
      */
     private function getDefaultPeriodsToProcess()
     {
-        return array('day', 'week', 'month', 'year', 'range');
+        return array('day', 'week', 'month', 'year', 'range', 'fisyear');
     }
 
     /**
@@ -1497,6 +1504,8 @@ class CronArchive
             $dateLastMax = self::DEFAULT_DATE_LAST_YEARS;
         } elseif ($period == 'week') {
             $dateLastMax = self::DEFAULT_DATE_LAST_WEEKS;
+        } elseif ($period == 'fisyear') {
+            $dateLastMax = self::DEFAULT_DATE_LAST_YEARS;
         }
         if (empty($lastTimestampWebsiteProcessed)) {
             $creationDateFor = \Piwik\Site::getCreationDateFor($idSite);

--- a/core/Date.php
+++ b/core/Date.php
@@ -901,7 +901,7 @@ class Date
      * Adds a period to `$this` date and returns the result in a new Date instance.
      *
      * @param int $n The number of periods to add. Can be negative.
-     * @param string $period The type of period to add (YEAR, MONTH, WEEK, DAY, ...)
+     * @param string $period The type of period to add (YEAR, MONTH, WEEK, DAY, FISYEAR...)
      * @return \Piwik\Date
      */
     public function addPeriod($n, $period)
@@ -920,6 +920,11 @@ class Date
 
             $daysToAdd = min($dateInfo['mday'], self::getMaxDaysInMonth($ts)) - 1;
             $ts += self::NUM_SECONDS_IN_DAY * $daysToAdd;
+        } elseif (strtolower($period) == 'fisyear') {
+            $templabel = 'year';
+            $time = $n < 0 ? "$n $templabel" : "+$n $templabel";
+
+            $ts = strtotime($time, $this->timestamp);
         } else {
             $time = $n < 0 ? "$n $period" : "+$n $period";
 

--- a/core/Period.php
+++ b/core/Period.php
@@ -172,7 +172,7 @@ abstract class Period
     /**
      * Returns the label for the current period.
      *
-     * @return string `"day"`, `"week"`, `"month"`, `"year"`, `"range"`
+     * @return string `"day"`, `"week"`, `"month"`, `"year"`, `"range"`, `"fisyear"`
      */
     public function getLabel()
     {

--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -54,6 +54,10 @@ class Factory
             case 'year':
                 return new Year($date);
                 break;
+
+            case 'fisyear':
+                return new FisYear($date);
+                break;
         }
     }
 

--- a/core/Period/FisYear.php
+++ b/core/Period/FisYear.php
@@ -59,8 +59,6 @@ class FisYear extends Period
      * Also adjusts the financial year in function of what is needed
      * (ex. 2016 or 2017 in fiscal year 2016-2017)
      *
-     * todomc : Trouver une façon de propager la date jusqu'ici pour définir la bonne
-     *          année fiscale.
      */
     protected function generate()
     {

--- a/core/Period/FisYear.php
+++ b/core/Period/FisYear.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Period;
+
+use Piwik\Date;
+use Piwik\Period;
+use Piwik\Config;
+
+/**
+ */
+class FisYear extends Period
+{
+    const PERIOD_ID = 6;
+
+    protected $label = 'fisyear';
+
+    /**
+     * Returns the current period as a localized short string
+     *
+     * @return string
+     */
+    public function getLocalizedShortString()
+    {
+        return $this->getLocalizedLongString();
+    }
+
+    /**
+     * Returns the current period as a localized long string
+     *
+     * @return string
+     */
+    public function getLocalizedLongString()
+    {
+        //"2016-2017"
+        $out = $this->getDateStart()->getLocalized(Date::DATE_FORMAT_YEAR) . '-' . $this->getDateEnd()->getLocalized(Date::DATE_FORMAT_YEAR);
+        return $out;
+    }
+
+    /**
+     * Returns the current period as a string
+     *
+     * @return string
+     */
+    public function getPrettyString()
+    {
+        //"2016-2017"
+        $out = $this->getDateStart()->toString('Y'). '-' . $this->getDateEnd()->toString('Y');
+        return $out;
+    }
+
+    /**
+     * Generates the subperiods (one for each month of the financial year)
+     * Also adjusts the financial year in function of what is needed
+     * (ex. 2016 or 2017 in fiscal year 2016-2017)
+     *
+     * todomc : Trouver une façon de propager la date jusqu'ici pour définir la bonne
+     *          année fiscale.
+     */
+    protected function generate()
+    {
+        if ($this->subperiodsProcessed) {
+            return;
+        }
+
+        parent::generate();
+
+        $startMonth = Config::getInstance()->General['fiscal_year_start_month'];
+        $year = $this->date->toString("Y");
+
+        //If the month of the date is lower then the starting month,
+        //we are in the previous fiscal year
+        if ($this->date->toString("m") < $startMonth) {
+            $year -= 1;
+        }
+        
+        for ($i = $startMonth; $i < ($startMonth + 12); $i++) {
+            if ($i < 13) {
+                $this->addSubperiod(new Month(
+                        Date::factory("$year-$i-01")
+                    )
+                );
+            } else {
+                $this->addSubperiod(new Month(
+                        Date::factory(strval($year + 1) . "-" . strval($i - 12) . "-01")
+                    )
+                );                
+            }
+        }
+    }
+    /**
+     * Returns the current period as a string
+     *
+     * @param string $format
+     * @return array
+     */
+    public function toString($format = 'ignored')
+    {
+        $this->generate();
+
+        $stringMonth = array();
+        foreach ($this->subperiods as $month) {
+            $stringMonth[] = $month->getDateStart()->toString("Y") . "-" . $month->getDateStart()->toString("m") . "-01";
+        }
+
+        return $stringMonth;
+    }
+
+    public function getImmediateChildPeriodLabel()
+    {
+        return 'month';
+    }
+
+    public function getParentPeriodLabel()
+    {
+        return null;
+    }
+}

--- a/core/Period/Range.php
+++ b/core/Period/Range.php
@@ -167,6 +167,10 @@ class Range extends Period
             case 'year':
                 $lastN = min($lastN, 10);
                 break;
+
+            case 'fisyear':
+                $lastN = min($lastN, 10);
+                break;
         }
         return $lastN;
     }

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -15,6 +15,7 @@ use Piwik\Period\Month;
 use Piwik\Period\Range;
 use Piwik\Period\Week;
 use Piwik\Period\Year;
+use Piwik\Period\FisYear;
 use Piwik\Plugins\UsersManager\API as APIUsersManager;
 use Piwik\Translation\Translator;
 
@@ -41,6 +42,7 @@ class Piwik
         'month' => Month::PERIOD_ID,
         'year'  => Year::PERIOD_ID,
         'range' => Range::PERIOD_ID,
+        'fisyear' => FisYear::PERIOD_ID,
     );
 
     /**

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -220,6 +220,10 @@ abstract class Controller
                 'singular' => Piwik::translate('General_DateRangeInPeriodList'),
                 'plural' => Piwik::translate('General_DateRangeInPeriodList')
             ),
+            'fisyear'  => array(
+                'singular' => Piwik::translate('Intl_PeriodFiscalYear'),
+                'plural' => Piwik::translate('Intl_PeriodFiscalYears'),
+            ),
         );
 
         $periodNames = array_intersect_key($periodNames, array_fill_keys($availablePeriods, true));

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -639,6 +639,11 @@ abstract class Controller
         $view->startDate = $dateStart;
         $view->endDate = $dateEnd;
 
+        //Get the starting month of the fiscal year if "fisyear" is present in periods allowed
+        if (in_array('fisyear', self::getEnabledPeriodsInUI())) {
+            $view->fisYearStartMonth = Config::getInstance()->General['fiscal_year_start_month'];
+        }
+
         $language = LanguagesManager::getLanguageForSession();
         $view->language = !empty($language) ? $language : LanguagesManager::getLanguageCodeForCurrentUser();
 

--- a/core/Scheduler/Schedule/Schedule.php
+++ b/core/Scheduler/Schedule/Schedule.php
@@ -27,6 +27,7 @@ abstract class Schedule
     const PERIOD_HOUR = 'hour';
     const PERIOD_YEAR = 'year';
     const PERIOD_RANGE = 'range';
+    const PERIOD_FISYEAR = 'fisyear';
 
     /**
      * @link http://php.net/manual/en/function.date.php, format string : 'G'

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -301,7 +301,7 @@ class SettingsPiwik
         $result = !empty($generalSettings[$settingName]) && $generalSettings[$settingName] == 1;
 
         // check enable_processing_unique_visitors_year_and_range for backwards compatibility
-        if (($periodLabel == 'year' || $periodLabel == 'range')
+        if (($periodLabel == 'fisyear' || $periodLabel == 'year' || $periodLabel == 'range')
             && isset($generalSettings['enable_processing_unique_visitors_year_and_range'])
         ) {
             $result |= $generalSettings['enable_processing_unique_visitors_year_and_range'] == 1;

--- a/lang/en.json
+++ b/lang/en.json
@@ -429,6 +429,8 @@
         "XFromY": "%1$s from %2$s",
         "YearlyReport": "yearly",
         "YearlyReports": "Yearly reports",
+        "FiscalYearlyReport": "yearly",
+        "FiscalYearlyReports": "Yearly reports (Fiscal)",
         "YearsDays": "%1$s years %2$s days",
         "Yes": "Yes",
         "YouAreCurrentlyUsing": "You are currently using Piwik %s.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -429,6 +429,8 @@
         "XFromY": "%1$s de %2$s",
         "YearlyReport": "annuel",
         "YearlyReports": "Rapports annuels",
+        "FiscalYearlyReport": "annuel",
+        "FiscalYearlyReports": "Rapports annuels (Année financière)",
         "YearsDays": "%1$s années %2$s jours",
         "Yes": "Oui",
         "YouAreCurrentlyUsing": "Vous utilisez actuellement Piwik %s",

--- a/plugins/CoreHome/javascripts/calendar.js
+++ b/plugins/CoreHome/javascripts/calendar.js
@@ -18,7 +18,7 @@
         return Math.ceil((daysSinceYearStart + onejan.getDay()) / 7);
     };
 
-    var currentYear, currentMonth, currentDay, currentDate, currentWeek;
+    var currentFiscalYear, currentYear, currentMonth, currentDay, currentDate, currentWeek;
 
     function formatDateString(date) {
         var month = date.getMonth() + 1;
@@ -82,6 +82,12 @@
             displayDate = _pk_translate('Intl_Month_Long_StandAlone_' + (currentMonth+1)) + ' ' + currentYear;
         } else if (selectedPeriod === 'year') {
             displayDate = currentYear;
+        } else if (selectedPeriod === 'fisyear') {
+            if (currentMonth+1 < piwik.fisYearStartMonth) {
+                displayDate = (Number(currentYear)-1) + "-" + currentYear;
+            } else {
+                displayDate = currentYear + "-" + (Number(currentYear)+1);
+            }
         } else if (selectedPeriod === 'range' || selectedPeriod === 'week') {
             displayDate = _pk_translate('General_DateRangeFromTo', [piwik.startDateString, piwik.endDateString]);
         }
@@ -174,6 +180,19 @@
             && dateYear == currentYear
             ) {
             valid = true;
+        }
+        else if (piwik.period == "fisyear") {
+            if ((currentMonth + 1) >= piwik.fisYearStartMonth) {
+                if ((dateYear == currentYear && (dateMonth + 1) >= piwik.fisYearStartMonth)
+                || (dateYear == currentYear+1 && (dateMonth + 1) < piwik.fisYearStartMonth)) {
+                    valid = true;
+                }
+            } else {
+                if ((dateYear == currentYear-1 && (dateMonth + 1) >= piwik.fisYearStartMonth)
+                || (dateYear == currentYear && (dateMonth + 1) < piwik.fisYearStartMonth)) {
+                    valid = true;
+                }
+            }
         }
         else if (piwik.period == "week"
             && date.getWeek() == currentWeek
@@ -354,6 +373,11 @@
                     $('a', $(this).parent().parent()).addClass('ui-state-hover');
                     toggleWhitespaceHighlighting('ui-state-hover', true, true);
                     break;
+                case 'fisyear':
+                    // highlight table (month + whitespace)
+                    $('a', $(this).parent().parent()).addClass('ui-state-hover');
+                    toggleWhitespaceHighlighting('ui-state-hover', true, true);
+                    break;
             }
         };
 
@@ -364,6 +388,11 @@
 
             // color whitespace
             if (piwik.period == 'year') {
+                var viewedYear = $('.ui-datepicker-year', datepickerElem).val(),
+                    toggle = selectedPeriod == 'year' && currentYear == viewedYear;
+                toggleWhitespaceHighlighting('ui-datepicker-current-period', toggle, toggle);
+            }
+            else if (piwik.period == 'fisyear') {
                 var viewedYear = $('.ui-datepicker-year', datepickerElem).val(),
                     toggle = selectedPeriod == 'year' && currentYear == viewedYear;
                 toggleWhitespaceHighlighting('ui-datepicker-current-period', toggle, toggle);
@@ -574,14 +603,14 @@
             togglePeriodPickers(true);
 
             // set months step to 12 for year period (or set back to 1 if leaving year period)
-            if (selectedPeriod == 'year' || lastPeriod == 'year') {
+            if (selectedPeriod == 'year' || lastPeriod == 'year' || selectedPeriod == 'fisyear' || lastPeriod == 'fisyear') {
                 // setting stepMonths will change the month in view back to the selected date. to avoid
                 // we set the selected date to the month in view.
                 var currentMonth = $('.ui-datepicker-month', datepickerElem).val(),
                     currentYear = $('.ui-datepicker-year', datepickerElem).val();
 
                 datepickerElem
-                    .datepicker('option', 'stepMonths', selectedPeriod == 'year' ? 12 : 1)
+                    .datepicker('option', 'stepMonths', (selectedPeriod == 'year') || (selectedPeriod == 'fisyear') ? 12 : 1)
                     .datepicker('setDate', new Date(currentYear, currentMonth));
             }
 

--- a/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
+++ b/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
@@ -147,6 +147,8 @@ class Evolution extends JqplotGraph
                 return 24;
             case 'year':
                 return 5;
+            case 'fisyear':
+                return 5;
             case 'day':
             default:
                 return 30;
@@ -186,6 +188,9 @@ class Evolution extends JqplotGraph
                 $steps = 5;
                 break;
             case 'year':
+                $steps = 5;
+                break;
+            case 'fisyear':
                 $steps = 5;
                 break;
             default:

--- a/plugins/DBStats/Reports/Base.php
+++ b/plugins/DBStats/Reports/Base.php
@@ -52,6 +52,7 @@ abstract class Base extends \Piwik\Plugin\Report
         $view->config->addTranslations(array(
             'label'          => Piwik::translate('DBStats_Table'),
             'year'           => Piwik::translate('Intl_PeriodYear'),
+            'fisyear'        => Piwik::translate('Intl_PeriodFiscalYear'),
             'data_size'      => Piwik::translate('DBStats_DataSize'),
             'index_size'     => Piwik::translate('DBStats_IndexSize'),
             'total_size'     => Piwik::translate('DBStats_TotalSize'),

--- a/plugins/Insights/lang/en.json
+++ b/plugins/Insights/lang/en.json
@@ -30,6 +30,7 @@
         "TitleRowNewDetails": "'%1$s' increased by %2$s and is new compared to %3$s.",
         "WeekComparedToPreviousWeek": "previous week",
         "WidgetCategory": "Insights",
-        "YearComparedToPreviousYear": "previous year"
+        "YearComparedToPreviousYear": "previous year",
+        "FiscalYearComparedToPreviousYear": "previous fiscal year"
     }
 }

--- a/plugins/Insights/lang/fr.json
+++ b/plugins/Insights/lang/fr.json
@@ -30,6 +30,7 @@
         "TitleRowNewDetails": "'%1$s' augmenté de %2$s et est nouveau comparé à %3$s.",
         "WeekComparedToPreviousWeek": "semaine précédente",
         "WidgetCategory": "Idées",
-        "YearComparedToPreviousYear": "année précédente"
+        "YearComparedToPreviousYear": "année précédente",
+        "FiscalYearComparedToPreviousYear": "année financière précédente"
     }
 }

--- a/plugins/Insights/templates/insightControls.twig
+++ b/plugins/Insights/templates/insightControls.twig
@@ -27,6 +27,8 @@
             {{ 'Insights_WeekComparedToPreviousWeek'|translate }}
         {% elseif period == 'year' %}
             {{ 'Insights_YearComparedToPreviousYear'|translate }}
+        {% elseif period == 'fisyear' %}
+            {{ 'Insights_FiscalYearComparedToPreviousYear'|translate }}
         {% endif %}
         {% endif %}
     </div>

--- a/plugins/Intl/lang/en.json
+++ b/plugins/Intl/lang/en.json
@@ -577,6 +577,8 @@
         "PeriodWeeks": "weeks",
         "PeriodYear": "year",
         "PeriodYears": "years",
+        "PeriodFiscalYear": "fiscal year",
+        "PeriodFiscalYears": "fiscal years",
         "Seconds": "seconds",
         "Time_AM": "AM",
         "Time_PM": "PM",

--- a/plugins/Intl/lang/fr.json
+++ b/plugins/Intl/lang/fr.json
@@ -577,6 +577,8 @@
         "PeriodWeeks": "semaines",
         "PeriodYear": "année",
         "PeriodYears": "ans",
+        "PeriodFiscalYear": "année financière",
+        "PeriodFiscalYears": "années financières",
         "Seconds": "secondes",
         "Time_AM": "AM",
         "Time_PM": "PM",

--- a/plugins/Morpheus/templates/_jsGlobalVariables.twig
+++ b/plugins/Morpheus/templates/_jsGlobalVariables.twig
@@ -25,6 +25,8 @@
 
     {% if period is defined %}piwik.period = "{{ period }}";{% endif %}
 
+    {% if fisYearStartMonth is defined %}piwik.fisYearStartMonth = "{{ fisYearStartMonth }}";{% endif %}
+
 {# piwik.currentDateString should not be used other than by the calendar Javascript
             (it is not set to the expected value when period=range)
         Use broadcast.getValueFromUrl('date') instead

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -100,7 +100,7 @@ class API extends \Piwik\Plugin\API
      */
     public function setDeleteReportsSettings($enableDeleteReports = 0, $deleteReportsOlderThan = 3,
                                              $keepBasic = 0, $keepDay = 0, $keepWeek = 0, $keepMonth = 0,
-                                             $keepYear = 0, $keepRange = 0, $keepSegments = 0)
+                                             $keepYear = 0, $keepRange = 0, $keepSegments = 0, $keepFiscalYear = 0)
     {
         $settings = array();
 
@@ -119,6 +119,7 @@ class API extends \Piwik\Plugin\API
         $settings['delete_reports_keep_week_reports']    = (int) $keepWeek;
         $settings['delete_reports_keep_month_reports']   = (int) $keepMonth;
         $settings['delete_reports_keep_year_reports']    = (int) $keepYear;
+        $settings['delete_reports_keep_fisyear_reports'] = (int) $keepFiscalYear;
         $settings['delete_reports_keep_range_reports']   = (int) $keepRange;
         $settings['delete_reports_keep_segment_reports'] = (int) $keepSegments;
         $settings['delete_logs_max_rows_per_query']      = PiwikConfig::getInstance()->Deletelogs['delete_logs_max_rows_per_query'];

--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -64,6 +64,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $settings['delete_reports_keep_week_reports']    = Common::getRequestVar("keepWeek", 0);
         $settings['delete_reports_keep_month_reports']   = Common::getRequestVar("keepMonth", 0);
         $settings['delete_reports_keep_year_reports']    = Common::getRequestVar("keepYear", 0);
+        $settings['delete_reports_keep_fisyear_reports'] = Common::getRequestVar("keepFiscalYear", 0);
         $settings['delete_reports_keep_range_reports']   = Common::getRequestVar("keepRange", 0);
         $settings['delete_reports_keep_segment_reports'] = Common::getRequestVar("keepSegments", 0);
         $settings['delete_logs_max_rows_per_query']      = PiwikConfig::getInstance()->Deletelogs['delete_logs_max_rows_per_query'];
@@ -123,6 +124,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                       'description' => ''
                 )
             );
+            //$view->fiscalYearEnabled = PiwikConfig::getInstance()->General['fiscal_year_enabled'];
+            $view->fiscalYearEnabled = strpos(PiwikConfig::getInstance()->General['enabled_periods_API'], "fisyear");
             $view->scheduleDeletionOptions = array(
                 array('key' => '1',
                       'value' => Piwik::translate('Intl_PeriodDay')),

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -54,6 +54,7 @@ class PrivacyManager extends Plugin
         'delete_reports_keep_week_reports'     => 'Deletereports',
         'delete_reports_keep_month_reports'    => 'Deletereports',
         'delete_reports_keep_year_reports'     => 'Deletereports',
+        'delete_reports_keep_fisyear_reports'  => 'Deletereports',
         'delete_reports_keep_range_reports'    => 'Deletereports',
         'delete_reports_keep_segment_reports'  => 'Deletereports',
     );
@@ -275,6 +276,7 @@ class PrivacyManager extends Plugin
      * - delete_reports_keep_week_reports: If set to 1, keeps old weekly reports.
      * - delete_reports_keep_month_reports: If set to 1, keeps old monthly reports.
      * - delete_reports_keep_year_reports: If set to 1, keeps old yearly reports.
+     * - delete_reports_keep_fisyear_reports: If set to 1, keeps old fiscal year reports.
      */
     public function deleteReportData()
     {

--- a/plugins/PrivacyManager/ReportsPurger.php
+++ b/plugins/PrivacyManager/ReportsPurger.php
@@ -352,6 +352,7 @@ class ReportsPurger
      * -'delete_reports_keep_week_reports': 1 if weekly reports should be kept, 0 if otherwise.
      * -'delete_reports_keep_month_reports': 1 if monthly reports should be kept, 0 if otherwise.
      * -'delete_reports_keep_year_reports': 1 if yearly reports should be kept, 0 if otherwise.
+     * -'delete_reports_keep_fisyear_reports': 1 if fiscal year reports should be kept, 0 if otherwise.
      * -'delete_reports_keep_range_reports': 1 if range reports should be kept, 0 if otherwise.
      * -'delete_reports_keep_segment_reports': 1 if reports for segments should be kept, 0 if otherwise.
      * -'delete_logs_max_rows_per_query': Maximum number of rows to delete in one DELETE query.

--- a/plugins/PrivacyManager/templates/privacySettings.twig
+++ b/plugins/PrivacyManager/templates/privacySettings.twig
@@ -190,6 +190,13 @@
                          title="{{ 'General_YearlyReports'|translate|e('html_attr') }} ({{ 'General_Recommended'|translate|e('html_attr') }})"
                          value="{{ deleteData.config.delete_reports_keep_year_reports }}">
                     </div>
+                    {# todomc : Delete old Reports pour le fiscal year avec un keep recommended #}
+                    <div piwik-field uicontrol="checkbox" name="deleteReportsKeepFisYear"
+                         ng-model="deleteReports.keepDataForFisYear"
+                         ng-change="deleteReports.reloadDbStats()"
+                         title="{{ 'General_FiscalYearlyReports'|translate|e('html_attr') }} ({{ 'General_Recommended'|translate|e('html_attr') }})"
+                         value="{{ deleteData.config.delete_reports_keep_fiscal_year_reports }}">
+                    </div>
                     <div piwik-field uicontrol="checkbox" name="deleteReportsKeepRange"
                          ng-model="deleteReports.keepDataForRange"
                          ng-change="deleteReports.reloadDbStats()"

--- a/plugins/PrivacyManager/templates/privacySettings.twig
+++ b/plugins/PrivacyManager/templates/privacySettings.twig
@@ -190,13 +190,14 @@
                          title="{{ 'General_YearlyReports'|translate|e('html_attr') }} ({{ 'General_Recommended'|translate|e('html_attr') }})"
                          value="{{ deleteData.config.delete_reports_keep_year_reports }}">
                     </div>
-                    {# todomc : Delete old Reports pour le fiscal year avec un keep recommended #}
+                    {% if fiscalYearEnabled %}
                     <div piwik-field uicontrol="checkbox" name="deleteReportsKeepFisYear"
                          ng-model="deleteReports.keepDataForFisYear"
                          ng-change="deleteReports.reloadDbStats()"
                          title="{{ 'General_FiscalYearlyReports'|translate|e('html_attr') }} ({{ 'General_Recommended'|translate|e('html_attr') }})"
-                         value="{{ deleteData.config.delete_reports_keep_fiscal_year_reports }}">
+                         value="{{ deleteData.config.delete_reports_keep_fisyear_reports }}">
                     </div>
+                    {% endif %}
                     <div piwik-field uicontrol="checkbox" name="deleteReportsKeepRange"
                          ng-model="deleteReports.keepDataForRange"
                          ng-change="deleteReports.reloadDbStats()"

--- a/plugins/PrivacyManager/tests/Integration/DataPurgingTest.php
+++ b/plugins/PrivacyManager/tests/Integration/DataPurgingTest.php
@@ -479,6 +479,8 @@ class DataPurgingTest extends IntegrationTestCase
     /**
      * Test that purgeData works correctly when the 'keep yearly reports' setting is set to true.
      */
+
+    //todomc : S'informer sur le keep yearly reports pour voir si je dois faire la même chose pour le fisyear
     public function testPurgeDataDeleteReportsKeepYearlyReports()
     {
         PrivacyManager::savePurgeDataSettings(array(

--- a/plugins/PrivacyManager/tests/Integration/DataPurgingTest.php
+++ b/plugins/PrivacyManager/tests/Integration/DataPurgingTest.php
@@ -130,6 +130,7 @@ class DataPurgingTest extends IntegrationTestCase
         $settings['delete_reports_keep_week_reports'] = 0;
         $settings['delete_reports_keep_month_reports'] = 0;
         $settings['delete_reports_keep_year_reports'] = 0;
+        $settings['delete_reports_keep_fisyear_reports'] = 0;
         $settings['delete_reports_keep_range_reports'] = 0;
         $settings['delete_reports_keep_segment_reports'] = 0;
         PrivacyManager::savePurgeDataSettings($settings);
@@ -480,11 +481,47 @@ class DataPurgingTest extends IntegrationTestCase
      * Test that purgeData works correctly when the 'keep yearly reports' setting is set to true.
      */
 
-    //todomc : S'informer sur le keep yearly reports pour voir si je dois faire la même chose pour le fisyear
     public function testPurgeDataDeleteReportsKeepYearlyReports()
     {
         PrivacyManager::savePurgeDataSettings(array(
                                                          'delete_reports_keep_year_reports' => 1
+                                                    ));
+
+        // get purge data prediction
+        $prediction = PrivacyManager::getPurgeEstimate();
+
+        // perform checks on prediction
+        $events = 3; // only the event action for the three purged day, dayAgo=x are purged (others are still in use)
+        $contents = 3; // one content impression per day, so 3 purged
+        $expectedPrediction = array(
+            Common::prefixTable('log_conversion')          => 6,
+            Common::prefixTable('log_link_visit_action')   => 6 + $events + $contents,
+            Common::prefixTable('log_visit')               => 3,
+            Common::prefixTable('log_conversion_item')     => 3,
+            Common::prefixTable('archive_numeric_2012_01') => -1,
+            Common::prefixTable('archive_blob_2012_01')    => 14  // 5 days, 4 weeks & 1 year to remove + 1 garbage report + 2 range reports + 1 segmented report
+        );
+        $this->assertEquals($expectedPrediction, $prediction);
+
+        // purge data
+        $this->_setTimeToRun();
+        $this->assertTrue( $this->instance->deleteLogData() );
+        $this->assertTrue($this->instance->deleteReportData() );
+
+        // perform checks
+        $this->checkLogDataPurged();
+        $this->_checkReportsAndMetricsPurged($janBlobsRemaining = 1, $janNumericRemaining = 49);
+    }
+
+    /**
+     * Test that purgeData works correctly when the 'keep fiscal year reports' setting is set to true.
+     */
+
+    //todo : Not sure how this function should be used or when it should be called
+    public function testPurgeDataDeleteReportsKeepFiscalYearReports()
+    {
+        PrivacyManager::savePurgeDataSettings(array(
+                                                         'delete_reports_keep_fisyear_reports' => 1
                                                     ));
 
         // get purge data prediction

--- a/plugins/PrivacyManager/tests/Integration/PrivacyManagerTest.php
+++ b/plugins/PrivacyManager/tests/Integration/PrivacyManagerTest.php
@@ -77,6 +77,7 @@ class PrivacyManagerTest extends IntegrationTestCase
             'delete_reports_keep_week_reports' => 0,
             'delete_reports_keep_month_reports' => 1,
             'delete_reports_keep_year_reports' => 1,
+            'delete_reports_keep_fisyear_reports' => 1,
             'delete_reports_keep_range_reports' => 0,
             'delete_reports_keep_segment_reports' => 0,
         );

--- a/plugins/ScheduledReports/ScheduledReports.php
+++ b/plugins/ScheduledReports/ScheduledReports.php
@@ -652,11 +652,12 @@ class ScheduledReports extends \Piwik\Plugin
     public static function getPeriodToFrequencyAsAdjective()
     {
         return array(
-            Schedule::PERIOD_DAY   => Piwik::translate('General_DailyReport'),
-            Schedule::PERIOD_WEEK  => Piwik::translate('General_WeeklyReport'),
-            Schedule::PERIOD_MONTH => Piwik::translate('General_MonthlyReport'),
-            Schedule::PERIOD_YEAR  => Piwik::translate('General_YearlyReport'),
-            Schedule::PERIOD_RANGE => Piwik::translate('General_RangeReports'),
+            Schedule::PERIOD_DAY     => Piwik::translate('General_DailyReport'),
+            Schedule::PERIOD_WEEK    => Piwik::translate('General_WeeklyReport'),
+            Schedule::PERIOD_MONTH   => Piwik::translate('General_MonthlyReport'),
+            Schedule::PERIOD_YEAR    => Piwik::translate('General_YearlyReport'),
+            Schedule::PERIOD_FISYEAR => Piwik::translate('General_FiscalYearlyReport'),
+            Schedule::PERIOD_RANGE   => Piwik::translate('General_RangeReports'),
         );
     }
 

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -193,7 +193,6 @@ class Controller extends ControllerAdmin
             'week'       => $this->translator->translate('General_CurrentWeek'),
             'month'      => $this->translator->translate('General_CurrentMonth'),
             'year'       => $this->translator->translate('General_CurrentYear'),
-            //todomc : S'assurer que l'année courante soit sélectionner en fonction de la date et du début de l'année financière'
             'fisyear'    => $this->translator->translate('General_CurrentYear'),
         );
 

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -193,6 +193,8 @@ class Controller extends ControllerAdmin
             'week'       => $this->translator->translate('General_CurrentWeek'),
             'month'      => $this->translator->translate('General_CurrentMonth'),
             'year'       => $this->translator->translate('General_CurrentYear'),
+            //todomc : S'assurer que l'année courante soit sélectionner en fonction de la date et du début de l'année financière'
+            'fisyear'    => $this->translator->translate('General_CurrentYear'),
         );
 
         $mappingDatesToPeriods = array(
@@ -205,6 +207,7 @@ class Controller extends ControllerAdmin
             'week' => 'week',
             'month' => 'month',
             'year' => 'year',
+            'fisyear' => 'fisyear',
         );
 
         // assertion


### PR DESCRIPTION
Added support for the showing of a fiscal year in the UI and the pre-processing the fiscal year through the core:archive console command.

For the fiscal year to be enabled, you need to add the following lines in the config.ini.php file :
[General]
enabled_periods_UI = "day,week,month,year,range,fisyear"
enabled_periods_API = "day,week,month,year,range,fisyear"
fiscal_year_start_month = 4

[Deletereports]
delete_reports_keep_fisyear_reports = 1

The fiscal_year_start_month is the first month of the fiscal year.
The delete_reports_keep_fisyear_reports is for the default option in the privacy settings for keeping old reports.