### PR TITLE
Fix a possible issue when there are more than 2 billion visits tracked and system is 32 bits

### DIFF
--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -369,7 +369,7 @@ class Visit implements VisitInterface
         }
 
         $idSite = $this->request->getIdSite();
-        $idVisit = (int)$this->visitProperties->getProperty('idvisit');
+        $idVisit = $this->visitProperties->getProperty('idvisit');
 
         $wasInserted = $this->getModel()->updateVisit($idSite, $idVisit, $valuesToUpdate);
 


### PR DESCRIPTION
as reported in https://forum.matomo.org/t/piwik-log-visit-not-inserting-data-for-high-idvisit-value/26922/3