### PR TITLE
Make sure to fetch all segments

### DIFF
--- a/plugins/SegmentEditor/SegmentList.php
+++ b/plugins/SegmentEditor/SegmentList.php
@@ -20,6 +20,7 @@ class SegmentList
     {
         $segments = Request::processRequest('API.getSegmentsMetadata', array(
             'idSites' => array($idSite),
+            'filter_limit' => '-1'
         ));
 
         foreach ($segments as $segment) {


### PR DESCRIPTION
When eg a report or API is rendered and has a filter_limit URL parameter, the filter_limit is applied here and then eg returns only 10 segments instead of say 100.
