### PR TITLE
Fix too much whitespace in title

### DIFF
--- a/plugins/Morpheus/templates/layout.twig
+++ b/plugins/Morpheus/templates/layout.twig
@@ -4,7 +4,11 @@
         {% block head %}
             <meta charset="utf-8">
             <title>
-                {%- block pageTitle -%}{%- if title is defined %}{{ title }} - {% endif %}{%- if categoryTitle is defined %}{{ categoryTitle }} - {% endif %}Matomo{%- endblock -%}
+                {%- block pageTitle %}
+                    {%- if title is defined -%}{{ title }} - {% endif -%}
+                    {%- if categoryTitle is defined -%}{{ categoryTitle }} - {% endif -%}
+                    Matomo
+                {%- endblock -%}
             </title>
             <meta http-equiv="X-UA-Compatible" content="IE=EDGE,chrome=1"/>
             <meta name="viewport" content="initial-scale=1.0"/>

--- a/plugins/Morpheus/templates/layout.twig
+++ b/plugins/Morpheus/templates/layout.twig
@@ -4,11 +4,7 @@
         {% block head %}
             <meta charset="utf-8">
             <title>
-                {%- block pageTitle -%}
-                    {%- if title is defined %}{{ title }} - {% endif %}
-                    {%- if categoryTitle is defined %}{{ categoryTitle }} - {% endif %}
-                    Matomo
-                {%- endblock -%}
+                {%- block pageTitle -%}{%- if title is defined %}{{ title }} - {% endif %}{%- if categoryTitle is defined %}{{ categoryTitle }} - {% endif %}Matomo{%- endblock -%}
             </title>
             <meta http-equiv="X-UA-Compatible" content="IE=EDGE,chrome=1"/>
             <meta name="viewport" content="initial-scale=1.0"/>


### PR DESCRIPTION
In login screen, the title may contain too much whitespace and as a result the title may not be fully visible. see 
![image](https://user-images.githubusercontent.com/273120/43099848-9336a82a-8f17-11e8-938f-db56ddd3390f.png)
