### PR TITLE
Added cookie_domain setting for third party cookie

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -677,6 +677,11 @@ cookie_expire = 33955200;
 ; This is used for the Ignore cookie, and the third party cookie if use_third_party_id_cookie = 1
 cookie_path =
 
+; The domain on the server in which the cookie will be available on.
+; Defaults to empty. See spec in https://curl.haxx.se/rfc/cookie_spec.html
+; This is used for the third party cookie if use_third_party_id_cookie = 1
+cookie_domain =
+
 ; set to 0 if you want to stop tracking the visitors. Useful if you need to stop all the connections on the DB.
 record_statistics = 1
 

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -629,7 +629,14 @@ class Request
             $this->getCookieName(),
             $this->getCookieExpire(),
             $this->getCookiePath());
+       
+        $domain = $this->getCookieDomain();
+        if (!empty($domain)) {
+            $cookie->setDomain($domain);
+        }
+            
         Common::printDebug($cookie);
+        
         return $cookie;
     }
 
@@ -646,6 +653,11 @@ class Request
     protected function getCookiePath()
     {
         return TrackerConfig::getConfigValue('cookie_path');
+    }
+
+    protected function getCookieDomain()
+    {
+        return TrackerConfig::getConfigValue('cookie_domain');
     }
 
     /**


### PR DESCRIPTION
Added setting "cookie_domain" for third party cookies.
This is useful, when piwik is running on a subdomain, and you want to access the global visitorid (_pk_uid) from your websites.

Maybe it would be also a good idea to adjust the JS API to allow easy access to the global visitorid.

At the moment this is just a proposal, I will contact @mattab .
