### PR TITLE
Check for super user access when cleaning visitor details.

### DIFF
--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -155,7 +155,7 @@ class Visitor implements VisitorInterface
     public static function cleanVisitorDetails($visitorDetails)
     {
         $toUnset = array('config_id');
-        if (Piwik::isUserIsAnonymous()) {
+        if (Piwik::isUserIsAnonymous() && !Piwik::hasUserSuperUserAccess()) {
             $toUnset[] = 'idvisitor';
             $toUnset[] = 'user_id';
             $toUnset[] = 'location_ip';


### PR DESCRIPTION
The comment for cleanVisitorDetails() says that the function checks for Super User or admin access, this adds the Super User check.