### PR TITLE
Improve performance for real time map

### DIFF
--- a/plugins/UserCountryMap/Controller.php
+++ b/plugins/UserCountryMap/Controller.php
@@ -26,8 +26,8 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/functions.php';
  */
 class Controller extends \Piwik\Plugin\Controller
 {
-    // By default plot up to the last 7 days of visitors on the map, for low traffic sites
-    const REAL_TIME_WINDOW = 'last7';
+    // By default plot up to the last 3 days of visitors on the map, for low traffic sites
+    const REAL_TIME_WINDOW = 'last3';
     
     /**
      * @var Translator


### PR DESCRIPTION
Only look at last 3 days for real time map. In theory even only the last 1-2 days is enough since it is called real time so for sure we wouldn't need to include anything older than 24 hours.

fix #12722