### PR TITLE
Use saved ViewDataTable parameters mechanism for datatables displayed inside a widget container.

### DIFF
--- a/core/ViewDataTable/Factory.php
+++ b/core/ViewDataTable/Factory.php
@@ -107,7 +107,8 @@ class Factory
         $params = array();
 
         if (!isset($loadViewDataTableParametersForUser)) {
-            $loadViewDataTableParametersForUser = ('0' == Common::getRequestVar('widget', '0', 'string'));
+            $containerId = Common::getRequestVar('containerId', '', 'string');
+            $loadViewDataTableParametersForUser = ($containerId != '' || '0' == Common::getRequestVar('widget', '0', 'string'));
         }
 
         if ($loadViewDataTableParametersForUser) {
@@ -116,7 +117,7 @@ class Factory
             if (!empty($report) && $controllerAction === $apiAction) {
                 $paramsKey = $report->getId();
             }
-            $params = Manager::getViewDataTableParameters($login, $paramsKey);
+            $params = Manager::getViewDataTableParameters($login, $paramsKey, $containerId);
         }
 
         if (!self::isDefaultViewTypeForReportFixed($report)) {

--- a/core/ViewDataTable/Factory.php
+++ b/core/ViewDataTable/Factory.php
@@ -106,8 +106,9 @@ class Factory
 
         $params = array();
 
+        $containerId = Common::getRequestVar('containerId', '', 'string');
+
         if (!isset($loadViewDataTableParametersForUser)) {
-            $containerId = Common::getRequestVar('containerId', '', 'string');
             $loadViewDataTableParametersForUser = ($containerId != '' || '0' == Common::getRequestVar('widget', '0', 'string'));
         }
 

--- a/core/ViewDataTable/Manager.php
+++ b/core/ViewDataTable/Manager.php
@@ -243,9 +243,9 @@ class Manager
         Option::deleteLike('viewDataTableParameters_' . $userLogin . '_%');
     }
 
-    public static function getViewDataTableParameters($login, $controllerAction)
+    public static function getViewDataTableParameters($login, $controllerAction, $containerId = null)
     {
-        $paramsKey = self::buildViewDataTableParametersOptionKey($login, $controllerAction);
+        $paramsKey = self::buildViewDataTableParametersOptionKey($login, $controllerAction, $containerId);
         $params    = Option::get($paramsKey);
 
         if (empty($params)) {
@@ -273,9 +273,10 @@ class Manager
      * @param $login
      * @param $controllerAction
      * @param $parametersToOverride
+     * @param string|null $containerId
      * @throws \Exception
      */
-    public static function saveViewDataTableParameters($login, $controllerAction, $parametersToOverride)
+    public static function saveViewDataTableParameters($login, $controllerAction, $parametersToOverride, $containerId = null)
     {
         $params = self::getViewDataTableParameters($login, $controllerAction);
 
@@ -294,7 +295,7 @@ class Manager
             $params[$key] = $value;
         }
 
-        $paramsKey = self::buildViewDataTableParametersOptionKey($login, $controllerAction);
+        $paramsKey = self::buildViewDataTableParametersOptionKey($login, $controllerAction, $containerId);
 
         // when setting an invalid parameter, we fail and let user know
         self::errorWhenSettingNonOverridableParameter($controllerAction, $params);
@@ -302,9 +303,13 @@ class Manager
         Option::set($paramsKey, json_encode($params));
     }
 
-    private static function buildViewDataTableParametersOptionKey($login, $controllerAction)
+    private static function buildViewDataTableParametersOptionKey($login, $controllerAction, $containerId)
     {
-        return sprintf('viewDataTableParameters_%s_%s', $login, $controllerAction);
+        $result = sprintf('viewDataTableParameters_%s_%s', $login, $controllerAction);
+        if (!empty($containerId)) {
+            $result .= '_' . $containerId;
+        }
+        return $result;
     }
 
     /**

--- a/plugins/CoreHome/Controller.php
+++ b/plugins/CoreHome/Controller.php
@@ -297,7 +297,8 @@ class Controller extends \Piwik\Plugin\Controller
         $reportId   = Common::getRequestVar('report_id', null, 'string');
         $parameters = (array) Common::getRequestVar('parameters', null, 'json');
         $login      = Piwik::getCurrentUserLogin();
+        $containerId = Common::getRequestVar('containerId', '', 'string');
 
-        ViewDataTableManager::saveViewDataTableParameters($login, $reportId, $parameters);
+        ViewDataTableManager::saveViewDataTableParameters($login, $reportId, $parameters, $containerId);
     }
 }

--- a/plugins/CoreHome/angularjs/widget/widget.directive.js
+++ b/plugins/CoreHome/angularjs/widget/widget.directive.js
@@ -45,6 +45,7 @@
                                 widget.parameters.widget = '1';
                                 angular.forEach(widget.widgets, function (widget) {
                                     widget.parameters.widget = '1';
+                                    widget.parameters.containerId = containerId;
                                 });
                             }
                             scope.widget = widget;

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1338,22 +1338,25 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         }
     },
 
-    // Tell parent widget that the parameters of this table was updated,
     notifyWidgetParametersChange: function (domWidget, parameters) {
-        var widget = $(domWidget).closest('[widgetId]');
+        var widget = $(domWidget).closest('[widgetId],[containerid]');
         // trigger setParameters event on base element
 
-        if (widget && widget.length) {
+        // Tell parent widget that the parameters of this table were updated, but only if we're not part of a widget
+        // container. widget containers send ajax requests for each child widget, and the child widgets' parameters
+        // are not saved with the container widget.
+        if (widget && widget.length && widget[0].hasAttribute('widgetId')) {
             widget.trigger('setParameters', parameters);
         } else {
-
+            var containerId = widget && widget.length ? widget.attr('containerid') : undefined;
             var reportId = $(domWidget).closest('[data-report]').attr('data-report');
 
             var ajaxRequest = new ajaxHelper();
             ajaxRequest.addParams({
                 module: 'CoreHome',
                 action: 'saveViewDataTableParameters',
-                report_id: reportId
+                report_id: reportId,
+                containerId: containerId,
             }, 'get');
             ajaxRequest.withTokenInUrl();
             ajaxRequest.addParams({

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1356,7 +1356,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                 module: 'CoreHome',
                 action: 'saveViewDataTableParameters',
                 report_id: reportId,
-                containerId: containerId,
+                containerId: containerId
             }, 'get');
             ajaxRequest.withTokenInUrl();
             ajaxRequest.addParams({


### PR DESCRIPTION
Changes:

* Introduce new `containerId` parameter sent by widget containers when getting child widgets. If found in a request, ViewDataTable will look for persisted ViewDataTable parameters.
* `containerId` is appended to the option name for persisted parameters when present. This separates reports used within widget containers from the same reports used outside of widget containers. So if a user adds a metric to the `Visits Overview (with graph)`, the change won't affect the `Visitors > Overview` page.
* Call `CoreHome.saveViewDataTableParameters` when a report is either not in a widget (as before), or is in a widget but is in a widget container (new).

Fixes #11499