### PR TITLE
make HTML in safemode-page valid

### DIFF
--- a/plugins/CorePluginsAdmin/templates/safemode.twig
+++ b/plugins/CorePluginsAdmin/templates/safemode.twig
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <meta name="robots" content="noindex,nofollow">
@@ -21,6 +22,7 @@
                 text-decoration: underline;
             }
         </style>
+        <title>A fatal error occurred</title>
     </head>
     <body>
 
@@ -30,11 +32,11 @@
 
         {% if isAllowedToTroubleshootAsSuperUser or not isAnonymousUser %}
             <p>
-                The following error just broke Piwik{% if showVersion %} (v{{ piwikVersion }}){%  endif %}:
-                <pre>{{ lastError.message }}</pre>
-                in
-                <pre>{{ lastError.file }} line {{ lastError.line }}</pre>
+                The following error just broke Piwik{% if showVersion %} (v{{ piwikVersion }}){% endif %}:
             </p>
+            <pre>{{ lastError.message }}</pre>
+            <p>in</p>
+            <pre>{{ lastError.file }} line {{ lastError.line }}</pre>
 
             <hr>
             <h3>Troubleshooting</h3>

--- a/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:474891899e2f81e9079aba72bb3e48f8cd1a27b24a67aa68e4d10f432685fda1
-size 203076
+oid sha256:be07a618205e1e295ebda34ab707c00abf66c365aaea269a83e8265b55f93350
+size 203309


### PR DESCRIPTION
A small fix, because I noticed that the HTML on the safemode page doesn't validate.

`<pre>` aren't allowed inside of `<p>` as they are also block elements and therefore are closing the `<p>`.