### PR TITLE
Do not allow piwik global frontend date properties to have value of p…

### DIFF
--- a/plugins/CoreHome/angularjs/common/services/piwik.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik.js
@@ -31,6 +31,16 @@
 
             piwik.period = period;
 
+            var dateRange = piwikPeriods.parse(period, date).getDateRange();
+            piwik.startDateString = $.datepicker.formatDate('yy-mm-dd', dateRange[0]);
+            piwik.endDateString = $.datepicker.formatDate('yy-mm-dd', dateRange[1]);
+
+            // do not set anything to previous7/last7, as piwik frontend code does not
+            // expect those values.
+            if (piwik.period === 'range') {
+                date = piwik.startDateString + ',' + piwik.endDateString;
+            }
+
             if (date && date.indexOf(',') > -1) {
                 var dateParts = date.split(',');
                 if (dateParts[1]) {
@@ -41,10 +51,6 @@
             } else {
                 piwik.currentDateString = date;
             }
-
-            var dateRange = piwikPeriods.parse(period, date).getDateRange();
-            piwik.startDateString = $.datepicker.formatDate('yy-mm-dd', dateRange[0]);
-            piwik.endDateString = $.datepicker.formatDate('yy-mm-dd', dateRange[1]);
         }
 
         function isValidPeriod(periodStr, dateStr) {


### PR DESCRIPTION
…revious7/last7, since the frontend does not expect those values.

(I believe this is the safest change.)

Fixes #12321