### PR TITLE
Allow different reports pre-archiving frequency for each period

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -287,6 +287,9 @@ time_before_month_archive_considered_outdated = -1
 ; Same as config setting "time_before_week_archive_considered_outdated" but it is only applied to yearly archives
 time_before_year_archive_considered_outdated = -1
 
+; Same as config setting "time_before_week_archive_considered_outdated" but it is only applied to range archives
+time_before_range_archive_considered_outdated = -1
+
 ; This setting is overriden in the UI, under "General Settings".
 ; The default value is to allow browsers to trigger the Piwik archiving process.
 ; This setting is only used if it hasn't been overridden via the UI yet, or if enable_general_settings_admin=0

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -276,6 +276,17 @@ default_period = day
 ; This setting is only used if it hasn't been overriden via the UI yet, or if enable_general_settings_admin=0
 time_before_today_archive_considered_outdated = 150
 
+; Time in seconds after which an archive will be computed again. This setting is used only for week's statistics.
+; If set to "-1" (default), it will fall back to the UI setting under "General settings" unless enable_general_settings_admin=0
+; is set. In this case it will default to "time_before_today_archive_considered_outdated";
+time_before_week_archive_considered_outdated = -1
+
+; Same as config setting "time_before_week_archive_considered_outdated" but it is only applied to monthly archives
+time_before_month_archive_considered_outdated = -1
+
+; Same as config setting "time_before_week_archive_considered_outdated" but it is only applied to yearly archives
+time_before_year_archive_considered_outdated = -1
+
 ; This setting is overriden in the UI, under "General Settings".
 ; The default value is to allow browsers to trigger the Piwik archiving process.
 ; This setting is only used if it hasn't been overridden via the UI yet, or if enable_general_settings_admin=0

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -115,8 +115,10 @@ class Rules
     public static function getMinTimeProcessedForTemporaryArchive(
         Date $dateStart, \Piwik\Period $period, Segment $segment, Site $site)
     {
+        $todayArchiveTimeToLive = self::getPeriodArchiveTimeToLiveDefault($period->getLabel());
+
         $now = time();
-        $minimumArchiveTime = $now - Rules::getTodayArchiveTimeToLive();
+        $minimumArchiveTime = $now - $todayArchiveTimeToLive;
 
         $idSites = array($site->getId());
         $isArchivingDisabled = Rules::isArchivingDisabledFor($idSites, $segment, $period->getLabel());
@@ -156,6 +158,23 @@ class Rules
             }
         }
         return self::getTodayArchiveTimeToLiveDefault();
+    }
+
+    public static function getPeriodArchiveTimeToLiveDefault($periodLabel)
+    {
+        if (empty($periodLabel) || strtolower($periodLabel) === 'day') {
+            return self::getTodayArchiveTimeToLive();
+        }
+
+        $config = Config::getInstance();
+        $general = $config->General;
+
+        $key = sprintf('time_before_%s_archive_considered_outdated', $periodLabel);
+        if (isset($general[$key]) && is_numeric($general[$key]) && $general[$key] > 0) {
+            return $general[$key];
+        }
+
+        return self::getTodayArchiveTimeToLive();
     }
 
     public static function getTodayArchiveTimeToLiveDefault()

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1284,8 +1284,8 @@ class CronArchive
             $ttl = Rules::getPeriodArchiveTimeToLiveDefault($period);
 
             if (!empty($ttl) && $ttl !== $this->todayArchiveTimeToLive) {
-                $this->logger->info("- Reports for $period will be processed at most every " . $ttl
-                    . " seconds. You can change this value in config/config.ini.php by changing the value for 'time_before_" . $period . "_archive_considered_outdated' in the '[General]' section.");
+                $this->logger->info("- Reports for this $period will be processed at most every " . $ttl
+                    . " seconds. You can change this value in config/config.ini.php by editing 'time_before_" . $period . "_archive_considered_outdated' in the '[General]' section.");
             }
         }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1279,6 +1279,16 @@ class CronArchive
         }
         $this->logger->info("- Reports for today will be processed at most every " . $this->todayArchiveTimeToLive
             . " seconds. You can change this value in Piwik UI > Settings > General Settings.");
+
+        foreach (array('week', 'month', 'year', 'range') as $period) {
+            $ttl = Rules::getPeriodArchiveTimeToLiveDefault($period);
+
+            if (!empty($ttl) && $ttl !== $this->todayArchiveTimeToLive) {
+                $this->logger->info("- Reports for $period will be processed at most every " . $ttl
+                    . " seconds. You can change this value in config/config.ini.php by changing the value for 'time_before_" . $period . "_archive_considered_outdated' in the '[General]' section.");
+            }
+        }
+
         $this->logger->info("- Reports for the current week/month/year will be refreshed at most every "
             . $this->processPeriodsMaximumEverySeconds . " seconds.");
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1280,17 +1280,17 @@ class CronArchive
         $this->logger->info("- Reports for today will be processed at most every " . $this->todayArchiveTimeToLive
             . " seconds. You can change this value in Piwik UI > Settings > General Settings.");
 
+        $this->logger->info("- Reports for the current week/month/year will be requested at most every "
+            . $this->processPeriodsMaximumEverySeconds . " seconds.");
+
         foreach (array('week', 'month', 'year', 'range') as $period) {
             $ttl = Rules::getPeriodArchiveTimeToLiveDefault($period);
 
             if (!empty($ttl) && $ttl !== $this->todayArchiveTimeToLive) {
-                $this->logger->info("- Reports for this $period will be processed at most every " . $ttl
+                $this->logger->info("- Reports for the current $period will be processed at most every " . $ttl
                     . " seconds. You can change this value in config/config.ini.php by editing 'time_before_" . $period . "_archive_considered_outdated' in the '[General]' section.");
             }
         }
-
-        $this->logger->info("- Reports for the current week/month/year will be refreshed at most every "
-            . $this->processPeriodsMaximumEverySeconds . " seconds.");
 
         // Try and not request older data we know is already archived
         if ($this->lastSuccessRunTimestamp !== false) {

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -93,7 +93,7 @@ NOTES
 - If you execute this script at least once per hour (or more often) in a crontab, you may disable 'Browser trigger archiving' in Piwik UI > Settings > General Settings.
   See the doc at: http://piwik.org/docs/setup-auto-archiving/
 - Reports for today will be processed at most every %s seconds. You can change this value in Piwik UI > Settings > General Settings.
-- Reports for the current week/month/year will be refreshed at most every %s seconds.
+- Reports for the current week/month/year will be requested at most every %s seconds.
 - Will process all 1 websites
 - Limiting segment archiving to following segments:
   * actions>=2;browserCode=FF

--- a/tests/PHPUnit/System/expected/test_ArchiveCronTest_archive_php_cron_output.txt
+++ b/tests/PHPUnit/System/expected/test_ArchiveCronTest_archive_php_cron_output.txt
@@ -18,7 +18,7 @@ INFO [2017-01-22 00:03:37] NOTES
 INFO [2017-01-22 00:03:37] - If you execute this script at least once per hour (or more often) in a crontab, you may disable 'Browser trigger archiving' in Piwik UI > Settings > General Settings.
 INFO [2017-01-22 00:03:37]   See the doc at: http://piwik.org/docs/setup-auto-archiving/
 INFO [2017-01-22 00:03:37] - Reports for today will be processed at most every 150 seconds. You can change this value in Piwik UI > Settings > General Settings.
-INFO [2017-01-22 00:03:37] - Reports for the current week/month/year will be refreshed at most every 3600 seconds.
+INFO [2017-01-22 00:03:37] - Reports for the current week/month/year will be requested at most every 3600 seconds.
 INFO [2017-01-22 00:03:37] - Will invalidate archived reports for 2012-08-09 for following websites ids: 1
 INFO [2017-01-22 00:03:37] - Will invalidate archived reports for 2012-08-10 for following websites ids: 1
 INFO [2017-01-22 00:03:37] - Will invalidate archived reports for 2012-08-11 for following websites ids: 1


### PR DESCRIPTION
refs #11965 

Added new config setting `time_before_$period_archive_considered_outdated = -1` to allow configuration of archive frequency per period. By default, nothing changes and it falls back to regular UI setting (or config setting for today). 

If value is configured and set to > 0, the value for that period will be applied. 

We could be smart and eg if today is set to 600, but weekly is set to 300, then we would still use 600 as there "shouldn't" be any updated version but it would be tricky to hard code this in there. Also the config name is generated generic based on "periodLabel" as several people are adding new features to allow new periods.

When using cron archive, it may still send an archive request for a period but it shouldn't actually archive it. A simple test would be to do a full archive.  Then set the setting for week period eg to 6000 and you will notice the weekly archive will be finished in a second. Then change setting back to "1" and you will notice it will re-archive the weekly archive.

If setting name and behaviour is fine, we will need to add it to developer changelog and maybe also consider another PR on top of this and https://github.com/piwik/piwik/pull/11972 (once #11972 is merged) to possibly allow archives that are even older than 12 hours if the period archives are supposed to be only archived eg every 24 hours.

There are no tests right now as there are no tests in general for the Rules class. Can add one though.

@mattab any thoughts? Be nice to have this in 3.1.0 already.