### PR TITLE
use JS handler for installing all paid plugins

### DIFF
--- a/plugins/Marketplace/templates/paid-plugins-install-list.twig
+++ b/plugins/Marketplace/templates/paid-plugins-install-list.twig
@@ -11,12 +11,8 @@
     </ul>
 
     <p>
-        <a href="{{ linkTo({'action': 'installAllPaidPlugins', 'nonce': installNonce}) }}" class="btn">
-            {{ 'Marketplace_InstallAllPurchasedPluginsAction'|translate(paidPluginsToInstallAtOnce|length) }}
-        </a>
-
-        <a href="{{ linkTo({'rand': random(999999)}) }}" class="btn-flat">
-            Cancel
-        </a>
+        <input role="install" type="button" data-href="{{ linkTo({'action': 'installAllPaidPlugins', 'nonce': installNonce}) }}"
+               value="{{ 'Marketplace_InstallAllPurchasedPluginsAction'|translate(paidPluginsToInstallAtOnce|length) }}">
+        <input role="cancel" type="button" value="{{ 'General_Cancel'|translate }}"/>
     </p>
 </div>

--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -237,11 +237,17 @@ var piwikHelper = {
                 button.attr('title', title);
             }
 
-            if(typeof handles[role] == 'function') {
+            if (typeof handles !== 'undefined' && typeof handles[role] == 'function') {
                 button.on('click', function(){
                     handles[role].apply()
                 });
             }
+            if (typeof $button.data('href') !== 'undefined') {
+                button.on('click', function () {
+                    window.location.href = $button.data('href');
+                })
+            }
+            
 
             $footer.append(button);
         });


### PR DESCRIPTION
fixes #12782

I am not entirely sure if this is the most elegant solution, but this way the modal works as every other one.
![grafik](https://user-images.githubusercontent.com/6266037/39400410-f8a8458c-4b2f-11e8-9ac1-132d50714bd9.png)

I only need a solution on how to mark the install button as primary.