### PR TITLE
Make it possible to show a header message for datatables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The Product Changelog at **[piwik.org/changelog](https://piwik.org/changelog)** 
 
 ### New APIs
 * Reports and visualizations can now hide the export icons with a new property `$view->config->show_export`.
+* Reports and visualizations can now show a message above the report with a new property `$view->config->show_header_message`.
 * The following events have been added:
   * `Metric.addMetrics` Triggered to add new metrics that cannot be picked up automatically by the platform.
   * `Metric.addComputedMetrics` Triggered to add computed metrics that are not generated automatically

--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -38,6 +38,7 @@ use Piwik\API\Request as ApiRequest;
  * itself:
  *
  * - report documentation,
+ * - a header message (if {@link Piwik\ViewDataTable\Config::$show_header_message} is set),
  * - a footer message (if {@link Piwik\ViewDataTable\Config::$show_footer_message} is set),
  * - a list of links to related reports (if {@link Piwik\ViewDataTable\Config::$related_reports} is set),
  * - a button that allows users to switch visualizations,

--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -373,11 +373,15 @@ class   Config
 
     /**
      * Stores an HTML message (if any) to display above the datatable view.
+     *
+     * Attention: Message will be printed raw. Don't forget to escape where needed!
      */
     public $show_header_message = false;
 
     /**
      * Stores an HTML message (if any) to display under the datatable view.
+     *
+     * Attention: Message will be printed raw. Don't forget to escape where needed!
      */
     public $show_footer_message = false;
 

--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -372,6 +372,11 @@ class   Config
     public $show_ecommerce = false;
 
     /**
+     * Stores an HTML message (if any) to display above the datatable view.
+     */
+    public $show_header_message = false;
+
+    /**
      * Stores an HTML message (if any) to display under the datatable view.
      */
     public $show_footer_message = false;

--- a/plugins/CoreHome/stylesheets/dataTable/_dataTable.less
+++ b/plugins/CoreHome/stylesheets/dataTable/_dataTable.less
@@ -183,7 +183,7 @@ table.dataTable img {
   position: absolute;
 }
 
-.datatableFooterMessage {
+.datatableHeaderMessage, .datatableFooterMessage {
   color: #888;
   text-align: left;
   margin: 10px;

--- a/plugins/CoreHome/templates/_dataTable.twig
+++ b/plugins/CoreHome/templates/_dataTable.twig
@@ -49,6 +49,10 @@
         {% if error is defined %}
             {{ error.message }}
         {% else %}
+            {% if properties.show_header_message is defined and properties.show_header_message is not empty %}
+                <div class='datatableHeaderMessage'>{{ properties.show_header_message | raw }}</div>
+            {% endif %}
+
             {% if isDataTableEmpty %}
                 <div class="pk-emptyDataTable">
                 {% if showReportDataWasPurgedMessage is defined and showReportDataWasPurgedMessage %}

--- a/plugins/Dashboard/stylesheets/widget.less
+++ b/plugins/Dashboard/stylesheets/widget.less
@@ -140,8 +140,10 @@
   background-color: @theme-color-widget-background;
 }
 
-.widget .datatableFooterMessage {
-  padding-left: 12px;
+.widget {
+  .datatableHeaderMessage, .datatableFooterMessage {
+    padding-left: 12px;
+  }
 }
 
 .bar-graph-colors[data-name=grid-background] {

--- a/plugins/Morpheus/stylesheets/main.less
+++ b/plugins/Morpheus/stylesheets/main.less
@@ -510,7 +510,7 @@ div.sparkline {
     color: @theme-color-text;
 }
 
-.datatableFooterMessage {
+.datatableHeaderMessage, .datatableFooterMessage {
     .font-default(13px, 18px);
     color: @color-silver;
     font-weight: normal;


### PR DESCRIPTION
As a plugin developer it would be useful to be able to configure a message that should be shown above a datatable. Current configuration only allows to define a message to be shown below in the footer.

As datatables can be quite long (e.g. when chosen to display > 25 entries) the footer message might not visible at first glance.