### PR TITLE
Correctly set date in page title when period changed via period selector

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -630,6 +630,7 @@ abstract class Controller
 
         $view->date = $this->strDate;
         $view->prettyDate = self::getCalendarPrettyDate($period);
+        // prettyDateLong is not used by core, leaving in case plugins may be using it
         $view->prettyDateLong = $period->getLocalizedLongString();
         $view->rawDate = $rawDate;
         $view->startDate = $dateStart;

--- a/plugins/CoreHome/angularjs/common/services/piwik.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik.js
@@ -10,9 +10,11 @@
     piwikService.$inject = ['piwikPeriods'];
 
     function piwikService(piwikPeriods) {
+        var originalTitle;
         piwik.helper    = piwikHelper;
         piwik.broadcast = broadcast;
         piwik.updatePeriodParamsFromUrl = updatePeriodParamsFromUrl;
+        piwik.updateDateInTitle = updateDateInTitle;
         return piwik;
 
         function updatePeriodParamsFromUrl() {
@@ -34,6 +36,8 @@
             var dateRange = piwikPeriods.parse(period, date).getDateRange();
             piwik.startDateString = $.datepicker.formatDate('yy-mm-dd', dateRange[0]);
             piwik.endDateString = $.datepicker.formatDate('yy-mm-dd', dateRange[1]);
+
+            updateDateInTitle(date, period);
 
             // do not set anything to previous7/last7, as piwik frontend code does not
             // expect those values.
@@ -60,6 +64,15 @@
             } catch (e) {
                 return false;
             }
+        }
+
+        function updateDateInTitle( date, period ) {
+            // Cache server-rendered page title
+            originalTitle = originalTitle || document.title;
+            var titleParts = originalTitle.split('-');
+            var dateString = ' ' + piwikPeriods.parse(period, date).getPrettyString() + ' ';
+            titleParts.splice(1, 0, dateString);
+            document.title = titleParts.join('-');
         }
     }
 

--- a/plugins/Morpheus/templates/dashboard.twig
+++ b/plugins/Morpheus/templates/dashboard.twig
@@ -8,7 +8,7 @@
     <![endif]-->
 {% endblock %}
 
-{% set title %}{{ siteName|raw }}{% if prettyDateLong is defined %} - {{ prettyDateLong }}{% endif %} - {{ 'CoreHome_WebAnalyticsReports'|translate }}{% endset %}
+{% set title %}{{ siteName|raw }} - {{ 'CoreHome_WebAnalyticsReports'|translate }}{% endset %}
 
 {% block pageDescription %}Web Analytics report for {{ siteName|escape("html_attr") }} - Matomo{% endblock %}
 


### PR DESCRIPTION
Fixes #12162

Hello! In this change:
- Added a new protected method `getLongPrettyDate` to `Piwik\Plugin\Controller`.
- Added a new public method `getDateString` to `Piwik\Plugins\CoreHome\Controller`.
- Added a new XHR request to the calendar.js module in CoreHome, to get a new "long pretty date string" when the user has updated the date or range.

<strike>In calendar.js, the logic to fetch new string/update page title has been appended to `propagateNewUrlParams`, but in retrospect this would be better in its own function, perhaps still invoked from `propagateNewUrlParams`?</strike> (done)

In `Piwik\Plugin\Controller`, the logic inside `getLongPrettyDate` is currently is copy/pasted from `setGeneralVariablesView`. I tried to tease apart the duplicated logic, but it started to become a time sink so I wanted to seek feedback on this approach before spending further time de-duplicating this logic.

Your thoughts?