### PR TITLE
Respect maintenance mode when archiving

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -289,7 +289,7 @@ class CronArchive
      */
     public function main()
     {
-        if ($this->isMaintenanceModeEnabled() == 1) {
+        if ($this->isMaintenanceModeEnabled()) {
             $this->logger->info("Archiving won't run because maintenance mode is enabled");
             return;
         }
@@ -367,7 +367,7 @@ class CronArchive
 
         do {
 
-            if ($this->isMaintenanceModeEnabled() == 1) {
+            if ($this->isMaintenanceModeEnabled()) {
                 $this->logger->info("Archiving will stop now because maintenance mode is enabled");
                 return;
             }

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -279,11 +279,21 @@ class CronArchive
         $this->invalidator = StaticContainer::get('Piwik\Archive\ArchiveInvalidator');
     }
 
+    private function isMaintenanceModeEnabled()
+    {
+        return Config::getInstance()->General['maintenance_mode'] == 1;
+    }
+
     /**
      * Initializes and runs the cron archiver.
      */
     public function main()
     {
+        if ($this->isMaintenanceModeEnabled() == 1) {
+            $this->logger->info("Archiving won't run because maintenance mode is enabled");
+            return;
+        }
+
         $self = $this;
         Access::doAsSuperUser(function () use ($self) {
             $self->init();
@@ -356,6 +366,12 @@ class CronArchive
         $this->logger->info("Starting Piwik reports archiving...");
 
         do {
+
+            if ($this->isMaintenanceModeEnabled() == 1) {
+                $this->logger->info("Archiving will stop now because maintenance mode is enabled");
+                return;
+            }
+
             $idSite = $this->websites->getNextSiteId();
 
             if (null === $idSite) {


### PR DESCRIPTION
When maintenance mode is enabled the archiver should not start and also not start working on a next website. 

On top we could throw an exception in `archiveReportsFor()` but AFAIK the request will fail anyway since the API will basically return an error. And in `archiveReportsFor()` should not be like a `if (maintenanceEnabled) return` because it could result in random bugs as we might set some flags like the site was considered archived. If we want to avoid sending requests eg in `archiveReportsFor()` we should throw an exception instead like `if (maintenanceEnabled) throw new Exception('Maintenance mode is enabled')` so the core archiver will stop.

Feel free to tweak messages.