### PR TITLE
Fix selecting code with one click does not work anymore

### DIFF
--- a/plugins/CoreHome/angularjs/common/directives/select-on-focus.js
+++ b/plugins/CoreHome/angularjs/common/directives/select-on-focus.js
@@ -35,7 +35,13 @@
                     // .select() + focus and blur seems to not work on pre elements
                     var range = document.createRange();
                     range.selectNode(this);
-                    window.getSelection().addRange(range);
+                    var selection = window.getSelection();
+                    if (selection && selection.rangeCount > 0) {
+                        selection.removeAllRanges();
+                    }
+                    if (selection) {
+                        selection.addRange(range);
+                    }
                 }
 
                 function onBlurHandler(event) {


### PR DESCRIPTION
This worked for me locally and seems suggested by https://developer.mozilla.org/en-US/docs/Web/API/Selection/addRange

fix #12637 