### PR TITLE
Fixing missing Google indexed pages and Domain age information in SEO Rankings widget

### DIFF
--- a/plugins/SEO/Metric/DomainAge.php
+++ b/plugins/SEO/Metric/DomainAge.php
@@ -115,7 +115,7 @@ class DomainAge implements MetricsProvider
     private function getAgeWhoisCom($domain)
     {
         $data = $this->getUrl('https://www.whois.com/whois/' . urlencode($domain));
-        preg_match('#(?:Creation Date|Created On|created):\s*([ \ta-z0-9\/\-:\.]+)#si', $data, $p);
+        preg_match('#(?:Creation Date|Created On|created|Registration Date):\s*([ \ta-z0-9\/\-:\.]+)#si', $data, $p);
         if (!empty($p[1])) {
             $value = strtotime(trim($p[1]));
             if ($value === false) {

--- a/plugins/SEO/Metric/Google.php
+++ b/plugins/SEO/Metric/Google.php
@@ -17,7 +17,7 @@ use Psr\Log\LoggerInterface;
  */
 class Google implements MetricsProvider
 {
-    const SEARCH_URL = 'http://www.google.com/search?hl=en&q=site%3A';
+    const SEARCH_URL = 'https://www.google.com/search?hl=en&q=site%3A';
 
     /**
      * @var LoggerInterface


### PR DESCRIPTION
1. "Google indexed pages" was empty: fetchIndexedPagesCount() in Google class didn't manage to retrieve the page because of a redirect (302 Moved) to https://.
2. Domain age was sometimes empty when https://www.whois.com/whois/ was queried. Need to search for string "Registration Date:".