### PR TITLE
Enable LOAD DATA LOCAL INFILE for PHP >= 5.6.17 when mysqlnd is used.

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -580,9 +580,6 @@ tmp_path = "/tmp"
 ; This may for example be useful when doing Mysql AWS replication
 enable_load_data_infile = 1
 
-; Set this setting to 1 when the Matomo php files are not on the same server as the database server
-load_data_infile_remote = 0
-
 ; By setting this option to 0:
 ; - links to Enable/Disable/Uninstall plugins will be hidden and disabled
 ; - links to Uninstall themes will be disabled (but user can still enable/disable themes)

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -580,6 +580,9 @@ tmp_path = "/tmp"
 ; This may for example be useful when doing Mysql AWS replication
 enable_load_data_infile = 1
 
+; Set this setting to 1 when the Matomo php files are not on the same server as the database server
+load_data_infile_remote = 0
+
 ; By setting this option to 0:
 ; - links to Enable/Disable/Uninstall plugins will be hidden and disabled
 ; - links to Uninstall themes will be disabled (but user can still enable/disable themes)


### PR DESCRIPTION
The bug was fixed for mysqlnd in PHP 5.6.17, so "LOAD DATA LOCAL INFILE" can be used when mysqlnd is used and PHP => 5.6.17,

function_exists('mysqli_get_client_stats') is used to check whether mysqlnd is active.

See https://bugs.php.net/bug.php?id=68077