### PR TITLE
Using a different port than 25 for SMTP

### DIFF
--- a/core/Mail.php
+++ b/core/Mail.php
@@ -119,7 +119,6 @@ class Mail extends Zend_Mail
         $host = trim($mailConfig['host']);
         $tr = new \Zend_Mail_Transport_Smtp($host, $smtpConfig);
         Mail::setDefaultTransport($tr);
-        @ini_set("smtp_port", $mailConfig['port']);
     }
 
     public function send($transport = null)

--- a/core/Mail.php
+++ b/core/Mail.php
@@ -111,6 +111,10 @@ class Mail extends Zend_Mail
         if (!empty($mailConfig['encryption'])) {
             $smtpConfig['ssl'] = $mailConfig['encryption'];
         }
+        
+        if (!empty($mailConfig['port'])) {
+            $smtpConfig['port'] = $mailConfig['port'];
+        }
 
         $host = trim($mailConfig['host']);
         $tr = new \Zend_Mail_Transport_Smtp($host, $smtpConfig);


### PR DESCRIPTION
This PR fixes different port than 25 using for SMTP.

I strongly recommend removing this line.
```php
@ini_set("smtp_port", $mailConfig['port']);
```

That is just an insane line of code. Why would you want to modify the ini setting of the smtp port if it is not used anyway? Why would you want  suppress errors for that? Avoid using `ini_set` at any cost I would say.