### PR TITLE
When general settings admin is disabled, do not show archive settings

### DIFF
--- a/plugins/CoreAdminHome/templates/generalSettings.twig
+++ b/plugins/CoreAdminHome/templates/generalSettings.twig
@@ -9,9 +9,10 @@
 
     {{ ajax.errorDiv() }}
     {{ ajax.loadingDiv() }}
-<div piwik-content-block content-title="{{ 'CoreAdminHome_ArchivingSettings'|translate|e('html_attr') }}">
-    <div ng-controller="ArchivingController as archivingSettings">
-        {% if isGeneralSettingsAdminEnabled %}
+
+{% if isGeneralSettingsAdminEnabled %}
+    <div piwik-content-block content-title="{{ 'CoreAdminHome_ArchivingSettings'|translate|e('html_attr') }}">
+        <div ng-controller="ArchivingController as archivingSettings">
             <div class="form-group row">
                 <h3 class="col s12">{{ 'General_AllowPiwikArchivingToTriggerBrowser'|translate }}</h3>
                 <div class="col s12 m6">
@@ -44,47 +45,38 @@
                     </div>
                 </div>
             </div>
-        {% else %}
-            <div piwik-field uicontrol="radio" name="mailUseSmtp"
-                 disabled="true"
-                 introduction="{{ 'General_AllowPiwikArchivingToTriggerBrowser'|translate|e('html_attr') }}"
-                 title="{{ 'General_Yes'|translate|e('html_attr') }}"
-                 value="1">
-            </div>
-        {% endif %}
 
-        <div class="form-group row">
-            <h3 class="col s12">
-                {{ 'General_ReportsContainingTodayWillBeProcessedAtMostEvery'|translate }}
-            </h3>
-            <div class="input-field col s12 m6">
-                <input  type="text" value='{{ todayArchiveTimeToLive  }}' id='todayArchiveTimeToLive' {% if not isGeneralSettingsAdminEnabled %}disabled="disabled"{% endif %} />
-                <span class="form-description">
-                    {{ 'General_RearchiveTimeIntervalOnlyForTodayReports'|translate }}
-                </span>
+            <div class="form-group row">
+                <h3 class="col s12">
+                    {{ 'General_ReportsContainingTodayWillBeProcessedAtMostEvery'|translate }}
+                </h3>
+                <div class="input-field col s12 m6">
+                    <input  type="text" value='{{ todayArchiveTimeToLive  }}' id='todayArchiveTimeToLive' {% if not isGeneralSettingsAdminEnabled %}disabled="disabled"{% endif %} />
+                    <span class="form-description">
+                        {{ 'General_RearchiveTimeIntervalOnlyForTodayReports'|translate }}
+                    </span>
+                </div>
+                <div class="col s12 m6">
+                    {% if isGeneralSettingsAdminEnabled %}
+                        <div class="form-help">
+                            {% if showWarningCron %}
+                                <strong>
+                                    {{ 'General_NewReportsWillBeProcessedByCron'|translate }}<br/>
+                                    {{ 'General_ReportsWillBeProcessedAtMostEveryHour'|translate }}
+                                    {{ 'General_IfArchivingIsFastYouCanSetupCronRunMoreOften'|translate }}<br/>
+                                </strong>
+                            {% endif %}
+                            {{ 'General_SmallTrafficYouCanLeaveDefault'|translate( todayArchiveTimeToLiveDefault ) }}
+                            <br/>
+                            {{ 'General_MediumToHighTrafficItIsRecommendedTo'|translate(1800,3600) }}
+                        </div>
+                    {% endif %}
+                </div>
             </div>
-            <div class="col s12 m6">
-                {% if isGeneralSettingsAdminEnabled %}
-                    <div class="form-help">
-                        {% if showWarningCron %}
-                            <strong>
-                                {{ 'General_NewReportsWillBeProcessedByCron'|translate }}<br/>
-                                {{ 'General_ReportsWillBeProcessedAtMostEveryHour'|translate }}
-                                {{ 'General_IfArchivingIsFastYouCanSetupCronRunMoreOften'|translate }}<br/>
-                            </strong>
-                        {% endif %}
-                        {{ 'General_SmallTrafficYouCanLeaveDefault'|translate( todayArchiveTimeToLiveDefault ) }}
-                        <br/>
-                        {{ 'General_MediumToHighTrafficItIsRecommendedTo'|translate(1800,3600) }}
-                    </div>
-                {% endif %}
-            </div>
+
+            <div onconfirm="archivingSettings.save()" saving="archivingSettings.isLoading" piwik-save-button></div>
         </div>
-
-        <div onconfirm="archivingSettings.save()" saving="archivingSettings.isLoading" piwik-save-button></div>
     </div>
-</div>
-{% if isGeneralSettingsAdminEnabled %}
     <div piwik-content-block content-title="{{ 'CoreAdminHome_EmailServerSettings'|translate|e('html_attr') }}">
 
         <div piwik-form ng-controller="MailSmtpController as mailSettings">


### PR DESCRIPTION
The currently shown settings are wrong anyway (eg it always says YES browser archiving is enabled and shows how often it is archived but both values may be very wrong). Also it is not needed to show this information when the admin is disabled.