### PR TITLE
Changes to support custom periods

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -88,5 +88,4 @@ return array(
 
     'Piwik\Tracker\Settings' => DI\object()
         ->constructorParameter('isSameFingerprintsAcrossWebsites', DI\get('ini.Tracker.enable_fingerprinting_across_websites')),
-
 );

--- a/core/Archive/ArchiveQuery.php
+++ b/core/Archive/ArchiveQuery.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Archive;
+
+
+use Piwik\DataTable;
+
+interface ArchiveQuery
+{
+    /**
+     * @param string|string[] $names
+     * @return false|number|array
+     */
+    public function getNumeric($names);
+
+    /**
+     * @param string|string[] $names
+     * @return DataTable|DataTable\Map
+     */
+    public function getDataTableFromNumeric($names);
+
+    /**
+     * @param $names
+     * @return mixed
+     */
+    public function getDataTableFromNumericAndMergeChildren($names);
+
+    /**
+     * @param string $name
+     * @param int|string|null $idSubtable
+     * @return DataTable|DataTable\Map
+     */
+    public function getDataTable($name, $idSubtable = null);
+
+    /**
+     * @param string $name
+     * @param int|string|null $idSubtable
+     * @param int|null $depth
+     * @param bool $addMetadataSubtableId
+     * @return DataTable|DataTable\Map
+     */
+    public function getDataTableExpanded($name, $idSubtable = null, $depth = null, $addMetadataSubtableId = true);
+}

--- a/core/Archive/ArchiveQueryFactory.php
+++ b/core/Archive/ArchiveQueryFactory.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Archive;
+
+use Piwik\Archive;
+use Piwik\Period;
+use Piwik\Segment;
+use Piwik\Site;
+use Piwik\Period\Factory as PeriodFactory;
+
+class ArchiveQueryFactory
+{
+    public function __construct()
+    {
+        // empty
+    }
+
+    /**
+     * @see \Piwik\Archive::build()
+     */
+    public function build($idSites, $strPeriod, $strDate, $strSegment = false, $_restrictSitesToLogin = false)
+    {
+        list($websiteIds, $timezone, $idSiteIsAll) = $this->getSiteInfoFromQueryParam($idSites, $_restrictSitesToLogin);
+        list($allPeriods, $isMultipleDate) = $this->getPeriodInfoFromQueryParam($strDate, $strPeriod, $timezone);
+        $segment = $this->getSegmentFromQueryParam($strSegment, $websiteIds);
+
+        return $this->factory($segment, $allPeriods, $websiteIds, $idSiteIsAll, $isMultipleDate);
+    }
+
+    /**
+     * @see \Piwik\Archive::factory()
+     */
+    public function factory(Segment $segment, array $periods, array $idSites, $idSiteIsAll = false, $isMultipleDate = false)
+    {
+        $forceIndexedBySite = false;
+        $forceIndexedByDate = false;
+
+        if ($idSiteIsAll || count($idSites) > 1) {
+            $forceIndexedBySite = true;
+        }
+
+        if (count($periods) > 1 || $isMultipleDate) {
+            $forceIndexedByDate = true;
+        }
+
+        $params = new Parameters($idSites, $periods, $segment);
+
+        return $this->newInstance($params, $forceIndexedBySite, $forceIndexedByDate);
+    }
+
+    public function newInstance(Parameters $params, $forceIndexedBySite, $forceIndexedByDate)
+    {
+        return new Archive($params, $forceIndexedBySite, $forceIndexedByDate);
+    }
+
+    /**
+     * Parses the site ID string provided in the 'idSite' query parameter to a list of
+     * website IDs.
+     *
+     * @param string $idSites the value of the 'idSite' query parameter
+     * @param bool $_restrictSitesToLogin
+     * @return array an array containing three elements:
+     *     - an array of website IDs
+     *     - string timezone to use (or false to use no timezone) when creating periods.
+     *     - true if the request was for all websites (this forces the archive result to
+     *       be indexed by site, even if there is only one site in Piwik)
+     */
+    protected function getSiteInfoFromQueryParam($idSites, $_restrictSitesToLogin)
+    {
+        $websiteIds = Site::getIdSitesFromIdSitesString($idSites, $_restrictSitesToLogin);
+
+        $timezone = false;
+        if (count($websiteIds) == 1) {
+            $timezone = Site::getTimezoneFor($websiteIds[0]);
+        }
+
+        $idSiteIsAll = $idSites == Archive::REQUEST_ALL_WEBSITES_FLAG;
+
+        return [$websiteIds, $timezone, $idSiteIsAll];
+    }
+
+    /**
+     * Parses the date & period query parameters into a list of periods.
+     *
+     * @param string $strDate the value of the 'date' query parameter
+     * @param string $strPeriod the value of the 'period' query parameter
+     * @param string $timezone the timezone to use when constructing periods.
+     * @return array an array containing two elements:
+     *     - the list of period objects to query archive data for
+     *     - true if the request was for multiple periods (ie, two months, two weeks, etc.), false if otherwise.
+     *       (this forces the archive result to be indexed by period, even if the list of periods
+     *       has only one period).
+     */
+    protected function getPeriodInfoFromQueryParam($strDate, $strPeriod, $timezone)
+    {
+        if (Period::isMultiplePeriod($strDate, $strPeriod)) {
+            $oPeriod    = PeriodFactory::build($strPeriod, $strDate, $timezone);
+            $allPeriods = $oPeriod->getSubperiods();
+        } else {
+            $oPeriod    = PeriodFactory::makePeriodFromQueryParams($timezone, $strPeriod, $strDate);
+            $allPeriods = array($oPeriod);
+        }
+
+        $isMultipleDate = Period::isMultiplePeriod($strDate, $strPeriod);
+
+        return [$allPeriods, $isMultipleDate];
+    }
+
+    /**
+     * Parses the segment query parameter into a Segment object.
+     *
+     * @param string $strSegment the value of the 'segment' query parameter.
+     * @param int[] $websiteIds the list of sites being queried.
+     * @return Segment
+     */
+    protected function getSegmentFromQueryParam($strSegment, $websiteIds)
+    {
+        return new Segment($strSegment, $websiteIds);
+    }
+}

--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -159,7 +159,11 @@ class Parameters
     public function isSingleSiteDayArchive()
     {
         $oneSite = $this->isSingleSite();
-        $oneDay = $this->getPeriod()->getLabel() == 'day';
+
+        $period = $this->getPeriod();
+        $secondsInPeriod = $period->getDateEnd()->getTimestampUTC() - $period->getDateStart()->getTimestampUTC();
+        $oneDay = $secondsInPeriod <= Date::NUM_SECONDS_IN_DAY;
+
         return $oneDay && $oneSite;
     }
 

--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -154,6 +154,26 @@ class Parameters
     }
 
     /**
+     * Returns the start day of the period in the site's timezone (includes the time of day).
+     *
+     * @return Date
+     */
+    public function getDateTimeStart()
+    {
+        return $this->getPeriod()->getDateTimeStart()->setTimezone($this->getSite()->getTimezone());
+    }
+
+    /**
+     * Returns the end day of the period in the site's timezone (includes the time of day).
+     *
+     * @return Date
+     */
+    public function getDateTimeEnd()
+    {
+        return $this->getPeriod()->getDateTimeEnd()->setTimezone($this->getSite()->getTimezone());
+    }
+
+    /**
      * @return bool
      */
     public function isSingleSiteDayArchive()

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -49,11 +49,11 @@ class PluginsArchiver
      */
     public static $archivers = array();
 
-    public function __construct(Parameters $params, $isTemporaryArchive)
+    public function __construct(Parameters $params, $isTemporaryArchive, ArchiveWriter $archiveWriter = null)
     {
         $this->params = $params;
         $this->isTemporaryArchive = $isTemporaryArchive;
-        $this->archiveWriter = new ArchiveWriter($this->params, $this->isTemporaryArchive);
+        $this->archiveWriter = $archiveWriter ?: new ArchiveWriter($this->params, $this->isTemporaryArchive);
         $this->archiveWriter->initNewArchive();
 
         $this->logAggregator = new LogAggregator($params);

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -11,8 +11,10 @@ namespace Piwik\DataAccess;
 use Piwik\ArchiveProcessor\Parameters;
 use Piwik\Common;
 use Piwik\DataArray;
+use Piwik\Date;
 use Piwik\Db;
 use Piwik\Metrics;
+use Piwik\Period;
 use Piwik\Tracker\GoalManager;
 
 /**
@@ -147,8 +149,8 @@ class LogAggregator
      */
     public function __construct(Parameters $params)
     {
-        $this->dateStart = $params->getDateStart();
-        $this->dateEnd = $params->getDateEnd();
+        $this->dateStart = $params->getDateTimeStart();
+        $this->dateEnd = $params->getDateTimeEnd();
         $this->segment = $params->getSegment();
         $this->sites = $params->getIdSites();
     }
@@ -503,7 +505,7 @@ class LogAggregator
      */
     protected function getGeneralQueryBindParams()
     {
-        $bind = array($this->dateStart->getDateStartUTC(), $this->dateEnd->getDateEndUTC());
+        $bind = array($this->dateStart->toString(Date::DATE_TIME_FORMAT), $this->dateEnd->toString(Date::DATE_TIME_FORMAT));
         $bind = array_merge($bind, $this->sites);
 
         return $bind;

--- a/core/Date.php
+++ b/core/Date.php
@@ -178,17 +178,34 @@ class Date
     }
 
     /**
-     * Returns the start of the day of the current timestamp in UTC. For example,
-     * if the current timestamp is `'2007-07-24 14:04:24'` in UTC, the result will
-     * be `'2007-07-24'`.
-     *
      * @return string
+     * @deprecated
      */
     public function getDateStartUTC()
     {
+        return $this->getStartOfDay()->toString(self::DATE_TIME_FORMAT);
+    }
+
+    /**
+     * Returns the start of the day of the current timestamp in UTC. For example,
+     * if the current timestamp is `'2007-07-24 14:04:24'` in UTC, the result will
+     * be `'2007-07-24'` as a Date.
+     *
+     * @return Date
+     */
+    public function getStartOfDay()
+    {
         $dateStartUTC = gmdate('Y-m-d', $this->timestamp);
-        $date = Date::factory($dateStartUTC)->setTimezone($this->timezone);
-        return $date->toString(self::DATE_TIME_FORMAT);
+        return Date::factory($dateStartUTC)->setTimezone($this->timezone);
+    }
+
+    /**
+     * @return string
+     * @deprecated
+     */
+    public function getDateEndUTC()
+    {
+        return $this->getEndOfDay()->toString(self::DATE_TIME_FORMAT);
     }
 
     /**
@@ -196,13 +213,12 @@ class Date
      * if the current timestamp is `'2007-07-24 14:03:24'` in UTC, the result will
      * be `'2007-07-24 23:59:59'`.
      *
-     * @return string
+     * @return Date
      */
-    public function getDateEndUTC()
+    public function getEndOfDay()
     {
         $dateEndUTC = gmdate('Y-m-d 23:59:59', $this->timestamp);
-        $date = Date::factory($dateEndUTC)->setTimezone($this->timezone);
-        return $date->toString(self::DATE_TIME_FORMAT);
+        return Date::factory($dateEndUTC)->setTimezone($this->timezone);
     }
 
     /**

--- a/core/Period.php
+++ b/core/Period.php
@@ -135,6 +135,26 @@ abstract class Period
     }
 
     /**
+     * Returns the start date & time of this period.
+     *
+     * @return Date
+     */
+    public function getDateTimeStart()
+    {
+        return $this->getDateStart()->getStartOfDay();
+    }
+
+    /**
+     * Returns the end date & time of this period.
+     *
+     * @return Date
+     */
+    public function getDateTimeEnd()
+    {
+        return $this->getDateEnd()->getEndOfDay();
+    }
+
+    /**
      * Returns the last day of the period.
      *
      * @return Date

--- a/plugins/ImageGraph/ImageGraph.php
+++ b/plugins/ImageGraph/ImageGraph.php
@@ -14,6 +14,7 @@ use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Period;
 use Piwik\Period\Range;
+use Piwik\Piwik;
 use Piwik\Scheduler\Scheduler;
 use Piwik\Site;
 use Piwik\Url;

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -36,7 +36,14 @@ class Archive extends PiwikArchive
     {
         return parent::get($archiveNames, $archiveDataType, $idSubtable);
     }
+}
 
+class CustomArchiveQueryFactory extends PiwikArchive\ArchiveQueryFactory
+{
+    public function newInstance(\Piwik\Archive\Parameters $params, $forceIndexedBySite, $forceIndexedByDate)
+    {
+        return new Archive($params, $forceIndexedBySite, $forceIndexedByDate);
+    }
 }
 
 /**
@@ -251,7 +258,7 @@ class ArchiveTest extends IntegrationTestCase
         $this->assertEquals('UserLanguage_LanguageCode fr', $userLanguageReport->getFirstRow()->getColumn('label'));
         $this->assertEquals('UserLanguage_LanguageCode fr', $userLanguageReport->getLastRow()->getColumn('label'));
 
-        $parameters = new Parameters(new Site(1), $period, new Segment('', ''));
+        $parameters = new Parameters(new Site(1), $period, new Segment('', []));
         $parameters->setRequestedPlugin('UserLanguage');
 
         $result    = ArchiveSelector::getArchiveIdAndVisits($parameters, $period->getDateStart()->getDateStartUTC());
@@ -387,9 +394,20 @@ class ArchiveTest extends IntegrationTestCase
         return $archive->getNumeric('nb_visits');
     }
 
+    /**
+     * @return Archive
+     */
     private function getArchive($period, $day = '2010-03-04,2010-03-07')
     {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return Archive::build(self::$fixture->idSite, $period, $day);
+    }
+
+    public function provideContainerConfig()
+    {
+        return [
+            PiwikArchive\ArchiveQueryFactory::class => \DI\object(CustomArchiveQueryFactory::class),
+        ];
     }
 }
 

--- a/tests/PHPUnit/Integration/Period/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Period/FactoryTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Period;
+
+use Piwik\Config;
+use Piwik\Period;
+use Piwik\Period\Day;
+use Piwik\Period\Month;
+use Piwik\Period\Range;
+use Piwik\Period\Week;
+use Piwik\Period\Year;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+class TestPeriod
+{
+    // empty
+}
+
+class TestPeriodFactory extends Period\Factory
+{
+    /**
+     * @var Config
+     */
+    private $config;
+
+    // use constructor to make sure period factories are injected
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    public function shouldHandle($strPeriod, $strDate)
+    {
+        return $strPeriod == 'customperiod';
+    }
+
+    public function make($strPeriod, $date, $timezone)
+    {
+        return new TestPeriod();
+    }
+}
+
+class MockPluginManager extends \Piwik\Plugin\Manager
+{
+    public function findComponents($componentName, $expectedSubclass)
+    {
+        if ($componentName == 'PeriodFactory') {
+            return [
+                TestPeriodFactory::class,
+            ];
+        }
+
+        return parent::findComponents($componentName, $expectedSubclass);
+    }
+}
+
+class FactoryTest extends IntegrationTestCase
+{
+    /**
+     * @dataProvider getBuildTestData
+     */
+    public function test_build_CreatesCorrectPeriodInstances($strPeriod, $date, $timezone, $expectedPeriodClass,
+                                                            $expectedRangeString)
+    {
+        $period = Period\Factory::build($strPeriod, $date, $timezone);
+        $this->assertInstanceOf($expectedPeriodClass, $period);
+        $this->assertEquals($expectedRangeString, $period->getRangeString());
+    }
+
+    public function getBuildTestData()
+    {
+        return [
+            ['day', '2015-01-01', 'UTC', Day::class, '2015-01-01,2015-01-01'],
+            ['week', '2015-01-01', 'UTC', Week::class, '2014-12-29,2015-01-04'],
+            ['month', '2015-01-01', 'UTC', Month::class, '2015-01-01,2015-01-31'],
+            ['year', '2015-01-01', 'UTC', Year::class, '2015-01-01,2015-12-31'],
+
+            ['range', '2015-01-01,2015-01-10', 'UTC', Range::class, '2015-01-01,2015-01-10'],
+            ['range', '2015-01-01,2015-01-10', 'Antarctica/Casey', Range::class, '2015-01-01,2015-01-10'],
+
+            // multiple periods
+            ['day', '2015-01-01,2015-01-10', 'UTC', Range::class, '2015-01-01,2015-01-10'],
+            ['week', '2015-01-01,2015-01-10', 'UTC', Range::class, '2014-12-29,2015-01-11'],
+            ['month', '2015-01-01,2015-02-10', 'UTC', Range::class, '2015-01-01,2015-02-28'],
+            ['year', '2015-01-01,2016-01-10', 'UTC', Range::class, '2015-01-01,2016-12-31'],
+        ];
+    }
+
+    public function test_build_CreatesCustomPeriodInstances()
+    {
+        Config::getInstance()->General['enabled_periods_API'] .= ',customperiod';
+
+        $period = Period\Factory::build('customperiod', '2015-01-01');
+        $this->assertInstanceOf(TestPeriod::class, $period);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage General_ExceptionInvalidPeriod
+     */
+    public function test_build_ThrowsIfPeriodIsUnrecognized()
+    {
+        Period\Factory::build('garbageperiod', '2015-01-01');
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage General_ExceptionInvalidPeriod
+     */
+    public function test_build_ThrowsIfPeriodIsNotEnabledForApi()
+    {
+        Config::getInstance()->General['enabled_periods_API'] = 'day';
+        Period\Factory::build('week', '2015-01-01');
+    }
+
+    public function provideContainerConfig()
+    {
+        return [
+            \Piwik\Plugin\Manager::class => \DI\object(MockPluginManager::class),
+        ];
+    }
+}

--- a/tests/PHPUnit/Unit/PeriodTest.php
+++ b/tests/PHPUnit/Unit/PeriodTest.php
@@ -52,40 +52,6 @@ class PeriodTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($label);
     }
 
-    public function testFactoryDay()
-    {
-        $period = Period\Factory::build('day', Date::today());
-        $this->assertInstanceOf('\Piwik\Period\Day', $period);
-    }
-
-    public function testFactoryMonth()
-    {
-        $period = Period\Factory::build('month', Date::today());
-        $this->assertInstanceOf('\Piwik\Period\Month', $period);
-    }
-
-    public function testFactoryWeek()
-    {
-        $period = Period\Factory::build('week', Date::today());
-        $this->assertInstanceOf('\Piwik\Period\Week', $period);
-    }
-
-    public function testFactoryYear()
-    {
-        $period = Period\Factory::build('year', Date::today());
-        $this->assertInstanceOf('\Piwik\Period\Year', $period);
-    }
-
-    public function testFactoryInvalid()
-    {
-        try {
-            Period\Factory::build('inValid', Date::today());
-        } catch (\Exception $e) {
-            return;
-        }
-        $this->fail('Expected Exception not raised');
-    }
-
     public function testValidate_ValidDates()
     {
         Period::checkDateFormat('today');


### PR DESCRIPTION
This PR contains the following changes which allow defining & handling custom period types.

## Changes

* Add the ArchiveQueryFactory class & ArchiveQuery interface so plugins can intercept Archive instance creation.
* Add the CustomPeriodFactory interface to handle creating new period instances.
* Make period responsible for determining start/end time of periods so aggregation is not limited to days w/o times.
* Allow specifying a custom archive writer in PluginsArchiver.

## Notes

* This PR should be reviewed for any potential BC breaks. Don't think there are any, but I may have missed something.
* This PR can be reviewed commit by commit.