### PR TITLE
Do not use idGoal param for reports with goal metrics

### DIFF
--- a/plugins/Goals/Pages.php
+++ b/plugins/Goals/Pages.php
@@ -263,9 +263,7 @@ class Pages
 
         if ($idGoal === '') {
             // if no idGoal, use 0 for overview. Must be string! Otherwise Piwik_View_HtmlTable_Goals fails.
-            $customParams['idGoal'] = '0';
-        } else {
-            $customParams['idGoal'] = $idGoal;
+            $idGoal = '0';
         }
 
         $translationHelper = new TranslationHelper();
@@ -292,6 +290,12 @@ class Pages
                     $params = array_merge($customParams, $report['parameters']);
                 } else {
                     $params = $customParams;
+                }
+
+                if (isset($report['viewDataTable']) && $report['viewDataTable'] == 'tableGoals') {
+                    $params['showGoalMetricsFor'] = $idGoal;
+                } else {
+                    $params['idGoal'] = $idGoal;
                 }
 
                 $widget = $this->createWidgetForReport($report['module'], $report['action']);

--- a/plugins/Goals/Visualizations/Goals.php
+++ b/plugins/Goals/Visualizations/Goals.php
@@ -58,7 +58,7 @@ class Goals extends HtmlTable
     {
         // set view properties based on goal requested
         $idSite = Common::getRequestVar('idSite', null, 'int');
-        $idGoal = Common::getRequestVar('idGoal', AddColumnsProcessedMetricsGoal::GOALS_OVERVIEW, 'string');
+        $idGoal = Common::getRequestVar('showGoalMetricsFor', AddColumnsProcessedMetricsGoal::GOALS_OVERVIEW, 'string');
 
         $goalsToProcess = null;
         if (Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER == $idGoal) {


### PR DESCRIPTION
This is kind of a "quick" fix for #11526. But Row Evolution will show the same as when clicking on it in a non "Goal" report. Alternatively we could also simply deactivate Row Evolution for those Goals reports.
 
Note: I guess it would be awesome to be able to select the goal metrics for row evolution in this case, but that needs a bit more work.
