### PR TITLE
Do not assert on sort order of equal elements

### DIFF
--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
@@ -256,21 +256,7 @@ class JoinGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = $this->makeGenerator($tables);
         usort($tables, array($generator, 'sortTablesForJoin'));
 
-        $expected = array(
-            'log_link_visit_action',
-            array (
-                'table' => 'log_action',
-                'tableAlias' => 'log_action_visit_exit_idaction_name',
-                'joinOn' => 'log_visit.visit_exit_idaction_name = log_action_visit_exit_idaction_name.idaction',
-            ),
-            array (
-                'table' => 'log_action',
-                'tableAlias' => 'log_action_idaction_name',
-                'joinOn' => 'log_link_visit_action.idaction_name = log_action_idaction_name.idaction',
-            ),
-        );
-
-        $this->assertEquals($expected, $tables);
+        $this->assertEquals('log_link_visit_action', $tables[0]);
     }
 
     public function test_sortTablesForJoin_anotherTest2MakingSureWorksOhPhp5_5()
@@ -295,21 +281,7 @@ class JoinGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = $this->makeGenerator($tables);
         usort($tables, array($generator, 'sortTablesForJoin'));
 
-        $expected = array(
-            'log_link_visit_action',
-            array (
-                'table' => 'log_action',
-                'tableAlias' => 'log_action_idaction_name',
-                'joinOn' => 'log_link_visit_action.idaction_name = log_action_idaction_name.idaction',
-            ),
-            array (
-                'table' => 'log_action',
-                'tableAlias' => 'log_action_visit_exit_idaction_name',
-                'joinOn' => 'log_visit.visit_exit_idaction_name = log_action_visit_exit_idaction_name.idaction',
-            ),
-        );
-
-        $this->assertEquals($expected, $tables);
+        $this->assertEquals('log_link_visit_action', $tables[0]);
     }
 
     public function test_sortTablesForJoin_shouldSortTablesWithCustomJoinRequiringEachOther1()
@@ -411,21 +383,7 @@ class JoinGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = $this->makeGenerator($tables);
         usort($tables, array($generator, 'sortTablesForJoin'));
 
-        $expected = array(
-            'log_link_visit_action',
-            array(
-                'table' => 'log_action',
-                'tableAlias' => 'log_action_idaction_event_action',
-                'joinOn' => "log_link_visit_action.idaction_event_action = log_action_idaction_event_action.idaction"
-            ),
-            array(
-                'table' => 'log_action',
-                'tableAlias' => 'log_action_visit_entry_idaction_name',
-                'joinOn' => "log_visit.visit_entry_idaction_name = log_action_visit_entry_idaction_name.idaction"
-            )
-        );
-
-        $this->assertEquals($expected, $tables);
+        $this->assertEquals('log_link_visit_action', $tables[0]);
     }
 
     private function generate($tables)


### PR DESCRIPTION
Three tests in `Piwik\Tests\Unit\DataAccess\JoinGeneratorTest` fail on PHP 7.

PHP 7 contained [a change](http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.sort-order) to `uasort()` and friends that may result in different sorting of values that compare as equal.

The three tests all sort three tables where the two of them do not depend on each other and may thus be returned in order. Hence we should not make assertions on their relative order.