### PR TITLE
missing POST in password reset form

### DIFF
--- a/plugins/Login/templates/login.twig
+++ b/plugins/Login/templates/login.twig
@@ -128,7 +128,7 @@
                     <div class="message_container">
                     </div>
 
-                    <form id="reset_form" ng-non-bindable>
+                    <form id="reset_form" method="post" ng-non-bindable>
                         <div class="row">
                             <div class="col s12 input-field">
                                 <input type="hidden" name="form_nonce" id="reset_form_nonce" value="{{ nonce }}"/>


### PR DESCRIPTION
Missing method="post" in password reset form might impose a security issue