### PR TITLE
Fix widget pagination when switching to related report

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -242,13 +242,18 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
         var container = $('#' + self.workingDivId + ' .piwik-graph');
 
+        var ajaxRequest = new ajaxHelper();
+
+        if (self.param.totalRows) {
+            ajaxRequest.addParams({'totalRows': self.param.totalRows}, 'post');
+            delete self.param.totalRows;
+        }
+
         var params = {};
         for (var key in self.param) {
             if (typeof self.param[key] != "undefined" && self.param[key] != '')
                 params[key] = self.param[key];
         }
-
-        var ajaxRequest = new ajaxHelper();
 
         ajaxRequest.addParams(params, 'get');
         ajaxRequest.withTokenInUrl();


### PR DESCRIPTION
The URLs for related reports are built using all GET parameters. As the totalRows param is send with the widget requests in order not to determine it again, it was appended to those URLs as well. Sending this param by POST removes it from the related reports URLs

fixes #12369