### PR TITLE
Do not use CliMulti archiving strategy if ps does not show current process

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -177,8 +177,8 @@ class Process
             return false;
         }
 
-        if (count(self::getRunningProcesses()) > 0) {
-            return true;
+        if (!in_array(getmypid(), self::getRunningProcesses())) {
+            return false;
         }
 
         if (!self::isProcFSMounted()) {


### PR DESCRIPTION
In the core:archive command I get following message for every site:
```
Got invalid response from API request: ...
The response was empty. This usually means a server error. A solution to this error is generally to increase the value of 'memory_limit' in your php.ini file.
For more information and the error message please check in your PHP CLI error log file. As this core:archive command triggers PHP processes over the CLI, you can find where PHP CLI logs are stored by running this command: php -i | grep error_log
```

After looking in the code I found following solution.

The sub commands are executed in the background with the & sign.
The output file doesn't exists when it is looking for content.