### PR TITLE
Log a job ID for cli commands

### DIFF
--- a/plugins/Monolog/Processor/RequestIdProcessor.php
+++ b/plugins/Monolog/Processor/RequestIdProcessor.php
@@ -19,10 +19,6 @@ class RequestIdProcessor
 
     public function __invoke(array $record)
     {
-        if (Common::isPhpCliMode()) {
-            return $record;
-        }
-
         if (empty($this->currentRequestKey)) {
             $this->currentRequestKey = substr(Common::generateUniqId(), 0, 5);
         }

--- a/plugins/Monolog/Processor/RequestIdProcessor.php
+++ b/plugins/Monolog/Processor/RequestIdProcessor.php
@@ -20,7 +20,11 @@ class RequestIdProcessor
     public function __invoke(array $record)
     {
         if (empty($this->currentRequestKey)) {
-            $this->currentRequestKey = substr(Common::generateUniqId(), 0, 5);
+            if (Common::isPhpCliMode()) {
+                $this->currentRequestKey = getmypid();
+            } else {
+                $this->currentRequestKey = substr(Common::generateUniqId(), 0, 5);
+            }
         }
 
         $record['extra']['request_id'] = $this->currentRequestKey;

--- a/plugins/Monolog/config/cli.php
+++ b/plugins/Monolog/config/cli.php
@@ -24,6 +24,6 @@ return array(
         $handler->setFormatter(new ConsoleFormatter($c->get('log.console.format'), null, true, true));
         return $handler;
     },
-    'log.console.format' => '%start_tag%%level_name% [%datetime%]%end_tag% %message%' . PHP_EOL,
+    'log.console.format' => '%start_tag%%level_name% [%datetime%] %extra.request_id% %end_tag% %message%' . PHP_EOL,
 
 );

--- a/plugins/Monolog/tests/Integration/LogTest.php
+++ b/plugins/Monolog/tests/Integration/LogTest.php
@@ -26,12 +26,12 @@ class LogTest extends IntegrationTestCase
 {
     const TESTMESSAGE = 'test%smessage';
     const STRING_MESSAGE_FORMAT = '[%tag%] %message%';
-    const STRING_MESSAGE_FORMAT_SPRINTF = "[%s] %s";
+    const STRING_MESSAGE_FORMAT_SPRINTF = "[%s] [%s] %s";
 
-    public static $expectedExceptionOutput = '[Monolog] LogTest.php(112): dummy error message
+    public static $expectedExceptionOutput = '[Monolog] [%s] LogTest.php(112): dummy error message
   dummy backtrace';
 
-    public static $expectedErrorOutput = '[Monolog] dummyerrorfile.php(145): Unknown error (102) - dummy error string
+    public static $expectedErrorOutput = '[Monolog] [%s] dummyerrorfile.php(145): Unknown error (102) - dummy error string
   dummy backtrace';
 
     public function setUp()
@@ -99,7 +99,7 @@ class LogTest extends IntegrationTestCase
         $error = new \ErrorException("dummy error string", 0, 102, "dummyerrorfile.php", 145);
         Log::error($error);
 
-        $this->checkBackend($backend, self::$expectedErrorOutput, $formatMessage = false, $tag = 'Monolog');
+        $this->checkBackend($backend, sprintf(self::$expectedErrorOutput, getmypid()), $formatMessage = false, $tag = 'Monolog');
     }
 
     /**
@@ -112,7 +112,7 @@ class LogTest extends IntegrationTestCase
         $exception = new Exception("dummy error message");
         Log::error($exception);
 
-        $this->checkBackend($backend, self::$expectedExceptionOutput, $formatMessage = false, $tag = 'Monolog');
+        $this->checkBackend($backend, sprintf(self::$expectedExceptionOutput, getmypid()), $formatMessage = false, $tag = 'Monolog');
     }
 
     /**
@@ -192,7 +192,7 @@ class LogTest extends IntegrationTestCase
     private function checkBackend($backend, $expectedMessage, $formatMessage = false, $tag = false)
     {
         if ($formatMessage) {
-            $expectedMessage = sprintf(self::STRING_MESSAGE_FORMAT_SPRINTF, $tag, $expectedMessage);
+            $expectedMessage = sprintf(self::STRING_MESSAGE_FORMAT_SPRINTF, $tag, getmypid(), $expectedMessage);
         }
 
         if ($backend == 'file') {
@@ -201,7 +201,7 @@ class LogTest extends IntegrationTestCase
             $fileContents = file_get_contents(self::getLogFileLocation());
             $fileContents = $this->removePathsFromBacktrace($fileContents);
 
-            $expectedMessage = str_replace("\n ", "\n[Monolog]", $expectedMessage);
+            $expectedMessage = str_replace("\n ", "\n[Monolog] [" . getmypid() . "]", $expectedMessage);
 
             $this->assertEquals($expectedMessage . "\n", $fileContents);
         } else if ($backend == 'database') {


### PR DESCRIPTION
looks like this where 60d1f is the job ID in this case. We could also wrap it in brackets or something. 

![image](https://user-images.githubusercontent.com/273120/38649253-a07eb910-3e49-11e8-9607-5269dde8c5b5.png)

I'm not sure why this was disabled in the past for cli commands. I'm finding this super useful when investigating issues. For example imagine 2 or more `core:archive > archive.log` are running at the same time. Now both jobs will be writing into that log and it is not clear which action is performed by which process. The requestId lets you `grep` information only for a specific job for example and see when there were for example any possible concurrency issues etc.