### PR TITLE
Make sure all users are returned

### DIFF
--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -163,7 +163,7 @@ class Controller extends Plugin\ControllerAdmin
         $view->deactivateNonce = Nonce::getNonce(static::DEACTIVATE_NONCE);
         $view->pluginsInfo = $this->getPluginsInfo($themesOnly);
 
-        $users = Request::processRequest('UsersManager.getUsers');
+        $users = Request::processRequest('UsersManager.getUsers', array('filter_limit' => '-1'));
         $view->otherUsersCount = count($users) - 1;
         $view->themeEnabled = $this->pluginManager->getThemeEnabled()->getPluginName();
 


### PR DESCRIPTION
I did not check specifically but would presume getUsers will only return max 100 users here. Ideally we would instead have a method to directly get the number of users count which would be much faster... For some Piwik installations loading this page might take a wee bit longer.
