### PR TITLE
Use renamed composer packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "symfony/event-dispatcher": "~2.6.0",
         "pear/pear_exception": "~1.0.0",
         "piwik/referrer-spam-blacklist": "~1.0",
-        "piwik/searchengine-and-social-list": "~1.0",
+        "matomo/searchengine-and-social-list": "~1.0",
         "tecnickcom/tcpdf": "~6.0",
         "piwik/piwik-php-tracker": "^1.0",
         "composer/semver": "~1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/monolog-bridge": "~2.6.0",
         "symfony/event-dispatcher": "~2.6.0",
         "pear/pear_exception": "~1.0.0",
-        "piwik/referrer-spam-blacklist": "~1.0",
+        "matomo/referrer-spam-blacklist": "~1.0",
         "matomo/searchengine-and-social-list": "~1.0",
         "tecnickcom/tcpdf": "~6.0",
         "piwik/piwik-php-tracker": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "82f53e2d85d7df7c7ce8871bb9ae0c7e",
+    "content-hash": "09fe6cb3a6b305cd0013ee7cb97e4635",
     "packages": [
         {
             "name": "composer/semver",
@@ -209,6 +209,28 @@
             "description": "lessphp is a compiler for LESS written in PHP.",
             "homepage": "http://leafo.net/lessphp/",
             "time": "2014-11-24T18:39:20+00:00"
+        },
+        {
+            "name": "matomo/referrer-spam-blacklist",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/matomo-org/referrer-spam-blacklist.git",
+                "reference": "fdad7e12ad33a98e085c44255f3b208dca3e66ea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/matomo-org/referrer-spam-blacklist/zipball/fdad7e12ad33a98e085c44255f3b208dca3e66ea",
+                "reference": "fdad7e12ad33a98e085c44255f3b208dca3e66ea",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Public Domain"
+            ],
+            "description": "Community-contributed list of referrer spammers",
+            "time": "2018-01-29T17:33:37+00:00"
         },
         {
             "name": "matomo/searchengine-and-social-list",
@@ -952,28 +974,6 @@
                 "tracker"
             ],
             "time": "2017-11-09T03:20:23+00:00"
-        },
-        {
-            "name": "piwik/referrer-spam-blacklist",
-            "version": "1.0.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/piwik/referrer-spam-blacklist.git",
-                "reference": "ad7c2296d5bac58c5bea771f355dc49dd4fc8141"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/piwik/referrer-spam-blacklist/zipball/ad7c2296d5bac58c5bea771f355dc49dd4fc8141",
-                "reference": "ad7c2296d5bac58c5bea771f355dc49dd4fc8141",
-                "shasum": ""
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Public Domain"
-            ],
-            "description": "Community-contributed list of referrer spammers",
-            "time": "2017-03-28T04:31:29+00:00"
         },
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "39dbe45e9a9ada455d5b38be7e6f5fad",
+    "content-hash": "82f53e2d85d7df7c7ce8871bb9ae0c7e",
     "packages": [
         {
             "name": "composer/semver",
@@ -209,6 +209,28 @@
             "description": "lessphp is a compiler for LESS written in PHP.",
             "homepage": "http://leafo.net/lessphp/",
             "time": "2014-11-24T18:39:20+00:00"
+        },
+        {
+            "name": "matomo/searchengine-and-social-list",
+            "version": "1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/matomo-org/searchengine-and-social-list.git",
+                "reference": "e204de3e68e750bfdace0469f1ade74f416024fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/matomo-org/searchengine-and-social-list/zipball/e204de3e68e750bfdace0469f1ade74f416024fb",
+                "reference": "e204de3e68e750bfdace0469f1ade74f416024fb",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Public Domain"
+            ],
+            "description": "Search engine and social network definitions used by Matomo (formerly Piwik)",
+            "time": "2018-01-29T16:36:29+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -722,7 +744,7 @@
             ],
             "authors": [
                 {
-                    "name": "The Piwik Team",
+                    "name": "The Matomo Team",
                     "email": "hello@piwik.org",
                     "homepage": "http://piwik.org/the-piwik-team/"
                 }
@@ -812,7 +834,7 @@
             ],
             "authors": [
                 {
-                    "name": "The Piwik Team",
+                    "name": "The Matomo Team",
                     "email": "hello@piwik.org",
                     "homepage": "http://piwik.org/the-piwik-team/"
                 }
@@ -917,12 +939,12 @@
             ],
             "authors": [
                 {
-                    "name": "The Piwik Team",
+                    "name": "The Matomo Team",
                     "email": "hello@piwik.org",
                     "homepage": "http://piwik.org/the-piwik-team/"
                 }
             ],
-            "description": "PHP Client for Piwik Analytics Tracking API",
+            "description": "PHP Client for Matomo Analytics Tracking API",
             "homepage": "http://piwik.org",
             "keywords": [
                 "analytics",
@@ -952,28 +974,6 @@
             ],
             "description": "Community-contributed list of referrer spammers",
             "time": "2017-03-28T04:31:29+00:00"
-        },
-        {
-            "name": "piwik/searchengine-and-social-list",
-            "version": "1.3.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/piwik/searchengine-and-social-list.git",
-                "reference": "4ee85edc474a5e65cc785df470164037aaebc317"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/piwik/searchengine-and-social-list/zipball/4ee85edc474a5e65cc785df470164037aaebc317",
-                "reference": "4ee85edc474a5e65cc785df470164037aaebc317",
-                "shasum": ""
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Public Domain"
-            ],
-            "description": "Search engine and social network definitions used by Piwik",
-            "time": "2017-09-10T11:20:27+00:00"
         },
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -234,25 +234,28 @@
         },
         {
             "name": "matomo/searchengine-and-social-list",
-            "version": "1.4",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/searchengine-and-social-list.git",
-                "reference": "e204de3e68e750bfdace0469f1ade74f416024fb"
+                "reference": "7f0bd9f27196885544813d5c847142c9f411f9ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/searchengine-and-social-list/zipball/e204de3e68e750bfdace0469f1ade74f416024fb",
-                "reference": "e204de3e68e750bfdace0469f1ade74f416024fb",
+                "url": "https://api.github.com/repos/matomo-org/searchengine-and-social-list/zipball/7f0bd9f27196885544813d5c847142c9f411f9ab",
+                "reference": "7f0bd9f27196885544813d5c847142c9f411f9ab",
                 "shasum": ""
+            },
+            "replace": {
+                "piwik/searchengine-and-social-list": "*"
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Public Domain"
+                "CC0-1.0"
             ],
             "description": "Search engine and social network definitions used by Matomo (formerly Piwik)",
-            "time": "2018-01-29T16:36:29+00:00"
+            "time": "2018-01-29T18:13:08+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -766,7 +769,7 @@
             ],
             "authors": [
                 {
-                    "name": "The Matomo Team",
+                    "name": "The Piwik Team",
                     "email": "hello@piwik.org",
                     "homepage": "http://piwik.org/the-piwik-team/"
                 }
@@ -778,6 +781,7 @@
                 "file",
                 "redis"
             ],
+            "abandoned": "matomo/cache",
             "time": "2016-11-15T02:33:06+00:00"
         },
         {
@@ -785,12 +789,12 @@
             "version": "1.2.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/piwik/component-decompress.git",
+                "url": "https://github.com/matomo-org/component-decompress.git",
                 "reference": "15088059c38378939db8a3490b67b569797a6a3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/piwik/component-decompress/zipball/15088059c38378939db8a3490b67b569797a6a3a",
+                "url": "https://api.github.com/repos/matomo-org/component-decompress/zipball/15088059c38378939db8a3490b67b569797a6a3a",
                 "reference": "15088059c38378939db8a3490b67b569797a6a3a",
                 "shasum": ""
             },
@@ -814,6 +818,7 @@
             "license": [
                 "LGPL-3.0"
             ],
+            "abandoned": "matomo/decompress",
             "time": "2017-07-14T10:45:10+00:00"
         },
         {
@@ -821,12 +826,12 @@
             "version": "3.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/piwik/device-detector.git",
+                "url": "https://github.com/matomo-org/device-detector.git",
                 "reference": "caf2d15349caffd94a8cfe46edf4061fbc99f70b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/piwik/device-detector/zipball/caf2d15349caffd94a8cfe46edf4061fbc99f70b",
+                "url": "https://api.github.com/repos/matomo-org/device-detector/zipball/caf2d15349caffd94a8cfe46edf4061fbc99f70b",
                 "reference": "caf2d15349caffd94a8cfe46edf4061fbc99f70b",
                 "shasum": ""
             },
@@ -856,7 +861,7 @@
             ],
             "authors": [
                 {
-                    "name": "The Matomo Team",
+                    "name": "The Piwik Team",
                     "email": "hello@piwik.org",
                     "homepage": "http://piwik.org/the-piwik-team/"
                 }
@@ -901,6 +906,7 @@
             "license": [
                 "LGPL-3.0"
             ],
+            "abandoned": "matomo/ini",
             "time": "2016-01-14T21:13:33+00:00"
         },
         {
@@ -961,12 +967,12 @@
             ],
             "authors": [
                 {
-                    "name": "The Matomo Team",
+                    "name": "The Piwik Team",
                     "email": "hello@piwik.org",
                     "homepage": "http://piwik.org/the-piwik-team/"
                 }
             ],
-            "description": "PHP Client for Matomo Analytics Tracking API",
+            "description": "PHP Client for Piwik Analytics Tracking API",
             "homepage": "http://piwik.org",
             "keywords": [
                 "analytics",
@@ -1633,7 +1639,7 @@
                 "performance",
                 "profiling"
             ],
-            "time": "2015-02-26 14:37:51"
+            "time": "2015-02-26T14:37:51+00:00"
         },
         {
             "name": "guzzle/guzzle",

--- a/core/Tracker/Visit/ReferrerSpamFilter.php
+++ b/core/Tracker/Visit/ReferrerSpamFilter.php
@@ -78,7 +78,7 @@ class ReferrerSpamFilter
             $this->spammerList = unserialize($list);
         } else {
             // Fallback to reading the bundled list
-            $file = PIWIK_VENDOR_PATH . '/piwik/referrer-spam-blacklist/spammers.txt';
+            $file = PIWIK_VENDOR_PATH . '/matomo/referrer-spam-blacklist/spammers.txt';
             $this->spammerList = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         }
 

--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -116,11 +116,11 @@ class Tasks extends \Piwik\Plugin\Tasks
     /**
      * Update the referrer spam blacklist
      *
-     * @see https://github.com/piwik/referrer-spam-blacklist
+     * @see https://github.com/matomo-org/referrer-spam-blacklist
      */
     public function updateSpammerBlacklist()
     {
-        $url = 'https://raw.githubusercontent.com/piwik/referrer-spam-blacklist/master/spammers.txt';
+        $url = 'https://raw.githubusercontent.com/matomo-org/referrer-spam-blacklist/master/spammers.txt';
         $list = Http::sendHttpRequest($url, 30);
         $list = preg_split("/\r\n|\n|\r/", $list);
         if (count($list) < 10) {

--- a/plugins/Referrers/SearchEngine.php
+++ b/plugins/Referrers/SearchEngine.php
@@ -23,7 +23,7 @@ class SearchEngine extends Singleton
     const OPTION_STORAGE_NAME = 'SearchEngineDefinitions';
 
     /** @var string location of definition file (relative to PIWIK_INCLUDE_PATH) */
-    const DEFINITION_FILE = '/vendor/piwik/searchengine-and-social-list/SearchEngines.yml';
+    const DEFINITION_FILE = '/vendor/matomo/searchengine-and-social-list/SearchEngines.yml';
 
     protected $definitionList = null;
 

--- a/plugins/Referrers/Social.php
+++ b/plugins/Referrers/Social.php
@@ -20,7 +20,7 @@ class Social extends Singleton
     const OPTION_STORAGE_NAME = 'SocialDefinitions';
 
     /** @var string location of definition file (relative to PIWIK_INCLUDE_PATH) */
-    const DEFINITION_FILE = '/vendor/piwik/searchengine-and-social-list/Socials.yml';
+    const DEFINITION_FILE = '/vendor/matomo/searchengine-and-social-list/Socials.yml';
 
     protected $definitionList = null;
 

--- a/plugins/Referrers/Tasks.php
+++ b/plugins/Referrers/Tasks.php
@@ -26,11 +26,11 @@ class Tasks extends \Piwik\Plugin\Tasks
     /**
      * Update the search engine definitions
      *
-     * @see https://github.com/piwik/searchengine-and-social-list
+     * @see https://github.com/matomo-org/searchengine-and-social-list
      */
     public function updateSearchEngines()
     {
-        $url = 'https://raw.githubusercontent.com/piwik/searchengine-and-social-list/master/SearchEngines.yml';
+        $url = 'https://raw.githubusercontent.com/matomo-org/searchengine-and-social-list/master/SearchEngines.yml';
         $list = Http::sendHttpRequest($url, 30);
         $searchEngines = SearchEngine::getInstance()->loadYmlData($list);
         if (count($searchEngines) < 200) {
@@ -46,7 +46,7 @@ class Tasks extends \Piwik\Plugin\Tasks
      */
     public function updateSocials()
     {
-        $url = 'https://raw.githubusercontent.com/piwik/searchengine-and-social-list/master/Socials.yml';
+        $url = 'https://raw.githubusercontent.com/matomo-org/searchengine-and-social-list/master/Socials.yml';
         $list = Http::sendHttpRequest($url, 30);
         $socials = Social::getInstance()->loadYmlData($list);
         if (count($socials) < 50) {

--- a/plugins/Referrers/Tasks.php
+++ b/plugins/Referrers/Tasks.php
@@ -42,7 +42,7 @@ class Tasks extends \Piwik\Plugin\Tasks
     /**
      * Update the social definitions
      *
-     * @see https://github.com/piwik/searchengine-and-social-list
+     * @see https://github.com/matomo-org/searchengine-and-social-list
      */
     public function updateSocials()
     {


### PR DESCRIPTION
Our composer packages are still listed under the vendor piwik on packagist. As there is no way to rename them, we need to create new packages and mark the old ones as abandoned.

As the two packages below only provide text/yml files, that should be in use by any plugin it should be fine to rename them already...

- [x] `piwik/referrer-spam-blacklist` -> `matomo/referrer-spam-blacklist`
- [x] `piwik/searchengine-and-social-list` -> `matomo/searchengine-and-social-list`
