### PR TITLE
Ensure to also install plugins when there is a POST request

### DIFF
--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -332,10 +332,13 @@ class FrontController extends Singleton
 
         $this->throwIfPiwikVersionIsOlderThanDBSchema();
 
-        if (empty($_GET['module'])
-            || empty($_GET['action'])
-            || $_GET['module'] !== 'Installation'
-            || !in_array($_GET['action'], array('getInstallationCss', 'getInstallationJs'))) {
+        $module = Common::getRequestVar('module', false, 'string');
+        $action = Common::getRequestVar('action', false);
+
+        if (empty($module)
+            || empty($action)
+            || $module !== 'Installation'
+            || !in_array($action, array('getInstallationCss', 'getInstallationJs'))) {
             \Piwik\Plugin\Manager::getInstance()->installLoadedPlugins();
         }
 

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -332,8 +332,8 @@ class FrontController extends Singleton
 
         $this->throwIfPiwikVersionIsOlderThanDBSchema();
 
-        $module = Common::getRequestVar('module', false, 'string');
-        $action = Common::getRequestVar('action', false);
+        $module = Piwik::getModule();
+        $action = Piwik::getAction();
 
         if (empty($module)
             || empty($action)


### PR DESCRIPTION
I'm not sure if this was implemented like this on purpose? But currently we wouldn't be installing any plugin until a request is posted. This can cause various problems for example when a new plugin is activated, but then the user only POSTS requests to API. This requests will then possibly fail as the plugin is not installed. 