### PR TITLE
Hide file integrity warnings from SEO site verification processes

### DIFF
--- a/core/FileIntegrity.php
+++ b/core/FileIntegrity.php
@@ -79,7 +79,7 @@ class FileIntegrity
             'plugins/ImageGraph/fonts/unifont.ttf',
             'vendor/autoload.php',
             'vendor/composer/autoload_real.php',
-            'vendor/szymach/c-pchart/app/*.db',
+            'vendor/szymach/c-pchart/app/*',
             'tmp/*',
             // Search engine sites verification
             'google*.html',

--- a/core/FileIntegrity.php
+++ b/core/FileIntegrity.php
@@ -79,8 +79,12 @@ class FileIntegrity
             'plugins/ImageGraph/fonts/unifont.ttf',
             'vendor/autoload.php',
             'vendor/composer/autoload_real.php',
-            'vendor/szymach/c-pchart/app/cache/*.db',
+            'vendor/szymach/c-pchart/app/*.db',
             'tmp/*',
+            // Search engine sites verification
+            'google*.html',
+            'BingSiteAuth.xml',
+            'yandex*.html',
             // Files below are not expected but they used to be present in older Piwik versions and may be still here
             // As they are not going to cause any trouble we won't report them as 'File to delete'
             '*.coveralls.yml',


### PR DESCRIPTION
also fixes https://github.com/piwik/piwik/issues/12050 - verified on demo.piwik.org where we also had this warning
