### PR TITLE
Hide limit control in empty data tables

### DIFF
--- a/plugins/CoreHome/templates/_dataTableFooter.twig
+++ b/plugins/CoreHome/templates/_dataTableFooter.twig
@@ -21,7 +21,7 @@
                 {% include "@CoreHome/_dataTableActions.twig" %}
             </div>
 
-            {% if properties.show_footer_icons and properties.show_pagination_control or properties.show_limit_control %}
+            {% if not isDataTableEmpty and (properties.show_footer_icons and properties.show_pagination_control or properties.show_limit_control) %}
                 <div class="col s3 m3 limitSelection"
                      title="{{ 'General_RowsToDisplay'|translate }}" alt="{{ 'General_RowsToDisplay'|translate }}"
                      ></div>


### PR DESCRIPTION
Currently every empty data table has full access to the controls. Like getting a CSV export or changing the rows displayed. But as there is no data to control they work but (at least to me) give the subtle impression there might be a setting to get some data displayed that was previously hidden.

As a change for that behaviour was rather simple I decided to go ahead with a PR to check if such a change is favorable.

For a nicer visual impression the whitespace should probably be modified to vertically center the message again instead of like right now just hide the footer:

http://builds-artifacts.piwik.org/mneudert/piwik/hide-empty-data-table-controls/97/EmptySite_emptySiteDashboard_ignored.png

(side-by-side displays the changes rather nice)