### PR TITLE
Add rel="noopener noreferrer" to a link

### DIFF
--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -79,7 +79,7 @@ class Response
                 Common::sendResponseCode(400);
             }
             Common::printDebug("Empty request => Matomo page");
-            echo "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank'>digital analytics platform</a> for web and mobile.";
+            echo "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer'>digital analytics platform</a> for web and mobile.";
         } else {
             $this->outputApiResponse($tracker);
             Common::printDebug("Nothing to notice => default behaviour");

--- a/tests/PHPUnit/Integration/TrackerTest.php
+++ b/tests/PHPUnit/Integration/TrackerTest.php
@@ -251,7 +251,7 @@ class TrackerTest extends IntegrationTestCase
 
         $response = $this->tracker->main($this->getDefaultHandler(), $requestSet);
 
-        $expected = "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank'>digital analytics platform</a> for web and mobile.";
+        $expected = "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer'>digital analytics platform</a> for web and mobile.";
         $this->assertEquals($expected, $response);
     }
 

--- a/tests/PHPUnit/Unit/Tracker/ResponseTest.php
+++ b/tests/PHPUnit/Unit/Tracker/ResponseTest.php
@@ -127,7 +127,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $tracker->setCountOfLoggedRequests(0);
         $this->response->outputResponse($tracker);
 
-        $this->assertEquals("This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank'>digital analytics platform</a> for web and mobile.",
+        $this->assertEquals("This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer'>digital analytics platform</a> for web and mobile.",
             $this->response->getOutput());
     }
 


### PR DESCRIPTION
Hi there,

first thanks for Matomo, I use it on several website, really happy with it. 👍 

While running a detectify on one of my website, it found that the `piwik/piwik.php` is giving this text
`This resource is part of Matomo. Keep full control of your data with the leading free and open source digital analytics platform for web and mobile.` with a link to Matomo using `target="_blank"`.

And it advised me to add `rel="noopener noreferrer"` to this link, which is indeed, a good security pratice, see https://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c for example.

I've modified all the files where I found it, hope this will be enough.

Cheers,
Nicolas