### PR TITLE
Render only known action types

### DIFF
--- a/plugins/Live/templates/getLastVisitsStart.twig
+++ b/plugins/Live/templates/getLastVisitsStart.twig
@@ -144,7 +144,8 @@
                                 {% elseif action.eventCategory|default(false) is not empty %}
                                     <img  class="iconPadding" src='{{ action.icon }}'
                                         title="{{ 'Events_Event'|translate }} {{ action.eventCategory }} - {{ action.eventAction }} {% if action.eventName is defined %}- {{ action.eventName }}{% endif %} {% if action.eventValue is defined %}- {{ action.eventValue }}{% endif %}"/>
-                                {% else %}
+                                {% elseif action.type == 'goal' or action.type == constant('\Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER') or
+                                          action.type == constant('\Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_CART') %}
                                     <img class='iconPadding' src="{{ action.icon }}"
                                          title="{{ action.goalName }} - {% if action.revenue > 0 %}{{ 'General_ColumnRevenue'|translate }}: {{ action.revenue|money(idSite)|raw }} - {% endif %} {{ action.serverTimePretty }}"/>
                                 {% endif %}


### PR DESCRIPTION
With the refactoring of visitor details new action types can be included (for example content actions).
As the real time widget hasn't been adjusted, such actions might result in an error as they are tried to be rendered as a goal/ecommerce action.
This change will exclude those action from being rendered for now. We can later adjust the widget to also render custom actions.

refs #12033 
fixes #12037