### PR TITLE
Adds update script to remove GeoIP2 plugin from marketplace

### DIFF
--- a/core/Updates/3.5.1-b1.php
+++ b/core/Updates/3.5.1-b1.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Filesystem;
+use Piwik\Notification;
+use Piwik\Plugin\Manager;
+use Piwik\SettingsServer;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+
+class Updates_3_5_1_b1 extends PiwikUpdates
+{
+    public function doUpdate(Updater $updater)
+    {
+        // try to deactivate and remove the GeoIP2 plugin from marketplace,
+        // which causes problems with GeoIp2 plugin included in core
+        // Skip for Windows as file system is case insensitive and names are handled equal
+        try {
+            if (!SettingsServer::isWindows() && is_dir(PIWIK_INCLUDE_PATH . '/plugins/GeoIP2')) {
+                // first remove the plugin files, as trying to deactivate would load the plugin files resulting in a fatal error
+                Filesystem::unlinkRecursive(PIWIK_INCLUDE_PATH . '/plugins/GeoIP2', true);
+
+                // if plugin was activated, trigger deactivation to remove the config entry and set a notification
+                if (Manager::getInstance()->isPluginActivated('GeoIP2')) {
+                    @Manager::getInstance()->deactivatePlugin('GeoIP2');
+                    $notification = new Notification('GeoIP2 plugin from Marketplace has been removed due to compatibility issues. Please check your geolocation settings.');
+                    $notification->context = Notification::CONTEXT_WARNING;
+                    $notification->type = Notification::TYPE_PERSISTENT;
+                    Notification\Manager::notify('GeoIP2_update_warning', $notification);
+                }
+
+                // uninstall the plugin to remove it from config
+                @Manager::getInstance()->uninstallPlugin('GeoIP2');
+            }
+        } catch (\Exception $e) {
+        }
+    }
+}

--- a/core/Updates/3.5.1-b1.php
+++ b/core/Updates/3.5.1-b1.php
@@ -22,9 +22,11 @@ class Updates_3_5_1_b1 extends PiwikUpdates
     {
         // try to deactivate and remove the GeoIP2 plugin from marketplace,
         // which causes problems with GeoIp2 plugin included in core
-        // Skip for Windows as file system is case insensitive and names are handled equal
+        // Skip if new file `isoRegionNames.php` is detected within `GeoIP2` directory, as that means filesystem is case
+        // insensitive and GeoIP2 plugin has been partially overwritten by GeoIp2 plugin
         try {
-            if (!SettingsServer::isWindows() && is_dir(PIWIK_INCLUDE_PATH . '/plugins/GeoIP2')) {
+            if (is_dir(PIWIK_INCLUDE_PATH . '/plugins/GeoIP2') && !file_exists(PIWIK_INCLUDE_PATH . '/plugins/GeoIP2/data/isoRegionNames.php')) {
+
                 // first remove the plugin files, as trying to deactivate would load the plugin files resulting in a fatal error
                 Filesystem::unlinkRecursive(PIWIK_INCLUDE_PATH . '/plugins/GeoIP2', true);
 

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '3.5.0';
+    const VERSION = '3.5.1-b1';
 
     public function isStableVersion($version)
     {

--- a/plugins/GeoIp2/tests/Integration/LocationProviderTest.php
+++ b/plugins/GeoIp2/tests/Integration/LocationProviderTest.php
@@ -11,7 +11,7 @@ namespace Piwik\Plugins\GeoIp2\tests\Integration;
 use Piwik\Plugins\GeoIp2\LocationProvider\GeoIp2;
 
 /**
- * @group GeoIp2x
+ * @group GeoIp2
  */
 class ConvertRegionCodesToIsoTest extends \PHPUnit_Framework_TestCase
 {

--- a/plugins/GeoIp2/tests/Integration/UpdateTest.php
+++ b/plugins/GeoIp2/tests/Integration/UpdateTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\GeoIp2\tests\Integration;
+
+/**
+ * @group GeoIp2
+ */
+class UpdateTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEnsureFileForUpdateIsPresent()
+    {
+        // In update Updates_3_5_1_b1 the file `plugins/GeoIp2/data/isoRegionNames.php` is used to check file system
+        // case sensitivity. Therefor we need to ensure this file is present unless the update script isn't changed
+        $this->assertFileExists(PIWIK_INCLUDE_PATH . '/plugins/GeoIp2/data/isoRegionNames.php');
+    }
+}


### PR DESCRIPTION
Note: The Update script tries to completely remove the GeoIP2 plugin from file system. This is required, as as soon as the plugin gets loaded it results in a fatal. Even if the plugin is deactivated.

fixes #12886