### PR TITLE
Fix core:updater needs to be executed twice

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -31,6 +31,12 @@ class Filesystem
         TrackerCache::deleteTrackerCache();
         PiwikCache::flushAll();
         self::clearPhpCaches();
+        
+        $pluginManager = Plugin\Manager::getInstance();
+        $plugins = $pluginManager->getLoadedPlugins();
+        foreach ($plugins as $plugin) {
+            $plugin->reloadPluginInformation();
+        }
     }
 
     /**


### PR DESCRIPTION
I haven't tried to reproduce it actually but this will reload all plugin information after clearing the cache and then should find the plugin update on the first try.

fix #11831