### PR TITLE
Escape ampersands in tracker URLs

### DIFF
--- a/plugins/Morpheus/templates/javascriptCode.twig
+++ b/plugins/Morpheus/templates/javascriptCode.twig
@@ -15,6 +15,6 @@
 </script>
 {% if not loadAsync %}<script type='text/javascript' src="{$protocol}{$piwikUrl}/piwik.js"></script>
 {% endif %}
-{% if trackNoScript %}<noscript><p><img src="{$protocol}{$piwikUrl}/piwik.php?idsite={$idSite}&rec=1" style="border:0;" alt="" /></p></noscript>
+{% if trackNoScript %}<noscript><p><img src="{$protocol}{$piwikUrl}/piwik.php?idsite={$idSite}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
 {% endif %}
 <!-- End Matomo Code -->

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -167,10 +167,11 @@ class API extends \Piwik\Plugin\API
          */
         Piwik::postEvent('SitesManager.getImageTrackingCode', array(&$piwikUrl, &$urlParams));
 
-        $piwikUrl = (ProxyHttp::isHttps() ? "https://" : "http://") . $piwikUrl . '/piwik.php';
-        return "<!-- Matomo Image Tracker-->
-<img src=\"$piwikUrl?" . Url::getQueryStringFromParameters($urlParams) . "\" style=\"border:0\" alt=\"\" />
+        $url = (ProxyHttp::isHttps() ? "https://" : "http://") . $piwikUrl . '/piwik.php?' . Url::getQueryStringFromParameters($urlParams);
+        $html = "<!-- Matomo Image Tracker-->
+<img src=\"" . htmlspecialchars($url, ENT_COMPAT, 'UTF-8') . "\" style=\"border:0\" alt=\"\" />
 <!-- End Matomo -->";
+        return htmlspecialchars($html, ENT_COMPAT, 'UTF-8');
     }
 
     /**

--- a/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
@@ -62,7 +62,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
-&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//piwik-server/piwik/piwik.php?idsite=1&amp;rec=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
+&lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//piwik-server/piwik/piwik.php?idsite=1&amp;amp;rec=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
 &lt;!-- End Matomo Code --&gt;
 ";
 


### PR DESCRIPTION
Ampersands needs to be HTML-encoded, even when used in URLs. The generated tracking code for the image tracker does not do this.

**Expected**
```
<!-- Matomo Image Tracker-->
<img src="http://example.com/piwik.php?idsite=1&amp;rec=1" style="border:0" alt="" />
<!-- End Matomo -->
```

**Actual**
```
<!-- Matomo Image Tracker-->
<img src="http://example.com/piwik.php?idsite=1&rec=1" style="border:0" alt="" />
<!-- End Matomo -->
```