### PR TITLE
Replace piwik url with example url when not having a protocol

### DIFF
--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -295,6 +295,11 @@ class Response
      */
     private function replacePiwikUrl($apiResponse)
     {
-        return str_replace(Fixture::getRootUrl(), "http://example.com/piwik/", $apiResponse);
+        $rootUrl = Fixture::getRootUrl();
+        $rootUrlRel = str_replace(array('http://', 'https://'), '//', $rootUrl);
+
+        $apiResponse = str_replace($rootUrl, "http://example.com/piwik/", $apiResponse);
+        $apiResponse = str_replace($rootUrlRel, "//example.com/piwik/", $apiResponse);
+        return $apiResponse;
     }
 }


### PR DESCRIPTION
Eg when a test contains `//localhost/...` then it will be replaced with `//example.com/piwik` in the future so there is no difference between travis and local