### PR TITLE
Add Common::stripHeader()

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -1143,6 +1143,19 @@ class Common
     }
 
     /**
+     * Strips outgoing header.
+     *
+     * @param string $name The header name.
+     */
+    public static function stripHeader($name)
+    {
+        // don't strip header in CLI mode
+        if (!Common::isPhpCliMode() and !headers_sent()) {
+            header_remove($name);
+        }
+    }
+
+    /**
      * Sends the given response code if supported.
      *
      * @param int $code  Eg 204

--- a/core/ProxyHttp.php
+++ b/core/ProxyHttp.php
@@ -217,8 +217,8 @@ class ProxyHttp
     public static function overrideCacheControlHeaders($override = null)
     {
         if ($override || self::isHttps()) {
-            Common::sendHeader('Pragma: ');
-            Common::sendHeader('Expires: ');
+            Common::stripHeader('Pragma');
+            Common::stripHeader('Expires');
             if (in_array($override, array('public', 'private', 'no-cache', 'no-store'))) {
                 Common::sendHeader("Cache-Control: $override, must-revalidate");
             } else {

--- a/core/View/OneClickDone.php
+++ b/core/View/OneClickDone.php
@@ -59,9 +59,9 @@ class OneClickDone
     public function render()
     {
         // set response headers
+        @Common::stripHeader('Pragma');
+        @Common::stripHeader('Expires');
         @Common::sendHeader('Content-Type: text/html; charset=UTF-8');
-        @Common::sendHeader('Pragma: ');
-        @Common::sendHeader('Expires: ');
         @Common::sendHeader('Cache-Control: must-revalidate');
         @Common::sendHeader('X-Frame-Options: deny');
 


### PR DESCRIPTION
A few places in Matomo, HTTP headers are “deleted” like this: `Common::sendHeader('Expires: ')`.

In general, the semantics of an empty string in an HTTP header is not the same as the semantics of an absent header. E.g. the Expires header [only allows a date](https://tools.ietf.org/html/rfc7234#section-5.3), not an empty string.

Instead, we should simply remove the header using [header_remove()](http://php.net/header_remove).