### PR TITLE
Make it possible to use line breaks in placeholders

### DIFF
--- a/plugins/CoreHome/angularjs/common/directives/attributes.js
+++ b/plugins/CoreHome/angularjs/common/directives/attributes.js
@@ -35,6 +35,13 @@
                             if (angular.isObject(value)) {
                                 value = JSON.stringify(value);
                             }
+
+                            // replace line breaks in placeholder with big amount of spaces for safari,
+                            // as line breaks are not support there
+                            if (key === 'placeholder' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
+                                value = value.replace(/(?:\r\n|\r|\n)/g, (new Array(200)).join(' '));
+                            }
+
                             if (key === 'disabled') {
                                 element.prop(key, value);
                             } else {

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
@@ -17,7 +17,8 @@
 				<uiControlAttributes>
 					<cols>25</cols>
 					<rows>3</rows>
-					<placeholder>https://siteUrl.com/                                                 https://siteUrl2.com/</placeholder>
+					<placeholder>https://siteUrl.com/
+https://siteUrl2.com/</placeholder>
 				</uiControlAttributes>
 				<availableValues />
 				<description />

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
@@ -17,8 +17,8 @@
 				<uiControlAttributes>
 					<cols>25</cols>
 					<rows>3</rows>
-					<placeholder>https://siteUrl.com/
-https://siteUrl2.com/</placeholder>
+					<placeholder>http://example.com/
+https://www.example.org/</placeholder>
 				</uiControlAttributes>
 				<availableValues />
 				<description />

--- a/plugins/WebsiteMeasurable/Settings/Urls.php
+++ b/plugins/WebsiteMeasurable/Settings/Urls.php
@@ -41,7 +41,7 @@ class Urls extends \Piwik\Settings\Measurable\MeasurableProperty
         $config->uiControlAttributes = array(
           'cols' => '25',
           'rows' => '3',
-          'placeholder' => "https://siteUrl.com/                                                 https://siteUrl2.com/",
+          'placeholder' => "https://siteUrl.com/\nhttps://siteUrl2.com/",
         );
 
         $self = $this;

--- a/plugins/WebsiteMeasurable/Settings/Urls.php
+++ b/plugins/WebsiteMeasurable/Settings/Urls.php
@@ -41,7 +41,7 @@ class Urls extends \Piwik\Settings\Measurable\MeasurableProperty
         $config->uiControlAttributes = array(
           'cols' => '25',
           'rows' => '3',
-          'placeholder' => "https://siteUrl.com/\nhttps://siteUrl2.com/",
+          'placeholder' => "http://example.com/\nhttps://www.example.org/",
         );
 
         $self = $this;

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
@@ -22,7 +22,8 @@
 						<uiControlAttributes>
 							<cols>25</cols>
 							<rows>3</rows>
-							<placeholder>https://siteUrl.com/                                                 https://siteUrl2.com/</placeholder>
+							<placeholder>https://siteUrl.com/
+https://siteUrl2.com/</placeholder>
 						</uiControlAttributes>
 						<availableValues />
 						<description />

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
@@ -22,8 +22,8 @@
 						<uiControlAttributes>
 							<cols>25</cols>
 							<rows>3</rows>
-							<placeholder>https://siteUrl.com/
-https://siteUrl2.com/</placeholder>
+							<placeholder>http://example.com/
+https://www.example.org/</placeholder>
 						</uiControlAttributes>
 						<availableValues />
 						<description />

--- a/tests/UI/expected-screenshots/MeasurableManager_add_measurable_view.png
+++ b/tests/UI/expected-screenshots/MeasurableManager_add_measurable_view.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e790ab2766030f1b8fa28f8d70db8529fa3c49c34c884c1efd9cfcd2bdc296b6
-size 433684
+oid sha256:5d1e604ea6b71778e00693466cee77a6864a432f4cd9f36f14f3d777d31b3092
+size 433946


### PR DESCRIPTION
for safari those line breaks will be replaced with 200 white spaces, as line breaks aren't supported there

fixes #13035
replaces #13036