### PR TITLE
Make join table sort stable

### DIFF
--- a/core/DataAccess/LogQueryBuilder/JoinGenerator.php
+++ b/core/DataAccess/LogQueryBuilder/JoinGenerator.php
@@ -286,11 +286,11 @@ class JoinGenerator
                 $tBName = $tB['table'];
             }
 
-            if ($tBName && isset($tA['joinOn']) && strpos($tA['joinOn'], $tBName) !== false) {
+            if ($tBName && isset($tA['joinOn']) && strpos($tA['joinOn'] . '.', $tBName) !== false) {
                 return 1;
             }
 
-            if ($tAName && isset($tB['joinOn']) && strpos($tB['joinOn'], $tAName) !== false) {
+            if ($tAName && isset($tB['joinOn']) && strpos($tB['joinOn'] . '.', $tAName) !== false) {
                 return -1;
             }
 
@@ -317,14 +317,10 @@ class JoinGenerator
         }
 
         if ($weightA === $weightB) {
-            return 0;
+            return strcmp($tAName, $tBName);
         }
 
-        if ($weightA > $weightB) {
-            return 1;
-        }
-
-        return -1;
+        return $weightA - $weightB;
     }
     
 }

--- a/core/DataAccess/LogQueryBuilder/JoinGenerator.php
+++ b/core/DataAccess/LogQueryBuilder/JoinGenerator.php
@@ -294,7 +294,7 @@ class JoinGenerator
                 return -1;
             }
 
-            return 0;
+            return strcmp($tAName, $tBName);
         }
 
         if (is_array($tA)) {

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -423,10 +423,10 @@ class SegmentTest extends IntegrationTestCase
                     sum(log_link_visit_action.time_spent) as `13`,
                     sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
              FROM $logLinkVisitActionTable AS log_link_visit_action
-                  LEFT JOIN $logVisitTable AS log_visit
-                       ON log_visit.idvisit = log_link_visit_action.idvisit
                   LEFT JOIN $logActionTable AS log_action
                        ON log_link_visit_action.idaction_url = log_action.idaction
+                  LEFT JOIN $logVisitTable AS log_visit
+                       ON log_visit.idvisit = log_link_visit_action.idvisit
              WHERE ( log_link_visit_action.server_time >= ?
                  AND log_link_visit_action.server_time <= ?
                  AND log_link_visit_action.idsite = ? )
@@ -554,8 +554,8 @@ class SegmentTest extends IntegrationTestCase
                     sum(log_link_visit_action.time_spent) as `13`,
                     sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
              FROM $logLinkVisitActionTable AS log_link_visit_action 
-             LEFT JOIN $logVisitTable AS log_visit ON log_visit.idvisit = log_link_visit_action.idvisit 
              LEFT JOIN $logActionTable AS log_action ON log_link_visit_action.idaction_name = log_action.idaction
+             LEFT JOIN $logVisitTable AS log_visit ON log_visit.idvisit = log_link_visit_action.idvisit 
              WHERE ( log_link_visit_action.server_time >= ?
                  AND log_link_visit_action.server_time <= ?
                  AND log_link_visit_action.idsite = ? )
@@ -718,8 +718,8 @@ class SegmentTest extends IntegrationTestCase
                     sum(case visitAlias.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `6`
              FROM $logLinkVisitActionTable AS log_link_visit_action 
              LEFT JOIN $logActionTable AS log_action ON log_link_visit_action.idaction_url = log_action.idaction 
-             LEFT JOIN $logVisitTable AS visitAlias ON visitAlias.idvisit = log_link_visit_action.idvisit 
              LEFT JOIN $logActionTable AS actionAlias ON log_link_visit_action.idaction_url = actionAlias.idaction
+             LEFT JOIN $logVisitTable AS visitAlias ON visitAlias.idvisit = log_link_visit_action.idvisit 
              WHERE ( log_link_visit_action.server_time >= ?
                  AND log_link_visit_action.server_time <= ?
                  AND log_link_visit_action.idsite = ? )
@@ -969,8 +969,8 @@ class SegmentTest extends IntegrationTestCase
                   SELECT log_action_visit_entry_idaction_name.name, log_action_idaction_event_action.name as name02fd90a35677a359ea5611a4bc456a6f, log_visit.idvisit, log_visit.idvisitor, log_visit.visit_total_actions, log_visit.visit_goal_converted 
                   FROM $logVisitTable AS log_visit 
                   LEFT JOIN $logLinkVisitActionTable AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit 
-                  LEFT JOIN $logActionTable AS log_action_visit_entry_idaction_name ON log_visit.visit_entry_idaction_name = log_action_visit_entry_idaction_name.idaction 
                   LEFT JOIN $logActionTable AS log_action_idaction_event_action ON log_link_visit_action.idaction_event_action = log_action_idaction_event_action.idaction
+                  LEFT JOIN $logActionTable AS log_action_visit_entry_idaction_name ON log_visit.visit_entry_idaction_name = log_action_visit_entry_idaction_name.idaction 
                   ORDER BY nb_uniq_visits, log_action_idaction_event_action.name LIMIT 0, 33 ) 
                 AS log_inner 
                 GROUP BY log_inner.name, log_inner.name02fd90a35677a359ea5611a4bc456a6f 

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
@@ -248,7 +248,7 @@ class JoinGeneratorTest extends \PHPUnit_Framework_TestCase
                 array (
                     'table' => 'log_action',
                     'tableAlias' => 'log_action_visit_exit_idaction_name',
-                    'joinOn' => 'log_visit.visit_exit_idaction_name = log_action_visit_exit_idaction_name.idaction',
+                    'joinOn' => 'log_link_visit_action.idaction_name = log_action_visit_exit_idaction_name.idaction',
                 ),
         )
         ;
@@ -266,7 +266,7 @@ class JoinGeneratorTest extends \PHPUnit_Framework_TestCase
             array (
                 'table' => 'log_action',
                 'tableAlias' => 'log_action_visit_exit_idaction_name',
-                'joinOn' => 'log_visit.visit_exit_idaction_name = log_action_visit_exit_idaction_name.idaction',
+                'joinOn' => 'log_link_visit_action.idaction_name = log_action_visit_exit_idaction_name.idaction',
             ),
         );
 

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
@@ -183,8 +183,8 @@ class JoinGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $expected  = 'log_link_visit_action AS log_link_visit_action ';
         $expected .= 'LEFT JOIN log_action AS log_action ON log_link_visit_action.idaction_url = log_action.idaction ';
-        $expected .= 'RIGHT JOIN log_visit AS log_visit ON log_visit.idvisit = log_link_visit_action.idvisit ';
-        $expected .= 'RIGHT JOIN log_action AS log_action_r ON log_link_visit_action.idaction_test = log_action_r.idaction';
+        $expected .= 'RIGHT JOIN log_action AS log_action_r ON log_link_visit_action.idaction_test = log_action_r.idaction ';
+        $expected .= 'RIGHT JOIN log_visit AS log_visit ON log_visit.idvisit = log_link_visit_action.idvisit';
         $this->assertEquals($expected, $generator->getJoinString());
     }
 
@@ -260,13 +260,13 @@ class JoinGeneratorTest extends \PHPUnit_Framework_TestCase
             'log_link_visit_action',
             array (
                 'table' => 'log_action',
-                'tableAlias' => 'log_action_visit_exit_idaction_name',
-                'joinOn' => 'log_visit.visit_exit_idaction_name = log_action_visit_exit_idaction_name.idaction',
+                'tableAlias' => 'log_action_idaction_name',
+                'joinOn' => 'log_link_visit_action.idaction_name = log_action_idaction_name.idaction',
             ),
             array (
                 'table' => 'log_action',
-                'tableAlias' => 'log_action_idaction_name',
-                'joinOn' => 'log_link_visit_action.idaction_name = log_action_idaction_name.idaction',
+                'tableAlias' => 'log_action_visit_exit_idaction_name',
+                'joinOn' => 'log_visit.visit_exit_idaction_name = log_action_visit_exit_idaction_name.idaction',
             ),
         );
 


### PR DESCRIPTION
As discussed in #12778, the table sort in `Piwik\DataAccess\LogQueryBuilder\JoinGenerator` should be stable for more reliable testing.

In case the order of two joins is irrelevant, they are now sorted by the table alias which should be unique. This makes the sorting identical in PHP 5 and PHP 7.