### PR TITLE
Option::set() INSERT ... ON DUPLICATE KEY can be slow

### DIFF
--- a/core/Option.php
+++ b/core/Option.php
@@ -190,12 +190,23 @@ class Option
     {
         $autoLoad = (int)$autoLoad;
 
-        $sql  = 'INSERT INTO `' . Common::prefixTable('option') . '` (option_name, option_value, autoload) ' .
-                ' VALUES (?, ?, ?) ' .
-                ' ON DUPLICATE KEY UPDATE option_value = ?';
-        $bind = array($name, $value, $autoLoad, $value);
+        $sql  = 'UPDATE `' . Common::prefixTable('option') . '` SET option_value = ?, autoload = ? WHERE option_name = ?';
+        $bind = array($value, $autoLoad, $name);
 
-        Db::query($sql, $bind);
+        $result = Db::query($sql, $bind);
+
+        $rowsUpdated = Db::get()->rowCount($result);
+
+        if (! $rowsUpdated) {
+            try {
+                $sql  = 'INSERT INTO `' . Common::prefixTable('option') . '` (option_name, option_value, autoload) ' .
+                        'VALUES (?, ?, ?) ';
+                $bind = array($name, $value, $autoLoad);
+
+                Db::query($sql, $bind);
+            } catch (\Exception $e) {
+            }
+        }
 
         $this->all[$name] = $value;
     }


### PR DESCRIPTION
https://www.percona.com/blog/2010/07/14/why-insert-on-duplicate-key-update-may-be-slow-by-incurring-disk-seeks/ explains:

> Instead, what MySQL does is the following:
>
> * call handler::write_row to attempt an insertion, if it succeeds, we are done
> * if handler::write_row returns an error indicating a duplicate key, outside of the handler, apply the necessary update to the row
> * call handler::update_row to apply the update
> ...
> So, the moral of the story is this. In MySQL, “insert … on duplicate key update” is slower than “replace into”.

`REPLACE INTO` might be faster but the semantics are:
```
INSERT;
if failure then
    DELETE;
    INSERT;
fi
```

Since `Option::set()` is largely called to update the value for an existing setting, we should try:

```
UPDATE;

if affected_rows === 0 then
    INSERT;
fi
```

It's not an atomic operation but overall, this approach strikes a good balance between performance and ACID.
