### PR TITLE
Disallow indexing for pages doing a redirect

### DIFF
--- a/core/Url.php
+++ b/core/Url.php
@@ -461,6 +461,7 @@ class Url
             || strpos($url, 'index.php') === 0
         ) {
             Common::sendResponseCode(302);
+            Common::sendHeader("X-Robots-Tag: noindex");
             Common::sendHeader("Location: $url");
         } else {
             echo "Invalid URL to redirect to.";


### PR DESCRIPTION
According to https://developers.google.com/search/reference/robots_meta_tag?hl=en#using-the-x-robots-tag-http-header adding this header should prevent Google from indexing those pages doing a redirect