### PR TITLE
Prevent possible error languageTranslateWithCode is not defined

### DIFF
--- a/plugins/UserLanguage/Columns/Language.php
+++ b/plugins/UserLanguage/Columns/Language.php
@@ -15,6 +15,8 @@ use Piwik\Tracker\Action;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
 
+require_once PIWIK_INCLUDE_PATH . '/plugins/UserLanguage/functions.php';
+
 class Language extends VisitDimension
 {
     protected $columnName = 'location_browser_lang';


### PR DESCRIPTION
Prevents possible error: `Call to undefined function Piwik\\Plugins\\UserLanguage\\languageTranslateWithCode()`