### PR TITLE
 Log on DEBUG level all SQL archiving queries

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -185,8 +185,8 @@ class LogAggregator
             $query['sql'] = 'SELECT /* ' . $this->queryOriginHint . ' */' . substr($query['sql'], strlen($select));
         }
 
-	// Uncomment to log on DEBUG level all archiving queries
-        // $this->logger->debug($query['sql']);
+	// Log on DEBUG level all SQL archiving queries
+        $this->logger->debug($query['sql']);
 
         return $query;
     }


### PR DESCRIPTION
As long as it does not create performance regression or impact, it would be really useful to have this by default in Piwik, makes it useful to troubleshoot archiving problems without having to patch this file and uncomment this logger line.

Learn more about logging: https://piwik.org/faq/how-to/faq_20991/
and https://piwik.org/faq/troubleshooting/faq_115/