### PR TITLE
Modals popover can now be closed with keyboard

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -248,6 +248,12 @@ var piwikHelper = {
             delete options.fixedFooter;
         }
 
+        if (options && !options.ready) {
+            options.ready = function () {
+                $(".modal.open a").focus();
+            };
+        }
+
         domElem.show();
         $content.openModal(options);
     },


### PR DESCRIPTION
Possible solution to #12439
Changed focus to the anchor on "no" button