### PR TITLE
JS Tracker: Prevent possible infinite loop when page is unloading 

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -1398,7 +1398,7 @@ if (typeof window.Piwik !== 'object') {
             var aliasTime = now.getTimeAlias();
             if( (expireDateTime - aliasTime) > 3000) // fix bug #12108
             {
-                return;
+                expireDateTime = aliasTime + 3000;
             }
             
             /*

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -1393,6 +1393,14 @@ if (typeof window.Piwik !== 'object') {
             var now;
 
             executePluginMethod('unload');
+
+            now  = new Date();
+            var aliasTime = now.getTimeAlias();
+            if( (expireDateTime - aliasTime) > 3000) // fix bug #12108
+            {
+                return;
+            }
+            
             /*
              * Delay/pause (blocks UI)
              */


### PR DESCRIPTION
Bugfix #12108 
Infinite Loop Bug in beforeUnloadHandler()
 prevent infinite loop when delta > 3 seconds