### PR TITLE
improve integration in Firefox Quantum and Chrome Android

### DIFF
--- a/plugins/CoreHome/javascripts/manifest.json
+++ b/plugins/CoreHome/javascripts/manifest.json
@@ -36,6 +36,8 @@
   "start_url": "../../../",
   "display": "standalone",
   "orientation": "portrait",
+  "background_color": "#edecec",
+  "theme_color": "#37474f",
   "prefer_related_applications": true,
   "related_applications": [
     {

--- a/plugins/CoreHome/templates/_favicon.twig
+++ b/plugins/CoreHome/templates/_favicon.twig
@@ -2,4 +2,5 @@
     <link rel="shortcut icon" href="{{ customFavicon }}"/>
 {% else %}
     <link rel="shortcut icon" href="plugins/CoreHome/images/favicon.png"/>
+    <link rel="icon" type='image/png' sizes='256x256' href="plugins/CoreHome/images/applogo_256.png"/>
 {% endif %}

--- a/plugins/Morpheus/templates/layout.twig
+++ b/plugins/Morpheus/templates/layout.twig
@@ -21,6 +21,7 @@
 
             {% include "@CoreHome/_favicon.twig" %}
             {% include "@CoreHome/_applePinnedTabIcon.twig" %}
+            <meta name="theme-color" content="#37474f">
             {% include "_jsGlobalVariables.twig" %}
             {% include "_jsCssIncludes.twig" %}
 


### PR DESCRIPTION
`<meta name="theme-color" content="#37474f">` colors the Navbar in Chrome Android (and Firefox Desktop with VivaldiFox) in the dark grey.

![screenshot_20180121-110400](https://user-images.githubusercontent.com/6266037/35192916-0ab1e116-fe9b-11e7-9b05-c2634c811dda.png)

```
"background_color": "#edecec",
"theme_color": "#37474f",
```
cause the splash screen of the webapp on Android to have the same background and navbar color as Piwik.

![screenshot_20180121-110414](https://user-images.githubusercontent.com/6266037/35192919-0e14727e-fe9b-11e7-8721-4de8e4c7de85.png)

![screenshot_20180121-110420](https://user-images.githubusercontent.com/6266037/35192920-10ab0912-fe9b-11e7-913e-7a070df0c5a4.png)

Adding a higher resolution icon to `<link rel="icon" />` (probably) causes Firefox to show the large logo on the new tab site in Firefox 47+ ([which is quite a mystery](https://webmasters.stackexchange.com/questions/111355/how-to-make-a-large-icon-appear-in-firefoxs-new-tab-top-sites/112175))

![grafik](https://user-images.githubusercontent.com/6266037/35192932-49b46424-fe9b-11e7-95a3-03efedb2d32a.png)
