### PR TITLE
Use latest referrer spam blacklist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/monolog-bridge": "~2.6.0",
         "symfony/event-dispatcher": "~2.6.0",
         "pear/pear_exception": "~1.0.0",
-        "matomo/referrer-spam-blacklist": "~1.0",
+        "matomo/referrer-spam-blacklist": "~1.1",
         "matomo/searchengine-and-social-list": "~1.0",
         "tecnickcom/tcpdf": "~6.0",
         "piwik/piwik-php-tracker": "^1.0",


### PR DESCRIPTION
My referrer log is full of spam, the domains are on the list but Matomo is using a version of the list from a year ago