### PR TITLE
Add visitor details events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The Product Changelog at **[piwik.org/changelog](https://piwik.org/changelog)** 
 ### New Segments
 * New Segment added: `visitStartServerMinute` for Server time - minute (Start of visit)
 * New Segment added: `visitEndServerMinute` for Server time - minute (End of visit)
+* New events added to add and filter visitor details: `Live.addVisitorDetails` and `Live.filterVisitorDetails`
 
 
 ### New APIs

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -78,6 +78,20 @@ class Visitor implements VisitorInterface
                 new VisitorDetails() // needs to be first
             ];
 
+            /**
+             * Triggered to add new visitor details that cannot be picked up by the platform automatically.
+             *
+             * **Example**
+             *
+             *     public function addVisitorDetails(&$visitorDetails)
+             *     {
+             *         $visitorDetails[] = new CustomVisitorDetails();
+             *     }
+             *
+             * @param VisitorDetailsAbstract[] $visitorDetails An array of visitorDetails
+             */
+            Piwik::postEvent('Live.addVisitorDetails', array(&$instances));
+
             foreach (self::getAllVisitorDetailsClasses() as $className) {
                 $instance = new $className();
 
@@ -87,6 +101,24 @@ class Visitor implements VisitorInterface
 
                 $instances[] = $instance;
             }
+
+            /**
+             * Triggered to filter / restrict vistor details.
+             *
+             * **Example**
+             *
+             *     public function filterVisitorDetails(&$visitorDetails)
+             *     {
+             *         foreach ($visitorDetails as $index => $visitorDetail) {
+             *              if (strpos(get_class($visitorDetail), 'MyPluginName') !== false) {}
+             *                  unset($visitorDetails[$index]); // remove all visitor details for a specific plugin
+             *              }
+             *         }
+             *     }
+             *
+             * @param VisitorDetailsAbstract[] $visitorDetails An array of visitorDetails
+             */
+            Piwik::postEvent('Live.filterVisitorDetails', array(&$instances));
 
             $cache->save($cacheId, $instances);
         }


### PR DESCRIPTION
Similar to Report.add/filterReports, Widget.add/filterWidgets, etc

We can change naming but kept it consistent with these existing events. It may be a bit confusing to have `Live.addVisitorDetails` and `Live.filterVisitorDetails` vs `Live.getAllVisitorDetails`. For `Live.getAllVisitorDetails` you would then expect it returns maybe all visitor detail instances. The first 2 work basically on the raw instances, whereas `Live.getAllVisitorDetails` works on the actual visitor details data. Any thoughts @sgiehl ?