### PR TITLE
Add cross domain linking helper text

### DIFF
--- a/plugins/CoreAdminHome/lang/en.json
+++ b/plugins/CoreAdminHome/lang/en.json
@@ -27,7 +27,7 @@
         "JSTracking_CodeNoteBeforeClosingHead": "Make sure this code is on every page of your website. We recommend to paste it immediately before the closing %1$s tag.",
         "JSTracking_CustomCampaignQueryParam": "Use custom query parameter names for the campaign name & keyword",
         "JSTracking_CrossDomain": "By default, the visitor ID that identifies a unique visitor is stored in the browser's first party cookies which can only be accessed by pages on the same domain. Enabling cross domain linking lets you track all the actions and pageviews of a specific visitor into the same visit even when they view pages on several domains. Whenever a user clicks on a link to one of your website's alias URLs, it will append a URL parameter pk_vid forwarding the Visitor ID.",
-        "JSTracking_CrossDomain_NeedsMultipleDomains": "Note: To use cross domain linking, you must specify more than one domain name for your website.",
+        "JSTracking_CrossDomain_NeedsMultipleDomains": "Note: To use cross domain linking, you must specify more than one domain name (URLs) for your website.",
         "JSTracking_CustomCampaignQueryParamDesc": "Note: %1$sPiwik will automatically detect Google Analytics parameters.%2$s",
         "JSTracking_DisableCookies": "Disable all tracking cookies",
         "JSTracking_DisableCookiesDesc": "Disables all first party cookies. Existing Piwik cookies for this website will be deleted on the next page view.",

--- a/plugins/CoreAdminHome/lang/en.json
+++ b/plugins/CoreAdminHome/lang/en.json
@@ -27,6 +27,7 @@
         "JSTracking_CodeNoteBeforeClosingHead": "Make sure this code is on every page of your website. We recommend to paste it immediately before the closing %1$s tag.",
         "JSTracking_CustomCampaignQueryParam": "Use custom query parameter names for the campaign name & keyword",
         "JSTracking_CrossDomain": "By default, the visitor ID that identifies a unique visitor is stored in the browser's first party cookies which can only be accessed by pages on the same domain. Enabling cross domain linking lets you track all the actions and pageviews of a specific visitor into the same visit even when they view pages on several domains. Whenever a user clicks on a link to one of your website's alias URLs, it will append a URL parameter pk_vid forwarding the Visitor ID.",
+        "JSTracking_CrossDomain_NeedsMultipleDomains": "Note: To use cross domain linking, you must specify more than one domain name for your website.",
         "JSTracking_CustomCampaignQueryParamDesc": "Note: %1$sPiwik will automatically detect Google Analytics parameters.%2$s",
         "JSTracking_DisableCookies": "Disable all tracking cookies",
         "JSTracking_DisableCookiesDesc": "Disables all first party cookies. Existing Piwik cookies for this website will be deleted on the next page view.",

--- a/plugins/CoreAdminHome/templates/trackingCodeGenerator.twig
+++ b/plugins/CoreAdminHome/templates/trackingCodeGenerator.twig
@@ -145,6 +145,8 @@
                 {# cross domain support #}
                 <div id="jsCrossDomain" class="inline-help-node">
                     {{ "CoreAdminHome_JSTracking_CrossDomain"|translate }}
+                    <br/>
+                    {{ 'CoreAdminHome_JSTracking_CrossDomain_NeedsMultipleDomains'|translate }}
                 </div>
 
                 <div piwik-field uicontrol="checkbox" name="javascript-tracking-cross-domain"


### PR DESCRIPTION
Fixes #11866

Adds some additional helper text clarifying the need for more than one domain name to exist before cross domain linking can be used.

Adds a new i18n key `CoreAdminHome_JSTracking_CrossDomain_NeedsMultipleDomains`.

I explored having this additional text only show up if a user has only 1 domain name set up, but this information was not already available in the `Site` data cache (that I could find), and I did not think it warranted a database request. Let me know if you disagree and would like me to add the behavior I described (only show text if user only has 1 domain set up).

🍻 