### PR TITLE
Do not fetch the environment in list of processes

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -242,7 +242,7 @@ class Process
 
     public static function getListOfRunningProcesses()
     {
-        $processes = `ps ex 2>/dev/null`;
+        $processes = `ps x 2>/dev/null`;
         if (empty($processes)) {
             return array();
         }


### PR DESCRIPTION
Small tweak to https://github.com/matomo-org/matomo/pull/13161 . Noticed this on a different linux... otherwise the same archive command would appear multiple times see eg 

```
string(468) "11112 ?        Ss     0:00 /bin/sh -c php /home/foo/console core:archive --no-ansi >> /home/foo/test.log EDITOR=nano LANG=en_US.UTF-8 MAILTO=foo@foo.com SHELL=/bin/sh HOME=/home/fooPATH=/usr/bin:/bin LOGNAME=foo"
  string(502) "11113 ?        S      0:00 /usr/php /home/foo/console core:archive --no-ansi SHELL=/bin/sh MAILTO=foo@foo.com PHPRC=/home/foo/admin/config/php PATH=/usr/bin:/bin PWD=/home/foo EDITOR=nano LANG=en_US.UTF-8 SHLVL=0 HOME=/home/foo LOGNAME=foo"
```

When using `ps ex` in this case it figured the same archiver is running twice when it is only once.