### PR TITLE
Improve the style of the glossary

### DIFF
--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -762,5 +762,6 @@ class Plugin extends \Piwik\Plugin
     public function getStylesheetFiles(&$stylesheets)
     {
         $stylesheets[] = "plugins/API/stylesheets/listAllAPI.less";
+        $stylesheets[] = "plugins/API/stylesheets/glossary.less";
     }
 }

--- a/plugins/API/stylesheets/glossary.less
+++ b/plugins/API/stylesheets/glossary.less
@@ -1,0 +1,11 @@
+
+.glossary .table-of-contents a {
+  box-sizing: content-box;
+  padding: 0 10px 5px;
+  &:hover, &.active {
+    text-decoration: none;
+    padding: 0 10px 3px;
+    border-left: none;
+    border-bottom: 2px solid @color-blue-piwik;
+  }
+}

--- a/plugins/API/stylesheets/listAllAPI.less
+++ b/plugins/API/stylesheets/listAllAPI.less
@@ -31,3 +31,14 @@
     margin-bottom: 5px;
     margin-left: 20px;
 }
+
+.pageWrap .table-of-contents a {
+    box-sizing: content-box;
+    padding: 0 10px 5px;
+    &:hover, &.active {
+        text-decoration: none;
+        padding: 0 10px 3px;
+        border-left: none;
+        border-bottom: 2px solid @color-blue-piwik;
+    }
+}

--- a/plugins/API/stylesheets/listAllAPI.less
+++ b/plugins/API/stylesheets/listAllAPI.less
@@ -32,13 +32,3 @@
     margin-left: 20px;
 }
 
-.pageWrap .table-of-contents a {
-    box-sizing: content-box;
-    padding: 0 10px 5px;
-    &:hover, &.active {
-        text-decoration: none;
-        padding: 0 10px 3px;
-        border-left: none;
-        border-bottom: 2px solid @color-blue-piwik;
-    }
-}

--- a/plugins/API/templates/glossary.twig
+++ b/plugins/API/templates/glossary.twig
@@ -14,7 +14,7 @@
         </div>
     </div>
 
-    <div class="row">
+    <div class="row glossary">
         <div class="col s12">
             <ul class="tabs">
                 {% for keyword, item in glossaryItems %}

--- a/tests/UI/expected-screenshots/UIIntegrationTest_glossary.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_glossary.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7cb68582e3bcfbd7352b77776ce71ef142ce5bbc2f5076cd872d59fabeb8dbb6
-size 493318
+oid sha256:829da44ae55b0bce5a3d207243c7d250326f944755e9291b46e13ec5750f5bff
+size 493328

--- a/tests/UI/expected-screenshots/UIIntegrationTest_glossary_widgetized.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_glossary_widgetized.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c38434b4c90b8f010e8b24772d6b58bd4b3406f693f42d4816d33b3bf87b89f8
-size 601226
+oid sha256:f76a0bd0e86a1a99e1a1cf30fec8d4092f5d827c30db992164b40045833be067
+size 601225


### PR DESCRIPTION
Improve the style of the glossary.

Also made line blue so it fits the tabs above. 
![screenshot_20180707_093732](https://user-images.githubusercontent.com/6266037/42408218-5fe197ce-81c9-11e8-9bad-595ecfb17f3c.png)

Is this the right file to add the CSS?

PS: I think the glossary is a bit too well hidden (I only found a small link on the help page). Maybe it should be a bit more prominent as I think many Matomo users don't know about it.