### PR TITLE
Use a higher precision for rates to show more accurate percentage values

### DIFF
--- a/core/Plugin/ComputedMetric.php
+++ b/core/Plugin/ComputedMetric.php
@@ -121,7 +121,12 @@ class ComputedMetric extends ProcessedMetric
         $metric1 = $this->getMetric($row, $this->metric1);
         $metric2 = $this->getMetric($row, $this->metric2);
 
-        return Piwik::getQuotientSafe($metric1, $metric2, $precision = 2);
+        $precision = 2;
+        if ($this->aggregation === self::AGGREGATION_RATE) {
+            $precision = 3;
+        }
+
+        return Piwik::getQuotientSafe($metric1, $metric2, $precision);
     }
 
     private function getDetectedType()


### PR DESCRIPTION
Currently, we round to two decimals. This means when calculating the percentage (`x 100`) we show eg only 1% or 5% in custom reports. However, for conversion rates etc we should show more accurate values and therefore need to use a higher precision.