### PR TITLE
Unsanatize emails when checking if valid

### DIFF
--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -573,7 +573,7 @@ class Piwik
     {
         /** @var \Zend_Validate_EmailAddress $zendEmailValidator */
         $zendEmailValidator = StaticContainer::get('Zend_Validate_EmailAddress');
-        return $zendEmailValidator->isValid($emailAddress);
+        return $zendEmailValidator->isValid(Common::unsanitizeInputValue($emailAddress));
     }
 
     /**


### PR DESCRIPTION
fixes #11796
When checking for valid email, use the common function to unsantize the input to allow for special characters in email addresses