### PR TITLE
Configuration for Piwik behind nginx reverse proxy with path rewrite

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -489,6 +489,10 @@ multi_server_environment = 0
 ;proxy_ips[] = 199.27.128.0/21
 ;proxy_ips[] = 173.245.48.0/20
 
+; Set to 1 if you're using a proxy which is rewriting the URI.
+; By enabling this flag the header HTTP_X_FORWARDED_URI will be considered for the current script name.
+proxy_uri_header = 0
+
 ; Whether to enable trusted host checking. This can be disabled if you're running Piwik
 ; on several URLs and do not wish to constantly edit the trusted host list.
 enable_trusted_host_check = 1

--- a/core/Url.php
+++ b/core/Url.php
@@ -128,8 +128,16 @@ class Url
     {
         $url = '';
 
+        // insert extra path info if proxy_uri_header is set and enabled
+        if (isset(Config::getInstance()->General['proxy_uri_header'])
+            && Config::getInstance()->General['proxy_uri_header'] == 1
+            && !empty($_SERVER['HTTP_X_FORWARDED_URI'])
+        ) {
+            $url .= $_SERVER['HTTP_X_FORWARDED_URI'];
+        }
+
         if (!empty($_SERVER['REQUEST_URI'])) {
-            $url = $_SERVER['REQUEST_URI'];
+            $url .= $_SERVER['REQUEST_URI'];
 
             // strip http://host (Apache+Rails anomaly)
             if (preg_match('~^https?://[^/]+($|/.*)~D', $url, $matches)) {


### PR DESCRIPTION
If you're using Piwik behind a reverse proxy with a different path like "rewrite ^/piwik/(.*)$ /$1 break;" (nginx.conf), you can provide a header "proxy_set_header X-Forwarded-Uri /piwik;". If you're enabling the config "proxy_uri_header = 1", the header will be considered to the current script name.

It's necessary, because the redirect after login and links e.g. the logo are not working correctly without.

See question at [https://stackoverflow.com/q/46080031/5453237](https://stackoverflow.com/q/46080031/5453237)