### PR TITLE
Give developers the possibility to compare translation keys in different languages

### DIFF
--- a/plugins/LanguagesManager/angularjs/translationsearch/translationsearch.controller.js
+++ b/plugins/LanguagesManager/angularjs/translationsearch/translationsearch.controller.js
@@ -11,21 +11,58 @@
 
     function TranslationSearchController(piwikApi) {
 
-        var vm = this;
-        vm.existingTranslations = [];
-
-        fetchTranslations();
-
-        function fetchTranslations() {
+        function fetchTranslations(languageCode) {
             piwikApi.fetch({
                 method: 'LanguagesManager.getTranslationsForLanguage',
                 filter_limit: -1,
-                languageCode: 'en'
+                languageCode: languageCode
             }).then(function (response) {
                 if (response) {
-                    vm.existingTranslations = response;
+                    if (languageCode === 'en') {
+                        vm.existingTranslations = response;
+                    } else {
+                        vm.compareTranslations = {};
+                        angular.forEach(response, function (translation) {
+                            vm.compareTranslations[translation.label] = translation.value;
+                        });
+                    }
                 }
             });
         }
+
+        function fetchLanguages() {
+            piwikApi.fetch({
+                method: 'LanguagesManager.getAvailableLanguagesInfo',
+                filter_limit: -1
+            }).then(function (languages) {
+                vm.languages = [{key: '', value: 'None'}];
+                if (languages) {
+                    angular.forEach(languages, function (language) {
+                        if (language.code === 'en') {
+                            return;
+                        }
+                        vm.languages.push({key: language.code, value: language.name});
+                    });
+                }
+            });
+        }
+
+        var vm = this;
+        vm.compareTranslations = null;
+        vm.existingTranslations = [];
+        vm.languages = [];
+        vm.compareLanguage = '';
+
+        this.doCompareLanguage = function () {
+            if (vm.compareLanguage) {
+                vm.compareTranslations = null;
+                fetchTranslations(vm.compareLanguage);
+            }
+        };
+
+        fetchTranslations('en');
+
+        fetchLanguages();
+
     }
 })();

--- a/plugins/LanguagesManager/angularjs/translationsearch/translationsearch.directive.html
+++ b/plugins/LanguagesManager/angularjs/translationsearch/translationsearch.directive.html
@@ -6,7 +6,18 @@
         Enter a search term to find translations and their corresponding keys:
     </p>
 
-    <input type="text" placeholder="Search for English translation" title="Search for English translation. Max 1000 results will be shown." ng-model="translationSearch.searchTerm" style="width:271px">
+    <div piwik-field uicontrol="text" name="alias"
+         inline-help="Search for English translation. Max 1000 results will be shown."
+         ng-model="translationSearch.searchTerm"
+         placeholder="Search for English translation">
+    </div>
+
+    <div piwik-field uicontrol="select" name="translationSearch.compareLanguage"
+         inline-help="Optionally select a language to compare the English language with."
+         ng-model="translationSearch.compareLanguage"
+         ng-change="translationSearch.doCompareLanguage()"
+         options='translationSearch.languages'>
+    </div>
 
     <br />
     <br />
@@ -18,12 +29,14 @@
             <tr>
                 <th style="width:250px;">Key</th>
                 <th>English translation</th>
+                <th ng-show="translationSearch.compareLanguage && translationSearch.compareTranslations">Compare translation</th>
             </tr>
         </thead>
         <tbody>
             <tr ng-repeat="translation in translationSearch.existingTranslations | filter:translationSearch.searchTerm | limitTo: 1000">
                 <td>{{ translation.label }}</td>
                 <td>{{ translation.value }}</td>
+                <td ng-show="translationSearch.compareLanguage && translationSearch.compareTranslations">{{ translationSearch.compareTranslations[translation.label] }}</td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
Something I quite often need to do is to look for wordings we use in Matomo app for certain features etc. In the past I have always used the Translation Search tools for developers in Matomo app. So I search for a translation string, find the translation key, then look in the code of the app for that translation key in the needed language. This is quite a bit of work. Instead it would be great to directly see the translated translation key in another language in the UI (optionally).

This is now possible (optionally):
![image](https://user-images.githubusercontent.com/273120/35256699-e83696b6-0059-11e8-8963-db87994f543f.png)

From what I can see there are no UI tests for this feature so far and didn't want to add new ones anyway as it is pure developer tool.
