### PR TITLE
removes usage of deprecated jQuery.size() (#11874)

### DIFF
--- a/plugins/Actions/javascripts/actionsDataTable.js
+++ b/plugins/Actions/javascripts/actionsDataTable.js
@@ -66,7 +66,7 @@
             if (!self.param.filter_pattern_recursive) {
                 self.numberOfSubtables = rows.filter('.subDataTable').click(function () {
                     self.onClickActionSubDataTable(this)
-                }).size();
+                }).length;
             }
             self.applyCosmetics(domElem, rows);
             self.handleColumnHighlighting(domElem);

--- a/plugins/CoreHome/angularjs/common/directives/field-condition.js
+++ b/plugins/CoreHome/angularjs/common/directives/field-condition.js
@@ -59,7 +59,7 @@
             scope.allValues = {};
             angular.forEach(fieldNames, function (name) {
                 var actualField = $('.form-group [name=' + name + ']').first();
-                if (actualField.size()) {
+                if (actualField.length) {
                     scope.allValues[name] = getValueFromElement(actualField);
                     actualField.on('change', function () {
                         scope.allValues[name] = getValueFromElement($(this));

--- a/plugins/CoreHome/angularjs/content-block/content-block.directive.js
+++ b/plugins/CoreHome/angularjs/content-block/content-block.directive.js
@@ -38,7 +38,7 @@
 
                 return function (scope, element, attrs) {
                     var inlineHelp = element.find('[ng-transclude] > .contentHelp');
-                    if (inlineHelp.size()) {
+                    if (inlineHelp.length) {
                         scope.helpText = inlineHelp.html();
                         inlineHelp.remove();
                     }
@@ -54,14 +54,14 @@
 
                     var contentTopPosition = false;
 
-                    if (adminContent.size()) {
+                    if (adminContent.length) {
                         contentTopPosition = adminContent.offset().top;
                     }
 
                     if (contentTopPosition || contentTopPosition === 0) {
                         var parents = element.parentsUntil('.col', '[piwik-widget-loader]');
                         var topThis;
-                        if (parents.size()) {
+                        if (parents.length) {
                             // when shown within the widget loader, we need to get the offset of that element
                             // as the widget loader might be still shown. Would otherwise not position correctly
                             // the widgets on the admin home page

--- a/plugins/CoreHome/angularjs/selector/selector.directive.js
+++ b/plugins/CoreHome/angularjs/selector/selector.directive.js
@@ -24,7 +24,7 @@
 
                     var $position = element.find('.dropdown.positionInViewport');
 
-                    if ($position.size()) {
+                    if ($position.length) {
                         piwik.helper.setMarginLeftToBeInViewport($position);
                     }
                 });
@@ -66,7 +66,7 @@
 
                     var $position = element.find('.dropdown.positionInViewport');
 
-                    if ($position.size()) {
+                    if ($position.length) {
                         piwik.helper.setMarginLeftToBeInViewport($position);
                     }
                 });

--- a/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.js
+++ b/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.js
@@ -135,11 +135,11 @@
                             if (scope.widgetName) {
                                 // we need to respect the widget title, which overwrites a possibly set report title
                                 var $title = currentElement.find('> .card-content .card-title');
-                                if ($title.size()) {
+                                if ($title.length) {
                                     $title.text(scope.widgetName);
                                 } else {
                                     $title = currentElement.find('> h2');
-                                    if ($title.size()) {
+                                    if ($title.length) {
                                         $title.text(scope.widgetName);
                                     }
                                 }

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -603,14 +603,14 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         } else {
             var inReportPage = domElem.parents('.theWidgetContent').first();
             var displayedAsCard = inReportPage.find('> .card > .card-content');
-            if (displayedAsCard.size()) {
+            if (displayedAsCard.length) {
                 $domNodeToSetOverflow = displayedAsCard.first();
             } else {
                 $domNodeToSetOverflow = inReportPage;
             }
         }
 
-        if (!$domNodeToSetOverflow || !$domNodeToSetOverflow.size()) {
+        if (!$domNodeToSetOverflow || !$domNodeToSetOverflow.length) {
             return;
         }
 
@@ -795,7 +795,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         });
 
         var $searchAction = $('.dataTableAction.searchAction', domElem);
-        if (!$searchAction.size()) {
+        if (!$searchAction.length) {
             return;
         }
 
@@ -1353,7 +1353,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             $('.dropdownConfigureIcon', domElem).remove();
         }
 
-        if (ul.find('li').size() == 0) {
+        if (!ul.find('li').length) {
             hideConfigurationIcon();
             return;
         }
@@ -1680,7 +1680,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                 $(this).toggleClass('expanded');
                 self.repositionRowActions($(this));
             }
-        ).size();
+        ).length;
     },
 
     // tooltip for column documentation
@@ -1710,7 +1710,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                 // headline
                 top = top + thPosTop;
 
-                if (th.next().size() == 0) {
+                if (!th.next().length) {
                     left = (-1 * tooltip.outerWidth()) + th.width() +
                         parseInt(th.css('padding-right'), 10);
                 }
@@ -1734,7 +1734,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
     },
 
     canHandleRowEvents: function (domElem) {
-        return domElem.find('table > tbody > tr').size() <= this.maxNumRowsToHandleEvents;
+        return domElem.find('table > tbody > tr').length <= this.maxNumRowsToHandleEvents;
     },
 
     handleRowActions: function (domElem) {
@@ -1773,19 +1773,19 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             }
 
             var $headline = domElem.prev('h2');
-            if (!$headline.size()) {
+            if (!$headline.length) {
                 return;
             }
 
             var $title = $headline.find('.title:not(.ng-hide)');
-            if ($title.size()) {
+            if ($title.length) {
                 $title.text(relatedReportName);
 
                 var scope = $title.scope();
 
                 if (scope) {
                     var $doc = domElem.find('.reportDocumentation');
-                    if ($doc.size()) {
+                    if ($doc.length) {
                         scope.inlineHelp = $.trim($doc.html());
                     }
                     scope.featureName = $.trim(relatedReportName);

--- a/plugins/CoreHome/javascripts/dataTable_rowactions.js
+++ b/plugins/CoreHome/javascripts/dataTable_rowactions.js
@@ -79,7 +79,7 @@ DataTable_RowActions_Registry.register({
             // we look for the data table instance in the dom
             var report = param.split(':')[0];
             var div = $(require('piwik/UI').DataTable.getDataTableByReport(report));
-            if (div.size() > 0 && div.data('uiControlObject')) {
+            if (div.length && div.data('uiControlObject')) {
                 dataTable = div.data('uiControlObject');
                 if (typeof dataTable.rowEvolutionActionInstance != 'undefined') {
                     return dataTable.rowEvolutionActionInstance;
@@ -184,7 +184,7 @@ DataTable_RowAction.prototype.trigger = function (tr, e, subTableLabel) {
             // .prev(.levelX) does not work for some reason => do it "by hand"
             var findLevel = 'level' + (level - 1);
             var ptr = tr;
-            while ((ptr = ptr.prev()).size() > 0) {
+            while ((ptr = ptr.prev()).length) {
                 if (!ptr.hasClass(findLevel) || ptr.hasClass('nodata')) {
                     continue;
                 }
@@ -360,7 +360,7 @@ DataTable_RowActions_RowEvolution.prototype.showRowEvolution = function (apiMeth
 
         // use the popover title returned from the server
         var title = box.find('div.popover-title');
-        if (title.size() > 0) {
+        if (title.length) {
             Piwik_Popover.setTitle(title.html());
             title.remove();
         }

--- a/plugins/CoreHome/templates/widgetContainer.twig
+++ b/plugins/CoreHome/templates/widgetContainer.twig
@@ -7,7 +7,7 @@
         $(function () {
 
             var piwikWidget = $('[piwik-widget][containerid={{ containerId|e('js') }}]');
-            var isExportedAsWidget = $('body > .widget').size();
+            var isExportedAsWidget = $('body > .widget').length;
 
             if (!isExportedAsWidget) {
                 angular.element(document).injector().invoke(function($compile) {

--- a/plugins/CoreVisualizations/javascripts/seriesPicker.js
+++ b/plugins/CoreVisualizations/javascripts/seriesPicker.js
@@ -266,8 +266,8 @@
                     }
                 });
 
-                var noRowSelected = this._pickerPopover.find('.pickRow').size() > 0
-                                 && this._pickerPopover.find('.pickRow input:checked').size() == 0;
+                var noRowSelected = this._pickerPopover.find('.pickRow').length > 0
+                                 && this._pickerPopover.find('.pickRow input:checked').length === 0;
                 if (columns.length > 0 && !noRowSelected) {
                     $(this).trigger('seriesPicked', [columns, rows]);
 

--- a/plugins/Dashboard/javascripts/dashboardObject.js
+++ b/plugins/Dashboard/javascripts/dashboardObject.js
@@ -353,7 +353,7 @@
 
         var $dashboardElement = $(' > .col', dashboardElement);
 
-        if (!$dashboardElement.size()) {
+        if (!$dashboardElement.length) {
             return;
         }
 
@@ -605,7 +605,7 @@
         $(layoutColumnSelector).each(function () {
             columns[columnNumber] = [];
             var items = $('[widgetId]', this);
-            for (var j = 0; j < items.size(); j++) {
+            for (var j = 0; j < items.length; j++) {
                 columns[columnNumber][j] = $(items[j]).dashboardWidget('getWidgetObject');
 
                 // Do not store segment in the dashboard layout

--- a/plugins/Dashboard/javascripts/dashboardWidget.js
+++ b/plugins/Dashboard/javascripts/dashboardWidget.js
@@ -125,12 +125,12 @@
                 /* move widget icons into datatable top actions
                 var $buttons = currentWidget.find('.buttons .button');
                 var $controls = currentWidget.find('.dataTableControls .dataTableAction').first();
-                if ($buttons.size() && $controls.size()) {
+                if ($buttons.length && $controls.length) {
                     $buttons.find('.button').addClass('dataTableAction');
                     $buttons.insertBefore($controls);
                 }*/
 
-                if (currentWidget.parents('body').size()) {
+                if (currentWidget.parents('body').length) {
                     // there might be race conditions, eg widget might be just refreshed while whole dashboard is also
                     // removed from DOM
                     piwikHelper.compileAngularComponents($widgetContent);

--- a/plugins/Installation/javascripts/installation.js
+++ b/plugins/Installation/javascripts/installation.js
@@ -15,7 +15,7 @@ $(document).ready(function() {
         var $help = $(help);
         var $row = $help.parents('.row').first();
 
-        if ($row.size()) {
+        if ($row.length) {
             $help.addClass('col s12 m12 l6');
             $row.append($help);
         }

--- a/plugins/Live/javascripts/SegmentedVisitorLog.js
+++ b/plugins/Live/javascripts/SegmentedVisitorLog.js
@@ -3,7 +3,7 @@ var SegmentedVisitorLog = function() {
     function getDataTableFromApiMethod(apiMethod)
     {
         var div = $(require('piwik/UI').DataTable.getDataTableByReport(apiMethod));
-        if (div.size() > 0 && div.data('uiControlObject')) {
+        if (div.length && div.data('uiControlObject')) {
             return div.data('uiControlObject');
         }
     }
@@ -107,7 +107,7 @@ var SegmentedVisitorLog = function() {
             var title = box.find('h2[piwik-enriched-headline]');
             var defaultTitle = title.text();
 
-            if (title.size() > 0) {
+            if (title.length) {
                 title.remove();
             }
 

--- a/plugins/Live/javascripts/rowaction.js
+++ b/plugins/Live/javascripts/rowaction.js
@@ -21,7 +21,7 @@
     function getDataTableFromApiMethod(apiMethod)
     {
         var div = $(require('piwik/UI').DataTable.getDataTableByReport(apiMethod));
-        if (div.size() > 0 && div.data('uiControlObject')) {
+        if (div.length && div.data('uiControlObject')) {
             return div.data('uiControlObject');
         }
     }

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -432,7 +432,7 @@ var piwikHelper = {
     lazyScrollTo: function(elem, time, forceScroll)
     {
         var $elem = $(elem);
-        if (!$elem.size()) {
+        if (!$elem.length) {
             return;
         }
 

--- a/plugins/Overlay/client/client.js
+++ b/plugins/Overlay/client/client.js
@@ -185,7 +185,7 @@ var Piwik_Overlay_Client = (function () {
 
             return function () {
                 item.remove();
-                if (statusBar.children().size() == 0) {
+                if (!statusBar.children().length) {
                     statusBar.hide();
                 }
             };
@@ -194,7 +194,7 @@ var Piwik_Overlay_Client = (function () {
         /** Hide all notifications with a certain class */
         hideNotifications: function (className) {
             statusBar.find('.PIS_' + className).remove();
-            if (statusBar.children().size() == 0) {
+            if (!statusBar.children().length) {
                 statusBar.hide();
             }
         },

--- a/plugins/Overlay/client/followingpages.js
+++ b/plugins/Overlay/client/followingpages.js
@@ -246,7 +246,7 @@ var Piwik_Overlay_FollowingPages = (function () {
                     }
 
                     // see comment in highlightLink()
-                    if (hasOneChild && linkTag.find('> img').size() == 1) {
+                    if (hasOneChild && linkTag.find('> img').length === 1) {
                         offset = linkTag.find('> img').offset();
                         if (offset.left == 0 && offset.top == 0) {
                             offset = linkTag.offset();
@@ -318,7 +318,7 @@ var Piwik_Overlay_FollowingPages = (function () {
         var visibility = el.css('visibility');
         if (visibility == 'inherit') {
             el = el.parent();
-            if (el.size() > 0) {
+            if (el.length) {
                 return getVisibility(el);
             }
         }
@@ -326,21 +326,21 @@ var Piwik_Overlay_FollowingPages = (function () {
     }
 
     /**
-     * Find out whether a link has only one child. Using .children().size() == 1 doesn't work
+     * Find out whether a link has only one child. Using .children().length === 1 doesn't work
      * because it doesn't take additional text nodes into account.
      */
     function checkHasOneChild(linkTag) {
-        var hasOneChild = (linkTag.children().size() == 1);
+        var hasOneChild = (linkTag.children().length === 1);
         if (hasOneChild) {
             // if the element contains one tag and some text, hasOneChild is set incorrectly
             var contents = linkTag.contents();
-            if (contents.size() > 1) {
+            if (contents.length > 1) {
                 // find non-empty text nodes
                 contents = contents.filter(function () {
                     return this.nodeType == 3 && // text node
                         $.trim(this.data).length > 0; // contains more than whitespaces
                 });
-                if (contents.size() > 0) {
+                if (contents.length) {
                     hasOneChild = false;
                 }
             }
@@ -354,7 +354,7 @@ var Piwik_Overlay_FollowingPages = (function () {
             return typeof this.piwikDiscovered == 'undefined' || this.piwikDiscovered === null;
         });
 
-        if (newLinks.size() == 0) {
+        if (!newLinks.length) {
             return;
         }
 
@@ -386,7 +386,7 @@ var Piwik_Overlay_FollowingPages = (function () {
 
         var offset, height;
         var hasOneChild = checkHasOneChild(linkTag);
-        if (hasOneChild && linkTag.find('img').size() == 1) {
+        if (hasOneChild && linkTag.find('img').length === 1) {
             // if the <a> tag contains only an <img>, the offset and height methods don't work properly.
             // as a result, the box around the image link would be wrong. we use the image to derive
             // the offset and height instead of the link to get correct values.

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -72,7 +72,7 @@ var Piwik_Overlay = (function () {
 
                 $sidebar.empty().append($response).show();
 
-                if ($sidebar.find('.overlayNoData').size() == 0) {
+                if (!$sidebar.find('.overlayNoData').length) {
                     $rowEvolutionLink.show();
                     $transitionsLink.show();
                     if ($('#segment').val()) {

--- a/plugins/Transitions/javascripts/transitions.js
+++ b/plugins/Transitions/javascripts/transitions.js
@@ -1571,7 +1571,7 @@ Piwik_Transitions_Util = {
      */
     replacePlaceholderInHtml: function (container, value, spanClass) {
         var span = container.find('span');
-        if (span.size() == 0) {
+        if (!span.length) {
             var html = container.html().replace(/%s/, '<span></span>');
             span = container.html(html).find('span');
             if (!spanClass) {

--- a/plugins/UserCountryMap/javascripts/visitor-map.js
+++ b/plugins/UserCountryMap/javascripts/visitor-map.js
@@ -1172,7 +1172,7 @@
 
                         // use the popover title returned from the server
                         var title = box.find('div.popover-title');
-                        if (title.size() > 0) {
+                        if (title.length) {
                             Piwik_Popover.setTitle(title.html());
                             title.remove();
                         }
@@ -1251,7 +1251,7 @@
 
                     }
                     // check if CSS is already loaded
-                    if ($("link[href='" + config.mapCssPath + "']").size() === 0) {
+                    if (!$("link[href='" + config.mapCssPath + "']").length) {
                         // not loaded
                         map.loadCSS(config.mapCssPath, postCSSLoad);
                     } else {

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -248,10 +248,10 @@ PageRenderer.prototype._selectFrame = function (frameNameOrPosition, callback) {
             // todo eventually we should also try to find frame by position
             var frame = window.jQuery('iframe[name=' + frameName + ']');
 
-            if (!frame.size()) {
+            if (!frame.length) {
                 frame = window.jQuery('iframe[id=' + frameName + ']');
             }
-            if (frame.size()) {
+            if (frame.length) {
                 return frame.offset();
             }
 


### PR DESCRIPTION
As discovered in #11874 the page overlay breaks when the overlayed page contains it's own version of jQuery. To be specific a version of the 3.x range.

Looking at the console log the culprit is https://api.jquery.com/size/ not being available on a selector result. It was dropped in 3.x after being deprecated since 1.8. And the jQuery from the opened site replaces the one packaged with Piwik.

This patch replaces all calls I could find with the suggested `.length` access. There are 2 additional calls in the `AnonymousPiwikUsageMeasurement` plugin I know of but those need a separate PR.

For good measurement I replaced all calls to `size()` with a boolean style `.length` access. If the more prevalent style should be a real integer check like `.length > 0` I will happily adjust them.