### PR TITLE
Improve test for non unix line endings

### DIFF
--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -417,7 +417,6 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
                 strpos($file, '/tests/') !== false ||
                 strpos($file, '/lang/') !== false ||
                 strpos($file, 'yuicompressor') !== false ||
-                strpos($file, '/libs/') !== false ||
                 (strpos($file, '/vendor') !== false && strpos($file, '/vendor/piwik') === false) ||
                 strpos($file, '/tmp/') !== false ||
                 strpos($file, '/phantomjs/') !== false

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -2873,7 +2873,7 @@ function PiwikTest() {
         
         tracker.setUserId('test');
         var replacedUrl = makeReplaceHrefForCrossDomainLink('http://www.example.com');
-        ok(replacedUrl.indexOf('http://www.example.com?pk_vid=a94a8fe5ccb19ba615') === 0, 'replaceHrefForCrossDomainLink, should set parameters if a URL is given ' + replacedUrl);
+        ok(replacedUrl.indexOf('http://www.example.com?pk_vid=a94a8fe5ccb19ba615') === 0, 'replaceHrefForCrossDomainLink, should set parameters if a URL is given');
         ok(replacedUrl.indexOf(browserId) > 20, 'replaceHrefForCrossDomainLink, should set browserId if a url is given');
 
         replacedUrl = makeReplaceHrefForCrossDomainLink(makeUrlWithVisitorId(true, currentTimestamp, 'foobar'));


### PR DESCRIPTION
`libs` folder have been skipped before. That didn't let us notice #11869 before.

fixes #11869 