### PR TITLE
Improves / Fixes some UI tests

### DIFF
--- a/tests/UI/expected-screenshots/Dashboard_rowevolution.png
+++ b/tests/UI/expected-screenshots/Dashboard_rowevolution.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:056cb8e56446622dfca8b937268655e9a268f03b084c7faa60362110ae67a3aa
+size 71105

--- a/tests/UI/expected-screenshots/Overlay_page_new_links.png
+++ b/tests/UI/expected-screenshots/Overlay_page_new_links.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37d5585ce3c48cb49c152a1f7b67dff826e5bad59ce2b0c07298672c99d95b70
-size 105869
+oid sha256:dc9dd34c74e1f3572fa646f289a92c60d5c5dd49a778ff1a5c9af1300cfc72f4
+size 118366

--- a/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0928197e1ce7e33e4080043a11add57af4ef0d597d394e0b2370ef6d68cf5896
-size 202320
+oid sha256:474891899e2f81e9079aba72bb3e48f8cd1a27b24a67aa68e4d10f432685fda1
+size 203076

--- a/tests/UI/specs/Dashboard_spec.js
+++ b/tests/UI/specs/Dashboard_spec.js
@@ -133,8 +133,8 @@ describe("Dashboard", function () {
     });
 
     it("should open row evolution", function (done) {
-        expect.screenshot("rowevolution").to.be.capture(function (page) {
-            page.mouseMove('#widgetActionsgetPageUrls table.dataTable tbody tr:contains(thankyou)');
+        expect.screenshot("rowevolution").to.be.captureSelector('.ui-dialog:visible', function (page) {
+            page.mouseMove('#widgetActionsgetPageUrls table.dataTable tbody tr:contains(thankyou) td:first-child', 100);
             page.mouseMove('a.actionRowEvolution:visible'); // necessary to get popover to display
             page.click('a.actionRowEvolution:visible', 2000);
         }, done);

--- a/tests/UI/specs/Overlay_spec.js
+++ b/tests/UI/specs/Overlay_spec.js
@@ -70,17 +70,10 @@ describe("Overlay", function () {
 
     it("should show stats for new links when dropdown opened", function (done) {
         expect.screenshot("page_new_links").to.be.capture(function (page) {
-            var pos = page.webpage.evaluate(function () {
-                var iframe = $('iframe'),
-                    innerOffset = $('.dropdown-toggle', iframe.contents()).offset();
-                return {
-                    x: iframe.offset().left + innerOffset.left + 32, // position is incorrect for some reason w/o adding pixels
-                    y: iframe.offset().top + innerOffset.top
-                };
-            });
-            page.sendMouseEvent('click', pos);
-            page.wait(2000);
-
+            page.reload(2500);
+            page.evaluate(function(){
+                $('.dropdown-toggle', $('iframe').contents())[0].click();
+            }, 500);
             removeOptOutIframe(page);
         }, done);
     });

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -562,6 +562,14 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         expect.screenshot('fatal_error_safemode').to.be.capture(function (page) {
             page.load("?" + generalParams + "&module=CorePluginsAdmin&action=safemode&idSite=1&period=day&date=yesterday&activated"
                     + "&error_message=" + message + "&error_file=" + file + "&error_line=" + line + "&tests_hide_piwik_version=1");
+            page.evaluate(function () {
+                var elements = document.querySelectorAll('table tr td:nth-child(2)');
+                for (var i in elements) {
+                    if (elements.hasOwnProperty(i) && elements[i].innerText.match(/^[0-9]\.[0-9]\.[0-9]$/)) {
+                        elements[i].innerText = '3.0.0'
+                    }
+                }
+            });
         }, done);
     });
 


### PR DESCRIPTION
* Improves `UIIntegrationTest_fatal_error_safemode` by overwriting all shown version numbers of plugins. This eliminates the need to update the screenshot with every new plugin release.

* Fixes `Overlay_page_new_links`, which was failing a long time already

* Fixes `Dashboard_rowevolution`, which was added to prevent new regressions, but wasn't working correctly

fixes #11550 