### PR TITLE
write timezone (in our case: always "UTC") in log messages

### DIFF
--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -38,7 +38,7 @@ class LineMessageFormatter implements FormatterInterface
     public function format(array $record)
     {
         $class = isset($record['extra']['class']) ? $record['extra']['class'] : '';
-        $date = $record['datetime']->format('Y-m-d H:i:s e');
+        $date = $record['datetime']->format('Y-m-d H:i:s T');
 
         $message = trim($record['message']);
 

--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -38,7 +38,7 @@ class LineMessageFormatter implements FormatterInterface
     public function format(array $record)
     {
         $class = isset($record['extra']['class']) ? $record['extra']['class'] : '';
-        $date = $record['datetime']->format('Y-m-d H:i:s');
+        $date = $record['datetime']->format('Y-m-d H:i:s e');
 
         $message = trim($record['message']);
 

--- a/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
+++ b/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
@@ -33,7 +33,7 @@ class LineMessageFormatterTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $formatted = "ERROR Foo 1970-01-01 00:00:00 Hello world\n";
+        $formatted = "ERROR Foo 1970-01-01 00:00:00 +00:00 Hello world\n";
 
         $this->assertEquals($formatted, $formatter->format($record));
     }

--- a/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
+++ b/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
@@ -33,7 +33,7 @@ class LineMessageFormatterTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $formatted = "ERROR Foo 1970-01-01 00:00:00 +00:00 Hello world\n";
+        $formatted = "ERROR Foo 1970-01-01 00:00:00 GMT+0000 Hello world\n";
 
         $this->assertEquals($formatted, $formatter->format($record));
     }


### PR DESCRIPTION
This PR adds ` e` (see http://php.net/manual/en/function.date.php) to the Monolog date format. Since Piwik uses "UTC" as the default timezone, this will always add " UTC" to the end of the date string. Log lines will look like this:

```WARNING Referrers[2017-07-24 18:04:14 UTC] Some message```

This resolves problems with external tools reading the Piwik log. Previously, these tools assumed that the time was displayed in the system timezone. (See for example https://github.com/piwik/piwik/issues/2888#issuecomment-317319713 and https://github.com/piwik/piwik/issues/11888).