### PR TITLE
Geoip1 should still be available even when Geoip2 is available

### DIFF
--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -170,9 +170,7 @@ abstract class LocationProvider
             $plugins   = PluginManager::getInstance()->getPluginsLoadedAndActivated();
             foreach ($plugins as $plugin) {
                 foreach (self::getLocationProviders($plugin) as $instance) {
-                    if ($instance->isVisible()) {
-                        self::$providers[] = $instance;
-                    }
+                    self::$providers[] = $instance;
                 }
             }
         }
@@ -280,6 +278,7 @@ abstract class LocationProvider
             $info['status'] = $status;
             $info['statusMessage'] = $statusMessage;
             $info['location'] = $location;
+            $info['isVisible'] = $provider->isVisible();
 
             $allInfo[$info['order']] = $info;
         }

--- a/plugins/UserCountry/templates/adminIndex.twig
+++ b/plugins/UserCountry/templates/adminIndex.twig
@@ -30,7 +30,7 @@
         <div class="col s12 push-m9 m3">{{ 'General_InfoFor'|translate(thisIP) }}</div>
     </div>
 
-    {% for id,provider in locationProviders %}
+    {% for id,provider in locationProviders if provider.isVisible %}
     <div class="row form-group provider{{ id|e('html_attr') }}">
         <div class="col s12 m4 l2">
             <p>


### PR DESCRIPTION
Because geoip1 can still be useful even when geoip2 is available (for example, geoip1 seems faster)

(this is a patch we hot-fixed on Cloud)

cc @sgiehl 