### PR TITLE
Fix always all plugin settings are saved in the backend

### DIFF
--- a/plugins/CorePluginsAdmin/API.php
+++ b/plugins/CorePluginsAdmin/API.php
@@ -49,7 +49,9 @@ class API extends \Piwik\Plugin\API
 
         try {
             foreach ($pluginsSettings as $pluginSetting) {
-                $pluginSetting->save();
+                if (!empty($settingValues[$pluginSetting->getPluginName()])) {
+                    $pluginSetting->save();
+                }
             }
         } catch (Exception $e) {
             throw new Exception(Piwik::translate('CoreAdminHome_PluginSettingsSaveFailed'));
@@ -71,7 +73,9 @@ class API extends \Piwik\Plugin\API
 
         try {
             foreach ($pluginsSettings as $pluginSetting) {
-                $pluginSetting->save();
+                if (!empty($settingValues[$pluginSetting->getPluginName()])) {
+                    $pluginSetting->save();
+                }
             }
         } catch (Exception $e) {
             throw new Exception(Piwik::translate('CoreAdminHome_PluginSettingsSaveFailed'));


### PR DESCRIPTION
Be good to have this in 3.5.0 but fine if not.
fix #12826 