### PR TITLE
Extends TestRunner options for Travis trusty distribution selection

### DIFF
--- a/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
+++ b/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
@@ -42,6 +42,7 @@ class GenerateTravisYmlFile extends ConsoleCommand
              ->addOption('repo-root-dir', null, InputOption::VALUE_REQUIRED, "Path to the repo for whom a .travis.yml file will be generated for.")
              ->addOption('force-php-tests', null, InputOption::VALUE_NONE, "Forces the presence of the PHP tests jobs for plugin builds.")
              ->addOption('force-ui-tests', null, InputOption::VALUE_NONE, "Forces the presence of the UI tests jobs for plugin builds.")
+             ->addOption('dist-trusty', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' trusty distribution.")
              ->addOption('sudo-false', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' container environment.");
     }
 

--- a/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
+++ b/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
@@ -42,7 +42,7 @@ class GenerateTravisYmlFile extends ConsoleCommand
              ->addOption('repo-root-dir', null, InputOption::VALUE_REQUIRED, "Path to the repo for whom a .travis.yml file will be generated for.")
              ->addOption('force-php-tests', null, InputOption::VALUE_NONE, "Forces the presence of the PHP tests jobs for plugin builds.")
              ->addOption('force-ui-tests', null, InputOption::VALUE_NONE, "Forces the presence of the UI tests jobs for plugin builds.")
-             ->addOption('sudo-false', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' new infrastructure.");
+             ->addOption('sudo-false', null, InputOption::VALUE_NONE, "If supplied, the .travis.yml file will use travis' container environment.");
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
Belongs to piwik/travis-scripts#38.

The fork commit obviously has to be removed for merging. It is currently only in place to ensure a test plugin can be used with the new generator option.