### PR TITLE
Hides "invalid site" error from non-super-users

### DIFF
--- a/plugins/SitesManager/Controller.php
+++ b/plugins/SitesManager/Controller.php
@@ -148,8 +148,11 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $javascriptGenerator = new TrackerCodeGenerator();
         $piwikUrl = Url::getCurrentUrlWithoutFileName();
 
-        if (!$this->site) {
+        if (!$this->site && Piwik::hasUserSuperUserAccess()) {
             throw new UnexpectedWebsiteFoundException('Invalid site ' . $this->idSite);
+        } elseif (!$this->site) {
+            // redirect to login form
+            Piwik::checkUserHasViewAccess($this->idSite);
         }
 
         return $this->renderTemplate('siteWithoutData', array(


### PR DESCRIPTION
[refs #11848]

This patch displays the login page for regular users while still showing the "invalid site" message for a super user. That might not be the usual way for this kind of behaviour but is easily changeable by just modifying that check.

As there has been no UITest failing for this change it might be interesting to add a new one to the test suite.