### PR TITLE
Set the piwik domain before initialising environment so the correct config will be used

### DIFF
--- a/misc/cron/updatetoken.php
+++ b/misc/cron/updatetoken.php
@@ -51,13 +51,14 @@ function getPiwikDomain()
     return null;
 }
 
-$environment = new Environment('cli');
-$environment->init();
 
 $piwikDomain = getPiwikDomain();
 if($piwikDomain) {
     Url::setHost($piwikDomain);
 }
+
+$environment = new Environment('cli');
+$environment->init();
 
 $token = Db::get()->fetchOne("SELECT token_auth
                               FROM " . Common::prefixTable("user") . "


### PR DESCRIPTION
We're experiencing a problem where the `updatetoken.php` sometimes fails.

A workaround to this issue is to specify a token_auth to the Log Analytics script https://piwik.org/log-analytics/ from an existing user from the DB, rather than rely on the `updatetoken.php` script.