### PR TITLE
During installer, better detect adblockers that may block Matomo css/js files

### DIFF
--- a/plugins/CoreHome/lang/en.json
+++ b/plugins/CoreHome/lang/en.json
@@ -84,6 +84,8 @@
         "MenuEntries": "Menu entries",
         "Segments": "Segments",
         "OneClickUpdateNotPossibleAsMultiServerEnvironment": "The one-click update is not available as you are using Matomo with multiple servers. Please download the latest version from %1$s to proceed.",
+        "CssDidntLoad": "Your browser was unable to load the style of this page.",
+        "JsDidntLoad": "Your browser was unable to load the scripts of this page.",
         "AdblockIsMaybeUsed": "In case you are using an ad blocker, please disable it for this site to make sure Matomo works without any issues.",
         "ChangeCurrentWebsite": "Choose a website, currently selected website: %s",
         "LeadingAnalyticsPlatformRespectsYourPrivacy": "The leading open analytics platform that respects your privacy.",

--- a/plugins/CoreHome/templates/_adblockDetect.twig
+++ b/plugins/CoreHome/templates/_adblockDetect.twig
@@ -22,14 +22,20 @@
             }
 
             if (wasMostLikelyCausedByAdblock) {
-                var warning = document.createElement('h3');
-                warning.innerHTML = '{{ 'CoreHome_AdblockIsMaybeUsed'|translate|e('js') }}';
+                var shouldGetHiddenElement = document.getElementById("should-get-hidden");
+                var warning = document.createElement('p');
+                warning.innerText = '{{ 'CoreHome_AdblockIsMaybeUsed'|translate|e('js') }}';
 
-                body[0].appendChild(warning);
-                warning.style.color = 'red';
-                warning.style.fontWeight = 'bold';
-                warning.style.marginLeft = '16px';
-                warning.style.marginBottom = '16px';
+                if (shouldGetHiddenElement) {
+                    shouldGetHiddenElement.appendChild(warning);
+                } else {
+                    body[0].insertBefore(warning, body[0].firstChild);
+                    warning.style.color = 'red';
+                    warning.style.fontWeight = 'bold';
+                    warning.style.marginLeft = '16px';
+                    warning.style.marginBottom = '16px';
+                    warning.style.fontSize = '20px';
+                }
             }
         })();
     }

--- a/plugins/Installation/javascripts/installation.js
+++ b/plugins/Installation/javascripts/installation.js
@@ -20,4 +20,5 @@ $(document).ready(function() {
             $row.append($help);
         }
     });
+    $(".should-get-hidden-by-js").hide();
 });

--- a/plugins/Installation/stylesheets/installation.css
+++ b/plugins/Installation/stylesheets/installation.css
@@ -121,3 +121,7 @@ p.next-step:first-child {
 .system-check-legend {
     font-size: 13px;
 }
+
+.should-get-hidden-by-css {
+    display: none;
+}

--- a/plugins/Installation/templates/layout.twig
+++ b/plugins/Installation/templates/layout.twig
@@ -12,15 +12,6 @@
 </head>
 <body ng-app="app" id="installation">
 <div class="container">
-    <div id="should-get-hidden"
-         style="color: red;margin-left: 16px;margin-bottom: 16px;font-weight:bold;font-size: 20px">
-        <p class="should-get-hidden-by-js">
-            {{ 'CoreHome_JsDidntLoad'|translate }}
-        </p>
-        <p class="should-get-hidden-by-css">
-            {{ 'CoreHome_CssDidntLoad'|translate }}
-        </p>
-    </div>
 
     <div class="header">
         <div class="logo">
@@ -78,6 +69,16 @@
         </div>
     </div>
 
+</div>
+
+<div id="should-get-hidden"
+     style="color: red;margin-left: 16px;margin-bottom: 16px;font-weight:bold;font-size: 20px">
+    <p class="should-get-hidden-by-js">
+        {{ 'CoreHome_JsDidntLoad'|translate }}
+    </p>
+    <p class="should-get-hidden-by-css">
+        {{ 'CoreHome_CssDidntLoad'|translate }}
+    </p>
 </div>
 {% include "@CoreHome/_adblockDetect.twig" %}
 </body>

--- a/plugins/Installation/templates/layout.twig
+++ b/plugins/Installation/templates/layout.twig
@@ -11,8 +11,16 @@
     <link rel="shortcut icon" href="plugins/CoreHome/images/favicon.png"/>
 </head>
 <body ng-app="app" id="installation">
-
 <div class="container">
+    <div id="should-get-hidden"
+         style="color: red;margin-left: 16px;margin-bottom: 16px;font-weight:bold;font-size: 20px">
+        <p class="should-get-hidden-by-js">
+            {{ 'CoreHome_JsDidntLoad'|translate }}
+        </p>
+        <p class="should-get-hidden-by-css">
+            {{ 'CoreHome_CssDidntLoad'|translate }}
+        </p>
+    </div>
 
     <div class="header">
         <div class="logo">
@@ -71,6 +79,6 @@
     </div>
 
 </div>
-
+{% include "@CoreHome/_adblockDetect.twig" %}
 </body>
 </html>


### PR DESCRIPTION
extends #5094, fixes #11660 and hopefully also fixes #10652

I just remembered that I once opened an issue about AdBlock detection.

Improvements:
- also add the detection to the installer (as it is most important there)
- add warning to the top of the page instead of end as nobody scrolls down
- add an additional check if CSS and JS are loading correctly by hiding a warning
  - I only added it to the installer as it may cause flashes of the warning
  - also catches cases where the JS and CSS generated by the server are broken
  - also warns when user has disabled Javascript
     - should work when one uses NoScript or similar

This needs some testing as there are a lot of edge cases that I didn't test.

I have no idea how the error message should read, so it's just a placeholder