### PR TITLE
Auto-detect timezone and currency in installer

### DIFF
--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -30,6 +30,8 @@ if (!defined('PIWIK_VENDOR_PATH')) {
 require_once PIWIK_INCLUDE_PATH . '/core/testMinimumPhpVersion.php';
 
 session_cache_limiter('nocache');
+
+define('PIWIK_DEFAULT_TIMEZONE', @date_default_timezone_get());
 @date_default_timezone_set('UTC');
 
 disableEaccelerator();

--- a/plugins/Installation/FormFirstWebsiteSetup.php
+++ b/plugins/Installation/FormFirstWebsiteSetup.php
@@ -15,6 +15,7 @@ use HTML_QuickForm2_Factory;
 use HTML_QuickForm2_Rule;
 use NumberFormatter;
 use Piwik\Access;
+use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugins\SitesManager\API;
 use Piwik\QuickForm2;
@@ -39,9 +40,11 @@ class FormFirstWebsiteSetup extends QuickForm2
         $timezones = API::getInstance()->getTimezonesList();
         $timezones = array_merge(array('No timezone' => Piwik::translate('SitesManager_SelectACity')), $timezones);
 
-        // Use server timezone as default. If server timezone is UTC, it is likely
-        // a default not specified explicitly by the sysadm, so ignore this.
-        $timezone = PIWIK_DEFAULT_TIMEZONE;
+        // Use server timezone as default, unless a default timezone has already
+        // been defined from outside the installation wizard.
+        // If the server timezone is UTC, it is likely a default not specified
+        // explicitly by the sysadm, so ignore this.
+        $timezone = Option::get(API::OPTION_DEFAULT_TIMEZONE) ?: PIWIK_DEFAULT_TIMEZONE;
         if (in_array(strtolower($timezone), array('utc', 'etc/utc', 'gmt', 'etc/gmt'))) {
             $timezone = null;
         }
@@ -99,7 +102,7 @@ class Rule_isValidTimezone extends HTML_QuickForm2_Rule
         }
 
         // If intl extension is installed, get default currency from timezone country.
-        if ($timezone && class_exists('NumberFormatter')) {
+        if (!Option::get(API::OPTION_DEFAULT_CURRENCY) && $timezone && class_exists('NumberFormatter')) {
             try {
                 $zone = new DateTimeZone($timezone);
                 $location = $zone->getLocation();

--- a/plugins/Installation/FormFirstWebsiteSetup.php
+++ b/plugins/Installation/FormFirstWebsiteSetup.php
@@ -42,7 +42,7 @@ class FormFirstWebsiteSetup extends QuickForm2
         // Use server timezone as default. If server timezone is UTC, it is likely
         // a default not specified explicitly by the sysadm, so ignore this.
         $timezone = PIWIK_DEFAULT_TIMEZONE;
-        if (in_array($timezone, array('UTC', 'Etc/UTC', 'GMT', 'Etc/GMT'))) {
+        if (in_array(strtolower($timezone), array('utc', 'etc/utc', 'gmt', 'etc/gmt'))) {
             $timezone = null;
         }
 


### PR DESCRIPTION
To make it easier to install Matomo, the installer should try to auto-detect the timezone and currency.

If PHP or the operating system is configured to use a timezone other than UTC, it is highly likely that this timezone is relevant to use as the default timezone for Matomo. We should preselect this timezone in the timezone selector in the installer, so the user does not have to look for the proper timezone in the huge list of timezones.

Once we have the timezone, we can find the corresponding country and (if the [Intl extension](http://php.net/intl) is installed) currency. This is likely a better default than the hard-coded default, USD.
