### PR TITLE
Make old Sparkline Library support PHP 7.2

### DIFF
--- a/libs/sparkline/lib/Sparkline.php
+++ b/libs/sparkline/lib/Sparkline.php
@@ -405,7 +405,7 @@ class Sparkline extends SparklineObject {
   }
 
   function DrawImageCopyResampled($dhandle, $shandle, $dx, $dy, $sx, $sy, $dw, $dh, $sw, $sh) {
-    $this->Debug("Sparkline :: DrawImageCopyResampled($dhhandle, $shandle, $dx, $dy, $sx, $sy, $dw, $dh, $sw, $sh)", DEBUG_DRAW);
+    $this->Debug("Sparkline :: DrawImageCopyResampled($dhandle, $shandle, $dx, $dy, $sx, $sy, $dw, $dh, $sw, $sh)", DEBUG_DRAW);
     if (!$this->IsError()) {
       return imagecopyresampled($dhandle,  // dest handle
                                 $shandle,  // src  handle

--- a/libs/sparkline/lib/Sparkline.php
+++ b/libs/sparkline/lib/Sparkline.php
@@ -22,9 +22,9 @@ define('FONT_3', 3);
 define('FONT_4', 4);
 define('FONT_5', 5);
 
-require_once dirname(__FILE__).'/Object.php';
+require_once dirname(__FILE__).'/SparklineObject.php';
 
-class Sparkline extends Object {
+class Sparkline extends SparklineObject {
 
   var $imageX;
   var $imageY;

--- a/libs/sparkline/lib/SparklineObject.php
+++ b/libs/sparkline/lib/SparklineObject.php
@@ -69,7 +69,7 @@ function log_write($string, $type = '', $date = false) {
   }
 } // function log_write
 
-class Object {
+class SparklineObject {
 
   var $isError;
   var $logFile;


### PR DESCRIPTION
Quick fix for #12065 until #12066 is ready to merge.
Refs #11936

Also fixed a typo in the library (but I guess that code isn't executed, otherwise we should have noticed in the last 10 years (since https://github.com/piwik/piwik/commit/e8700c0c7dd08869b93ed1d092d90bb7cd3716e3))