### PR TITLE
Redirect to a different site if deleting idSite in URL

### DIFF
--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
@@ -191,12 +191,12 @@
 
             // if the current idSite in the URL is the site we're deleting, then we have to make to change it. otherwise,
             // if a user goes to another page, the invalid idSite may cause a fatal error.
-            if (broadcast.getValueFromUrl('idSite') === $scope.site.idsite) {
+            if (broadcast.getValueFromUrl('idSite') == $scope.site.idsite) {
                 var sites = $scope.adminSites.sites;
 
                 var otherSite;
                 for (var i = 0; i !== sites.length; ++i) {
-                    if (sites[i].idsite !== $scope.site.idsite) {
+                    if (sites[i].idsite != $scope.site.idsite) {
                         otherSite = sites[i];
                         break;
                     }

--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
@@ -187,6 +187,25 @@
         };
 
         var deleteSite = function() {
+            var redirectParams = $scope.redirectParams;
+
+            // if the current idSite in the URL is the site we're deleting, then we have to make to change it. otherwise,
+            // if a user goes to another page, the invalid idSite may cause a fatal error.
+            if (broadcast.getValueFromUrl('idSite') === $scope.site.idsite) {
+                var sites = $scope.adminSites.sites;
+
+                var otherSite;
+                for (var i = 0; i !== sites.length; ++i) {
+                    if (sites[i].idsite !== $scope.site.idsite) {
+                        otherSite = sites[i];
+                        break;
+                    }
+                }
+
+                if (otherSite) {
+                    redirectParams = $.extend({}, redirectParams, { idSite: otherSite.idsite });
+                }
+            }
 
             var ajaxHandler = new ajaxHelper();
 
@@ -197,7 +216,7 @@
                 method: 'SitesManager.deleteSite'
             }, 'GET');
 
-            ajaxHandler.redirectOnSuccess($scope.redirectParams);
+            ajaxHandler.redirectOnSuccess(redirectParams);
             ajaxHandler.setLoadingElement();
             ajaxHandler.send();
         };


### PR DESCRIPTION
Avoids later errors if user clicks on a link w/ the invalid idSite.

Fixes #12617 

@matomo-org/core-team  I wonder if it would also be good not to swallow this exception: https://github.com/matomo-org/matomo/blob/3.x-dev/core/Plugin/Controller.php#L133
The error would have made a lot more sense to me w/ an "invalid idSite" message.

TODO:
* [ ] check if this solves the cloud issue, perhaps by patching staging