### PR TITLE
Ensure to cancel an archive process if it is already running

### DIFF
--- a/core/Archiver/Request.php
+++ b/core/Archiver/Request.php
@@ -10,6 +10,7 @@ namespace Piwik\Archiver;
 
 class Request
 {
+    const ABORT = 'abort';
     /**
      * @var string
      */
@@ -36,8 +37,7 @@ class Request
     public function start()
     {
         if ($this->before) {
-            $callable = $this->before;
-            $callable();
+            return call_user_func($this->before);
         }
     }
 

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -126,12 +126,21 @@ class CliMulti
     private function start($piwikUrls)
     {
         foreach ($piwikUrls as $index => $url) {
+            $shouldStart = null;
             if ($url instanceof Request) {
-                $url->start();
+                $shouldStart = $url->start();
             }
 
             $cmdId = $this->generateCommandId($url) . $index;
-            $this->executeUrlCommand($cmdId, $url);
+
+            if ($shouldStart === Request::ABORT) {
+                // output is needed to ensure same order of url to response
+                $output = new Output($cmdId);
+                $output->write('Skipped');
+                $this->outputs[] = $output;
+            } else {
+                $this->executeUrlCommand($cmdId, $url);
+            }
         }
     }
 


### PR DESCRIPTION
In https://github.com/matomo-org/matomo/pull/12702 we added a check to not run the same archiver twice. However, we still noticed the same command appearing multiple times.

After looking through the code for a while I realized that we start max 3 concurrent archivers at a time. And if an option is set, we might even only start 1 archiver at a time.

When archiving any period, we generate the archiving URL for the period plus all segments. If there are 9 segments, there would be 10 URLs. The thing is that we checked at URL generation time whether an URL is already being executed or not. But because we run max 3 jobs concurrent, an archiving job might be only started much later when all previous requests have finished. 

This means we should also check at the time just shortly before the execution of an archiver whether such a job is already running. 

I have to say I have not tested the script yet but it should work. For now seeing if the tests succeed.