### PR TITLE
Deprecates the `historyService` along with `broadcast.init`, `broadcast.propagateAjax`, `broadcast.pageLoad`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ Piwik is now Matomo. Read more about this change in the [official announcement](
 
 * New HTTP API `API.getMatomoVersion` was introduced. The previous HTTP API `API.getPiwikVersion` will still work but will now be hidden from the API reference page.
 
+## Piwik 3.2.2
+
+### Breaking Changes
+* The `historyService` along with `broadcast.init`, `broadcast.propagateAjax`, `broadcast.pageLoad` have been deprecated and will be removed in Piwik 4. 
+
+
 ## Piwik 3.2.1
 
 ### New APIs

--- a/plugins/CoreHome/angularjs/history/history.service.js
+++ b/plugins/CoreHome/angularjs/history/history.service.js
@@ -12,6 +12,8 @@
  * This service replaces the previously used jQuery history extension.
  *
  * Should only be used by the broadcast object.
+ *
+ * @deprecated in 3.2.2, will be removed in Piwik 4
  */
 (function (window, $, broadcast) {
     angular.module('piwikApp').service('historyService', historyService);

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -185,7 +185,6 @@ var broadcast = {
     },
 
     /**
-     * ONLY USED BY OVERLAY
      * propagateAjax -- update hash values then make ajax calls.
      *    example :
      *       1) <a href="javascript:broadcast.propagateAjax('module=Referrers&action=getKeywords')">View keywords report</a>
@@ -194,6 +193,8 @@ var broadcast = {
      * Will propagate your new value into the current hash string and make ajax calls.
      *
      * NOTE: this method will only make ajax call and replacing main content.
+     *
+     * @deprecated in 3.2.2, will be removed in Piwik 4.
      *
      * @param {string} ajaxUrl  querystring with parameters to be updated
      * @param {boolean} [disableHistory]  the hash change won't be available in the browser history
@@ -291,8 +292,6 @@ var broadcast = {
      * Example:
      *         1) We want to update idSite to both search query and hash then reload the page,
      *         2) update period to both search query and hash then reload page.
-     *
-     * ** If you'd like to make ajax call with new values then use propagateAjax ** *
      *
      * Expecting:
      *         str = "param1=newVal1&param2=newVal2";

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -446,10 +446,6 @@ var broadcast = {
      *                       handler.
      */
     propagateNewPopoverParameter: function (handlerName, value) {
-        // init broadcast if not already done (it is required to make popovers work in widgetize mode)
-        if (broadcast.isWidgetizedDashboard()) {
-            broadcast.init(true);
-        }
 
         var $location = angular.element(document).injector().get('$location');
 

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -52,6 +52,9 @@ var broadcast = {
 
     /**
      * Initializes broadcast object
+     *
+     * @deprecated in 3.2.2, will be removed in Piwik 4
+     *
      * @return {void}
      */
     init: function (noLoadingMessage) {
@@ -77,6 +80,8 @@ var broadcast = {
      * 3. after pushing "Go Back" button of a browser
      *
      * * Note: the method is manipulated in Overlay/javascripts/Piwik_Overlay.js - keep this in mind when making changes.
+     *
+     * @deprecated since 3.2.2, will be removed in Piwik 4
      *
      * @param {string}  hash to load page with
      * @return {void}

--- a/plugins/Dashboard/templates/_header.twig
+++ b/plugins/Dashboard/templates/_header.twig
@@ -16,3 +16,4 @@
 {% include "_jsCssIncludes.twig" %}
 </head>
 <body id="standalone" ng-app="app">
+<div piwik-popover-handler></div>

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -186,26 +186,19 @@ var Piwik_Overlay = (function () {
             }, 50);
 
             // handle window resize
-            // we manipulate broadcast.pageload because it unbinds all resize events on window
-            var originalPageload = broadcast.pageload;
-            broadcast.pageload = function (hash) {
-                originalPageload(hash);
-                $(window).resize(function () {
-                    adjustDimensions();
-                });
-            };
             $(window).resize(function () {
                 adjustDimensions();
             });
 
-            // handle hash change
-            broadcast.loadAjaxContent = hashChangeCallback;
+            angular.element(document).injector().invoke(function ($rootScope) {
+                $rootScope.$on('$locationChangeSuccess', function () {
+                    hashChangeCallback(broadcast.getHash());
+                });
 
-            broadcast._isInit = false;
-            broadcast.init();
+                hashChangeCallback(broadcast.getHash());
+            });
 
             if (window.location.href.split('#').length == 1) {
-                // if there's no hash, broadcast won't trigger the callback - we have to do it here
                 hashChangeCallback('');
             }
 
@@ -277,6 +270,10 @@ var Piwik_Overlay = (function () {
 
                 // available in global scope
                 var currentHashStr = broadcast.getHash();
+
+                if (currentHashStr.charAt(0) == '?') {
+                    currentHashStr = currentHashStr.substr(1);
+                }
 
                 currentHashStr = broadcast.updateParamValue('l=' + newFrameLocation, currentHashStr);
 

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -270,14 +270,19 @@ var Piwik_Overlay = (function () {
                 currentLocation = getOverlayLocationFromHash(locationParts[1]);
             }
 
-            var newLocation = Overlay_Helper.encodeFrameUrl(currentUrl);
+            var newFrameLocation = Overlay_Helper.encodeFrameUrl(currentUrl);
 
-            if (newLocation != currentLocation) {
+            if (newFrameLocation != currentLocation) {
                 updateComesFromInsideFrame = true;
-                // put the current iframe url in the main url to enable refresh and deep linking.
-                // use disableHistory=true to make sure that the back and forward buttons can be
-                // used on the iframe (which in turn notifies the parent about the location change)
-                broadcast.propagateAjax('l=' + newLocation, true);
+
+                // available in global scope
+                var currentHashStr = broadcast.getHash();
+
+                currentHashStr = broadcast.updateParamValue('l=' + newFrameLocation, currentHashStr);
+
+                var newLocation = window.location.href.split('#')[0] + '#?' + currentHashStr;
+                // window.location.replace changes the current url without pushing it on the browser's history stack
+                window.location.replace(newLocation);
             } else {
                 // happens when the url is changed by hand or when the l parameter is there on page load
                 loadSidebar(currentUrl);

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -140,6 +140,10 @@ var Piwik_Overlay = (function () {
         var location = getOverlayLocationFromHash(urlHash);
         location = Overlay_Helper.decodeFrameUrl(location);
 
+        if (location == iframeCurrentPageNormalized) {
+            return;
+        }
+
         if (!updateComesFromInsideFrame) {
             var iframeUrl = iframeSrcBase;
             if (location) {


### PR DESCRIPTION
those methods have been used by overlay and in widgetized dashboard only and should now not be used anywhere

refs #6037