### PR TITLE
ensure Updater::getComponentUpdates returns null if no update is available

### DIFF
--- a/core/Updater.php
+++ b/core/Updater.php
@@ -528,9 +528,7 @@ class Updater
         if (count($componentsWithUpdateFile) == 0) {
             $this->columnsUpdater->onNoUpdateAvailable($columnsVersions);
 
-            if (!$this->hasNewVersion('core')) {
-                return null;
-            }
+            return null;
         }
 
         return $componentsWithUpdateFile;


### PR DESCRIPTION
I'm not 100% sure if this change might not also skip some core update screens in UI if no updates need to be executed

fixes #13017