### PR TITLE
Do not archive a period when a sub period is processing

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -282,12 +282,14 @@ class CliMulti
         $hostname = Url::getHost($checkIfTrusted = false);
         $commandToCheck = $this->buildCommand($hostname, $query, $output = '', $escape = false);
 
-        $currentlyRunningJobs = `ps ex`;
+        $currentlyRunningJobs = `ps aux`;
 
         $posStart = strpos($commandToCheck, 'console climulti');
         $posPid = strpos($commandToCheck, '&pid='); // the pid is random each time so we need to ignore it.
         $shortendCommand = substr($commandToCheck, $posStart, $posPid - $posStart);
         // equals eg console climulti:request -q --piwik-domain= --superuser module=API&method=API.get&idSite=1&period=month&date=2018-04-08,2018-04-30&format=php&trigger=archivephp
+        $shortendCommand      = preg_replace("/([&])date=.*?(&|$)/", "", $shortendCommand);
+        $currentlyRunningJobs = preg_replace("/([&])date=.*?(&|$)/", "", $currentlyRunningJobs);
 
         if (strpos($currentlyRunningJobs, $shortendCommand) !== false) {
             Log::debug($shortendCommand . ' is already running');


### PR DESCRIPTION
Should fix https://github.com/matomo-org/matomo/issues/12718 but couldn't really test it.

Initially I had a bit different solution where I tried to match exact date but the date in the cli command might be different every day and we should never execute for example any monthly archive if a weekly archive is active.

This PR is based on https://github.com/matomo-org/matomo/pull/12702 and this PR should be merged before #12702