### PR TITLE
Validate premium feature license correctly when cancelled

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -194,6 +194,11 @@ class Plugin
         return $this->pluginInformation;
     }
 
+    final public function isPremiumFeature()
+    {
+        return !empty($this->pluginInformation['price']['base']);
+    }
+
     /**
      * Returns a list of events with associated event observers.
      *

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -15,6 +15,7 @@ use Piwik\Columns\Dimension;
 use Piwik\Config;
 use Piwik\Config as PiwikConfig;
 use Piwik\Container\StaticContainer;
+use Piwik\Development;
 use Piwik\EventDispatcher;
 use Piwik\Exception\PluginDeactivatedException;
 use Piwik\Filesystem;
@@ -890,7 +891,7 @@ class Manager
             $info = $newPlugin->getInformation();
             $hasInternet = Config::getInstance()->General['enable_internet_features'];
 
-            if (!empty($info['price']['base']) && $hasInternet) {
+            if (!empty($info['price']['base']) && $hasInternet && !Development::isEnabled()) {
                 try {
 
                     $cacheKey = 'MarketplacePluginMissingLicense' . $pluginName;
@@ -902,12 +903,12 @@ class Manager
                         $plugins = StaticContainer::get('Piwik\Plugins\Marketplace\Plugins');
 
                         try {
-                            $pluginInfo = $plugins->getPluginInfo($pluginName);
+                            $licenseInfo = $plugins->getLicenseValidInfo($pluginName);
                         } catch (\Exception $e) {
-                            $pluginInfo = array();
+                            $licenseInfo = array();
                         }
 
-                        $pluginLicenseInfo = array('missing' => !empty($pluginInfo['isMissingLicense']));
+                        $pluginLicenseInfo = array('missing' => !empty($licenseInfo['isMissingLicense']));
                         $cache->save($cacheKey, $pluginLicenseInfo, Client::CACHE_TIMEOUT_IN_SECONDS);
                     }
 

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -892,7 +892,7 @@ class Manager
             && $this->isPluginActivated($pluginName)) {
 
             $cacheKey = 'MarketplacePluginMissingLicense' . $pluginName;
-            $cache = Cache::getLazyCache();
+            $cache = self::getLicenseCache();
 
             if ($cache->contains($cacheKey)) {
                 $pluginLicenseInfo = $cache->fetch($cacheKey);
@@ -905,7 +905,8 @@ class Manager
                 }
 
                 $pluginLicenseInfo = array('missing' => !empty($licenseInfo['isMissingLicense']));
-                $cache->save($cacheKey, $pluginLicenseInfo, Client::CACHE_TIMEOUT_IN_SECONDS);
+                $sixHours = 3600 * 6;
+                $cache->save($cacheKey, $pluginLicenseInfo, $sixHours);
             }
 
             if (!empty($pluginLicenseInfo['missing'])) {
@@ -917,6 +918,11 @@ class Manager
         $pluginsToPostPendingEventsTo[] = $newPlugin;
 
         return $pluginsToPostPendingEventsTo;
+    }
+
+    public static function getLicenseCache()
+    {
+        return Cache::getLazyCache();
     }
 
     public function getIgnoredBogusPlugins()

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -887,8 +887,9 @@ class Manager
             && $this->isPluginActivated($pluginName)) {
 
             $info = $newPlugin->getInformation();
+            $hasInternet = Config::getInstance()->General['enable_internet_features'];
 
-            if (!empty($info['price']['base'])) {
+            if (!empty($info['price']['base']) && $hasInternet) {
                 try {
 
                     $cacheKey = 'MarketplacePluginMissingLicense' . $pluginName;

--- a/plugins/Marketplace/Controller.php
+++ b/plugins/Marketplace/Controller.php
@@ -89,6 +89,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         // this is also like a self-repair to clear the caches :)
         $this->marketplaceApi->clearAllCacheEntries();
         $this->consumer->clearCache();
+        // invalidate cache for plugin/manager
+        Plugin\Manager::getLicenseCache()->flushAll();
 
         $hasLicenseKey = $this->licenseKey->has();
 

--- a/plugins/Marketplace/Marketplace.php
+++ b/plugins/Marketplace/Marketplace.php
@@ -32,6 +32,11 @@ class Marketplace extends \Piwik\Plugin
         );
     }
 
+    public function isTrackerPlugin()
+    {
+        return true;
+    }
+
     public function checkForUpdates()
     {
         $marketplace = StaticContainer::get('Piwik\Plugins\Marketplace\Api\Client');

--- a/plugins/Marketplace/Plugins.php
+++ b/plugins/Marketplace/Plugins.php
@@ -238,8 +238,10 @@ class Plugins
         $plugin['isInvalid']    = $this->pluginManager->isPluginThirdPartyAndBogus($plugin['name']);
         $plugin['canBeUpdated'] = $plugin['isInstalled'] && $this->hasPluginUpdate($plugin);
         $plugin['lastUpdated'] = $this->toShortDate($plugin['lastUpdated']);
-        $plugin['hasExceededLicense'] = !empty($plugin['isInstalled']) && !empty($plugin['shop']) && empty($plugin['isFree']) && empty($plugin['isDownloadable']) && !empty($plugin['consumer']['license']['isValid']) && !empty($plugin['consumer']['license']['isExceeded']);
-        $plugin['isMissingLicense'] = !empty($plugin['isInstalled']) && !empty($plugin['shop']) && empty($plugin['isFree']) && empty($plugin['isDownloadable']) && empty($plugin['consumer']['license']);
+
+        $isProFeature = !empty($plugin['isInstalled']) && !empty($plugin['shop']) && empty($plugin['isFree']) && empty($plugin['isDownloadable']);
+        $plugin['hasExceededLicense'] = $isProFeature && !empty($plugin['consumer']['license']['isValid']) && !empty($plugin['consumer']['license']['isExceeded']);
+        $plugin['isMissingLicense'] = $isProFeature && (empty($plugin['consumer']['license']) || (!empty($plugin['consumer']['license']['status']) && $plugin['consumer']['license']['status'] === 'Cancelled'));
 
         if (!empty($plugin['owner'])
             && strtolower($plugin['owner']) === 'piwikpro'

--- a/plugins/Marketplace/Plugins.php
+++ b/plugins/Marketplace/Plugins.php
@@ -64,6 +64,17 @@ class Plugins
         return $plugin;
     }
 
+    public function getLicenseValidInfo($pluginName)
+    {
+        $plugin = $this->marketplaceClient->getPluginInfo($pluginName);
+        $plugin = $this->enrichLicenseInformation($plugin);
+
+        return array(
+            'hasExceededLicense' => !empty($plugin['hasExceededLicense']),
+            'isMissingLicense' => !empty($plugin['isMissingLicense'])
+        );
+    }
+
     public function getAvailablePluginNames($themesOnly)
     {
         if ($themesOnly) {
@@ -239,9 +250,12 @@ class Plugins
         $plugin['canBeUpdated'] = $plugin['isInstalled'] && $this->hasPluginUpdate($plugin);
         $plugin['lastUpdated'] = $this->toShortDate($plugin['lastUpdated']);
 
-        $isProFeature = !empty($plugin['isInstalled']) && !empty($plugin['shop']) && empty($plugin['isFree']) && empty($plugin['isDownloadable']);
-        $plugin['hasExceededLicense'] = $isProFeature && !empty($plugin['consumer']['license']['isValid']) && !empty($plugin['consumer']['license']['isExceeded']);
-        $plugin['isMissingLicense'] = $isProFeature && (empty($plugin['consumer']['license']) || (!empty($plugin['consumer']['license']['status']) && $plugin['consumer']['license']['status'] === 'Cancelled'));
+        if ($plugin['isInstalled']) {
+            $plugin = $this->enrichLicenseInformation($plugin);
+        } else {
+            $plugin['hasExceededLicense'] = false;
+            $plugin['isMissingLicense'] = false;
+        }
 
         if (!empty($plugin['owner'])
             && strtolower($plugin['owner']) === 'piwikpro'
@@ -271,6 +285,19 @@ class Plugins
         }
 
         $plugin = $this->addMissingRequirements($plugin);
+
+        return $plugin;
+    }
+
+    private function enrichLicenseInformation($plugin)
+    {
+        if (empty($plugin)) {
+            return $plugin;
+        }
+
+        $isPremiumFeature = !empty($plugin['shop']) && empty($plugin['isFree']) && empty($plugin['isDownloadable']);
+        $plugin['hasExceededLicense'] = $isPremiumFeature && !empty($plugin['consumer']['license']['isValid']) && !empty($plugin['consumer']['license']['isExceeded']);
+        $plugin['isMissingLicense'] = $isPremiumFeature && (empty($plugin['consumer']['license']) || (!empty($plugin['consumer']['license']['status']) && $plugin['consumer']['license']['status'] === 'Cancelled'));
 
         return $plugin;
     }

--- a/plugins/Marketplace/Plugins/InvalidLicenses.php
+++ b/plugins/Marketplace/Plugins/InvalidLicenses.php
@@ -198,6 +198,9 @@ class InvalidLicenses
                         $pluginNames['noLicense'][] = $pluginName;
                     } elseif (!empty($plugin['consumer']['license']['isExceeded'])) {
                         $pluginNames['exceeded'][] = $pluginName;
+                    } elseif (isset($plugin['consumer']['license']['status'])
+                              && $plugin['consumer']['license']['status'] === 'Cancelled') {
+                        $pluginNames['noLicense'][] = $pluginName;
                     } elseif (isset($plugin['consumer']['license']['isValid'])
                            && empty($plugin['consumer']['license']['isValid'])) {
                         $pluginNames['expired'][] = $pluginName;

--- a/plugins/Marketplace/Plugins/InvalidLicenses.php
+++ b/plugins/Marketplace/Plugins/InvalidLicenses.php
@@ -118,7 +118,7 @@ class InvalidLicenses
             $loginUrlEnd = '</a>';
         }
 
-        $message = $this->translator->translate('Marketplace_LicenseMissingDescription', array($plugins, '<br/>', "<strong>" . $loginUrl, $loginUrlEnd. "</strong>"));
+        $message = $this->translator->translate('Marketplace_LicenseMissingDeactivatedDescription', array($plugins, '<br/>', "<strong>" . $loginUrl, $loginUrlEnd. "</strong>"));
 
         if (Piwik::hasUserSuperUserAccess()) {
             $message .= ' ' . $this->getSubscritionSummaryMessage();

--- a/plugins/Marketplace/lang/en.json
+++ b/plugins/Marketplace/lang/en.json
@@ -31,7 +31,7 @@
     "LicenseKeyDeletedSuccess": "License key successfully deleted.",
     "Exceeded": "Exceeded",
     "LicenseMissing": "License missing",
-    "LicenseMissingDescription": "You are using the following plugins without a license: %1$s. %2$sTo resolve this issue either update your license key, %3$sget a subscription now%4$s or deactivate the plugin.",
+    "LicenseMissingDescription": "The following plugins have been deactivated because you are using them without a license: %1$s. %2$sTo resolve this issue either update your license key, %3$sget a subscription now%4$s or deactivate the plugin.",
     "PluginLicenseMissingDescription": "You are not allowed to download this plugin because there is no license for this plugin. To resolve this issue either update your license key, get a subscription or uninstall the plugin.",
     "LicenseExceeded": "License exceeded",
     "LicenseExceededDescription": "The licenses for the following plugins are no longer valid as the number of authorized users for the license is exceeded: %1$s. %2$sYou will not be able to download updates for these plugins. To resolve this issue either delete some users or %3$supgrade the subscription now%4$s.",

--- a/plugins/Marketplace/lang/en.json
+++ b/plugins/Marketplace/lang/en.json
@@ -31,7 +31,7 @@
     "LicenseKeyDeletedSuccess": "License key successfully deleted.",
     "Exceeded": "Exceeded",
     "LicenseMissing": "License missing",
-    "LicenseMissingDescription": "The following plugins have been deactivated because you are using them without a license: %1$s. %2$sTo resolve this issue either update your license key, %3$sget a subscription now%4$s or deactivate the plugin.",
+    "LicenseMissingDeactivatedDescription": "The following plugins have been deactivated because you are using them without a license: %1$s. %2$sTo resolve this issue either update your license key, %3$sget a subscription now%4$s or deactivate the plugin.",
     "PluginLicenseMissingDescription": "You are not allowed to download this plugin because there is no license for this plugin. To resolve this issue either update your license key, get a subscription or uninstall the plugin.",
     "LicenseExceeded": "License exceeded",
     "LicenseExceededDescription": "The licenses for the following plugins are no longer valid as the number of authorized users for the license is exceeded: %1$s. %2$sYou will not be able to download updates for these plugins. To resolve this issue either delete some users or %3$supgrade the subscription now%4$s.",

--- a/plugins/Marketplace/tests/Integration/Plugins/InvalidLicensesTest.php
+++ b/plugins/Marketplace/tests/Integration/Plugins/InvalidLicensesTest.php
@@ -223,7 +223,7 @@ class InvalidLicensesTest extends IntegrationTestCase
 
         $this->assertEquals('', $expired->getMessageExceededLicenses());
         $this->assertEquals('', $expired->getMessageExpiredLicenses());
-        $this->assertEquals('You are using the following plugins without a license: <strong>PaidPlugin1</strong>. <br/>To resolve this issue either update your license key, <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageNoLicense());
+        $this->assertEquals('The following plugins have been deactivated because you are using them without a license: <strong>PaidPlugin1</strong>. <br/>To resolve this issue either update your license key, <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageNoLicense());
     }
 
     public function test_getMessageExceededLicenses_getMessageExpiredLicenses_invalidLicenses_PaidPluginActivated()
@@ -244,7 +244,7 @@ class InvalidLicensesTest extends IntegrationTestCase
     public function test_getMessageMissingLicenses_getMessageMissingLicenses_PaidPluginActivated()
     {
         $expired = $this->buildWithNoLicense();
-        $this->assertEquals('You are using the following plugins without a license: <strong>PaidPlugin1</strong>. <br/>To resolve this issue either update your license key, <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageNoLicense());
+        $this->assertEquals('The following plugins have been deactivated because you are using them without a license: <strong>PaidPlugin1</strong>. <br/>To resolve this issue either update your license key, <strong><a href="https://shop.piwik.org/my-account" target="_blank" rel="noreferrer">get a subscription now</a></strong> or deactivate the plugin. <br/><a href="?module=Marketplace&action=subscriptionOverview">View your plugin subscriptions.</a>', $expired->getMessageNoLicense());
     }
 
     private function buildWithValidLicense()

--- a/plugins/Marketplace/tests/Integration/PluginsTest.php
+++ b/plugins/Marketplace/tests/Integration/PluginsTest.php
@@ -128,6 +128,60 @@ class PluginsTest extends IntegrationTestCase
         $this->assertSame('plugins', $this->service->action);
     }
 
+    public function test_getLicenseValidInfo_noSuchPluginExists()
+    {
+        $plugin = $this->plugins->getPluginInfo('fooBarBaz');
+        $this->assertSame(array(), $plugin);
+    }
+
+    public function test_getLicenseValidInfo_shouldEnrichLicenseInformation()
+    {
+        $this->service->returnFixture('v2.0_plugins_Barometer_info.json');
+        $plugin = $this->plugins->getLicenseValidInfo('PaidPlugin1');
+
+        unset($plugin['versions']);
+
+        $expected = array (
+            'hasExceededLicense' => false,
+            'isMissingLicense' => false,
+        );
+        $this->assertEquals($expected, $plugin);
+    }
+
+    public function test_getLicenseValidInfo_missingLicense()
+    {
+        $this->service->returnFixture('v2.0_plugins_PaidPlugin1_info.json');
+        $plugin = $this->plugins->getLicenseValidInfo('PaidPlugin1');
+
+        unset($plugin['versions']);
+
+        $expected = array (
+            'hasExceededLicense' => false,
+            'isMissingLicense' => true,
+        );
+        $this->assertEquals($expected, $plugin);
+    }
+
+    public function test_getLicenseValidInfo_validLicense()
+    {
+        $this->service->returnFixture('v2.0_consumer-access_token-consumer2_paid1.json');
+        $plugin = $this->plugins->getLicenseValidInfo('Barometer');
+
+        unset($plugin['versions']);
+
+        $expected = array (
+            'hasExceededLicense' => false,
+            'isMissingLicense' => false,
+        );
+        $this->assertEquals($expected, $plugin);
+    }
+
+    public function test_getLicenseValidInfo_notInstalledPlugin_shouldCallCorrectService()
+    {
+        $this->plugins->getLicenseValidInfo('Barometer');
+        $this->assertSame('plugins/Barometer/info', $this->service->action);
+    }
+
     public function test_getPluginInfo_noSuchPluginExists()
     {
         $plugin = $this->plugins->getPluginInfo('fooBarBaz');

--- a/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_notification_plugincheck_noLicense.png
+++ b/plugins/Marketplace/tests/UI/expected-screenshots/Marketplace_notification_plugincheck_noLicense.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c3de246e0bc1b50b8d7164bb4f9b1968fcf8008fe093e012204ffe01ba97a66
-size 22057
+oid sha256:501735f2e19db857247c19900d256680c207abebd5567a2699d92280482f6ff7
+size 24328

--- a/plugins/Marketplace/tests/resources/v2.0_plugins-purchase_type-paid-access_token-consumer1_paid2_custom1.json
+++ b/plugins/Marketplace/tests/resources/v2.0_plugins-purchase_type-paid-access_token-consumer1_paid2_custom1.json
@@ -108,7 +108,7 @@
       "documentation":"",
       "changelog":""},"download":null}],"isDownloadable":false,"changelog":{"url":""},"consumer":{"license":{"startDate":"2014-05-27 04:46:05",
     "endDate":"2014-06-01 06:22:35",
-    "nextPaymentDate":null,"status":"Cancelled",
+    "nextPaymentDate":null,"status":"On Hold",
     "productType":"Up to 4 users",
     "isValid":false,"isExceeded":false,"isExpiredSoon":false},"loginUrl":"https:\/\/shop.piwik.org\/my-account"}},{"name":"PaidPlugin2",
   "displayName":"Paid Plugin 2",

--- a/plugins/Marketplace/tests/resources/v2.0_plugins-purchase_type-paid-num_users-201-access_token-consumer1_paid2_custom1.json
+++ b/plugins/Marketplace/tests/resources/v2.0_plugins-purchase_type-paid-num_users-201-access_token-consumer1_paid2_custom1.json
@@ -109,7 +109,7 @@
       "documentation":"",
       "changelog":""},"download":null}],"isDownloadable":false,"changelog":{"url":""},"consumer":{"license":{"startDate":"2014-05-27 04:46:05",
     "endDate":"2014-06-01 06:22:35",
-    "nextPaymentDate":null,"status":"Cancelled",
+    "nextPaymentDate":null,"status":"On Hold",
     "productType":"Up to 4 users",
     "isValid":false,"isExceeded":false,"isExpiredSoon":false},"loginUrl":"https:\/\/shop.piwik.org\/my-account"}},{"name":"PaidPlugin2",
   "displayName":"Paid Plugin 2",

--- a/tests/PHPUnit/Integration/Plugin/ManagerTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ManagerTest.php
@@ -147,8 +147,8 @@ class ManagerTest extends IntegrationTestCase
 
     private function assertOnlyTrackerPluginsAreLoaded($expectedPluginNamesLoaded)
     {
-        // should currently load between 10 and 27 plugins
-        $this->assertLessThan(27, count($this->manager->getLoadedPlugins()));
+        // should currently load between 10 and 28 plugins
+        $this->assertLessThan(28, count($this->manager->getLoadedPlugins()));
         $this->assertGreaterThan(10, count($this->manager->getLoadedPlugins()));
 
         // we need to make sure it actually only loaded the correct ones


### PR DESCRIPTION
So far we did not consider a cancelled subscription as "missing license", only when no license existed at all. Also we now deactivated a plugin when the license is missing. We check the license once per hour. I would cache it for longer but the problem is, if someone renews the license then it would take eg 12 hours to activate the plugin. Also I wanted to initially use the eager cache which would be slightly faster, however the eager cache is being cached for 12 hours...

Tried to write a test for this but it's quite hard.