### PR TITLE
Show a special offer if one is defined for a plugin

### DIFF
--- a/plugins/Marketplace/templates/plugin-details.twig
+++ b/plugins/Marketplace/templates/plugin-details.twig
@@ -175,6 +175,8 @@
                                 <br />
                             {% endif %}
                         </div>
+                        
+                        {% if plugin.specialOffer is defined and plugin.specialOffer %}<p style="color: green;"><br />{{ plugin.specialOffer }}</p>{% endif %}
 
                         <p><br /></p>
                         <dl>


### PR DESCRIPTION
Tried to integrate it into the description remotely from the marketplace but doesn't look as good as this solution:
![image](https://user-images.githubusercontent.com/273120/37939925-2e0a4bee-31c2-11e8-8787-21a04d61376c.png)
