### PR TITLE
Add event to allow altering the request URL that CronArchive uses.

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1701,6 +1701,11 @@ class CronArchive
             $url .= "&testmode=1";
         }
 
+        /**
+         * @ignore
+         */
+        Piwik::postEvent('CronArchive.alterArchivingRequestUrl', [&$url]);
+
         return $url;
     }
 


### PR DESCRIPTION
So a plugin could add a query param to archiving requests.

Not API.