### PR TITLE
API: when an invalid format is specified, keep the error message shorter

### DIFF
--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -67,7 +67,13 @@ class ExceptionHandler
     {
         Common::sendHeader('Content-Type: text/html; charset=utf-8');
 
-        echo self::getErrorResponse($exception);
+        try {
+            echo self::getErrorResponse($exception);
+        } catch(Exception $e) {
+            // When there are failures while generating the HTML error response itself,
+            // we simply print out the error message instead.
+            echo $exception->getMessage();
+        }
 
         exit(1);
     }


### PR DESCRIPTION
This will fix the issue where particularly crafted request will result in displaying stack traces

follows up https://github.com/piwik/piwik/pull/12357

Example request on Demo: https://demo.piwik.org/?module=API&method=VisitsSummary.getVisits&idSite=1&period=day&date=last10&format=xmls&token_auth=XYZANONYMIZED

which outputs file paths:

```
Piwik encoutered an error: Uncaught Exception: Renderer format 'xmls' not valid. Try any of the following instead: console, csv, html, json2, json, original, php, rss, tsv, xml. in /home/piwik-demo/storage/www/demo.piwik.org/core/API/ApiRenderer.php:134
Stack trace:
#0 /home/piwik-demo/storage/www/demo.piwik.org/core/API/ResponseBuilder.php(40): Piwik\API\ApiRenderer::factory('xmls', Array)
#1 /home/piwik-demo/storage/www/demo.piwik.org/core/ExceptionHandler.php(89): Piwik\API\ResponseBuilder->__construct('xmls')
#2 /home/piwik-demo/storage/www/demo.piwik.org/core/ExceptionHandler.php(70): Piwik\ExceptionHandler::getErrorResponse(Object(Exception))
#3 /home/piwik-demo/storage/www/demo.piwik.org/core/ExceptionHandler.php(36): Piwik\ExceptionHandler::dieWithHtmlErrorPage(Object(Exception))
#4 [internal function]: Piwik\ExceptionHandler::handleException(Object(Exception))
#5 {main}
  thrown (which lead to: Renderer format 'xmls' not valid. Try any of the following instead: console, csv, html, json2, json, original, php, rss, tsv, xml.)
```

After the fix the output is simply:

```
Renderer format 'xmls' not valid. Try any of the following instead: console, csv, html, json2, json, original, php, rss, tsv, xml.
```