### PR TITLE
Allow hostnames to be configured in login whitelist

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -394,7 +394,9 @@ login_password_recovery_replyto_email_address = "no-reply@{DOMAIN}"
 login_password_recovery_replyto_email_name = "No-reply"
 
 ; When configured, only users from a configured IP can log into your Matomo. You can define one or multiple
-; IPv4, IPv6, and IP ranges. This whitelist also affects API requests unless you disabled it via the setting
+; IPv4, IPv6, and IP ranges. You may also define hostnames. However, resolving hostnames in each request 
+; may slightly slow down your Matomo.
+; This whitelist also affects API requests unless you disabled it via the setting
 ; "login_whitelist_apply_to_reporting_api_requests" below. Note that neither this setting, nor the
 ; "login_whitelist_apply_to_reporting_api_requests" restricts authenticated tracking requests (tracking requests
 ; with a "token_auth" URL parameter).
@@ -404,6 +406,7 @@ login_password_recovery_replyto_email_name = "No-reply"
 ; login_whitelist_ip[] = 204.93.177.0/24
 ; login_whitelist_ip[] = 199.27.128.0/21
 ; login_whitelist_ip[] = 2001:db8::/48
+; login_whitelist_ip[] = matomo.org
 
 ; By default, if a whitelisted IP address is specified via "login_whitelist_ip[]", the reporting user interface as
 ; well as HTTP Reporting API requests will only work for these whitelisted IPs.

--- a/config/global.php
+++ b/config/global.php
@@ -138,7 +138,21 @@ return array(
         if (!empty($general['login_whitelist_ip']) && is_array($general['login_whitelist_ip'])) {
             $ips = $general['login_whitelist_ip'];
         }
-        return $ips;
+        
+        $ipsResolved = array();
+
+        foreach ($ips as $ip) {
+            if (filter_var($ip, FILTER_VALIDATE_IP)) {
+                $ipsResolved[] = $ip;
+            } else {
+                $ipFromHost = @gethostbyname($ip);
+                if (!empty($ipFromHost)) {
+                    $ipsResolved[] = $ipFromHost;
+                }
+            }
+        }
+
+        return $ipsResolved;
     },
 
     'Zend_Validate_EmailAddress' => function () {

--- a/plugins/CoreHome/tests/Integration/LoginWhitelistTest.php
+++ b/plugins/CoreHome/tests/Integration/LoginWhitelistTest.php
@@ -110,6 +110,12 @@ class LoginWhitelistTest extends IntegrationTestCase
         $this->assertSame(['192.168.33.1', '127.0.0.1', '2001:0db8:85a3:0000:0000:8a2e:0370:7334'], $this->whitelist->getWhitelistedLoginIps());
     }
 
+    public function test_getWhitelistedLoginIps_shouldResolveIp()
+    {
+        $this->setGeneralConfig('login_whitelist_ip', ['192.168.33.1', 'matomo.org', '127.0.0.1']);
+        $this->assertSame(['192.168.33.1', '185.31.40.177', '127.0.0.1'], $this->whitelist->getWhitelistedLoginIps());
+    }
+
     public function test_getWhitelistedLoginIps_shouldNotBeCheckedIfOnlyEmptyEntries()
     {
         $this->setGeneralConfig('login_whitelist_ip', ['', '192.168.33.1 ', ' ']);

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:217492649ef815fe53021553dcb8c5eb7b283d815bd20c993cb1f174b34c6d70
-size 3934051
+oid sha256:4820f035a5917e2964ff04a2bfd185d76bc788d674c6aa2fb4222c5b32b97d1e
+size 3946642


### PR DESCRIPTION
May be useful in combination with for example DynDNS providers. Or should we rather have a `login.whitelist.hostnames`?