### PR TITLE
Do not show default value when default value is an array

### DIFF
--- a/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.html
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.html
@@ -18,7 +18,7 @@
 
             <span class="inline-help" ng-bind-html="formField.inlineHelp"></span>
 
-            <span ng-show="formField.defaultValue && formField.uiControl != 'checkbox' && formField.uiControl != 'radio'">
+            <span ng-show="formField.defaultValuePretty && formField.uiControl != 'checkbox' && formField.uiControl != 'radio'">
                 <br />
                 {{ 'General_Default'|translate }}:
                 <span>{{formField.defaultValuePretty|limitTo:50}}</span>

--- a/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
@@ -281,6 +281,10 @@
                 function formatPrettyDefaultValue(defaultValue, availableOptions) {
 
                     if (!angular.isArray(availableOptions)) {
+                        if (angular.isArray(defaultValue)) {
+                            return null;
+                        }
+                        
                         return defaultValue;
                     }
 

--- a/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
@@ -279,7 +279,14 @@
                 }
 
                 function formatPrettyDefaultValue(defaultValue, availableOptions) {
-
+                    if (angular.isString(defaultValue) && defaultValue) {
+                        // eg default value for multi tuple
+                        var defaultParsed = JSON.parse(defaultValue);
+                        if (angular.isObject(defaultParsed)) {
+                            return null;
+                        }
+                    }
+                    
                     if (!angular.isArray(availableOptions)) {
                         if (angular.isArray(defaultValue)) {
                             return null;


### PR DESCRIPTION
Otherwise it shows a json encoded array as default value.
![image](https://user-images.githubusercontent.com/273120/39668260-e67af2b8-511c-11e8-883a-ef0964539eb6.png)

Especially in combination with the new form field multi tuple added in https://github.com/matomo-org/matomo/pull/12807
