### PR TITLE
Destroy database connection only if it has a connection already

### DIFF
--- a/core/Db.php
+++ b/core/Db.php
@@ -141,7 +141,9 @@ class Db
      */
     public static function destroyDatabaseObject()
     {
-        DbHelper::disconnectDatabase();
+        if (self::hasDatabaseObject()) {
+            DbHelper::disconnectDatabase();
+        }
         self::$connection = null;
     }
 


### PR DESCRIPTION
Otherwise it would create a connection just to destroy it. Noticed this when my tests were failing because of this.

```
Failed to setup fixture: TEST INITIALIZATION FAILED: SQLSTATE[HY000] [1049] Unknown database 'piwik_tests'
#0 libs/Zend/Db/Adapter/Pdo/Mysql.php(109): Zend_Db_Adapter_Pdo_Abstract->_connect()
#1 core/Db/Adapter/Pdo/Mysql.php(96): Zend_Db_Adapter_Pdo_Mysql->_connect()
#2 core/Db/Adapter/Pdo/Mysql.php(74): Piwik\Db\Adapter\Pdo\Mysql->_connect()
#3 core/Db/Adapter.php(51): Piwik\Db\Adapter\Pdo\Mysql->getConnection()
#4 core/Db.php(122): Piwik\Db\Adapter::factory('PDO\\MYSQL', Array)
#5 core/Db.php(54): Piwik\Db::createDatabaseObject()
#6 core/DbHelper.php(142): Piwik\Db::get()
#7 core/Db.php(144): Piwik\DbHelper::disconnectDatabase()
#8 tests/PHPUnit/Framework/Fixture.php(869): Piwik\Db::destroyDatabaseObject()
#9 tests/PHPUnit/Framework/Fixture.php(227): Piwik\Tests\Framework\Fixture::connectWithoutDatabase()
#10 tests/PHPUnit/Framework/TestCase/SystemTestCase.php(76): Piwik\Tests\Framework\Fixture->performSetUp()
#11 tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php(61): Piwik\Tests\Framework\TestCase\SystemTestCase::setUpBeforeClass()
```