### PR TITLE
Fix DI is not used in tracker updater command

### DIFF
--- a/plugins/CustomPiwikJs/Commands/UpdateTracker.php
+++ b/plugins/CustomPiwikJs/Commands/UpdateTracker.php
@@ -55,7 +55,9 @@ class UpdateTracker extends ConsoleCommand
             $pluginTrackerFiles->ignoreMinified();
         }
 
-        $updater = new TrackerUpdater($sourceFile, $targetFile);
+        $updater = StaticContainer::getContainer()->make('Piwik\Plugins\CustomPiwikJs\TrackerUpdater', array(
+            'fromFile' => $sourceFile, 'toFile' => $targetFile
+        ));
         $updater->setTrackerFiles($pluginTrackerFiles);
         $updater->checkWillSucceed();
         $updater->update();


### PR DESCRIPTION
This means that when someone is decorating this class, it is not being executed.