### PR TITLE
Avoid too many DB connections error in tests

### DIFF
--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -79,7 +79,7 @@ abstract class IntegrationTestCase extends SystemTestCase
         static::$fixture->extraDefinitions = array_merge(static::provideContainerConfigBeforeClass(), $this->provideContainerConfig());
         static::$fixture->createEnvironmentInstance();
 
-        Db::createDatabaseObject();
+        Db::get();
         Fixture::loadAllPlugins(new TestingEnvironmentVariables(), get_class($this), self::$fixture->extraPluginsToLoad);
 
         Access::getInstance()->setSuperUserAccess(true);


### PR DESCRIPTION
Currently, we always create a new DB connection after each test. If a class holds a reference to it say eg

```php
public function __construct(){
    $this->db = Db::get();
}
```

Then eventually all tests will fail with the error `Zend_Db_Adapter_Exception: SQLSTATE[08004] [1040] Too many connections`.

Tried using `Db::destroyDatabaseObject();Db::createDatabaseObject()` instead but it didn't work.

Will need to see if tests succeed.