### PR TITLE
[RFC] splitting up responsibilities in Archive.php

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -144,13 +144,13 @@ class Archive
      * @param bool $forceIndexedByDate Whether to force index the result of a query by period.
      */
     public function __construct(Parameters $params, $forceIndexedBySite = false,
-                                   $forceIndexedByDate = false)
+                                   $forceIndexedByDate = false, ArchiveTableStore $archiveTableStore = null)
     {
         $this->params = $params;
         $this->forceIndexedBySite = $forceIndexedBySite;
         $this->forceIndexedByDate = $forceIndexedByDate;
 
-        $this->archiveTableStore = StaticContainer::get(ArchiveTableStore::class);
+        $this->archiveTableStore = $archiveTableStore ?: StaticContainer::get(ArchiveTableStore::class);
     }
 
     /**

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -716,8 +716,8 @@ class Archive
 
         foreach ($idarchivesByReport as $doneFlag => $idarchivesByDate) {
             foreach ($idarchivesByDate as $dateRange => $idarchives) {
-                foreach ($idarchives as $idarchive) {
-                    $this->idarchives[$doneFlag][$dateRange][] = $idarchive;
+                foreach ($idarchives as $idSite => $idarchive) {
+                    $this->idarchives[$doneFlag][$dateRange][$idSite] = $idarchive;
                 }
             }
         }
@@ -872,17 +872,17 @@ class Archive
 
         $periodString = $period->getRangeString();
 
-        $idSites = array($site->getId());
+        $idSite = $site->getId();
         
         // process for each plugin as well
         foreach ($archiveGroups as $plugin) {
-            $doneFlag = $this->getDoneStringForPlugin($plugin, $idSites);
+            $doneFlag = $this->getDoneStringForPlugin($plugin, [$idSite]);
             $this->initializeArchiveIdCache($doneFlag);
 
             $idArchive = $archiveLoader->prepareArchive($plugin);
 
             if ($idArchive) {
-                $this->idarchives[$doneFlag][$periodString][] = $idArchive;
+                $this->idarchives[$doneFlag][$periodString][$idSite] = $idArchive;
             }
         }
     }

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -897,13 +897,12 @@ class Archive
         $idArchivesByMonth = array();
 
         foreach (array_keys($doneFlags) as $doneFlag) {
-            if (empty($this->idarchives[$doneFlag])) {
-                continue;
-            }
-
-            foreach ($this->idarchives[$doneFlag] as $dateRange => $idarchives) {
-                foreach ($idarchives as $id) {
-                    $idArchivesByMonth[$dateRange][] = $id;
+            foreach ($this->params->getPeriods() as $period) {
+                $dateRange = $period->getRangeString();
+                foreach ($this->params->getIdSites() as $idSite) {
+                    if (isset($this->idarchives[$doneFlag][$dateRange][$idSite])) {
+                        $idArchivesByMonth[$dateRange][] = $this->idarchives[$doneFlag][$dateRange][$idSite];
+                    }
                 }
             }
         }

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -621,14 +621,13 @@ class Archive
             $doneFlag = $this->getDoneStringForPlugin($plugin, $this->params->getIdSites());
 
             $doneFlags[$doneFlag] = true;
-            if (!isset($this->idarchives[$doneFlag])) {
-                $archiveGroup = $this->getArchiveGroupOfPlugin($plugin);
 
-                if ($archiveGroup == self::ARCHIVE_ALL_PLUGINS_FLAG) {
-                    $archiveGroup = reset($plugins);
-                }
-                $archiveGroups[] = $archiveGroup;
+            $archiveGroup = $this->getArchiveGroupOfPlugin($plugin);
+
+            if ($archiveGroup == self::ARCHIVE_ALL_PLUGINS_FLAG) {
+                $archiveGroup = reset($plugins);
             }
+            $archiveGroups[] = $archiveGroup;
 
             $globalDoneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($this->params->getSegment());
             if ($globalDoneFlag !== $doneFlag) {
@@ -703,6 +702,7 @@ class Archive
      */
     private function cacheArchiveIdsWithoutLaunching($plugins)
     {
+        // TODO: if the archives already exist in the cache, we don't need to re-query
         $idarchivesByReport = ArchiveSelector::getArchiveIds(
             $this->params->getIdSites(), $this->params->getPeriods(), $this->params->getSegment(), $plugins);
 
@@ -878,6 +878,10 @@ class Archive
         foreach ($archiveGroups as $plugin) {
             $doneFlag = $this->getDoneStringForPlugin($plugin, [$idSite]);
             $this->initializeArchiveIdCache($doneFlag);
+
+            if (isset($this->idarchives[$doneFlag][$periodString][$idSite])) {
+                continue;
+            }
 
             $idArchive = $archiveLoader->prepareArchive($plugin);
 

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -706,14 +706,6 @@ class Archive
         $idarchivesByReport = ArchiveSelector::getArchiveIds(
             $this->params->getIdSites(), $this->params->getPeriods(), $this->params->getSegment(), $plugins);
 
-        // initialize archive ID cache for each report
-        foreach ($plugins as $plugin) {
-            $doneFlag = $this->getDoneStringForPlugin($plugin, $this->params->getIdSites());
-            $this->initializeArchiveIdCache($doneFlag);
-            $globalDoneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($this->params->getSegment());
-            $this->initializeArchiveIdCache($globalDoneFlag);
-        }
-
         foreach ($idarchivesByReport as $doneFlag => $idarchivesByDate) {
             foreach ($idarchivesByDate as $dateRange => $idarchives) {
                 foreach ($idarchives as $idSite => $idarchive) {
@@ -799,12 +791,15 @@ class Archive
      *
      * @param string $doneFlag
      */
+    /*
+     TODO: instead of this function, let's set idarchive entries to null (for done flag, idarchive + period)
     private function initializeArchiveIdCache($doneFlag)
     {
         if (!isset($this->idarchives[$doneFlag])) {
             $this->idarchives[$doneFlag] = array();
         }
     }
+    */
 
     /**
      * Returns the archiving group identifier given a plugin.
@@ -877,8 +872,6 @@ class Archive
         // process for each plugin as well
         foreach ($archiveGroups as $plugin) {
             $doneFlag = $this->getDoneStringForPlugin($plugin, [$idSite]);
-            $this->initializeArchiveIdCache($doneFlag);
-
             if (isset($this->idarchives[$doneFlag][$periodString][$idSite])) {
                 continue;
             }

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -52,9 +52,15 @@ class ArchiveInvalidator
      */
     private $model;
 
-    public function __construct(Model $model)
+    /**
+     * @var IdArchiveCache
+     */
+    private $idArchiveCache;
+
+    public function __construct(Model $model, IdArchiveCache $idArchiveCache)
     {
         $this->model = $model;
+        $this->idArchiveCache = $idArchiveCache;
     }
 
     public function rememberToInvalidateArchivedReportsLater($idSite, Date $date)
@@ -260,6 +266,11 @@ class ArchiveInvalidator
             }
 
             $this->model->updateArchiveAsInvalidated($table, $idSites, $dates[$tableDate], $segment);
+
+            // since we invalidated archives for these sites, remove those entries from the cache
+            // NOTE: we could be more precise and only invalidate the archives that updateArchiveAsInvalidated
+            // invalidates, but that would be a lot harder.
+            $this->idArchiveCache->flushBySite($idSites);
         }
     }
 

--- a/core/Archive/ArchiveQueryFactory.php
+++ b/core/Archive/ArchiveQueryFactory.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Archive;
+
+use Piwik\Archive;
+use Piwik\Period;
+use Piwik\Segment;
+use Piwik\Site;
+use Piwik\Period\Factory as PeriodFactory;
+
+class ArchiveQueryFactory
+{
+    public function build($idSites, $period, $strDate, $segment = false, $_restrictSitesToLogin = false)
+    {
+        $websiteIds = Site::getIdSitesFromIdSitesString($idSites, $_restrictSitesToLogin);
+
+        $timezone = false;
+        if (count($websiteIds) == 1) {
+            $timezone = Site::getTimezoneFor($websiteIds[0]);
+        }
+
+        if (Period::isMultiplePeriod($strDate, $period)) {
+            $oPeriod    = PeriodFactory::build($period, $strDate, $timezone);
+            $allPeriods = $oPeriod->getSubperiods();
+        } else {
+            $oPeriod    = PeriodFactory::makePeriodFromQueryParams($timezone, $period, $strDate);
+            $allPeriods = array($oPeriod);
+        }
+
+        $segment        = new Segment($segment, $websiteIds);
+        $idSiteIsAll    = $idSites == Archive::REQUEST_ALL_WEBSITES_FLAG;
+        $isMultipleDate = Period::isMultiplePeriod($strDate, $period);
+
+        return $this->factory($segment, $allPeriods, $websiteIds, $idSiteIsAll, $isMultipleDate);
+    }
+
+    public function factory($segment, $periods, $idSites, $idSiteIsAll, $isMultipleDate)
+    {
+        $forceIndexedBySite = false;
+        $forceIndexedByDate = false;
+
+        if ($idSiteIsAll || count($idSites) > 1) {
+            $forceIndexedBySite = true;
+        }
+
+        if (count($periods) > 1 || $isMultipleDate) {
+            $forceIndexedByDate = true;
+        }
+
+        $params = new Parameters($idSites, $periods, $segment);
+
+        return $this->newArchiveInstance($params, $forceIndexedBySite, $forceIndexedByDate);
+    }
+
+    protected function newArchiveInstance(Parameters $params, $forceIndexedBySite, $forceIndexedByDate)
+    {
+        return new Archive($params, $forceIndexedBySite, $forceIndexedByDate);
+    }
+}

--- a/core/Archive/ArchiveTableStore.php
+++ b/core/Archive/ArchiveTableStore.php
@@ -108,15 +108,15 @@ class ArchiveTableStore
         return ArchiveSelector::getArchiveIdAndVisits($params, $minDatetimeArchiveProcessedUTC);
     }
 
-    public function insertRecord(ArchiveProcessorParams $params, $column, $value)
+    public function insertRecord(ArchiveProcessorParams $params, $idArchive, $column, $value)
     {
-        $archiveWriter = new ArchiveWriter($params);
+        $archiveWriter = new ArchiveWriter($params, $idArchive);
         $archiveWriter->insertRecord($column, $value);
     }
 
-    public function insertBlobRecord(ArchiveProcessorParams $params, $name, $values)
+    public function insertBlobRecord(ArchiveProcessorParams $params, $idArchive, $name, $values)
     {
-        $archiveWriter = new ArchiveWriter($params);
+        $archiveWriter = new ArchiveWriter($params, $idArchive);
         $archiveWriter->insertBlobRecord($name, $values);
     }
 
@@ -126,9 +126,9 @@ class ArchiveTableStore
         return $archiveWriter->initNewArchive();
     }
 
-    public function finishArchive(ArchiveProcessorParams $params, $status)
+    public function finishArchive(ArchiveProcessorParams $params, $idArchive, $status)
     {
-        $archiveWriter = new ArchiveWriter($params);
+        $archiveWriter = new ArchiveWriter($params, $idArchive);
         $archiveWriter->finalizeArchive($status);
     }
 

--- a/core/Archive/ArchiveTableStore.php
+++ b/core/Archive/ArchiveTableStore.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Archive;
+
+
+use Piwik\Archive;
+use Piwik\ArchiveProcessor\Rules;
+use Piwik\Cache\Transient;
+use Piwik\DataAccess\ArchiveSelector;
+use Piwik\Date;
+use Piwik\Log;
+use Piwik\Metrics;
+use Piwik\Period;
+use Piwik\Site;
+
+class ArchiveTableStore
+{
+    /**
+     * @var IdArchiveCache
+     */
+    private $idArchiveCache;
+
+    /**
+     * @var ArchiveInvalidator
+     */
+    private $invalidator;
+
+    /**
+     * @var Transient
+     */
+    private $transientCache;
+
+    public function __construct(IdArchiveCache $idArchiveCache, ArchiveInvalidator $invalidator,
+                                Transient $transientCache)
+    {
+        $this->idArchiveCache = $idArchiveCache;
+        $this->invalidator = $invalidator;
+        $this->transientCache = $transientCache;
+    }
+
+    /**
+     * Returns archive IDs for the sites, periods and archive names that are being
+     * queried. This function will use the idarchive cache if it has the right data,
+     * query archive tables for IDs w/o launching archiving, or launch archiving and
+     * get the idarchive from ArchiveProcessor instances.
+     *
+     * @param string[] $archiveNames
+     * @return array
+     */
+    public function getArchiveIds(Parameters $params, $archiveNames)
+    {
+        $plugins = $this->getRequestedPlugins($archiveNames);
+
+        // figure out which archives haven't been processed (if an archive has been processed,
+        // then we have the archive IDs in $this->idarchives)
+        $doneFlags     = array();
+        $archiveGroups = array();
+        foreach ($plugins as $plugin) {
+            $doneFlag = $this->getDoneStringForPlugin($params, $plugin, $params->getIdSites());
+
+            $doneFlags[$doneFlag] = true;
+
+            $archiveGroup = $this->getArchiveGroupOfPlugin($params, $plugin);
+
+            if ($archiveGroup == Archive::ARCHIVE_ALL_PLUGINS_FLAG) {
+                $archiveGroup = reset($plugins);
+            }
+            $archiveGroups[] = $archiveGroup;
+
+            $globalDoneFlag = Rules::getDoneFlagArchiveContainsAllPlugins($params->getSegment());
+            if ($globalDoneFlag !== $doneFlag) {
+                $doneFlags[$globalDoneFlag] = true;
+            }
+        }
+
+        $archiveGroups = array_unique($archiveGroups);
+
+        // cache id archives for plugins we haven't processed yet
+        if (!empty($archiveGroups)) {
+            if (!Rules::isArchivingDisabledFor($params->getIdSites(), $params->getSegment(), $params->getPeriodLabel())) {
+                $this->cacheArchiveIdsAfterLaunching($params, $archiveGroups);
+            } else {
+                $this->cacheArchiveIdsWithoutLaunching($params, $plugins);
+            }
+        }
+
+        $idArchivesByMonth = $this->getIdArchivesByMonth($params, $doneFlags);
+
+        return $idArchivesByMonth;
+    }
+
+    public function getArchiveData(array $archiveIds, array $archiveNames, $archiveDataType, $idSubtable = null)
+    {
+        return ArchiveSelector::getArchiveData($archiveIds, $archiveNames, $archiveDataType, $idSubtable);
+    }
+
+    /**
+     * Gets the IDs of the archives we're querying for and stores them in $this->archives.
+     * This function will launch the archiving process for each period/site/plugin if
+     * metrics/reports have not been calculated/archived already.
+     *
+     * @param array $archiveGroups @see getArchiveGroupOfReport
+     * @param array $plugins List of plugin names to archive.
+     */
+    private function cacheArchiveIdsAfterLaunching(Parameters $params, $archiveGroups)
+    {
+        $this->invalidatedReportsIfNeeded($params);
+
+        $today = Date::today();
+
+        foreach ($params->getPeriods() as $period) {
+            $twoDaysBeforePeriod = $period->getDateStart()->subDay(2);
+            $twoDaysAfterPeriod = $period->getDateEnd()->addDay(2);
+
+            foreach ($params->getIdSites() as $idSite) {
+                $site = new Site($idSite);
+
+                // if the END of the period is BEFORE the website creation date
+                // we already know there are no stats for this period
+                // we add one day to make sure we don't miss the day of the website creation
+                if ($twoDaysAfterPeriod->isEarlier($site->getCreationDate())) {
+                    // TODO: use Logger
+                    Log::debug("Archive site %s, %s (%s) skipped, archive is before the website was created.",
+                        $idSite, $period->getLabel(), $period->getPrettyString());
+                    continue;
+                }
+
+                // if the starting date is in the future we know there is no visiidsite = ?t
+                if ($twoDaysBeforePeriod->isLater($today)) {
+                    Log::debug("Archive site %s, %s (%s) skipped, archive is after today.",
+                        $idSite, $period->getLabel(), $period->getPrettyString());
+                    continue;
+                }
+
+                $this->prepareArchive($params, $archiveGroups, $site, $period);
+            }
+        }
+    }
+
+    /**
+     * Gets the IDs of the archives we're querying for and stores them in $this->archives.
+     * This function will not launch the archiving process (and is thus much, much faster
+     * than cacheArchiveIdsAfterLaunching).
+     *
+     * @param array $plugins List of plugin names from which data is being requested.
+     */
+    private function cacheArchiveIdsWithoutLaunching(Parameters $params, $plugins)
+    {
+        // TODO: if the archives already exist in the cache, we don't need to re-query
+        $idarchivesByReport = ArchiveSelector::getArchiveIds(
+            $params->getIdSites(), $params->getPeriods(), $params->getSegment(), $plugins);
+
+        foreach ($idarchivesByReport as $doneFlag => $idarchivesByDate) {
+            foreach ($idarchivesByDate as $dateRange => $idArchives) {
+                foreach ($idArchives as $idSite => $idArchive) {
+                    $this->idArchiveCache->set($idSite, $dateRange, $doneFlag, $idArchive);
+                }
+            }
+        }
+    }
+
+
+    /**
+     * @param $archiveGroups
+     * @param $site
+     * @param $period
+     */
+    private function prepareArchive(Parameters $params, array $archiveGroups, Site $site, Period $period)
+    {
+        $parameters = new \Piwik\ArchiveProcessor\Parameters($site, $period, $params->getSegment());
+        $archiveLoader = new \Piwik\ArchiveProcessor\Loader($parameters);
+
+        $periodString = $period->getRangeString();
+
+        $idSite = $site->getId();
+
+        // process for each plugin as well
+        foreach ($archiveGroups as $plugin) {
+            $doneFlag = $this->getDoneStringForPlugin($params, $plugin, [$idSite]);
+            if ($this->idArchiveCache->has($idSite, $periodString, $doneFlag)) {
+                continue;
+            }
+
+            $idArchive = $archiveLoader->prepareArchive($plugin);
+            $this->idArchiveCache->set($idSite, $periodString, $doneFlag, $idArchive);
+        }
+    }
+
+    private function getIdArchivesByMonth(Parameters $params, $doneFlags)
+    {
+        // order idarchives by the table month they belong to
+        $idArchivesByMonth = array();
+
+        foreach (array_keys($doneFlags) as $doneFlag) {
+            foreach ($params->getPeriods() as $period) {
+                $dateRange = $period->getRangeString();
+                foreach ($params->getIdSites() as $idSite) {
+                    if ($this->idArchiveCache->hasNonEmpty($idSite, $dateRange, $doneFlag)) {
+                        $idArchivesByMonth[$dateRange][] = $this->idArchiveCache->get($idSite, $dateRange, $doneFlag);
+                    }
+                }
+            }
+        }
+
+        return $idArchivesByMonth;
+    }
+
+    /**
+     * Returns the archiving group identifier given a plugin.
+     *
+     * More than one plugin can be called at once when archiving. In such a case
+     * we don't want to launch archiving three times for three plugins if doing
+     * it once is enough, so getArchiveIds makes sure to get the archive group of
+     * all reports.
+     *
+     * If the period isn't a range, then all plugins' archiving code is executed.
+     * If the period is a range, then archiving code is executed individually for
+     * each plugin.
+     */
+    private function getArchiveGroupOfPlugin(Parameters $params, $plugin)
+    {
+        $periods = $params->getPeriods();
+        $periodLabel = reset($periods)->getLabel();
+
+        if (Rules::shouldProcessReportsAllPlugins($params->getIdSites(), $params->getSegment(), $periodLabel)) {
+            return Archive::ARCHIVE_ALL_PLUGINS_FLAG;
+        }
+
+        return $plugin;
+    }
+
+    private function getSiteIdsThatAreRequestedInThisArchiveButWereNotInvalidatedYet(Parameters $params)
+    {
+        $id = 'Archive.SiteIdsOfRememberedReportsInvalidated';
+
+        if (!$this->transientCache->contains($id)) {
+            $this->transientCache->save($id, array());
+        }
+
+        $siteIdsAlreadyHandled = $this->transientCache->fetch($id);
+        $siteIdsRequested      = $params->getIdSites();
+
+        foreach ($siteIdsRequested as $index => $siteIdRequested) {
+            $siteIdRequested = (int) $siteIdRequested;
+
+            if (in_array($siteIdRequested, $siteIdsAlreadyHandled)) {
+                unset($siteIdsRequested[$index]); // was already handled previously, do not do it again
+            } else {
+                $siteIdsAlreadyHandled[] = $siteIdRequested; // we will handle this id this time
+            }
+        }
+
+        $this->transientCache->save($id, $siteIdsAlreadyHandled);
+
+        return $siteIdsRequested;
+    }
+
+    private function invalidatedReportsIfNeeded(Parameters $params)
+    {
+        $siteIdsRequested = $this->getSiteIdsThatAreRequestedInThisArchiveButWereNotInvalidatedYet($params);
+
+        if (empty($siteIdsRequested)) {
+            return; // all requested site ids were already handled
+        }
+
+        $sitesPerDays = $this->invalidator->getRememberedArchivedReportsThatShouldBeInvalidated();
+
+        foreach ($sitesPerDays as $date => $siteIds) {
+            if (empty($siteIds)) {
+                continue;
+            }
+
+            $siteIdsToActuallyInvalidate = array_intersect($siteIds, $siteIdsRequested);
+
+            if (empty($siteIdsToActuallyInvalidate)) {
+                continue; // all site ids that should be handled are already handled
+            }
+
+            try {
+                $this->invalidator->markArchivesAsInvalidated($siteIdsToActuallyInvalidate, array(Date::factory($date)), false);
+            } catch (\Exception $e) {
+                Site::clearCache();
+                throw $e;
+            }
+        }
+
+        Site::clearCache();
+    }
+
+    /**
+     * Returns the list of plugins that archive the given reports.
+     *
+     * @param array $archiveNames
+     * @return array
+     */
+    private function getRequestedPlugins($archiveNames)
+    {
+        $result = array();
+
+        foreach ($archiveNames as $name) {
+            $result[] = self::getPluginForReport($name);
+        }
+
+        return array_unique($result);
+    }
+
+    /**
+     * Returns the name of the plugin that archives a given report.
+     *
+     * @param string $report Archive data name, eg, `'nb_visits'`, `'DevicesDetection_...'`, etc.
+     * @return string Plugin name.
+     * @throws \Exception If a plugin cannot be found or if the plugin for the report isn't
+     *                    activated.
+     */
+    private static function getPluginForReport($report)
+    {
+        // Core metrics are always processed in Core, for the requested date/period/segment
+        if (in_array($report, Metrics::getVisitsMetricNames())) {
+            $report = 'VisitsSummary_CoreMetrics';
+        } // Goal_* metrics are processed by the Goals plugin (HACK)
+        elseif (strpos($report, 'Goal_') === 0) {
+            $report = 'Goals_Metrics';
+        } elseif (strrpos($report, '_returning') === strlen($report) - strlen('_returning')) { // HACK
+            $report = 'VisitFrequency_Metrics';
+        }
+
+        $plugin = substr($report, 0, strpos($report, '_'));
+        if (empty($plugin)
+            || !\Piwik\Plugin\Manager::getInstance()->isPluginActivated($plugin)
+        ) {
+            throw new \Exception("Error: The report '$report' was requested but it is not available at this stage."
+                . " (Plugin '$plugin' is not activated.)");
+        }
+        return $plugin;
+    }
+    /**
+     * Returns the done string flag for a plugin using this instance's segment & periods.
+     * @param string $plugin
+     * @return string
+     */
+    private function getDoneStringForPlugin(Parameters $params, $plugin, $idSites)
+    {
+        return Rules::getDoneStringFlagFor($idSites, $params->getSegment(), $params->getPeriodLabel(), $plugin);
+    }
+}

--- a/core/Archive/IdArchiveCache.php
+++ b/core/Archive/IdArchiveCache.php
@@ -69,4 +69,16 @@ class IdArchiveCache
     {
         $this->idArchives[$idSite][$dateRange][$doneFlag] = $idArchive;
     }
+
+    public function flushBySite(array $idSites)
+    {
+        foreach ($idSites as $idSite) {
+            unset($this->idArchives[$idSite]);
+        }
+    }
+
+    public function flushAll()
+    {
+        $this->idArchives = [];
+    }
 }

--- a/core/Archive/IdArchiveCache.php
+++ b/core/Archive/IdArchiveCache.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Archive;
+
+/**
+ * Returns list of archive IDs for the site, periods and segment we are querying with.
+ * Archive IDs are indexed by done flag, period and idSite, ie:
+ *
+ * array(
+ *     '1' => array(
+ *         '2010-01-01' => ['done.Referrers' => 1],
+ *         '2010-01-02' => ['done.Referrers' => 1],
+ *     ),
+ *     '2' => array(
+ *         '2010-01-01' => ['done.VisitsSummary' => 3],
+ *         '2010-01-02' => ['done.VisitsSummary' => 4],
+ *     ),
+ * )
+ *
+ * or,
+ *
+ * array(
+ *     '1' => array(
+ *         '2010-01-01' => ['done.all' => 1],
+ *         '2010-01-02' => ['done.Goals' => 2],
+ *     ),
+ * )
+ *
+ * If an archive has no metrics, the value will be false-y.
+ *
+ * @return array
+ */
+class IdArchiveCache
+{
+    /**
+     * @var array
+     */
+    private $idArchives = [];
+
+    public function has($idSite, $dateRange, $doneFlag)
+    {
+        return isset($this->idArchives[$idSite][$dateRange][$doneFlag]);
+    }
+
+    /**
+     * Returns true if the archive for $idSite, $dateRange and $doneFlag has been queried,
+     * AND has visits.
+     *
+     * @return bool
+     */
+    public function hasNonEmpty($idSite, $dateRange, $doneFlag)
+    {
+        return !empty($this->idArchives[$idSite][$dateRange][$doneFlag]);
+    }
+
+    public function get($idSite, $dateRange, $doneFlag)
+    {
+        return $this->idArchives[$idSite][$dateRange][$doneFlag];
+    }
+
+    public function set($idSite, $dateRange, $doneFlag, $idArchive)
+    {
+        $this->idArchives[$idSite][$dateRange][$doneFlag] = $idArchive;
+    }
+}

--- a/core/Archive/Parameters.php
+++ b/core/Archive/Parameters.php
@@ -24,6 +24,8 @@ class Parameters
     /**
      * The list of Period's to query archive data for.
      *
+     * NOTE: every period must be of the same type (ie, all months or all days, etc.)
+     *
      * @var Period[]
      */
     private $periods = array();
@@ -55,5 +57,10 @@ class Parameters
     public function getIdSites()
     {
         return $this->idSites;
+    }
+
+    public function getPeriodLabel()
+    {
+        return reset($this->periods)->getLabel();
     }
 }

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\Archive\ArchiveTableStore;
 use Piwik\Archive\DataTableFactory;
 use Piwik\ArchiveProcessor\Parameters;
 use Piwik\ArchiveProcessor\Rules;
@@ -75,9 +76,9 @@ use Piwik\DataTable\Row;
 class ArchiveProcessor
 {
     /**
-     * @var \Piwik\DataAccess\ArchiveWriter
+     * @var ArchiveTableStore
      */
-    private $archiveWriter;
+    private $archiveTableStore;
 
     /**
      * @var \Piwik\DataAccess\LogAggregator
@@ -110,11 +111,11 @@ class ArchiveProcessor
      */
     private $skipUniqueVisitorsCalculationForMultipleSites = true;
 
-    public function __construct(Parameters $params, ArchiveWriter $archiveWriter, LogAggregator $logAggregator)
+    public function __construct(Parameters $params, ArchiveTableStore $archiveTableStore, LogAggregator $logAggregator)
     {
         $this->params = $params;
         $this->logAggregator = $logAggregator;
-        $this->archiveWriter = $archiveWriter;
+        $this->archiveTableStore = $archiveTableStore;
 
         $this->skipUniqueVisitorsCalculationForMultipleSites = Rules::shouldSkipUniqueVisitorsCalculationForMultipleSites();
     }
@@ -257,7 +258,7 @@ class ArchiveProcessor
 
         foreach ($metrics as $column => $value) {
             $value = Common::forceDotAsSeparatorForDecimalPoint($value);
-            $this->archiveWriter->insertRecord($column, $value);
+            $this->archiveTableStore->insertRecord($this->params, $column, $value);
         }
         // if asked for only one field to sum
         if (count($metrics) == 1) {
@@ -313,7 +314,7 @@ class ArchiveProcessor
         $value = round($value, 2);
         $value = Common::forceDotAsSeparatorForDecimalPoint($value);
 
-        $this->archiveWriter->insertRecord($name, $value);
+        $this->archiveTableStore->insertRecord($this->params, $name, $value);
     }
 
     /**
@@ -330,7 +331,7 @@ class ArchiveProcessor
      */
     public function insertBlobRecord($name, $values)
     {
-        $this->archiveWriter->insertBlobRecord($name, $values);
+        $this->archiveTableStore->insertBlobRecord($this->params, $name, $values);
     }
 
     /**

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -13,11 +13,11 @@ use Piwik\Archive\ArchiveTableStore;
 use Piwik\Archive\DataTableFactory;
 use Piwik\ArchiveProcessor\Parameters;
 use Piwik\ArchiveProcessor\Rules;
-use Piwik\DataAccess\ArchiveWriter;
 use Piwik\DataAccess\LogAggregator;
 use Piwik\DataTable\Manager;
 use Piwik\DataTable\Map;
 use Piwik\DataTable\Row;
+
 /**
  * Used by {@link Piwik\Plugin\Archiver} instances to insert and aggregate archive data.
  *
@@ -111,11 +111,18 @@ class ArchiveProcessor
      */
     private $skipUniqueVisitorsCalculationForMultipleSites = true;
 
-    public function __construct(Parameters $params, ArchiveTableStore $archiveTableStore, LogAggregator $logAggregator)
+    /**
+     * @var int
+     */
+    private $idArchive;
+
+    public function __construct(Parameters $params, ArchiveTableStore $archiveTableStore, LogAggregator $logAggregator,
+                                $idArchive)
     {
         $this->params = $params;
         $this->logAggregator = $logAggregator;
         $this->archiveTableStore = $archiveTableStore;
+        $this->idArchive = $idArchive;
 
         $this->skipUniqueVisitorsCalculationForMultipleSites = Rules::shouldSkipUniqueVisitorsCalculationForMultipleSites();
     }
@@ -258,7 +265,7 @@ class ArchiveProcessor
 
         foreach ($metrics as $column => $value) {
             $value = Common::forceDotAsSeparatorForDecimalPoint($value);
-            $this->archiveTableStore->insertRecord($this->params, $column, $value);
+            $this->archiveTableStore->insertRecord($this->params, $this->idArchive, $column, $value);
         }
         // if asked for only one field to sum
         if (count($metrics) == 1) {
@@ -314,7 +321,7 @@ class ArchiveProcessor
         $value = round($value, 2);
         $value = Common::forceDotAsSeparatorForDecimalPoint($value);
 
-        $this->archiveTableStore->insertRecord($this->params, $name, $value);
+        $this->archiveTableStore->insertRecord($this->params, $this->idArchive, $name, $value);
     }
 
     /**
@@ -331,7 +338,7 @@ class ArchiveProcessor
      */
     public function insertBlobRecord($name, $values)
     {
-        $this->archiveTableStore->insertBlobRecord($this->params, $name, $values);
+        $this->archiveTableStore->insertBlobRecord($this->params, $this->idArchive, $name, $values);
     }
 
     /**

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -382,7 +382,7 @@ class ArchiveProcessor
      * Note: public only for use in closure in PHP 5.3.
      *
      * @param $table
-     * @return \Piwik\Period
+     * @return bool
      */
     public function areColumnsNotAlreadyRenamed($table)
     {

--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -12,6 +12,7 @@ use Piwik\Archive;
 use Piwik\Cache;
 use Piwik\Config;
 use Piwik\DataAccess\ArchiveSelector;
+use Piwik\DataAccess\ArchiveWriter;
 use Piwik\Date;
 use Piwik\Period;
 use Piwik\Piwik;
@@ -97,7 +98,7 @@ class Loader
 
             $pluginsArchiver = new PluginsArchiver($this->params, $this->isArchiveTemporary());
             $metrics = $pluginsArchiver->callAggregateCoreMetrics();
-            $pluginsArchiver->finalizeArchive();
+            $pluginsArchiver->finalizeArchive($this->getFinalArchiveStatus());
 
             $this->params->setRequestedPlugin($requestedPlugin);
 
@@ -123,7 +124,7 @@ class Loader
         $forceArchivingWithoutVisits = !$this->isThereSomeVisits($visits) && $this->shouldArchiveForSiteEvenWhenNoVisits();
         $pluginsArchiver->callAggregateAllPlugins($visits, $visitsConverted, $forceArchivingWithoutVisits);
 
-        $idArchive = $pluginsArchiver->finalizeArchive();
+        $idArchive = $pluginsArchiver->finalizeArchive($this->getFinalArchiveStatus());
 
         return array($idArchive, $visits);
     }
@@ -246,5 +247,14 @@ class Loader
         }
 
         return $cache->fetch($cacheKey);
+    }
+
+    private function getFinalArchiveStatus()
+    {
+        $status = ArchiveWriter::DONE_OK;
+        if ($this->isArchiveTemporary()) {
+            $status = ArchiveWriter::DONE_OK_TEMPORARY;
+        }
+        return $status;
     }
 }

--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -96,7 +96,11 @@ class Loader
 
             $this->params->setRequestedPlugin('VisitsSummary');
 
-            $pluginsArchiver = new PluginsArchiver($this->params, $this->isArchiveTemporary());
+            $archiveWriter = new ArchiveWriter($this->params);
+
+            $pluginsArchiver = new PluginsArchiver($this->params, $archiveWriter, $this->isArchiveTemporary());
+            $pluginsArchiver->initNewArchive();
+
             $metrics = $pluginsArchiver->callAggregateCoreMetrics();
             $pluginsArchiver->finalizeArchive($this->getFinalArchiveStatus());
 
@@ -111,7 +115,10 @@ class Loader
 
     protected function prepareAllPluginsArchive($visits, $visitsConverted)
     {
-        $pluginsArchiver = new PluginsArchiver($this->params, $this->isArchiveTemporary());
+        $archiveWriter = new ArchiveWriter($this->params);
+
+        $pluginsArchiver = new PluginsArchiver($this->params, $archiveWriter, $this->isArchiveTemporary());
+        $pluginsArchiver->initNewArchive();
 
         if ($this->mustProcessVisitCount($visits)
             || $this->doesRequestedPluginIncludeVisitsSummary()

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -53,7 +53,7 @@ class PluginsArchiver
     {
         $this->params = $params;
         $this->isTemporaryArchive = $isTemporaryArchive;
-        $this->archiveWriter = new ArchiveWriter($this->params, $this->isTemporaryArchive);
+        $this->archiveWriter = new ArchiveWriter($this->params);
         $this->archiveWriter->initNewArchive();
 
         $this->logAggregator = new LogAggregator($params);
@@ -160,10 +160,10 @@ class PluginsArchiver
         }
     }
 
-    public function finalizeArchive()
+    public function finalizeArchive($status)
     {
-        $this->params->logStatusDebug($this->archiveWriter->isArchiveTemporary);
-        $this->archiveWriter->finalizeArchive();
+        $this->params->logStatusDebug($this->isTemporaryArchive);
+        $this->archiveWriter->finalizeArchive($status);
         return $this->archiveWriter->getIdArchive();
     }
 

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -10,7 +10,6 @@
 namespace Piwik\ArchiveProcessor;
 
 use Piwik\ArchiveProcessor;
-use Piwik\Common;
 use Piwik\DataAccess\ArchiveWriter;
 use Piwik\DataAccess\LogAggregator;
 use Piwik\DataTable\Manager;
@@ -49,12 +48,11 @@ class PluginsArchiver
      */
     public static $archivers = array();
 
-    public function __construct(Parameters $params, $isTemporaryArchive)
+    public function __construct(Parameters $params, ArchiveWriter $archiveWriter, $isTemporaryArchive)
     {
         $this->params = $params;
         $this->isTemporaryArchive = $isTemporaryArchive;
-        $this->archiveWriter = new ArchiveWriter($this->params);
-        $this->archiveWriter->initNewArchive();
+        $this->archiveWriter = $archiveWriter;
 
         $this->logAggregator = new LogAggregator($params);
 
@@ -283,5 +281,10 @@ class PluginsArchiver
         Piwik::postEvent('Archiving.makeNewArchiverObject', array($archiver, $pluginName, $this->params, $this->isTemporaryArchive));
 
         return $archiver;
+    }
+
+    public function initNewArchive()
+    {
+        $this->archiveWriter->initNewArchive();
     }
 }

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -9,8 +9,8 @@
 
 namespace Piwik\ArchiveProcessor;
 
+use Piwik\Archive\ArchiveTableStore;
 use Piwik\ArchiveProcessor;
-use Piwik\DataAccess\ArchiveWriter;
 use Piwik\DataAccess\LogAggregator;
 use Piwik\DataTable\Manager;
 use Piwik\Metrics;
@@ -48,15 +48,15 @@ class PluginsArchiver
      */
     public static $archivers = array();
 
-    public function __construct(Parameters $params, ArchiveWriter $archiveWriter, $isTemporaryArchive)
+    public function __construct(Parameters $params, ArchiveTableStore $archiveTableStore, $isTemporaryArchive)
     {
         $this->params = $params;
         $this->isTemporaryArchive = $isTemporaryArchive;
-        $this->archiveWriter = $archiveWriter;
+        $this->archiveTableStore = $archiveTableStore;
 
         $this->logAggregator = new LogAggregator($params);
 
-        $this->archiveProcessor = new ArchiveProcessor($this->params, $this->archiveWriter, $this->logAggregator);
+        $this->archiveProcessor = new ArchiveProcessor($this->params, $archiveTableStore, $this->logAggregator);
 
         $this->isSingleSiteDayArchive = $this->params->isSingleSiteDayArchive();
     }
@@ -161,8 +161,7 @@ class PluginsArchiver
     public function finalizeArchive($status)
     {
         $this->params->logStatusDebug($this->isTemporaryArchive);
-        $this->archiveWriter->finalizeArchive($status);
-        return $this->archiveWriter->getIdArchive();
+        $this->archiveTableStore->finishArchive($this->params, $status);
     }
 
     /**
@@ -285,6 +284,6 @@ class PluginsArchiver
 
     public function initNewArchive()
     {
-        $this->archiveWriter->initNewArchive();
+        return $this->archiveTableStore->startArchive($this->params);
     }
 }

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -209,7 +209,7 @@ class ArchiveSelector
                 //FIXMEA duplicate with Archive.php
                 $dateStr = $row['date1'] . ',' . $row['date2'];
 
-                $result[$row['name']][$dateStr][] = $row['idarchive'];
+                $result[$row['name']][$dateStr][$row['idsite']] = $row['idarchive'];
             }
         }
 

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -9,13 +9,11 @@
 namespace Piwik\DataAccess;
 
 use Exception;
-use Piwik\Archive;
 use Piwik\Archive\Chunk;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\ArchiveProcessor;
 use Piwik\Db;
 use Piwik\Db\BatchInsert;
-use Piwik\Period;
 
 /**
  * This class is used to create a new Archive.

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -61,7 +61,7 @@ class ArchiveWriter
         'name',
         'value');
 
-    public function __construct(ArchiveProcessor\Parameters $params, $isArchiveTemporary)
+    public function __construct(ArchiveProcessor\Parameters $params)
     {
         $this->idArchive = false;
         $this->idSite    = $params->getSite()->getId();
@@ -70,7 +70,6 @@ class ArchiveWriter
 
         $idSites = array($this->idSite);
         $this->doneFlag = Rules::getDoneStringFlagFor($idSites, $this->segment, $this->period->getLabel(), $params->getRequestedPlugin());
-        $this->isArchiveTemporary = $isArchiveTemporary;
 
         $this->dateStart = $this->period->getDateStart();
     }
@@ -126,14 +125,14 @@ class ArchiveWriter
         $this->logArchiveStatusAsIncomplete();
     }
 
-    public function finalizeArchive()
+    public function finalizeArchive($status)
     {
         $numericTable = $this->getTableNumeric();
         $idArchive    = $this->getIdArchive();
 
         $this->getModel()->deletePreviousArchiveStatus($numericTable, $idArchive, $this->doneFlag);
 
-        $this->logArchiveStatusAsFinal();
+        $this->logArchiveStatusAsFinal($status);
     }
 
     protected function compress($data)
@@ -163,14 +162,8 @@ class ArchiveWriter
         $this->insertRecord($this->doneFlag, self::DONE_ERROR);
     }
 
-    protected function logArchiveStatusAsFinal()
+    protected function logArchiveStatusAsFinal($status) // TODO: remove this method
     {
-        $status = self::DONE_OK;
-
-        if ($this->isArchiveTemporary) {
-            $status = self::DONE_OK_TEMPORARY;
-        }
-
         $this->insertRecord($this->doneFlag, $status);
     }
 

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -59,9 +59,9 @@ class ArchiveWriter
         'name',
         'value');
 
-    public function __construct(ArchiveProcessor\Parameters $params)
+    public function __construct(ArchiveProcessor\Parameters $params, $idArchive = false)
     {
-        $this->idArchive = false;
+        $this->idArchive = $idArchive;
         $this->idSite    = $params->getSite()->getId();
         $this->segment   = $params->getSegment();
         $this->period    = $params->getPeriod();

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -108,7 +108,7 @@ class ArchiveWriter
         $this->insertRecord($name, $values);
     }
 
-    public function getIdArchive()
+    private function getIdArchive()
     {
         if ($this->idArchive === false) {
             throw new Exception("Must call allocateNewArchiveId() first");
@@ -119,8 +119,9 @@ class ArchiveWriter
 
     public function initNewArchive()
     {
-        $this->allocateNewArchiveId();
+        $idArchive = $this->allocateNewArchiveId();
         $this->logArchiveStatusAsIncomplete();
+        return $idArchive;
     }
 
     public function finalizeArchive($status)

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -358,7 +358,6 @@ class Fixture extends \PHPUnit_Framework_Assert
 
     public function clearInMemoryCaches()
     {
-        Archive::clearStaticCache();
         DataTableManager::getInstance()->deleteAll();
         Option::clearCache();
         Site::clearCache();

--- a/tests/PHPUnit/Integration/Archive/ChunksTest.php
+++ b/tests/PHPUnit/Integration/Archive/ChunksTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Tests\Integration\Archive;
 use Piwik\Archive;
 use Piwik\ArchiveProcessor;
 use Piwik\ArchiveProcessor\Parameters;
+use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\DataAccess\ArchiveWriter;
 use Piwik\DataTable;
@@ -53,6 +54,7 @@ class ChunksTest extends IntegrationTestCase
 
         $recordName = 'Actions_MyRecord';
         $archiver = $this->createPluginsArchiver();
+        $archiver->initNewArchive();
         $archiver->archiveProcessor->insertBlobRecord($recordName, $blobs);
         $archiver->finalizeArchive(ArchiveWriter::DONE_OK);
 
@@ -139,11 +141,7 @@ class ChunksTest extends IntegrationTestCase
     private function createPluginsArchiver()
     {
         $params = $this->createArchiveProcessorParamaters();
-
-        $archiveWriter = new ArchiveWriter($params);
-        $archiveWriter->initNewArchive();
-
-        return new ArchiveProcessor\PluginsArchiver($params, $archiveWriter, $isTemporary = false);
+        return new ArchiveProcessor\PluginsArchiver($params, StaticContainer::get(Archive\ArchiveTableStore::class), $isTemporary = false);
     }
 
     public function provideContainerConfig()

--- a/tests/PHPUnit/Integration/Archive/ChunksTest.php
+++ b/tests/PHPUnit/Integration/Archive/ChunksTest.php
@@ -12,6 +12,7 @@ use Piwik\Archive;
 use Piwik\ArchiveProcessor;
 use Piwik\ArchiveProcessor\Parameters;
 use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\DataAccess\ArchiveWriter;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 use Piwik\Date;
@@ -53,10 +54,10 @@ class ChunksTest extends IntegrationTestCase
         $recordName = 'Actions_MyRecord';
         $archiver = $this->createPluginsArchiver();
         $archiver->archiveProcessor->insertBlobRecord($recordName, $blobs);
-        $archiver->finalizeArchive();
+        $archiver->finalizeArchive(ArchiveWriter::DONE_OK);
 
         // verify they were split into chunks
-        $archiveRows = $this->getAllRowsFromArchiveBlobTable('name');
+        $archiveRows = $this->getAllRowsFromArchiveBlobTable();
         $expectedArchiveNames = array(
             $recordName,
             $recordName. '_chunk_0_99',

--- a/tests/PHPUnit/Integration/Archive/ChunksTest.php
+++ b/tests/PHPUnit/Integration/Archive/ChunksTest.php
@@ -140,7 +140,10 @@ class ChunksTest extends IntegrationTestCase
     {
         $params = $this->createArchiveProcessorParamaters();
 
-        return new ArchiveProcessor\PluginsArchiver($params, $isTemporary = false);
+        $archiveWriter = new ArchiveWriter($params);
+        $archiveWriter->initNewArchive();
+
+        return new ArchiveProcessor\PluginsArchiver($params, $archiveWriter, $isTemporary = false);
     }
 
     public function provideContainerConfig()

--- a/tests/PHPUnit/Integration/ArchiveProcessingTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessingTest.php
@@ -10,9 +10,11 @@ namespace Piwik\Tests\Integration;
 
 use Exception;
 use Piwik\Access;
+use Piwik\Archive\ArchiveTableStore;
 use Piwik\ArchiveProcessor;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\Date;
 use Piwik\Db;
@@ -102,7 +104,7 @@ class ArchiveProcessingTest extends IntegrationTestCase
         $segment = new Segment('', $site->getId());
 
         $params = new ArchiveProcessor\Parameters($site, $period, $segment);
-        return new ArchiveProcessorTest($params);
+        return new ArchiveProcessorTest($params, StaticContainer::get(ArchiveTableStore::class));
     }
 
     /**

--- a/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
@@ -69,6 +69,7 @@ class PluginsArchiverTest extends IntegrationTestCase
 
         $this->pluginsArchiver = new CustomPluginsArchiver($this->createArchiveProcessorParamaters(),
             StaticContainer::get(ArchiveTableStore::class), $isTemporary = false);
+        $this->pluginsArchiver->initNewArchive();
     }
 
     private function createArchiveProcessorParamaters()

--- a/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
@@ -7,8 +7,10 @@
  */
 namespace Piwik\Tests\Integration\Archive;
 
+use Piwik\Archive\ArchiveTableStore;
 use Piwik\ArchiveProcessor\PluginsArchiver;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\Segment;
 use Piwik\Site;
 use Piwik\Db;
@@ -65,7 +67,8 @@ class PluginsArchiverTest extends IntegrationTestCase
 
         Fixture::createWebsite('2015-01-01 00:00:00');
 
-        $this->pluginsArchiver = new CustomPluginsArchiver($this->createArchiveProcessorParamaters(), $isTemporary = false);
+        $this->pluginsArchiver = new CustomPluginsArchiver($this->createArchiveProcessorParamaters(),
+            StaticContainer::get(ArchiveTableStore::class), $isTemporary = false);
     }
 
     private function createArchiveProcessorParamaters()

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -14,6 +14,7 @@ use Piwik\ArchiveProcessor\Parameters;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\ArchiveSelector;
 use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\DataAccess\ArchiveWriter;
@@ -278,7 +279,7 @@ class ArchiveTest extends IntegrationTestCase
         $archiveWriter            = new ArchiveWriter($parameters, !!$idArchive);
         $archiveWriter->idArchive = $idArchive;
 
-        $archiveProcessor = new ArchiveProcessor($parameters, $archiveWriter,
+        $archiveProcessor = new ArchiveProcessor($parameters, StaticContainer::get(PiwikArchive\ArchiveTableStore::class),
             new LogAggregator($parameters));
 
         $archiveProcessor->setNumberOfVisits(1, 1);

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -280,7 +280,7 @@ class ArchiveTest extends IntegrationTestCase
         $archiveWriter->idArchive = $idArchive;
 
         $archiveProcessor = new ArchiveProcessor($parameters, StaticContainer::get(PiwikArchive\ArchiveTableStore::class),
-            new LogAggregator($parameters));
+            new LogAggregator($parameters), $idArchive);
 
         $archiveProcessor->setNumberOfVisits(1, 1);
 
@@ -363,7 +363,7 @@ class ArchiveTest extends IntegrationTestCase
         foreach ($blobs as $name => $blob) {
             $writer->insertBlobRecord($name, $blob);
         }
-        $writer->finalizeArchive();
+        $writer->finalizeArchive(ArchiveWriter::DONE_OK);
     }
 
     private function assertArchiveTablesAreNotEmpty($tableMonth)

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -35,7 +35,14 @@ class Archive extends PiwikArchive
     {
         return parent::get($archiveNames, $archiveDataType, $idSubtable);
     }
+}
 
+class TestArchiveQueryFactory extends PiwikArchive\ArchiveQueryFactory
+{
+    protected function newArchiveInstance(PiwikArchive\Parameters $params, $forceIndexedBySite, $forceIndexedByDate)
+    {
+        return new Archive($params, $forceIndexedBySite, $forceIndexedByDate);
+    }
 }
 
 /**
@@ -387,9 +394,15 @@ class ArchiveTest extends IntegrationTestCase
         return $archive->getNumeric('nb_visits');
     }
 
+    /**
+     * @param $period
+     * @param string $day
+     * @return Archive
+     */
     private function getArchive($period, $day = '2010-03-04,2010-03-07')
     {
-        return Archive::build(self::$fixture->idSite, $period, $day);
+        $factory = new TestArchiveQueryFactory();
+        return $factory->build(self::$fixture->idSite, $period, $day);
     }
 }
 

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Integration\DataAccess;
 
+use Piwik\Archive\IdArchiveCache;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\CronArchive\SitesToReprocessDistributedList;
 use Piwik\DataAccess\ArchiveTableCreator;
@@ -61,7 +62,7 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->invalidator = new ArchiveInvalidator(new Model());
+        $this->invalidator = new ArchiveInvalidator(new Model(), new IdArchiveCache());
     }
 
     public function test_rememberToInvalidateArchivedReportsLater_shouldCreateAnEntryInCaseThereIsNoneYet()

--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -8,8 +8,10 @@
 namespace Piwik\Tests\System;
 
 use Piwik\Application\Kernel\GlobalSettingsProvider;
+use Piwik\Archive\IdArchiveCache;
 use Piwik\Cache;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Tests\Framework\Mock\TestConfig;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
@@ -32,6 +34,7 @@ class BlobReportLimitingTest extends SystemTestCase
     public function setUp()
     {
         Cache::getTransientCache()->flushAll();
+        StaticContainer::get(IdArchiveCache::class)->flushAll();
         parent::setUp();
     }
 

--- a/tests/PHPUnit/System/OneVisitorOneWebsiteSeveralDaysDateRangeArchivingTest.php
+++ b/tests/PHPUnit/System/OneVisitorOneWebsiteSeveralDaysDateRangeArchivingTest.php
@@ -148,9 +148,11 @@ class OneVisitorOneWebsiteSeveralDaysDateRangeArchivingTest extends SystemTestCa
             'archive_numeric_2011_01' => (6 + 3),
 
             // nothing in Feb
-            'archive_blob_2011_02'    => 0,
             'archive_numeric_2011_02' => 0,
         );
+        $tablesThatShouldNotExist = [
+            'archive_blob_2011_02',
+        ];
         foreach ($tests as $table => $expectedRows) {
             $sql = "SELECT count(*) FROM " . Common::prefixTable($table) . " WHERE period = " . Piwik::$idPeriods['range'];
             $countBlobs = Db::get()->fetchOne($sql);
@@ -159,6 +161,9 @@ class OneVisitorOneWebsiteSeveralDaysDateRangeArchivingTest extends SystemTestCa
                 $this->printDebugWhenTestFails($table);
             }
             $this->assertEquals($expectedRows, $countBlobs, "$table expected $expectedRows, got $countBlobs");
+        }
+        foreach ($tablesThatShouldNotExist as $table) {
+            $this->assertEmpty(Db::fetchAll("SHOW TABLES LIKE '$table'"));
         }
     }
 


### PR DESCRIPTION
This PR is a Proof of concept, so should not be merged. I want to get these ideas vetted before moving forward.

## Changes in this PR

* Extracted the `$idArchives` cache in Archive.php to a separate class that is loaded through DI. This decouples the cache from the specific Archive instance that holds it. It also makes the cache last throughout a request.
* Extract archive ID fetching, archive data fetching & archiving process initialization from Archive.php to a new class called ArchiveTableStore. I didn't want to spend too much time changing things if this wasn't deemed a good idea, so I just moved code, I didn't refactor existing code.
* Extract Archive instance creation into a new ArchiveQueryFactory class. This required making the Archive class constructor public.

## Changes that haven't been made yet

* Adding the archive table insertion code in ArchiveProcessor (& whatever other classes) to ArchiveTableStore.
* Extracting the archive initialization process from ArchiveTableStore somehow (haven't thought of how).
* Creating an interface for ArchiveTableStore to implement (called RecordDataStore or something) to generalize & specify how "archive data" is stored.

These don't have to be done in a single PR.

## Purpose

The purpose of these changes are to allow plugins to do the following things:

1. Override Archive instance creation via the new factory class to handle, eg, new period types.
2. Supply a custom ArchiveTableStore to Archive class so it's possible to bypass archiving entirely for certain requests.

Together this will allow re-using other plugins' API methods that serve reports w/ a custom period type and/or disabling the use of the archive tables (so the request always aggregates & doesn't store new data in the archive tables).

## Other things it might enable

Eventually the use of a RecordDataStore interface might enable different backends being used for archive data.