### PR TITLE
Fix undefined variable

### DIFF
--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -62,7 +62,7 @@ class OptOutManager
      * @param string $javascript
      * @param bool $inline
      */
-    public function addJavascript($javascript, $inline = true)
+    public function addJavaScript($javascript, $inline = true)
     {
         $type = $inline ? 'inline' : 'external';
         $this->javascripts[$type][] = $javascript;
@@ -71,7 +71,7 @@ class OptOutManager
     /**
      * @return array
      */
-    public function getJavascripts()
+    public function getJavaScripts()
     {
         return $this->javascripts;
     }
@@ -203,7 +203,7 @@ class OptOutManager
 
         $this->view = new View("@CoreAdminHome/optOut");
 
-        $this->addJavaScript('plugins/CoreAdminHome/javascripts/optOut.js', $false);
+        $this->addJavaScript('plugins/CoreAdminHome/javascripts/optOut.js', false);
 
         $this->view->setXFrameOptions('allow');
         $this->view->dntFound = $dntFound;
@@ -212,7 +212,7 @@ class OptOutManager
         $this->view->language = $lang;
         $this->view->showConfirmOnly = Common::getRequestVar('showConfirmOnly', false, 'int');
         $this->view->reloadUrl = $reloadUrl;
-        $this->view->javascripts = $this->getJavascripts();
+        $this->view->javascripts = $this->getJavaScripts();
         $this->view->stylesheets = $this->getStylesheets();
         $this->view->title = $this->getTitle();
         $this->view->queryParameters = $this->getQueryParameters();


### PR DESCRIPTION
Fix the following error:

> WARNING: /home/chsc/www/matomo/plugins/CoreAdminHome/OptOutManager.php(206): Notice - Undefined variable: false - Matomo 3.6.0-b1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)

Also, use consistent case for JavaScript in function names.