### PR TITLE
Pass --piwik-domain value to phpunit via environment variable…

### DIFF
--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -44,6 +44,16 @@ if (getenv('PIWIK_USE_XHPROF') == 1) {
     \Piwik\Profiler::setupProfilerXHProf();
 }
 
+function setPiwikDomainFromEnvVar()
+{
+    $piwikDomain = getenv('PIWIK_DOMAIN');
+    if (!empty($piwikDomain)) {
+        $_SERVER['HTTP_HOST'] = $piwikDomain;
+    }
+}
+
+setPiwikDomainFromEnvVar();
+
 // setup container for tests
 function setupRootContainer() {
     // before running tests, delete the TestingEnvironmentVariables file, since it can indirectly mess w/


### PR DESCRIPTION
…so correct INI config will be used in tests.

I'm using multiple INI configs to separate different environments (primarily docker vs local). Unfortunately, --piwik-domain option has no effect on tests:run, since that invokes phpunit directly (so the normal config.ini.php file is used).

This PR works around that by passing the piwik domain via environment variable to phpunit, and handling it in bootstrap.php (if it's found).

This change would make development more convenient for me, but it's not life or death. It means if I switch contexts, I don't have to manually change config.ini.php.