### PR TITLE
Do not run the same archive command twice

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -282,12 +282,14 @@ class CliMulti
         $hostname = Url::getHost($checkIfTrusted = false);
         $commandToCheck = $this->buildCommand($hostname, $query, $output = '', $escape = false);
 
-        $currentlyRunningJobs = `ps ex`;
+        $currentlyRunningJobs = `ps aux`;
 
         $posStart = strpos($commandToCheck, 'console climulti');
         $posPid = strpos($commandToCheck, '&pid='); // the pid is random each time so we need to ignore it.
         $shortendCommand = substr($commandToCheck, $posStart, $posPid - $posStart);
         // equals eg console climulti:request -q --piwik-domain= --superuser module=API&method=API.get&idSite=1&period=month&date=2018-04-08,2018-04-30&format=php&trigger=archivephp
+        $shortendCommand      = preg_replace("/([&])date=.*?(&|$)/", "", $shortendCommand);
+        $currentlyRunningJobs = preg_replace("/([&])date=.*?(&|$)/", "", $currentlyRunningJobs);
 
         if (strpos($currentlyRunningJobs, $shortendCommand) !== false) {
             Log::debug($shortendCommand . ' is already running');

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -280,22 +280,18 @@ class CliMulti
 
         $query = UrlHelper::getQueryFromUrl($url, array('pid' => 'removeme'));
         $hostname = Url::getHost($checkIfTrusted = false);
-        $commandsToCheck = array();
-        $commandsToCheck[] = $this->buildCommand($hostname, $query, '', true);
-        $commandsToCheck[] = $this->buildCommand($hostname, $query, '', false);
+        $commandToCheck = $this->buildCommand($hostname, $query, $output = '', $escape = false);
 
         $currentlyRunningJobs = `ps ex`;
 
-        foreach ($commandsToCheck as $commandToCheck) {
-            $posStart = strpos($commandToCheck, 'console climulti');
-            $posPid = strpos($commandToCheck, '&pid='); // the pid is random each time so we need to ignore it.
-            $shortendCommand = substr($commandToCheck, $posStart, $posPid - $posStart);
-            // equals eg console climulti:request -q --piwik-domain= --superuser module=API&method=API.get&idSite=1&period=month&date=2018-04-08,2018-04-30&format=php&trigger=archivephp
+        $posStart = strpos($commandToCheck, 'console climulti');
+        $posPid = strpos($commandToCheck, '&pid='); // the pid is random each time so we need to ignore it.
+        $shortendCommand = substr($commandToCheck, $posStart, $posPid - $posStart);
+        // equals eg console climulti:request -q --piwik-domain= --superuser module=API&method=API.get&idSite=1&period=month&date=2018-04-08,2018-04-30&format=php&trigger=archivephp
 
-            if (strpos($currentlyRunningJobs, $shortendCommand) !== false) {
-                Log::debug($shortendCommand . ' is already running');
-                return true;
-            }
+        if (strpos($currentlyRunningJobs, $shortendCommand) !== false) {
+            Log::debug($shortendCommand . ' is already running');
+            return true;
         }
 
         return false;

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -871,9 +871,9 @@ class CronArchive
         $this->visitsToday += $visitsToday;
         $this->websitesWithVisitsSinceLastRun++;
 
-        $this->archiveReportsFor($idSite, "day", $this->getApiDateParameter($idSite, "day", $processDaysSince), $archiveSegments = true, $timer, $visitsToday, $visitsLastDays);
+        $dayArchiveWasSuccessful = $this->archiveReportsFor($idSite, "day", $this->getApiDateParameter($idSite, "day", $processDaysSince), $archiveSegments = true, $timer, $visitsToday, $visitsLastDays);
 
-        return true;
+        return $dayArchiveWasSuccessful;
     }
 
     /**

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -921,6 +921,13 @@ class CronArchive
         // already processed above for "day"
         if ($period != "day") {
 
+            $periodInProgress = $this->isAlreadyArchivingAnyLowerPeriod($idSite, $period);
+            if ($periodInProgress) {
+                $this->logger->info("- skipping archiving for period '{period}' because processing the period '{periodcheck}' is already in progress.", array('period' => $period, 'periodcheck' => $periodInProgress));
+                $success = false;
+                return $success;
+            }
+
             if ($cliMulti->isCommandAlreadyRunning($url)) {
                 $this->logArchiveWebsiteAlreadyInProcess($idSite, $period, $date);
                 $success = false;
@@ -1705,11 +1712,18 @@ class CronArchive
 
         $segmentCount = count($segments);
         $processedSegmentCount = 0;
+
         foreach ($segments as $segment) {
             $dateParamForSegment = $this->segmentArchivingRequestUrlProvider->getUrlParameterDateString($idSite, $period, $date, $segment);
 
             $urlWithSegment = $this->getVisitsRequestUrl($idSite, $period, $dateParamForSegment, $segment);
             $urlWithSegment = $this->makeRequestUrl($urlWithSegment);
+
+            $periodInProgress = $this->isAlreadyArchivingAnyLowerPeriod($idSite, $period);
+            if ($periodInProgress) {
+                $this->logger->info("- skipping segment archiving for period '{period}' with segment '{segment}' because processing the period '{periodcheck}' is already in progress.", array('segment' => $segment, 'period' => $period, 'periodcheck' => $periodInProgress));
+                continue;
+            }
 
             if ($cliMulti->isCommandAlreadyRunning($urlWithSegment)) {
                 $this->logger->info("- skipping segment archiving for '{segment}' because such a process is already in progress.", array('segment' => $segment));
@@ -1732,6 +1746,32 @@ class CronArchive
         }
 
         return $urlsWithSegment;
+    }
+
+    private function isAlreadyArchivingAnyLowerPeriod($idSite, $period, $segment = false)
+    {
+        $periodOrder = array('day', 'week', 'month', 'year');
+        $cliMulti = $this->makeCliMulti();
+
+        $index = array_search($period, $periodOrder);
+        if ($index > 0) {
+            // we only need to check for week, month, year if any earlier period is already running
+            // so when period = month, then we check for day and week
+
+            for ($i = 0; $i < $index; $i++) {
+                $periodToCheck = $periodOrder[$i];
+
+                // the date will be ignored in isCommandAlreadyRunning() because it could be any date
+                $urlCheck = $this->getVisitsRequestUrl($idSite, $periodToCheck, 'last2', $segment);
+                $urlCheck = $this->makeRequestUrl($urlCheck);
+
+                if ($cliMulti->isCommandAlreadyRunning($urlCheck)) {
+                    return $periodToCheck;
+                }
+            }
+        }
+
+        return false;
     }
 
     private function createSitesToArchiveQueue($websitesIds)

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -940,11 +940,6 @@ class CronArchive
                 $urls[] = $url;
                 $this->logArchiveWebsite($idSite, $period, $date);
             }
-        } else {
-            if ($cliMulti->isCommandAlreadyRunning($url)) {
-                $this->logArchiveWebsiteAlreadyInProcess($idSite, $period, $date);
-                return;
-            }
         }
 
         $segmentRequestsCount = 0;

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -714,6 +714,10 @@ class CronArchive
             $date = $this->getApiDateParameter($idSite, $period, $lastTimestampWebsiteProcessedPeriods);
             $periodArchiveWasSuccessful = $this->archiveReportsFor($idSite, $period, $date, $archiveSegments = true, $timer);
             $success = $periodArchiveWasSuccessful && $success;
+            if(!$success) {
+                // if it failed, we abort the current website processing
+                return $success;
+            }
         }
 
         if ($this->shouldProcessPeriod('range')) {
@@ -808,6 +812,7 @@ class CronArchive
         $cliMulti = $this->makeCliMulti();
         if ($cliMulti->isCommandAlreadyRunning($this->makeRequestUrl($url))) {
             $this->logger->info("Skipped website id $idSite, such a process is already in progress, " . $timerWebsite->__toString());
+            $this->skipped++;
             return false;
         }
 
@@ -928,6 +933,8 @@ class CronArchive
         if ($period != "day") {
             if ($cliMulti->isCommandAlreadyRunning($url)) {
                 $this->logArchiveWebsiteAlreadyInProcess($idSite, $period, $date);
+                $success = false;
+                return $success;
             } else {
                 $urls[] = $url;
                 $this->logArchiveWebsite($idSite, $period, $date);

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -924,6 +924,7 @@ class CronArchive
         $cliMulti = $this->makeCliMulti();
 
         $noSegmentUrl = $url;
+
         // already processed above for "day"
         if ($period != "day") {
             if ($cliMulti->isCommandAlreadyRunning($url)) {
@@ -931,6 +932,11 @@ class CronArchive
             } else {
                 $urls[] = $url;
                 $this->logArchiveWebsite($idSite, $period, $date);
+            }
+        } else {
+            if ($cliMulti->isCommandAlreadyRunning($url)) {
+                $this->logArchiveWebsiteAlreadyInProcess($idSite, $period, $date);
+                return;
             }
         }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -932,14 +932,15 @@ class CronArchive
 
         // already processed above for "day"
         if ($period != "day") {
+
             if ($cliMulti->isCommandAlreadyRunning($url)) {
                 $this->logArchiveWebsiteAlreadyInProcess($idSite, $period, $date);
                 $success = false;
                 return $success;
-            } else {
-                $urls[] = $url;
-                $this->logArchiveWebsite($idSite, $period, $date);
             }
+
+            $urls[] = $url;
+            $this->logArchiveWebsite($idSite, $period, $date);
         }
 
         $segmentRequestsCount = 0;
@@ -963,8 +964,10 @@ class CronArchive
 
             if ($noSegmentUrl === $url && $success) {
                 $stats = @unserialize($content);
+
                 if (!is_array($stats)) {
                     $this->logError("Error unserializing the following response from $url: " . $content);
+                    $success = false;
                 }
 
                 if ($period == 'range') {


### PR DESCRIPTION
Currently, the cron archiver might start the same archiving command twice. For example when a site takes long to archive. To avoid running the same archiving process in parallel, we should check if such a job is already running and if so, not start the same archive command again.  

I did some simple testing on my local machine but might need some more testing.

Only supports CLI archiving, not web archiving.