### PR TITLE
Fixes regression: rowevolution not working in overlay mode

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable_rowactions.js
+++ b/plugins/CoreHome/javascripts/dataTable_rowactions.js
@@ -413,7 +413,7 @@ DataTable_RowActions_RowEvolution.prototype.showRowEvolution = function (apiMeth
         }
     }
 
-    if (self.dataTable.jsViewDataTable === 'tableGoals') {
+    if (self.dataTable && self.dataTable.jsViewDataTable === 'tableGoals') {
         // remove idGoal param, when it's set for goal visualizations
         if (extraParams['idGoal']) {
             delete(extraParams['idGoal']);


### PR DESCRIPTION
One of the latest updates seem to have broken row evolution in overlay mode.