### PR TITLE
Refactoring tests

### DIFF
--- a/plugins/BulkTracking/tests/Integration/BulkTrackingTest.php
+++ b/plugins/BulkTracking/tests/Integration/BulkTrackingTest.php
@@ -92,7 +92,7 @@ class BulkTrackingTest extends BulkTrackingTestCase
         $handler = null;
         $this->bulk->setHandlerIfBulkRequest($handler);
 
-        $this->assertTrue($handler instanceof Handler);
+        $this->assertInstanceOf(Handler::class, $handler);
     }
 
     public function test_setHandlerIfBulkRequest_shouldNotSetAHandler_IfOneIsAlreadySetEvenIfItIsABulkRequest()
@@ -124,14 +124,14 @@ class BulkTrackingTest extends BulkTrackingTestCase
 
         $handler = DefaultHandler\Factory::make();
 
-        $this->assertTrue($handler instanceof Handler);
+        $this->assertInstanceOf(Handler::class, $handler);
     }
 
     public function test_registerEvents_shouldListenToNewTrackerEventAndNotCreateBulkHandler_IfNotBulkRequest()
     {
         $handler = DefaultHandler\Factory::make();
 
-        $this->assertTrue($handler instanceof DefaultHandler);
+        $this->assertInstanceOf(DefaultHandler::class, $handler);
     }
 
     public function test_registerEvents_shouldListenToInitRequestSetEventAndInit_IfBulkRequest()

--- a/plugins/BulkTracking/tests/Integration/TrackerTest.php
+++ b/plugins/BulkTracking/tests/Integration/TrackerTest.php
@@ -58,7 +58,7 @@ class TrackerTest extends BulkTrackingTestCase
     public function test_main_shouldUseBulkHandler()
     {
         $handler = $this->getHandler();
-        $this->assertTrue($handler instanceof Handler);
+        $this->assertInstanceOf(Handler::class, $handler);
     }
 
     public function test_main_shouldReturnBulkTrackingResponse()

--- a/plugins/CustomPiwikJs/tests/Integration/FileTest.php
+++ b/plugins/CustomPiwikJs/tests/Integration/FileTest.php
@@ -73,7 +73,7 @@ class FileTest extends IntegrationTestCase
         }
         $this->assertTrue(is_writable(dirname($path)));
         $this->assertFalse(is_writable($path));
-        $this->assertTrue(file_exists($path));
+        $this->assertFileExists($path);
         return $file;
     }
 

--- a/plugins/CustomPiwikJs/tests/Integration/PluginTrackerFilesTest.php
+++ b/plugins/CustomPiwikJs/tests/Integration/PluginTrackerFilesTest.php
@@ -57,7 +57,7 @@ class PluginTrackerFilesTest extends IntegrationTestCase
         $foundFiles = $trackerFiles->find();
 
         $this->assertCount(1, $foundFiles);
-        $this->assertTrue(isset($foundFiles['CustomPiwikJs']));
+        $this->assertArrayHasKey('CustomPiwikJs', $foundFiles);
         $this->assertEquals('tracker.min.js', $foundFiles['CustomPiwikJs']->getName());
     }
 
@@ -68,7 +68,7 @@ class PluginTrackerFilesTest extends IntegrationTestCase
         $foundFiles = $trackerFiles->find();
 
         $this->assertCount(1, $foundFiles);
-        $this->assertTrue(isset($foundFiles['CustomPiwikJs']));
+        $this->assertArrayHasKey('CustomPiwikJs', $foundFiles);
         $this->assertEquals('tracker.js', $foundFiles['CustomPiwikJs']->getName());
     }
 
@@ -78,8 +78,8 @@ class PluginTrackerFilesTest extends IntegrationTestCase
         $foundFiles = $trackerFiles->find();
 
         $this->assertCount(2, $foundFiles);
-        $this->assertTrue(isset($foundFiles['CustomPiwikJs']));
-        $this->assertTrue(isset($foundFiles['Goals']));
+        $this->assertArrayHasKey('CustomPiwikJs', $foundFiles);
+        $this->assertArrayHasKey('Goals', $foundFiles);
         $this->assertEquals('tracker.js', $foundFiles['CustomPiwikJs']->getName());
         $this->assertEquals('tracker.min.js', $foundFiles['Goals']->getName());
     }
@@ -98,8 +98,8 @@ class PluginTrackerFilesTest extends IntegrationTestCase
 
         $foundFiles = $trackerFiles->find();
         $this->assertCount(1, $foundFiles);
-        $this->assertTrue(isset($foundFiles['CustomPiwikJs']));
-        $this->assertFalse(isset($foundFiles['Goals']));
+        $this->assertArrayHasKey('CustomPiwikJs', $foundFiles);
+        $this->assertArrayNotHasKey('Goals', $foundFiles);
     }
 
     public function test_find_shouldNotReturnATrackerFile_IfPluginIsNotActivatedOrLoaded()
@@ -108,14 +108,14 @@ class PluginTrackerFilesTest extends IntegrationTestCase
         $foundFiles = $trackerFiles->find();
 
         $this->assertCount(1, $foundFiles);
-        $this->assertTrue(isset($foundFiles['Goals']));
+        $this->assertArrayHasKey('Goals', $foundFiles);
         $this->assertEquals('tracker.min.js', $foundFiles['Goals']->getName());
 
         $trackerFiles = new CustomPluginTrackerFiles('Goals', 'MyNotExistingPlugin');
         $foundFiles = $trackerFiles->find();
 
         $this->assertCount(1, $foundFiles);
-        $this->assertTrue(isset($foundFiles['Goals']));
+        $this->assertArrayHasKey('Goals', $foundFiles);
         $this->assertEquals('tracker.js', $foundFiles['Goals']->getName());
     }
 

--- a/plugins/CustomPiwikJs/tests/Integration/TrackerUpdaterTest.php
+++ b/plugins/CustomPiwikJs/tests/Integration/TrackerUpdaterTest.php
@@ -63,8 +63,8 @@ class TrackerUpdaterTest extends IntegrationTestCase
         $updater = $this->makeUpdater();
         $fromFile = $updater->getFromFile();
         $toFile = $updater->getToFile();
-        $this->assertTrue($fromFile instanceof File);
-        $this->assertTrue($toFile instanceof File);
+        $this->assertInstanceOf(File::class, $fromFile);
+        $this->assertInstanceOf(File::class, $toFile);
 
         $this->assertSame(basename(TrackerUpdater::ORIGINAL_PIWIK_JS), $fromFile->getName());
         $this->assertSame(basename(TrackerUpdater::TARGET_PIWIK_JS), $toFile->getName());
@@ -135,7 +135,7 @@ class TrackerUpdaterTest extends IntegrationTestCase
         $updater = $this->makeUpdater(null, $targetFile);
         $content = $updater->getCurrentTrackerFileContent();
 
-        $this->assertSame(file_get_contents($targetFile), $content);
+        $this->assertStringEqualsFile($targetFile, $content);
     }
 
     public function test_getUpdatedTrackerFileContent_returnsGeneratedPiwikJsWithMergedTrackerFiles_WhenTheyExist()
@@ -177,7 +177,7 @@ var myArray = [];
         $updater->setTrackerFiles(new PluginTrackerFilesMock(array()));
         $content = $updater->getUpdatedTrackerFileContent();
 
-        $this->assertSame(file_get_contents($source), $content);
+        $this->assertStringEqualsFile($source, $content);
     }
 
     public function test_update_shouldNotThrowAnError_IfTargetFileIsNotWritable()
@@ -198,7 +198,7 @@ var myArray = [];
         // mock that does not find any files . therefore there is nothing to di
         $updater->update();
 
-        $this->assertSame(file_get_contents($source), file_get_contents($target));
+        $this->assertFileEquals($source, $target);
         $this->assertNull($this->piwikJsChangedEventPath);
     }
 

--- a/plugins/CustomPiwikJs/tests/System/PiwikJsContentTest.php
+++ b/plugins/CustomPiwikJs/tests/System/PiwikJsContentTest.php
@@ -25,7 +25,7 @@ class PiwikJsContentTest extends SystemTestCase
         $piwikMin = PIWIK_DOCUMENT_ROOT . TrackerUpdater::ORIGINAL_PIWIK_JS;
         $piwikJs = PIWIK_DOCUMENT_ROOT . TrackerUpdater::TARGET_PIWIK_JS;
 
-        $this->assertSame(file_get_contents($piwikMin), file_get_contents($piwikJs));
+        $this->assertFileEquals($piwikMin, $piwikJs);
     }
 
     public function test_piwikJsContainsHook()

--- a/plugins/LanguagesManager/Test/Integration/LanguagesManagerTest.php
+++ b/plugins/LanguagesManager/Test/Integration/LanguagesManagerTest.php
@@ -200,22 +200,22 @@ class LanguagesManagerTest extends \PHPUnit_Framework_TestCase
             $name = $translations['Intl']['EnglishLanguageName'];
 
             if ($language != 'en') {
-                $this->assertFalse($name == 'English', "for $language");
+                $this->assertNotEquals('English', $name, "for $language");
             }
 
             $languageCode = substr($language, 0, 2);
-            $this->assertTrue(isset($languagesReference[$languageCode]));
+            $this->assertArrayHasKey($languageCode, $languagesReference);
             $names = $languagesReference[$languageCode];
 
             if (isset($languagesReference[$language])) {
                 if (is_array($names)) {
-                    $this->assertTrue(in_array($name, $names), "$language: failed because $name not a known language name");
+                    $this->assertContains($name, $names, "$language: failed because $name not a known language name");
                 } else {
-                    $this->assertTrue($name == $names, "$language: failed because $name == $names");
+                    $this->assertEquals($name, $names, "$language: failed because $name == $names");
                 }
             } else {
                 if (is_array($names)) {
-                    $this->assertTrue(strpos($name, $names[0]) !== false);
+                    $this->assertContains($names[0], $name);
                 } else {
                     $this->fail("$language: expected an array of language names");
                 }
@@ -234,9 +234,9 @@ class LanguagesManagerTest extends \PHPUnit_Framework_TestCase
         $languageDataProvider = StaticContainer::get('Piwik\Intl\Data\Provider\LanguageDataProvider');
 
         $languages = $languageDataProvider->getLanguageList();
-        $this->assertTrue(count($languages) > 0);
+        $this->assertGreaterThan(0, count($languages));
         foreach ($languages as $langCode => $langs) {
-            $this->assertTrue(strlen($langCode) == 2, "$langCode length = 2");
+            $this->assertEquals(2, strlen($langCode), "$langCode length = 2");
             $this->assertTrue(is_array($langs) && count($langs) >= 1, "$langCode array(names) >= 1");
         }
     }

--- a/plugins/Marketplace/tests/Integration/PluginsTest.php
+++ b/plugins/Marketplace/tests/Integration/PluginsTest.php
@@ -333,9 +333,9 @@ class PluginsTest extends IntegrationTestCase
             if ($name === 'SecurityInfo') {
                 $this->assertTrue($plugin['isFree']);
                 $this->assertFalse($plugin['isPaid']);
-                $this->assertTrue(in_array($plugin['isInstalled'], array(true, false), true));
+                $this->assertContains($plugin['isInstalled'], array(true, false));
                 $this->assertFalse($plugin['isInvalid']);
-                $this->assertTrue(isset($plugin['canBeUpdated']));
+                $this->assertArrayHasKey('canBeUpdated', $plugin);
                 $this->assertSame(array(), $plugin['missingRequirements']);
                 $this->assertSame(Plugin\Manager::getInstance()->isPluginActivated('SecurityInfo'), $plugin['isActivated']);
             } elseif ($name === 'SimplePageBuilder') {
@@ -350,7 +350,7 @@ class PluginsTest extends IntegrationTestCase
             }
         }
     }
-    
+
     public function test_getAllPaidPlugins_shouldFetchOnlyPaidPlugins()
     {
         $this->plugins->getAllPaidPlugins();

--- a/plugins/Marketplace/tests/Integration/ServiceTest.php
+++ b/plugins/Marketplace/tests/Integration/ServiceTest.php
@@ -60,7 +60,7 @@ class ServiceTest extends IntegrationTestCase
     {
         $this->service->returnFixture('v2.0_consumer-access_token-consumer1_paid2_custom1.json');
         $consumer = $this->service->fetch('consumer', array());
-        $this->assertTrue(is_array($consumer));
+        $this->assertInternalType('array', $consumer);
         $this->assertNotEmpty($consumer);
     }
 

--- a/plugins/Marketplace/tests/System/Api/ClientTest.php
+++ b/plugins/Marketplace/tests/System/Api/ClientTest.php
@@ -89,7 +89,7 @@ class ClientTest extends SystemTestCase
         $this->assertEquals($expectedPluginKeys, array_keys($plugin));
         $this->assertSame('SecurityInfo', $plugin['name']);
         $this->assertSame('piwik', $plugin['owner']);
-        $this->assertTrue(is_array($plugin['keywords']));
+        $this->assertInternalType('array', $plugin['keywords']);
         $this->assertNotEmpty($plugin['authors']);
         $this->assertGreaterThan(1000, $plugin['numDownloads']);
         $this->assertTrue($plugin['isFree']);

--- a/plugins/Marketplace/tests/System/Api/ServiceTest.php
+++ b/plugins/Marketplace/tests/System/Api/ServiceTest.php
@@ -69,7 +69,7 @@ class ServiceTest extends SystemTestCase
         $service = $this->buildService();
         $response = $service->fetch('plugins', array());
 
-        $this->assertTrue(is_array($response));
+        $this->assertInternalType('array', $response);
         $this->assertArrayHasKey('plugins', $response);
         $this->assertGreaterThanOrEqual(30, count($response['plugins']));
         foreach ($response['plugins'] as $plugin) {

--- a/plugins/Monolog/tests/Integration/LogTest.php
+++ b/plugins/Monolog/tests/Integration/LogTest.php
@@ -196,7 +196,7 @@ class LogTest extends IntegrationTestCase
         }
 
         if ($backend == 'file') {
-            $this->assertTrue(file_exists(self::getLogFileLocation()));
+            $this->assertFileExists(self::getLogFileLocation());
 
             $fileContents = file_get_contents(self::getLogFileLocation());
             $fileContents = $this->removePathsFromBacktrace($fileContents);
@@ -229,7 +229,7 @@ class LogTest extends IntegrationTestCase
     private function checkNoMessagesLogged($backend)
     {
         if ($backend == 'file') {
-            $this->assertFalse(file_exists(self::getLogFileLocation()));
+            $this->assertFileNotExists(self::getLogFileLocation());
         } else if ($backend == 'database') {
             $this->assertEquals(0, Db::fetchOne("SELECT COUNT(*) FROM " . Common::prefixTable('logger_message')));
         }

--- a/plugins/MultiSites/tests/Integration/ControllerTest.php
+++ b/plugins/MultiSites/tests/Integration/ControllerTest.php
@@ -27,13 +27,13 @@ class ControllerTest extends SystemTestCase
     public function test_getAllWithGroups()
     {
         $sites = $this->requestGetAllWithGroups(array('filter_limit' => 20));
-        $this->assertTrue(is_string($sites));
+        $this->assertInternalType('string', $sites);
 
         $sites = json_decode($sites, true);
 
         // as limit is 20 make sure it returns all 15 sites but we do not check for all the detailed sites info,
         // this is tested in other tests. We only check for first site.
-        $this->assertSame(15, count($sites['sites']));
+        $this->assertCount(15, $sites['sites']);
         $this->assertEquals(array(
             'label' => 'Site 1',
             'nb_visits' => '2',
@@ -70,7 +70,7 @@ class ControllerTest extends SystemTestCase
         $sites = $this->requestGetAllWithGroups(array('filter_limit' => 5));
         $sites = json_decode($sites, true);
 
-        $this->assertSame(5, count($sites['sites']));
+        $this->assertCount(5, $sites['sites']);
         $this->assertSame(15, $sites['numSites']);
         $this->assertReturnedSitesEquals(array(1, 2, 3, 4, 5), $sites);
     }
@@ -80,7 +80,7 @@ class ControllerTest extends SystemTestCase
         $sites = $this->requestGetAllWithGroups(array('filter_limit' => 5, 'filter_offset' => 4));
         $sites = json_decode($sites, true);
 
-        $this->assertSame(5, count($sites['sites']));
+        $this->assertCount(5, $sites['sites']);
         $this->assertSame(15, $sites['numSites']);
         $this->assertReturnedSitesEquals(array(5, 6, 7, 8, 9), $sites);
     }
@@ -91,7 +91,7 @@ class ControllerTest extends SystemTestCase
         $sites = $this->requestGetAllWithGroups(array('filter_limit' => 5, 'pattern' => $pattern));
         $sites = json_decode($sites, true);
 
-        $this->assertSame(5, count($sites['sites']));
+        $this->assertCount(5, $sites['sites']);
         $this->assertSame(1 + 6, $sites['numSites']); // Site 1 + Site10-15
         $this->assertReturnedSitesEquals(array(1, 10, 11, 12, 13), $sites);
     }

--- a/plugins/Referrers/tests/Unit/SearchEngineTest.php
+++ b/plugins/Referrers/tests/Unit/SearchEngineTest.php
@@ -50,28 +50,28 @@ class SearchEngineTest extends \PHPUnit_Framework_TestCase
         $searchEngines = array();
         foreach (SearchEngine::getInstance()->getDefinitions() as $host => $info) {
             if (isset($info['backlink']) && $info['backlink'] !== false) {
-                $this->assertTrue(strrpos($info['backlink'], "{k}") !== false, $host . " search URL is not defined correctly, must contain the macro {k}");
+                $this->assertContains("{k}", $info['backlink'], $host . " search URL is not defined correctly, must contain the macro {k}");
             }
 
             if (!array_key_exists($info['name'], $searchEngines)) {
                 $searchEngines[$info['name']] = true;
 
-                $this->assertTrue(strpos($host, '{}') === false, $host . " search URL is the master record and should not contain {}");
+                $this->assertNotContains('{}', $host, $host . " search URL is the master record and should not contain {}");
             }
 
             if (isset($info['charsets']) && $info['charsets'] !== false) {
                 $this->assertTrue(is_array($info['charsets']) || is_string($info['charsets']), $host . ' charsets must be either a string or an array');
 
                 if (is_string($info['charsets'])) {
-                    $this->assertTrue(trim($info['charsets']) !== '', $host . ' charsets cannot be an empty string');
-                    $this->assertTrue(strpos($info['charsets'], ' ') === false, $host . ' charsets cannot contain spaces');
+                    $this->assertNotSame('', trim($info['charsets']), $host . ' charsets cannot be an empty string');
+                    $this->assertNotContains(' ', $info['charsets'], $host . ' charsets cannot contain spaces');
 
                 }
 
                 if (is_array($info['charsets'])) {
-                    $this->assertTrue(count($info['charsets']) > 0, $host . ' charsets cannot be an empty array');
-                    $this->assertTrue(strpos(serialize($info['charsets']), '""') === false, $host . ' charsets in array cannot be empty stringss');
-                    $this->assertTrue(strpos(serialize($info['charsets']), ' ') === false, $host . ' charsets in array cannot contain spaces');
+                    $this->assertGreaterThan(0, count($info['charsets']), $host . ' charsets cannot be an empty array');
+                    $this->assertNotContains('""', serialize($info['charsets']), $host . ' charsets in array cannot be empty stringss');
+                    $this->assertNotContains(' ', serialize($info['charsets']), $host . ' charsets in array cannot contain spaces');
                 }
             }
         }
@@ -141,7 +141,7 @@ class SearchEngineTest extends \PHPUnit_Framework_TestCase
         if (!array_key_exists($searchEngine['name'], $searchEngines)) {
             $searchEngines[$searchEngine['name']] = $url;
 
-            $this->assertTrue(in_array($name['host'] . '.png', $favicons), $name['host']);
+            $this->assertContains($name['host'] . '.png', $favicons, $name['host']);
         }
     }
 
@@ -167,7 +167,7 @@ class SearchEngineTest extends \PHPUnit_Framework_TestCase
             }
 
             $host = substr($name, 0, -4);
-            $this->assertTrue(array_key_exists($host, $searchEngines), $host);
+            $this->assertArrayHasKey($host, $searchEngines, $host);
         }
     }
 }

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -202,9 +202,9 @@ class ApiTest extends IntegrationTestCase
         }
 
         $idReport = self::addReport(self::getMonthlyEmailReportData($this->idSite));
-        $this->assertEquals(1, count(APIScheduledReports::getInstance()->getReports()));
+        $this->assertCount(1, APIScheduledReports::getInstance()->getReports());
         APIScheduledReports::getInstance()->deleteReport($idReport);
-        $this->assertEquals(0, count(APIScheduledReports::getInstance()->getReports()));
+        $this->assertCount(0, APIScheduledReports::getInstance()->getReports());
     }
 
     /**

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -169,7 +169,7 @@ class ApiTest extends IntegrationTestCase
         $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($siteInfo['ts_created'])));
 
         $siteUrls = API::getInstance()->getSiteUrlsFromId($idsite);
-        $this->assertEquals(1, count($siteUrls));
+        $this->assertCount(1, $siteUrls);
     }
 
     /**
@@ -770,19 +770,19 @@ class ApiTest extends IntegrationTestCase
 
         // Also test that the group was set to empty, and is searchable
         $websites = API::getInstance()->getSitesFromGroup('');
-        $this->assertEquals(1, count($websites));
+        $this->assertCount(1, $websites);
 
         // the Update doesn't change the group field
         API::getInstance()->updateSite($idsite, "test toto@{}", $newMainUrl);
         $websites = API::getInstance()->getSitesFromGroup('');
-        $this->assertEquals(1, count($websites));
+        $this->assertCount(1, $websites);
 
         // Updating the group to something
         $group = 'something';
         API::getInstance()->updateSite($idsite, "test toto@{}", $newMainUrl, $ecommerce = 0, $ss = true, $ss_kwd = null, $ss_cat = '', $ips = null, $parametersExclude = null, $timezone = null, $currency = null, $group);
 
         $websites = API::getInstance()->getSitesFromGroup($group);
-        $this->assertEquals(1, count($websites));
+        $this->assertCount(1, $websites);
         $this->assertEquals(date('Y-m-d'), date('Y-m-d', strtotime($websites[0]['ts_created'])));
 
         // Updating the group to nothing
@@ -790,7 +790,7 @@ class ApiTest extends IntegrationTestCase
         $type = 'mobileAppTest';
         API::getInstance()->updateSite($idsite, "test toto@{}", $newMainUrl, $ecommerce = 0, $ss = false, $ss_kwd = '', $ss_cat = null, $ips = null, $parametersExclude = null, $timezone = null, $currency = null, $group, $startDate = '2010-01-01', $excludedUserAgent = null, $keepUrlFragment = 1, $type);
         $websites = API::getInstance()->getSitesFromGroup($group);
-        $this->assertEquals(1, count($websites));
+        $this->assertCount(1, $websites);
         $this->assertEquals('2010-01-01', date('Y-m-d', strtotime($websites[0]['ts_created'])));
 
         // Test setting the website type
@@ -838,7 +838,7 @@ class ApiTest extends IntegrationTestCase
             $excludedIps = null, $excludedQueryParameters = null, $timezone = null, $currency = null, $group, $startDate = '2011-01-01');
 
         $websites = API::getInstance()->getSitesFromGroup($group);
-        $this->assertEquals(1, count($websites));
+        $this->assertCount(1, $websites);
 
         $newurls = array("http://piwiknew2.com",
                          "http://piwiknew2.net",
@@ -852,11 +852,11 @@ class ApiTest extends IntegrationTestCase
 
         // no result for the group before update
         $websites = API::getInstance()->getSitesFromGroup($group);
-        $this->assertEquals(0, count($websites));
+        $this->assertCount(0, $websites);
 
         // Testing that the group was updated properly (and testing that the group value is trimmed before inserted/searched)
         $websites = API::getInstance()->getSitesFromGroup($groupAfter . ' ');
-        $this->assertEquals(1, count($websites));
+        $this->assertCount(1, $websites);
         $this->assertEquals('2011-01-01', date('Y-m-d', strtotime($websites[0]['ts_created'])));
 
         // Test fetch website groups
@@ -1148,16 +1148,16 @@ class ApiTest extends IntegrationTestCase
         API::getInstance()->addSite("site3", array("http://piwik.com", "http://piwik.org"));
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.org');
-        $this->assertTrue(count($idsites) == 1);
+        $this->assertCount(1, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://www.piwik.org');
-        $this->assertTrue(count($idsites) == 1);
+        $this->assertCount(1, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.net');
-        $this->assertTrue(count($idsites) == 2);
+        $this->assertCount(2, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.com');
-        $this->assertTrue(count($idsites) == 3);
+        $this->assertCount(3, $idsites);
     }
 
     public function test_getSitesIdFromSiteUrl_MatchesBothHttpAndHttpsUrls_AsSuperUser()
@@ -1185,28 +1185,28 @@ class ApiTest extends IntegrationTestCase
     private function assert_getSitesIdFromSiteUrl_matchesBothHttpAndHttpsUrls()
     {
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.org');
-        $this->assertTrue(count($idsites) == 1);
+        $this->assertCount(1, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('piwik.org');
-        $this->assertTrue(count($idsites) == 1);
+        $this->assertCount(1, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('https://www.piwik.org');
-        $this->assertTrue(count($idsites) == 1);
+        $this->assertCount(1, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('https://example.com');
-        $this->assertTrue(count($idsites) == 1);
+        $this->assertCount(1, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl("fb://special-url");
-        $this->assertTrue(count($idsites) == 1);
+        $this->assertCount(1, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('https://random-example.com');
-        $this->assertTrue(count($idsites) == 0);
+        $this->assertCount(0, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('not-found.piwik.org');
-        $this->assertTrue(count($idsites) == 0);
+        $this->assertCount(0, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('piwik.org/not-found/');
-        $this->assertTrue(count($idsites) == 0);
+        $this->assertCount(0, $idsites);
     }
 
     public function test_getSitesIdFromSiteUrl_AsUser()
@@ -1233,13 +1233,13 @@ class ApiTest extends IntegrationTestCase
 
         $this->assertFalse(Piwik::hasUserSuperUserAccess());
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.com');
-        $this->assertEquals(1, count($idsites));
+        $this->assertCount(1, $idsites);
 
         // testing URL normalization
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://www.piwik.com');
-        $this->assertEquals(1, count($idsites));
+        $this->assertCount(1, $idsites);
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.net');
-        $this->assertEquals(1, count($idsites));
+        $this->assertCount(1, $idsites);
 
         FakeAccess::$superUser = false;
         FakeAccess::$identity = 'user2';
@@ -1247,7 +1247,7 @@ class ApiTest extends IntegrationTestCase
         FakeAccess::setIdSitesAdmin(array(3));
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.com');
-        $this->assertEquals(2, count($idsites));
+        $this->assertCount(2, $idsites);
 
         FakeAccess::$superUser = false;
         FakeAccess::$identity = 'user3';
@@ -1255,10 +1255,10 @@ class ApiTest extends IntegrationTestCase
         FakeAccess::setIdSitesAdmin(array(3));
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.com');
-        $this->assertEquals(3, count($idsites));
+        $this->assertCount(3, $idsites);
 
         $idsites = API::getInstance()->getSitesIdFromSiteUrl('https://www.piwik.com');
-        $this->assertEquals(3, count($idsites));
+        $this->assertCount(3, $idsites);
     }
 
     public function test_getSitesFromTimezones_ReturnsCorrectIdSites()

--- a/plugins/UserCountry/tests/Unit/UserCountryTest.php
+++ b/plugins/UserCountry/tests/Unit/UserCountryTest.php
@@ -161,13 +161,13 @@ class UserCountryTest extends \PHPUnit_Framework_TestCase
     {
         $geoIpDir = PIWIK_INCLUDE_PATH . '/tests/lib/geoip-files';
 
-        $this->assertFalse(file_exists($geoIpDir . '/GeoIPCity.dat.broken'));
+        $this->assertFileNotExists($geoIpDir . '/GeoIPCity.dat.broken');
 
-        $this->assertFalse(file_exists($geoIpDir . '/GeoIPISP.dat'));
-        $this->assertTrue(file_exists($geoIpDir . '/GeoIPISP.dat.broken'));
+        $this->assertFileNotExists($geoIpDir . '/GeoIPISP.dat');
+        $this->assertFileExists($geoIpDir . '/GeoIPISP.dat.broken');
 
-        $this->assertFalse(file_exists($geoIpDir . '/GeoIPOrg.dat'));
-        $this->assertTrue(file_exists($geoIpDir . '/GeoIPOrg.dat.broken'));
+        $this->assertFileNotExists($geoIpDir . '/GeoIPOrg.dat');
+        $this->assertFileExists($geoIpDir . '/GeoIPOrg.dat.broken');
     }
 }
 

--- a/plugins/UsersManager/tests/Integration/UsersManagerTest.php
+++ b/plugins/UsersManager/tests/Integration/UsersManagerTest.php
@@ -684,15 +684,15 @@ class UsersManagerTest extends IntegrationTestCase
 
         // Test getUsersWithSiteAccess
         $users = $this->api->getUsersWithSiteAccess($id1, $access = 'view');
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
         $this->assertEquals('user1', $users[0]['login']);
         $users = $this->api->getUsersWithSiteAccess($id2, $access = 'view');
-        $this->assertEquals(2, count($users));
+        $this->assertCount(2, $users);
         $users = $this->api->getUsersWithSiteAccess($id1, $access = 'admin');
-        $this->assertEquals(1, count($users));
+        $this->assertCount(1, $users);
         $this->assertEquals('user2', $users[0]['login']);
         $users = $this->api->getUsersWithSiteAccess($id3, $access = 'admin');
-        $this->assertEquals(0, count($users));
+        $this->assertCount(0, $users);
     }
 
     /**

--- a/tests/PHPUnit/Fixtures/InvalidVisits.php
+++ b/tests/PHPUnit/Fixtures/InvalidVisits.php
@@ -56,7 +56,7 @@ class InvalidVisits extends Fixture
         // Trigger empty request
         $trackerUrl = self::getTrackerUrl();
         $response = Http::fetchRemoteFile($trackerUrl);
-        self::assertTrue(strpos($response, 'Keep full control of your data with the leading free') !== false, 'Piwik empty request response not correct: ' . $response);
+        self::assertContains('Keep full control of your data with the leading free', $response, 'Piwik empty request response not correct: ' . $response);
 
         $t = self::getTracker($idSite, $dateTime, $defaultInit = true);
 

--- a/tests/PHPUnit/Fixtures/SomeVisitsAllConversions.php
+++ b/tests/PHPUnit/Fixtures/SomeVisitsAllConversions.php
@@ -93,9 +93,9 @@ class SomeVisitsAllConversions extends Fixture
         // Update & set to not allow multiple
         $goals = API::getInstance()->getGoals($idSite);
         $goal = $goals[$idGoal_OneConversionPerVisit];
-        self::assertTrue($goal['allow_multiple'] == 0);
+        self::assertEquals(0, $goal['allow_multiple']);
         API::getInstance()->updateGoal($idSite, $idGoal_OneConversionPerVisit, $goal['name'], @$goal['match_attribute'], @$goal['pattern'], @$goal['pattern_type'], @$goal['case_sensitive'], $goal['revenue'], $goal['allow_multiple'] = 1);
-        self::assertTrue($goal['allow_multiple'] == 1);
+        self::assertEquals(1, $goal['allow_multiple']);
 
         // 1st goal should Now be tracked
         $t->setForceVisitDateTime(Date::factory($dateTime)->addHour(0.61)->getDatetime());

--- a/tests/PHPUnit/Fixtures/SomeVisitsCustomVariablesCampaignsNotHeuristics.php
+++ b/tests/PHPUnit/Fixtures/SomeVisitsCustomVariablesCampaignsNotHeuristics.php
@@ -70,7 +70,7 @@ class SomeVisitsCustomVariablesCampaignsNotHeuristics extends Fixture
         self::checkResponse($t->doTrackPageView('incredible title!'));
 
         $visitorId = $t->getVisitorId();
-        self::assertTrue(strlen($visitorId) == 16);
+        self::assertEquals(16, strlen($visitorId));
 
         $this->testFirstPartyCookies($t);
 
@@ -80,7 +80,7 @@ class SomeVisitsCustomVariablesCampaignsNotHeuristics extends Fixture
 
         // Make sure the ID is different at first
         $visitorId2 = $t2->getVisitorId();
-        self::assertTrue($visitorId != $visitorId2);
+        self::assertNotEquals($visitorId, $visitorId2);
 
         // Then force the visitor ID
         $t2->setVisitorId($visitorId);

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -419,8 +419,8 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
         if(!is_string($response)) {
             $response = json_encode($response);
         }
-        self::assertTrue(stripos($response, 'error') === false, "error in $response");
-        self::assertTrue(stripos($response, 'exception') === false, "exception in $response");
+        self::assertFalse(stripos($response, 'error'), "error in $response");
+        self::assertFalse(stripos($response, 'exception'), "exception in $response");
     }
 
     protected static function getProcessedAndExpectedDirs()

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -209,7 +209,7 @@ class Response
         if (!is_array($fieldsToRemove)) {
             $fieldsToRemove = array();
         }
-        
+
         foreach ($fieldsToRemove as $xml) {
             $input = $this->removeXmlElement($input, $xml);
         }
@@ -227,7 +227,7 @@ class Response
 
         // check we didn't delete the whole string
         if ($testNotSmallAfter && $input != $oldInput) {
-            $this->assertTrue(strlen($input) > 100);
+            $this->assertGreaterThan(100, strlen($input));
         }
         return $input;
     }

--- a/tests/PHPUnit/Integration/Archive/ChunksTest.php
+++ b/tests/PHPUnit/Integration/Archive/ChunksTest.php
@@ -81,7 +81,7 @@ class ChunksTest extends IntegrationTestCase
         // verify the subtables were actually splitted into chunks
         foreach ($archiveRows as $row) {
             $value = unserialize(gzuncompress($row['value']));
-            $this->assertTrue(is_array($value));
+            $this->assertInternalType('array', $value);
             if ($row['name'] == $recordName) {
                 $this->assertCount($numSubtablesToGenerate, $value); // 1053 rows
             } elseif ($row['name'] == $recordName . '_chunk_1000_1099') {

--- a/tests/PHPUnit/Integration/Archive/DataTableFactoryTest.php
+++ b/tests/PHPUnit/Integration/Archive/DataTableFactoryTest.php
@@ -93,11 +93,11 @@ class DataTableFactoryTest extends IntegrationTestCase
 
         $map = $factory->makeMerged($index, $indices);
 
-        $this->assertTrue($map instanceof DataTable\Map);
+        $this->assertInstanceOf(DataTable\Map::class, $map);
         $this->assertRowCountEquals(2, $map);
 
         foreach ($map->getDataTables() as $label => $table) {
-            $this->assertTrue(in_array($label, array($this->date1, $this->date2)));
+            $this->assertContains($label, array($this->date1, $this->date2));
             $this->assertTableIsDataTableSimpleInstance($table);
             $this->assertRowCountEquals(1, $table);
             $this->assertRowEquals($this->defaultRow, $this->site1, $table->getFirstRow());
@@ -120,7 +120,7 @@ class DataTableFactoryTest extends IntegrationTestCase
 
         $map = $factory->makeMerged($index, $indices);
 
-        $this->assertTrue($map instanceof DataTable\Map);
+        $this->assertInstanceOf(DataTable\Map::class, $map);
         $this->assertRowCountEquals(2, $map);
 
         foreach ($map->getDataTables() as $label => $table) {
@@ -209,12 +209,12 @@ class DataTableFactoryTest extends IntegrationTestCase
 
         $map = $factory->makeMerged($index, $indices);
 
-        $this->assertTrue($map instanceof DataTable\Map);
+        $this->assertInstanceOf(DataTable\Map::class, $map);
         $this->assertRowCountEquals(2, $map);
         $this->assertSame('date', $map->getKeyName());
 
         foreach ($map->getDataTables() as $label => $table) {
-            $this->assertTrue(in_array($label, array($this->date1, $this->date2)));
+            $this->assertContains($label, array($this->date1, $this->date2));
             $this->assertTableIsDataTableInstance($table);
             $this->assertRowCountEquals(2, $table);
             $this->assertTableMetadataEquals($label, $table);
@@ -248,11 +248,11 @@ class DataTableFactoryTest extends IntegrationTestCase
 
         $map = $factory->makeMerged($index, $indices);
 
-        $this->assertTrue($map instanceof DataTable\Map);
+        $this->assertInstanceOf(DataTable\Map::class, $map);
         $this->assertRowCountEquals(2, $map);
 
         foreach ($map->getDataTables() as $label => $table) {
-            $this->assertTrue(in_array($label, array($this->date1, $this->date2)));
+            $this->assertContains($label, array($this->date1, $this->date2));
             $this->assertTableIsDataTableInstance($table);
             $this->assertRowCountEquals(2, $table);
             $this->assertTableMetadataEquals($label, $table);
@@ -282,7 +282,7 @@ class DataTableFactoryTest extends IntegrationTestCase
         $period = $dataTable->getMetadata(DataTableFactory::TABLE_METADATA_PERIOD_INDEX);
 
         $this->assertFalse($dataTable->getMetadata(DataTableFactory::TABLE_METADATA_SITE_INDEX));
-        $this->assertTrue($period instanceof Period);
+        $this->assertInstanceOf(Period::class, $period);
         $this->assertSame($expectedPeriod, $period->toString());
     }
 
@@ -305,13 +305,13 @@ class DataTableFactoryTest extends IntegrationTestCase
 
     private function assertTableIsDataTableInstance($table)
     {
-        $this->assertTrue($table instanceof DataTable);
-        $this->assertFalse($table instanceof DataTable\Simple);
+        $this->assertInstanceOf(DataTable::class, $table);
+        $this->assertNotInstanceOf(DataTable\Simple::class, $table);
     }
 
     private function assertTableIsDataTableSimpleInstance($table)
     {
-        $this->assertTrue($table instanceof DataTable\Simple);
+        $this->assertInstanceOf(DataTable\Simple::class, $table);
     }
 
     private function createFactory($resultIndices)

--- a/tests/PHPUnit/Integration/Category/CategoryListTest.php
+++ b/tests/PHPUnit/Integration/Category/CategoryListTest.php
@@ -54,8 +54,8 @@ class CategoryListTest extends IntegrationTestCase
     {
         $list = CategoryList::get();
 
-        $this->assertTrue(5 < count($list->getCategory('General_Actions')->getSubcategories()));
-        $this->assertTrue(5 < count($list->getCategory('General_Visitors')->getSubcategories()));
+        $this->assertGreaterThan(5, count($list->getCategory('General_Actions')->getSubcategories()));
+        $this->assertGreaterThan(5, count($list->getCategory('General_Visitors')->getSubcategories()));
         $this->assertTrue($list->getCategory('General_Actions')->hasSubcategory('General_Pages'));
     }
 

--- a/tests/PHPUnit/Integration/EmailValidatorTest.php
+++ b/tests/PHPUnit/Integration/EmailValidatorTest.php
@@ -35,7 +35,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
             }
         }
         $minimumTlds = 1200;
-        $this->assertGreaterThan( $minimumTlds, count($tlds), "expected to download at least $minimumTlds domain names");
+        $this->assertGreaterThan($minimumTlds, count($tlds), "expected to download at least $minimumTlds domain names");
         return $tlds;
     }
 

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -36,7 +36,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertNotNull(Http::getTransportMethod());
         $result = Http::sendHttpRequestBy($method, Fixture::getRootUrl() . 'piwik.js', 30);
-        $this->assertTrue(strpos($result, 'Piwik') !== false);
+        $this->assertContains('Piwik', $result);
     }
 
     public function testFetchApiLatestVersion()
@@ -88,7 +88,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(206, $result['status']);
         $this->assertTrue(isset($result['headers']['Content-Range']));
         $this->assertEquals('bytes 10-20/', substr($result['headers']['Content-Range'], 0, 12));
-        $this->assertTrue(in_array($result['headers']['Content-Type'], array('application/x-javascript', 'application/javascript')));
+        $this->assertContains($result['headers']['Content-Type'], array('application/x-javascript', 'application/javascript'));
     }
 
     /**
@@ -119,8 +119,8 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $result['status']);
 
         $this->assertTrue(isset($result['headers']['Content-Length']), "Content-Length header not set!");
-        $this->assertTrue(is_numeric($result['headers']['Content-Length']), "Content-Length header not numeric!");
-        $this->assertTrue(in_array($result['headers']['Content-Type'], array('application/zip', 'application/x-zip-compressed')));
+        $this->assertInternalType('numeric', $result['headers']['Content-Length'], "Content-Length header not numeric!");
+        $this->assertContains($result['headers']['Content-Type'], array('application/zip', 'application/x-zip-compressed'));
     }
 
     /**

--- a/tests/PHPUnit/Integration/OptionTest.php
+++ b/tests/PHPUnit/Integration/OptionTest.php
@@ -115,7 +115,7 @@ class OptionTest extends IntegrationTestCase
 
         // insert guard - to test unescaped underscore
         Option::set('adefaultReport', '0', true);
-        $this->assertTrue(Option::get('adefaultReport') === '0');
+        $this->assertSame('0', Option::get('adefaultReport'));
 
         // populate table, expect '1'
         Option::set('anonymous_defaultReport', '1', true);

--- a/tests/PHPUnit/Integration/PiwikTest.php
+++ b/tests/PHPUnit/Integration/PiwikTest.php
@@ -48,7 +48,7 @@ class PiwikTest extends IntegrationTestCase
      */
     public function testIsNumericValid($toTest)
     {
-        $this->assertTrue(is_numeric($toTest), $toTest . " not valid but should!");
+        $this->assertInternalType('numeric', $toTest, $toTest . " not valid but should!");
     }
 
     /**
@@ -70,7 +70,7 @@ class PiwikTest extends IntegrationTestCase
      */
     public function testIsNumericNotValid($toTest)
     {
-        $this->assertFalse(is_numeric($toTest), $toTest . " valid but shouldn't!");
+        $this->assertNotInternalType('numeric', $toTest, $toTest . " valid but shouldn't!");
     }
 
     public function testSecureDiv()

--- a/tests/PHPUnit/Integration/Plugin/CategoriesTest.php
+++ b/tests/PHPUnit/Integration/Plugin/CategoriesTest.php
@@ -52,7 +52,7 @@ class CategoriesTest extends IntegrationTestCase
         $this->assertGreaterThanOrEqual(4, count($categories));
 
         foreach ($categories as $category) {
-            $this->assertTrue($category instanceof Category);
+            $this->assertInstanceOf(Category::class, $category);
         }
     }
 
@@ -72,7 +72,7 @@ class CategoriesTest extends IntegrationTestCase
         $this->assertGreaterThanOrEqual(10, count($subcategories));
 
         foreach ($subcategories as $subcategory) {
-            $this->assertTrue($subcategory instanceof Subcategory);
+            $this->assertInstanceOf(Subcategory::class, $subcategory);
             $this->assertNotEmpty($subcategory->getId());
         }
     }

--- a/tests/PHPUnit/Integration/Plugin/ReleaseChannelsTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ReleaseChannelsTest.php
@@ -48,7 +48,7 @@ class ReleaseChannelsTest extends IntegrationTestCase
         $this->assertCount(4, $channels);
 
         foreach ($channels as $channel) {
-            $this->assertTrue($channel instanceof ReleaseChannel);
+            $this->assertInstanceOf(ReleaseChannel::class, $channel);
         }
     }
 

--- a/tests/PHPUnit/Integration/Plugin/SettingsProviderTest.php
+++ b/tests/PHPUnit/Integration/Plugin/SettingsProviderTest.php
@@ -60,7 +60,7 @@ class SettingsProviderTest extends IntegrationTestCase
     {
         $settings = $this->settings->getSystemSettings($this->examplePlugin);
 
-        $this->assertTrue($settings instanceof SystemSettings);
+        $this->assertInstanceOf(SystemSettings::class, $settings);
         $this->assertSame($this->examplePlugin, $settings->getPluginName());
     }
 
@@ -89,7 +89,7 @@ class SettingsProviderTest extends IntegrationTestCase
         $this->assertArrayHasKey('QueuedTracking', $settings);
 
         foreach ($settings as $setting) {
-            $this->assertTrue($setting instanceof SystemSettings);
+            $this->assertInstanceOf(SystemSettings::class, $setting);
         }
     }
 
@@ -97,7 +97,7 @@ class SettingsProviderTest extends IntegrationTestCase
     {
         $settings = $this->settings->getUserSettings($this->examplePlugin);
 
-        $this->assertTrue($settings instanceof UserSettings);
+        $this->assertInstanceOf(UserSettings::class, $settings);
         $this->assertSame($this->examplePlugin, $settings->getPluginName());
     }
 
@@ -124,7 +124,7 @@ class SettingsProviderTest extends IntegrationTestCase
         $this->assertArrayHasKey($this->examplePlugin, $settings);
 
         foreach ($settings as $setting) {
-            $this->assertTrue($setting instanceof UserSettings);
+            $this->assertInstanceOf(UserSettings::class, $setting);
         }
     }
 
@@ -132,7 +132,7 @@ class SettingsProviderTest extends IntegrationTestCase
     {
         $settings = $this->settings->getMeasurableSettings($this->examplePlugin, $idSite = 1, $idType = null);
 
-        $this->assertTrue($settings instanceof MeasurableSettings);
+        $this->assertInstanceOf(MeasurableSettings::class, $settings);
         $this->assertSame($this->examplePlugin, $settings->getPluginName());
     }
 
@@ -158,7 +158,7 @@ class SettingsProviderTest extends IntegrationTestCase
         $this->assertArrayHasKey($this->examplePlugin, $settings);
 
         foreach ($settings as $setting) {
-            $this->assertTrue($setting instanceof MeasurableSettings);
+            $this->assertInstanceOf(MeasurableSettings::class, $setting);
         }
     }
 

--- a/tests/PHPUnit/Integration/Plugin/WidgetsProviderTest.php
+++ b/tests/PHPUnit/Integration/Plugin/WidgetsProviderTest.php
@@ -53,7 +53,7 @@ class WidgetsProviderTest extends IntegrationTestCase
         $this->assertGreaterThanOrEqual(3, count($configs));
 
         foreach ($configs as $config) {
-            $this->assertTrue($config instanceof WidgetContainerConfig);
+            $this->assertInstanceOf(WidgetContainerConfig::class, $config);
         }
     }
 
@@ -64,8 +64,8 @@ class WidgetsProviderTest extends IntegrationTestCase
         $this->assertGreaterThanOrEqual(10, count($configs));
 
         foreach ($configs as $config) {
-            $this->assertTrue($config instanceof WidgetConfig);
-            $this->assertFalse($config instanceof WidgetContainerConfig);
+            $this->assertInstanceOf(WidgetConfig::class, $config);
+            $this->assertNotInstanceOf(WidgetContainerConfig::class, $config);
         }
     }
 

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -138,7 +138,7 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
         // Check the index.php has "backtrace disabled"
         $content = file_get_contents(PIWIK_INCLUDE_PATH . "/index.php");
         $expected = "define('PIWIK_PRINT_ERROR_BACKTRACE', false);";
-        $this->assertTrue( false !== strpos($content, $expected), 'index.php should contain: ' . $expected);
+        $this->assertContains($expected, $content, 'index.php should contain: ' . $expected);
     }
 
     private function _checkEqual($key, $valueExpected)
@@ -162,7 +162,7 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
             }
 
             $content = file_get_contents($file);
-            $this->assertFalse(strpos($content, $patternFailIfFound), 'found in ' . $file);
+            $this->assertNotContains($patternFailIfFound, $content, 'found in ' . $file);
         }
     }
 
@@ -266,12 +266,12 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
     public function testProfilingDisabledInProduction()
     {
         require_once 'Tracker/Db.php';
-        $this->assertTrue(\Piwik\Tracker\Db::isProfilingEnabled() === false, 'SQL profiler should be disabled in production! See Db::$profiling');
+        $this->assertFalse(\Piwik\Tracker\Db::isProfilingEnabled(), 'SQL profiler should be disabled in production! See Db::$profiling');
     }
 
     public function testPiwikTrackerDebugIsOff()
     {
-        $this->assertTrue(!isset($GLOBALS['PIWIK_TRACKER_DEBUG']));
+        $this->assertArrayNotHasKey('PIWIK_TRACKER_DEBUG', $GLOBALS);
         $this->assertEquals(0, $this->globalConfig['Tracker']['debug']);
 
         $tracker = new Tracker();
@@ -361,7 +361,7 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
             $chmod = substr(decoct(fileperms($pathToTest)), -3);
             $valid = array('777', '775', '755');
             $command = "find $pluginsPath -type d -exec chmod 755 {} +";
-            $this->assertTrue(in_array($chmod, $valid),
+            $this->assertContains($chmod, $valid,
                     "Some directories within plugins/ are not chmod 755 \n\nGot: $chmod for : $pathToTest \n\n".
                     "Run this command to set all directories to 755: \n$command\n");;
         }
@@ -399,7 +399,7 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
 
             $enabled = in_array($pluginName, $pluginsBundledWithPiwik);
 
-            $this->assertTrue( $enabled + $disabled === 1,
+            $this->assertSame(1, $enabled + $disabled,
                 "Plugin $pluginName should be either enabled (in global.ini.php) or disabled (in Piwik\\Plugin\\Manager).
                 It is currently (enabled=".(int)$enabled. ", disabled=" . (int)$disabled . ")"
             );
@@ -435,13 +435,13 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
                 // expect CRLF
                 if (preg_match('/\.(bat|ps1)$/', $file)) {
                     $contents = str_replace("\r\n", '', $contents);
-                    $this->assertTrue(strpos($contents, "\n") === false, 'Incorrect line endings in ' . $file);
+                    $this->assertNotContains("\n", $contents, 'Incorrect line endings in ' . $file);
                 } else {
                     // expect native
                     $hasWindowsEOL = strpos($contents, "\r\n");
 
                     // overwrite translations files with incorrect line endings
-                    $this->assertTrue($hasWindowsEOL === false, 'Incorrect line endings \r\n found in ' . $file);
+                    $this->assertFalse($hasWindowsEOL, 'Incorrect line endings \r\n found in ' . $file);
                 }
             }
         }
@@ -454,10 +454,10 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
         $pattern = '/\x5b\x5c{2}.*\x5c{2}[\x22\x27]/';
         $contents = file_get_contents(PIWIK_DOCUMENT_ROOT . '/js/piwik.js');
 
-        $this->assertTrue(preg_match($pattern, $contents) == 0);
+        $this->assertEquals(0, preg_match($pattern, $contents));
 
         $contents = file_get_contents(PIWIK_DOCUMENT_ROOT . '/piwik.js');
-        $this->assertTrue(preg_match($pattern, $contents) == 0);
+        $this->assertEquals(0, preg_match($pattern, $contents));
     }
 
     public function test_piwikJs_minified_isUpToDate()

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -501,14 +501,14 @@ class SegmentTest extends IntegrationTestCase
                     log_action.name as url,
                     sum(log_link_visit_action.time_spent) as `13`,
                     sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
-             FROM $logLinkVisitActionTable AS log_link_visit_action 
-             LEFT JOIN $logActionTable AS log_action ON log_link_visit_action.idaction_url = log_action.idaction 
-             LEFT JOIN $logVisitTable AS log_visit ON log_visit.idvisit = log_link_visit_action.idvisit 
-             LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action_foo ON log_link_visit_action.idvisit = log_link_visit_action_foo.idvisit 
-             LEFT JOIN $logActionTable AS log_action_foo ON log_link_visit_action_foo.idaction_url = log_action_foo.idaction 
-             LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action_bar ON log_link_visit_action.idvisit = log_link_visit_action_bar.idvisit 
-             LEFT JOIN $logActionTable AS log_action_bar ON log_link_visit_action_bar.idaction_url = log_action_bar.idaction 
-             LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action_baz ON log_link_visit_action.idvisit = log_link_visit_action_baz.idvisit 
+             FROM $logLinkVisitActionTable AS log_link_visit_action
+             LEFT JOIN $logActionTable AS log_action ON log_link_visit_action.idaction_url = log_action.idaction
+             LEFT JOIN $logVisitTable AS log_visit ON log_visit.idvisit = log_link_visit_action.idvisit
+             LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action_foo ON log_link_visit_action.idvisit = log_link_visit_action_foo.idvisit
+             LEFT JOIN $logActionTable AS log_action_foo ON log_link_visit_action_foo.idaction_url = log_action_foo.idaction
+             LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action_bar ON log_link_visit_action.idvisit = log_link_visit_action_bar.idvisit
+             LEFT JOIN $logActionTable AS log_action_bar ON log_link_visit_action_bar.idaction_url = log_action_bar.idaction
+             LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action_baz ON log_link_visit_action.idvisit = log_link_visit_action_baz.idvisit
              LEFT JOIN $logActionTable AS log_action_baz ON log_link_visit_action_baz.idaction_url = log_action_baz.idaction
              WHERE ( log_link_visit_action.server_time >= ?
                  AND log_link_visit_action.server_time <= ?
@@ -553,8 +553,8 @@ class SegmentTest extends IntegrationTestCase
                     log_action.name as url,
                     sum(log_link_visit_action.time_spent) as `13`,
                     sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
-             FROM $logLinkVisitActionTable AS log_link_visit_action 
-             LEFT JOIN $logVisitTable AS log_visit ON log_visit.idvisit = log_link_visit_action.idvisit 
+             FROM $logLinkVisitActionTable AS log_link_visit_action
+             LEFT JOIN $logVisitTable AS log_visit ON log_visit.idvisit = log_link_visit_action.idvisit
              LEFT JOIN $logActionTable AS log_action ON log_link_visit_action.idaction_name = log_action.idaction
              WHERE ( log_link_visit_action.server_time >= ?
                  AND log_link_visit_action.server_time <= ?
@@ -716,9 +716,9 @@ class SegmentTest extends IntegrationTestCase
                     actionAlias.name as url,
                     sum(log_link_visit_action.time_spent) as `13`,
                     sum(case visitAlias.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
-             FROM $logLinkVisitActionTable AS log_link_visit_action 
-             LEFT JOIN $logActionTable AS log_action ON log_link_visit_action.idaction_url = log_action.idaction 
-             LEFT JOIN $logVisitTable AS visitAlias ON visitAlias.idvisit = log_link_visit_action.idvisit 
+             FROM $logLinkVisitActionTable AS log_link_visit_action
+             LEFT JOIN $logActionTable AS log_action ON log_link_visit_action.idaction_url = log_action.idaction
+             LEFT JOIN $logVisitTable AS visitAlias ON visitAlias.idvisit = log_link_visit_action.idvisit
              LEFT JOIN $logActionTable AS actionAlias ON log_link_visit_action.idaction_url = actionAlias.idaction
              WHERE ( log_link_visit_action.server_time >= ?
                  AND log_link_visit_action.server_time <= ?
@@ -964,16 +964,16 @@ class SegmentTest extends IntegrationTestCase
 
         $expected = array(
             "sql"  => "
-                SELECT log_inner.name AS 'EntryPageTitle', log_inner.name02fd90a35677a359ea5611a4bc456a6f AS 'EventAction', count(distinct log_inner.idvisit) AS 'nb_uniq_visits', count(distinct log_inner.idvisitor) AS 'nb_uniq_visitors', sum(case log_inner.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) AS 'bounce_count', sum(log_inner.visit_total_actions) AS 'sum_actions', sum(log_inner.visit_goal_converted) AS 'sum_visit_goal_converted' 
-                FROM ( 
-                  SELECT log_action_visit_entry_idaction_name.name, log_action_idaction_event_action.name as name02fd90a35677a359ea5611a4bc456a6f, log_visit.idvisit, log_visit.idvisitor, log_visit.visit_total_actions, log_visit.visit_goal_converted 
-                  FROM $logVisitTable AS log_visit 
-                  LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit 
-                  LEFT JOIN $logActionTable AS log_action_visit_entry_idaction_name ON log_visit.visit_entry_idaction_name = log_action_visit_entry_idaction_name.idaction 
+                SELECT log_inner.name AS 'EntryPageTitle', log_inner.name02fd90a35677a359ea5611a4bc456a6f AS 'EventAction', count(distinct log_inner.idvisit) AS 'nb_uniq_visits', count(distinct log_inner.idvisitor) AS 'nb_uniq_visitors', sum(case log_inner.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) AS 'bounce_count', sum(log_inner.visit_total_actions) AS 'sum_actions', sum(log_inner.visit_goal_converted) AS 'sum_visit_goal_converted'
+                FROM (
+                  SELECT log_action_visit_entry_idaction_name.name, log_action_idaction_event_action.name as name02fd90a35677a359ea5611a4bc456a6f, log_visit.idvisit, log_visit.idvisitor, log_visit.visit_total_actions, log_visit.visit_goal_converted
+                  FROM $logVisitTable AS log_visit
+                  LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
+                  LEFT JOIN $logActionTable AS log_action_visit_entry_idaction_name ON log_visit.visit_entry_idaction_name = log_action_visit_entry_idaction_name.idaction
                   LEFT JOIN $logActionTable AS log_action_idaction_event_action ON log_link_visit_action.idaction_event_action = log_action_idaction_event_action.idaction
-                  ORDER BY nb_uniq_visits, log_action_idaction_event_action.name LIMIT 0, 33 ) 
-                AS log_inner 
-                GROUP BY log_inner.name, log_inner.name02fd90a35677a359ea5611a4bc456a6f 
+                  ORDER BY nb_uniq_visits, log_action_idaction_event_action.name LIMIT 0, 33 )
+                AS log_inner
+                GROUP BY log_inner.name, log_inner.name02fd90a35677a359ea5611a4bc456a6f
                 ORDER BY nb_uniq_visits, log_inner.name02fd90a35677a359ea5611a4bc456a6f",
             "bind" => array(1));
 
@@ -1016,15 +1016,15 @@ class SegmentTest extends IntegrationTestCase
                   sum(log_inner.time_spent) as `13`,
                   sum(case log_inner.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
 			FROM
-				
+
         (
-            
+
 			SELECT
-				log_link_visit_action.idvisit, 
-log_visit.idvisit as idvisit5d489886e80b4258a9407b219a4e2811, 
-log_visit.idvisitor, 
-log_action.name, 
-log_link_visit_action.time_spent, 
+				log_link_visit_action.idvisit,
+log_visit.idvisit as idvisit5d489886e80b4258a9407b219a4e2811,
+log_visit.idvisitor,
+log_action.name,
+log_link_visit_action.time_spent,
 log_visit.visit_total_actions
 			FROM
 				log_visit AS log_visit LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
@@ -1306,7 +1306,7 @@ log_visit.visit_total_actions
             ));
 
         $cache = StaticContainer::get('Piwik\Tracker\TableLogAction\Cache');
-        $this->assertTrue( empty($cache->isEnabled) );
+        $this->assertEmpty($cache->isEnabled);
         $this->assertCacheWasHit($hit = 0);
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
@@ -1376,7 +1376,7 @@ log_visit.visit_total_actions
             ));
 
         $cache = StaticContainer::get('Piwik\Tracker\TableLogAction\Cache');
-        $this->assertTrue( !empty($cache->isEnabled) );
+        $this->assertNotEmpty($cache->isEnabled);
 
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }
@@ -1445,7 +1445,7 @@ log_visit.visit_total_actions
             ));
 
         $cache = StaticContainer::get('Piwik\Tracker\TableLogAction\Cache');
-        $this->assertTrue( !empty($cache->isEnabled) );
+        $this->assertNotEmpty($cache->isEnabled);
 
         $this->assertEquals($this->removeExtraWhiteSpaces($expected), $this->removeExtraWhiteSpaces($query));
     }

--- a/tests/PHPUnit/Integration/ServeStaticFileTest.php
+++ b/tests/PHPUnit/Integration/ServeStaticFileTest.php
@@ -247,7 +247,7 @@ class ServeStaticFileTest extends \PHPUnit_Framework_TestCase
         curl_close($curlHandle);
 
         // Tests response content, it has to be equal to the test file. If not equal, double compression occurred
-        $this->assertEquals($fullResponse, file_get_contents(TEST_FILE_LOCATION));
+        $this->assertStringEqualsFile(TEST_FILE_LOCATION, $fullResponse);
     }
 
     /**
@@ -272,7 +272,7 @@ class ServeStaticFileTest extends \PHPUnit_Framework_TestCase
         curl_close($curlHandle);
 
         // Tests response content, it has to be equal to the test file
-        $this->assertEquals($fullResponse, file_get_contents(TEST_FILE_LOCATION));
+        $this->assertStringEqualsFile(TEST_FILE_LOCATION, $fullResponse);
 
         // Tests deflate compression has been used
         $deflateFileLocation = $this->getCompressedFileLocation() . ".deflate";
@@ -306,7 +306,7 @@ class ServeStaticFileTest extends \PHPUnit_Framework_TestCase
         curl_close($curlHandle);
 
         // Tests response content, it has to be equal to the test file
-        $this->assertEquals($fullResponse, file_get_contents(TEST_FILE_LOCATION));
+        $this->assertStringEqualsFile(TEST_FILE_LOCATION, $fullResponse);
 
         // Tests gzip compression has been used
         $gzipFileLocation = $this->getCompressedFileLocation() . ".gz";
@@ -416,8 +416,8 @@ class ServeStaticFileTest extends \PHPUnit_Framework_TestCase
         clearstatcache();
 
         // check no compressed files created
-        $this->assertFalse(file_exists($this->getCompressedFileLocation() . ".deflate"));
-        $this->assertFalse(file_exists($this->getCompressedFileLocation() . ".gz"));
+        $this->assertFileNotExists($this->getCompressedFileLocation() . ".deflate");
+        $this->assertFileNotExists($this->getCompressedFileLocation() . ".gz");
 
         // check $partialResponse
         $this->assertEquals(PARTIAL_BYTE_END - PARTIAL_BYTE_START, $responseInfo["size_download"]);
@@ -479,7 +479,7 @@ class ServeStaticFileTest extends \PHPUnit_Framework_TestCase
         $this->assertFileNotExists($this->getCompressedFileLocation() . ".gz");
 
         // check $fullResponse
-        $this->assertEquals(file_get_contents(TEST_FILE_LOCATION), $fullResponse);
+        $this->assertStringEqualsFile(TEST_FILE_LOCATION, $fullResponse);
 
         $this->removeCompressedFiles();
     }

--- a/tests/PHPUnit/Integration/Settings/Measurable/MeasurableSettingsTest.php
+++ b/tests/PHPUnit/Integration/Settings/Measurable/MeasurableSettingsTest.php
@@ -35,7 +35,7 @@ class MeasurableSettingsTest extends BaseSettingsTestCase
 
     public function test_weAreWorkingWithMeasurableSettings()
     {
-        $this->assertTrue($this->settings instanceof MeasurableSettings);
+        $this->assertInstanceOf(MeasurableSettings::class, $this->settings);
     }
 
     public function test_constructor_getPluginName_canDetectPluginNameAutomatically()
@@ -50,7 +50,7 @@ class MeasurableSettingsTest extends BaseSettingsTestCase
     {
         $setting = $this->makeSetting('myName');
 
-        $this->assertTrue($setting instanceof MeasurableSetting);
+        $this->assertInstanceOf(MeasurableSetting::class, $setting);
     }
 
 }

--- a/tests/PHPUnit/Integration/Settings/Plugin/SystemSettingsTest.php
+++ b/tests/PHPUnit/Integration/Settings/Plugin/SystemSettingsTest.php
@@ -23,7 +23,7 @@ class SystemSettingsTest extends BaseSettingsTestCase
 
     public function test_weAreWorkingWithSystemSettings()
     {
-        $this->assertTrue($this->settings instanceof SystemSettings);
+        $this->assertInstanceOf(SystemSettings::class, $this->settings);
     }
 
     public function test_constructor_getPluginName_canDetectPluginNameAutomatically()
@@ -37,7 +37,7 @@ class SystemSettingsTest extends BaseSettingsTestCase
     {
         $setting = $this->makeSetting('myName');
 
-        $this->assertTrue($setting instanceof SystemSetting);
+        $this->assertInstanceOf(SystemSetting::class, $setting);
     }
 
 }

--- a/tests/PHPUnit/Integration/Settings/Plugin/UserSettingsTest.php
+++ b/tests/PHPUnit/Integration/Settings/Plugin/UserSettingsTest.php
@@ -29,7 +29,7 @@ class UserSettingsTest extends BaseSettingsTestCase
 
     public function test_weAreWorkingWithUserSettings()
     {
-        $this->assertTrue($this->settings instanceof UserSettings);
+        $this->assertInstanceOf(UserSettings::class, $this->settings);
     }
 
     public function test_constructor_getPluginName_canDetectPluginNameAutomatically()
@@ -43,7 +43,7 @@ class UserSettingsTest extends BaseSettingsTestCase
     {
         $setting = $this->makeSetting('myName');
 
-        $this->assertTrue($setting instanceof UserSetting);
+        $this->assertInstanceOf(UserSetting::class, $setting);
     }
 
 }

--- a/tests/PHPUnit/Integration/Settings/Storage/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/FactoryTest.php
@@ -42,10 +42,10 @@ class FactoryTest extends IntegrationTestCase
     public function test_getPluginStorage_shouldReturnStorageWithPluginBackend()
     {
         $storage = $this->factory->getPluginStorage('PluginName', $login = 'user5');
-        $this->assertTrue($storage instanceof Storage);
+        $this->assertInstanceOf(Storage::class, $storage);
 
         $backend = $storage->getBackend();
-        $this->assertTrue($backend instanceof PluginSettingsTable);
+        $this->assertInstanceOf(PluginSettingsTable::class, $backend);
         $this->assertSame('PluginSettings_PluginName_User_user5', $backend->getStorageId());
     }
 
@@ -55,16 +55,16 @@ class FactoryTest extends IntegrationTestCase
         $storage = $this->factory->getPluginStorage('pluginName', 'userlogin');
         SettingsServer::setIsNotTrackerApiRequest();
 
-        $this->assertTrue($storage->getBackend() instanceof Cache);
+        $this->assertInstanceOf(Cache::class, $storage->getBackend());
     }
 
     public function test_getMeasurableSettingsStorage_shouldReturnStorageWithMeasurableSettingsBackend()
     {
         $storage = $this->factory->getMeasurableSettingsStorage($idSite = 4, 'PluginNameFoo');
-        $this->assertTrue($storage instanceof Storage);
+        $this->assertInstanceOf(Storage::class, $storage);
 
         $backend = $storage->getBackend();
-        $this->assertTrue($backend instanceof MeasurableSettingsTable);
+        $this->assertInstanceOf(MeasurableSettingsTable::class, $backend);
         $this->assertSame('MeasurableSettings_4_PluginNameFoo', $backend->getStorageId());
     }
 
@@ -74,26 +74,26 @@ class FactoryTest extends IntegrationTestCase
         $storage = $this->factory->getMeasurableSettingsStorage($idSite = 4, 'PluginNameFoo');
         SettingsServer::setIsNotTrackerApiRequest();
 
-        $this->assertTrue($storage->getBackend() instanceof Cache);
+        $this->assertInstanceOf(Cache::class, $storage->getBackend());
     }
 
     public function test_getMeasurableSettingsStorage_shouldReturnNonPersistentStorageWhenEmptySiteIsGiven()
     {
         $storage = $this->factory->getMeasurableSettingsStorage($idSite = 0, 'PluginNameFoo');
-        $this->assertTrue($storage instanceof Storage);
+        $this->assertInstanceOf(Storage::class, $storage);
 
         $backend = $storage->getBackend();
-        $this->assertTrue($backend instanceof NullBackend);
+        $this->assertInstanceOf(NullBackend::class, $backend);
         $this->assertSame('measurableSettings0#PluginNameFoo#nonpersistent', $backend->getStorageId());
     }
 
     public function test_getSitesTable_shouldReturnStorageWithSitesTableBackend()
     {
         $storage = $this->factory->getSitesTable($idSite = 3);
-        $this->assertTrue($storage instanceof Storage);
+        $this->assertInstanceOf(Storage::class, $storage);
 
         $backend = $storage->getBackend();
-        $this->assertTrue($backend instanceof SitesTable);
+        $this->assertInstanceOf(SitesTable::class, $backend);
         $this->assertSame('SitesTable_3', $backend->getStorageId());
     }
 
@@ -103,26 +103,26 @@ class FactoryTest extends IntegrationTestCase
         $storage = $this->factory->getSitesTable($idSite = 3);
         SettingsServer::setIsNotTrackerApiRequest();
 
-        $this->assertTrue($storage->getBackend() instanceof Cache);
+        $this->assertInstanceOf(Cache::class, $storage->getBackend());
     }
 
     public function test_getSitesTable_shouldReturnNonPersistentStorageWhenEmptySiteIsGiven()
     {
         $storage = $this->factory->getSitesTable($idSite = 0);
-        $this->assertTrue($storage instanceof Storage);
+        $this->assertInstanceOf(Storage::class, $storage);
 
         $backend = $storage->getBackend();
-        $this->assertTrue($backend instanceof NullBackend);
+        $this->assertInstanceOf(NullBackend::class, $backend);
         $this->assertSame('sitesTable#0#nonpersistent', $backend->getStorageId());
     }
 
     public function test_getNonPersistentStorage_shouldReturnStorageWithNullBackend()
     {
         $storage = $this->factory->getNonPersistentStorage('myKey');
-        $this->assertTrue($storage instanceof Storage);
+        $this->assertInstanceOf(Storage::class, $storage);
 
         $backend = $storage->getBackend();
-        $this->assertTrue($backend instanceof NullBackend);
+        $this->assertInstanceOf(NullBackend::class, $backend);
         $this->assertSame('myKey', $backend->getStorageId());
     }
 
@@ -132,7 +132,7 @@ class FactoryTest extends IntegrationTestCase
         $storage = $this->factory->getNonPersistentStorage('anykey');
         SettingsServer::setIsNotTrackerApiRequest();
 
-        $this->assertTrue($storage->getBackend() instanceof NullBackend);
+        $this->assertInstanceOf(NullBackend::class, $storage->getBackend());
     }
 
     public function test_getNonPersistentStorage_shouldNotUseCache()
@@ -149,7 +149,7 @@ class FactoryTest extends IntegrationTestCase
         $backend = new NullBackend('test');
         $storage = $this->factory->makeStorage($backend);
 
-        $this->assertTrue($storage instanceof Storage);
+        $this->assertInstanceOf(Storage::class, $storage);
 
         $this->assertSame($backend, $storage->getBackend());
     }

--- a/tests/PHPUnit/Integration/SqlTest.php
+++ b/tests/PHPUnit/Integration/SqlTest.php
@@ -37,12 +37,12 @@ class SqlTest extends IntegrationTestCase
     public function testOptimize()
     {
         // make sure optimizing myisam tables works
-        $this->assertTrue(Db::optimizeTables(array('table1', 'table2')) !== false);
+        $this->assertNotFalse(Db::optimizeTables(array('table1', 'table2')));
 
         // make sure optimizing both myisam & innodb results in optimizations
-        $this->assertTrue(Db::optimizeTables(array('table1', 'table2', 'table3', 'table4')) !== false);
+        $this->assertNotFalse(Db::optimizeTables(array('table1', 'table2', 'table3', 'table4')));
 
         // make sure innodb tables are skipped
-        $this->assertTrue(Db::optimizeTables(array('table3', 'table4')) === false);
+        $this->assertFalse(Db::optimizeTables(array('table3', 'table4')));
     }
 }

--- a/tests/PHPUnit/Integration/TrackerTest.php
+++ b/tests/PHPUnit/Integration/TrackerTest.php
@@ -49,15 +49,15 @@ class TrackerTest extends IntegrationTestCase
     public function tearDown()
     {
         $this->restoreConfigFile();
-        
+
         if($this->tracker) {
             $this->tracker->disconnectDatabase();
         }
-        
+
         if (array_key_exists('PIWIK_TRACKER_DEBUG', $GLOBALS)) {
             unset($GLOBALS['PIWIK_TRACKER_DEBUG']);
         }
-        
+
         parent::tearDown();
     }
 
@@ -89,7 +89,7 @@ class TrackerTest extends IntegrationTestCase
 
     public function test_loadTrackerEnvironment_shouldSetGlobalsDebugVar_WhichShouldBeDisabledByDefault()
     {
-        $this->assertTrue(!array_key_exists('PIWIK_TRACKER_DEBUG', $GLOBALS));
+        $this->assertArrayNotHasKey('PIWIK_TRACKER_DEBUG', $GLOBALS);
 
         Tracker::loadTrackerEnvironment();
 
@@ -98,7 +98,7 @@ class TrackerTest extends IntegrationTestCase
 
     public function test_loadTrackerEnvironment_shouldSetGlobalsDebugVar()
     {
-        $this->assertTrue(!array_key_exists('PIWIK_TRACKER_DEBUG', $GLOBALS));
+        $this->assertArrayNotHasKey('PIWIK_TRACKER_DEBUG', $GLOBALS);
 
         $oldConfig = Tracker\TrackerConfig::getConfigValue('debug');
         Tracker\TrackerConfig::setConfigValue('debug', 1);
@@ -113,7 +113,7 @@ class TrackerTest extends IntegrationTestCase
 
     public function test_loadTrackerEnvironment_shouldEnableTrackerMode()
     {
-        $this->assertTrue(!array_key_exists('PIWIK_TRACKER_DEBUG', $GLOBALS));
+        $this->assertArrayNotHasKey('PIWIK_TRACKER_DEBUG', $GLOBALS);
 
         $this->assertFalse(SettingsServer::isTrackerApiRequest());
 
@@ -124,7 +124,7 @@ class TrackerTest extends IntegrationTestCase
 
     public function test_loadTrackerEnvironment_shouldNotThrow_whenConfigNotFound()
     {
-        $this->assertTrue(!array_key_exists('PIWIK_TRACKER_DEBUG', $GLOBALS));
+        $this->assertArrayNotHasKey('PIWIK_TRACKER_DEBUG', $GLOBALS);
 
         $this->assertFalse(SettingsServer::isTrackerApiRequest());
 
@@ -137,7 +137,7 @@ class TrackerTest extends IntegrationTestCase
         Tracker::loadTrackerEnvironment();
 
         $this->assertTrue(SettingsServer::isTrackerApiRequest());
-        
+
         //always reset on the test itself
         $this->restoreConfigFile();
     }
@@ -410,7 +410,7 @@ class TrackerTest extends IntegrationTestCase
     {
         rename($this->getLocalConfigPath(), $this->getLocalConfigPathMoved());
     }
-    
+
     protected function restoreConfigFile()
     {
         if(file_exists($this->getLocalConfigPathMoved())){

--- a/tests/PHPUnit/Integration/TravisEnvironmentTest.php
+++ b/tests/PHPUnit/Integration/TravisEnvironmentTest.php
@@ -25,7 +25,7 @@ class TravisEnvironmentTest extends IntegrationTestCase
             return;
         }
 
-        $this->assertTrue(in_array($mysqlAdapter, array('PDO_MYSQL', 'PDO\MYSQL', 'MYSQLI')));
+        $this->assertContains($mysqlAdapter, array('PDO_MYSQL', 'PDO\MYSQL', 'MYSQLI'));
 
         $db = Db::get();
 

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/FactoryTest.php
@@ -46,7 +46,7 @@ class FactoryTest extends IntegrationTestCase
     public function setUp()
     {
         parent::setUp();
-        
+
         $this->testTablePrefixed = Common::prefixTable($this->testTable);
         $this->factory = new Factory();
     }
@@ -55,7 +55,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->sql();
 
-        $this->assertTrue($migration instanceof Sql);
+        $this->assertInstanceOf(Sql::class, $migration);
     }
 
     public function test_sql_forwardsQueryAndErrorCode()
@@ -70,7 +70,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->boundSql();
 
-        $this->assertTrue($migration instanceof BoundSql);
+        $this->assertInstanceOf(BoundSql::class, $migration);
     }
 
     public function test_boundSql_forwardsParameters()
@@ -85,7 +85,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->createTable();
 
-        $this->assertTrue($migration instanceof CreateTable);
+        $this->assertInstanceOf(CreateTable::class, $migration);
     }
 
     public function test_createTable_forwardsParameters()
@@ -108,7 +108,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->factory->dropTable($this->testTable);
 
-        $this->assertTrue($migration instanceof DropTable);
+        $this->assertInstanceOf(DropTable::class, $migration);
     }
 
     public function test_dropTable_forwardsParameters()
@@ -123,7 +123,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->dropColumn();
 
-        $this->assertTrue($migration instanceof DropColumn);
+        $this->assertInstanceOf(DropColumn::class, $migration);
     }
 
     public function test_dropColumn_forwardsParameters()
@@ -146,7 +146,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->addColumn(null);
 
-        $this->assertTrue($migration instanceof AddColumn);
+        $this->assertInstanceOf(AddColumn::class, $migration);
     }
 
     public function test_addColumn_forwardsParameters_noLastColumn()
@@ -161,7 +161,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->addColumns(null);
 
-        $this->assertTrue($migration instanceof AddColumns);
+        $this->assertInstanceOf(AddColumns::class, $migration);
     }
 
     public function test_addColumns_forwardsParameters()
@@ -184,7 +184,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->changeColumn();
 
-        $this->assertTrue($migration instanceof ChangeColumn);
+        $this->assertInstanceOf(ChangeColumn::class, $migration);
     }
 
     public function test_changeColumn_forwardsParameters()
@@ -199,7 +199,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->changeColumnType();
 
-        $this->assertTrue($migration instanceof ChangeColumnType);
+        $this->assertInstanceOf(ChangeColumnType::class, $migration);
     }
 
     public function test_changeColumnType_forwardsParameters()
@@ -214,7 +214,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->changeColumnTypes();
 
-        $this->assertTrue($migration instanceof ChangeColumnTypes);
+        $this->assertInstanceOf(ChangeColumnTypes::class, $migration);
     }
 
     public function test_changeColumnTypes_forwardsParameters()
@@ -229,7 +229,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->addIndex();
 
-        $this->assertTrue($migration instanceof AddIndex);
+        $this->assertInstanceOf(AddIndex::class, $migration);
     }
 
     public function test_addIndex_forwardsParameters_generatesIndexNameAutomatically()
@@ -252,7 +252,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->addUniqueKey();
 
-        $this->assertTrue($migration instanceof AddUniqueKey);
+        $this->assertInstanceOf(AddUniqueKey::class, $migration);
     }
 
     public function test_addUniqueKey_forwardsParameters_generatesIndexNameAutomatically()
@@ -275,7 +275,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->dropIndex();
 
-        $this->assertTrue($migration instanceof DropIndex);
+        $this->assertInstanceOf(DropIndex::class, $migration);
     }
 
     public function test_addIndex_forwardsParameters()
@@ -290,7 +290,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->addPrimaryKey();
 
-        $this->assertTrue($migration instanceof AddPrimaryKey);
+        $this->assertInstanceOf(AddPrimaryKey::class, $migration);
     }
 
     public function test_addPrimaryKey_forwardsParameters()
@@ -305,7 +305,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->insert();
 
-        $this->assertTrue($migration instanceof Insert);
+        $this->assertInstanceOf(Insert::class, $migration);
     }
 
     public function test_insert_forwardsParameters()
@@ -319,7 +319,7 @@ class FactoryTest extends IntegrationTestCase
     public function test_batchInsert_returnsBatchInsertInstance()
     {
         $migration = $this->batchInsert();
-        $this->assertTrue($migration instanceof BatchInsert);
+        $this->assertInstanceOf(BatchInsert::class, $migration);
     }
 
     public function test_batchInsert_forwardsParameters()

--- a/tests/PHPUnit/Integration/Updater/Migration/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/FactoryTest.php
@@ -34,12 +34,12 @@ class FactoryTest extends IntegrationTestCase
 
     public function test_db_holdsDatabaseFactory()
     {
-        $this->assertTrue($this->factory->db instanceof DbFactory);
+        $this->assertInstanceOf(DbFactory::class, $this->factory->db);
     }
 
     public function test_plugin_holdsPluginFactory()
     {
-        $this->assertTrue($this->factory->plugin instanceof PluginFactory);
+        $this->assertInstanceOf(PluginFactory::class, $this->factory->plugin);
     }
 
 }

--- a/tests/PHPUnit/Integration/Updater/Migration/Plugin/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Plugin/FactoryTest.php
@@ -37,7 +37,7 @@ class FactoryTest extends IntegrationTestCase
     {
         $migration = $this->factory->activate($this->pluginName);
 
-        $this->assertTrue($migration instanceof Activate);
+        $this->assertInstanceOf(Activate::class, $migration);
     }
 
     public function test_sql_forwardsQueryAndErrorCode()

--- a/tests/PHPUnit/Integration/UpdaterTest.php
+++ b/tests/PHPUnit/Integration/UpdaterTest.php
@@ -24,7 +24,7 @@ class UpdaterTest extends IntegrationTestCase
         $updater->markComponentSuccessfullyUpdated('testpluginUpdates', '0.4');
         $componentsWithUpdateFile = $updater->getComponentsWithUpdateFile(array('testpluginUpdates' => '0.5'));
 
-        $this->assertEquals(1, count($componentsWithUpdateFile));
+        $this->assertCount(1, $componentsWithUpdateFile);
 
         $result = $updater->updateComponents($componentsWithUpdateFile);
 
@@ -38,7 +38,7 @@ class UpdaterTest extends IntegrationTestCase
         $updater = new Updater(PIWIK_INCLUDE_PATH . '/tests/resources/Updater/core/');
         $updater->markComponentSuccessfullyUpdated('core', '0.1');
         $componentsWithUpdateFile = $updater->getComponentsWithUpdateFile(array('core' => '0.3'));
-        $this->assertEquals(1, count($componentsWithUpdateFile));
+        $this->assertCount(1, $componentsWithUpdateFile);
     }
 
     public function testUpdaterChecksGivenPluginVersionAndDetectsMultipleUpdateFileInOrder()
@@ -47,9 +47,9 @@ class UpdaterTest extends IntegrationTestCase
         $updater->markComponentSuccessfullyUpdated('testpluginUpdates', '0.1beta');
         $componentsWithUpdateFile = $updater->getComponentsWithUpdateFile(array('testpluginUpdates' => '0.1'));
 
-        $this->assertEquals(1, count($componentsWithUpdateFile));
+        $this->assertCount(1, $componentsWithUpdateFile);
         $updateFiles = $componentsWithUpdateFile['testpluginUpdates'];
-        $this->assertEquals(2, count($updateFiles));
+        $this->assertCount(2, $updateFiles);
 
         $path = PIWIK_INCLUDE_PATH . '/tests/resources/Updater/testpluginUpdates/';
         $expectedInOrder = array(
@@ -73,7 +73,7 @@ class UpdaterTest extends IntegrationTestCase
             'testpluginUpdates' => '0.1',
             'core' => '0.3'
         ));
-        $this->assertEquals(2, count($componentsWithUpdateFile));
+        $this->assertCount(2, $componentsWithUpdateFile);
         reset($componentsWithUpdateFile);
         $this->assertEquals('core', key($componentsWithUpdateFile));
     }

--- a/tests/PHPUnit/Integration/WidgetsListTest.php
+++ b/tests/PHPUnit/Integration/WidgetsListTest.php
@@ -52,10 +52,10 @@ class WidgetsListTest extends IntegrationTestCase
             'About Piwik' => 10,
         );
         // number of main categories
-        $this->assertEquals(count($numberOfWidgets), count($widgetsPerCategory));
+        $this->assertCount(count($numberOfWidgets), $widgetsPerCategory);
 
         foreach ($numberOfWidgets as $category => $widgetCount) {
-            $this->assertEquals($widgetCount, count($widgetsPerCategory[$category]), sprintf("Widget: %s", $category));
+            $this->assertCount($widgetCount, $widgetsPerCategory[$category], sprintf("Widget: %s", $category));
         }
     }
 
@@ -83,7 +83,7 @@ class WidgetsListTest extends IntegrationTestCase
         $_GET['idSite'] = 1;
 
         $perCategory = $this->getWidgetsPerCategory(WidgetsList::get());
-        $this->assertEquals($initialGoalsWidgets, count($perCategory['Goals_Goals']));
+        $this->assertCount($initialGoalsWidgets, $perCategory['Goals_Goals']);
 
 
         API::getInstance()->addGoal(1, 'Goal 1 - Thank you', 'title', 'Thank you', 'contains', $caseSensitive = false, $revenue = 10, $allowMultipleConversions = 1);
@@ -91,8 +91,8 @@ class WidgetsListTest extends IntegrationTestCase
         $perCategory = $this->getWidgetsPerCategory(WidgetsList::get());
 
         // number of main categories
-        $this->assertEquals(10, count($perCategory));
-        $this->assertEquals($initialGoalsWidgets + 2, count($perCategory['Goals_Goals'])); // make sure widgets for that goal were added
+        $this->assertCount(10, $perCategory);
+        $this->assertCount($initialGoalsWidgets + 2, $perCategory['Goals_Goals']); // make sure widgets for that goal were added
     }
 
     public function testGetWithGoalsAndEcommerce()
@@ -105,7 +105,7 @@ class WidgetsListTest extends IntegrationTestCase
         $perCategory = $this->getWidgetsPerCategory(WidgetsList::get());
 
         // number of main categories
-        $this->assertEquals(11, count($perCategory));
+        $this->assertCount(11, $perCategory);
 
         // check if each category has the right number of widgets
         $numberOfWidgets = array(
@@ -114,7 +114,7 @@ class WidgetsListTest extends IntegrationTestCase
         );
 
         foreach ($numberOfWidgets as $category => $widgetCount) {
-            $this->assertEquals($widgetCount, count($perCategory[$category]));
+            $this->assertCount($widgetCount, $perCategory[$category]);
         }
     }
 

--- a/tests/PHPUnit/System/ArchiveCronTest.php
+++ b/tests/PHPUnit/System/ArchiveCronTest.php
@@ -166,7 +166,7 @@ class ArchiveCronTest extends SystemTestCase
 
         try {
             $this->assertTrue(is_readable($expectedOutputFile));
-            $this->assertEquals(file_get_contents($expectedOutputFile), $output);
+            $this->assertStringEqualsFile($expectedOutputFile, $output);
         } catch (Exception $ex) {
             $this->comparisonFailures[] = $ex;
         }

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -156,8 +156,8 @@ class CliMultiTest extends SystemTestCase
         $response = $this->cliMulti->request($urls);
 
         $message = "Response was: " . substr( implode("\n\n", $response), 0, 4000);
-        $this->assertTrue(false !== strpos($response[0], '<meta name="generator" content="Matomo - free/libre analytics platform"/>'), $message);
-        $this->assertTrue(false !== strpos($response[0], 'Widgetize the full dashboard'). $message);
+        $this->assertContains('<meta name="generator" content="Matomo - free/libre analytics platform"/>', $message, $response[0]);
+        $this->assertContains('Widgetize the full dashboard'. $message, $response[0]);
     }
 
     public function test_shouldFallback_IfAsyncIsNotSupported()

--- a/tests/PHPUnit/System/ImportLogsTest.php
+++ b/tests/PHPUnit/System/ImportLogsTest.php
@@ -120,13 +120,13 @@ class ImportLogsTest extends SystemTestCase
 
         // make sure sites aren't created twice
         $piwikDotNet = API::getInstance()->getSitesIdFromSiteUrl('http://piwik.net');
-        $this->assertEquals(1, count($piwikDotNet));
+        $this->assertCount(1, $piwikDotNet);
 
         $anothersiteDotCom = API::getInstance()->getSitesIdFromSiteUrl('http://anothersite.com');
-        $this->assertEquals(1, count($anothersiteDotCom));
+        $this->assertCount(1, $anothersiteDotCom);
 
         $whateverDotCom = API::getInstance()->getSitesIdFromSiteUrl('http://whatever.com');
-        $this->assertEquals(1, count($whateverDotCom));
+        $this->assertCount(1, $whateverDotCom);
 
         // make sure invalid requests are reported correctly
         $this->assertContains('The Piwik tracker identified 2 invalid requests on lines: 10, 11', $output);

--- a/tests/PHPUnit/System/TrackGoalsAllowMultipleConversionsPerVisitTest.php
+++ b/tests/PHPUnit/System/TrackGoalsAllowMultipleConversionsPerVisitTest.php
@@ -39,11 +39,11 @@ class TrackGoalsAllowMultipleConversionsPerVisitTest extends SystemTestCase
 
         // test delete is working as expected
         $goals = API::getInstance()->getGoals($idSite);
-        $this->assertTrue(5 == count($goals));
+        $this->assertCount(5, $goals);
         API::getInstance()->deleteGoal($idSite, self::$fixture->idGoal_OneConversionPerVisit);
         API::getInstance()->deleteGoal($idSite, self::$fixture->idGoal_MultipleConversionPerVisit);
         $goals = API::getInstance()->getGoals($idSite);
-        $this->assertTrue(3 == count($goals));
+        $this->assertCount(3, $goals);
     }
 
     public function getApiForTesting()

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -89,7 +89,7 @@ class TrackerTest extends IntegrationTestCase
         $this->assertEquals(1, $this->getCountOfConversions());
 
         $conversionItems = $this->getConversionItems();
-        $this->assertEquals(3, count($conversionItems));
+        $this->assertCount(3, $conversionItems);
 
         $this->assertActionEquals('"scarysku', $conversionItems[0]['idaction_sku']);
         $this->assertActionEquals('superscarymovie"', $conversionItems[0]['idaction_name']);
@@ -117,7 +117,7 @@ class TrackerTest extends IntegrationTestCase
         $this->assertEquals(1, $this->getCountOfConversions());
 
         $conversionItems = $this->getConversionItems();
-        $this->assertEquals(1, count($conversionItems));
+        $this->assertCount(1, $conversionItems);
 
         $this->assertActionEquals('"scarysku&', $conversionItems[0]['idaction_sku']);
         $this->assertActionEquals('superscarymovie\'', $conversionItems[0]['idaction_name']);
@@ -133,7 +133,7 @@ class TrackerTest extends IntegrationTestCase
         Fixture::checkResponse($response);
 
         $this->assertEquals(1, $this->getCountOfConversions());
-        $this->assertEquals(0, count($this->getConversionItems()));
+        $this->assertCount(0, $this->getConversionItems());
     }
 
     public function test_trackingEcommerceOrder_DoesNotFail_WhenNonArrayUsedWithEcommerceItemsParam()
@@ -145,7 +145,7 @@ class TrackerTest extends IntegrationTestCase
         Fixture::checkResponse($response);
 
         $this->assertEquals(0, $this->getCountOfConversions());
-        $this->assertEquals(0, count($this->getConversionItems()));
+        $this->assertCount(0, $this->getConversionItems());
     }
 
     public function test_trackingWithLangParameter_ForwardsLangParameter_ToDefaultLocationProvider()

--- a/tests/PHPUnit/Unit/CacheTest.php
+++ b/tests/PHPUnit/Unit/CacheTest.php
@@ -19,7 +19,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
     {
         $cache = Cache::getLazyCache();
 
-        $this->assertTrue($cache instanceof Cache\Lazy);
+        $this->assertInstanceOf(Cache\Lazy::class, $cache);
     }
 
     public function test_getLazyCache_shouldAlwaysReturnTheSameInstance()
@@ -34,7 +34,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
     {
         $cache = Cache::getEagerCache();
 
-        $this->assertTrue($cache instanceof Cache\Eager);
+        $this->assertInstanceOf(Cache\Eager::class, $cache);
     }
 
     public function test_getEagerCache_shouldAlwaysReturnTheSameInstance()
@@ -49,7 +49,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
     {
         $cache = Cache::getTransientCache();
 
-        $this->assertTrue($cache instanceof Cache\Transient);
+        $this->assertInstanceOf(Cache\Transient::class, $cache);
     }
 
     public function test_getTransientCache_shouldAlwaysReturnTheSameInstance()

--- a/tests/PHPUnit/Unit/Category/CategoryTest.php
+++ b/tests/PHPUnit/Unit/Category/CategoryTest.php
@@ -100,7 +100,7 @@ class CategoryTest extends \PHPUnit_Framework_TestCase
         $this->addSubcategories(array('myid' => 'myname', 'myid2' => 'myname2'));
 
         $subcategory = $this->category->getSubcategory('myid2');
-        $this->assertTrue($subcategory instanceof Subcategory);
+        $this->assertInstanceOf(Subcategory::class, $subcategory);
         $this->assertSame('myname2', $subcategory->getName());
     }
 

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -232,16 +232,16 @@ class CommonTest extends PHPUnit_Framework_TestCase
         switch ($type) {
             case 'int':
             case 'integer':
-                $this->assertTrue(is_int($return));
+                $this->assertInternalType('int', $return);
                 break;
             case 'float':
-                $this->assertTrue(is_float($return));
+                $this->assertInternalType('float', $return);
                 break;
             case 'string':
-                $this->assertTrue(is_string($return));
+                $this->assertInternalType('string', $return);
                 break;
             case 'array':
-                $this->assertTrue(is_array($return));
+                $this->assertInternalType('array', $return);
                 break;
         }
     }

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -386,7 +386,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config(new GlobalSettingsProvider($sourceConfigFile, $configFile));
         $config->forceSave();
 
-        $this->assertEquals(file_get_contents($sourceConfigFile), file_get_contents($configFile));
+        $this->assertFileEquals($sourceConfigFile, $configFile);
 
         if(file_exists($configFile)){
             @unlink($configFile);
@@ -398,7 +398,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $userFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/config.ini.php';
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
         $commonFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/common.config.ini.php';
-        
+
         $config = new Config(new GlobalSettingsProvider($globalFile, $userFile, $commonFile));
 
         $configCategory = $config->getFromGlobalConfig('Category');
@@ -406,25 +406,25 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('value2', $configCategory['key2']);
         $this->assertEquals(array('key1' => 'value1', 'key2' => 'value2'), $configCategory);
     }
-    
+
     public function testFromCommonConfig()
     {
         $userFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/config.ini.php';
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
         $commonFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/common.config.ini.php';
-    
+
         $config = new Config(new GlobalSettingsProvider($globalFile, $userFile, $commonFile));
 
         $configCategory = $config->getFromCommonConfig('Category');
         $this->assertEquals(array('key2' => 'valueCommon', 'key3' => '${@piwik(crash))}'), $configCategory);
     }
-    
+
     public function testFromLocalConfig()
     {
         $userFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/config.ini.php';
         $globalFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/global.ini.php';
         $commonFile = PIWIK_INCLUDE_PATH . '/tests/resources/Config/common.config.ini.php';
-    
+
         $config = new Config(new GlobalSettingsProvider($globalFile, $userFile, $commonFile));
 
         $configCategory = $config->getFromLocalConfig('Category');

--- a/tests/PHPUnit/Unit/Container/IniConfigDefinitionSourceTest.php
+++ b/tests/PHPUnit/Unit/Container/IniConfigDefinitionSourceTest.php
@@ -34,7 +34,7 @@ class IniConfigDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         /** @var ValueDefinition $definition */
         $definition = $definitionSource->getDefinition('ini.foo');
 
-        $this->assertTrue($definition instanceof ValueDefinition);
+        $this->assertInstanceOf(ValueDefinition::class, $definition);
         $this->assertEquals('ini.foo', $definition->getName());
         $this->assertSame(array(), $definition->getValue());
     }
@@ -75,7 +75,7 @@ class IniConfigDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         /** @var ValueDefinition $definition */
         $definition = $definitionSource->getDefinition('ini.General');
 
-        $this->assertTrue($definition instanceof ValueDefinition);
+        $this->assertInstanceOf(ValueDefinition::class, $definition);
         $this->assertEquals('ini.General', $definition->getName());
         $this->assertInternalType('array', $definition->getValue());
         $this->assertEquals(array('foo' => 'bar'), $definition->getValue());
@@ -97,7 +97,7 @@ class IniConfigDefinitionSourceTest extends \PHPUnit_Framework_TestCase
         /** @var ValueDefinition $definition */
         $definition = $definitionSource->getDefinition('ini.General.foo');
 
-        $this->assertTrue($definition instanceof ValueDefinition);
+        $this->assertInstanceOf(ValueDefinition::class, $definition);
         $this->assertEquals('ini.General.foo', $definition->getName());
         $this->assertEquals('bar', $definition->getValue());
     }

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
@@ -118,7 +118,7 @@ class JoinTablesTest extends \PHPUnit_Framework_TestCase
     public function test_getLogTable_shouldReturnInstanceOfLogTable_IfTableExists()
     {
         $visit = $this->tables->getLogTable('log_visit');
-        $this->assertFalse($visit instanceof Visit);
+        $this->assertNotInstanceOf(Visit::class, $visit);
     }
 
     public function test_getLogTable_shouldReturnNull_IfLogTableDoesNotExist()

--- a/tests/PHPUnit/Unit/DataTable/MapTest.php
+++ b/tests/PHPUnit/Unit/DataTable/MapTest.php
@@ -102,7 +102,7 @@ class Test_DataTable_Map extends \PHPUnit_Framework_TestCase
 
         // check that the first sub-DataTable is a DataTable with 4 rows
         $subDataTable1 = $result->getTable('subDataTable1');
-        $this->assertTrue($subDataTable1 instanceof DataTable);
+        $this->assertInstanceOf(DataTable::class, $subDataTable1);
         $this->assertEquals(4, $subDataTable1->getRowsCount());
 
         // check that the first two rows of the first sub-table have 'subArray1' as the label
@@ -115,7 +115,7 @@ class Test_DataTable_Map extends \PHPUnit_Framework_TestCase
 
         // check that the second sub-DataTable is a DataTable with 4 rows
         $subDataTable2 = $result->getTable('subDataTable2');
-        $this->assertTrue($subDataTable2 instanceof DataTable);
+        $this->assertInstanceOf(DataTable::class, $subDataTable2);
         $this->assertEquals(4, $subDataTable2->getRowsCount());
 
         // check that the first two rows of the second sub-table have 'subArray1' as the label

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -69,13 +69,13 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
 
         // normal row
         $idToDelete = 1;
-        $this->assertEquals(2, count($table->getRowFromId($idToDelete)->getColumns()));
+        $this->assertCount(2, $table->getRowFromId($idToDelete)->getColumns());
         $table->deleteRow($idToDelete);
         $this->assertFalse($table->getRowFromId($idToDelete));
 
         // summary row special case
         $idToDelete = DataTable::ID_SUMMARY_ROW;
-        $this->assertEquals(2, count($table->getRowFromId($idToDelete)->getColumns()));
+        $this->assertCount(2, $table->getRowFromId($idToDelete)->getColumns());
         $table->deleteRow($idToDelete);
         $this->assertFalse($table->getRowFromId($idToDelete));
     }
@@ -329,8 +329,8 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
 
         $table = DataTable::fromSerializedArray($table);
         $row1  = $table->getFirstRow();
-        $this->assertTrue($row1 instanceof \Piwik\DataTable\Row);
-        $this->assertFalse($row1 instanceof \Piwik\DataTable\Row\DataTableSummaryRow); // we convert summary rows to Row instances
+        $this->assertInstanceOf(\Piwik\DataTable\Row::class, $row1);
+        $this->assertNotInstanceOf(\Piwik\DataTable\Row\DataTableSummaryRow::class, $row1); // we convert summary rows to Row instances
 
         $this->assertEquals($label, $row1->getColumn('label'));
         $this->assertEquals($column2, $row1->getColumn(2));
@@ -656,7 +656,7 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
         // make sure the rows subtableId were updated as well.
         foreach ($tables as $index => $serializedRows) {
             $rows = unserialize($serializedRows);
-            $this->assertTrue(is_array($rows));
+            $this->assertInternalType('array', $rows);
 
             if (0 === $index) {
                 // root table, make sure correct amount of rows are in subtables
@@ -664,7 +664,7 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
             }
 
             foreach ($rows as $row) {
-                $this->assertTrue(is_array($row));
+                $this->assertInternalType('array', $row);
 
                 $subtableId = $row[Row::DATATABLE_ASSOCIATED];
 
@@ -972,7 +972,7 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
         $serializedStrings = $table2->getSerialized();
 
         // both the main table and the sub table are serialized
-        $this->assertEquals(sizeof($serializedStrings), 2);
+        $this->assertCount(2, $serializedStrings);
 
         // the serialized string references the id subtable
         $unserialized = unserialize($serializedStrings[0]);
@@ -987,7 +987,7 @@ class DataTableTest extends \PHPUnit_Framework_TestCase
         $serializedStrings = $table2->getSerialized();
 
         // - the serialized table does NOT contain the sub table
-        $this->assertEquals(sizeof($serializedStrings), 1); // main table only is serialized
+        $this->assertCount(1, $serializedStrings); // main table only is serialized
         $unserialized = unserialize($serializedStrings[0]);
 
         // - the serialized string does NOT contain the id subtable (the row was cleaned up as expected)

--- a/tests/PHPUnit/Unit/Period/RangeTest.php
+++ b/tests/PHPUnit/Unit/Period/RangeTest.php
@@ -191,8 +191,8 @@ class RangeTest extends BasePeriodTest
             )
         );
 
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
-        $this->assertEquals(count($correct), $range2->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
+        $this->assertCount($range2->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
         $this->assertEquals($correct, $range2->toString());
         $this->assertEquals('2007-12-17,2008-01-06' , $range2->getRangeString());
@@ -234,7 +234,7 @@ class RangeTest extends BasePeriodTest
                 11 => '2007-12-01',
             ),
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
         $this->assertEquals('2006-01-01,2007-12-31', $range->getRangeString());
     }
@@ -329,7 +329,7 @@ class RangeTest extends BasePeriodTest
             ),
         );
 
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
         $this->assertEquals('2006-12-01,2007-01-31', $range->getRangeString());
     }
@@ -663,7 +663,7 @@ class RangeTest extends BasePeriodTest
                 '2008-01-06',
             )
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -676,7 +676,7 @@ class RangeTest extends BasePeriodTest
             '2013-10-30'
         );
 
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -690,7 +690,7 @@ class RangeTest extends BasePeriodTest
             '2013-10-31'
         );
 
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -707,7 +707,7 @@ class RangeTest extends BasePeriodTest
             '2013-11-03',
         );
 
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -741,7 +741,7 @@ class RangeTest extends BasePeriodTest
                 '2008-01-02',
                 '2008-01-03',
             );
-            $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+            $this->assertCount($range->getNumberOfSubperiods(), $correct);
             $this->assertEquals($correct, $range->toString());
         }
     }
@@ -755,7 +755,7 @@ class RangeTest extends BasePeriodTest
             '2007-12-31',
             '2008-01-01',
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -774,7 +774,7 @@ class RangeTest extends BasePeriodTest
                 '2008-01-06',
             )
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -795,7 +795,7 @@ class RangeTest extends BasePeriodTest
             '2008-01-07',
             '2008-01-08',
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -826,7 +826,7 @@ class RangeTest extends BasePeriodTest
                 '2008-01-06',
             ),
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -896,7 +896,7 @@ class RangeTest extends BasePeriodTest
             "2011-11-01",
             "2011-11-02",
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -1020,7 +1020,7 @@ class RangeTest extends BasePeriodTest
                 "2011-10-17",
             );
 
-            $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+            $this->assertCount($range->getNumberOfSubperiods(), $correct);
             $this->assertEquals($correct, $range->toString());
         }
     }
@@ -1068,7 +1068,7 @@ class RangeTest extends BasePeriodTest
                 "2011-09-29",
                 "2011-09-30",
             ));
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -1128,7 +1128,7 @@ class RangeTest extends BasePeriodTest
                 "2011-08-30",
                 "2011-08-31",
             ));
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -1156,7 +1156,7 @@ class RangeTest extends BasePeriodTest
             '2008-01-02',
             '2008-01-03',
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -1169,7 +1169,7 @@ class RangeTest extends BasePeriodTest
             '2008-01-01',
             '2008-01-02',
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 
@@ -1181,7 +1181,7 @@ class RangeTest extends BasePeriodTest
             date('Y-m-d', time() - 86400 * 2),
             date('Y-m-d', time() - 86400 * 1),
         );
-        $this->assertEquals(count($correct), $range->getNumberOfSubperiods());
+        $this->assertCount($range->getNumberOfSubperiods(), $correct);
         $this->assertEquals($correct, $range->toString());
     }
 

--- a/tests/PHPUnit/Unit/Report/ReportWidgetFactoryTest.php
+++ b/tests/PHPUnit/Unit/Report/ReportWidgetFactoryTest.php
@@ -60,7 +60,7 @@ class ReportWidgetFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $config = $this->factory->createContainerWidget('myId');
 
-        $this->assertTrue($config instanceof WidgetContainerConfig);
+        $this->assertInstanceOf(WidgetContainerConfig::class, $config);
         $this->assertSame('myId', $config->getId());
         $this->assertSame('Goals_Goals', $config->getCategoryId());
         $this->assertSame('General_Overview', $config->getSubcategoryId());
@@ -71,7 +71,7 @@ class ReportWidgetFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $config = $this->factory->createWidget();
 
-        $this->assertTrue($config instanceof ReportWidgetConfig);
+        $this->assertInstanceOf(ReportWidgetConfig::class, $config);
         $this->assertSame('Report_MyCustomReportName', $config->getName());
         $this->assertSame('Goals_Goals', $config->getCategoryId());
         $this->assertSame('General_Overview', $config->getSubcategoryId());
@@ -91,7 +91,7 @@ class ReportWidgetFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $config = $this->factory->createCustomWidget('customAction');
 
-        $this->assertTrue($config instanceof ReportWidgetConfig);
+        $this->assertInstanceOf(ReportWidgetConfig::class, $config);
         $this->assertSame('Report_MyCustomReportName', $config->getName());
         $this->assertSame('Goals_Goals', $config->getCategoryId());
         $this->assertSame('General_Overview', $config->getSubcategoryId());

--- a/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
@@ -103,10 +103,10 @@ class RequestSetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->buildRequest(2), $setRequests[2]);
         $this->assertEquals($this->buildRequest(6), $setRequests[4]);
 
-        $this->assertTrue($setRequests[1] instanceof Request);
+        $this->assertInstanceOf(Request::class, $setRequests[1]);
         $this->assertEquals(array('idsite' => 9), $setRequests[1]->getParams());
 
-        $this->assertTrue($setRequests[3] instanceof Request);
+        $this->assertInstanceOf(Request::class, $setRequests[3]);
         $this->assertEquals(array('idsite' => 3), $setRequests[3]->getParams());
 
         $this->assertCount(5, $setRequests);
@@ -224,7 +224,7 @@ class RequestSetTest extends \PHPUnit_Framework_TestCase
     {
         $serverBackup = $_SERVER;
         $cookieBackup = $_COOKIE;
-        
+
         $this->requestSet->setEnvironment($this->getFakeEnvironment());
         $this->requestSet->restoreEnvironment();
 
@@ -266,7 +266,7 @@ class RequestSetTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedRequests, $state['requests']);
         $this->assertEquals('mytoken', $state['tokenAuth']);
-        $this->assertTrue(is_numeric($state['time']));
+        $this->assertInternalType('numeric', $state['time']);
         $this->assertEquals(array('server' => $_SERVER, 'cookie' => $_COOKIE), $state['env']);
     }
 

--- a/tests/PHPUnit/Unit/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestTest.php
@@ -457,7 +457,7 @@ class RequestTest extends UnitTestCase
     {
         $cookie = $this->request->makeThirdPartyCookieUID();
 
-        $this->assertTrue($cookie instanceof Cookie);
+        $this->assertInstanceOf(Cookie::class, $cookie);
     }
 
     public function test_makeThirdPartyCookie_ShouldPreconfigureTheCookieInstance()


### PR DESCRIPTION
I've refactored several tests, using:
- `assertFileExists` and `assertFileNotExists` instead of `file_exists` function;
- `assertArrayHasKey` and `assertArrayNotHasKey` instead of `isset` and `array_key_exists` functions;
- `assertStringEqualsFile` instead of `file_get_contents` function when comparing a `string` and a file;
- `assertFileEquals` instead of `file_get_contents` function when comparing two files;
- `assertGreaterThan` and `assertLessThan` for mathematical comparisons;
- `assertFalse` and `assertNotFalse` instead of strict comparisons with `false` keyword;
- `assertTrue` instead of strict comparisons with `true` keyword;
- `assertEmpty` and `assertNotEmpty` instead of `empty` function;
- `assertInternalType` instead of `is_*` functions;
- `assertEquals` and `assertNotEquals` instead of comparisons;
- `assertSame` and `assertNotSame` instead of comparisons;
- `assertContains` instead of `in_array` and `strpos` functions;
- `assertCount` instead of `count` and `sizeof` functions;
- `assertInstanceOf` and `assertNotInstanceOf` instead of `instanceof` operator.