### PR TITLE
Fixed undefined APIRequest in Visualization.php

### DIFF
--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -749,7 +749,7 @@ class Visualization extends ViewDataTable
     public function buildApiRequestArray()
     {
         $requestArray = $this->request->getRequestArray();
-        $request = APIRequest::getRequestArrayFromString($requestArray);
+        $request = ApiRequest::getRequestArrayFromString($requestArray);
 
         if (false === $this->config->enable_sort) {
             $request['filter_sort_column'] = '';


### PR DESCRIPTION
I have no clue how this worked all the time, but after migrating to a new Server I always got an error on all visualizations.
After investigating that further, I found out that APIRequest is not defined, but ApiRequest is (line 32). After changing that, everything works.

I haven't done any extensive testing or anything like that, but as it is a really small change on a misspelling (?), I hope that's fine.