### PR TITLE
Add plugin.json for Contents plugin

### DIFF
--- a/plugins/Contents/plugin.json
+++ b/plugins/Contents/plugin.json
@@ -1,0 +1,4 @@
+{
+ "name": "Contents",
+ "description": "Content and banner tracking lets you measure the performance (views, clicks, CTR) of any piece of content on your pages (Banner ad, image, any item)."
+}


### PR DESCRIPTION
Without it, it did not load the translation keys on my local installation as it was ignored by the plugin manager.

This is because we check here for a valid plugin structure https://github.com/piwik/piwik/blob/3.0.4/core/Plugin/Manager.php#L301 but Contents has neither plugin.json nor a plugin file
