### PR TITLE
Ignore table not found errors when removing plugin or measurable settings

### DIFF
--- a/core/Settings/Storage/Backend/MeasurableSettingsTable.php
+++ b/core/Settings/Storage/Backend/MeasurableSettingsTable.php
@@ -150,8 +150,15 @@ class MeasurableSettingsTable implements BackendInterface
      */
     public static function removeAllSettingsForSite($idSite)
     {
-        $query = sprintf('DELETE FROM %s WHERE idsite = ?', Common::prefixTable('site_setting'));
-        Db::query($query, array($idSite));
+        try {
+            $query = sprintf('DELETE FROM %s WHERE idsite = ?', Common::prefixTable('site_setting'));
+            Db::query($query, array($idSite));
+        } catch (Exception $e) {
+            if ($e->getCode() != 42) {
+                // ignore table not found error, which might occur when updating from an older version of Piwik
+                throw $e;
+            }
+        }
     }
 
     /**
@@ -161,7 +168,14 @@ class MeasurableSettingsTable implements BackendInterface
      */
     public static function removeAllSettingsForPlugin($pluginName)
     {
-        $query = sprintf('DELETE FROM %s WHERE plugin_name = ?', Common::prefixTable('site_setting'));
-        Db::query($query, array($pluginName));
+        try {
+            $query = sprintf('DELETE FROM %s WHERE plugin_name = ?', Common::prefixTable('site_setting'));
+            Db::query($query, array($pluginName));
+        } catch (Exception $e) {
+            if ($e->getCode() != 42) {
+                // ignore table not found error, which might occur when updating from an older version of Piwik
+                throw $e;
+            }
+        }
     }
 }

--- a/core/Settings/Storage/Backend/PluginSettingsTable.php
+++ b/core/Settings/Storage/Backend/PluginSettingsTable.php
@@ -155,8 +155,15 @@ class PluginSettingsTable implements BackendInterface
             throw new Exception('No userLogin specified. Cannot remove all settings for this user');
         }
 
-        $table = Common::prefixTable('plugin_setting');
-        Db::get()->query(sprintf('DELETE FROM %s WHERE user_login = ?', $table), array($userLogin));
+        try {
+            $table = Common::prefixTable('plugin_setting');
+            Db::get()->query(sprintf('DELETE FROM %s WHERE user_login = ?', $table), array($userLogin));
+        } catch (Exception $e) {
+            if ($e->getCode() != 42) {
+                // ignore table not found error, which might occur when updating from an older version of Piwik
+                throw $e;
+            }
+        }
     }
 
     /**
@@ -169,7 +176,14 @@ class PluginSettingsTable implements BackendInterface
      */
     public static function removeAllSettingsForPlugin($pluginName)
     {
-        $table = Common::prefixTable('plugin_setting');
-        Db::get()->query(sprintf('DELETE FROM %s WHERE plugin_name = ?', $table), array($pluginName));
+        try {
+            $table = Common::prefixTable('plugin_setting');
+            Db::get()->query(sprintf('DELETE FROM %s WHERE plugin_name = ?', $table), array($pluginName));
+        } catch (Exception $e) {
+            if ($e->getCode() != 42) {
+                // ignore table not found error, which might occur when updating from an older version of Piwik
+                throw $e;
+            }
+        }
     }
 }


### PR DESCRIPTION
As described in #11067, it might happen the plugin or measurable settings might not have been created when updating from an old version.

Ignoring those table not found errors seems to be the simplest solution, as there is no need to remove anything if the table doesn't exist at all

fixes #11067