### PR TITLE
Do not load/apply local DI config in tests

### DIFF
--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -88,7 +88,8 @@ class ContainerFactory
         }
 
         // User config
-        if (file_exists(PIWIK_USER_PATH . '/config/config.php')) {
+        if (file_exists(PIWIK_USER_PATH . '/config/config.php')
+            && !in_array('test', $this->environments, true)) {
             $builder->addDefinitions(PIWIK_USER_PATH . '/config/config.php');
         }
 


### PR DESCRIPTION
I often have tests failing because I have in my local `config/config.php` a DI value overwritten which is set in `plugins/*/config/test.php` or `plugins/*/config/config.php` for example. I was thinking a quick fix by to ignore the local config file when executing tests which is I presume similar to what we do with the config ini file?

Any thoughts @diosmosis ?

Will need to see if tests still pass but I would expect so.