### PR TITLE
Fix datatable control overlapping issue

### DIFF
--- a/plugins/CoreHome/stylesheets/dataTable/_dataTable.less
+++ b/plugins/CoreHome/stylesheets/dataTable/_dataTable.less
@@ -543,7 +543,6 @@ td.cellSubDataTable .loadingPiwik {
 
 .dataTableControls {
   text-align: left;
-  position: relative;
   padding-left: 0 !important;
 
   &.col {

--- a/plugins/Dashboard/javascripts/dashboardWidget.js
+++ b/plugins/Dashboard/javascripts/dashboardWidget.js
@@ -314,6 +314,7 @@
             var self = this;
             this.element.dialog({
                 title: '',
+                dialogClass: 'widgetoverlay',
                 modal: true,
                 width: width,
                 position: ['center', 'center'],

--- a/plugins/Dashboard/stylesheets/widget.less
+++ b/plugins/Dashboard/stylesheets/widget.less
@@ -147,3 +147,10 @@
 .bar-graph-colors[data-name=grid-background] {
     color: @theme-color-widget-background !important;
 }
+
+
+.widgetoverlay {
+  .widget, .ui-dialog-content {
+      position: static;
+  }
+}


### PR DESCRIPTION
Aims to fix #10605
Also fixes overlay problem of footer controls in overlay (maximized widget)

Tested in latest Chrome, Firefox + Internet Explorer