### PR TITLE
Small performance improvements in ArchiveProcessor

### DIFF
--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -536,6 +536,10 @@ class ArchiveProcessor
             $columnsToRenameAfterAggregation = self::$columnsToRenameAfterAggregation;
         }
 
+        if (empty($columnsToRenameAfterAggregation)) {
+            return;
+        }
+        
         foreach ($table->getRows() as $row) {
             foreach ($columnsToRenameAfterAggregation as $oldName => $newName) {
                 $row->renameColumn($oldName, $newName);


### PR DESCRIPTION
There is no need to recursively iterate over all dataTables, when there is no column to rename.