### PR TITLE
When resetting translations, add general translation keys

### DIFF
--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -194,7 +194,7 @@ class Translator
     public function reset()
     {
         $this->currentLanguage = $this->getDefaultLanguage();
-        $this->directories = array();
+        $this->directories = array(PIWIK_INCLUDE_PATH . '/lang');
         $this->translations = array();
     }
 


### PR DESCRIPTION
This does actually not fix anything but I noticed the problem of the missing `lang/en.json` directory while debugging another problem with "General" translation keys. Thought I still issue the PR as it could potentially fix some issues. Feel free to merge or not.

Problem: Currently we add the `lang/en.json` directory in the constructor, but when resetting the translation, this directory is never added again meaning General translations will be missing.