### PR TITLE
show ASN org as ORG aswell

### DIFF
--- a/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
@@ -135,6 +135,7 @@ class Php extends GeoIp2
                     case 'GeoLite2-ASN':
                         $lookupResult = $ispGeoIp->asn($ip);
                         $result[self::ISP_KEY] = $lookupResult->autonomousSystemOrganization;
+                        $result[self::ORG_KEY] = $lookupResult->autonomousSystemOrganization;
                         break;
                 }
             } catch (AddressNotFoundException $e) {


### PR DESCRIPTION
See: https://forum.matomo.org/t/geoip-2-organizations-not-showing/28843/2

With the legacy GeoIP plugin, both keys where set to the same value. We should not break that with GeoIp2.