### PR TITLE
fix/improve handling of tmp directory config

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -20,9 +20,12 @@ return array(
         } else {
             $instanceId = '';
         }
-        
-        $tmp = Config::getInstance()->General['tmp_path'];
-        
+
+        /** @var Piwik\Config\ $config */
+        $config = $c->get('Piwik\Config');
+        $general = $config->General;
+        $tmp = empty($general['tmp_path']) ? '/tmp' : $general['tmp_path'];
+
         return $root . $tmp . $instanceId;
     },
 


### PR DESCRIPTION
we need to define a default in `global.php` as otherwise there are strange things happening if `global.ini.php` file is missing. Piwik then uses an empty tmp path, resulting in overwriting Piwik's `index.php` to prevent directory listing of the tmp path.

Test were failing because the behavior of missing `global.ini.php` is tested in `EnvironmentValidationTest`.

follow up #12189
replaces #12361 