### PR TITLE
Glossary: make sure to return all metrics and reports

### DIFF
--- a/plugins/API/Controller.php
+++ b/plugins/API/Controller.php
@@ -153,8 +153,8 @@ class Controller extends \Piwik\Plugin\Controller
         Piwik::checkUserHasSomeViewAccess();
 
         return $this->renderTemplate('glossary', array(
-            'reports' => Request::processRequest('API', array('method' => 'API.getGlossaryReports')),
-            'metrics' => Request::processRequest('API', array('method' => 'API.getGlossaryMetrics')),
+            'reports' => Request::processRequest('API', array('method' => 'API.getGlossaryReports', 'filter_limit' => -1)),
+            'metrics' => Request::processRequest('API', array('method' => 'API.getGlossaryMetrics', 'filter_limit' => -1)),
         ));
     }
 }


### PR DESCRIPTION
Add filter_limit=-1 to Request::processRequest calls
