### PR TITLE
Add possibility to specify an icon and onclick handler for submenu items

### DIFF
--- a/core/Menu/MenuAbstract.php
+++ b/core/Menu/MenuAbstract.php
@@ -101,10 +101,12 @@ abstract class MenuAbstract extends Singleton
      *                          that can be used to build the URL.
      * @param int $order The order hint.
      * @param bool|string $tooltip An optional tooltip to display or false to display the tooltip.
+     * @param bool|string $icon An icon classname, such as "icon-add". Only supported by admin menu
+     * @param bool|string $onclick Will execute the on click handler instead of executing the link. Only supported by admin menu.
      * @since 2.7.0
      * @api
      */
-    public function addItem($menuName, $subMenuName, $url, $order = 50, $tooltip = false)
+    public function addItem($menuName, $subMenuName, $url, $order = 50, $tooltip = false, $icon = false, $onclick = false)
     {
         // make sure the idSite value used is numeric (hack-y fix for #3426)
         if (isset($url['idSite']) && !is_numeric($url['idSite'])) {
@@ -117,7 +119,9 @@ abstract class MenuAbstract extends Singleton
             $subMenuName,
             $url,
             $order,
-            $tooltip
+            $tooltip,
+            $icon,
+            $onclick
         );
     }
 
@@ -145,7 +149,7 @@ abstract class MenuAbstract extends Singleton
      * @param int $order
      * @param bool|string $tooltip Tooltip to display.
      */
-    private function buildMenuItem($menuName, $subMenuName, $url, $order = 50, $tooltip = false)
+    private function buildMenuItem($menuName, $subMenuName, $url, $order = 50, $tooltip = false, $icon = false, $onclick = false)
     {
         if (!isset($this->menu[$menuName])) {
             $this->menu[$menuName] = array(
@@ -170,6 +174,8 @@ abstract class MenuAbstract extends Singleton
             $this->menu[$menuName][$subMenuName]['_order'] = $order;
             $this->menu[$menuName][$subMenuName]['_name'] = $subMenuName;
             $this->menu[$menuName][$subMenuName]['_tooltip'] = $tooltip;
+            $this->menu[$menuName][$subMenuName]['_icon'] = $icon;
+            $this->menu[$menuName][$subMenuName]['_onclick'] = $onclick;
             $this->menu[$menuName]['_hasSubmenu'] = true;
 
             if (!array_key_exists('_tooltip', $this->menu[$menuName])) {
@@ -184,7 +190,7 @@ abstract class MenuAbstract extends Singleton
     private function buildMenu()
     {
         foreach ($this->menuEntries as $menuEntry) {
-            $this->buildMenuItem($menuEntry[0], $menuEntry[1], $menuEntry[2], $menuEntry[3], $menuEntry[4]);
+            $this->buildMenuItem($menuEntry[0], $menuEntry[1], $menuEntry[2], $menuEntry[3], $menuEntry[4], $menuEntry[5], $menuEntry[6]);
         }
     }
 

--- a/plugins/CoreHome/templates/_menu.twig
+++ b/plugins/CoreHome/templates/_menu.twig
@@ -27,7 +27,13 @@
                                     >
                                         <a class="item" tabindex="5" target="_self"
                                            title="{{ urlParameters._tooltip|default('')|translate|e('html_attr') }}"
-                                           href="index.php?{{ urlParameters._url|urlRewriteWithParameters|slice(1) }}">
+                                            {% if urlParameters._onclick is defined and urlParameters._onclick %}
+                                                onclick="{{ urlParameters._onclick|e('html_attr') }};return false;"
+                                            {% endif %}
+                                            {% if urlParameters._url %}
+                                                href="index.php?{{ urlParameters._url|urlRewriteWithParameters|slice(1) }}"
+                                            {% endif %}>
+                                            {% if urlParameters._icon is defined and urlParameters._icon %}<span class="icon {{ urlParameters._icon|e('html_attr') }}" style="margin-right: 5px;"></span>{% endif %}
                                             {{ name|translate }}
                                         </a>
                                     </li>


### PR DESCRIPTION
I needed this feature for the admin menu template.

It's basically like this:

![image](https://user-images.githubusercontent.com/273120/39414610-c9516930-4c8d-11e8-8804-f25f762b5caf.png)

It doesn't load a new page but instead executes an action directly. Couldn't find a different place to put such an action and thinking the menu is the best for it as the context is there.