### PR TITLE
Validate goal pattern and type in API

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -823,13 +823,7 @@ class GoalManager
     {
         switch ($pattern_type) {
             case 'regex':
-                $pattern = $goal['pattern'];
-                if (strpos($pattern, '/') !== false
-                    && strpos($pattern, '\\/') === false
-                ) {
-                    $pattern = str_replace('/', '\\/', $pattern);
-                }
-                $pattern = '/' . $pattern . '/';
+                $pattern = self::formatRegex($goal['pattern']);
                 if (!$goal['case_sensitive']) {
                     $pattern .= 'i';
                 }
@@ -856,5 +850,21 @@ class GoalManager
                 break;
         }
         return $match;
+    }
+
+    /**
+     * Formats a goal regex pattern to a usable regex
+     *
+     * @param string $pattern
+     * @return string
+     */
+    public static function formatRegex($pattern)
+    {
+        if (strpos($pattern, '/') !== false
+            && strpos($pattern, '\\/') === false
+        ) {
+            $pattern = str_replace('/', '\\/', $pattern);
+        }
+        return '/' . $pattern . '/';
     }
 }

--- a/core/Validators/Regex.php
+++ b/core/Validators/Regex.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Validators;
+
+use Piwik\Piwik;
+
+class Regex extends BaseValidator
+{
+    public function validate($value)
+    {
+        if ($this->isValueBare($value)) {
+            return;
+        }
+
+        if (@preg_match($value, '') === false) {
+            throw new Exception(Piwik::translate('General_ValidatorErrorNoValidRegex', array($value)));
+        }
+    }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -451,6 +451,7 @@
         "ValidatorErrorCharacterTooLong": "The value contains \"%1$s\" characters but should contain at most %2$s characters.",
         "ValidatorErrorNotUrlLike": "The value \"%s\" does not look like a URL.",
         "ValidatorErrorNotEmailLike": "The value \"%s\" does not look like a valid email.",
+        "ValidatorErrorNoValidRegex": "The value \"%s\" is no valid regex.",
         "ValidatorErrorXNotWhitelisted": "The value \"%1$s\" is not allowed, use one of: %2$s.",
         "ValidatorErrorInvalidDateTimeFormat": "The date \"%1$s\" does not have the correct format, please use %2$s",
         "WarningFileIntegrityNoManifest": "File integrity check could not be performed due to missing manifest.inc.php.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -451,7 +451,7 @@
         "ValidatorErrorCharacterTooLong": "The value contains \"%1$s\" characters but should contain at most %2$s characters.",
         "ValidatorErrorNotUrlLike": "The value \"%s\" does not look like a URL.",
         "ValidatorErrorNotEmailLike": "The value \"%s\" does not look like a valid email.",
-        "ValidatorErrorNoValidRegex": "The value \"%s\" is no valid regex.",
+        "ValidatorErrorNoValidRegex": "The value \"%s\" is not a valid regular expression.",
         "ValidatorErrorXNotWhitelisted": "The value \"%1$s\" is not allowed, use one of: %2$s.",
         "ValidatorErrorInvalidDateTimeFormat": "The date \"%1$s\" does not have the correct format, please use %2$s",
         "WarningFileIntegrityNoManifest": "File integrity check could not be performed due to missing manifest.inc.php.",

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -136,6 +136,7 @@ class API extends \Piwik\Plugin\API
         $this->checkPatternIsValid($patternType, $pattern, $matchAttribute);
         $name        = $this->checkName($name);
         $pattern     = $this->checkPattern($pattern);
+        $patternType = $this->checkPatternType($patternType);
         $description = $this->checkDescription($description);
 
         $revenue = Common::forceDotAsSeparatorForDecimalPoint((float)$revenue);
@@ -188,6 +189,7 @@ class API extends \Piwik\Plugin\API
 
         $name        = $this->checkName($name);
         $description = $this->checkDescription($description);
+        $patternType = $this->checkPatternType($patternType);
         $pattern     = $this->checkPattern($pattern);
         $this->checkPatternIsValid($patternType, $pattern, $matchAttribute);
 
@@ -218,6 +220,10 @@ class API extends \Piwik\Plugin\API
         ) {
             throw new Exception(Piwik::translate('Goals_ExceptionInvalidMatchingString', array("http:// or https://", "http://www.yourwebsite.com/newsletter/subscribed.html")));
         }
+
+        if ($patternType == 'regex' && @preg_match(GoalManager::formatRegex($pattern), '') === false) {
+            throw new \Exception(Piwik::translate('Goals_ExceptionInvalidGoalPatternRegex', [$pattern]));
+        }
     }
 
     private function checkName($name)
@@ -228,6 +234,19 @@ class API extends \Piwik\Plugin\API
     private function checkDescription($description)
     {
         return urldecode($description);
+    }
+
+    private function checkPatternType($patternType)
+    {
+        $patternType = strtolower($patternType);
+
+        $validPatternTypes = ['exact', 'contains', 'regex'];
+
+        if (!in_array($patternType, $validPatternTypes)) {
+            throw new \Exception(Piwik::translate('Goals_ExceptionInvalidGoalPatternType', [$patternType, implode(', ', $validPatternTypes)]));
+        }
+
+        return $patternType;
     }
 
     private function checkPattern($pattern)

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -242,7 +242,7 @@ class API extends \Piwik\Plugin\API
 
         $validPatternTypes = ['exact', 'contains', 'regex'];
 
-        if (!in_array($patternType, $validPatternTypes)) {
+        if (!empty($patternType) && !in_array($patternType, $validPatternTypes)) {
             throw new \Exception(Piwik::translate('Goals_ExceptionInvalidGoalPatternType', [$patternType, implode(', ', $validPatternTypes)]));
         }
 

--- a/plugins/Goals/lang/en.json
+++ b/plugins/Goals/lang/en.json
@@ -55,6 +55,8 @@
         "EcommerceOverview": "Ecommerce Overview",
         "EcommerceReports": "Ecommerce Reports",
         "ExceptionInvalidMatchingString": "If you choose 'exact match', the matching string must be a URL starting with %1$s. For example, '%2$s'.",
+        "ExceptionInvalidGoalPatternType": "The given goal pattern type '%1$s' is invalid. Valid pattern types are %2$s",
+        "ExceptionInvalidGoalPatternRegex": "The given goal pattern regex '%1$s' is invalid.",
         "ExternalWebsiteUrl": "external website URL",
         "Filename": "filename",
         "GoalConversion": "Goal conversion",

--- a/plugins/Goals/lang/en.json
+++ b/plugins/Goals/lang/en.json
@@ -55,8 +55,6 @@
         "EcommerceOverview": "Ecommerce Overview",
         "EcommerceReports": "Ecommerce Reports",
         "ExceptionInvalidMatchingString": "If you choose 'exact match', the matching string must be a URL starting with %1$s. For example, '%2$s'.",
-        "ExceptionInvalidGoalPatternType": "The given goal pattern type '%1$s' is invalid. Valid pattern types are %2$s",
-        "ExceptionInvalidGoalPatternRegex": "The given goal pattern regex '%1$s' is invalid.",
         "ExternalWebsiteUrl": "external website URL",
         "Filename": "filename",
         "GoalConversion": "Goal conversion",

--- a/plugins/Goals/tests/Integration/APITest.php
+++ b/plugins/Goals/tests/Integration/APITest.php
@@ -69,6 +69,31 @@ class APITest extends IntegrationTestCase
         $this->assertGoal($idGoal, 'MyName', '', 'title', 'normal title', 'exact', 1, 50, 1);
     }
 
+    public function test_addGoal_ShouldSucceed_IfRegexPageTitle()
+    {
+        $idGoal = $this->api->addGoal($this->idSite, 'MyName', 'title', 'rere(.*)', 'regex', true, 50, true);
+
+        $this->assertGoal($idGoal, 'MyName', '', 'title', 'rere(.*)', 'regex', 1, 50, 1);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Goals_ExceptionInvalidGoalPatternType
+     */
+    public function test_addGoal_shouldThrowException_IfPatternTypeIsInvalid()
+    {
+        $this->api->addGoal($this->idSite, 'MyName', 'external_website', 'www.test.de', 'invalid');
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Goals_ExceptionInvalidGoalPatternRegex
+     */
+    public function test_addGoal_shouldThrowException_IfPatternRegexIsInvalid()
+    {
+        $this->api->addGoal($this->idSite, 'MyName', 'url', '/(%$f', 'regex');
+    }
+
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage Goals_ExceptionInvalidMatchingString

--- a/plugins/Goals/tests/Integration/APITest.php
+++ b/plugins/Goals/tests/Integration/APITest.php
@@ -78,7 +78,7 @@ class APITest extends IntegrationTestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage Goals_ExceptionInvalidGoalPatternType
+     * @expectedExceptionMessage General_ValidatorErrorXNotWhitelisted
      */
     public function test_addGoal_shouldThrowException_IfPatternTypeIsInvalid()
     {
@@ -87,7 +87,7 @@ class APITest extends IntegrationTestCase
 
     /**
      * @expectedException \Exception
-     * @expectedExceptionMessage Goals_ExceptionInvalidGoalPatternRegex
+     * @expectedExceptionMessage General_ValidatorErrorNoValidRegex
      */
     public function test_addGoal_shouldThrowException_IfPatternRegexIsInvalid()
     {


### PR DESCRIPTION
Goal pattern type and pattern regexes will now be validated in API when creating or updating goals.

refs #12683 