### PR TITLE
Prevent diagnostic output from being cut off on cli

### DIFF
--- a/plugins/Diagnostics/Commands/Run.php
+++ b/plugins/Diagnostics/Commands/Run.php
@@ -47,13 +47,13 @@ class Run extends ConsoleCommand
             }
 
             if (count($items) === 1) {
-                $output->writeln($result->getLabel() . ': ' . $this->formatItem($items[0]), OutputInterface::OUTPUT_PLAIN);
+                $output->writeln($result->getLabel() . ': ' . $this->formatItem($items[0]), OutputInterface::OUTPUT_NORMAL);
                 continue;
             }
 
             $output->writeln($result->getLabel() . ':');
             foreach ($items as $item) {
-                $output->writeln("\t- " . $this->formatItem($item), OutputInterface::OUTPUT_PLAIN);
+                $output->writeln("\t- " . $this->formatItem($item), OutputInterface::OUTPUT_NORMAL);
             }
         }
 
@@ -82,7 +82,7 @@ class Run extends ConsoleCommand
             '<%s>%s %s</%s>',
             $tag,
             strtoupper($item->getStatus()),
-            preg_replace('/\<br\s*\/?\>/i', "\n", $item->getComment()),
+            preg_replace('%</?[a-z][a-z0-9]*[^<>]*>%sim', '', preg_replace('/\<br\s*\/?\>/i', "\n", $item->getComment())),
             $tag
         );
     }


### PR DESCRIPTION
output has been done using `OutputInterface::OUTPUT_PLAIN`. This call an `strip_tags` internally.
Problem with diagnostics output is, that at tries to print
```
--> Please delete these directories to prevent errors. <--
```
strip_tags cuts it of at `<--` as it's detected as comment/tag.

The output now uses `OutputInterface::OUTPUT_NORMAL`, which doesn't do a `strip_tags`. Instead the tag removal is done manually using a preg_replace.

fixes #11789 