### PR TITLE
Use current date and period for overlay links

### DIFF
--- a/plugins/Overlay/javascripts/rowaction.js
+++ b/plugins/Overlay/javascripts/rowaction.js
@@ -49,7 +49,7 @@ DataTable_RowActions_Overlay.prototype.onClick = function (actionA, tr, e) {
         }
 
         if (link) {
-            var href = Overlay_Helper.getOverlayLink(this.dataTable.param.idSite, 'month', 'today', segment, link);
+            var href = Overlay_Helper.getOverlayLink(this.dataTable.param.idSite, piwik.period, piwik.currentDateString, segment, link);
 
             actionA.attr({
                 target: '_blank',


### PR DESCRIPTION
Overlays currently open showing data for the current month. Not sure if that would be the expected behavior, but imho it should show the current selected date and period instead.