### PR TITLE
Adding new events triggered when dynamic files are changed by Piwik.

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -381,17 +381,25 @@ class Config
         if ($output !== null
             && $output !== false
         ) {
+            $localPath = $this->getLocalPath();
 
             if ($this->doNotWriteConfigInTests) {
                 // simulate whether it would be successful
-                $success = is_writable($this->getLocalPath());
+                $success = is_writable($localPath);
             } else {
-                $success = @file_put_contents($this->getLocalPath(), $output);
+                $success = @file_put_contents($localPath, $output);
             }
 
             if ($success === false) {
                 throw $this->getConfigNotWritableException();
             }
+
+            /**
+             * Triggered when a INI config file is changed on disk.
+             *
+             * @param string $localPath Absolute path to the changed file on the server.
+             */
+            Piwik::postEvent('Core.configFileChanged', [$localPath]);
         }
 
         if ($clear) {

--- a/plugins/CustomPiwikJs/.gitignore
+++ b/plugins/CustomPiwikJs/.gitignore
@@ -1,1 +1,2 @@
 tests/System/processed/*xml
+tests/resources/MyNotExisIngFilessss.js

--- a/plugins/CustomPiwikJs/TrackerUpdater.php
+++ b/plugins/CustomPiwikJs/TrackerUpdater.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\CustomPiwikJs;
 use Piwik\Container\StaticContainer;
 use Piwik\Plugins\CustomPiwikJs\TrackingCode\PiwikJsManipulator;
 use Piwik\Plugins\CustomPiwikJs\TrackingCode\PluginTrackerFiles;
+use Piwik\Piwik;
 
 /**
  * Updates the Piwik JavaScript Tracker "piwik.js" in case plugins extend the tracker.
@@ -130,6 +131,13 @@ class TrackerUpdater
 
         if ($newContent !== $this->getCurrentTrackerFileContent()) {
             $this->toFile->save($newContent);
+
+            /**
+             * Triggered after the tracker JavaScript content (the content of the piwik.js file) is changed.
+             *
+             * @param string $absolutePath The path to the new piwik.js file.
+             */
+            Piwik::postEvent('CustomPiwikJs.piwikJsChanged', [$this->toFile->getPath()]);
         }
     }
 }

--- a/plugins/CustomPiwikJs/tests/Integration/TrackerUpdaterTest.php
+++ b/plugins/CustomPiwikJs/tests/Integration/TrackerUpdaterTest.php
@@ -46,6 +46,11 @@ class TrackerUpdaterTest extends IntegrationTestCase
         if (file_exists($target)) {
             unlink($target);
         }
+
+        $nonExistentFile = $this->dir . 'MyNotExisIngFilessss.js';
+        if (file_exists($nonExistentFile)) {
+            unlink($nonExistentFile);
+        }
     }
 
     private function makeUpdater($from = null, $to = null)
@@ -177,7 +182,7 @@ var myArray = [];
 
     public function test_update_shouldNotThrowAnError_IfTargetFileIsNotWritable()
     {
-        $updater = $this->makeUpdater(null, $this->dir . 'MyNotExisIngFilessss.js');
+        $updater = $this->makeUpdater(null, $this->dir . 'not-writable/MyNotExisIngFilessss.js');
         $updater->update();
         $this->assertTrue(true);
         $this->assertNull($this->piwikJsChangedEventPath);

--- a/plugins/CustomPiwikJs/tests/Integration/TrackerUpdaterTest.php
+++ b/plugins/CustomPiwikJs/tests/Integration/TrackerUpdaterTest.php
@@ -22,11 +22,13 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 class TrackerUpdaterTest extends IntegrationTestCase
 {
     private $dir;
+    private $piwikJsChangedEventPath = null;
 
     public function setUp()
     {
         parent::setUp();
         $this->dir = PIWIK_DOCUMENT_ROOT . '/plugins/CustomPiwikJs/tests/resources/';
+        $this->piwikJsChangedEventPath = null;
 
         $this->cleanUp();
     }
@@ -178,6 +180,7 @@ var myArray = [];
         $updater = $this->makeUpdater(null, $this->dir . 'MyNotExisIngFilessss.js');
         $updater->update();
         $this->assertTrue(true);
+        $this->assertNull($this->piwikJsChangedEventPath);
     }
 
     public function test_update_shouldNotWriteToFileIfThereIsNothingToChange()
@@ -191,6 +194,7 @@ var myArray = [];
         $updater->update();
 
         $this->assertSame(file_get_contents($source), file_get_contents($target));
+        $this->assertNull($this->piwikJsChangedEventPath);
     }
 
     public function test_update_targetFileIfPluginsDefineDifferentFiles()
@@ -221,6 +225,17 @@ var PiwikJs = "mytest";
 
 var myArray = [];
 ', file_get_contents($target));
+        $this->assertEquals($target, $this->piwikJsChangedEventPath);
     }
 
+    public function provideContainerConfig()
+    {
+        return [
+            'observers.global' => \DI\add([
+                ['CustomPiwikJs.piwikJsChanged', function ($path) {
+                    $this->piwikJsChangedEventPath = $path;
+                }],
+            ]),
+        ];
+    }
 }


### PR DESCRIPTION
Added a couple new events that are triggered when changes are made to dynamic files on a Piwik server. The events include:

* `Core.configFileChanged`: triggered when an INI config file is changed
* `CoreAdminHome.customLogoChanged`: triggered when a custom logo/favicon file is updated
* `CustomPiwikJs.piwikJsChanged`: triggered when tracker JS is regenerated & saved