### PR TITLE
Trigger DB failed exception also for POST API requests

### DIFF
--- a/plugins/Installation/Installation.php
+++ b/plugins/Installation/Installation.php
@@ -45,7 +45,7 @@ class Installation extends \Piwik\Plugin
 
         $errorMessage = $exception->getMessage();
 
-        if (Request::isApiRequest($_GET)) {
+        if (Request::isApiRequest(null)) {
             $ex = new DatabaseConnectionFailedException($errorMessage);
             throw $ex;
         }


### PR DESCRIPTION
Currently, we show the error only when an API request is done via GET but I think it should be also shown when it is a POST. By passing null it will actually use `GET + POST`.