### PR TITLE
Do not show bundles in premium feature widgets

### DIFF
--- a/plugins/Marketplace/Widgets/GetNewPlugins.php
+++ b/plugins/Marketplace/Widgets/GetNewPlugins.php
@@ -46,6 +46,10 @@ class GetNewPlugins extends Widget
 
         $plugins = $this->marketplaceApiClient->searchForPlugins('', '', Sort::METHOD_LAST_UPDATED, PurchaseType::TYPE_ALL);
 
+        $plugins = array_filter($plugins, function ($plugin) {
+            return empty($plugin['isBundle']);
+        });
+
         return $this->renderTemplate($template, array(
             'plugins' => array_splice($plugins, 0, 3)
         ));

--- a/plugins/Marketplace/Widgets/GetPremiumFeatures.php
+++ b/plugins/Marketplace/Widgets/GetPremiumFeatures.php
@@ -42,6 +42,10 @@ class GetPremiumFeatures extends Widget
 
         $plugins = $this->marketplaceApiClient->searchForPlugins('', '', Sort::METHOD_LAST_UPDATED, PurchaseType::TYPE_PAID);
 
+        $plugins = array_filter($plugins, function ($plugin) {
+            return empty($plugin['isBundle']);
+        });
+
         if (empty($plugins)) {
             $plugins = array();
         } else {

--- a/plugins/Marketplace/templates/getPremiumFeatures.twig
+++ b/plugins/Marketplace/templates/getPremiumFeatures.twig
@@ -1,6 +1,6 @@
 <div class="getNewPlugins getPremiumFeatures widgetBody">
     <div class="row">
-        {% for plugin in plugins %}
+        {% for plugin in plugins if not plugin.isBundle %}
             <div class="col s12 m4">
 
                 <h3 class="pluginName" piwik-plugin-name="{{ plugin.name|e('html_attr') }}">{{ plugin.displayName }}</h3>

--- a/plugins/Marketplace/templates/getPremiumFeatures.twig
+++ b/plugins/Marketplace/templates/getPremiumFeatures.twig
@@ -1,6 +1,6 @@
 <div class="getNewPlugins getPremiumFeatures widgetBody">
     <div class="row">
-        {% for plugin in plugins if not plugin.isBundle %}
+        {% for plugin in plugins %}
             <div class="col s12 m4">
 
                 <h3 class="pluginName" piwik-plugin-name="{{ plugin.name|e('html_attr') }}">{{ plugin.displayName }}</h3>


### PR DESCRIPTION
In "Latest Marketplace Updates" and "Premium Features" widgets which are on the admin home page, do not show bundles as it seems less confusing etc and I think it is not needed to show them there. Better to show individual features.