### PR TITLE
Minor internal formatting tweak for detecting an already running command

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -292,8 +292,8 @@ class CliMulti
         $posPid = strpos($commandToCheck, '&pid='); // the pid is random each time so we need to ignore it.
         $shortendCommand = substr($commandToCheck, $posStart, $posPid - $posStart);
         // equals eg console climulti:request -q --piwik-domain= --superuser module=API&method=API.get&idSite=1&period=month&date=2018-04-08,2018-04-30&format=php&trigger=archivephp
-        $shortendCommand      = preg_replace("/([&])date=.*?(&|$)/", "", $shortendCommand);
-        $currentlyRunningJobs = preg_replace("/([&])date=.*?(&|$)/", "", $currentlyRunningJobs);
+        $shortendCommand      = preg_replace("/([&])date=.*?(&|$)/", "&", $shortendCommand);
+        $currentlyRunningJobs = preg_replace("/([&])date=.*?(&|$)/", "&", $currentlyRunningJobs);
 
         if (strpos($currentlyRunningJobs, $shortendCommand) !== false) {
             Log::debug($shortendCommand . ' is already running');


### PR DESCRIPTION
This change is really not needed as in both cases in the command to check and in the list of commands we currently replace the result with an empty string and both apply same behavior. It's really just for debugging/reading purposes... 

Currently, a matched string would be replaced from
from `period=month&date=2018-04-08,2018-04-30&format=php...` to 
from `period=monthformat=php...` whereas with this PR it would be `period=month&format=php...`