### PR TITLE
Show activity indicator only for plugin settings that is being updated

### DIFF
--- a/plugins/CorePluginsAdmin/angularjs/plugin-settings/plugin-settings.controller.js
+++ b/plugins/CorePluginsAdmin/angularjs/plugin-settings/plugin-settings.controller.js
@@ -57,7 +57,7 @@
             });
 
             piwikApi.post({method: apiMethod}, {settingValues: values}).then(function (success) {
-                self.isSaving[settings.pluginName] = true
+                self.isSaving[settings.pluginName] = false;
 
                 var UI = require('piwik/UI');
                 var notification = new UI.Notification();

--- a/plugins/CorePluginsAdmin/angularjs/plugin-settings/plugin-settings.controller.js
+++ b/plugins/CorePluginsAdmin/angularjs/plugin-settings/plugin-settings.controller.js
@@ -15,6 +15,7 @@
         var self = this;
 
         this.isLoading = true;
+        this.isSaving = {};
 
         var apiMethod = 'CorePluginsAdmin.getUserSettings';
 
@@ -35,7 +36,7 @@
                 apiMethod = 'CorePluginsAdmin.setSystemSettings';
             }
 
-            this.isLoading = true;
+            this.isSaving[settings.pluginName] = true;
 
             var values = {};
             if (!values[settings.pluginName]) {
@@ -56,7 +57,7 @@
             });
 
             piwikApi.post({method: apiMethod}, {settingValues: values}).then(function (success) {
-                self.isLoading = false;
+                self.isSaving[settings.pluginName] = true
 
                 var UI = require('piwik/UI');
                 var notification = new UI.Notification();
@@ -66,7 +67,7 @@
                 notification.scrollToNotification();
 
             }, function () {
-                self.isLoading = false;
+                self.isSaving[settings.pluginName] = false;
             });
         };
     }

--- a/plugins/CorePluginsAdmin/angularjs/plugin-settings/plugin-settings.directive.html
+++ b/plugins/CorePluginsAdmin/angularjs/plugin-settings/plugin-settings.directive.html
@@ -16,7 +16,7 @@
                    value="{{ 'General_Save'|translate }}"
                    class="pluginsSettingsSubmit btn"/>
 
-            <div piwik-activity-indicator loading="pluginSettings.isLoading"></div>
+            <div piwik-activity-indicator loading="pluginSettings.isLoading || pluginSettings.isSaving[settings.pluginName]"></div>
 
         </div>
 


### PR DESCRIPTION
fixes https://github.com/matomo-org/matomo/issues/12825

Ideally, the structure of the widget would have been updated to 

- plugin-settings
-- plugin-setting
-- plugin-setting

but as there are currently no other issues it should be fine.