### PR TITLE
New system check diagnostic for max_execution_time (#11050)

### DIFF
--- a/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
@@ -18,11 +18,6 @@ class PhpSettingsCheck implements Diagnostic
      * @var Translator
      */
     private $translator;
-    
-    /**
-     * @var array[]
-     */
-    private $requiredSettings = array();
 
     public function __construct(Translator $translator)
     {
@@ -35,9 +30,6 @@ class PhpSettingsCheck implements Diagnostic
 
         $result = new DiagnosticResult($label);
         
-        /**
-         * @var PhpSettingsCheckService $setting
-         */
         foreach ($this->getRequiredSettings() as $setting) {
             if (!$setting->check()) {
                 $status = DiagnosticResult::STATUS_ERROR;
@@ -59,23 +51,23 @@ class PhpSettingsCheck implements Diagnostic
     }
 
     /**
-     * @return array[]
+     * @return PhpSettingsCheckService[]
      */
     private function getRequiredSettings()
     {
-        $this->addRequiredSetting(new PhpSettingsCheckService('session.auto_start', 0));
+        $requiredSettings[] = new PhpSettingsCheckService('session.auto_start', 0);
         
         $maxExecutionTime = new PhpSettingsCheckService('max_execution_time', 0);
         $maxExecutionTime->addRequiredValue(30, '>=');
-        $this->addRequiredSetting($maxExecutionTime);
+        $requiredSettings[] = $maxExecutionTime;
 
         if ($this->isPhpVersionAtLeast56() && ! defined("HHVM_VERSION") && !$this->isPhpVersionAtLeast70()) {
             // always_populate_raw_post_data must be -1
             // removed in PHP 7
-            $this->addRequiredSetting(new PhpSettingsCheckService('always_populate_raw_post_data', -1));
+            $requiredSettings[] = new PhpSettingsCheckService('always_populate_raw_post_data', -1);
         }
         
-        return $this->requiredSettings;
+        return $requiredSettings;
     }
 
     private function isPhpVersionAtLeast56()
@@ -88,9 +80,4 @@ class PhpSettingsCheck implements Diagnostic
         return version_compare(PHP_VERSION, '7.0.0-dev', '>=');
     }
     
-    private function addRequiredSetting(PhpSettingsCheckService $checkRequiredValues){
-        $this->requiredSettings[] = $checkRequiredValues;
-        
-        return $this;
-    }
 }

--- a/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
@@ -51,20 +51,20 @@ class PhpSettingsCheck implements Diagnostic
     }
 
     /**
-     * @return PhpSettingsCheckService[]
+     * @return RequiredPhpSetting[]
      */
     private function getRequiredSettings()
     {
-        $requiredSettings[] = new PhpSettingsCheckService('session.auto_start', 0);
+        $requiredSettings[] = new RequiredPhpSetting('session.auto_start', 0);
         
-        $maxExecutionTime = new PhpSettingsCheckService('max_execution_time', 0);
+        $maxExecutionTime = new RequiredPhpSetting('max_execution_time', 0);
         $maxExecutionTime->addRequiredValue(30, '>=');
         $requiredSettings[] = $maxExecutionTime;
 
         if ($this->isPhpVersionAtLeast56() && ! defined("HHVM_VERSION") && !$this->isPhpVersionAtLeast70()) {
             // always_populate_raw_post_data must be -1
             // removed in PHP 7
-            $requiredSettings[] = new PhpSettingsCheckService('always_populate_raw_post_data', -1);
+            $requiredSettings[] = new RequiredPhpSetting('always_populate_raw_post_data', -1);
         }
         
         return $requiredSettings;

--- a/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpSettingsCheck.php
@@ -32,7 +32,7 @@ class PhpSettingsCheck implements Diagnostic
         
         foreach ($this->getRequiredSettings() as $setting) {
             if (!$setting->check()) {
-                $status = DiagnosticResult::STATUS_ERROR;
+                $status = $setting->getErrorResult();
                 $comment = sprintf(
                     '%s <br/><br/><em>%s</em><br/><em>%s</em><br/>',
                     $setting,
@@ -56,9 +56,10 @@ class PhpSettingsCheck implements Diagnostic
     private function getRequiredSettings()
     {
         $requiredSettings[] = new RequiredPhpSetting('session.auto_start', 0);
-        
+    
         $maxExecutionTime = new RequiredPhpSetting('max_execution_time', 0);
         $maxExecutionTime->addRequiredValue(30, '>=');
+        $maxExecutionTime->setErrorResult(DiagnosticResult::STATUS_WARNING);
         $requiredSettings[] = $maxExecutionTime;
 
         if ($this->isPhpVersionAtLeast56() && ! defined("HHVM_VERSION") && !$this->isPhpVersionAtLeast70()) {

--- a/plugins/Diagnostics/Diagnostic/PhpSettingsCheckService.php
+++ b/plugins/Diagnostics/Diagnostic/PhpSettingsCheckService.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Piwik\Plugins\Diagnostics\Diagnostic;
+
+class PhpSettingsCheckService
+{
+    
+    /** @var string */
+    private $setting;
+    
+    /** @var array */
+    private $requiredValues;
+    
+    /**
+     * @param string $setting
+     * @param int $requiredValue
+     * @param string $operator
+     */
+    public function __construct($setting, $requiredValue, $operator = '=')
+    {
+        $this->setting = $setting;
+        $this->addRequiredValue($requiredValue, $operator);
+    }
+    
+    /**
+     * @param int $requiredValue
+     * @param string $operator
+     *
+     * @return $this
+     */
+    public function addRequiredValue($requiredValue, $operator)
+    {
+        if(!is_int($requiredValue)){
+            throw new \InvalidArgumentException('Required value must be an integer.');
+        }
+        
+        $this->requiredValues[] = array(
+            'requiredValue' => $requiredValue,
+            'operator' => $operator,
+            'isOk' => null,
+        );
+        
+        return $this;
+    }
+    
+    /**
+     * Checks required values against php.ini value.
+     *
+     * @return bool
+     */
+    public function check()
+    {
+        $currentValue = (int) ini_get($this->setting);
+        
+        $return = false;
+        foreach($this->requiredValues as $key => $requiredValue){
+            $this->requiredValues[$key]['isOk'] = version_compare($currentValue, $requiredValue['requiredValue'], $requiredValue['operator']);
+            
+            if($this->requiredValues[$key]['isOk']){
+                $return = true;
+            }
+        }
+        
+        return $return;
+    }
+    
+    public function __toString()
+    {
+        $checks = array();
+        foreach($this->requiredValues as $requiredValue){
+            $checks[] = $requiredValue['operator'] . ' ' . $requiredValue['requiredValue'];
+        }
+        
+        return $this->setting . ' ' . implode(' || ', $checks);
+    }
+    
+}

--- a/plugins/Diagnostics/Diagnostic/RequiredPhpSetting.php
+++ b/plugins/Diagnostics/Diagnostic/RequiredPhpSetting.php
@@ -11,6 +11,9 @@ class RequiredPhpSetting
     /** @var array */
     private $requiredValues;
     
+    /** @var string */
+    private $errorResult = DiagnosticResult::STATUS_ERROR;
+    
     /**
      * @param string $setting
      * @param int $requiredValue
@@ -41,6 +44,30 @@ class RequiredPhpSetting
         );
         
         return $this;
+    }
+    
+    /**
+     * @param $errorResult
+     *
+     * @return $this
+     */
+    public function setErrorResult($errorResult)
+    {
+        if ($errorResult !== DiagnosticResult::STATUS_WARNING && $errorResult !== DiagnosticResult::STATUS_ERROR) {
+            throw new \InvalidArgumentException('Error result must be either DiagnosticResult::STATUS_WARNING or DiagnosticResult::STATUS_ERROR.');
+        }
+        
+        $this->errorResult = $errorResult;
+        
+        return $this;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getErrorResult()
+    {
+        return $this->errorResult;
     }
     
     /**

--- a/plugins/Diagnostics/Diagnostic/RequiredPhpSetting.php
+++ b/plugins/Diagnostics/Diagnostic/RequiredPhpSetting.php
@@ -2,7 +2,7 @@
 
 namespace Piwik\Plugins\Diagnostics\Diagnostic;
 
-class PhpSettingsCheckService
+class RequiredPhpSetting
 {
     
     /** @var string */
@@ -37,7 +37,7 @@ class PhpSettingsCheckService
         $this->requiredValues[] = array(
             'requiredValue' => $requiredValue,
             'operator' => $operator,
-            'isOk' => null,
+            'isValid' => null,
         );
         
         return $this;
@@ -54,9 +54,9 @@ class PhpSettingsCheckService
         
         $return = false;
         foreach($this->requiredValues as $key => $requiredValue){
-            $this->requiredValues[$key]['isOk'] = version_compare($currentValue, $requiredValue['requiredValue'], $requiredValue['operator']);
+            $this->requiredValues[$key]['isValid'] = version_compare($currentValue, $requiredValue['requiredValue'], $requiredValue['operator']);
             
-            if($this->requiredValues[$key]['isOk']){
+            if($this->requiredValues[$key]['isValid']){
                 $return = true;
             }
         }
@@ -71,7 +71,7 @@ class PhpSettingsCheckService
             $checks[] = $requiredValue['operator'] . ' ' . $requiredValue['requiredValue'];
         }
         
-        return $this->setting . ' ' . implode(' || ', $checks);
+        return $this->setting . ' ' . implode(' OR ', $checks);
     }
     
 }


### PR DESCRIPTION
New system check diagnostic for max_execution_time (#11050)

I don't know if I didn't overdid it. If so and you don't like the new `PhpSettingsCheckService` class feel free to close that PR and I'll make new PR with different approach.

If `PhpSettingsCheckService` is fine should I move it to DI like `Translator`?