### PR TITLE
Slightly faster location provider instance creation

### DIFF
--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -354,12 +354,12 @@ abstract class LocationProvider
      */
     public static function getProviderById($providerId)
     {
-        foreach (self::getAvailableProviders() as $provider) {
-            if ($provider->getId() == $providerId) {
+        foreach (self::getAllProviders() as $provider) {
+            if ($provider->getId() == $providerId && $provider->isAvailable()) {
                 return $provider;
             }
         }
-
+        
         return null;
     }
 


### PR DESCRIPTION
Currently, on each tracking request it checks for each location provider whether each location provider is available which can put a bit of load on the filesystem etc. Instead we should check it only for the requested provider. Maybe we could even cache at some point whether a provider is available or not! Also ideally eventually we would be able to directly create an instance of the needed provider but that shouldn't improve performance crazy much.