### PR TITLE
Improves truncate twig filter

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -25,11 +25,11 @@ use Twig_SimpleTest;
 
 function piwik_filter_truncate($string, $size)
 {
-    if (strlen($string) < $size) {
+    if (Common::mb_strlen(html_entity_decode($string)) <= $size) {
         return $string;
     } else {
-        $array = str_split($string, $size);
-        return array_shift($array) . "...";
+        preg_match('/^(&(?:[a-z\d]+|#\d+|#x[a-f\d]+);|.){'.$size.'}/i', $string, $shortenString);
+        return reset($shortenString) . "...";
     }
 }
 

--- a/tests/PHPUnit/Unit/TwigTest.php
+++ b/tests/PHPUnit/Unit/TwigTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit;
+
+require_once(PIWIK_INCLUDE_PATH . '/core/Twig.php');
+
+/**
+ * @group Twig
+ */
+class TwigTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getTruncateTests
+     */
+    public function testPiwikFilterTruncate($in, $size, $out)
+    {
+        $truncated = \Piwik\piwik_filter_truncate($in, $size);
+        $this->assertEquals($out, $truncated);
+    }
+
+    public function getTruncateTests()
+    {
+        return [
+            ['abc', 4, 'abc'],
+            ['abc&quot;', 4, 'abc&quot;'],
+            ['abc&nbsp;', 4, 'abc&nbsp;'],
+            ['abcdef', 3, 'abc...'],
+            ['ab&amp;ef', 3, 'ab&amp;...'],
+            ['some&#9660;thing', 5, 'some&#9660;...'],
+            ['ab&ef ;', 3, 'ab&...'],
+            ['&lt;&gt;&#9660;&nbsp;', 4, '&lt;&gt;&#9660;&nbsp;']
+        ];
+    }
+}


### PR DESCRIPTION
Currently the truncate twig filter might cut off encoded entities or cut strings to early if encoded entities are within it, this changes should prevent that.