### PR TITLE
Tracking: Write current interaction position for all actions

### DIFF
--- a/plugins/Actions/Columns/InteractionPosition.php
+++ b/plugins/Actions/Columns/InteractionPosition.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\Actions\Columns;
 
+use Piwik\Plugins\Events\Actions\ActionEvent;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
@@ -33,7 +34,13 @@ class InteractionPosition extends ActionDimension
         if ($shouldCount && $visitor->isNewVisit()) {
             return 1;
         } else if ($shouldCount) {
-            return VisitTotalInteractions::getCurrentInteractionPosition($request);
+            return VisitTotalInteractions::getNextInteractionPosition($request);
+        }
+
+        // we re-use same interaction position as last page view eg for events etc.
+        $position = VisitTotalInteractions::getCurrentInteractionPosition($request);
+        if ($position >= 1) {
+            return $position;
         }
 
         return false;

--- a/plugins/Actions/Columns/VisitTotalInteractions.php
+++ b/plugins/Actions/Columns/VisitTotalInteractions.php
@@ -74,6 +74,17 @@ class VisitTotalInteractions extends VisitDimension
     {
         $position = $request->getMetadata('Actions', 'visit_total_interactions');
 
+        return (int) $position;
+    }
+
+    /**
+     * @param Request $request
+     * @return int
+     */
+    public static function getNextInteractionPosition($request)
+    {
+        $position = self::getCurrentInteractionPosition($request);
+
         $position = $position + 1;
 
         // Remove this in Piwik 4

--- a/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_day.xml
@@ -14,6 +14,7 @@
 				
 				
 				<pageId>1</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -21,6 +22,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -35,8 +37,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -51,8 +55,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -67,8 +73,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -83,8 +91,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -99,8 +109,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -115,8 +127,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -131,8 +145,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -147,8 +163,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,8 +181,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -179,8 +199,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -195,8 +217,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
@@ -307,6 +331,7 @@
 				
 				
 				<pageId>13</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -314,6 +339,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -328,8 +354,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -344,8 +372,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -360,8 +390,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -376,8 +408,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -392,8 +426,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -408,8 +444,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -424,8 +462,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -440,8 +480,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -456,8 +498,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -472,8 +516,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -488,8 +534,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>

--- a/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_day.xml
@@ -14,7 +14,6 @@
 				
 				
 				<pageId>1</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -22,7 +21,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -37,10 +35,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -55,10 +51,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -73,10 +67,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -91,10 +83,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -109,10 +99,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -127,10 +115,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -145,10 +131,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,10 +147,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -181,10 +163,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -199,10 +179,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -217,15 +195,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -236,7 +218,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -272,10 +253,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>
@@ -326,7 +307,6 @@
 				
 				
 				<pageId>13</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -334,7 +314,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -349,10 +328,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -367,10 +344,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -385,10 +360,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -403,10 +376,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -421,10 +392,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -439,10 +408,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -457,10 +424,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -475,10 +440,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -493,10 +456,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -511,10 +472,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -529,15 +488,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -548,7 +511,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -584,10 +546,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>

--- a/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_month.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_month.xml
@@ -14,6 +14,7 @@
 				
 				
 				<pageId>1</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -21,6 +22,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -35,8 +37,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -51,8 +55,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -67,8 +73,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -83,8 +91,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -99,8 +109,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -115,8 +127,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -131,8 +145,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -147,8 +163,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,8 +181,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -179,8 +199,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -195,8 +217,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
@@ -307,6 +331,7 @@
 				
 				
 				<pageId>13</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -314,6 +339,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -328,8 +354,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -344,8 +372,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -360,8 +390,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -376,8 +408,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -392,8 +426,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -408,8 +444,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -424,8 +462,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -440,8 +480,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -456,8 +498,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -472,8 +516,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -488,8 +534,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>

--- a/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_month.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents__Live.getLastVisitsDetails_month.xml
@@ -14,7 +14,6 @@
 				
 				
 				<pageId>1</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -22,7 +21,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -37,10 +35,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -55,10 +51,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -73,10 +67,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -91,10 +83,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -109,10 +99,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -127,10 +115,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -145,10 +131,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,10 +147,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -181,10 +163,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -199,10 +179,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -217,15 +195,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -236,7 +218,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -272,10 +253,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>
@@ -326,7 +307,6 @@
 				
 				
 				<pageId>13</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -334,7 +314,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -349,10 +328,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -367,10 +344,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -385,10 +360,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -403,10 +376,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -421,10 +392,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -439,10 +408,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -457,10 +424,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -475,10 +440,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -493,10 +456,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -511,10 +472,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -529,15 +488,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -548,7 +511,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -584,10 +546,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>

--- a/plugins/Contents/tests/System/expected/test_Contents_contentInteractionMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_contentInteractionMatch__Live.getLastVisitsDetails_day.xml
@@ -14,6 +14,7 @@
 				
 				
 				<pageId>1</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -21,6 +22,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -35,8 +37,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -51,8 +55,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -67,8 +73,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -83,8 +91,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -99,8 +109,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -115,8 +127,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -131,8 +145,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -147,8 +163,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,8 +181,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -179,8 +199,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -195,8 +217,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
@@ -307,6 +331,7 @@
 				
 				
 				<pageId>13</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -314,6 +339,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -328,8 +354,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -344,8 +372,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -360,8 +390,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -376,8 +408,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -392,8 +426,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -408,8 +444,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -424,8 +462,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -440,8 +480,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -456,8 +498,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -472,8 +516,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -488,8 +534,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>

--- a/plugins/Contents/tests/System/expected/test_Contents_contentInteractionMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_contentInteractionMatch__Live.getLastVisitsDetails_day.xml
@@ -14,7 +14,6 @@
 				
 				
 				<pageId>1</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -22,7 +21,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -37,10 +35,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -55,10 +51,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -73,10 +67,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -91,10 +83,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -109,10 +99,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -127,10 +115,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -145,10 +131,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,10 +147,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -181,10 +163,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -199,10 +179,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -217,15 +195,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -236,7 +218,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -272,10 +253,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>
@@ -326,7 +307,6 @@
 				
 				
 				<pageId>13</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -334,7 +314,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -349,10 +328,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -367,10 +344,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -385,10 +360,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -403,10 +376,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -421,10 +392,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -439,10 +408,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -457,10 +424,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -475,10 +440,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -493,10 +456,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -511,10 +472,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -529,15 +488,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -548,7 +511,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -584,10 +546,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>

--- a/plugins/Contents/tests/System/expected/test_Contents_contentTargetMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_contentTargetMatch__Live.getLastVisitsDetails_day.xml
@@ -14,6 +14,7 @@
 				
 				
 				<pageId>1</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -21,6 +22,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -35,8 +37,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -51,8 +55,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -67,8 +73,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -83,8 +91,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -99,8 +109,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -115,8 +127,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -131,8 +145,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -147,8 +163,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,8 +181,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -179,8 +199,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -195,8 +217,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
@@ -307,6 +331,7 @@
 				
 				
 				<pageId>13</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -314,6 +339,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -328,8 +354,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -344,8 +372,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -360,8 +390,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -376,8 +408,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -392,8 +426,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -408,8 +444,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -424,8 +462,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -440,8 +480,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -456,8 +498,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -472,8 +516,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -488,8 +534,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>

--- a/plugins/Contents/tests/System/expected/test_Contents_contentTargetMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_contentTargetMatch__Live.getLastVisitsDetails_day.xml
@@ -14,7 +14,6 @@
 				
 				
 				<pageId>1</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -22,7 +21,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -37,10 +35,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -55,10 +51,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -73,10 +67,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -91,10 +83,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -109,10 +99,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -127,10 +115,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -145,10 +131,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,10 +147,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -181,10 +163,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -199,10 +179,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -217,15 +195,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -236,7 +218,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -272,10 +253,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>
@@ -326,7 +307,6 @@
 				
 				
 				<pageId>13</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -334,7 +314,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -349,10 +328,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -367,10 +344,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -385,10 +360,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -403,10 +376,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -421,10 +392,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -439,10 +408,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -457,10 +424,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -475,10 +440,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -493,10 +456,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -511,10 +472,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -529,15 +488,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -548,7 +511,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -584,10 +546,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>

--- a/plugins/Contents/tests/System/expected/test_ContentscontentNameOrPieceMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_ContentscontentNameOrPieceMatch__Live.getLastVisitsDetails_day.xml
@@ -14,6 +14,7 @@
 				
 				
 				<pageId>1</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -21,6 +22,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -35,8 +37,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -51,8 +55,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -67,8 +73,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -83,8 +91,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -99,8 +109,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -115,8 +127,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -131,8 +145,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -147,8 +163,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,8 +181,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -179,8 +199,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -195,8 +217,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
@@ -307,6 +331,7 @@
 				
 				
 				<pageId>13</pageId>
+				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -314,6 +339,7 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -328,8 +354,10 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -344,8 +372,10 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -360,8 +390,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -376,8 +408,10 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -392,8 +426,10 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -408,8 +444,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -424,8 +462,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -440,8 +480,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -456,8 +498,10 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -472,8 +516,10 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -488,8 +534,10 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
+				<bandwidth />
 				<interactionPosition>1</interactionPosition>
 				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>

--- a/plugins/Contents/tests/System/expected/test_ContentscontentNameOrPieceMatch__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Contents/tests/System/expected/test_ContentscontentNameOrPieceMatch__Live.getLastVisitsDetails_day.xml
@@ -14,7 +14,6 @@
 				
 				
 				<pageId>1</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -22,7 +21,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -37,10 +35,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -55,10 +51,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -73,10 +67,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -91,10 +83,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -109,10 +99,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -127,10 +115,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -145,10 +131,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -163,10 +147,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -181,10 +163,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -199,10 +179,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -217,15 +195,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -236,7 +218,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -272,10 +253,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>
@@ -326,7 +307,6 @@
 				
 				
 				<pageId>13</pageId>
-				<bandwidth />
 				<timeSpent>271</timeSpent>
 				<timeSpentPretty>4 min 31s</timeSpentPretty>
 				<generationTimeMilliseconds>333</generationTimeMilliseconds>
@@ -334,7 +314,6 @@
 				<interactionPosition>1</interactionPosition>
 				<icon />
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -349,10 +328,8 @@
 				<contentPiece>Unknown</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -367,10 +344,8 @@
 				<contentPiece />
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -385,10 +360,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -403,10 +376,8 @@
 				<contentPiece>/path/ad2.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -421,10 +392,8 @@
 				<contentPiece>/path/ad.jpg</contentPiece>
 				<contentTarget>http://www.example.com</contentTarget>
 				<contentInteraction>submit</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -439,10 +408,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -457,10 +424,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/</contentTarget>
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -475,10 +440,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -493,10 +456,8 @@
 				<contentPiece>Click NOW</contentPiece>
 				<contentTarget>http://piwik.org/download</contentTarget>
 				<contentInteraction>click</contentInteraction>
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -511,10 +472,8 @@
 				<contentPiece>Click to download Piwik now</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 			<row>
 				<type>13</type>
@@ -529,15 +488,19 @@
 				<contentPiece>movie.mov</contentPiece>
 				<contentTarget />
 				<contentInteraction />
-				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
 		</actionDetails>
 		<goalConversions>0</goalConversions>
 		<siteCurrency>USD</siteCurrency>
 		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		
+		
 		
 		
 		
@@ -548,7 +511,6 @@
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
-		
 		<visitEcommerceStatus>none</visitEcommerceStatus>
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
@@ -584,10 +546,10 @@
 		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
 		<browserCode>FF</browserCode>
 		<browserVersion>3.6</browserVersion>
-		<totalEcommerceRevenue>0.00</totalEcommerceRevenue>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0.00</totalAbandonedCartsRevenue>
+		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest__Live.getLastVisitsDetails_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest__Live.getLastVisitsDetails_range.xml
@@ -203,7 +203,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -219,7 +219,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -234,7 +234,7 @@
 				<eventCategory>Cat8</eventCategory>
 				<eventAction>Action8</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name8</eventName>
@@ -543,7 +543,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -559,7 +559,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -574,7 +574,7 @@
 				<eventCategory>Cat7</eventCategory>
 				<eventAction>Action7</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name7</eventName>
@@ -905,7 +905,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -921,7 +921,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -936,7 +936,7 @@
 				<eventCategory>Cat6</eventCategory>
 				<eventAction>Action6</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name6</eventName>
@@ -1245,7 +1245,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1261,7 +1261,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1276,7 +1276,7 @@
 				<eventCategory>Cat5</eventCategory>
 				<eventAction>Action5</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name5</eventName>
@@ -1607,7 +1607,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1623,7 +1623,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1638,7 +1638,7 @@
 				<eventCategory>Cat4</eventCategory>
 				<eventAction>Action4</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name4</eventName>
@@ -1947,7 +1947,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1963,7 +1963,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1978,7 +1978,7 @@
 				<eventCategory>Cat3</eventCategory>
 				<eventAction>Action3</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name3</eventName>
@@ -2143,7 +2143,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -2159,7 +2159,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -2174,7 +2174,7 @@
 				<eventCategory>Cat3</eventCategory>
 				<eventAction>Action3</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name3</eventName>
@@ -2641,7 +2641,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -2657,7 +2657,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -2672,7 +2672,7 @@
 				<eventCategory>Cat2</eventCategory>
 				<eventAction>Action2</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name2</eventName>
@@ -2859,7 +2859,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -2875,7 +2875,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -2890,7 +2890,7 @@
 				<eventCategory>Cat2</eventCategory>
 				<eventAction>Action2</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name2</eventName>
@@ -3335,7 +3335,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -3351,7 +3351,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -3366,7 +3366,7 @@
 				<eventCategory>Cat1</eventCategory>
 				<eventAction>Action1</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name1</eventName>
@@ -3531,7 +3531,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -3547,7 +3547,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -3562,7 +3562,7 @@
 				<eventCategory>Cat1</eventCategory>
 				<eventAction>Action1</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name1</eventName>
@@ -3727,7 +3727,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -3743,7 +3743,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -3758,7 +3758,7 @@
 				<eventCategory>Cat1</eventCategory>
 				<eventAction>Action1</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name1</eventName>
@@ -3915,7 +3915,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -3931,7 +3931,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -3946,7 +3946,7 @@
 				<eventCategory>Cat1</eventCategory>
 				<eventAction>Action1</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name1</eventName>
@@ -4709,7 +4709,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -4725,7 +4725,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -4740,7 +4740,7 @@
 				<eventCategory>Cat0</eventCategory>
 				<eventAction>Action0</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name0</eventName>
@@ -4927,7 +4927,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -4943,7 +4943,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -4958,7 +4958,7 @@
 				<eventCategory>Cat0</eventCategory>
 				<eventAction>Action0</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name0</eventName>
@@ -5145,7 +5145,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -5161,7 +5161,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -5176,7 +5176,7 @@
 				<eventCategory>Cat0</eventCategory>
 				<eventAction>Action0</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name0</eventName>
@@ -5355,7 +5355,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -5371,7 +5371,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -5386,7 +5386,7 @@
 				<eventCategory>Cat0</eventCategory>
 				<eventAction>Action0</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name0</eventName>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_day.xml
@@ -620,7 +620,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -644,7 +644,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -668,7 +668,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -692,7 +692,7 @@
 				<bandwidth />
 				<timeSpent>30</timeSpent>
 				<timeSpentPretty>30s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -716,7 +716,7 @@
 				<bandwidth />
 				<timeSpent>30</timeSpent>
 				<timeSpentPretty>30s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -740,7 +740,7 @@
 				<bandwidth />
 				<timeSpent>1</timeSpent>
 				<timeSpentPretty>1s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -765,7 +765,7 @@
 				<bandwidth />
 				<timeSpent>0</timeSpent>
 				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -801,7 +801,7 @@
 				<bandwidth />
 				<timeSpent>1499</timeSpent>
 				<timeSpentPretty>24 min 59s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/event.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -836,7 +836,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Princess Mononoke (もののけ姫)</eventName>
@@ -854,7 +854,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Ponyo (崖の上のポニョ)</eventName>
@@ -872,7 +872,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -890,7 +890,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -908,7 +908,7 @@
 				<bandwidth />
 				<timeSpent>1320</timeSpent>
 				<timeSpentPretty>22 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -924,7 +924,7 @@
 				<eventCategory>Movie</eventCategory>
 				<eventAction>play25%</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -1792,7 +1792,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Princess Mononoke (もののけ姫)</eventName>
@@ -1810,7 +1810,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Ponyo (崖の上のポニョ)</eventName>
@@ -1828,7 +1828,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -1846,7 +1846,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -1864,7 +1864,7 @@
 				<bandwidth />
 				<timeSpent>1320</timeSpent>
 				<timeSpentPretty>22 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -1880,7 +1880,7 @@
 				<eventCategory>Movie</eventCategory>
 				<eventAction>play25%</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_month.xml
@@ -763,7 +763,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Princess Mononoke (もののけ姫)</eventName>
@@ -781,7 +781,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Ponyo (崖の上のポニョ)</eventName>
@@ -799,7 +799,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -817,7 +817,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -835,7 +835,7 @@
 				<bandwidth />
 				<timeSpent>1320</timeSpent>
 				<timeSpentPretty>22 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -851,7 +851,7 @@
 				<eventCategory>Movie</eventCategory>
 				<eventAction>play25%</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -1572,7 +1572,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -1596,7 +1596,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -1620,7 +1620,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -1644,7 +1644,7 @@
 				<bandwidth />
 				<timeSpent>30</timeSpent>
 				<timeSpentPretty>30s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -1668,7 +1668,7 @@
 				<bandwidth />
 				<timeSpent>30</timeSpent>
 				<timeSpentPretty>30s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -1692,7 +1692,7 @@
 				<bandwidth />
 				<timeSpent>1</timeSpent>
 				<timeSpentPretty>1s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -1717,7 +1717,7 @@
 				<bandwidth />
 				<timeSpent>0</timeSpent>
 				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>La fiancée de l'eau</eventName>
@@ -1753,7 +1753,7 @@
 				<bandwidth />
 				<timeSpent>1499</timeSpent>
 				<timeSpentPretty>24 min 59s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/event.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1788,7 +1788,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Princess Mononoke (もののけ姫)</eventName>
@@ -1806,7 +1806,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Ponyo (崖の上のポニョ)</eventName>
@@ -1824,7 +1824,7 @@
 				<bandwidth />
 				<timeSpent>60</timeSpent>
 				<timeSpentPretty>1 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -1842,7 +1842,7 @@
 				<bandwidth />
 				<timeSpent>120</timeSpent>
 				<timeSpentPretty>2 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -1860,7 +1860,7 @@
 				<bandwidth />
 				<timeSpent>1320</timeSpent>
 				<timeSpentPretty>22 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>
@@ -1876,7 +1876,7 @@
 				<eventCategory>Movie</eventCategory>
 				<eventAction>play25%</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Spirited Away (千と千尋の神隠し)</eventName>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Live.getLastVisitsDetails_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Live.getLastVisitsDetails_range.xml
@@ -1396,7 +1396,7 @@
 				
 				<pageId>38</pageId>
 				<bandwidth>43</bandwidth>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<customVariables>

--- a/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Live.getLastVisitsDetails_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs_siteIdThree_TrackedUsingLogReplayWithFixedSiteId__Live.getLastVisitsDetails_range.xml
@@ -1297,7 +1297,7 @@
 				
 				<pageId>58</pageId>
 				<bandwidth>43</bandwidth>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<customVariables>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_offsetAndLimit_1__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_offsetAndLimit_1__Live.getLastVisitsDetails_month.xml
@@ -77,7 +77,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -93,7 +93,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -108,7 +108,7 @@
 				<eventCategory>Cat8</eventCategory>
 				<eventAction>Action8</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name8</eventName>
@@ -417,7 +417,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -433,7 +433,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -448,7 +448,7 @@
 				<eventCategory>Cat7</eventCategory>
 				<eventAction>Action7</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name7</eventName>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_offsetAndLimit_2__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_offsetAndLimit_2__Live.getLastVisitsDetails_month.xml
@@ -221,7 +221,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -237,7 +237,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -252,7 +252,7 @@
 				<eventCategory>Cat6</eventCategory>
 				<eventAction>Action6</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name6</eventName>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_sortByIdVisit__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_sortByIdVisit__Live.getLastVisitsDetails_month.xml
@@ -203,7 +203,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -219,7 +219,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -234,7 +234,7 @@
 				<eventCategory>Cat8</eventCategory>
 				<eventAction>Action8</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name8</eventName>
@@ -543,7 +543,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -559,7 +559,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -574,7 +574,7 @@
 				<eventCategory>Cat7</eventCategory>
 				<eventAction>Action7</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name7</eventName>
@@ -905,7 +905,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -921,7 +921,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -936,7 +936,7 @@
 				<eventCategory>Cat6</eventCategory>
 				<eventAction>Action6</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name6</eventName>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_sortDesc__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_Live.getLastVisitsDetails_sortDesc__Live.getLastVisitsDetails_month.xml
@@ -203,7 +203,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -219,7 +219,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -234,7 +234,7 @@
 				<eventCategory>Cat8</eventCategory>
 				<eventAction>Action8</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name8</eventName>
@@ -543,7 +543,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -559,7 +559,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -574,7 +574,7 @@
 				<eventCategory>Cat7</eventCategory>
 				<eventAction>Action7</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name7</eventName>
@@ -905,7 +905,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -921,7 +921,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -936,7 +936,7 @@
 				<eventCategory>Cat6</eventCategory>
 				<eventAction>Action6</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name6</eventName>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest__Live.getLastVisitsDetails_month.xml
@@ -203,7 +203,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -219,7 +219,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -234,7 +234,7 @@
 				<eventCategory>Cat8</eventCategory>
 				<eventAction>Action8</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name8</eventName>
@@ -543,7 +543,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -559,7 +559,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -574,7 +574,7 @@
 				<eventCategory>Cat7</eventCategory>
 				<eventAction>Action7</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name7</eventName>
@@ -905,7 +905,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -921,7 +921,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -936,7 +936,7 @@
 				<eventCategory>Cat6</eventCategory>
 				<eventAction>Action6</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name6</eventName>
@@ -1245,7 +1245,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1261,7 +1261,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1276,7 +1276,7 @@
 				<eventCategory>Cat5</eventCategory>
 				<eventAction>Action5</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name5</eventName>
@@ -1607,7 +1607,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1623,7 +1623,7 @@
 				<bandwidth />
 				<timeSpent>180</timeSpent>
 				<timeSpentPretty>3 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -1638,7 +1638,7 @@
 				<eventCategory>Cat4</eventCategory>
 				<eventAction>Action4</eventAction>
 				<bandwidth />
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
 				<eventName>Name4</eventName>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_withCookieSupport__Live.getLastVisitsDetails_day.xml
@@ -181,7 +181,7 @@
 				<bandwidth />
 				<timeSpent>360</timeSpent>
 				<timeSpentPretty>6 min 0s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -197,7 +197,7 @@
 				<bandwidth />
 				<timeSpent>72</timeSpent>
 				<timeSpentPretty>1 min 12s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/download.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -213,7 +213,7 @@
 				<bandwidth />
 				<timeSpent>108</timeSpent>
 				<timeSpentPretty>1 min 48s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>
@@ -229,7 +229,7 @@
 				<bandwidth />
 				<timeSpent>72</timeSpent>
 				<timeSpentPretty>1 min 12s</timeSpentPretty>
-				<interactionPosition />
+				<interactionPosition>2</interactionPosition>
 				<icon>plugins/Morpheus/images/link.png</icon>
 				
 				<bandwidth_pretty>0 M</bandwidth_pretty>


### PR DESCRIPTION
For events, downloads, ... lets set the `interaction_position` as well instead of having it `null`. We set the position to the same position as the last page view. This way we can find out which page was viewed followed by an event.

In Piwik 4 we will need to rename `interaction_position` to something like `pageview_position` https://github.com/piwik/piwik/issues/12124 as an event is technically an interaction as well and should increase the counter compared to using the same counter as on the pageview. (refs https://github.com/piwik/piwik/issues/9199 )

Known issues:
When a user has 2 tabs open, and works on both tabs, the interaction position on any following action will always be set to the interaction position of the last tab.