### PR TITLE
No longer show "this is demo.piwik.org" message in top control

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -432,7 +432,7 @@
         "YearsDays": "%1$s years %2$s days",
         "Yes": "Yes",
         "YouAreCurrentlyUsing": "You are currently using Piwik %s.",
-        "YouAreViewingDemoShortMessage": "You are viewing the demo of Piwik",
+        "YouAreViewingDemoShortMessage": "You are viewing the demo of %1$sPiwik%2$s",
         "YouMustBeLoggedIn": "You must be logged in to access this functionality.",
         "YourChangesHaveBeenSaved": "Your changes have been saved."
     },

--- a/lang/en.json
+++ b/lang/en.json
@@ -432,7 +432,7 @@
         "YearsDays": "%1$s years %2$s days",
         "Yes": "Yes",
         "YouAreCurrentlyUsing": "You are currently using Piwik %s.",
-        "YouAreViewingDemoShortMessage": "You are viewing the demo of %1$sPiwik%2$s",
+        "YouAreViewingDemoMessage": "You are viewing the demo of %1$sPiwik%2$s",
         "YouMustBeLoggedIn": "You must be logged in to access this functionality.",
         "YourChangesHaveBeenSaved": "Your changes have been saved."
     },

--- a/plugins/CoreHome/javascripts/top_controls.js
+++ b/plugins/CoreHome/javascripts/top_controls.js
@@ -48,16 +48,6 @@ function initTopControls() {
             $('.top_controls').css('opacity', '1');
         }
 
-        var header = $('#header_message.isPiwikDemo');
-        if (header.length) {
-            // make sure isPiwikDemo message is always fully visible, move it to the right if needed
-            var lastSelector = $('.top_controls .piwikTopControl:last');
-
-            var overlap = getOverlap(header[0], lastSelector[0]);
-            if (header[0] !== lastSelector[0] && overlap !== 0) {
-                header.css('right', (Math.abs(overlap) + 18) * -1);
-            }
-        }
     }
 }
 

--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -112,7 +112,6 @@ nav {
     .top_controls {
       height: auto;
 
-      .isPiwikDemo,
       .piwikTopControl {
         position: static !important;
         float: none;
@@ -134,10 +133,6 @@ nav {
         .icon-search {
           left: 30px;
         }
-      }
-
-      .isPiwikDemo {
-        margin-top: 8px;
       }
     }
   }

--- a/plugins/CoreHome/templates/_headerMessage.twig
+++ b/plugins/CoreHome/templates/_headerMessage.twig
@@ -10,17 +10,13 @@
     </span>
 {% endset %}
 
-{% if isPiwikDemo or (latest_version_available and hasSomeViewAccess and not isUserIsAnonymous) or (isSuperUser and isAdminArea is defined and isAdminArea) %}
+{% if (latest_version_available and hasSomeViewAccess and not isUserIsAnonymous) or (isSuperUser and isAdminArea is defined and isAdminArea) %}
 <div piwik-expand-on-hover
      id="header_message"
-     class="piwikSelector borderedControl {% if isPiwikDemo or not latest_version_available %}header_info{% else %}{% endif %} {% if isPiwikDemo %}isPiwikDemo{% else %}piwikTopControl{% endif %} {% if latest_version_available %}update_available{% endif %}"
+     class="piwikSelector borderedControl {% if not latest_version_available %}header_info{% else %}{% endif %} piwikTopControl {% if latest_version_available %}update_available{% endif %}"
         >
 
-        {% if isPiwikDemo %}
-        <a class="title" style="cursor:default;">
-            {{ 'General_YouAreViewingDemoShortMessage'|translate }}
-          </a>
-        {% elseif latest_version_available %}
+        {% if latest_version_available and not isPiwikDemo %}
         <a class="title" href="?module=CoreUpdater&action=newVersionAvailable" style="cursor:pointer;">
             {{ 'General_NewUpdatePiwikX'|translate(latest_version_available) }}
             <span class="icon-warning"></span>
@@ -32,13 +28,6 @@
         {% endif %}
 
     <div class="dropdown positionInViewport">
-        {% if isPiwikDemo %}
-            {{ 'General_DownloadFullVersion'|translate("<a rel='noreferrer' href='https://piwik.org/'>","</a>","<a rel='noreferrer' href='https://piwik.org'>piwik.org</a>")|raw }}
-            <br/>
-            {% if isSuperUser and isAdminArea is defined and isAdminArea %}
-                <br/>
-            {% endif %}
-        {% endif %}
         {% if latest_version_available and isSuperUser %}
             {% if isMultiServerEnvironment %}
                 {{ 'CoreHome_OneClickUpdateNotPossibleAsMultiServerEnvironment'|translate("<a rel='noreferrer' href='https://builds.piwik.org/piwik-" ~ latest_version_available ~ ".zip'>","</a>")|raw }}
@@ -50,13 +39,6 @@
             {% set updateSubject = 'General_NewUpdatePiwikX'|translate(latest_version_available)|e('url') %}
             {{ 'General_PiwikXIsAvailablePleaseNotifyPiwikAdmin'|translate("<a href='?module=Proxy&action=redirect&url=http://piwik.org/' target='_blank'>Piwik</a> <a href='?module=Proxy&action=redirect&url=http://piwik.org/changelog/' target='_blank'>" ~ latest_version_available ~ "</a>", "<a href='mailto:" ~ superUserEmails ~ "?subject=" ~ updateSubject ~ "'>", "</a>")|raw }}
             <br />
-        {% endif %}
-
-        {% if isPiwikDemo and isSuperUser and isAdminArea is defined and isAdminArea %}
-            <br/>
-            {{ updateCheck|raw }}
-            <br/>
-            <br/>
         {% endif %}
 
         {{ 'General_YouAreCurrentlyUsing'|translate(piwik_version) }}


### PR DESCRIPTION
Removing some special code for demo.piwik.org which should not be in core. We will instead add this in a different plugin.

I also updated the translation key `YouAreViewingDemoShortMessage ` in the hope this will invalidate all existing translations? I don't want to have the whole sentence as a link as it does not look nice and it is not as much noticeable as a link.