### PR TITLE
Switch UITests to travis trusty environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,14 +64,13 @@ matrix:
     - php: 5.6
       env: TEST_SUITE=AllTests MYSQL_ADAPTER=MYSQLI ALLTEST_EXTRA_OPTIONS="--run-second-half-only"
       sudo: required
-    - php: 5.5
+    # UITests use a specific version because the default 5.5 (== 5.5.38) is missing FreeType support
+    - php: 5.5.33
       env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL UITEST_EXTRA_OPTIONS="--run-first-half-only"
       sudo: false
-      dist: precise
-    - php: 5.5
+    - php: 5.5.33
       env: TEST_SUITE=UITests MYSQL_ADAPTER=PDO_MYSQL UITEST_EXTRA_OPTIONS="--run-second-half-only"
       sudo: false
-      dist: precise
 
 dist: trusty
 


### PR DESCRIPTION
After some testing on Travis (https://travis-ci.org/mneudert/travis-php-gd_info) I found that `PHP 5.5.33` is the latest available version in the 5.5 range with active FreeType support. Due to the EOL of PHP 5.5 I don't think there will be a recompilation to provide FreeType support with `PHP 5.5.38` so this should be the best way to switch from `precise` to `trusty`.

[Refs #11986]