### PR TITLE
DeviceDetection, display themed "refresh" button

### DIFF
--- a/plugins/DevicesDetection/templates/detection.twig
+++ b/plugins/DevicesDetection/templates/detection.twig
@@ -47,7 +47,7 @@
         <form action="{{ linkTo({}) }}" method="POST">
             <textarea name="ua">{{ userAgent }}</textarea>
             <br />
-            <input type="submit" value="{{ 'General_Refresh'|translate }}" />
+            <input type="submit" value="{{ 'General_Refresh'|translate }}" class="btn" />
         </form>
 
         <h3>{{ 'DevicesDetection_ColumnOperatingSystem'|translate|e('html_attr') }}</h3>


### PR DESCRIPTION
In settings, device detection:
Display themed button refresh instead of browser default one.