### PR TITLE
Fix AnonymousPiwikUsageMeasurement is shown as "third-party"

### DIFF
--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -229,7 +229,7 @@ class Controller extends Plugin\ControllerAdmin
 
             if (isset($plugin['info']) && isset($plugin['info']['authors'])) {
                 foreach ($plugin['info']['authors'] as $author) {
-                    if (in_array(strtolower($author['name']), array('piwik', 'innocraft', 'matomo-org'))) {
+                    if (in_array(strtolower($author['name']), array('piwik', 'innocraft', 'matomo', 'matomo-org'))) {
                         $plugin['isOfficialPlugin'] = true;
                         break;
                     }


### PR DESCRIPTION
This is because it is comparing here author name instead of owner... We will eventually need to change this to owner in the next version.