### PR TITLE
Hide GeoIP2 server module settings by default

### DIFF
--- a/plugins/GeoIp2/SystemSettings.php
+++ b/plugins/GeoIp2/SystemSettings.php
@@ -22,11 +22,20 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     /** @var Setting[] */
     public $geoIp2variables;
 
+    /** @var Setting */
+    public $useCustomVars;
+
     protected function init()
     {
         $this->title = Piwik::translate('GeoIp2_ServerBasedVariablesConfiguration');
 
         $geoIpAdminEnabled = UserCountry::isGeoLocationAdminEnabled();
+
+        $this->useCustomVars = $this->makeSetting('geoip2usecustom', false, FieldConfig::TYPE_BOOL, function (FieldConfig $field) {
+            $field->title = Piwik::translate('GeoIp2_ShowCustomServerVariablesConfig');
+            $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
+        });
+        $this->useCustomVars->setIsWritableByCurrentUser($geoIpAdminEnabled);
 
         foreach (ServerModule::$defaultGeoIpServerVars as $name => $value) {
             $this->geoIp2variables[$name] = $this->createGeoIp2ServerVarSetting($name, $value);
@@ -39,6 +48,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
         return $this->makeSetting('geoip2var_'.$name, $default = $defaultValue, FieldConfig::TYPE_STRING, function (FieldConfig $field) use ($name) {
             $field->title = Piwik::translate('GeoIp2_ServerVariableFor', '<strong>' . str_replace('_', ' ', $name) . '</strong>');
             $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
+            $field->condition = 'geoip2usecustom==1';
         });
     }
 }

--- a/plugins/GeoIp2/lang/en.json
+++ b/plugins/GeoIp2/lang/en.json
@@ -9,6 +9,7 @@
     "LocationProviderDesc_ServerModule2": "If you have to import log files or do something else that requires setting IP addresses, use the %3$sPHP GeoIP 2 implementation%4$s and install %1$smaxminddb extension%2$s.",
     "ServerBasedVariablesConfiguration": "Configuration for server variables used by GeoIP 2 server modules",
     "GeoIPVariablesConfigurationHere": "You can configure used server variables %1$shere%2$s.",
+    "ShowCustomServerVariablesConfig": "I use the Geoip2 server module (Nginx, Apache...) and want to configure server variables",
     "ServerVariableFor": "Server variable for %s"
   }
 }

--- a/tests/PHPUnit/System/expected/test_ImportLogs__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__CorePluginsAdmin.getSystemSettings.xml
@@ -5,6 +5,22 @@
 		<title>Configuration for server variables used by GeoIP 2 server modules</title>
 		<settings>
 			<row>
+				<name>geoip2usecustom</name>
+				<title>I use the Geoip2 server module (Nginx, Apache...) and want to configure server variables</title>
+				<value>0</value>
+				<defaultValue>0</defaultValue>
+				<type>boolean</type>
+				<uiControl>checkbox</uiControl>
+				<uiControlAttributes>
+				</uiControlAttributes>
+				<availableValues />
+				<description />
+				<inlineHelp />
+				<templateFile />
+				<introduction />
+				<condition />
+			</row>
+			<row>
 				<name>geoip2var_continent_code</name>
 				<title>Server variable for &lt;strong&gt;continent code&lt;/strong&gt;</title>
 				<value>MM_CONTINENT_CODE</value>
@@ -18,7 +34,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_continent_name</name>
@@ -34,7 +50,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_country_code</name>
@@ -50,7 +66,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_country_name</name>
@@ -66,7 +82,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_region_code</name>
@@ -82,7 +98,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_region_name</name>
@@ -98,7 +114,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_lat</name>
@@ -114,7 +130,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_long</name>
@@ -130,7 +146,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_postal_code</name>
@@ -146,7 +162,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_city_name</name>
@@ -162,7 +178,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_isp</name>
@@ -178,7 +194,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_org</name>
@@ -194,7 +210,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 		</settings>
 	</row>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__CorePluginsAdmin.getSystemSettings.xml
@@ -5,6 +5,22 @@
 		<title>Configuration for server variables used by GeoIP 2 server modules</title>
 		<settings>
 			<row>
+				<name>geoip2usecustom</name>
+				<title>I use the Geoip2 server module (Nginx, Apache...) and want to configure server variables</title>
+				<value>0</value>
+				<defaultValue>0</defaultValue>
+				<type>boolean</type>
+				<uiControl>checkbox</uiControl>
+				<uiControlAttributes>
+				</uiControlAttributes>
+				<availableValues />
+				<description />
+				<inlineHelp />
+				<templateFile />
+				<introduction />
+				<condition />
+			</row>
+			<row>
 				<name>geoip2var_continent_code</name>
 				<title>Server variable for &lt;strong&gt;continent code&lt;/strong&gt;</title>
 				<value>MM_CONTINENT_CODE</value>
@@ -18,7 +34,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_continent_name</name>
@@ -34,7 +50,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_country_code</name>
@@ -50,7 +66,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_country_name</name>
@@ -66,7 +82,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_region_code</name>
@@ -82,7 +98,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_region_name</name>
@@ -98,7 +114,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_lat</name>
@@ -114,7 +130,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_long</name>
@@ -130,7 +146,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_postal_code</name>
@@ -146,7 +162,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_city_name</name>
@@ -162,7 +178,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_isp</name>
@@ -178,7 +194,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_org</name>
@@ -194,7 +210,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 		</settings>
 	</row>

--- a/tests/PHPUnit/System/expected/test_noVisit_PeriodIsLast__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_noVisit_PeriodIsLast__CorePluginsAdmin.getSystemSettings.xml
@@ -5,6 +5,22 @@
 		<title>Configuration for server variables used by GeoIP 2 server modules</title>
 		<settings>
 			<row>
+				<name>geoip2usecustom</name>
+				<title>I use the Geoip2 server module (Nginx, Apache...) and want to configure server variables</title>
+				<value>0</value>
+				<defaultValue>0</defaultValue>
+				<type>boolean</type>
+				<uiControl>checkbox</uiControl>
+				<uiControlAttributes>
+				</uiControlAttributes>
+				<availableValues />
+				<description />
+				<inlineHelp />
+				<templateFile />
+				<introduction />
+				<condition />
+			</row>
+			<row>
 				<name>geoip2var_continent_code</name>
 				<title>Server variable for &lt;strong&gt;continent code&lt;/strong&gt;</title>
 				<value>MM_CONTINENT_CODE</value>
@@ -18,7 +34,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_continent_name</name>
@@ -34,7 +50,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_country_code</name>
@@ -50,7 +66,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_country_name</name>
@@ -66,7 +82,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_region_code</name>
@@ -82,7 +98,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_region_name</name>
@@ -98,7 +114,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_lat</name>
@@ -114,7 +130,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_long</name>
@@ -130,7 +146,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_postal_code</name>
@@ -146,7 +162,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_city_name</name>
@@ -162,7 +178,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_isp</name>
@@ -178,7 +194,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_org</name>
@@ -194,7 +210,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 		</settings>
 	</row>

--- a/tests/PHPUnit/System/expected/test_noVisit__CorePluginsAdmin.getSystemSettings.xml
+++ b/tests/PHPUnit/System/expected/test_noVisit__CorePluginsAdmin.getSystemSettings.xml
@@ -5,6 +5,22 @@
 		<title>Configuration for server variables used by GeoIP 2 server modules</title>
 		<settings>
 			<row>
+				<name>geoip2usecustom</name>
+				<title>I use the Geoip2 server module (Nginx, Apache...) and want to configure server variables</title>
+				<value>0</value>
+				<defaultValue>0</defaultValue>
+				<type>boolean</type>
+				<uiControl>checkbox</uiControl>
+				<uiControlAttributes>
+				</uiControlAttributes>
+				<availableValues />
+				<description />
+				<inlineHelp />
+				<templateFile />
+				<introduction />
+				<condition />
+			</row>
+			<row>
 				<name>geoip2var_continent_code</name>
 				<title>Server variable for &lt;strong&gt;continent code&lt;/strong&gt;</title>
 				<value>MM_CONTINENT_CODE</value>
@@ -18,7 +34,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_continent_name</name>
@@ -34,7 +50,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_country_code</name>
@@ -50,7 +66,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_country_name</name>
@@ -66,7 +82,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_region_code</name>
@@ -82,7 +98,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_region_name</name>
@@ -98,7 +114,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_lat</name>
@@ -114,7 +130,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_long</name>
@@ -130,7 +146,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_postal_code</name>
@@ -146,7 +162,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_city_name</name>
@@ -162,7 +178,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_isp</name>
@@ -178,7 +194,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 			<row>
 				<name>geoip2var_org</name>
@@ -194,7 +210,7 @@
 				<inlineHelp />
 				<templateFile />
 				<introduction />
-				<condition />
+				<condition>geoip2usecustom==1</condition>
 			</row>
 		</settings>
 	</row>

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06acc940692e711cdd42cf109d69f080870ac9c9d3c7d7db0bbe779c8d41595f
-size 3930148
+oid sha256:217492649ef815fe53021553dcb8c5eb7b283d815bd20c993cb1f174b34c6d70
+size 3934051

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_settings_general.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_settings_general.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2ea2bedad7625762257b2b537ff91325b53f7dacafbb4ac5885057d3ed4501a
-size 801113
+oid sha256:86067d07990deeb04b77ecdc8809dc3c647258dc4ca3dfd7b1b25ece1e0239f2
+size 708430


### PR DESCRIPTION
As most people won't use the server module it makes more sense to hide the settings by default.