### PR TITLE
Prevent tracking failures when invalid goal patterns are defined

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -852,7 +852,10 @@ class GoalManager
                 $match = ($matched == 0);
                 break;
             default:
-                StaticContainer::get('Psr\Log\LoggerInterface')->warning(Piwik::translate('General_ExceptionInvalidGoalPattern', array($pattern_type)));
+                try {
+                    StaticContainer::get('Psr\Log\LoggerInterface')->warning(Piwik::translate('General_ExceptionInvalidGoalPattern', array($pattern_type)));
+                } catch (\Exception $e) {
+                }
                 $match = false;
                 break;
         }

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -10,6 +10,7 @@ namespace Piwik\Tracker;
 
 use Exception;
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Piwik;
 use Piwik\Plugin\Dimension\ConversionDimension;
@@ -817,7 +818,6 @@ class GoalManager
      * @param $pattern_type
      * @param $url
      * @return bool
-     * @throws Exception
      */
     protected function isGoalPatternMatchingUrl($goal, $pattern_type, $url)
     {
@@ -852,7 +852,8 @@ class GoalManager
                 $match = ($matched == 0);
                 break;
             default:
-                throw new Exception(Piwik::translate('General_ExceptionInvalidGoalPattern', array($pattern_type)));
+                StaticContainer::get('Psr\Log\LoggerInterface')->warning(Piwik::translate('General_ExceptionInvalidGoalPattern', array($pattern_type)));
+                $match = false;
                 break;
         }
         return $match;


### PR DESCRIPTION
When an invalid goal pattern type is defined in database, and exception might be thrown while tracking.
As an exception does not make sense at this point at all it now will log a warning instead of throwing an exception.

This will not prevent anyone from storing invalid patterns in the database, but will prevent tracking failures for already stored invalid data.

refs #12683