### PR TITLE
No strict checking for idsite

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -524,7 +524,7 @@ class Access
         $idSitesAccessible = $this->getSitesIdWithAtLeastWriteAccess();
 
         foreach ($idSites as $idsite) {
-            if (!in_array($idsite, $idSitesAccessible, true)) {
+            if (!in_array($idsite, $idSitesAccessible)) {
                 throw new NoAccessException(Piwik::translate('General_ExceptionPrivilegeAccessWebsite', array("'write'", $idsite)));
             }
         }
@@ -548,7 +548,7 @@ class Access
         $idSitesAccessible = $this->getSitesIdWithCapability($capability);
 
         foreach ($idSites as $idsite) {
-            if (!in_array($idsite, $idSitesAccessible, true)) {
+            if (!in_array($idsite, $idSitesAccessible)) {
                 throw new NoAccessException(Piwik::translate('ExceptionCapabilityAccessWebsite', array("'" . $capability ."'", $idsite)));
             }
         }


### PR DESCRIPTION
While reviewing https://github.com/matomo-org/matomo/pull/13158 I noticed the third parameter for `in_array` to force string checking should not be set here I suppose as idSites might be either strings or integers.