### PR TITLE
Accept older temporary period archives

### DIFF
--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -128,11 +128,18 @@ class Rules
                 $minimumArchiveTime = false;
             } else {
                 // This week, this month, this year:
-                // accept any archive that was processed today after 00:00:01 this morning
                 $timezone = $site->getTimezone();
-                $minimumArchiveTime = Date::factory(Date::factory('now', $timezone)->getDateStartUTC())->setTimezone($timezone)->getTimestamp();
+                $hoursBackWeAcceptArchive = 12;
+                $minimumArchiveTimeToday = Date::factory(Date::factory('now', $timezone)->getDateStartUTC())->setTimezone($timezone)->getTimestamp();
+                $minimumArchiveTimeLastHours = Date::factory('now', $timezone)->subHour($hoursBackWeAcceptArchive)->setTimezone($timezone)->getTimestamp();
+
+                // either accept any archive that was processed today after 00:00:01 this morning
+                // or accept any archive that was generated within the last 12 hours.
+                // what ever time goes further back we accept
+                $minimumArchiveTime = min($minimumArchiveTimeToday, $minimumArchiveTimeLastHours);
             }
         }
+
         return $minimumArchiveTime;
     }
 


### PR DESCRIPTION
When browser archiving is disabled, and it is eg shortly after midnight but no new period archive has been processed yet, the reports for week / month / year will all show zeros. This is because we only accept temporary archives from the same day. 

However, if it is just after midnight, or an hour after midnight, any archive that is like only a few hours old is still accurate enough and potentially even more accurate then any archive that was fetched eg at 4pm and generated at 8am (which we would still consider acceptable currently as it is generated on the same day).

I went with 12 hours for now. Could also only allow up to 6 hours back but someone might actually configure larger processing intervals via #11965 in the future and therefore 12 should be better. Ideally in #11965, if someone sets eg 24 hours for "yearly periods", then we would adjust this number to 24 hours back.

I tested it locally and worked for me but not sure re any possible side effects.