### PR TITLE
Use raw notification if exception contains html message

### DIFF
--- a/plugins/Marketplace/Controller.php
+++ b/plugins/Marketplace/Controller.php
@@ -303,6 +303,9 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
                 $notification = new Notification($e->getMessage());
                 $notification->context = Notification::CONTEXT_ERROR;
+                if (method_exists($e, 'isHtmlMessage') && $e->isHtmlMessage()) {
+                    $notification->raw = true;
+                }
                 Notification\Manager::notify('Marketplace_Install' . $pluginName, $notification);
 
                 $hasErrors = true;
@@ -404,6 +407,9 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             $notification->context = Notification::CONTEXT_ERROR;
             $notification->type = Notification::TYPE_PERSISTENT;
             $notification->flags = Notification::FLAG_CLEAR;
+            if (method_exists($e, 'isHtmlMessage') && $e->isHtmlMessage()) {
+                $notification->raw = true;
+            }
             Notification\Manager::notify('CorePluginsAdmin_InstallPlugin', $notification);
 
             Url::redirectToReferrer();


### PR DESCRIPTION
Some Exceptions [explicitly contain HTML messages](https://github.com/piwik/piwik/blob/master/core/Filechecks.php#L91-L102) for notifications. Those messages should be use "raw".

fixes #11172 
