### PR TITLE
Lower limit from 500 to 400 when searching for visits in GDPR data subject search

### DIFF
--- a/plugins/PrivacyManager/angularjs/manage-gdpr/managegdpr.controller.js
+++ b/plugins/PrivacyManager/angularjs/manage-gdpr/managegdpr.controller.js
@@ -177,7 +177,7 @@
                     module: 'API',
                     method: 'Live.getLastVisitsDetails',
                     segment: self.segment_filter,
-                    filter_limit: 501,
+                    filter_limit: 401,
                     doNotFetchActions: 1
                 }).then(function (visits) {
                     self.hasSearched = true;

--- a/plugins/PrivacyManager/angularjs/manage-gdpr/managegdpr.directive.html
+++ b/plugins/PrivacyManager/angularjs/manage-gdpr/managegdpr.directive.html
@@ -88,8 +88,8 @@
             </tr>
             </thead>
             <tbody>
-                <tr ng-show="(manageGdpr.dataSubjects|length) > 500">
-                    <td colspan="8">More than 500 results were found and the result was truncated to the first 500 visits.</td>
+                <tr ng-show="(manageGdpr.dataSubjects|length) > 400">
+                    <td colspan="8">More than 400 results were found and the result was truncated to the first 400 visits.</td>
                 </tr>
                 <tr ng-repeat="(index, dataSubject) in manageGdpr.dataSubjects" title="Last action: {{ dataSubject.lastActionDateTime }}">
                     <td class="checkInclude">


### PR DESCRIPTION
I searched for visits in the data subjects export/delete feature (Admin => GDPR tools).

It found 500 visits, when I then clicked on export, the request failed due to missing permissions. This was because the token_auth wasn't available in PHP even though it was sent as part of the request. It worked once I selected 10 less visits. I presume it might be the body length request limit or something that cut part of the request body. Changing it to 400 should improve this but eventually might need to lower it even further and if needed advice users to increase request limit (if that was the problem).