### PR TITLE
Reuse existing period archives when range date is requested when possible

### DIFF
--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -178,8 +178,7 @@ class ArchiveSelector
             $bind = array();
 
             if ($firstPeriod instanceof Range) {
-                $dateCondition = "period = ? AND date1 = ? AND date2 = ?";
-                $bind[] = $firstPeriod->getId();
+                $dateCondition = "date1 = ? AND date2 = ?";
                 $bind[] = $firstPeriod->getDateStart()->toString('Y-m-d');
                 $bind[] = $firstPeriod->getDateEnd()->toString('Y-m-d');
             } else {


### PR DESCRIPTION
fixes #12003
Did a simple test locally. Without this patch I see no data, with patch I see existing data from eg a week archive.

Not sure if this would have any downsides but can't think of any.