### PR TITLE
Add possibility for themes to change text color in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This is the Developer Changelog for Piwik platform developers. All changes in ou
 
 The Product Changelog at **[piwik.org/changelog](https://piwik.org/changelog)** lets you see more details about any Piwik release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Piwik 3.2.1
+
+### New APIs
+ * Themes can now customer the header text color using `@theme-color-header-text`
+
 ## Piwik 3.2.0
 
 ### New Segments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The Product Changelog at **[piwik.org/changelog](https://piwik.org/changelog)** 
 ## Piwik 3.2.1
 
 ### New APIs
- * Themes can now customer the header text color using `@theme-color-header-text`
+ * Themes can now customize the header text color using `@theme-color-header-text`
 
 ## Piwik 3.2.0
 

--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -47,6 +47,8 @@ nav {
   }
 
   ul a {
+    color: @theme-color-header-text !important;
+
     &:hover {
       text-decoration: none;
     }

--- a/plugins/ExampleTheme/stylesheets/theme.less
+++ b/plugins/ExampleTheme/stylesheets/theme.less
@@ -3,6 +3,7 @@
 @theme-color-brand: #5793d4;
 @theme-color-background-base: #d9e0e3;
 @theme-color-header-background: #0091ea;
+@theme-color-header-text: #0d0d0d;
 
 @theme-color-widget-title-background: #80d8ff;
 @theme-color-widget-title-text: #01579b;

--- a/plugins/Morpheus/stylesheets/theme.less
+++ b/plugins/Morpheus/stylesheets/theme.less
@@ -16,6 +16,7 @@
 @theme-color-headline-alternative: #4E4E4E;
 
 @theme-color-header-background: #37474f;
+@theme-color-header-text: @color-white;
 
 @theme-color-menu-contrast-text: @theme-color-text;
 @theme-color-menu-contrast-textSelected: @theme-color-menu-contrast-text;

--- a/tests/UI/expected-screenshots/Theme_home.png
+++ b/tests/UI/expected-screenshots/Theme_home.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1aff6ae7ace0d40ac6c1bace21f62ecb7e13a4ab130f8c6986192eec73b190f
-size 632565
+oid sha256:4750782a49bee8c1bddab7642460803395b2fea2843e471028d9eb532be2c72a
+size 632524


### PR DESCRIPTION
fixes #12201 If I understand it correctly, the color in the header should be changeable which I totally agree to in order to make it useful.

Expecting UI tests to fail for the theming part with black menu text color. 

For the variable I used the ending `-text` even though they are technically links (`-link`) to be consistent with the menu.