### PR TITLE
Small performance improvement in custom tracker

### DIFF
--- a/js/tracker.php
+++ b/js/tracker.php
@@ -48,7 +48,13 @@ if (!defined("PIWIK_KEEP_JS_TRACKER_COMMENT")
     $byteStart = 371; // length of comment header in bytes
 }
 
-$environment = new \Piwik\Application\Environment(null);
+class Validator {
+    public function validate() {}
+}
+$validator = new Validator();
+$environment = new \Piwik\Application\Environment(null, array(
+    'Piwik\Application\Kernel\EnvironmentValidator' => $validator
+));
 $environment->init();
 
 ProxyHttp::serverStaticFile($file, "application/javascript; charset=UTF-8", $daysExpireFarFuture, $byteStart, $byteEnd);


### PR DESCRIPTION
Skips validating the environment and eg checking whether config file exists, whether Piwik is installed etc. Doing this otherwise each time the JS tracker is requested can slow down serving the tracker and requires unnecessarily server resources. Eg when requesting piwik.js we would also not check whether Piwik is installed already.