### PR TITLE
Fixed double gif output when QueuedTracking plugin is enabled

### DIFF
--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -149,6 +149,13 @@ class Response
 
     private function outputTransparentGif()
     {
+        static $didOutput = false;
+        
+        if ($didOutput) {
+            return;
+        }
+        $didOutput = true;
+        
         $transGifBase64 = "R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
         Common::sendHeader('Content-Type: image/gif');
 


### PR DESCRIPTION
See https://github.com/piwik/plugin-QueuedTracking/issues/45

When the QueuedTracking plugin and its setting "Process during tracking request" are enabled, "Response->outputResponse()" is called twice, and thus the gif gets sent twice, which will mismatch the Content-Length header and cause some issues.

This patch adds a check to outputTransparentGif() to make sure the gif is only sent to output once.