### PR TITLE
Do not show header_message on piwik.org at all in reporting

### DIFF
--- a/plugins/CoreHome/templates/_headerMessage.twig
+++ b/plugins/CoreHome/templates/_headerMessage.twig
@@ -10,7 +10,7 @@
     </span>
 {% endset %}
 
-{% if (latest_version_available and hasSomeViewAccess and not isUserIsAnonymous) or (isSuperUser and isAdminArea is defined and isAdminArea) %}
+{% if (latest_version_available and not isPiwikDemo and hasSomeViewAccess and not isUserIsAnonymous) or (isSuperUser and isAdminArea is defined and isAdminArea) %}
 <div piwik-expand-on-hover
      id="header_message"
      class="piwikSelector borderedControl {% if not latest_version_available %}header_info{% else %}{% endif %} piwikTopControl {% if latest_version_available %}update_available{% endif %}"


### PR DESCRIPTION
Otherwise the topbar will be always hidden as there is no content for it. Only affects demo.piwik.org