### PR TITLE
3rd party cookie visitor ID value should not change over time

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -606,6 +606,18 @@ class Request
         return (bool)Config::getInstance()->Tracker['use_third_party_id_cookie'];
     }
 
+    public function getThirdPartyCookieVisitorId()
+    {
+        $cookie = $this->makeThirdPartyCookieUID();
+        $idVisitor = $cookie->get(0);
+        if ($idVisitor !== false
+            && strlen($idVisitor) == Tracker::LENGTH_HEX_ID_STRING
+        ) {
+            return $idVisitor;
+        }
+        return null;
+    }
+
     /**
      * Update the cookie information.
      */
@@ -669,43 +681,37 @@ class Request
      *
      * @throws Exception
      */
-    public function getVisitorId($forThirdPartyCookie = false)
+    public function getVisitorId()
     {
         $found = false;
         
-        if (!$forThirdPartyCookie) {
-            // If User ID is set it takes precedence
-            $userId = $this->getForcedUserId();
-            if ($userId) {
-                $userIdHashed = $this->getUserIdHashed($userId);
-                $idVisitor = $this->truncateIdAsVisitorId($userIdHashed);
-                Common::printDebug("Request will be recorded for this user_id = " . $userId . " (idvisitor = $idVisitor)");
-                $found = true;
-            }
-    
-            // Was a Visitor ID "forced" (@see Tracking API setVisitorId()) for this request?
-            if (!$found) {
-                $idVisitor = $this->getForcedVisitorId();
-                if (!empty($idVisitor)) {
-                    if (strlen($idVisitor) != Tracker::LENGTH_HEX_ID_STRING) {
-                        throw new InvalidRequestParameterException("Visitor ID (cid) $idVisitor must be " . Tracker::LENGTH_HEX_ID_STRING . " characters long");
-                    }
-                    Common::printDebug("Request will be recorded for this idvisitor = " . $idVisitor);
-                    $found = true;
+        // If User ID is set it takes precedence
+        $userId = $this->getForcedUserId();
+        if ($userId) {
+            $userIdHashed = $this->getUserIdHashed($userId);
+            $idVisitor = $this->truncateIdAsVisitorId($userIdHashed);
+            Common::printDebug("Request will be recorded for this user_id = " . $userId . " (idvisitor = $idVisitor)");
+            $found = true;
+        }
+
+        // Was a Visitor ID "forced" (@see Tracking API setVisitorId()) for this request?
+        if (!$found) {
+            $idVisitor = $this->getForcedVisitorId();
+            if (!empty($idVisitor)) {
+                if (strlen($idVisitor) != Tracker::LENGTH_HEX_ID_STRING) {
+                    throw new InvalidRequestParameterException("Visitor ID (cid) $idVisitor must be " . Tracker::LENGTH_HEX_ID_STRING . " characters long");
                 }
+                Common::printDebug("Request will be recorded for this idvisitor = " . $idVisitor);
+                $found = true;
             }
         }
 
         // - If set to use 3rd party cookies for Visit ID, read the cookie
         if (!$found) {
-            // - By default, reads the first party cookie ID
             $useThirdPartyCookie = $this->shouldUseThirdPartyCookie();
             if ($useThirdPartyCookie) {
-                $cookie = $this->makeThirdPartyCookieUID();
-                $idVisitor = $cookie->get(0);
-                if ($idVisitor !== false
-                    && strlen($idVisitor) == Tracker::LENGTH_HEX_ID_STRING
-                ) {
+                $idVisitor = $this->getThirdPartyCookieVisitorId();
+                if(!empty($idVisitor)) {
                     $found = true;
                 }
             }
@@ -718,15 +724,44 @@ class Request
         }
 
         if ($found) {
-            $truncated = $this->truncateIdAsVisitorId($idVisitor);
-            $binVisitorId = @Common::hex2bin($truncated);
-            if (!empty($binVisitorId)) {
-                return $binVisitorId;
-            }
+            return $this->getVisitorIdAsBinary($idVisitor);
         }
 
         return false;
     }
+
+    /**
+     * When creating a third party cookie, we want to ensure that the original value set in this 3rd party cookie
+     * sticks and is not overwritten later.
+     */
+    public function getVisitorIdForThirdPartyCookie()
+    {
+        $found = false;
+
+        // For 3rd party cookies, priority is on re-using the existing 3rd party cookie value
+        if (!$found) {
+            $useThirdPartyCookie = $this->shouldUseThirdPartyCookie();
+            if ($useThirdPartyCookie) {
+                $idVisitor = $this->getThirdPartyCookieVisitorId();
+                if(!empty($idVisitor)) {
+                    $found = true;
+                }
+            }
+        }
+
+        // If a third party cookie was not found, we default to the first party cookie
+        if (!$found) {
+            $idVisitor = Common::getRequestVar('_id', '', 'string', $this->params);
+            $found = strlen($idVisitor) >= Tracker::LENGTH_HEX_ID_STRING;
+        }
+
+        if ($found) {
+            return $this->getVisitorIdAsBinary($idVisitor);
+        }
+
+        return false;
+    }
+
 
     public function getIp()
     {
@@ -839,5 +874,19 @@ class Request
     public function getMetadata($pluginName, $key)
     {
         return isset($this->requestMetadata[$pluginName][$key]) ? $this->requestMetadata[$pluginName][$key] : null;
+    }
+
+    /**
+     * @param $idVisitor
+     * @return bool|string
+     */
+    private function getVisitorIdAsBinary($idVisitor)
+    {
+        $truncated = $this->truncateIdAsVisitorId($idVisitor);
+        $binVisitorId = @Common::hex2bin($truncated);
+        if (!empty($binVisitorId)) {
+            return $binVisitorId;
+        }
+        return false;
     }
 }

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -657,28 +657,30 @@ class Request
      *
      * @throws Exception
      */
-    public function getVisitorId()
+    public function getVisitorId($forThirdPartyCookie = false)
     {
         $found = false;
-
-        // If User ID is set it takes precedence
-        $userId = $this->getForcedUserId();
-        if ($userId) {
-            $userIdHashed = $this->getUserIdHashed($userId);
-            $idVisitor = $this->truncateIdAsVisitorId($userIdHashed);
-            Common::printDebug("Request will be recorded for this user_id = " . $userId . " (idvisitor = $idVisitor)");
-            $found = true;
-        }
-
-        // Was a Visitor ID "forced" (@see Tracking API setVisitorId()) for this request?
-        if (!$found) {
-            $idVisitor = $this->getForcedVisitorId();
-            if (!empty($idVisitor)) {
-                if (strlen($idVisitor) != Tracker::LENGTH_HEX_ID_STRING) {
-                    throw new InvalidRequestParameterException("Visitor ID (cid) $idVisitor must be " . Tracker::LENGTH_HEX_ID_STRING . " characters long");
-                }
-                Common::printDebug("Request will be recorded for this idvisitor = " . $idVisitor);
+        
+        if (!$forThirdPartyCookie) {
+            // If User ID is set it takes precedence
+            $userId = $this->getForcedUserId();
+            if ($userId) {
+                $userIdHashed = $this->getUserIdHashed($userId);
+                $idVisitor = $this->truncateIdAsVisitorId($userIdHashed);
+                Common::printDebug("Request will be recorded for this user_id = " . $userId . " (idvisitor = $idVisitor)");
                 $found = true;
+            }
+    
+            // Was a Visitor ID "forced" (@see Tracking API setVisitorId()) for this request?
+            if (!$found) {
+                $idVisitor = $this->getForcedVisitorId();
+                if (!empty($idVisitor)) {
+                    if (strlen($idVisitor) != Tracker::LENGTH_HEX_ID_STRING) {
+                        throw new InvalidRequestParameterException("Visitor ID (cid) $idVisitor must be " . Tracker::LENGTH_HEX_ID_STRING . " characters long");
+                    }
+                    Common::printDebug("Request will be recorded for this idvisitor = " . $idVisitor);
+                    $found = true;
+                }
             }
         }
 

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -627,12 +627,12 @@ class Request
             return;
         }
 
-        Common::printDebug("We manage the cookie...");
-
         $cookie = $this->makeThirdPartyCookieUID();
-        // idcookie has been generated in handleNewVisit or we simply propagate the old value
-        $cookie->set(0, bin2hex($idVisitor));
+        $idVisitor = bin2hex($idVisitor);
+        $cookie->set(0, $idVisitor);
         $cookie->save();
+
+        Common::printDebug(sprintf("We set the visitor ID to %s in the 3rd party cookie...", $idVisitor));
     }
 
     protected function makeThirdPartyCookieUID()

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -175,7 +175,7 @@ class Visit implements VisitInterface
         }
 
         // update the cookie with the new visit information
-        $this->request->setThirdPartyCookie($this->visitProperties->getProperty('idvisitor'));
+        $this->request->setThirdPartyCookie($this->request->getVisitorId(true));
 
         foreach ($this->requestProcessors as $processor) {
             Common::printDebug("Executing " . get_class($processor) . "::recordLogs()...");

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -175,7 +175,7 @@ class Visit implements VisitInterface
         }
 
         // update the cookie with the new visit information
-        $this->request->setThirdPartyCookie($this->request->getVisitorId(true));
+        $this->request->setThirdPartyCookie($this->request->getVisitorIdForThirdPartyCookie());
 
         foreach ($this->requestProcessors as $processor) {
             Common::printDebug("Executing " . get_class($processor) . "::recordLogs()...");


### PR DESCRIPTION
Once a 3rd party cookie is set, we persist it and don't overwrite the 3rd party cookie value, even when the visitor id may change in the backend, or for a specific website. This makes the [3rd party analytics cookie](https://matomo.org/faq/how-to/faq_118/) more useful and actually working as you'd expect.

Recreates https://github.com/matomo-org/matomo/pull/12592