### PR TITLE
remove "hoverable" class from divs

### DIFF
--- a/plugins/Live/templates/_dataTableViz_visitorLog.twig
+++ b/plugins/Live/templates/_dataTableViz_visitorLog.twig
@@ -3,7 +3,7 @@
 {% set cycleIndex=0 %}
 {% for visitor in dataTable.getRows() %}
     {% set visitorRow %}
-        <div class="card row hoverable">
+        <div class="card row">
 
             {% if visitor.getColumn('visitorId') is not empty and not clientSideParameters.hideProfileLink %}
                 <a class="visitor-log-visitor-profile-link visitorLogTooltip" title="{{ 'Live_ViewVisitorProfile'|translate }}" data-visitor-id="{{ visitor.getColumn("visitorId") }}">

--- a/plugins/SitesManager/templates/sites-list/site-fields.html
+++ b/plugins/SitesManager/templates/sites-list/site-fields.html
@@ -1,4 +1,4 @@
-<div class="site card hoverable" idsite="{{ site.idsite }}" ng-class="{'editingSite': site.editMode==true}">
+<div class="site card" idsite="{{ site.idsite }}" ng-class="{'editingSite': site.editMode==true}">
 <div class="card-content">
 
     <div class="row" ng-if="!site.editMode">


### PR DESCRIPTION
One thing that is bugging me a bit since Piwik 3 is that the cards in the visitor log are all animated on hover.
In my opinion such a strong animation should be limited to small objects and it always indicates that one can interact with it as it's a link or button.
I am not sure why the visitor log cards "move" as no other similar cards (sidebar/other reports) do so apart from the "manage websites" list for which I'd propose the same change.
  