### PR TITLE
Ensure segmented visitor log numeration doesn't break

### DIFF
--- a/plugins/Live/stylesheets/live.less
+++ b/plugins/Live/stylesheets/live.less
@@ -260,6 +260,10 @@ ol.visitorLog p {
 
   .visitorLog > li > div {
     width: 95%;
+
+    .segmentedVisitorLogPopover & {
+      width: 90%; // space in segmented visitor log isn't enough
+    }
   }
 
   .dataTableWrapper {

--- a/tests/UI/expected-screenshots/UIIntegrationTest_segmented_visitorlog.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_segmented_visitorlog.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b7b275d67f3acc358fde3fd522ad4f9746151fb98ba511a7519c4040df9e5559
-size 425335
+oid sha256:a6504cb4c017a8a6c459b24fd2885f85df6e7e2e267286086261524bbfaec1ec
+size 425000


### PR DESCRIPTION
Before there was a line break after the numeration if the number was higher than 99. This should now look good until the number is higher than 99999 (which should not happen due to the config limitation)