### PR TITLE
Do not check for license in test mode

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -888,7 +888,6 @@ class Manager
         if ($newPlugin->isPremiumFeature()
             && SettingsPiwik::isInternetEnabled()
             && !Development::isEnabled()
-            && (!defined('PIWIK_TEST_MODE') || !PIWIK_TEST_MODE)
             && $this->isPluginActivated('Marketplace')
             && $this->isPluginActivated($pluginName)) {
 
@@ -910,7 +909,7 @@ class Manager
                 $cache->save($cacheKey, $pluginLicenseInfo, $sixHours);
             }
 
-            if (!empty($pluginLicenseInfo['missing'])) {
+            if (!empty($pluginLicenseInfo['missing']) && (!defined('PIWIK_TEST_MODE') || !PIWIK_TEST_MODE)) {
                 $this->unloadPluginFromMemory($pluginName);
                 return $pluginsToPostPendingEventsTo;
             }

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -888,6 +888,7 @@ class Manager
         if ($newPlugin->isPremiumFeature()
             && SettingsPiwik::isInternetEnabled()
             && !Development::isEnabled()
+            && (!defined('PIWIK_TEST_MODE') || !PIWIK_TEST_MODE)
             && $this->isPluginActivated('Marketplace')
             && $this->isPluginActivated($pluginName)) {
 


### PR DESCRIPTION
In my case eg system tests wouldn't install the plugin anymore and any test wouldn't run anymore for premium features cause they wouldn't have a license.

The only other alternative be to change `Piwik\Plugins\Marketplace\Plugins` in all tests I reckon (excerpt for when testing this class).