### PR TITLE
Fix possible error in tag cloud visualization

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/Cloud.php
+++ b/plugins/CoreVisualizations/Visualizations/Cloud.php
@@ -78,6 +78,7 @@ class Cloud extends Visualization
         }
 
         $this->assignTemplateVar('labelMetadata', $labelMetadata);
+        $this->assignTemplateVar('cloudColumn', $columnToDisplay);
         $this->assignTemplateVar('cloudValues', $cloudValues);
     }
 

--- a/plugins/CoreVisualizations/templates/_dataTableViz_tagCloud.twig
+++ b/plugins/CoreVisualizations/templates/_dataTableViz_tagCloud.twig
@@ -1,4 +1,3 @@
-{% set cloudColumn = properties.columns_to_display[1] %}
 <div class="tagCloud">
 {% for word,value in cloudValues %}
     <span title="{{ value.word|rawSafeDecoded }} ({{ value.value }} {{ properties.translations[cloudColumn]|default(cloudColumn) }})" class="word size{{ value.size }}


### PR DESCRIPTION
fixes #12578

Was not able to reproduce, but the view did not handle if `columns_to_display[1]` was not set. But as the visualization does, it now passes the result to the view...