### PR TITLE
Use test database

### DIFF
--- a/plugins/CoreAdminHome/tests/Integration/SetConfigTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/SetConfigTest.php
@@ -192,8 +192,7 @@ class SetConfigTest extends ConsoleCommandTestCase
 
                 // copy over sections required for tests
                 $config->tests = $actualGlobalSettingsProvider->getSection('tests');
-                $config->database = $actualGlobalSettingsProvider->getSection('database');
-                $config->database_tests = $actualGlobalSettingsProvider->getSection('database_tests');
+                $config->database = $actualGlobalSettingsProvider->getSection('database_tests');
 
                 return $config;
             },


### PR DESCRIPTION
`Piwik\Plugins\CoreAdminHome\tests\Integration\Commands\SetConfigTest` tries to access the main database. This may fail due to lack of permission.

```
1) Piwik\Plugins\CoreAdminHome\tests\Integration\Commands\SetConfigTest
Failed to setup fixture: TEST INITIALIZATION FAILED: SQLSTATE[42000]: Syntax error or access violation: 1044 Access denied for user 'matomo_dev'@'localhost' to database 'matomo_test'
#0 /var/www/matomo/core/Db.php(168): Zend_Db_Adapter_Pdo_Abstract->exec('CREATE DATABASE...')
#1 /var/www/matomo/core/Db/Schema/Mysql.php(386): Piwik\Db::exec('CREATE DATABASE...')
#2 /var/www/matomo/core/Db/Schema.php(117): Piwik\Db\Schema\Mysql->createDatabase('matomo_test')
#3 /var/www/matomo/core/DbHelper.php(152): Piwik\Db\Schema->createDatabase('matomo_test')
#4 /var/www/matomo/tests/PHPUnit/Framework/Fixture.php(235): Piwik\DbHelper::createDatabase('matomo_test')
#5 /var/www/matomo/tests/PHPUnit/Framework/TestCase/SystemTestCase.php(76): Piwik\Tests\Framework\Fixture->performSetUp()
#6 /var/www/matomo/plugins/CoreAdminHome/tests/Integration/SetConfigTest.php(29): Piwik\Tests\Framework\TestCase\SystemTestCase::setUpBeforeClass()
#7 /var/www/matomo/vendor/phpunit/phpunit/src/Framework/TestSuite.php(672): Piwik\Plugins\CoreAdminHome\tests\Integration\Commands\SetConfigTest::setUpBeforeClass()
#8 /var/www/matomo/vendor/phpunit/phpunit/src/TextUI/TestRunner.php(440): PHPUnit_Framework_TestSuite->run(Object(PHPUnit_Framework_TestResult))
#9 /var/www/matomo/vendor/phpunit/phpunit/src/TextUI/Command.php(149): PHPUnit_TextUI_TestRunner->doRun(Object(PHPUnit_Framework_TestSuite), Array)
#10 /var/www/matomo/vendor/phpunit/phpunit/src/TextUI/Command.php(100): PHPUnit_TextUI_Command->run(Array, true)
#11 /var/www/matomo/vendor/phpunit/phpunit/phpunit(52): PHPUnit_TextUI_Command::main()
#12 {main}
```
