### PR TITLE
Add IP2Location to recommended geolocation providers and fix a possib…

### DIFF
--- a/plugins/UserCountry/Diagnostic/GeolocationDiagnostic.php
+++ b/plugins/UserCountry/Diagnostic/GeolocationDiagnostic.php
@@ -40,7 +40,13 @@ class GeolocationDiagnostic implements Diagnostic
 
         $currentProviderId = LocationProvider::getCurrentProviderId();
         $allProviders = LocationProvider::getAllProviderInfo();
-        $isRecommendedProvider = in_array($currentProviderId, array(LocationProvider\GeoIp\Php::ID, $currentProviderId == LocationProvider\GeoIp\Pecl::ID));
+        $recommendedProviders = array(LocationProvider\GeoIp\Php::ID, LocationProvider\GeoIp\Pecl::ID);
+        
+        if (defined('\Piwik\Plugins\IP2Location\LocationProvider\IP2Location::ID')) {
+            $recommendedProviders[] = \Piwik\Plugins\IP2Location\LocationProvider\IP2Location::ID;
+        }
+        
+        $isRecommendedProvider = in_array($currentProviderId, $recommendedProviders);
         $isProviderInstalled = (isset($allProviders[$currentProviderId]['status']) && $allProviders[$currentProviderId]['status'] == LocationProvider::INSTALLED);
 
         if ($isRecommendedProvider && $isProviderInstalled) {


### PR DESCRIPTION
Possible bug fix: As I understand it, the "$currentProviderId ==" code part is a possible typo and should not be there.

Changed: Added IP2Location as a recommended geolocation provider. It is a actively maintained plugin that provides good location data.
