### PR TITLE
piwikUrl.getSearchParam() should not set an empty URL value

### DIFF
--- a/plugins/CoreHome/angularjs/common/services/piwik-url.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik-url.js
@@ -36,11 +36,20 @@
 
             if (!search[paramName]) {
                 // see https://github.com/angular/angular.js/issues/7239 (issue is resolved but problem still exists)
-                search[paramName] = piwik.broadcast.getValueFromUrl(paramName);
+                var paramUrlValue = piwik.broadcast.getValueFromUrl(paramName);
+                if (paramUrlValue !== false
+                    && paramUrlValue !== ''
+                    && paramUrlValue !== null
+                    && paramUrlValue !== undefined
+                    && paramName !== 'token_auth') {
+                    search[paramName] = paramUrlValue;
+                } else {
+                    return paramUrlValue;
+                }
             }
 
             if (search[paramName]) {
-                var value =  search[paramName];
+                var value = search[paramName];
 
                 if (angular.isArray(search[paramName])) {
                     // use last one. Eg when having period=day&period=year angular would otherwise return ['day', 'year']


### PR DESCRIPTION
This fixes an issue that when changing for example the date, suddenly the log in screen is shown.

For example in a plugin I do

`var tokenAuth = piwikUrl.getSearchParam('token_auth')`

Which then sets indirectly `$search.token_auth=''` which then results in `&token_auth=undefined` in the URL. Meaning it will try to authenticate the user for the token `undefined` which won't work. Also I think in general we should not append the URL accidentally ever to the URL in the browser. 

Ideally, the `getSearchParam()` method should certainly not set a value indirectly here and it is a bug but not sure what side effects we would run into by removing the `search[paramName] = paramUrlValue;`

See DEV-1316