### PR TITLE
use same padding for all widget content

### DIFF
--- a/plugins/Dashboard/stylesheets/widget.less
+++ b/plugins/Dashboard/stylesheets/widget.less
@@ -87,6 +87,7 @@
         /** We do not want to show a material-card in a widget which is already a card */
         .card {
             box-shadow: 0 0;
+            padding: 0 10px;
 
             .card-content {
                 padding: 0;
@@ -95,6 +96,9 @@
         }
         .jqplot-graph {
             margin-top: 6px;
+        }
+        .sparkline {
+            padding: 0 10px;
         }
     }
 


### PR DESCRIPTION
this should fix uneven styling in widgets. could not monitor any unwanted differences, but it is possible.

For more infos including a screenshot of status quo see #12175 
