### PR TITLE
Make all new segments "Pre-processed" when browser_archiving_disabled_enforce=1

### DIFF
--- a/plugins/SegmentEditor/SegmentSelectorControl.php
+++ b/plugins/SegmentEditor/SegmentSelectorControl.php
@@ -94,7 +94,7 @@ class SegmentSelectorControl extends UIControl
 
     private function wouldApplySegment($savedSegment)
     {
-        if (!$this->isBrowserArchivingDisabledForSegments()) {
+        if (Rules::isBrowserArchivingAvailableForSegments()) {
             return true;
         }
 

--- a/plugins/SegmentEditor/SegmentSelectorControl.php
+++ b/plugins/SegmentEditor/SegmentSelectorControl.php
@@ -60,7 +60,7 @@ class SegmentSelectorControl extends UIControl
             $segmentsByCategory[$segment['category']][] = $segment;
         }
 
-        $this->createRealTimeSegmentsIsEnabled = Config::getInstance()->General['enable_create_realtime_segments'];
+        $this->createRealTimeSegmentsIsEnabled = $this->isCreatingRealTimeSegmentsEnabled();
         $this->segmentsByCategory   = $segmentsByCategory;
         $this->nameOfCurrentSegment = '';
         $this->isSegmentNotAppliedBecauseBrowserArchivingIsDisabled = 0;
@@ -94,9 +94,7 @@ class SegmentSelectorControl extends UIControl
 
     private function wouldApplySegment($savedSegment)
     {
-        $isBrowserArchivingDisabled = Config::getInstance()->General['browser_archiving_disabled_enforce'];
-
-        if (!$isBrowserArchivingDisabled) {
+        if (!$this->isBrowserArchivingDisabledForSegments()) {
             return true;
         }
 
@@ -132,5 +130,20 @@ class SegmentSelectorControl extends UIControl
             $translations[$key] = Piwik::translate($key);
         }
         return $translations;
+    }
+
+    protected function isCreatingRealTimeSegmentsEnabled()
+    {
+        // when browser archiving is disabled for segments, we force new segments to be created as pre-processed
+        if($this->isBrowserArchivingDisabledForSegments()) {
+            return false;
+        }
+
+        return (bool) Config::getInstance()->General['enable_create_realtime_segments'];
+    }
+
+    private function isBrowserArchivingDisabledForSegments()
+    {
+        return (bool) Config::getInstance()->General['browser_archiving_disabled_enforce'];
     }
 }

--- a/plugins/SegmentEditor/SegmentSelectorControl.php
+++ b/plugins/SegmentEditor/SegmentSelectorControl.php
@@ -135,15 +135,11 @@ class SegmentSelectorControl extends UIControl
     protected function isCreatingRealTimeSegmentsEnabled()
     {
         // when browser archiving is disabled for segments, we force new segments to be created as pre-processed
-        if($this->isBrowserArchivingDisabledForSegments()) {
+        if(!Rules::isBrowserArchivingAvailableForSegments()) {
             return false;
         }
 
         return (bool) Config::getInstance()->General['enable_create_realtime_segments'];
     }
 
-    private function isBrowserArchivingDisabledForSegments()
-    {
-        return (bool) Config::getInstance()->General['browser_archiving_disabled_enforce'];
-    }
 }


### PR DESCRIPTION
If real time processing of segments is disabled via browser_archiving_disabled_enforce=1
then any segment set to "segmented reports are processed in real time (default)"
will NEVER be showing data (except in the Live/real time reports)

With this PR all new segments will be set to "segmented reports are pre-processed (requires cron)"

It does not fix up existing real segments, but existing real time segments would display a modal explaining the issue (refs https://github.com/piwik/piwik/issues/12253)
