### PR TITLE
Add possibility to configure the number of max concurrent archivers: --concurrent-archivers

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -240,6 +240,15 @@ class Process
         return strpos($type, 'proc') === 0;
     }
 
+    public static function getListOfRunningProcesses()
+    {
+        $processes = `ps ex 2>/dev/null`;
+        if (empty($processes)) {
+            return array();
+        }
+        return explode("\n", $processes);
+    }
+
     /**
      * @return int[] The ids of the currently running processes
      */

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -49,6 +49,7 @@ class CoreArchiver extends ConsoleCommand
 
         $archiver->dateLastForced = $input->getOption('force-date-last-n');
         $archiver->concurrentRequestsPerWebsite = $input->getOption('concurrent-requests-per-website');
+        $archiver->maxConcurrentArchivers = $input->getOption('concurrent-archivers');
 
         $archiver->disableSegmentsArchiving = $input->getOption('skip-all-segments');
 
@@ -112,6 +113,8 @@ class CoreArchiver extends ConsoleCommand
             . "\nNote: if identical segments exist w/ different IDs, they will both be skipped, even if you only supply one ID.");
         $command->addOption('concurrent-requests-per-website', null, InputOption::VALUE_OPTIONAL,
             "When processing a website and its segments, number of requests to process in parallel", CronArchive::MAX_CONCURRENT_API_REQUESTS);
+        $command->addOption('concurrent-archivers', null, InputOption::VALUE_OPTIONAL,
+            "The number of max archivers to run in parallel", false);
         $command->addOption('disable-scheduled-tasks', null, InputOption::VALUE_NONE,
             "Skips executing Scheduled tasks (sending scheduled reports, db optimization, etc.).");
         $command->addOption('accept-invalid-ssl-certificate', null, InputOption::VALUE_NONE,


### PR DESCRIPTION
There is already a setting `concurrent-requests-per-website` to specify how many requests one archiver may issue at a time. This new setting `concurrent-archivers` allows additionally to limit how many archivers should run max. This is useful when an archiver takes a very long time and you don't want to eventually have like 10 or 20 archivers running at the same time.

I don't think this needs to be mentioned in the developer changelog.