### PR TITLE
Fix core:purge-old-archive-data failing in some cases

### DIFF
--- a/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
+++ b/plugins/CoreAdminHome/Commands/PurgeOldArchiveData.php
@@ -141,7 +141,12 @@ class PurgeOldArchiveData extends ConsoleCommand
 
                 list($year, $month) = explode('_', $tableDate);
 
-                $dates[] = Date::factory($year . '-' . $month . '-' . '01');
+                try {
+                    $date    = Date::factory($year . '-' . $month . '-' . '01');
+                    $dates[] = $date;
+                } catch (\Exception $e) {
+                    // this might occur if archive tables like piwik_archive_numeric_1875_09 exist
+                }
             }
         } else {
             $includeYearArchives = $input->getOption('include-year-archives');


### PR DESCRIPTION
If tables with names like `piwik_archive_numeric_1875_09` exist for any reason, the archive purger will fail, as the date information in the name couldn't be used to create a `Date` object...

I'm not 100% sure why such tables could have been created in the first place, but maybe we had a bug in the archiving sometimes that allowed triggering the archiving for any date given? Wasn't able to do so locally with current version.

fixes #11778 