### PR TITLE
Force HTTPS in the tracking code whenever HTTPS is currently being used

### DIFF
--- a/core/Tracker/TrackerCodeGenerator.php
+++ b/core/Tracker/TrackerCodeGenerator.php
@@ -12,7 +12,7 @@ use Piwik\Common;
 use Piwik\Piwik;
 use Piwik\Plugins\CustomVariables\CustomVariables;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
-use Piwik\SettingsPiwik;
+use Piwik\ProxyHttp;
 use Piwik\View;
 
 /**
@@ -137,7 +137,7 @@ class TrackerCodeGenerator
             'trackNoScript'           => $trackNoScript
         );
 
-        if (SettingsPiwik::isHttpsForced()) {
+        if (ProxyHttp::isHttps()) {
             $codeImpl['protocol'] = 'https://';
         }
 


### PR DESCRIPTION
it is better to force SSL as soon as the HTTPS is working and is being used for the Tracking code page. follows up https://github.com/matomo-org/matomo/issues/7366 https://github.com/matomo-org/matomo/pull/12799 