### PR TITLE
Disable visitorid overrides for third party cookie

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -657,28 +657,30 @@ class Request
      *
      * @throws Exception
      */
-    public function getVisitorId()
+    public function getVisitorId($forThirdPartyCookie = false)
     {
         $found = false;
-
-        // If User ID is set it takes precedence
-        $userId = $this->getForcedUserId();
-        if ($userId) {
-            $userIdHashed = $this->getUserIdHashed($userId);
-            $idVisitor = $this->truncateIdAsVisitorId($userIdHashed);
-            Common::printDebug("Request will be recorded for this user_id = " . $userId . " (idvisitor = $idVisitor)");
-            $found = true;
-        }
-
-        // Was a Visitor ID "forced" (@see Tracking API setVisitorId()) for this request?
-        if (!$found) {
-            $idVisitor = $this->getForcedVisitorId();
-            if (!empty($idVisitor)) {
-                if (strlen($idVisitor) != Tracker::LENGTH_HEX_ID_STRING) {
-                    throw new InvalidRequestParameterException("Visitor ID (cid) $idVisitor must be " . Tracker::LENGTH_HEX_ID_STRING . " characters long");
-                }
-                Common::printDebug("Request will be recorded for this idvisitor = " . $idVisitor);
+        
+        if (!$forThirdPartyCookie) {
+            // If User ID is set it takes precedence
+            $userId = $this->getForcedUserId();
+            if ($userId) {
+                $userIdHashed = $this->getUserIdHashed($userId);
+                $idVisitor = $this->truncateIdAsVisitorId($userIdHashed);
+                Common::printDebug("Request will be recorded for this user_id = " . $userId . " (idvisitor = $idVisitor)");
                 $found = true;
+            }
+    
+            // Was a Visitor ID "forced" (@see Tracking API setVisitorId()) for this request?
+            if (!$found) {
+                $idVisitor = $this->getForcedVisitorId();
+                if (!empty($idVisitor)) {
+                    if (strlen($idVisitor) != Tracker::LENGTH_HEX_ID_STRING) {
+                        throw new InvalidRequestParameterException("Visitor ID (cid) $idVisitor must be " . Tracker::LENGTH_HEX_ID_STRING . " characters long");
+                    }
+                    Common::printDebug("Request will be recorded for this idvisitor = " . $idVisitor);
+                    $found = true;
+                }
             }
         }
 

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -175,7 +175,7 @@ class Visit implements VisitInterface
         }
 
         // update the cookie with the new visit information
-        $this->request->setThirdPartyCookie($this->visitProperties->getProperty('idvisitor'));
+        $this->request->setThirdPartyCookie($this->request->getVisitorId(true));
 
         foreach ($this->requestProcessors as $processor) {
             Common::printDebug("Executing " . get_class($processor) . "::recordLogs()...");


### PR DESCRIPTION
Once a browser has been asigned a global visitorid (aka _pk_uid) site-local overrides should not change its value.

Note: The Queued Tracking Plugin also needs to be adjusted for this change.

At the moment this is just a proposal, I will contact @mattab to discuss this issue.
