### PR TITLE
Remove constraint for PHP 5.6 in scheduled report image generation check in tests.

### DIFF
--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -77,7 +77,6 @@ use ReflectionClass;
 class Fixture extends \PHPUnit_Framework_Assert
 {
     const IMAGES_GENERATED_ONLY_FOR_OS = 'linux';
-    const IMAGES_GENERATED_FOR_PHP = '5.6';
     const IMAGES_GENERATED_FOR_GD = '2.1.0';
     const DEFAULT_SITE_NAME = 'Piwik test';
 
@@ -805,7 +804,6 @@ class Fixture extends \PHPUnit_Framework_Assert
         $gdInfo = gd_info();
         return
             stristr(php_uname(), self::IMAGES_GENERATED_ONLY_FOR_OS) &&
-            strpos( phpversion(), self::IMAGES_GENERATED_FOR_PHP) !== false &&
             strpos( $gdInfo['GD Version'], self::IMAGES_GENERATED_FOR_GD) !== false;
     }
 


### PR DESCRIPTION
In my docker image which uses PHP 7.1 w/ a 2.1.0 compatible GD, I am able to run the scheduled report tests that generate images w/o issue (and they generate the same results as on travis). So I think the check for PHP 5.6 here might not be needed.

Could someone confirm? If it's really not needed, removing the line would make it a little bit easier for me to run them locally.

