### PR TITLE
Assorted events and changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ### New APIs
 * A new JavaScript tracker method `resetUserId` has been added to allow clearing user and visitor id.
 * A new event `Actions.addActionTypes` has been added, to allow plugins to add their custom action types.
+* A new event `API.Request.intercept` has been added which allows plugins to intercept API requests to perform custom logic, overriding the original API method.
+* A new event `Request.shouldDisablePostProcessing` has been added which allows plugins to disable DataTable post processing for individual API requests.
+* A new event `SitesManager.shouldPerformEmptySiteCheck` has been added to allow plugins to disable the empty site check for individual sites.
 
 ## Matomo 3.3.0
 

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -232,7 +232,7 @@ class Request
 
             list($module, $method) = $this->extractModuleAndMethod($moduleMethod);
             list($module, $method) = self::getRenamedModuleAndAction($module, $method);
-            
+
             PluginManager::getInstance()->checkIsPluginActivated($module);
 
             $apiClassName = self::getClassNameAPI($module);

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1048,7 +1048,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
     public function __sleep()
     {
-        return array('rows', 'summaryRow');
+        return array('rows', 'summaryRow', 'metadata');
     }
 
     /**

--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -66,7 +66,7 @@ abstract class Factory
      * @param string $period `"day"`, `"week"`, `"month"`, `"year"`, `"range"`.
      * @param Date|string $date A date within the period or the range of dates.
      * @param Date|string $timezone Optional timezone that will be used only when $period is 'range' or $date is 'last|previous'
-     * @throws Exception If `$strPeriod` is invalid.
+     * @throws Exception If `$strPeriod` is invalid or $date is invalid.
      * @return \Piwik\Period
      */
     public static function build($period, $date, $timezone = 'UTC')
@@ -80,8 +80,10 @@ abstract class Factory
             }
 
             $dateObject = Date::factory($date);
-        } else {
+        } else if (!empty($date)) {
             $dateObject = $date;
+        } else {
+            throw new \Exception("Invalid date supplied to Period\Factory::build(): " . gettype($date));
         }
 
         switch ($period) {

--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugin;
 
 use Piwik\API\DataTablePostProcessor;
 use Piwik\API\Proxy;
+use Piwik\API\Request;
 use Piwik\API\ResponseBuilder;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
@@ -262,6 +263,8 @@ class Visualization extends ViewDataTable
 
         $module = $this->requestConfig->getApiModuleToRequest();
         $method = $this->requestConfig->getApiMethodToRequest();
+
+        list($module, $method) = Request::getRenamedModuleAndAction($module, $method);
 
         PluginManager::getInstance()->checkIsPluginActivated($module);
 

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -68,8 +68,23 @@ class SitesManager extends \Piwik\Plugin
             return;
         }
 
+        $shouldPerformEmptySiteCheck = true;
+
+        /**
+         * Posted before checking to display the "No data has been recorded yet" message.
+         * If your Measurable should never have visits, you can use this event to make
+         * sure that message is never displayed.
+         *
+         * @param bool &$shouldPerformEmptySiteCheck Set this value to true to perform the
+         *                                           check, false if otherwise.
+         * @param int $siteId The ID of the site we would perform a check for.
+         */
+        Piwik::postEvent('SitesManager.shouldPerformEmptySiteCheck', [&$shouldPerformEmptySiteCheck, $siteId]);
+
         $trackerModel = new TrackerModel();
-        if ($trackerModel->isSiteEmpty($siteId)) {
+        if ($shouldPerformEmptySiteCheck
+            && $trackerModel->isSiteEmpty($siteId)
+        ) {
             $session = new SessionNamespace('siteWithoutData');
             if (!empty($session->ignoreMessage)) {
                 return;


### PR DESCRIPTION
Changes:
* Throw an exception in `Period\Factory::build()` if `$date` is null. This happened while I was developing and it took me a very long time to figure out what was going on. An exception would have helped.
* Use `Request::getRenamedModuleAndAction()` in `Visualization`. I found that was the one spot that didn't call this function before using `Piwik\Api\Proxy`.
* Add new `SitesManager.shouldPerformEmptySiteCheck` event so plugins can disable the check for certain sites.
* Added `API.Request.intercept` event to in `API\Proxy`. If a plugin sets `$returnedValue`, the actual function call is skipped.
* Added `Request.shouldDisablePostProcessing` so plugins can disable datatable post processing for certain requests (if, for example, the request's post processing is done somewhere else).
* Make sure datatable metadata is serialized w/ the datatable so information like report `totals` shows up when `serialize=1&original=1`. Don't think this will have a effect on DB size since only the rows are stored in the DB. Not sure what else serializes DataTable.

Note: I can cherry pick this into multiple PRs if needed & am also open to changing it.