### PR TITLE
Prevent label column from getting narrower when opening subtables

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -497,27 +497,13 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             return parseInt(maxWidth, 10);
         }
 
-        function removePaddingFromWidth(domElem, labelWidth) {
-            var maxPaddingLeft  = 0;
-            var maxPaddingRight = 0;
+        function removePaddingFromWidth(elem, labelWidth) {
+            var paddingLeft  = elem.css('paddingLeft');
+            paddingLeft      = paddingLeft ? Math.round(parseFloat(paddingLeft)) : 0;
+            var paddingRight = elem.css('paddingRight');
+            paddingRight     = paddingRight ? Math.round(parseFloat(paddingLeft)) : 0;
 
-            $('tbody tr td.label', domElem).each(function (i, node) {
-                $node = $(node);
-
-                var paddingLeft  = $node.css('paddingLeft');
-                paddingLeft      = paddingLeft ? Math.round(parseFloat(paddingLeft)) : 0;
-                var paddingRight = $node.css('paddingRight');
-                paddingRight     = paddingRight ? Math.round(parseFloat(paddingLeft)) : 0;
-
-                if (paddingLeft > maxPaddingLeft) {
-                    maxPaddingLeft = paddingLeft;
-                }
-                if (paddingRight > maxPaddingRight) {
-                    maxPaddingRight = paddingRight;
-                }
-            });
-
-            labelWidth = labelWidth - maxPaddingLeft - maxPaddingRight;
+            labelWidth = labelWidth - paddingLeft - paddingRight;
 
             return labelWidth;
         }
@@ -531,9 +517,6 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         if (isTableVisualization) {
             // we do this only for html tables
 
-            var minLabelWidth = 125;
-            var maxLabelWidth = 440;
-
             var tableWidth = getTableWidth(domElem);
             var labelColumnMinWidth = getLabelColumnMinWidth(domElem);
             var labelColumnMaxWidth = getLabelColumnMaxWidth(domElem);
@@ -546,10 +529,10 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                 labelColumnWidth = labelColumnMaxWidth;
             }
 
-            labelColumnWidth = removePaddingFromWidth(domElem, labelColumnWidth);
-
             if (labelColumnWidth) {
-                $('td.label', domElem).width(labelColumnWidth);
+                $('td.label', domElem).each(function() {
+                    $(this).width(removePaddingFromWidth($(this), labelColumnWidth));
+                });
             }
 
             $('td span.label', domElem).each(function () { self.tooltip($(this)); });

--- a/tests/UI/expected-screenshots/ActionsDataTable_auto_expand.png
+++ b/tests/UI/expected-screenshots/ActionsDataTable_auto_expand.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:25514d318c6bce2ac6a3981ce20f56d68383cf2aa920381aec25ad0f31f538c4
-size 355515
+oid sha256:0e1b77568aa2e64b27ed2075fd140ef249390c679d4d77b5bfe90af0d3424f30
+size 356940

--- a/tests/UI/expected-screenshots/ActionsDataTable_search.png
+++ b/tests/UI/expected-screenshots/ActionsDataTable_search.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1cd24288bab08727cb9a6cf32237b536e7085d3365d58c88d0c28aba60410dca
-size 77110
+oid sha256:45a08f49df7120c70ad4dfff7c34555c4176ac901d85df34effced315b7e3182
+size 76316

--- a/tests/UI/expected-screenshots/ActionsDataTable_subtables_loaded.png
+++ b/tests/UI/expected-screenshots/ActionsDataTable_subtables_loaded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b121015173e34025f68e7b140385b4c585bab135fe677a75c9684d43ef505c7
-size 360808
+oid sha256:b3ce7221353104bb30cf3a05c59ddcc919f7c8af34c3c2ab1f1cfe2785abdd8a
+size 360331

--- a/tests/UI/expected-screenshots/ViewDataTableTest_subtables_loaded.png
+++ b/tests/UI/expected-screenshots/ViewDataTableTest_subtables_loaded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63023d24fadff099ede1fc04ac0cf80e62e096e66cfa62788fb3c96e91a4131c
-size 71043
+oid sha256:c22ec3f63ed0d12d546eb2724d1004fec13707861d9f5ccba15941fc7df4dc9e
+size 71045


### PR DESCRIPTION
column width was set based on the smallest column (including all subtables).
now it will be calculated for each column.

fixes #12131 