### PR TITLE
Fix syntax for 'SHOW COLUMNS FROM' on MySQL 8

### DIFF
--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -318,7 +318,7 @@ class Mysql implements SchemaInterface
     {
         $db = $this->getDb();
 
-        $allColumns = $db->fetchAll("SHOW COLUMNS FROM . $tableName");
+        $allColumns = $db->fetchAll("SHOW COLUMNS FROM " . $tableName);
 
         $fields = array();
         foreach ($allColumns as $column) {


### PR DESCRIPTION
Closing quotation mark in this line seem to be placed at the wrong place:

https://github.com/matomo-org/matomo/blob/6c3ed181113cb8c96526e40e8cdc65cc4dc10599/core/Db/Schema/Mysql.php#L321

Should be:
```php
$allColumns = $db->fetchAll("SHOW COLUMNS FROM " . $tableName);
```
MySQL in versions < 8 ignores this error and _assumes_ the dot indicates a database name before the tablename which apparently can be empty.