### PR TITLE
Prevent undefined index 'enable_ssl' warning

### DIFF
--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -60,7 +60,7 @@ class Mysql extends Db
         }
 
 
-        if ($dbInfo['enable_ssl']) {
+        if (isset($dbInfo['enable_ssl']) && $dbInfo['enable_ssl']) {
 
             if (!empty($dbInfo['ssl_key'])) {
                 $this->mysqlOptions[PDO::MYSQL_ATTR_SSL_KEY] = $dbInfo['ssl_key'];


### PR DESCRIPTION
Fixes PHP Notice:  Undefined index: enable_ssl in /var/www/matomo/core/Tracker/Db/Pdo/Mysql.php on line 63

when enable_ssl is not defined in the Mysql section of config.ini