### PR TITLE
Fix metric selection in multi row evolution

### DIFF
--- a/plugins/CoreVisualizations/stylesheets/jqplot.css
+++ b/plugins/CoreVisualizations/stylesheets/jqplot.css
@@ -196,6 +196,7 @@ a.rowevolution-startmulti {
     color: #444;
     margin: 8px 0 0 0;
     padding: 0;
+    display: block;
 }
 
 /**

--- a/tests/UI/expected-screenshots/RowEvolution_multirow_evolution.png
+++ b/tests/UI/expected-screenshots/RowEvolution_multirow_evolution.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2159baa75c3612a2b4d9d64944c3065e5e93d80838a4f6227eaabad89e20a15
-size 47383
+oid sha256:c4cd0c3f213b93cfbfe9cff7c687dc21d9b147c5fee49e5912d5a01734c4cbcf
+size 48596

--- a/tests/UI/expected-screenshots/RowEvolution_multirow_evolution_other_metric.png
+++ b/tests/UI/expected-screenshots/RowEvolution_multirow_evolution_other_metric.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e54922b958a2c461779a7a1b78fd519216cb568c26894bebf731c7d1ed99054
-size 49068
+oid sha256:cd7a06004b82a8fe2a523e578d026739cba77dadd19e8e93e4a2a6198ebbca59
+size 51430


### PR DESCRIPTION
The select for choosing another metric was simply hidden. I guess that happened while 3.0 redesign.
This simple fix just displays the select again.

We could maybe switch to a better looking select box, but that will also require changes in javascript. So we should do this quick fix for the next release and consider changing it in a later release.