### PR TITLE
Make sure test fixture symlinks are created correctly

### DIFF
--- a/plugins/TestRunner/Commands/TestsSetupFixture.php
+++ b/plugins/TestRunner/Commands/TestsSetupFixture.php
@@ -157,7 +157,13 @@ class TestsSetupFixture extends ConsoleCommand
         foreach (array('libs', 'plugins', 'tests', 'misc', 'piwik.js') as $linkName) {
             $linkPath = PIWIK_INCLUDE_PATH . '/tests/PHPUnit/proxy/' . $linkName;
             if (!file_exists($linkPath)) {
-                symlink(PIWIK_INCLUDE_PATH . '/' . $linkName, $linkPath);
+                $success = @symlink($target, $linkPath);
+                // setting symlink might fail when the symlink already exists but pointing to a no longer existing path/file
+                // eg when sometimes running it on a VM and sometimes on the VM's host itself.
+                if (!$success) {
+                    unlink($target);
+                    symlink($target, $linkPath);
+                }
             }
         }
     }


### PR DESCRIPTION
See comment. Sometimes symlinks may not be created correctly and show a warning like this:

> /plugins/TestRunner/Commands/TestsSetupFixture.php(160): Warning - symlink(): No such file or directory

This happens when the symlink points to a not existing file. Instead we try to "repair" the symlink by removing the original symlink and setting the correct path.