### PR TITLE
Improve detection of piwik/matomo URL

### DIFF
--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -198,7 +198,7 @@ class SettingsPiwik
             // if URL changes, always update the cache
             || $currentUrl != $url
         ) {
-            $host = Url::getHostFromUrl($url);
+            $host = Url::getHostFromUrl($currentUrl);
 
             if (strlen($currentUrl) >= strlen('http://a/')
                 && !Url::isLocalHost($host)) {


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/11029 

For some reason that I cannot explain, it stored `127.0.0.1` as the matomo URL in the DB causing a bug in tag manager. So I opened a regular page in Matomo and was expecting it to correct the value in the option table but it didn't. I think this is because of the above change where it checks whether the previous URL is not a local host whereas it maybe should check on the current URL? 

See the debugger picture where it did not overwrite 127.0.0.1 with the correct current url/host because the host is currently a local host (127.0.0.1). If it checked whether the actual host is a local host, it would have updated it.

![image](https://user-images.githubusercontent.com/273120/42138715-f57456d4-7dd5-11e8-899c-6d28c59823ae.png)

Unfortunately, I don't know why it would have stored 127.0.0.1 in the first place. This is still another issue.