### PR TITLE
New "Event URL" segment `eventUrl` to segment on any Segment URL

### DIFF
--- a/core/Tracker/TableLogAction.php
+++ b/core/Tracker/TableLogAction.php
@@ -217,6 +217,7 @@ class TableLogAction
         $exactMatch = array(
             'outlinkUrl'         => Action::TYPE_OUTLINK,
             'downloadUrl'        => Action::TYPE_DOWNLOAD,
+            'eventUrl'           => Action::TYPE_EVENT,
             'eventAction'        => Action::TYPE_EVENT_ACTION,
             'eventCategory'      => Action::TYPE_EVENT_CATEGORY,
             'eventName'          => Action::TYPE_EVENT_NAME,

--- a/core/Tracker/TableLogAction.php
+++ b/core/Tracker/TableLogAction.php
@@ -180,7 +180,7 @@ class TableLogAction
             $sql = 'SELECT idaction FROM ' . Common::prefixTable('log_action') . ' WHERE type = ' . $actionType . ' )';
         } else {
             $actionType = self::guessActionTypeFromSegment($segmentName);
-            if ($actionType == Action::TYPE_PAGE_URL) {
+            if ($actionType == Action::TYPE_PAGE_URL || $segmentName == 'eventUrl') {
                 // for urls trim protocol and www because it is not recorded in the db
                 $valueToMatch = preg_replace('@^http[s]?://(www\.)?@i', '', $valueToMatch);
             }

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -666,7 +666,7 @@ class API extends \Piwik\Plugin\API
         $segmentsNeedActionsInfo = array('visitConvertedGoalId',
             'pageUrl', 'pageTitle', 'siteSearchKeyword',
             'entryPageTitle', 'entryPageUrl', 'exitPageTitle', 'exitPageUrl',
-            'outlinkUrl', 'downloadUrl'
+            'outlinkUrl', 'downloadUrl', 'eventUrl'
         );
         $isCustomVariablePage = stripos($segmentName, 'customVariablePage') !== false;
         $isEventSegment = stripos($segmentName, 'event') !== false;

--- a/plugins/Actions/Columns/ActionUrl.php
+++ b/plugins/Actions/Columns/ActionUrl.php
@@ -21,7 +21,7 @@ class ActionUrl extends ActionDimension
         $segment = new Segment();
         $segment->setSegment('actionUrl');
         $segment->setName('Actions_ColumnActionURL');
-        $segment->setUnionOfSegments(array('pageUrl', 'downloadUrl', 'outlinkUrl'));
+        $segment->setUnionOfSegments(array('pageUrl', 'downloadUrl', 'outlinkUrl', 'eventUrl'));
 
         $this->addSegment($segment);
     }

--- a/plugins/Events/Columns/EventUrl.php
+++ b/plugins/Events/Columns/EventUrl.php
@@ -17,7 +17,7 @@ class EventUrl extends ActionDimension
 {
     protected $columnName = 'idaction_url';
     protected $columnType = 'INTEGER(10) UNSIGNED DEFAULT NULL';
-    protected $segmentName = 'EventUrl';
+    protected $segmentName = 'eventUrl';
     protected $nameSingular = 'Events_EventUrl';
     protected $namePlural = 'Events_EventUrls';
     protected $type = self::TYPE_URL;

--- a/plugins/Events/Columns/EventUrl.php
+++ b/plugins/Events/Columns/EventUrl.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\Events\Columns;
+
+use Piwik\Columns\Discriminator;
+use Piwik\Columns\Join\ActionNameJoin;
+use Piwik\Plugin\Dimension\ActionDimension;
+use Piwik\Tracker\Action;
+
+class EventUrl extends ActionDimension
+{
+    protected $columnName = 'idaction_url';
+    protected $columnType = 'INTEGER(10) UNSIGNED DEFAULT NULL';
+    protected $segmentName = 'EventUrl';
+    protected $nameSingular = 'Events_EventUrl';
+    protected $namePlural = 'Events_EventUrls';
+    protected $type = self::TYPE_URL;
+    protected $acceptValues = 'The URL must be URL encoded, for example: http%3A%2F%2Fexample.com%2Fpath%2Fpage%3Fquery';
+    protected $category = 'Events_Events';
+    protected $sqlFilter = '\\Piwik\\Tracker\\TableLogAction::getIdActionFromSegment';
+
+    public function getDbColumnJoin()
+    {
+        return new ActionNameJoin();
+    }
+
+    public function getDbDiscriminator()
+    {
+        return new Discriminator('log_action', 'type', Action::TYPE_EVENT);
+    }
+
+}
+

--- a/plugins/Events/Columns/EventUrl.php
+++ b/plugins/Events/Columns/EventUrl.php
@@ -16,7 +16,6 @@ use Piwik\Tracker\Action;
 class EventUrl extends ActionDimension
 {
     protected $columnName = 'idaction_url';
-    protected $columnType = 'INTEGER(10) UNSIGNED DEFAULT NULL';
     protected $segmentName = 'eventUrl';
     protected $nameSingular = 'Events_EventUrl';
     protected $namePlural = 'Events_EventUrls';

--- a/plugins/Events/lang/en.json
+++ b/plugins/Events/lang/en.json
@@ -11,6 +11,8 @@
         "EventCategory": "Event Category",
         "EventName": "Event Name",
         "EventNames": "Event Names",
+        "EventUrl": "Event URL",
+        "EventUrls": "Event URLs",
         "Events": "Events",
         "EventsWithValue": "Events with a value",
         "EventsWithValueDocumentation": "Number of events where an Event value was set",

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -221,6 +221,7 @@ class Visitor implements VisitorInterface
             $flattenForActionType = array(
                 'outlink' => 'outlinkUrl',
                 'download' => 'downloadUrl',
+                'event' => 'eventUrl',
                 'action' => 'pageUrl'
             );
             foreach($flattenForActionType as $actionType => $flattenedKeyPrefix) {

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -832,9 +832,10 @@ class SegmentTest extends IntegrationTestCase
                             ON log_link_visit_action.idvisit = log_visit.idvisit
                           WHERE (( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 1 )) )
                                 OR ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 3 )) )
-                                OR ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 2 )) ) )
+                                OR ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 2 )) )
+                                OR ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', ?, '%') AND type = 10 )) ) )
                         GROUP BY log_visit.idvisit ORDER BY NULL ) AS log_inner",
-            "bind" => array('myTestUrl', 'myTestUrl', 'myTestUrl'));
+            "bind" => array('myTestUrl', 'myTestUrl', 'myTestUrl', 'myTestUrl'));
 
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionUrl__API.getSuggestedValuesForSegment.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionUrl__API.getSuggestedValuesForSegment.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<row>http://piwik.net/grue/lair</row>
 	<row>http://piwik.net/space/quest/iv</row>
-	<row>http://example-outlink.org/1.html</row>
+	<row>http://piwik.net/grue/lair</row>
 	<row>http://example.org/path/file1.zip</row>
 	<row>http://example.org/path/file0.zip</row>
+	<row>http://example-outlink.org/1.html</row>
 	<row>http://example-outlink.org/0.html</row>
-	<row>http://example.org/path/file2.zip</row>
-	<row>http://example.org/path/file3.zip</row>
 	<row>http://example-outlink.org/3.html</row>
+	<row>http://example.org/path/file3.zip</row>
 	<row>http://example-outlink.org/2.html</row>
-	<row>http://example.org/path/file4.zip</row>
-	<row>http://example.org/path/file5.zip</row>
-	<row>http://example.org/path/file8.zip</row>
-	<row>http://example-outlink.org/6.html</row>
+	<row>http://example.org/path/file2.zip</row>
 	<row>http://example-outlink.org/7.html</row>
-	<row>http://example-outlink.org/5.html</row>
-	<row>http://example-outlink.org/4.html</row>
-	<row>http://example.org/path/file7.zip</row>
 	<row>http://example-outlink.org/8.html</row>
+	<row>http://example.org/path/file4.zip</row>
+	<row>http://example-outlink.org/6.html</row>
 	<row>http://example.org/path/file6.zip</row>
+	<row>http://example-outlink.org/4.html</row>
+	<row>http://example-outlink.org/5.html</row>
+	<row>http://example.org/path/file8.zip</row>
+	<row>http://example.org/path/file7.zip</row>
+	<row>http://example.org/path/file5.zip</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionUrl__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_actionUrl__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>18</nb_visits>
-	<nb_actions>18</nb_actions>
-	<nb_visits_converted>18</nb_visits_converted>
-	<bounce_count>18</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>1</max_actions>
-	<bounce_rate>100%</bounce_rate>
-	<nb_actions_per_visit>1</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>17</nb_visits>
+	<nb_actions>77</nb_actions>
+	<nb_visits_converted>17</nb_visits_converted>
+	<bounce_count>0</bounce_count>
+	<sum_visit_length>27557</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>0%</bounce_rate>
+	<nb_actions_per_visit>4.5</nb_actions_per_visit>
+	<avg_time_on_site>1621</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_eventUrl__API.getSuggestedValuesForSegment.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_eventUrl__API.getSuggestedValuesForSegment.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>http://piwik.net/space/quest/iv</row>
+</result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_eventUrl__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_eventUrl__VisitsSummary.get_range.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<nb_visits>0</nb_visits>
+	<nb_actions>0</nb_actions>
+	<nb_visits_converted>0</nb_visits_converted>
+	<bounce_count>0</bounce_count>
+	<sum_visit_length>0</sum_visit_length>
+	<max_actions>0</max_actions>
+	<bounce_rate>0%</bounce_rate>
+	<nb_actions_per_visit>0</nb_actions_per_visit>
+	<avg_time_on_site>0</avg_time_on_site>
+</result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_eventUrl__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_eventUrl__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
+	<nb_visits>17</nb_visits>
+	<nb_actions>77</nb_actions>
+	<nb_visits_converted>17</nb_visits_converted>
 	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
+	<sum_visit_length>27557</sum_visit_length>
+	<max_actions>5</max_actions>
 	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_actions_per_visit>4.5</nb_actions_per_visit>
+	<avg_time_on_site>1621</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
@@ -460,6 +460,7 @@
 			<row>pageUrl</row>
 			<row>downloadUrl</row>
 			<row>outlinkUrl</row>
+			<row>eventUrl</row>
 		</unionOfSegments>
 	</row>
 	<row>
@@ -575,6 +576,13 @@
 		<category>Events</category>
 		<name>Event Name</name>
 		<segment>eventName</segment>
+	</row>
+	<row>
+		<type>dimension</type>
+		<category>Events</category>
+		<name>Event URL</name>
+		<segment>eventUrl</segment>
+		<acceptedValues>The URL must be URL encoded, for example: http%3A%2F%2Fexample.com%2Fpath%2Fpage%3Fquery</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>


### PR DESCRIPTION
Useful for many use cases for example:

* Creating Custom Reports such as "Top page URLs by Event action"
* Segmenting by Event URL and view events triggered on a specific Page URL
* Fixes #11131 Action URL segment could filter both Page URLs OR Event URLs (as advertised originally in the 2.16.0 changelog but it wasn't actually fully working yet)

TODO:

* Check & fix build