### PR TITLE
Moves ArchiveWebTest to Integration tests

### DIFF
--- a/tests/PHPUnit/Integration/ArchiveWebTest.php
+++ b/tests/PHPUnit/Integration/ArchiveWebTest.php
@@ -5,7 +5,7 @@
  * @link    http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
-namespace Piwik\Tests\System;
+namespace Piwik\Tests\Integration;
 
 use Piwik\Option;
 use Piwik\Http;

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -599,6 +599,11 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
             return false;
         }
 
+        // ignore downloaded geoip files
+        if(strpos($file, 'GeoIP') !== false && strpos($file, '.dat') !== false) {
+            return false;
+        }
+
         if($this->isFileIsAnIconButDoesNotBelongToDistribution($file)) {
             return false;
         }


### PR DESCRIPTION
To have running tests on travis again I (temporally) move the ArchiveWebTest to Integration tests.
 
refs #12691 