### PR TITLE
Several fixes/improvements to angular period selector

### DIFF
--- a/core/Period/PeriodValidator.php
+++ b/core/Period/PeriodValidator.php
@@ -38,6 +38,7 @@ class PeriodValidator
         $periodsAllowed = Config::getInstance()->General['enabled_periods_UI'];
         $periodsAllowed = array_map('trim', explode(',', $periodsAllowed));
         $periodsAllowed = array_unique($periodsAllowed);
+        $periodsAllowed = array_values($periodsAllowed);
         return $periodsAllowed;
     }
 
@@ -49,6 +50,7 @@ class PeriodValidator
         $periodsAllowed = Config::getInstance()->General['enabled_periods_API'];
         $periodsAllowed = array_map('trim', explode(',', $periodsAllowed));
         $periodsAllowed = array_unique($periodsAllowed);
+        $periodsAllowed = array_values($periodsAllowed);
         return $periodsAllowed;
     }
 }

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -378,6 +378,7 @@ class CoreHome extends \Piwik\Plugin
         $translationKeys[] = 'General_Delete';
         $translationKeys[] = 'General_Default';
         $translationKeys[] = 'General_LoadingData';
+        $translationKeys[] = 'General_Error';
         $translationKeys[] = 'General_ErrorRequest';
         $translationKeys[] = 'General_YourChangesHaveBeenSaved';
         $translationKeys[] = 'General_LearnMore';

--- a/plugins/CoreHome/angularjs/common/services/periods.js
+++ b/plugins/CoreHome/angularjs/common/services/periods.js
@@ -173,11 +173,34 @@
     }
 
     RangePeriod.parse = function parseRangePeriod(strDate) {
-        var parts = strDate.split(',');
-        var start = $.datepicker.parseDate('yy-mm-dd', parts[0]);
-        var end = $.datepicker.parseDate('yy-mm-dd', parts[1]);
+        var dates = [];
 
-        return new RangePeriod(start, end);
+        if (/^previous/.test(strDate)) {
+            dates = getLastNRange(strDate.substring(8), 1);
+        } else if (/^last/.test(strDate)) {
+            dates = getLastNRange(strDate.substring(4), 0);
+        } else {
+            var parts = strDate.split(',');
+            dates[0] = $.datepicker.parseDate('yy-mm-dd', parts[0]);
+            dates[1] = $.datepicker.parseDate('yy-mm-dd', parts[1]);
+        }
+
+        return new RangePeriod(dates[0], dates[1]);
+
+        function getLastNRange(strAmount, extraDaysStart) {
+            var nAmount = Math.max(parseInt(strAmount) - 1, 0);
+            if (isNaN(nAmount)) {
+                throw new Error('Invalid range date: ' + strDate);
+            }
+
+            var endDate = getToday();
+            endDate.setDate(endDate.getDate() - extraDaysStart);
+
+            var startDate = new Date(endDate.getTime());
+            startDate.setDate(startDate.getDate() - nAmount);
+
+            return [startDate, endDate];
+        }
     };
 
     RangePeriod.getDisplayText = function () {

--- a/plugins/CoreHome/angularjs/common/services/periods.js
+++ b/plugins/CoreHome/angularjs/common/services/periods.js
@@ -181,8 +181,8 @@
             dates = getLastNRange(strDate.substring(4), 0);
         } else {
             var parts = strDate.split(',');
-            dates[0] = $.datepicker.parseDate('yy-mm-dd', parts[0]);
-            dates[1] = $.datepicker.parseDate('yy-mm-dd', parts[1]);
+            dates[0] = parseDate(parts[0]);
+            dates[1] = parseDate(parts[1]);
         }
 
         return new RangePeriod(dates[0], dates[1]);
@@ -280,7 +280,13 @@
             return yesterday;
         }
 
-        return $.datepicker.parseDate('yy-mm-dd', strDate);
+        try {
+            return $.datepicker.parseDate('yy-mm-dd', strDate);
+        } catch (err) {
+            // angular swallows this error, so manual console log here
+            console.error(err.message || err);
+            throw err;
+        }
     }
 
     function getToday() {

--- a/plugins/CoreHome/angularjs/common/services/piwik.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik.js
@@ -19,9 +19,7 @@
             var date = piwik.broadcast.getValueFromHash('date');
             var period = piwik.broadcast.getValueFromHash('period');
 
-            if (!piwikPeriods.isRecognizedPeriod(period)
-                || !isValidDateStr(date)
-            ) {
+            if (!isValidPeriod(period, date)) {
                 // invalid data in URL
                 return;
             }
@@ -49,14 +47,9 @@
             piwik.endDateString = $.datepicker.formatDate('yy-mm-dd', dateRange[1]);
         }
 
-        function isValidDateStr(dateStr) {
-            if (dateStr.indexOf(',') !== -1) {
-                var dateParts = dateStr.split(',');
-                return isValidDateStr(dateParts[0]) && isValidDateStr(dateParts[1]);
-            }
-
+        function isValidPeriod(periodStr, dateStr) {
             try {
-                piwikPeriods.parseDate(dateStr);
+                piwikPeriods.get(periodStr).parse(dateStr);
                 return true;
             } catch (e) {
                 return false;

--- a/plugins/CoreHome/angularjs/period-selector/period-selector.controller.js
+++ b/plugins/CoreHome/angularjs/period-selector/period-selector.controller.js
@@ -85,11 +85,8 @@
             vm.selectedPeriod = strPeriod;
 
             if (strPeriod === 'range') {
-                var parts = strDate.split(',');
-                vm.startRangeDate = parts[0];
-                vm.endRangeDate = parts[1];
-
-                vm.dateValue = piwikPeriods.parseDate(parts[0]);
+                var period = piwikPeriods.get(strPeriod).parse(strDate);
+                vm.dateValue = period.startDate;
             } else {
                 vm.dateValue = piwikPeriods.parseDate(strDate);
                 setRangeStartEndFromPeriod(strPeriod, strDate);
@@ -118,7 +115,11 @@
                 date = formatDate(vm.dateValue);
             }
 
-            return piwikPeriods.parse(vm.periodValue, date).getPrettyString();
+            try {
+                return piwikPeriods.parse(vm.periodValue, date).getPrettyString();
+            } catch (e) {
+                return _pk_translate('General_Error');
+            }
         }
 
         function changeViewedPeriod(period) {

--- a/plugins/CoreHome/angularjs/period-selector/period-selector.controller.js
+++ b/plugins/CoreHome/angularjs/period-selector/period-selector.controller.js
@@ -37,8 +37,7 @@
         vm.$onChanges = $onChanges;
         vm.onRangeChange = onRangeChange;
         vm.isApplyEnabled = isApplyEnabled;
-
-        init();
+        vm.$onInit = init;
 
         function init() {
             vm.updateSelectedValuesFromHash();

--- a/plugins/CoreHome/angularjs/period-selector/period-selector.controller.js
+++ b/plugins/CoreHome/angularjs/period-selector/period-selector.controller.js
@@ -84,9 +84,13 @@
             vm.periodValue = strPeriod;
             vm.selectedPeriod = strPeriod;
 
+            vm.dateValue = vm.startRangeDate = vm.endRangeDate = null;
+
             if (strPeriod === 'range') {
                 var period = piwikPeriods.get(strPeriod).parse(strDate);
                 vm.dateValue = period.startDate;
+                vm.startRangeDate = formatDate(period.startDate);
+                vm.endRangeDate = formatDate(period.endDate);
             } else {
                 vm.dateValue = piwikPeriods.parseDate(strDate);
                 setRangeStartEndFromPeriod(strPeriod, strDate);


### PR DESCRIPTION
Changes:

* Fix issue where adding invalid value to `enabled_periods_UI`/`enabled_periods_API` INI config resulted in a JS object being passed to the period selector instead of array.
* Use $onInit in period selector of initing code in the directive factory function. Seems AngularJS swallows errors that occur there (**note to other devs**).
* Parse previousN/lastN dates correctly in `piwikPeriods` object.
* Always try and parse period/date string combo in period selector, since we can't assume range periods have comma separated dates.
* Angular swallows errors from datepicker.parseDate (because it throws strings), so added a console log for those errors.
* Display ERROR in period selector if period/date is invalid.

Fixes #12306
