### PR TITLE
Add possibility to trigger the archiving only for a specific plugin

### DIFF
--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -43,6 +43,8 @@ class Parameters
      */
     private $requestedPlugin = false;
 
+    private $onlyArchiveRequestedPlugin = false;
+
     /**
      * Constructor.
      *
@@ -61,6 +63,22 @@ class Parameters
     public function setRequestedPlugin($plugin)
     {
         $this->requestedPlugin = $plugin;
+    }
+
+    /**
+     * @ignore
+     */
+    public function onlyArchiveRequestedPlugin()
+    {
+        $this->onlyArchiveRequestedPlugin = true;
+    }
+
+    /**
+     * @ignore
+     */
+    public function shouldOnlyArchiveRequestedPlugin()
+    {
+        return $this->onlyArchiveRequestedPlugin;
     }
 
     /**

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -226,6 +226,11 @@ class PluginsArchiver
         if ($this->params->getRequestedPlugin() == $pluginName) {
             return true;
         }
+
+        if ($this->params->shouldOnlyArchiveRequestedPlugin()) {
+            return false;
+        }
+
         if (Rules::shouldProcessReportsAllPlugins(
             $this->params->getIdSites(),
             $this->params->getSegment(),


### PR DESCRIPTION
This feature allows a plugin to archive a specific plugin on demand.

For example if you have a plugin Foo that requires another plugin Bar to be archived with a specific segment of plugin Foo, you could do this in the archiver like this:

```php
public function aggregateDayReport()
{
    ...
   $this->archiveBar();
}
public function aggregateMultipleReports()
{
    ...
    $this->archiveBar();
}
private function archiveBar() {
        $segment = new \Piwik\Segment('fooSegment', array($site->getId()));

        $period =  $this->getParams()->getPeriod();
        $parameters = new ArchiveProcessor\Parameters($site, $period, $segment);
        $parameters->onlyArchiveRequestedPlugin();
        $archiveLoader = new ArchiveProcessor\Loader($parameters);

        // process for each plugin as well
        $idArchive = $archiveLoader->prepareArchive('UserCountry');
}
```

Currently, the workaround would be to add eg `;Segments[]="visitorType==returning,visitorType==returningCustomer"` to the config ini file. However, this will trigger the archiving for ALL reports even though it is only needed for one small report. This can make the difference of 3 minutes archiving time vs 50 minutes archiving time for a site.

When would this be useful? Say you are rending a segmented User Country Map like this:

```php
$params = array($fetch = false, 'fooSegment');
$content = FrontController::getInstance()->dispatch('UserCountryMap', 'visitorMap', $params);
```

Then you don't want to archive all reports for this segment, but only eg `UserCountry` reports.

This change may be also useful for later https://github.com/matomo-org/matomo/issues/11974 Eg when a plugin is being installed, it could call the code from `archiveBar()`  during activation for say the last X months. (it wouldn't 100% work though since if the plugin is activated through the browser, browser archiving would need to be enabled in this example, but it could be achieved by listening to archiving events). 

I was thinking of offering a more general solution for above use case, but would wait until there are more use cases because I currently have only one use case.

Be good to have this in 3.5.1, otherwise in 3.6.0