### PR TITLE
Improve memory usage for some action archivers

### DIFF
--- a/plugins/Actions/Archiver.php
+++ b/plugins/Actions/Archiver.php
@@ -167,7 +167,7 @@ class Archiver extends \Piwik\Plugin\Archiver
                 AND log_link_visit_action.%s IS NOT NULL"
             . $this->getWhereClauseActionIsNotEvent();
 
-        $groupBy = "log_action.idaction";
+        $groupBy = "log_link_visit_action.%s";
         $orderBy = "`" . PiwikMetrics::INDEX_PAGE_NB_HITS . "` DESC, name ASC";
 
         $rankingQuery = false;

--- a/plugins/Contents/Archiver.php
+++ b/plugins/Contents/Archiver.php
@@ -109,9 +109,9 @@ class Archiver extends \Piwik\Plugin\Archiver
                     AND log_link_visit_action.idaction_content_name IS NOT NULL
                     AND log_link_visit_action.idaction_content_interaction IS NULL";
 
-        $groupBy = "log_action_content_piece.idaction,
-                    log_action_content_target.idaction,
-                    log_action_content_name.idaction";
+        $groupBy = "log_link_visit_action.idaction_content_piece,
+                    log_link_visit_action.idaction_content_target,
+                    log_link_visit_action.idaction_content_name";
 
         $orderBy = "`" . Metrics::INDEX_NB_VISITS . "` DESC";
 

--- a/plugins/Events/Archiver.php
+++ b/plugins/Events/Archiver.php
@@ -172,9 +172,9 @@ class Archiver extends \Piwik\Plugin\Archiver
                     AND log_link_visit_action.idsite = ?
                     AND log_link_visit_action.idaction_event_category IS NOT NULL";
 
-        $groupBy = "log_action_event_category.idaction,
-                    log_action_event_action.idaction,
-                    log_action_event_name.idaction";
+        $groupBy = "og_link_visit_action.idaction_event_category,
+                    log_link_visit_action.idaction_event_action,
+                    log_link_visit_action.idaction_name";
 
         $orderBy = "`" . Metrics::INDEX_NB_VISITS . "` DESC";
 

--- a/plugins/Events/Archiver.php
+++ b/plugins/Events/Archiver.php
@@ -172,7 +172,7 @@ class Archiver extends \Piwik\Plugin\Archiver
                     AND log_link_visit_action.idsite = ?
                     AND log_link_visit_action.idaction_event_category IS NOT NULL";
 
-        $groupBy = "og_link_visit_action.idaction_event_category,
+        $groupBy = "log_link_visit_action.idaction_event_category,
                     log_link_visit_action.idaction_event_action,
                     log_link_visit_action.idaction_name";
 


### PR DESCRIPTION
Tested on some high load instance I noticed that when using previous query, it may for example create a 30GB temporary table whereas this way it uses only a 26MB temp table and should be faster. The explain for both queries is quite similar, although there is a slight difference:

![image](https://user-images.githubusercontent.com/273120/40212155-b198293c-5aa2-11e8-9737-7a58bffe0cfc.png)

It may even only depend on the data whether it makes a huge difference, but on the given dataset it certainly does. 

cc @mattab 