### PR TITLE
Aggregate 500 events in a sub-table instead of 100

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -468,7 +468,7 @@ datatable_archiving_maximum_rows_subtable_actions = 100
 ; maximum number of rows for any of the Events tables (Categories, Actions, Names)
 datatable_archiving_maximum_rows_events = 500
 ; maximum number of rows for sub-tables of the Events tables (eg. for the subtables Categories>Actions or Categories>Names).
-datatable_archiving_maximum_rows_subtable_events = 100
+datatable_archiving_maximum_rows_subtable_events = 500
 
 ; maximum number of rows for other tables (Providers, User settings configurations)
 datatable_archiving_maximum_rows_standard = 500


### PR DESCRIPTION
100 is too limited when it comes especially to tracking event names by event action or event category. 500 will cover a lot more use cases without compromising performance.