### PR TITLE
Support both LFS pointers and full objects in ReleaseCheckListTest::test_screenshotsStoredInLfs 

### DIFF
--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -110,7 +110,7 @@ class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
 
         $storedLfsFiles = explode("\n", `git lfs ls-files`);
         $cleanRevision  = function ($value) {
-            $parts = explode(' - ', $value);
+            $parts = explode(' ', $value);
             return array_pop($parts);
         };
         $storedLfsFiles = array_map($cleanRevision, $storedLfsFiles);


### PR DESCRIPTION
`PHPUnit\Integration\ReleaseCheckListTest::test_screenshotsStoredInLfs()` fails if the screenshots in LFS have been fetched using `git lfs pull`. This changes the output of `git lfs ls-files` from 

```
2bafb75901 - plugins/Actions/tests/UI/expected-screenshots/ActionsDataTable_auto_expand.png
```
to 
```
2bafb75901 * plugins/Actions/tests/UI/expected-screenshots/ActionsDataTable_auto_expand.png
```

The difference is only the state of the local working directory, so the test should allow both. 