### PR TITLE
Add matomo/component-cache and use new version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "piwik/device-detector": "~3.0",
         "piwik/decompress": "~1.0",
         "piwik/network": "~0",
-        "piwik/cache": "~1.0.0",
         "piwik/ini": "^1.0.6",
         "php-di/php-di": "^5.0.0",
         "psr/log": "~1.0",
@@ -46,7 +45,8 @@
         "tecnickcom/tcpdf": "~6.0",
         "piwik/piwik-php-tracker": "^1.0",
         "composer/semver": "~1.3.0",
-        "szymach/c-pchart": "^2.0"
+        "szymach/c-pchart": "^2.0",
+        "matomo/cache": "dev-small-mods@dev"
     },
     "require-dev": {
         "aws/aws-sdk-php": "2.7.1",
@@ -57,6 +57,7 @@
         "symfony/yaml": "~2.6.0"
     },
     "repositories": [
+        {"type":"vcs", "url":"https://github.com/matomo-org/component-cache"},
         {
             "type": "package",
             "package": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "piwik/piwik-php-tracker": "^1.0",
         "composer/semver": "~1.3.0",
         "szymach/c-pchart": "^2.0",
-        "matomo/cache": "dev-small-mods@dev"
+        "matomo/cache": "dev-small-mods@dev",
+        "piwik/cache": "^1.0"
     },
     "require-dev": {
         "aws/aws-sdk-php": "2.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "09fe6cb3a6b305cd0013ee7cb97e4635",
+    "content-hash": "cf282f530d9f7a29b9e0461a7fffcc16",
     "packages": [
         {
             "name": "composer/semver",
@@ -101,16 +101,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3"
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/b6f544a20f4807e81f7044d31e679ccbb1866dc3",
-                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/eb152c5100571c7a45470ff2a35095ab3f3b900b",
+                "reference": "eb152c5100571c7a45470ff2a35095ab3f3b900b",
                 "shasum": ""
             },
             "require": {
@@ -167,7 +167,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29T11:16:17+00:00"
+            "time": "2017-07-22T12:49:21+00:00"
         },
         {
             "name": "leafo/lessphp",
@@ -209,6 +209,61 @@
             "description": "lessphp is a compiler for LESS written in PHP.",
             "homepage": "http://leafo.net/lessphp/",
             "time": "2014-11-24T18:39:20+00:00"
+        },
+        {
+            "name": "matomo/cache",
+            "version": "dev-small-mods",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/matomo-org/component-cache.git",
+                "reference": "4ae0db14f780d8491a64ddfa8267e98dd95c6b54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/matomo-org/component-cache/zipball/4ae0db14f780d8491a64ddfa8267e98dd95c6b54",
+                "reference": "4ae0db14f780d8491a64ddfa8267e98dd95c6b54",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "~1.4",
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matomo\\Cache\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\Matomo\\Cache\\": "tests/"
+                }
+            },
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "The Matomo Team",
+                    "email": "hello@matomo.org",
+                    "homepage": "https://matomo.org/the-matomo-team/"
+                }
+            ],
+            "description": "PHP caching library based on Doctrine cache",
+            "keywords": [
+                "array",
+                "cache",
+                "file",
+                "redis"
+            ],
+            "support": {
+                "source": "https://github.com/matomo-org/component-cache/tree/small-mods",
+                "issues": "https://github.com/matomo-org/component-cache/issues"
+            },
+            "time": "2018-03-04T20:50:49+00:00"
         },
         {
             "name": "matomo/referrer-spam-blacklist",
@@ -735,54 +790,6 @@
                 "reflection"
             ],
             "time": "2015-11-29T10:34:25+00:00"
-        },
-        {
-            "name": "piwik/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/piwik/component-cache.git",
-                "reference": "5f6652574440d9886741918a1e4dc1c555820501"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/piwik/component-cache/zipball/5f6652574440d9886741918a1e4dc1c555820501",
-                "reference": "5f6652574440d9886741918a1e4dc1c555820501",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/cache": "~1.4",
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Piwik\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "The Piwik Team",
-                    "email": "hello@piwik.org",
-                    "homepage": "http://piwik.org/the-piwik-team/"
-                }
-            ],
-            "description": "PHP caching library based on Doctrine cache",
-            "keywords": [
-                "array",
-                "cache",
-                "file",
-                "redis"
-            ],
-            "abandoned": "matomo/cache",
-            "time": "2016-11-15T02:33:06+00:00"
         },
         {
             "name": "piwik/decompress",
@@ -2956,6 +2963,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "matomo/cache": 20,
         "facebook/xhprof": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf282f530d9f7a29b9e0461a7fffcc16",
+    "content-hash": "4c811ccff12dccfc2a431c7562344b60",
     "packages": [
         {
             "name": "composer/semver",
@@ -790,6 +790,54 @@
                 "reflection"
             ],
             "time": "2015-11-29T10:34:25+00:00"
+        },
+        {
+            "name": "piwik/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/piwik/component-cache.git",
+                "reference": "5f6652574440d9886741918a1e4dc1c555820501"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/piwik/component-cache/zipball/5f6652574440d9886741918a1e4dc1c555820501",
+                "reference": "5f6652574440d9886741918a1e4dc1c555820501",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "~1.4",
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Piwik\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "The Piwik Team",
+                    "email": "hello@piwik.org",
+                    "homepage": "http://piwik.org/the-piwik-team/"
+                }
+            ],
+            "description": "PHP caching library based on Doctrine cache",
+            "keywords": [
+                "array",
+                "cache",
+                "file",
+                "redis"
+            ],
+            "abandoned": "matomo/cache",
+            "time": "2016-11-15T02:33:06+00:00"
         },
         {
             "name": "piwik/decompress",

--- a/config/environment/dev.php
+++ b/config/environment/dev.php
@@ -2,7 +2,7 @@
 
 return array(
 
-    'Piwik\Cache\Backend' => DI\object('Piwik\Cache\Backend\ArrayCache'),
+    'Matomo\Cache\Backend' => DI\object('Matomo\Cache\Backend\ArrayCache'),
 
     'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\LoaderCache')
         ->constructor(DI\get('Piwik\Translation\Loader\DevelopmentLoader')),

--- a/config/environment/test.php
+++ b/config/environment/test.php
@@ -10,7 +10,7 @@ return array(
     // Disable logging
     'Psr\Log\LoggerInterface' => DI\object('Psr\Log\NullLogger'),
 
-    'Piwik\Cache\Backend' => function () {
+    'Matomo\Cache\Backend' => function () {
         return \Piwik\Cache::buildBackend('file');
     },
     'cache.eager.cache_id' => 'eagercache-test-',

--- a/config/global.php
+++ b/config/global.php
@@ -2,7 +2,7 @@
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\NotFoundException;
-use Piwik\Cache\Eager;
+use Matomo\Cache\Eager;
 use Piwik\SettingsServer;
 use Piwik\Config;
 
@@ -31,8 +31,8 @@ return array(
 
     'path.cache' => DI\string('{path.tmp}/cache/tracker/'),
 
-    'Piwik\Cache\Eager' => function (ContainerInterface $c) {
-        $backend = $c->get('Piwik\Cache\Backend');
+    'Matomo\Cache\Eager' => function (ContainerInterface $c) {
+        $backend = $c->get('Matomo\Cache\Backend');
         $cacheId = $c->get('cache.eager.cache_id');
 
         if (SettingsServer::isTrackerApiRequest()) {
@@ -50,7 +50,7 @@ return array(
 
         return $cache;
     },
-    'Piwik\Cache\Backend' => function (ContainerInterface $c) {
+    'Matomo\Cache\Backend' => function (ContainerInterface $c) {
         // If Piwik is not installed yet, it's possible the tmp/ folder is not writable
         // we prevent failing with an unclear message eg. coming from doctrine-cache
         // by forcing to use a cache backend which always works ie. array

--- a/core/Cache.php
+++ b/core/Cache.php
@@ -8,7 +8,11 @@
  */
 namespace Piwik;
 
-use Piwik\Cache\Backend;
+use Matomo\Cache\Backend;
+use Matomo\Cache\Eager;
+use Matomo\Cache\Lazy;
+use Matomo\Cache\Transient;
+use Piwik\Cache\BackendAdapter;
 use Piwik\Container\StaticContainer;
 
 class Cache
@@ -20,22 +24,22 @@ class Cache
      * an entry from the cache it will fetch the entry. Cache entries might be persisted but not necessarily. It
      * depends on the configured backend.
      *
-     * @return Cache\Lazy
+     * @return \Matomo\Cache\Lazy
      */
     public static function getLazyCache()
     {
-        return StaticContainer::get('Piwik\Cache\Lazy');
+        return StaticContainer::get(Lazy::class);
     }
 
     /**
      * This class is used to cache any data during one request. It won't be persisted between requests and it can
      * cache all kind of data, even objects or resources. This cache is very fast.
      *
-     * @return Cache\Transient
+     * @return \Matomo\Cache\Transient
      */
     public static function getTransientCache()
     {
-        return StaticContainer::get('Piwik\Cache\Transient');
+        return StaticContainer::get(Transient::class);
     }
 
     /**
@@ -49,11 +53,11 @@ class Cache
      * All cache entries it contains have the same life time. For fast performance it won't validate any cache ids.
      * It is not possible to cache any objects using this cache.
      *
-     * @return Cache\Eager
+     * @return \Matomo\Cache\Eager
      */
     public static function getEagerCache()
     {
-        return StaticContainer::get('Piwik\Cache\Eager');
+        return StaticContainer::get(Eager::class);
     }
 
     public static function flushAll()
@@ -65,11 +69,11 @@ class Cache
 
     /**
      * @param $type
-     * @return Cache\Backend
+     * @return Backend
      */
     public static function buildBackend($type)
     {
-        $factory = new Cache\Backend\Factory();
+        $factory = new Backend\Factory();
         $options = self::getOptions($type);
 
         $backend = $factory->buildBackend($type, $options);

--- a/core/CronArchive/SegmentArchivingRequestUrlProvider.php
+++ b/core/CronArchive/SegmentArchivingRequestUrlProvider.php
@@ -7,8 +7,8 @@
  */
 namespace Piwik\CronArchive;
 
-use Piwik\Cache\Cache;
-use Piwik\Cache\Transient;
+use Matomo\Cache\Cache;
+use Matomo\Cache\Transient;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Period\Factory as PeriodFactory;

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -280,7 +280,6 @@ class FrontController extends Singleton
             }
 
             Log::debug($exception);
-
             /**
              * Triggered when Piwik cannot connect to the database.
              *

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -110,7 +110,7 @@ class Plugin
      * perfect but efficient. If the cache is used we need to make sure to call setId() before usage as there
      * is maybe a different key set since last usage.
      *
-     * @var \Piwik\Cache\Eager
+     * @var \Matomo\Cache\Eager
      */
     private $cache;
 

--- a/core/Tracker/Cache.php
+++ b/core/Tracker/Cache.php
@@ -27,12 +27,12 @@ class Cache
 
     /**
      * Public for tests only
-     * @var \Piwik\Cache\Lazy
+     * @var \Matomo\Cache\Lazy
      */
     public static $cache;
 
     /**
-     * @return \Piwik\Cache\Lazy
+     * @return \Matomo\Cache\Lazy
      */
     private static function getCache()
     {

--- a/core/Tracker/TableLogAction/Cache.php
+++ b/core/Tracker/TableLogAction/Cache.php
@@ -31,11 +31,11 @@ class Cache
     private $logger;
 
     /**
-     * @var \Piwik\Cache\Lazy
+     * @var \Matomo\Cache\Lazy
      */
     private $cache;
 
-    public function __construct(LoggerInterface $logger, Config $config, \Piwik\Cache\Lazy $cache)
+    public function __construct(LoggerInterface $logger, Config $config, \Matomo\Cache\Lazy $cache)
     {
         $this->isEnabled = (bool)$config->General['enable_segments_subquery_cache'];
         $this->limitActionIds = $config->General['segments_subquery_cache_limit'];

--- a/core/Translation/Loader/LoaderCache.php
+++ b/core/Translation/Loader/LoaderCache.php
@@ -8,7 +8,7 @@
 
 namespace Piwik\Translation\Loader;
 
-use Piwik\Cache;
+use Matomo\Cache;
 
 /**
  * Caches the translations loaded by another loader.

--- a/plugins/Marketplace/Api/Client.php
+++ b/plugins/Marketplace/Api/Client.php
@@ -8,7 +8,7 @@
  */
 namespace Piwik\Plugins\Marketplace\Api;
 
-use Piwik\Cache;
+use Matomo\Cache;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Filesystem;

--- a/plugins/Marketplace/Plugins/InvalidLicenses.php
+++ b/plugins/Marketplace/Plugins/InvalidLicenses.php
@@ -8,7 +8,7 @@
  */
 namespace Piwik\Plugins\Marketplace\Plugins;
 
-use Piwik\Cache;
+use Matomo\Cache;
 use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Plugins\Marketplace\Api\Client;

--- a/plugins/Marketplace/tests/Framework/Mock/Client.php
+++ b/plugins/Marketplace/tests/Framework/Mock/Client.php
@@ -8,8 +8,8 @@
 
 namespace Piwik\Plugins\Marketplace\tests\Framework\Mock;
 
-use Piwik\Cache\Backend\NullCache;
-use Piwik\Cache\Lazy;
+use Matomo\Cache\Backend\NullCache;
+use Matomo\Cache\Lazy;
 use Psr\Log\NullLogger;
 
 class Client {

--- a/plugins/Marketplace/tests/Integration/Plugins/InvalidLicensesTest.php
+++ b/plugins/Marketplace/tests/Integration/Plugins/InvalidLicensesTest.php
@@ -8,8 +8,8 @@
 
 namespace Piwik\Plugins\Marketplace\tests\Integration\Plugins;
 
-use Piwik\Cache\Backend\ArrayCache;
-use Piwik\Cache\Eager;
+use Matomo\Cache\Backend\ArrayCache;
+use Matomo\Cache\Eager;
 use Piwik\Container\StaticContainer;
 use Piwik\Plugins\Marketplace\Consumer;
 use Piwik\Plugins\Marketplace\Plugins;

--- a/plugins/SEO/Metric/ProviderCache.php
+++ b/plugins/SEO/Metric/ProviderCache.php
@@ -21,7 +21,7 @@ class ProviderCache implements MetricsProvider
     private $provider;
 
     /**
-     * @var Cache\Lazy
+     * @var \Matomo\Cache\Lazy
      */
     private $cache;
 

--- a/plugins/SegmentEditor/Services/StoredSegmentService.php
+++ b/plugins/SegmentEditor/Services/StoredSegmentService.php
@@ -9,7 +9,7 @@
 namespace Piwik\Plugins\SegmentEditor\Services;
 
 use Piwik\Plugins\SegmentEditor\Model;
-use Piwik\Cache\Transient as TransientCache;
+use Matomo\Cache\Transient as TransientCache;
 
 
 /**

--- a/plugins/UserCountry/VisitorGeolocator.php
+++ b/plugins/UserCountry/VisitorGeolocator.php
@@ -8,8 +8,8 @@
  */
 namespace Piwik\Plugins\UserCountry;
 
-use Piwik\Cache\Cache;
-use Piwik\Cache\Transient;
+use Matomo\Cache\Cache;
+use Matomo\Cache\Transient;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\RawLogDao;

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -13,7 +13,7 @@ use Piwik\Archive;
 use Piwik\ArchiveProcessor\PluginsArchiver;
 use Piwik\Auth;
 use Piwik\Auth\Password;
-use Piwik\Cache\Backend\File;
+use Matomo\Cache\Backend\File;
 use Piwik\Cache as PiwikCache;
 use Piwik\Common;
 use Piwik\Config;

--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -98,7 +98,7 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
             \Piwik\Profiler::setupProfilerXHProf($mainRun = false, $setupDuringTracking = true);
         }
 
-        \Piwik\Cache\Backend\File::$invalidateOpCacheBeforeRead = true;
+        \Matomo\Cache\Backend\File::$invalidateOpCacheBeforeRead = true;
     }
 
     public function onEnvironmentBootstrapped()

--- a/tests/PHPUnit/Integration/CacheTest.php
+++ b/tests/PHPUnit/Integration/CacheTest.php
@@ -24,8 +24,8 @@ class CacheTest extends IntegrationTestCase
         $cache = Cache::getEagerCache();
         $cache->save('test', 'mycontent'); // make sure something was changed, otherwise it won't save anything
 
-        /** @var Cache\Backend $backend */
-        $backend = StaticContainer::get('Piwik\Cache\Backend');
+        /** @var \Matomo\Cache\Backend $backend */
+        $backend = StaticContainer::get('Matomo\Cache\Backend');
         $this->assertFalse($backend->doContains($storageId));
 
         Piwik::postEvent('Request.dispatch.end'); // should trigger save

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -1661,17 +1661,17 @@ log_visit.visit_total_actions
     {
         $self = $this;
 
-        $cacheProxy = $this->getMockBuilder('Piwik\Cache\Lazy')
+        $cacheProxy = $this->getMockBuilder('Matomo\Cache\Lazy')
                            ->setMethods(array('fetch', 'contains', 'save', 'delete', 'flushAll'))
                            ->disableOriginalConstructor()
                            ->getMock();
 
         $cacheProxy->expects($this->any())->method('fetch')->willReturnCallback(function ($id) {
-            $realCache = StaticContainer::get('Piwik\Cache\Lazy');
+            $realCache = StaticContainer::get('Matomo\Cache\Lazy');
             return $realCache->fetch($id);
         });
         $cacheProxy->expects($this->any())->method('contains')->willReturnCallback(function ($id) use ($self) {
-            $realCache = StaticContainer::get('Piwik\Cache\Lazy');
+            $realCache = StaticContainer::get('Matomo\Cache\Lazy');
 
             $result = $realCache->contains($id);
             if ($result) {
@@ -1681,15 +1681,15 @@ log_visit.visit_total_actions
             return $result;
         });
         $cacheProxy->expects($this->any())->method('save')->willReturnCallback(function ($id, $data, $lifetime = 0) {
-            $realCache = StaticContainer::get('Piwik\Cache\Lazy');
+            $realCache = StaticContainer::get('Matomo\Cache\Lazy');
             return $realCache->save($id, $data, $lifetime);
         });
         $cacheProxy->expects($this->any())->method('delete')->willReturnCallback(function ($id) {
-            $realCache = StaticContainer::get('Piwik\Cache\Lazy');
+            $realCache = StaticContainer::get('Matomo\Cache\Lazy');
             return $realCache->delete($id);
         });
         $cacheProxy->expects($this->any())->method('flushAll')->willReturnCallback(function () {
-            $realCache = StaticContainer::get('Piwik\Cache\Lazy');
+            $realCache = StaticContainer::get('Matomo\Cache\Lazy');
             return $realCache->flushAll();
         });
 

--- a/tests/PHPUnit/Unit/CacheTest.php
+++ b/tests/PHPUnit/Unit/CacheTest.php
@@ -8,6 +8,9 @@
 
 namespace Piwik\Tests\Unit;
 
+use Matomo\Cache\Eager;
+use Matomo\Cache\Lazy;
+use Matomo\Cache\Transient;
 use Piwik\Cache;
 
 /**
@@ -19,7 +22,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
     {
         $cache = Cache::getLazyCache();
 
-        $this->assertTrue($cache instanceof Cache\Lazy);
+        $this->assertTrue($cache instanceof Lazy);
     }
 
     public function test_getLazyCache_shouldAlwaysReturnTheSameInstance()
@@ -34,7 +37,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
     {
         $cache = Cache::getEagerCache();
 
-        $this->assertTrue($cache instanceof Cache\Eager);
+        $this->assertTrue($cache instanceof Eager);
     }
 
     public function test_getEagerCache_shouldAlwaysReturnTheSameInstance()
@@ -49,7 +52,7 @@ class CacheTest extends \PHPUnit_Framework_TestCase
     {
         $cache = Cache::getTransientCache();
 
-        $this->assertTrue($cache instanceof Cache\Transient);
+        $this->assertTrue($cache instanceof Transient);
     }
 
     public function test_getTransientCache_shouldAlwaysReturnTheSameInstance()

--- a/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
+++ b/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
@@ -84,6 +84,8 @@ class DeprecatedMethodsTest extends \PHPUnit_Framework_TestCase
 
         // THIS IS A REMINDER FOR PIWIK 4: We need to rename getColumnType() to getDbColumnType() and $columnType to $dbColumnType
         $this->assertDeprecatedMethodIsRemovedInPiwik4('Piwik\Columns\Dimension', 'getType');
+
+        $this->assertDeprecatedClassIsRemovedInPiwik4('Piwik\Cache\Backend\File');
     }
 
 
@@ -129,6 +131,11 @@ class DeprecatedMethodsTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($classExists, $errorMessage);
     }
 
+    private function assertDeprecatedClassIsRemovedInPiwik4($className)
+    {
+        $this->assertDeprecatedClassIsRemovedInPiwikVersion('4.0.0-b1', $className);
+    }
+
     private function assertDeprecatedMethodIsRemovedInPiwik3b1($className, $method)
     {
         $this->assertDeprecatedMethodIsRemovedInPiwikVersion('3.0.0-b1', $className, $method);
@@ -160,5 +167,20 @@ class DeprecatedMethodsTest extends \PHPUnit_Framework_TestCase
 
         $errorMessage = $className . '::' . $method . ' should be removed as the method is deprecated but it is not.';
         $this->assertFalse($methodExists, $errorMessage);
+    }
+
+    private function assertDeprecatedClassIsRemovedInPiwikVersion($piwikVersion, $className)
+    {
+        $version = Version::VERSION;
+        $classExists = class_exists($className);
+
+        if (-1 === version_compare($version, $piwikVersion)) {
+            $errorMessage = $className . ' should still exists until ' . $piwikVersion . ' although it is deprecated.';
+            $this->assertTrue($classExists, $errorMessage);
+            return;
+        }
+
+        $errorMessage = $className . ' should be removed as the class is deprecated but it is not.';
+        $this->assertFalse($classExists, $errorMessage);
     }
 }

--- a/tests/PHPUnit/Unit/Translation/Loader/LoaderCacheTest.php
+++ b/tests/PHPUnit/Unit/Translation/Loader/LoaderCacheTest.php
@@ -8,8 +8,8 @@
 
 namespace Piwik\Tests\Unit\Translation\Loader;
 
-use Piwik\Cache\Backend\ArrayCache;
-use Piwik\Cache\Lazy;
+use Matomo\Cache\Backend\ArrayCache;
+use Matomo\Cache\Lazy;
 use Piwik\Translation\Loader\LoaderCache;
 
 /**
@@ -19,7 +19,7 @@ class LoaderCacheTest extends \PHPUnit_Framework_TestCase
 {
     public function test_shouldNotLoad_ifInCache()
     {
-        $cache = $this->getMock('Piwik\Cache\Lazy', array(), array(), '', false);
+        $cache = $this->getMock('Matomo\Cache\Lazy', array(), array(), '', false);
         $cache->expects($this->any())
             ->method('fetch')
             ->willReturn(array('translations!'));
@@ -35,7 +35,7 @@ class LoaderCacheTest extends \PHPUnit_Framework_TestCase
 
     public function test_shouldLoad_ifNotInCache()
     {
-        $cache = $this->getMock('Piwik\Cache\Lazy', array(), array(), '', false);
+        $cache = $this->getMock('Matomo\Cache\Lazy', array(), array(), '', false);
         $cache->expects($this->any())
             ->method('fetch')
             ->willReturn(null);


### PR DESCRIPTION
**NOTE: do not merge this until the component-cache PR is merged & a new release made, AND after this PR is updated w/ the new version. Currently it's using a branch so we can see the tests pass.**

Changes:

* Update matomo/cache version & uses of Piwik\Cache => Matomo\Cache throughout Piwik core.
* Include original 1.X piwik/cache to keep backwards compatibility.

Note: the system test failure exists on 3.x-dev as well, not sure if it's random or not.
