### PR TITLE
Improve serialize dataTable performance

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1272,7 +1272,6 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         // For each row, get the serialized row
         // If it is associated to a sub table, get the serialized table recursively ;
         // but returns all serialized tables and subtable in an array of 1 dimension
-        // $aSerializedDataTable = array();
         foreach ($this->rows as $id => $row) {
             $subTable = $row->getSubtable();
             if ($subTable) {

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1293,7 +1293,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         // we then serialize the rows and store them in the serialized dataTable
         $rows = array();
         foreach ($this->rows as $id => $row) {
-            if (array_key_exists($id, $consecutiveSubtableIds)) {
+            if (isset($consecutiveSubtableIds[$id])) {
                 $backup = $row->subtableId;
                 $row->subtableId = $consecutiveSubtableIds[$id];
                 $rows[$id] = $row->export();

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1227,6 +1227,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      * @param int $maximumRowsInDataTable If not null, defines the maximum number of rows allowed in the serialized DataTable.
      * @param int $maximumRowsInSubDataTable If not null, defines the maximum number of rows allowed in serialized subtables.
      * @param string $columnToSortByBeforeTruncation The column to sort by before truncating, eg, `Metrics::INDEX_NB_VISITS`.
+     * @param array $aSerializedDataTable Will contain all the output arrays
      * @return array The array of serialized DataTables:
      *
      *                   array(
@@ -1244,7 +1245,8 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     public function getSerialized($maximumRowsInDataTable = null,
                                   $maximumRowsInSubDataTable = null,
-                                  $columnToSortByBeforeTruncation = null)
+                                  $columnToSortByBeforeTruncation = null,
+                                  &$aSerializedDataTable = array())
     {
         static $depth = 0;
         // make sure subtableIds are consecutive from 1 to N
@@ -1270,13 +1272,13 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         // For each row, get the serialized row
         // If it is associated to a sub table, get the serialized table recursively ;
         // but returns all serialized tables and subtable in an array of 1 dimension
-        $aSerializedDataTable = array();
+        // $aSerializedDataTable = array();
         foreach ($this->rows as $id => $row) {
             $subTable = $row->getSubtable();
             if ($subTable) {
                 $consecutiveSubtableIds[$id] = ++$subtableId;
                 $depth++;
-                $aSerializedDataTable = $aSerializedDataTable + $subTable->getSerialized($maximumRowsInSubDataTable, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation);
+                $aSerializedDataTable = $subTable->getSerialized($maximumRowsInSubDataTable, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation, $aSerializedDataTable);
                 $depth--;
             } else {
                 $row->removeSubtable();

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1277,7 +1277,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
             if ($subTable) {
                 $consecutiveSubtableIds[$id] = ++$subtableId;
                 $depth++;
-                $aSerializedDataTable = $subTable->getSerialized($maximumRowsInSubDataTable, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation, $aSerializedDataTable);
+                $subTable->getSerialized($maximumRowsInSubDataTable, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation, $aSerializedDataTable);
                 $depth--;
             } else {
                 $row->removeSubtable();


### PR DESCRIPTION
This seems to improve the performance of serializing a data table which is useful when archiving. In my case it made the archiving of a monthly archive almost twice as fast from about 120 seconds down to like 70seconds.

Before:
![image](https://user-images.githubusercontent.com/273120/32999210-7e03d8e8-ce05-11e7-8fa5-abb7a5b45bc9.png)

After 
![image](https://user-images.githubusercontent.com/273120/32999216-85255f8e-ce05-11e7-8034-2de85dbb5d68.png)

Why?
`getSerialized` is called here 385 times and took before 51 seconds, afterwards about 10 seconds. The thing is that `getSerialized` gets called recursive, and on the 2nd layer, it is called almost 8000 times, and on the third layer (when having 3 nested dataTables) it is called 40.000 times:

![image](https://user-images.githubusercontent.com/273120/32999270-d8d771c6-ce05-11e7-84c6-70b3db6f6fab.png)

When it is called 40.000 times, it doesn't take much time but on the 2nd layer, it spends about 40seconds in the method itself (excluding calling any methods). Looking at the function itself I realized the `$aSerializedDataTable + $subTable->getSerialized($maximumRowsInSubDataTable, $maximumRowsInSubDataTable, $columnToSortByBeforeTruncation, $aSerializedDataTable)` call which merges BIG arrays over time and seems to be the slow part.

So I changed it to `getSerialized($maximumRowsInDataTable = null, $maximumRowsInSubDataTable = null,		                                   $maximumRowsInSubDataTable = null, $columnToSortByBeforeTruncation = null)	                             $columnToSortByBeforeTruncation = null, $aSerializedDataTable = array())` which made it like 2 or 3 times slower because it is copying the arrays even more etc.

But when passing as reference it is suddenly fast (less copying):

![image](https://user-images.githubusercontent.com/273120/32999339-54962a46-ce06-11e7-9854-33680dab54bd.png)

It is down from 40 seconds to 2 seconds.