### PR TITLE
Trim any possible directory seperator in integrity check

### DIFF
--- a/core/FileIntegrity.php
+++ b/core/FileIntegrity.php
@@ -171,7 +171,7 @@ class FileIntegrity
 
         foreach (self::getPathsToInvestigate() as $file) {
             $file = substr($file, strlen(PIWIK_DOCUMENT_ROOT)); // remove piwik path to match format in manifest.inc.php
-            $file = ltrim($file, DIRECTORY_SEPARATOR);
+            $file = ltrim($file, "\\/");
             $directory = dirname($file);
 
             if(in_array($directory, $directoriesInManifest)) {
@@ -210,7 +210,7 @@ class FileIntegrity
                 continue;
             }
             $file = substr($file, strlen(PIWIK_DOCUMENT_ROOT)); // remove piwik path to match format in manifest.inc.php
-            $file = ltrim($file, DIRECTORY_SEPARATOR);
+            $file = ltrim($file, "\\/");
 
             if (self::isFileFromPluginNotInManifest($file, $pluginsInManifest)) {
                 continue;


### PR DESCRIPTION
hopefully works for all operating systems this way. Let's merge if anyone can confirm this fixes the problems reported for windows

fixes #12344 and fixes #12362