### PR TITLE
When generating URLs, only strip PATH_INFO  when it is not empty

### DIFF
--- a/core/Url.php
+++ b/core/Url.php
@@ -150,7 +150,7 @@ class Url
             }
 
             // strip path_info
-            if ($removePathInfo && isset($_SERVER['PATH_INFO'])) {
+            if ($removePathInfo && !empty($_SERVER['PATH_INFO'])) {
                 $url = substr($url, 0, -strlen($_SERVER['PATH_INFO']));
             }
         }


### PR DESCRIPTION
If PATH_INFO  is defined, but empty, this line otherwise causes the URL to be rewritten incorrectly
As reported in https://github.com/matomo-org/matomo/issues/6644#issuecomment-357399615