### PR TITLE
Prevent possible view access error

### DIFF
--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -329,7 +329,7 @@ class Model
 
         // SQL Filter with provided period
         if (!empty($period) && !empty($date)) {
-            if ($idSite === 'all') {
+            if ($idSite === 'all' || is_array($idSite)) {
                 $currentTimezone = Request::processRequest('SitesManager.getDefaultTimezone');
             } else {
                 $currentSite = $this->makeSite($idSite);


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/12842

I would assume this change fixes the issue. In theory it should still work even without this change and it usually does (cause it would use the first siteId within the list). It would be interesting to see what the `site` and `access` table on this instance looks like.

Update: I can think of an error when idSite 1 was deleted see https://3v4l.org/gEvUb 

So this change likely fixes it.