### PR TITLE
Make "localhost" the default database host form value

### DIFF
--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -82,7 +82,7 @@ class FormDatabaseSetup extends QuickForm2
 
         // default values
         $this->addDataSource(new HTML_QuickForm2_DataSource_Array(array(
-                                                                       'host'          => '127.0.0.1',
+                                                                       'host'          => 'localhost',
                                                                        'type'          => $defaultDatabaseType,
                                                                        'tables_prefix' => 'matomo_',
                                                                   )));


### PR DESCRIPTION
for new installations, replacing 127.0.0.1 to support MySQL / MariaDB unix user authentication
out of the box.

[Unix Socket Authentication](https://mariadb.com/kb/en/library/authentication-plugin-unix-socket/) does not work when the database host is given as `127.0.0.1`, like the current default.

For the NixOS Linux distribution, I [apply this patch downstream](https://github.com/NixOS/nixpkgs/blob/master/pkgs/servers/web-apps/matomo/make-localhost-default-database-host.patch) so that users only need to fill in `matomo` as username without creating, copying and storing a MySQL / MariaDB user pasword and are done.

This of course would require `localhost` to be defined *somehow*, but I never saw a distribution where there wasn't an entry e.g. in `/etc/hosts`.

Note that this is only affecting new installations, and if the database connection would fail, it could still be changed by the user to `127.0.0.1` or whatever they need.