### PR TITLE
Fix Tibetan cities display on China's city map

### DIFF
--- a/plugins/UserCountry/API.php
+++ b/plugins/UserCountry/API.php
@@ -161,7 +161,7 @@ class API extends \Piwik\Plugin\API
         $separator = Archiver::LOCATION_SEPARATOR;
         $unk = Visit::UNKNOWN_CODE;
         
-        // show visits from "1|ti" cities: Lasa, Lhasa, Lang, Nang, Lima, Moto, Dechen, Yanhuqu to "14|cn"
+        // show visits from "1|ti" cities to "14|cn"
         $dataTables = [$dataTable];
 
         if ($dataTable instanceof DataTable\Map) {
@@ -169,24 +169,15 @@ class API extends \Piwik\Plugin\API
         }
 
         foreach ($dataTables as $dt) {
-            if ($dt->getRowFromLabel('Lasa|1|ti') ||
-                $dt->getRowFromLabel('Lhasa|1|ti') ||
-                $dt->getRowFromLabel('Lang|1|ti') ||
-                $dt->getRowFromLabel('Nang|1|ti') ||
-                $dt->getRowFromLabel('Lima|1|ti') ||
-                $dt->getRowFromLabel('Moto|1|ti') ||
-                $dt->getRowFromLabel('Dechen|1|ti') ||
-                $dt->getRowFromLabel('Yanhuqu|1|ti')) {
-                $dt->filter('GroupBy', array(
-                    'label',
-                    function ($label) {
-                        if (in_array($label, array('Lasa|1|ti', 'Lhasa|1|ti', 'Lang|1|ti', 'Nang|1|ti', 'Lima|1|ti', 'Moto|1|ti', 'Dechen|1|ti', 'Yanhuqu|1|ti'))) {
-                            return str_replace('1|ti', '14|cn', $label);
-                        }
-                        return $label;
+            $dt->filter('GroupBy', array(
+                'label',
+                function ($label) {
+                    if (substr($label, -5) == '|1|ti') {
+                        return substr($label, 0, -5) . '|14|cn';
                     }
-                ));
-            }
+                    return $label;
+                }
+            ));
         }
 
         // split the label and put the elements into the 'city_name', 'region', 'country',

--- a/plugins/UserCountry/API.php
+++ b/plugins/UserCountry/API.php
@@ -160,6 +160,34 @@ class API extends \Piwik\Plugin\API
 
         $separator = Archiver::LOCATION_SEPARATOR;
         $unk = Visit::UNKNOWN_CODE;
+        
+        // show visits from "1|ti" cities: Lasa, Lhasa, Lang, Nang, Lima, Moto, Dechen, Yanhuqu to "14|cn"
+        $dataTables = [$dataTable];
+
+        if ($dataTable instanceof DataTable\Map) {
+            $dataTables = $dataTable->getDataTables();
+        }
+
+        foreach ($dataTables as $dt) {
+            if ($dt->getRowFromLabel('Lasa|1|ti') ||
+                $dt->getRowFromLabel('Lhasa|1|ti') ||
+                $dt->getRowFromLabel('Lang|1|ti') ||
+                $dt->getRowFromLabel('Nang|1|ti') ||
+                $dt->getRowFromLabel('Lima|1|ti') ||
+                $dt->getRowFromLabel('Moto|1|ti') ||
+                $dt->getRowFromLabel('Dechen|1|ti') ||
+                $dt->getRowFromLabel('Yanhuqu|1|ti')) {
+                $dt->filter('GroupBy', array(
+                    'label',
+                    function ($label) {
+                        if (in_array($label, array('Lasa|1|ti', 'Lhasa|1|ti', 'Lang|1|ti', 'Nang|1|ti', 'Lima|1|ti', 'Moto|1|ti', 'Dechen|1|ti', 'Yanhuqu|1|ti'))) {
+                            return str_replace('1|ti', '14|cn', $label);
+                        }
+                        return $label;
+                    }
+                ));
+            }
+        }
 
         // split the label and put the elements into the 'city_name', 'region', 'country',
         // 'lat' & 'long' metadata fields


### PR DESCRIPTION
#11930 only changed country and region level archive data. This PR remaps the city data so Tibetan cities are correctly displayed. Before the patch, no visits from Tibetan city is on the city level map (but visits from Tibet can be seen on the region level map).

![image](https://user-images.githubusercontent.com/3523264/30728611-c48ecbfe-9f8b-11e7-9461-941e2fe8b7b7.png)

Above is a screenshot on my server after applying the patch (Lhasa is now on the map).