### PR TITLE
Modify IdSite dimension so it is visible in customreports UI for use w/ CustomReports.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -338,6 +338,7 @@
         "ProductRevenue": "Product Revenue",
         "Measurable": "Measurable",
         "Measurables": "Measurables",
+        "MeasurableId": "Measurable ID",
         "PurchasedProducts": "Purchased Products",
         "Quantity": "Quantity",
         "RangeReports": "Custom date ranges",

--- a/plugins/CoreHome/Columns/IdSite.php
+++ b/plugins/CoreHome/Columns/IdSite.php
@@ -8,8 +8,10 @@
  */
 namespace Piwik\Plugins\CoreHome\Columns;
 
-use Piwik\Columns\Join\SiteNameJoin;
+use Piwik\Metrics\Formatter;
+use Piwik\Piwik;
 use Piwik\Plugin\Dimension\VisitDimension;
+use Piwik\Site;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
@@ -23,12 +25,9 @@ class IdSite extends VisitDimension
     // INDEX(idsite, config_id, visit_last_action_time) and we maybe not be sure whether config_id already exists at
     // installing point (we do not know whether visit_last_action_time or idsite column would be added first).
 
+    protected $nameSingular = 'General_Measurable';
+    protected $namePlural = 'General_Measurables';
     protected $type = self::TYPE_TEXT;
-
-    public function getDbColumnJoin()
-    {
-        return new SiteNameJoin();
-    }
 
     /**
      * @param Request $request
@@ -50,5 +49,15 @@ class IdSite extends VisitDimension
     public function onAnyGoalConversion(Request $request, Visitor $visitor, $action)
     {
         return $request->getIdSite();
+    }
+
+    public function formatValue($value, $idSite, Formatter $formatter)
+    {
+        try {
+            return Site::getNameFor($value);
+        } catch (\Exception $ex) {
+            $formatted = parent::formatValue($value, $idSite, $formatter);
+            return Piwik::translate('General_MeasurableId') . ': ' . $formatted;
+        }
     }
 }


### PR DESCRIPTION
Changes:
* Added name singular/plural properties to IdSite dimension so it appears in CustomReports list.
* Add SiteIdJoin and use in IdSite dimension so it selects the idsite and not the site name.
* Add formatValue() method to IdSite to get the site name & retain the site ID (which is appended to the site name). 

![image](https://user-images.githubusercontent.com/125140/38176422-608765ae-35a3-11e8-83f6-14ed993f2c92.png)

Fixes #12409 

CC @mattab / @tsteur 