### PR TITLE
Refactor archivers to support multiple idsites

### DIFF
--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -196,13 +196,19 @@ class Parameters
      */
     public function isSingleSiteDayArchive()
     {
-        $oneSite = $this->isSingleSite();
+        return $this->isDayArchive() && $this->isSingleSite();
+    }
 
+    /**
+     * @return bool
+     */
+    public function isDayArchive()
+    {
         $period = $this->getPeriod();
         $secondsInPeriod = $period->getDateEnd()->getTimestampUTC() - $period->getDateStart()->getTimestampUTC();
         $oneDay = $secondsInPeriod <= Date::NUM_SECONDS_IN_DAY;
 
-        return $oneDay && $oneSite;
+        return $oneDay;
     }
 
     public function isSingleSite()

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -76,6 +76,10 @@ class PluginsArchiver
          * @param bool $shouldAggregateFromRawData  Set to true, to aggregate from raw data, or false to aggregate multiple reports.
          * @param Parameters $params
          * @ignore
+         * @deprecated
+         *
+         * In Matomo 4.0 we should maybe remove this event, and instead maybe always archive from raw data when it is daily archive,
+         * no matter if single site or not. We cannot do this in Matomo 3.X as some custom plugin archivers may not be able to handle multiple sites.
          */
         Piwik::postEvent('ArchiveProcessor.shouldAggregateFromRawData', array(&$shouldAggregateFromRawData, $this->params));
 

--- a/plugins/Actions/Archiver.php
+++ b/plugins/Actions/Archiver.php
@@ -161,10 +161,8 @@ class Archiver extends \Piwik\Plugin\Archiver
             )
         );
 
-        $where = "log_link_visit_action.server_time >= ?
-                AND log_link_visit_action.server_time <= ?
-                AND log_link_visit_action.idsite = ?
-                AND log_link_visit_action.%s IS NOT NULL"
+        $where  = $this->getLogAggregator()->getWhereStatement('log_link_visit_action', 'server_time');
+        $where .= " AND log_link_visit_action.%s IS NOT NULL"
             . $this->getWhereClauseActionIsNotEvent();
 
         $groupBy = "log_link_visit_action.%s";
@@ -285,10 +283,8 @@ class Archiver extends \Piwik\Plugin\Archiver
                 sum(log_visit.visit_total_time) as `" . PiwikMetrics::INDEX_PAGE_ENTRY_SUM_VISIT_LENGTH . "`,
                 sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) as `" . PiwikMetrics::INDEX_PAGE_ENTRY_BOUNCE_COUNT . "`";
 
-        $where = "log_visit.visit_last_action_time >= ?
-                AND log_visit.visit_last_action_time <= ?
-                AND log_visit.idsite = ?
-                 AND log_visit.%s > 0";
+        $where  = $this->getLogAggregator()->getWhereStatement('log_visit', 'visit_last_action_time');
+        $where .= " AND log_visit.%s > 0";
 
         $groupBy = "log_visit.%s";
 
@@ -330,10 +326,8 @@ class Archiver extends \Piwik\Plugin\Archiver
                 count(distinct log_visit.idvisitor) as `" . PiwikMetrics::INDEX_PAGE_EXIT_NB_UNIQ_VISITORS . "`,
                 count(*) as `" . PiwikMetrics::INDEX_PAGE_EXIT_NB_VISITS . "`";
 
-        $where = "log_visit.visit_last_action_time >= ?
-                AND log_visit.visit_last_action_time <= ?
-                 AND log_visit.idsite = ?
-                 AND log_visit.%s > 0";
+        $where  = $this->getLogAggregator()->getWhereStatement('log_visit', 'visit_last_action_time');
+        $where .= " AND log_visit.%s > 0";
 
         $groupBy = "log_visit.%s";
 
@@ -374,10 +368,8 @@ class Archiver extends \Piwik\Plugin\Archiver
         $select = "log_link_visit_action.%s as idaction, $extraSelects
                 sum(log_link_visit_action.time_spent_ref_action) as `" . PiwikMetrics::INDEX_PAGE_SUM_TIME_SPENT . "`";
 
-        $where = "log_link_visit_action.server_time >= ?
-                AND log_link_visit_action.server_time <= ?
-                 AND log_link_visit_action.idsite = ?
-                 AND log_link_visit_action.time_spent_ref_action > 0
+        $where = $this->getLogAggregator()->getWhereStatement('log_link_visit_action', 'server_time');
+        $where .= " AND log_link_visit_action.time_spent_ref_action > 0
                  AND log_link_visit_action.%s > 0"
             . $this->getWhereClauseActionIsNotEvent();
 

--- a/plugins/Contents/Archiver.php
+++ b/plugins/Contents/Archiver.php
@@ -103,10 +103,8 @@ class Archiver extends \Piwik\Plugin\Archiver
             )
         );
 
-        $where = "log_link_visit_action.server_time >= ?
-                    AND log_link_visit_action.server_time <= ?
-                    AND log_link_visit_action.idsite = ?
-                    AND log_link_visit_action.idaction_content_name IS NOT NULL
+        $where = $this->getLogAggregator()->getWhereStatement('log_link_visit_action', 'server_time');
+        $where .= " AND log_link_visit_action.idaction_content_name IS NOT NULL
                     AND log_link_visit_action.idaction_content_interaction IS NULL";
 
         $groupBy = "log_link_visit_action.idaction_content_piece,
@@ -161,10 +159,8 @@ class Archiver extends \Piwik\Plugin\Archiver
             )
         );
 
-        $where = "log_link_visit_action.server_time >= ?
-                    AND log_link_visit_action.server_time <= ?
-                    AND log_link_visit_action.idsite = ?
-                    AND log_link_visit_action.idaction_content_name IS NOT NULL
+        $where  = $this->getLogAggregator()->getWhereStatement('log_link_visit_action', 'server_time');
+        $where .= " AND log_link_visit_action.idaction_content_name IS NOT NULL
                     AND log_link_visit_action.idaction_content_interaction IS NOT NULL";
 
         $groupBy = "log_action_content_piece.idaction,

--- a/plugins/Events/Archiver.php
+++ b/plugins/Events/Archiver.php
@@ -167,10 +167,8 @@ class Archiver extends \Piwik\Plugin\Archiver
             )
         );
 
-        $where = "log_link_visit_action.server_time >= ?
-                    AND log_link_visit_action.server_time <= ?
-                    AND log_link_visit_action.idsite = ?
-                    AND log_link_visit_action.idaction_event_category IS NOT NULL";
+        $where  = $this->getLogAggregator()->getWhereStatement('log_link_visit_action', 'server_time');
+        $where .= " AND log_link_visit_action.idaction_event_category IS NOT NULL";
 
         $groupBy = "log_link_visit_action.idaction_event_category,
                     log_link_visit_action.idaction_event_action,


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/13162

After looking into the code this seems to be way easier to implement than I thought it would be. This is because the bind was already always supporting multiple sites but only the query was not. The reason this worked in the past was simply that it was never called with multiple idsites, otherwise it would have directly failed.