### PR TITLE
Sessions with more security

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -3,6 +3,7 @@
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\NotFoundException;
 use Piwik\Cache\Eager;
+use Piwik\Session\SessionAuthCookieFactory;
 use Piwik\SettingsServer;
 
 return array(
@@ -90,4 +91,9 @@ return array(
 
     'Piwik\Tracker\Settings' => DI\object()
         ->constructorParameter('isSameFingerprintsAcrossWebsites', DI\get('ini.Tracker.enable_fingerprinting_across_websites')),
+
+    SessionAuthCookieFactory::class => DI\object()
+        ->constructorParameter('authCookieName', DI\get('ini.General.login_cookie_name'))
+        ->constructorParameter('authCookieValidTime', DI\get('ini.General.login_cookie_expire'))
+        ->constructorParameter('authCookiePath', DI\get('ini.General.login_cookie_path')),
 );

--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -105,7 +105,7 @@ class Cookie
      */
     public function isCookieFound()
     {
-        return isset($_COOKIE[$this->name]);
+        return self::isCookieInRequest($this->name);
     }
 
     /**
@@ -257,7 +257,7 @@ class Cookie
      *
      * @return string  Cookie content
      */
-    protected function generateContentString()
+    public function generateContentString()
     {
         $cookieStr = '';
 
@@ -393,5 +393,17 @@ class Cookie
     protected static function escapeValue($value)
     {
         return Common::sanitizeInputValues($value);
+    }
+
+    /**
+     * Returns true if a cookie named '$name' is in the current HTTP request,
+     * false if otherwise.
+     *
+     * @param string $name the name of the cookie
+     * @return boolean
+     */
+    public static function isCookieInRequest($name)
+    {
+        return isset($_COOKIE[$name]);
     }
 }

--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -370,6 +370,14 @@ class Cookie
     }
 
     /**
+     * Removes all values from the cookie.
+     */
+    public function clear()
+    {
+        $this->value = [];
+    }
+
+    /**
      * Returns an easy to read cookie dump
      *
      * @return string  The cookie dump

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -41,6 +41,7 @@ class Mysql implements SchemaInterface
                           token_auth CHAR(32) NOT NULL,
                           superuser_access TINYINT(2) unsigned NOT NULL DEFAULT '0',
                           date_registered TIMESTAMP NULL,
+                          ts_password_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                             PRIMARY KEY(login),
                             UNIQUE KEY uniq_keytoken(token_auth)
                           ) ENGINE=$engine DEFAULT CHARSET=utf8
@@ -447,11 +448,13 @@ class Mysql implements SchemaInterface
      */
     public function createAnonymousUser()
     {
+        $now = Date::factory('now')->getDatetime();
+
         // The anonymous user is the user that is assigned by default
         // note that the token_auth value is anonymous, which is assigned by default as well in the Login plugin
         $db = $this->getDb();
         $db->query("INSERT IGNORE INTO " . Common::prefixTable("user") . "
-                    VALUES ( 'anonymous', '', 'anonymous', 'anonymous@example.org', 'anonymous', 0, '" . Date::factory('now')->getDatetime() . "' );");
+                    VALUES ( 'anonymous', '', 'anonymous', 'anonymous@example.org', 'anonymous', 0, '$now', '$now' );");
     }
 
     /**

--- a/core/Session.php
+++ b/core/Session.php
@@ -52,6 +52,8 @@ class Session extends Zend_Session
         }
         self::$sessionStarted = true;
 
+        $config = Config::getInstance();
+
         // use cookies to store session id on the client side
         @ini_set('session.use_cookies', '1');
 
@@ -73,8 +75,11 @@ class Session extends Zend_Session
         // incorrectly invalidate the session
         @ini_set('session.referer_check', '');
 
+        // to preserve previous behavior piwik_auth provided when it contained a token_auth, we ensure
+        // the session data won't be deleted until the cookie expires.
+        @ini_set('session.gc_maxlifetime', $config->General['login_cookie_expire']);
+
         $currentSaveHandler = ini_get('session.save_handler');
-        $config = Config::getInstance();
 
         if (self::isFileBasedSessions()) {
             // Note: this handler doesn't work well in load-balanced environments and may have a concurrency issue with locked session files

--- a/core/Session/SessionAuth.php
+++ b/core/Session/SessionAuth.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Session;
+
+use Piwik\Auth;
+use Piwik\AuthResult;
+use Piwik\Plugins\UsersManager\Model as UsersModel;
+
+/**
+ * Validates already authenticated sessions.
+ *
+ * See {@link \Piwik\Session\SessionFingerprint} for more info.
+ */
+class SessionAuth implements Auth
+{
+    /**
+     * @var SessionAuthCookieFactory
+     */
+    private $sessionAuthCookieFactory;
+
+    public function __construct(SessionAuthCookieFactory $sessionAuthCookieFactory)
+    {
+        $this->sessionAuthCookieFactory = $sessionAuthCookieFactory;
+    }
+
+    public function getName()
+    {
+        // empty
+    }
+
+    public function setTokenAuth($token_auth)
+    {
+        // empty
+    }
+
+    public function getLogin()
+    {
+        // empty
+    }
+
+    public function getTokenAuthSecret()
+    {
+        // empty
+    }
+
+    public function setLogin($login)
+    {
+        // empty
+    }
+
+    public function setPassword($password)
+    {
+        // empty
+    }
+
+    public function setPasswordHash($passwordHash)
+    {
+        // empty
+    }
+
+    public function authenticate()
+    {
+        $sessionId = new SessionFingerprint();
+        $userModel = new UsersModel();
+
+        $cookie = $this->sessionAuthCookieFactory->getCookie($rememberMe = false);
+        $userNameInCookie = $cookie->get('user');
+        $cookieHash = $cookie->get('id');
+
+        $user = $userModel->getUser($userNameInCookie);
+        if (empty($user)) {
+            return $this->makeAuthFailure();
+        }
+
+        $userForSession = $sessionId->getUser();
+        if (empty($userForSession)) {
+            return $this->reAuthenticateSession($user, $cookieHash, $sessionId);
+        }
+
+        if (!$sessionId->isMatchingCurrentRequest()
+            || $userNameInCookie != $userForSession
+        ) {
+            return $this->makeAuthFailure();
+        }
+
+        return $this->makeAuthSuccess($user);
+    }
+
+    private function makeAuthFailure()
+    {
+        return new AuthResult(AuthResult::FAILURE, null, null);
+    }
+
+    private function makeAuthSuccess($user)
+    {
+        $this->setTokenAuth($user['token_auth']);
+
+        $isSuperUser = (int) $user['superuser_access'];
+        $code = $isSuperUser ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
+
+        return new AuthResult($code, $user['login'], $user['token_auth']);
+    }
+
+    /**
+     * Piwik uses the session cookie expiration time as the session expiration
+     * time. When a cookie expires, the session is no longer authenticated.
+     *
+     * Unfortunately, PHP's session.gc-probability INI config can delete a
+     * session server side, before the cookie expires. In this case, we have
+     * to securely re-authenticate, without revealing sensitive information
+     * in the cookie.
+     */
+    private function reAuthenticateSession($user, $cookieHash, SessionFingerprint $sessionId)
+    {
+        $passwordHelper = new Auth\Password();
+
+        $isValid = $passwordHelper->verify($user['token_auth'], $cookieHash);
+
+        if ($isValid) {
+            $sessionId->initialize($user['login']);
+            return $this->makeAuthSuccess($user);
+        } else {
+            return $this->makeAuthFailure();
+        }
+    }
+}

--- a/core/Session/SessionAuthCookieFactory.php
+++ b/core/Session/SessionAuthCookieFactory.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Session;
+
+use Piwik\Config;
+use Piwik\Cookie;
+
+class SessionAuthCookieFactory
+{
+    /**
+     * The authenticated session cookie's name. Defaults to the value of the `[General] login_cookie_name`
+     * INI config option.
+     *
+     * @var string
+     */
+    private $authCookieName;
+
+    /**
+     * The time in seconds before the authenticated session cookie expires. Only used if `$rememberMe`
+     * is true in the {@link initSession()} call.
+     *
+     * Defaults to the value of the `[General] login_cookie_expire` INI config option.
+     *
+     * @var int
+     */
+    private $authCookieValidTime;
+
+    /**
+     * The path for the authenticated session cookie. Defaults to the value of the `[General] login_cookie_path`
+     * INI config option.
+     *
+     * @var string
+     */
+    private $authCookiePath;
+
+    /**
+     * @var int
+     */
+    private $nowOverride;
+
+    public function __construct($authCookieName, $authCookieValidTime, $authCookiePath, $nowOverride = null)
+    {
+        $this->authCookieName = $authCookieName;
+        $this->authCookieValidTime = $authCookieValidTime;
+        $this->authCookiePath = $authCookiePath;
+        $this->nowOverride = $nowOverride;
+    }
+
+    public function getCookie($rememberMe)
+    {
+        $now = $this->nowOverride ?: time();
+        $authCookieExpiry = $rememberMe ? $now + $this->authCookieValidTime : 0;
+        $cookie = new Cookie($this->authCookieName, $authCookieExpiry, $this->authCookiePath);
+        return $cookie;
+    }
+
+    public function isCookieInRequest()
+    {
+        return Cookie::isCookieInRequest($this->authCookieName);
+    }
+}

--- a/core/Session/SessionFingerprint.php
+++ b/core/Session/SessionFingerprint.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Session;
+
+use Piwik\IP;
+
+/**
+ * Manages session information that is used to identify who the session
+ * is for.
+ *
+ * Once a session is authenticated using either a user name & password or
+ * token auth, some information about the user is stored in the session.
+ * This info includes the user name, the user's IP address and the user agent
+ * string of the user's client.
+ *
+ * In subsequent requests that use this session, we use the above information
+ * to verify that the session is allowed to be used by the person sending the
+ * request.
+ *
+ * This is accomplished by checking the request's IP address & user agent
+ * against what is stored in the session. If it doesn't then this is a
+ * session hijacking attempt.
+ */
+class SessionFingerprint
+{
+    const SESSION_SECRET_SESSION_VAR_NAME = 'session.secret';
+    const USER_NAME_SESSION_VAR_NAME = 'user.name';
+    const USER_INFO_SESSION_VAR_NAME = 'user.info';
+
+    public function getUser()
+    {
+        if (isset($_SESSION[self::USER_NAME_SESSION_VAR_NAME])) {
+            return $_SESSION[self::USER_NAME_SESSION_VAR_NAME];
+        }
+
+        return null;
+    }
+
+    public function getUserInfo()
+    {
+        if (isset($_SESSION[self::USER_INFO_SESSION_VAR_NAME])) {
+            return $_SESSION[self::USER_INFO_SESSION_VAR_NAME];
+        }
+
+        return null;
+    }
+
+    public function initialize($userName, $ip = null, $userAgent = null)
+    {
+        $_SESSION[self::USER_NAME_SESSION_VAR_NAME] = $userName;
+        $_SESSION[self::USER_INFO_SESSION_VAR_NAME] = [
+            'ip' => $ip ?: IP::getIpFromHeader(),
+            'ua' => $userAgent ?: $this->getUserAgent(),
+        ];
+    }
+
+    public function isMatchingCurrentRequest()
+    {
+        $requestIp = IP::getIpFromHeader();
+        $requestUa = $this->getUserAgent();
+
+        $userInfo = $this->getUserInfo();
+        if (empty($userInfo)) {
+            return false;
+        }
+
+        return $userInfo['ip'] == $requestIp && $userInfo['ua'] == $requestUa;
+    }
+
+    private function getUserAgent()
+    {
+        return array_key_exists('HTTP_USER_AGENT', $_SERVER) ? $_SERVER['HTTP_USER_AGENT'] : null;
+    }
+}

--- a/core/Updater/Migration/Db/AddColumn.php
+++ b/core/Updater/Migration/Db/AddColumn.php
@@ -23,5 +23,4 @@ class AddColumn extends Sql
 
         parent::__construct($sql, static::ERROR_CODE_DUPLICATE_COLUMN);
     }
-
 }

--- a/core/Updates/3.2.0-rc1.php
+++ b/core/Updates/3.2.0-rc1.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+/**
+ * Update for version 3.2.0-rc1.
+ */
+class Updates_3_2_0_rc1 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $addUserColumn = $this->migration->db->addColumn('user', 'ts_password_modified',
+            'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP');
+
+        return [
+            $addUserColumn,
+        ];
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+}

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -28,7 +28,6 @@ class Login extends \Piwik\Plugin
     public function registerEvents()
     {
         $hooks = array(
-            'Request.initAuthenticationObject' => 'initAuthenticationObject',
             'User.isNotAuthorized'             => 'noAccess',
             'API.Request.authenticate'         => 'ApiRequestAuthenticate',
             'AssetManager.getJavaScriptFiles'  => 'getJsFiles',
@@ -83,35 +82,12 @@ class Login extends \Piwik\Plugin
     }
 
     /**
-     * Initializes the authentication object.
-     * Listens to Request.initAuthenticationObject hook.
-     */
-    function initAuthenticationObject($activateCookieAuth = false)
-    {
-        $this->initAuthenticationFromCookie(StaticContainer::getContainer()->get('Piwik\Auth'), $activateCookieAuth);
-    }
-
-    /**
      * @param $auth
+     * @deprecated authenticating via cookie is handled in core by SessionAuth
      */
     public static function initAuthenticationFromCookie(\Piwik\Auth $auth, $activateCookieAuth)
     {
-        if (self::isModuleIsAPI() && !$activateCookieAuth) {
-            return;
-        }
-
-        $authCookieName = Config::getInstance()->General['login_cookie_name'];
-        $authCookieExpiry = 0;
-        $authCookiePath = Config::getInstance()->General['login_cookie_path'];
-        $authCookie = new Cookie($authCookieName, $authCookieExpiry, $authCookiePath);
-        $defaultLogin = 'anonymous';
-        $defaultTokenAuth = 'anonymous';
-        if ($authCookie->isCookieFound()) {
-            $defaultLogin = $authCookie->get('login');
-            $defaultTokenAuth = $authCookie->get('token_auth');
-        }
-        $auth->setLogin($defaultLogin);
-        $auth->setTokenAuth($defaultTokenAuth);
+        // empty
     }
 
 }

--- a/plugins/Login/SessionInitializer.php
+++ b/plugins/Login/SessionInitializer.php
@@ -15,6 +15,7 @@ use Piwik\AuthResult;
 use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
+use Piwik\Plugins\UsersManager\Model;
 use Piwik\ProxyHttp;
 use Piwik\Session;
 use Piwik\Session\SessionAuthCookieFactory;
@@ -139,8 +140,11 @@ class SessionInitializer
         $sessionIdentifier = new SessionFingerprint();
         $sessionIdentifier->initialize($authResult->getIdentity());
 
+        $userModel = new Model();
+        $user = $userModel->getUser($authResult->getIdentity());
+
         $cookie = $this->sessionCookieFactory->getCookie($rememberMe);
-        $cookie->set('id', $passwordHelper->hash($authResult->getTokenAuth()));
+        $cookie->set('id', $passwordHelper->hash($user['password']));
         $cookie->set('user', $authResult->getIdentity());
         $cookie->setSecure(ProxyHttp::isHttps());
         $cookie->setHttpOnly(true);

--- a/plugins/Login/SessionInitializer.php
+++ b/plugins/Login/SessionInitializer.php
@@ -142,6 +142,7 @@ class SessionInitializer
         $user = $userModel->getUser($authResult->getIdentity());
 
         $cookie = $this->sessionCookieFactory->getCookie($rememberMe);
+        $cookie->clear();
         $cookie->set('id', $sessionIdentifier->getHash($user['ts_password_modified']));
         $cookie->setSecure(ProxyHttp::isHttps());
         $cookie->setHttpOnly(true);

--- a/plugins/Login/SessionInitializer.php
+++ b/plugins/Login/SessionInitializer.php
@@ -10,15 +10,15 @@ namespace Piwik\Plugins\Login;
 
 use Exception;
 use Piwik\Auth as AuthInterface;
+use Piwik\Auth\Password;
 use Piwik\AuthResult;
-use Piwik\Config;
-use Piwik\Cookie;
-use Piwik\Db;
-use Piwik\Log;
+use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
 use Piwik\ProxyHttp;
 use Piwik\Session;
+use Piwik\Session\SessionAuthCookieFactory;
+use Piwik\Session\SessionFingerprint;
 
 /**
  * Initializes authenticated sessions using an Auth implementation.
@@ -35,6 +35,11 @@ use Piwik\Session;
 class SessionInitializer
 {
     /**
+     * @var SessionAuthCookieFactory
+     */
+    private $sessionCookieFactory;
+
+    /**
      * The UsersManager API instance.
      *
      * @var UsersManagerAPI
@@ -42,61 +47,19 @@ class SessionInitializer
     private $usersManagerAPI;
 
     /**
-     * The authenticated session cookie's name. Defaults to the value of the `[General] login_cookie_name`
-     * INI config option.
-     *
-     * @var string
-     */
-    private $authCookieName;
-
-    /**
-     * The time in seconds before the authenticated session cookie expires. Only used if `$rememberMe`
-     * is true in the {@link initSession()} call.
-     *
-     * Defaults to the value of the `[General] login_cookie_expire` INI config option.
-     *
-     * @var string
-     */
-    private $authCookieValidTime;
-
-    /**
-     * The path for the authenticated session cookie. Defaults to the value of the `[General] login_cookie_path`
-     * INI config option.
-     *
-     * @var string
-     */
-    private $authCookiePath;
-
-    /**
-     * Constructor.
-     *
      * @param UsersManagerAPI|null $usersManagerAPI
      * @param string|null $authCookieName
      * @param int|null $authCookieValidTime
      * @param string|null $authCookiePath
      */
-    public function __construct($usersManagerAPI = null, $authCookieName = null, $authCookieValidTime = null,
-                                $authCookiePath = null)
+    public function __construct(SessionAuthCookieFactory $sessionCookieFactory = null, $usersManagerAPI = null)
     {
+        $this->sessionCookieFactory = $sessionCookieFactory ?: StaticContainer::get(SessionAuthCookieFactory::class);
+
         if (empty($usersManagerAPI)) {
             $usersManagerAPI = UsersManagerAPI::getInstance();
         }
         $this->usersManagerAPI = $usersManagerAPI;
-
-        if (empty($authCookieName)) {
-            $authCookieName = Config::getInstance()->General['login_cookie_name'];
-        }
-        $this->authCookieName = $authCookieName;
-
-        if (empty($authCookieValidTime)) {
-            $authCookieValidTime = Config::getInstance()->General['login_cookie_expire'];
-        }
-        $this->authCookieValidTime = $authCookieValidTime;
-
-        if (empty($authCookiePath)) {
-            $authCookiePath = Config::getInstance()->General['login_cookie_path'];
-        }
-        $this->authCookiePath = $authCookiePath;
     }
 
     /**
@@ -148,21 +111,6 @@ class SessionInitializer
     }
 
     /**
-     * Returns a Cookie instance that manages the browser cookie used to store session
-     * information.
-     *
-     * @param bool $rememberMe Whether the authenticated session should be remembered after
-     *                         the browser is closed or not.
-     * @return Cookie
-     */
-    protected function getAuthCookie($rememberMe)
-    {
-        $authCookieExpiry = $rememberMe ? time() + $this->authCookieValidTime : 0;
-        $cookie = new Cookie($this->authCookieName, $authCookieExpiry, $this->authCookiePath);
-        return $cookie;
-    }
-
-    /**
      * Executed when the session could not authenticate.
      *
      * @param bool $rememberMe Whether the authenticated session should be remembered after
@@ -171,7 +119,7 @@ class SessionInitializer
      */
     protected function processFailedSession($rememberMe)
     {
-        $cookie = $this->getAuthCookie($rememberMe);
+        $cookie = $this->sessionCookieFactory->getCookie($rememberMe);
         $cookie->delete();
 
         throw new Exception(Piwik::translate('Login_LoginPasswordNotCorrect'));
@@ -186,9 +134,14 @@ class SessionInitializer
      */
     protected function processSuccessfulSession(AuthResult $authResult, $rememberMe)
     {
-        $cookie = $this->getAuthCookie($rememberMe);
-        $cookie->set('login', $authResult->getIdentity());
-        $cookie->set('token_auth', $this->getHashTokenAuth($authResult->getIdentity(), $authResult->getTokenAuth()));
+        $passwordHelper = new Password();
+
+        $sessionIdentifier = new SessionFingerprint();
+        $sessionIdentifier->initialize($authResult->getIdentity());
+
+        $cookie = $this->sessionCookieFactory->getCookie($rememberMe);
+        $cookie->set('id', $passwordHelper->hash($authResult->getTokenAuth()));
+        $cookie->set('user', $authResult->getIdentity());
         $cookie->setSecure(ProxyHttp::isHttps());
         $cookie->setHttpOnly(true);
         $cookie->save();

--- a/plugins/Login/SessionInitializer.php
+++ b/plugins/Login/SessionInitializer.php
@@ -135,8 +135,6 @@ class SessionInitializer
      */
     protected function processSuccessfulSession(AuthResult $authResult, $rememberMe)
     {
-        $passwordHelper = new Password();
-
         $sessionIdentifier = new SessionFingerprint();
         $sessionIdentifier->initialize($authResult->getIdentity());
 
@@ -144,8 +142,7 @@ class SessionInitializer
         $user = $userModel->getUser($authResult->getIdentity());
 
         $cookie = $this->sessionCookieFactory->getCookie($rememberMe);
-        $cookie->set('id', $passwordHelper->hash($user['password']));
-        $cookie->set('user', $authResult->getIdentity());
+        $cookie->set('id', $sessionIdentifier->getHash($user['ts_password_modified']));
         $cookie->setSecure(ProxyHttp::isHttps());
         $cookie->setHttpOnly(true);
         $cookie->save();
@@ -162,6 +159,7 @@ class SessionInitializer
      * @param string $login user login
      * @param string $token_auth authentication token
      * @return string hashed authentication token
+     * @deprecated
      */
     public static function getHashTokenAuth($login, $token_auth)
     {

--- a/plugins/Overlay/API.php
+++ b/plugins/Overlay/API.php
@@ -9,11 +9,8 @@
 namespace Piwik\Plugins\Overlay;
 
 use Exception;
-use Piwik\Access;
 use Piwik\Config;
-use Piwik\Container\StaticContainer;
 use Piwik\DataTable;
-use Piwik\Piwik;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\Plugins\SitesManager\SitesManager;
 use Piwik\Plugins\Transitions\API as APITransitions;
@@ -30,8 +27,6 @@ class API extends \Piwik\Plugin\API
      */
     public function getTranslations($idSite)
     {
-        $this->authenticate($idSite);
-
         $translations = array(
             'oneClick'         => 'Overlay_OneClick',
             'clicks'           => 'Overlay_Clicks',
@@ -48,8 +43,6 @@ class API extends \Piwik\Plugin\API
      */
     public function getExcludedQueryParameters($idSite)
     {
-        $this->authenticate($idSite);
-
         $sitesManager = APISitesManager::getInstance();
         $site = $sitesManager->getSiteFromId($idSite);
 
@@ -71,8 +64,6 @@ class API extends \Piwik\Plugin\API
      */
     public function getFollowingPages($url, $idSite, $period, $date, $segment = false)
     {
-        $this->authenticate($idSite);
-
         $url = PageUrl::excludeQueryParametersFromUrl($url, $idSite);
         // we don't unsanitize $url here. it will be done in the Transitions plugin.
 
@@ -99,39 +90,5 @@ class API extends \Piwik\Plugin\API
         }
 
         return $resultDataTable;
-    }
-
-    /** Do cookie authentication. This way, the token can remain secret. */
-    private function authenticate($idSite)
-    {
-        /**
-         * Triggered immediately before the user is authenticated.
-         *
-         * This event can be used by plugins that provide their own authentication mechanism
-         * to make that mechanism available. Subscribers should set the `'Piwik\Auth'` object in
-         * the container to an object that implements the {@link Piwik\Auth} interface.
-         *
-         * **Example**
-         *
-         *     use Piwik\Container\StaticContainer;
-         *
-         *     public function initAuthenticationObject($activateCookieAuth)
-         *     {
-         *         StaticContainer::getContainer()->set('Piwik\Auth', new LDAPAuth($activateCookieAuth));
-         *     }
-         *
-         * @param bool $activateCookieAuth Whether authentication based on `$_COOKIE` values should
-         *                                        be allowed.
-         */
-        Piwik::postEvent('Request.initAuthenticationObject', array($activateCookieAuth = true));
-
-        $auth = StaticContainer::get('Piwik\Auth');
-        $success = Access::getInstance()->reloadAccess($auth);
-
-        if (!$success) {
-            throw new Exception('Authentication failed');
-        }
-
-        Piwik::checkUserHasViewAccess($idSite);
     }
 }

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\UsersManager;
 
 use Piwik\Auth\Password;
 use Piwik\Common;
+use Piwik\Date;
 use Piwik\Db;
 use Piwik\Piwik;
 
@@ -199,7 +200,8 @@ class Model
             'email'            => $email,
             'token_auth'       => $tokenAuth,
             'date_registered'  => $dateRegistered,
-            'superuser_access' => 0
+            'superuser_access' => 0,
+            'ts_password_modified' => Date::now()->getDatetime(),
         );
 
         $db = $this->getDb();
@@ -221,6 +223,11 @@ class Model
         foreach ($fields as $key => $val) {
             $set[]  = "`$key` = ?";
             $bind[] = $val;
+        }
+
+        if (!empty($fields['password'])) {
+            $set[] = "ts_password_modified = ?";
+            $bind[] = Date::now()->getDatetime();
         }
 
         $bind[] = $userLogin;

--- a/plugins/UsersManager/tests/Integration/UsersManagerTest.php
+++ b/plugins/UsersManager/tests/Integration/UsersManagerTest.php
@@ -76,6 +76,7 @@ class UsersManagerTest extends IntegrationTestCase
         }
         $userAfter = $this->api->getUser($user["login"]);
         unset($userAfter['date_registered']);
+        unset($userAfter['ts_password_modified']);
         unset($userAfter['password']);
 
         // implicitly checks password!

--- a/tests/PHPUnit/Integration/Session/SessionAuthTest.php
+++ b/tests/PHPUnit/Integration/Session/SessionAuthTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Tests\Integration\Session;
+
+use Piwik\Auth\Password;
+use Piwik\AuthResult;
+use Piwik\Config;
+use Piwik\Container\StaticContainer;
+use Piwik\Plugins\UsersManager\Model;
+use Piwik\Session\SessionAuth;
+use Piwik\Session\SessionAuthCookieFactory;
+use Piwik\Session\SessionFingerprint;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Plugins\UsersManager\API as UsersManagerAPI;
+
+class SessionAuthTest extends IntegrationTestCase
+{
+    const TEST_IP = '11.22.33.44';
+    const TEST_UA = 'test-user-agent';
+    const TEST_OTHER_USER = 'testuser';
+
+    /**
+     * @var SessionAuth
+     */
+    private $testInstance;
+
+    public static function beforeTableDataCached()
+    {
+        parent::beforeTableDataCached();
+
+        UsersManagerAPI::getInstance()->addUser(self::TEST_OTHER_USER, 'testpass', 'test@example.com');
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->testInstance = StaticContainer::get(SessionAuth::class);
+    }
+
+    public function test_authenticate_ReturnsFailure_IfUsernameInSessionCookieIsInvalid()
+    {
+        $this->initializeSession(self::TEST_IP, self::TEST_UA, 'inavliduser');
+        $this->initializeRequest(self::TEST_IP, self::TEST_UA, 'inavliduser', 'invalidtokenauth');
+
+        $result = $this->testInstance->authenticate();
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+    }
+
+    public function test_authenticate_ReturnsFailure_IfCookieUsernameDiffersFromSessionUsername()
+    {
+        $this->initializeSession(self::TEST_IP, self::TEST_UA, Fixture::ADMIN_USER_LOGIN);
+        $this->initializeRequest(self::TEST_IP, self::TEST_UA, self::TEST_OTHER_USER);
+
+        $result = $this->testInstance->authenticate();
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+    }
+
+    public function test_authenticate_ReturnsFailure_IfRequestIpDiffersFromSessionIp()
+    {
+        $this->initializeSession(self::TEST_IP, self::TEST_UA, Fixture::ADMIN_USER_LOGIN);
+        $this->initializeRequest('55.55.55.55', self::TEST_UA, Fixture::ADMIN_USER_LOGIN);
+
+        $result = $this->testInstance->authenticate();
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+    }
+
+    public function test_authenticate_ReturnsFailure_IfRequestUserAgentDiffersFromSessionUserAgent()
+    {
+        $this->initializeSession(self::TEST_IP, self::TEST_UA, Fixture::ADMIN_USER_LOGIN);
+        $this->initializeRequest(self::TEST_IP, 'some-other-user-agent', Fixture::ADMIN_USER_LOGIN);
+
+        $result = $this->testInstance->authenticate();
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+    }
+
+    public function test_authenticate_ReturnsSuccess_IfRequestIpAndUserAgentMatchSession_AndCookieUsernameMatchesSessionUsername()
+    {
+        $this->initializeSession(self::TEST_IP, self::TEST_UA, self::TEST_OTHER_USER);
+        $this->initializeRequest(self::TEST_IP, self::TEST_UA, self::TEST_OTHER_USER);
+
+        $result = $this->testInstance->authenticate();
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+    }
+
+    public function test_authenticate_ReturnsSuperUserSuccess_IfRequestIpAndUserAgentMatchSession_AndCookieUsernameMatchesSessionUsername()
+    {
+        $this->initializeSession(self::TEST_IP, self::TEST_UA, Fixture::ADMIN_USER_LOGIN);
+        $this->initializeRequest(self::TEST_IP, self::TEST_UA, Fixture::ADMIN_USER_LOGIN);
+
+        $result = $this->testInstance->authenticate();
+        $this->assertEquals(AuthResult::SUCCESS_SUPERUSER_AUTH_CODE, $result->getCode());
+    }
+
+    public function test_authenticate_ReturnsFailure_IfReauthenticating_AndAuthHashIsInvalid()
+    {
+        // no session initialized
+        $this->initializeRequest(self::TEST_IP, self::TEST_UA, Fixture::ADMIN_USER_LOGIN, 'inavlidtokenauth');
+
+        $result = $this->testInstance->authenticate();
+        $this->assertEquals(AuthResult::FAILURE, $result->getCode());
+
+        $sessionFingerprint = new SessionFingerprint();
+        $this->assertNull($sessionFingerprint->getUser());
+    }
+
+    public function test_authenticate_ReturnsSuccess_IfReauthenticating_AndAuthHashIsValid()
+    {
+        // no session initialized
+        $this->initializeRequest(self::TEST_IP, self::TEST_UA, Fixture::ADMIN_USER_LOGIN);
+
+        $result = $this->testInstance->authenticate();
+        $this->assertEquals(AuthResult::SUCCESS_SUPERUSER_AUTH_CODE, $result->getCode());
+
+        $sessionFingerprint = new SessionFingerprint();
+        $this->assertEquals(Fixture::ADMIN_USER_LOGIN, $sessionFingerprint->getUser());
+        $this->assertEquals(['ip' => self::TEST_IP, 'ua' => self::TEST_UA], $sessionFingerprint->getUserInfo());
+    }
+
+    private function initializeRequest($ip, $userAgent, $userName, $tokenAuth = false)
+    {
+        if (empty($tokenAuth)) {
+            $model = new Model();
+            $user = $model->getUser($userName);
+            $tokenAuth = $user['token_auth'];
+        }
+
+        $sessionCookieFactory = StaticContainer::get(SessionAuthCookieFactory::class);
+        $passwordHelper = new Password();
+
+        $cookie = $sessionCookieFactory->getCookie(false);
+        $cookie->set('id', $passwordHelper->hash($tokenAuth));
+        $cookie->set('user', $userName);
+
+        $cookieName = Config::getInstance()->General['login_cookie_name'];
+        $_COOKIE[$cookieName] = $cookie->generateContentString();
+
+        $_SERVER['REMOTE_ADDR'] = $ip;
+        $_SERVER['HTTP_USER_AGENT'] = $userAgent;
+    }
+
+    private function initializeSession($ip, $userAgent, $userLogin)
+    {
+        $sessionFingerprint = new SessionFingerprint();
+        $sessionFingerprint->initialize($userLogin, $ip, $userAgent);
+    }
+
+    protected static function configureFixture($fixture)
+    {
+        parent::configureFixture($fixture);
+
+        $fixture->createSuperUser = true;
+    }
+}

--- a/tests/PHPUnit/Unit/CookieTest.php
+++ b/tests/PHPUnit/Unit/CookieTest.php
@@ -8,6 +8,8 @@
 
 namespace Piwik\Tests\Unit;
 
+use Piwik\Cookie;
+
 class CookieTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -151,5 +153,16 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         // arrays and objects cannot be used as keys, i.e., generates "Warning: Illegal offset type ..."
         $a = 'a:2:{i:0;a:0:{}O:28:"Test_Piwik_Cookie_Mock_Class":0:{}s:4:"test";';
         $this->assertFalse(safe_unserialize($a), "test: unserializing with illegal key");
+    }
+
+    public function test_isCookieInRequest_ReturnsTrueIfCookieExists()
+    {
+        $_COOKIE['abc'] = 'value';
+        $this->assertTrue(Cookie::isCookieInRequest('abc'));
+    }
+
+    public function test_isCookieInRequest_ReturnsFalseIfCookieExists()
+    {
+        $this->assertFalse(Cookie::isCookieInRequest('abc'));
     }
 }

--- a/tests/PHPUnit/Unit/Session/SessionAuthCookieFactoryTest.php
+++ b/tests/PHPUnit/Unit/Session/SessionAuthCookieFactoryTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Tests\Unit\Session;
+
+use Piwik\Cookie;
+use Piwik\Session\SessionAuthCookieFactory;
+
+class SessionAuthCookieFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    const COOKIE_NAME = 'test_auth';
+    const COOKIE_VALID_TIME = '60';
+    const COOKIE_PATH = '';
+    const TEST_NOW = 1000;
+
+    /**
+     * @var SessionAuthCookieFactory
+     */
+    private $testInstance;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->testInstance = new SessionAuthCookieFactory(
+            self::COOKIE_NAME, self::COOKIE_VALID_TIME, self::COOKIE_PATH, self::TEST_NOW);
+    }
+
+    public function test_getCookie_CreatesCorrectlyConfiguredCookieInstance()
+    {
+        $expectedCookieStr = 'COOKIE test_auth, rows count: 0, cookie size = 0 bytes, path: , expire: 1060
+array (
+)';
+
+        $cookie = $this->testInstance->getCookie(true);
+        $this->assertInstanceOf(Cookie::class, $cookie);
+        $this->assertEquals($expectedCookieStr, $cookie->__toString());
+    }
+
+    public function test_getCookie_CreatesCookieWithImmediateExpiry_IfRememberMeIsFalse()
+    {
+        $expectedCookieStr = 'COOKIE test_auth, rows count: 0, cookie size = 0 bytes, path: , expire: 0
+array (
+)';
+
+        $cookie = $this->testInstance->getCookie(false);
+        $this->assertInstanceOf(Cookie::class, $cookie);
+        $this->assertEquals($expectedCookieStr, $cookie->__toString());
+    }
+
+    public function test_isCookieInRequest_ReturnsTrue_IfConfiguredCookieIsPresent()
+    {
+        $_COOKIE[self::COOKIE_NAME] = 'sldkjfsdf';
+        $this->assertTrue($this->testInstance->isCookieInRequest());
+    }
+
+    public function test_isCookieInRequest_ReturnsFalse_IfConfiguredCookieIsNotPresent()
+    {
+        $this->assertFalse($this->testInstance->isCookieInRequest());
+    }
+}

--- a/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
+++ b/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Tests\Unit\Session;
+
+
+use Piwik\Session\SessionFingerprint;
+
+class SessionFingerprintTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SessionFingerprint
+     */
+    private $testInstance;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->testInstance = new SessionFingerprint();
+    }
+
+    public function test_getUser_ReturnsUserNameSessionVar_WhenSessionVarIsSet()
+    {
+        $_SESSION[SessionFingerprint::USER_NAME_SESSION_VAR_NAME] = 'testuser';
+        $this->assertEquals('testuser', $this->testInstance->getUser());
+    }
+
+    public function test_getUser_ReturnsNull_WhenSessionVarIsNotSet()
+    {
+        $this->assertNull($this->testInstance->getUser());
+    }
+
+    public function test_getUserInfo_ReturnsUserInfoSessionVar_WhenSessionVarIsSet()
+    {
+        $sessionVarValue = [
+            'ip' => 'someip',
+            'ua' => 'someua',
+        ];
+
+        $_SESSION[SessionFingerprint::USER_INFO_SESSION_VAR_NAME] = $sessionVarValue;
+        $this->assertEquals($sessionVarValue, $this->testInstance->getUserInfo());
+    }
+
+    public function test_getUserInfo_ReturnsNull_WhenSessionVarIsNotSet()
+    {
+        $this->assertNull($this->testInstance->getUserInfo());
+    }
+
+    public function test_initialize_SetsSessionVarsToCurrentRequest()
+    {
+        $_SERVER['REMOTE_ADDR'] = '55.66.77.88';
+        $_SERVER['HTTP_USER_AGENT'] = 'test-user-agent';
+        $this->testInstance->initialize('testuser');
+
+        $this->assertEquals('testuser', $_SESSION[SessionFingerprint::USER_NAME_SESSION_VAR_NAME]);
+        $this->assertEquals(
+            ['ip' => '55.66.77.88', 'ua' => 'test-user-agent'],
+            $_SESSION[SessionFingerprint::USER_INFO_SESSION_VAR_NAME]
+        );
+    }
+
+    public function test_initialize_DoesNotSetUserAgent_IfUserAgentIsNotInHttpRequest()
+    {
+        $_SERVER['REMOTE_ADDR'] = '55.66.77.88';
+        unset($_SERVER['HTTP_USER_AGENT']);
+        $this->testInstance->initialize('testuser');
+
+        $this->assertEquals('testuser', $_SESSION[SessionFingerprint::USER_NAME_SESSION_VAR_NAME]);
+        $this->assertEquals(
+            ['ip' => '55.66.77.88', 'ua' => null],
+            $_SESSION[SessionFingerprint::USER_INFO_SESSION_VAR_NAME]
+        );
+    }
+
+    public function test_initialize_DoesNotSetIpAddress_IfNoIpAddressInHttpRequest()
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+        $_SERVER['HTTP_USER_AGENT'] = 'test-user-agent';
+        $this->testInstance->initialize('testuser');
+
+        $this->assertEquals('testuser', $_SESSION[SessionFingerprint::USER_NAME_SESSION_VAR_NAME]);
+        $this->assertEquals(
+            ['ip' => '0.0.0.0', 'ua' => 'test-user-agent'],
+            $_SESSION[SessionFingerprint::USER_INFO_SESSION_VAR_NAME]
+        );
+    }
+
+    /**
+     * @dataProvider getTestDataForIsMatchingCurrentRequest
+     */
+    public function test_isMatchingCurrentRequest_ChecksIfSessionVarsMatchRequest(
+        $sessionIp, $sessionUa, $requestIp, $requestUa, $expectedResult
+    ) {
+        $_SESSION[SessionFingerprint::USER_INFO_SESSION_VAR_NAME] = [
+            'ip' => $sessionIp,
+            'ua' => $sessionUa,
+        ];
+
+        $_SERVER['REMOTE_ADDR'] = $requestIp;
+        $_SERVER['HTTP_USER_AGENT'] = $requestUa;
+
+        $this->assertEquals($expectedResult, $this->testInstance->isMatchingCurrentRequest());
+    }
+
+    public function getTestDataForIsMatchingCurrentRequest()
+    {
+        return [
+            ['11.22.33.44', 'test ua', '11.22.33.44', 'test ua', true],
+            ['11.22.33.55', 'test ua', '11.22.33.44', 'test ua', false],
+            ['11.22.33.44', 'nontest ua', '11.22.33.44', 'test ua', false],
+            [null, 'test ua', '11.22.33.44', 'test ua', false],
+            ['11.22.33.44', null, '11.22.33.44', 'test ua', false],
+        ];
+    }
+
+    public function test_isMatchingCurrentRequest_ReturnsFalse_IfUserInfoSessionVarDoesNotExist()
+    {
+        $_SERVER['REMOTE_ADDR'] = '11.22.33.44';
+        $_SERVER['HTTP_USER_AGENT'] = 'test-ua';
+
+        $this->assertEquals(false, $this->testInstance->isMatchingCurrentRequest());
+    }
+
+    public function test_isMatchingCurrentRequest_ReturnsFalse_IfRequestDetailsDoNotExist()
+    {
+        $_SESSION[SessionFingerprint::USER_INFO_SESSION_VAR_NAME] = [
+            'ip' => '11.22.33.44',
+            'ua' => 'test-ua',
+        ];
+
+        $this->assertEquals(false, $this->testInstance->isMatchingCurrentRequest());
+    }
+}


### PR DESCRIPTION
## Changes

_Note: security & performance considerations are discussed below._

* Changed concept of "cookie authentication". Currently, the token auth is stored insecurely in the piwik_auth cookie. When this cookie is in a request to Piwik, this token auth is used to authenticate the request. The authentication is also delegated to the Auth implementation. This PR changes the strategy.

  Now, the session stores information related to who the session is for (including IP address, user agent and a randomly generated secret). The piwik_auth cookie now contains a md5 hash of this randomly generated string + the last time a user's password was changed.

  If the cookie is present in a request, Piwik core will use `SessionAuth`, and bypass plugin based authentication altogether. SessionAuth will check that the session has been authenticated already, check that the request using the session is from the same place that initiated the session, and that the password hasn't changed since.

* A new column was added to the `user` table, `ts_password_modified`. This column holds the last time the user's password was changed. This column is used to automatically invalidate sessions after a user's password is changed (so we don't have to iterate over sessions or anything).

## BC Breaks

There should be no BC breaks. Plugins do not have to call `Login::initAuthenticationFromCookie()` anymore, but existing implementations don't have to be modified.

## Security Review

1. What info is compromised if the piwik_auth cookie is compromised?
  * The attacker would have access to the session ID and a md5 hash of the session secret. None of this information gives the attacker direct access to Piwik.
  * The attacker should also not be able to guess new session secrets, even if the system uses a weak random number generator, since secrets are only created after a user logs in.

2. Would an attacker be able to use the piwik_auth cookie to gain access to Piwik?
  * The token auth is no longer in the auth cookie, so they would not be able to use that.
  * The attacker could try to send the session cookies from another computer, but unless both the IP address and user agent are the same, they will not be able to use the existing session.
    * **If an attacker has access to a user's machine or wifi, they would be able to use the session (provided they have the correct browser or the user agent string).**

3. What would an attacker gain if the server side session variables were somehow compromised?
  * The attacker would have an IP address, user agent & user name, but would not have the token auth or password, since nothing of the sort is stored in the session.

4. Can an attacker generate their own valid piwik_auth hash?
  * Since the hash uses a secret that is unique to each session, they would have to know the secret of an existing session. Which means the hashes they generate would only be good for that one session.

### Possible attack vectors

The only way I can think of for an attacker to gain access to a session, is for the attacker to:

1. steal session cookies from an already authenticated session
2. use the session cookies from the same network as the user

## Performance Considerations

Since we're using a weak hash in SessionAuth, there's no real overhead to this solution.

Since sessions are not invalidated manually (eg, by iterating over every session), there is no overhead added to the change password workflow, either.

Keeping SessionAuth in core also allows plugin authentication to be more costly if required. Once a session is established, plugin based authentication won't happen again.

## Other Notes

1. This PR should not change how tracker requests are authenticated.
2. If cookies are sent w/ every AJAX request, then we don't need to pass the token auth to the client. (So we could potentially remove the token_auth from https://github.com/piwik/piwik/blob/9243b9a7b6fae8237596f76cda1fe8b6816463af/plugins/Morpheus/templates/_jsGlobalVariables.twig . Not sure if that would be a BC break, though.
3. The update for the ts_password_modified columns will log everyone out.

## Even more security

Some ideas for making Piwik even more secure (not necessarily related to this PR):

* Replace `Common::generateUniqId()`'s use of md5 & uniqid w/ `random_bytes()` (there's are polyfills for PHP 5.*, eg, https://github.com/symfony/polyfill). Would prevent attackers from being able to guess what new token auths would be.
* Add "recognized user agents" feature (akin to what facebook does). If a user logs in on an unknown device, it must be saved by an existing session before you can log in.
* Two factor auth (using virtual device preferably).
* Saving more information about the current device using Piwik (though I'm not sure if this info is available client side).
* Add a password strength requirement that encourages large passwords.

Fixes #6531 