### PR TITLE
Fix theme header color is not applied in login screen

### DIFF
--- a/plugins/Login/templates/login.twig
+++ b/plugins/Login/templates/login.twig
@@ -25,7 +25,7 @@
 
     <div id="notificationContainer">
     </div>
-    <nav class="blue-grey darken-3">
+    <nav>
         <div class="nav-wrapper">
             <span id="logo" class="brand-logo center">
 


### PR DESCRIPTION
When defining a different theme header background color, the color is not applied because of the set class. 

refs DEV-1377