### PR TITLE
Prevent possible error when goal deleted.

### DIFF
--- a/plugins/Live/templates/_profileSummary.twig
+++ b/plugins/Live/templates/_profileSummary.twig
@@ -19,7 +19,7 @@
         {% if visitorData.totalGoalConversions is defined %}
         <p>{% if visitorData.totalGoalConversions %}<strong>{% endif %}{{ 'Live_ConvertedNGoals'|translate(visitorData.totalGoalConversions) }}{% if visitorData.totalGoalConversions %}</strong>{% endif %}
         {%- if visitorData.totalGoalConversions %} (
-            {%- for idGoal, totalConversions in visitorData.totalConversionsByGoal -%}
+            {%- for idGoal, totalConversions in visitorData.totalConversionsByGoal if idGoal in goals -%}
             {%- set idGoal = idGoal[7:] -%}
             {%- if not loop.first %}, {% endif -%}{{- totalConversions }} {{ goals[idGoal]['name'] -}}
             {%- endfor -%}


### PR DESCRIPTION
Should prevent an error like this:

```
Error: {"message":"Key \"\" for array with keys \"4\" does not exist.","file":"plugins\/Live\/templates\/_profileSummary.twig","line":24}
```

The visitor log / profile fetches currently all goal conversions and does check whether a goal still exists so not sure why it is needed  (in https://github.com/piwik/piwik/blob/3.3.0-b1/plugins/Goals/VisitorDetails.php#L67 ). Where this happened the goal actually exists but the other first 3 goals are deleted.

Here is some output from visitor data and idGoal 4 is definitely set in `goals`
```

["totalConversionsByGoal"]=>
  array(2) {
    [1]=>
    int(0)
    ["idgoal=4"]=>
    int(1)
  }
```

It seems to cause an error when there is also an ecommerce action like here where I printed also `{{ goals|json_encode }}{{ visitorData.totalConversionsByGoal|json_encode }}`:

![image](https://user-images.githubusercontent.com/273120/34504696-0980a04e-f085-11e7-9086-4cf0ea692500.png)

Actually: This does not fix the problem because it would never show any entry as `idgoal=4` cannot be set in `Goals` so there must be a different fix.
