### PR TITLE
Better fetching of saved report parameters by report ID

### DIFF
--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -318,6 +318,26 @@ class Report
     }
 
     /**
+     *
+     * Processing a uniqueId for each report, can be used by UIs as a key to match a given report
+     * @return string
+     */
+    public function getId()
+    {
+        $params = $this->getParameters();
+
+        $paramsKey = $this->getModule() . '.' . $this->getAction();
+
+        if (!empty($params)) {
+            foreach ($params as $key => $value) {
+                $paramsKey .= '_' . $key . '--' . $value;
+            }
+        }
+
+        return $paramsKey;
+    }
+
+    /**
      * lets you add any amount of widgets for this report. If a report defines a {@link $categoryId} and a
      * {@link $subcategoryId} a widget will be generated automatically.
      *
@@ -390,6 +410,7 @@ class Report
         if (empty($restrictToColumns)) {
             $restrictToColumns = array_merge($allMetrics, array_keys($this->getProcessedMetrics()));
         }
+        $restrictToColumns = array_unique($restrictToColumns);
 
         $processedMetricsById = $this->getProcessedMetricsById();
         $metricsSet = array_flip($allMetrics);
@@ -840,7 +861,7 @@ class Report
 
         $result = array();
         foreach ($processedMetrics as $processedMetric) {
-            if ($processedMetric instanceof ProcessedMetric) { // instanceof check for backwards compatibility
+            if ($processedMetric instanceof ProcessedMetric || $processedMetric instanceof ArchivedMetric) { // instanceof check for backwards compatibility
                 $result[$processedMetric->getName()] = $processedMetric;
             }
         }

--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -410,7 +410,6 @@ class Report
         if (empty($restrictToColumns)) {
             $restrictToColumns = array_merge($allMetrics, array_keys($this->getProcessedMetrics()));
         }
-        $restrictToColumns = array_unique($restrictToColumns);
 
         $processedMetricsById = $this->getProcessedMetricsById();
         $metricsSet = array_flip($allMetrics);
@@ -861,7 +860,7 @@ class Report
 
         $result = array();
         foreach ($processedMetrics as $processedMetric) {
-            if ($processedMetric instanceof ProcessedMetric || $processedMetric instanceof ArchivedMetric) { // instanceof check for backwards compatibility
+            if ($processedMetric instanceof ProcessedMetric) { // instanceof check for backwards compatibility
                 $result[$processedMetric->getName()] = $processedMetric;
             }
         }

--- a/core/ViewDataTable/Factory.php
+++ b/core/ViewDataTable/Factory.php
@@ -106,12 +106,17 @@ class Factory
 
         $params = array();
 
-        if(is_null($loadViewDataTableParametersForUser)) {
+        if (!isset($loadViewDataTableParametersForUser)) {
             $loadViewDataTableParametersForUser = ('0' == Common::getRequestVar('widget', '0', 'string'));
         }
+
         if ($loadViewDataTableParametersForUser) {
             $login  = Piwik::getCurrentUserLogin();
-            $params = Manager::getViewDataTableParameters($login, $controllerAction);
+            $paramsKey = $controllerAction;
+            if (!empty($report) && $controllerAction === $apiAction) {
+                $paramsKey = $report->getId();
+            }
+            $params = Manager::getViewDataTableParameters($login, $paramsKey);
         }
 
         if (!self::isDefaultViewTypeForReportFixed($report)) {

--- a/tests/PHPUnit/Integration/ReportTest.php
+++ b/tests/PHPUnit/Integration/ReportTest.php
@@ -329,6 +329,17 @@ class ReportTest extends IntegrationTestCase
         $this->assertEquals($action, $report->getAction());
     }
 
+    public function test_getId_ShouldReturnOnlyReturnModuleAndActionWhenNoParametersSet()
+    {
+        $report = new GetExampleReport();
+        $this->assertEquals('ExampleReport.getExampleReport', $report->getId());
+    }
+
+    public function test_getId_ShouldReturnIncludeParamsIfSet()
+    {
+        $this->assertEquals('TestPlugin.getAdvancedReport_idGoal--1', $this->advancedReport->getId());
+    }
+
     public function test_getSubtableDimension_ShouldReturnNullIfNoSubtableActionExists()
     {
         $report = new GetExampleReport();


### PR DESCRIPTION
When fetching saved report parameters (from the DB options table, parameters that were changed eg when changing sort order etc), we currently fetch the report parameters based on the controller action. If there are many reports available for the same report, they all apply the same viewDataTableParams.

One problem is, whenever someone changes the report, those parameters will be saved towards the Report ID, but not the controller action see https://github.com/piwik/piwik/blob/3.0.5-b2/plugins/CoreHome/javascripts/dataTable.js#L1501-L1509 

This means a changed data table will never be applied for some reports. And if it was saved, it would be applied to all entities. This is why the report ID should be preferred over a plain controller action as it included eg also a goal id.

Need to see if tests still pass...