### PR TITLE
Allow plugins to define custom action types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ### New APIs
 * A new JavaScript tracker method `resetUserId` has been added to allow clearing user and visitor id.
+* A new event `Actions.addActionTypes` has been added, to allow plugins to add their custom action types.
 
 ## Matomo 3.3.0
 

--- a/plugins/Actions/Actions.php
+++ b/plugins/Actions/Actions.php
@@ -95,14 +95,30 @@ class Actions extends \Piwik\Plugin
 
     public function addActionTypes(&$types)
     {
-        $types += array(
-            Action::TYPE_PAGE_URL => 'pageviews',
-            Action::TYPE_CONTENT => 'contents',
-            Action::TYPE_SITE_SEARCH => 'sitesearches',
-            Action::TYPE_EVENT => 'events',
-            Action::TYPE_OUTLINK => 'outlinks',
-            Action::TYPE_DOWNLOAD => 'downloads'
-        );
+        $types[] = [
+            'id' => Action::TYPE_PAGE_URL,
+            'name' => 'pageviews'
+        ];
+        $types[] = [
+            'id' => Action::TYPE_CONTENT,
+            'name' => 'contents'
+        ];
+        $types[] = [
+            'id' => Action::TYPE_SITE_SEARCH,
+            'name' => 'sitesearches'
+        ];
+        $types[] = [
+            'id' => Action::TYPE_EVENT,
+            'name' => 'events'
+        ];
+        $types[] = [
+            'id' => Action::TYPE_OUTLINK,
+            'name' => 'outlinks'
+        ];
+        $types[] = [
+            'id' => Action::TYPE_DOWNLOAD,
+            'name' => 'downloads'
+        ];
     }
 
     public function isSiteSearchEnabled($idSites, $idSite)

--- a/plugins/Actions/Actions.php
+++ b/plugins/Actions/Actions.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\Actions;
 
 use Piwik\Site;
 use Piwik\Plugin\ViewDataTable;
+use Piwik\Tracker\Action;
 
 /**
  * Actions plugin
@@ -32,6 +33,7 @@ class Actions extends \Piwik\Plugin
             'Insights.addReportToOverview'    => 'addReportToInsightsOverview',
             'Metrics.getDefaultMetricTranslations' => 'addMetricTranslations',
             'Metrics.getDefaultMetricDocumentationTranslations' => 'addMetricDocumentationTranslations',
+            'Actions.addActionTypes' => 'addActionTypes'
         );
     }
 
@@ -89,6 +91,18 @@ class Actions extends \Piwik\Plugin
     {
         $jsFiles[] = "plugins/Actions/javascripts/actionsDataTable.js";
         $jsFiles[] = "plugins/Actions/javascripts/rowactions.js";
+    }
+
+    public function addActionTypes(&$types)
+    {
+        $types += array(
+            Action::TYPE_PAGE_URL => 'pageviews',
+            Action::TYPE_CONTENT => 'contents',
+            Action::TYPE_SITE_SEARCH => 'sitesearches',
+            Action::TYPE_EVENT => 'events',
+            Action::TYPE_OUTLINK => 'outlinks',
+            Action::TYPE_DOWNLOAD => 'downloads'
+        );
     }
 
     public function isSiteSearchEnabled($idSites, $idSite)

--- a/plugins/Actions/Columns/ActionType.php
+++ b/plugins/Actions/Columns/ActionType.php
@@ -32,7 +32,7 @@ class ActionType extends ActionDimension
 
     public function __construct()
     {
-        $this->acceptValues = 'A type of action, such as: pageviews, contents, events, outlinks';
+        $this->acceptValues = 'A type of action, such as: pageviews, contents, sitesearches, events, outlinks, downloads';
     }
 
     public function getEnumColumnValues()

--- a/plugins/Actions/Columns/ActionType.php
+++ b/plugins/Actions/Columns/ActionType.php
@@ -32,7 +32,7 @@ class ActionType extends ActionDimension
 
     public function __construct()
     {
-        $this->acceptValues = sprintf('A type of action, such as: %s', implode(', ', $this->getEnumColumnValues()));
+        $this->acceptValues = 'A type of action, such as: pageviews, contents, events, outlinks';
     }
 
     public function getEnumColumnValues()

--- a/plugins/Actions/Columns/ActionType.php
+++ b/plugins/Actions/Columns/ActionType.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\Actions\Columns;
 
 use Piwik\Columns\DimensionMetricFactory;
 use Piwik\Columns\MetricsList;
+use Piwik\Piwik;
 use Piwik\Plugin\Dimension\ActionDimension;
 use Piwik\Tracker\Action;
 use Exception;
@@ -21,15 +22,6 @@ use Exception;
  */
 class ActionType extends ActionDimension
 {
-    private $types = array(
-        Action::TYPE_PAGE_URL => 'pageviews',
-        Action::TYPE_CONTENT => 'contents',
-        Action::TYPE_SITE_SEARCH => 'sitesearches',
-        Action::TYPE_EVENT => 'events',
-        Action::TYPE_OUTLINK => 'outlinks',
-        Action::TYPE_DOWNLOAD => 'downloads'
-    );
-
     protected $columnName = 'type';
     protected $dbTableName = 'log_action';
     protected $segmentName = 'actionType';
@@ -40,12 +32,31 @@ class ActionType extends ActionDimension
 
     public function __construct()
     {
-        $this->acceptValues = sprintf('A type of action, such as: %s', implode(', ', $this->types));
+        $this->acceptValues = sprintf('A type of action, such as: %s', implode(', ', $this->getEnumColumnValues()));
     }
 
     public function getEnumColumnValues()
     {
-        return $this->types;
+        $types = [];
+        /**
+         * Triggered to determine the available action types
+         *
+         * Plugin can use this event to add their own action types, so they are available in segmentation
+         * The array maps internal ids to readable action type names used in visitor details
+         *
+         * **Example**
+         *
+         * public function addActionTypes(&$types)
+         * {
+         *     $types += array(
+         *         76 => 'media_play'
+         *      );
+         * }
+         *
+         * @param array $types
+         */
+        Piwik::postEvent('Actions.addActionTypes', [&$types]);
+        return $types;
     }
 
     public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)


### PR DESCRIPTION
Action types available for segmentation are currently fixed to those defined in core.
Plugins can now use the new event `Actions.addActionTypes` to register their custom action types.