### PR TITLE
Fix 3rd party cookie / global visitorid race condition

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -617,7 +617,7 @@ class Request
         return substr(trim($input), 0, CustomVariables::getMaxLengthCustomVariables());
     }
 
-    protected function shouldUseThirdPartyCookie()
+    public function shouldUseThirdPartyCookie()
     {
         return (bool)Config::getInstance()->Tracker['use_third_party_id_cookie'];
     }
@@ -640,6 +640,10 @@ class Request
     public function setThirdPartyCookie($idVisitor)
     {
         if (!$this->shouldUseThirdPartyCookie()) {
+            return;
+        }
+
+        if (\Piwik\Tracker\IgnoreCookie::isIgnoreCookieFound()) {
             return;
         }
 

--- a/js/tracker.php
+++ b/js/tracker.php
@@ -57,6 +57,19 @@ $environment = new \Piwik\Application\Environment(null, array(
 ));
 $environment->init();
 
+if (!\Piwik\Tracker\IgnoreCookie::isIgnoreCookieFound()) {
+    
+    $request = new \Piwik\Tracker\Request(array());
+    
+    if ($request->shouldUseThirdPartyCookie()) {
+        $visitorId = $request->getVisitorIdForThirdPartyCookie();
+        if (!$visitorId) {
+            $visitorId = \Piwik\Common::hex2bin(\Piwik\Tracker\Visit::generateUniqueVisitorId());
+        }
+        $request->setThirdPartyCookie($visitorId);
+    }
+}
+
 ProxyHttp::serverStaticFile($file, "application/javascript; charset=UTF-8", $daysExpireFarFuture, $byteStart, $byteEnd);
 
 exit;


### PR DESCRIPTION
When 3rd party cookies (_pk_uid) are enabled and a pageview is tracked to multiple siteids at once, then there is a race condition:

A new user without the 3rd party cookie arrives at page X.
The pageview of X is tracked to siteid A and at the same time to siteid B.
Both track requests do not  have the 3rd party cookie set.
When matomo processes these requests, it will use the visitorid that came with the request as visitorid for the 3rd party cookie.
Here is a race condition: one of the requests will win, its visitorid will be the new global visitorid in the 3rd party cookie.
The visitorid of the request that lost remains in the database as an additional visitor+visit, and thus corrupting the data.

My fix:
Set the 3rd party cookie when sending the piwik javascript code (in /js/tracker.php).
This will of course not fix the problem, when the js is loaded directly from /piwik.js.
Thus I would recommend to add this case to the FAQ: When using 3rd party cookies AND tracking to multiple siteids at once, one must use /js/tracker.php and not /piwik.js to load the js in the browser.