### PR TITLE
makes access_no_config UI test path independent

### DIFF
--- a/tests/UI/specs/Installation_spec.js
+++ b/tests/UI/specs/Installation_spec.js
@@ -36,6 +36,15 @@ describe("Installation", function () {
     it("should display an error message when trying to access a resource w/o a config.ini.php file", function (done) {
         expect.screenshot("access_no_config").to.be.capture(function (page) {
             page.load("?module=CoreHome&action=index&ignoreClearAllViewDataTableParameters=1");
+
+            page.evaluate(function () {
+                // ensure screenshots are reporting travis config file for comparison
+                // no jQuery existing on these error pages...
+                document.body.innerHTML = document.body.innerHTML.replace(
+                    /{\/.*\/test\.config\.ini\.php}/,
+                    '{/home/travis/build/piwik/piwik/tests/lib/screenshot-testing/../../../tmp/test.config.ini.php}'
+                );
+            });
         }, done);
     });
 


### PR DESCRIPTION
Currently the "Installation access_no_config" UI test displays the path to a file in the screenshot. This makes it impossible to succeed any comparison outside of the piwik organisation on travis.

This patch changes the path to always be the "official" one by replacing the found string (requiring to match the filename so that should be good enough) with the expected one. Also makes it possible to have a local run complete without failures.

For reference:
- before change: https://travis-ci.org/mneudert/piwik/jobs/255394715
- after change: https://travis-ci.org/mneudert/piwik/jobs/255829915