### PR TITLE
Fix AutoSuggest tests for segments with date types

### DIFF
--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -67,6 +67,12 @@ class API extends \Piwik\Plugin\API
      */
     private $processedReport;
 
+    /**
+     * For Testing purpose only
+     * @var int
+     */
+    public static $_autoSuggestLookBack = 60;
+
     public function __construct(SettingsProvider $settingsProvider, ProcessedReport $processedReport)
     {
         $this->settingsProvider = $settingsProvider;
@@ -602,7 +608,7 @@ class API extends \Piwik\Plugin\API
 
     private function getSuggestedValuesForSegmentName($idSite, $segment, $maxSuggestionsToReturn)
     {
-        $startDate = Date::now()->subDay(60)->toString();
+        $startDate = Date::now()->subDay(self::$_autoSuggestLookBack)->toString();
         $requestLastVisits = "method=Live.getLastVisitsDetails
         &idSite=$idSite
         &period=range
@@ -738,7 +744,7 @@ class Plugin extends \Piwik\Plugin
     }
 
     /**
-     * @see Piwik\Plugin::registerEvents
+     * @see \Piwik\Plugin::registerEvents
      */
     public function registerEvents()
     {

--- a/tests/PHPUnit/System/AutoSuggestAPITest.php
+++ b/tests/PHPUnit/System/AutoSuggestAPITest.php
@@ -214,8 +214,7 @@ class AutoSuggestAPITest extends SystemTestCase
     }
 }
 
-$year = date('m') > 1 ? date('Y') : (date('Y') - 1);
-$date = mktime(0, 0, 0, 1, 1, $year);
+$date = mktime(0, 0, 0, 1, 1, 2018);
 
 $lookBack = ceil((time() - $date) / 86400);
 

--- a/tests/PHPUnit/System/AutoSuggestAPITest.php
+++ b/tests/PHPUnit/System/AutoSuggestAPITest.php
@@ -12,6 +12,7 @@ use Piwik\Application\Environment;
 use Piwik\Columns\Dimension;
 use Piwik\Common;
 use Piwik\Date;
+use Piwik\Plugins\API\API;
 use Piwik\Plugins\CustomVariables\Columns\CustomVariableName;
 use Piwik\Plugins\CustomVariables\Columns\CustomVariableValue;
 use Piwik\Plugins\CustomVariables\Model;
@@ -213,5 +214,12 @@ class AutoSuggestAPITest extends SystemTestCase
     }
 }
 
+$year = date('m') > 1 ? date('Y') : (date('Y') - 1);
+$date = mktime(0, 0, 0, 1, 1, $year);
+
+$lookBack = ceil((time() - $date) / 86400);
+
+API::$_autoSuggestLookBack = $lookBack;
+
 AutoSuggestAPITest::$fixture = new ManyVisitsWithGeoIP();
-AutoSuggestAPITest::$fixture->dateTime = Date::yesterday()->subDay(30)->getDatetime();
+AutoSuggestAPITest::$fixture->dateTime = Date::factory($date)->getDatetime();

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerDate__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerDate__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>2</nb_visits>
-	<nb_actions>5</nb_actions>
-	<nb_visits_converted>2</nb_visits_converted>
-	<bounce_count>1</bounce_count>
-	<sum_visit_length>1621</sum_visit_length>
-	<max_actions>4</max_actions>
-	<bounce_rate>50%</bounce_rate>
-	<nb_actions_per_visit>2.5</nb_actions_per_visit>
-	<avg_time_on_site>811</avg_time_on_site>
+	<nb_visits>0</nb_visits>
+	<nb_actions>0</nb_actions>
+	<nb_visits_converted>0</nb_visits_converted>
+	<bounce_count>0</bounce_count>
+	<sum_visit_length>0</sum_visit_length>
+	<max_actions>0</max_actions>
+	<bounce_rate>0%</bounce_rate>
+	<nb_actions_per_visit>0</nb_actions_per_visit>
+	<avg_time_on_site>0</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerDayOfWeek__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerDayOfWeek__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>10</nb_visits>
-	<nb_actions>29</nb_actions>
-	<nb_visits_converted>10</nb_visits_converted>
-	<bounce_count>5</bounce_count>
-	<sum_visit_length>8105</sum_visit_length>
+	<nb_visits>3</nb_visits>
+	<nb_actions>7</nb_actions>
+	<nb_visits_converted>3</nb_visits_converted>
+	<bounce_count>2</bounce_count>
+	<sum_visit_length>1621</sum_visit_length>
 	<max_actions>5</max_actions>
-	<bounce_rate>50%</bounce_rate>
-	<nb_actions_per_visit>2.9</nb_actions_per_visit>
-	<avg_time_on_site>811</avg_time_on_site>
+	<bounce_rate>67%</bounce_rate>
+	<nb_actions_per_visit>2.3</nb_actions_per_visit>
+	<avg_time_on_site>540</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerDayOfYear__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerDayOfYear__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>8</nb_visits>
+	<nb_actions>24</nb_actions>
+	<nb_visits_converted>8</nb_visits_converted>
+	<bounce_count>4</bounce_count>
+	<sum_visit_length>6484</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>50%</bounce_rate>
+	<nb_actions_per_visit>3</nb_actions_per_visit>
+	<avg_time_on_site>811</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerMonth__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerMonth__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>24</nb_visits>
-	<nb_actions>66</nb_actions>
-	<nb_visits_converted>24</nb_visits_converted>
-	<bounce_count>12</bounce_count>
-	<sum_visit_length>19452</sum_visit_length>
+	<nb_visits>35</nb_visits>
+	<nb_actions>95</nb_actions>
+	<nb_visits_converted>35</nb_visits_converted>
+	<bounce_count>18</bounce_count>
+	<sum_visit_length>27557</sum_visit_length>
 	<max_actions>5</max_actions>
-	<bounce_rate>50%</bounce_rate>
-	<nb_actions_per_visit>2.8</nb_actions_per_visit>
-	<avg_time_on_site>811</avg_time_on_site>
+	<bounce_rate>51%</bounce_rate>
+	<nb_actions_per_visit>2.7</nb_actions_per_visit>
+	<avg_time_on_site>787</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerWeekOfYear__VisitsSummary.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_AutoSuggestAPITest_visitEndServerWeekOfYear__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>30</nb_visits>
+	<nb_actions>83</nb_actions>
+	<nb_visits_converted>30</nb_visits_converted>
+	<bounce_count>15</bounce_count>
+	<sum_visit_length>24315</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>50%</bounce_rate>
+	<nb_actions_per_visit>2.8</nb_actions_per_visit>
+	<avg_time_on_site>811</avg_time_on_site>
 </result>


### PR DESCRIPTION
All AutoSuggest tests ran with a date time from `NOW() - 30 days`. This was required as auto suggest only suggests values for the last 60 days. The new date/time segments are failing again and again, as the results vary from day to day. 

I've now implemented an option to modify the look back time for suggestions, so we can use a fixed date for tests

fixes #12606