### PR TITLE
If internet access is disabled, show a link to changelog instead of the update check link.

### DIFF
--- a/core/View.php
+++ b/core/View.php
@@ -44,6 +44,8 @@ if (!defined('PIWIK_USER_PATH')) {
  * - **show_autocompleter**: Whether the site selector should be shown or not.
  * - **loginModule**: The name of the currently used authentication module.
  * - **userAlias**: The alias of the current user.
+ * - **isInternetEnabled**: Whether the matomo server is allowed to connect to
+ *                          external networks.
  *
  * ### Template Naming Convention
  *
@@ -245,6 +247,7 @@ class View implements ViewInterface
             $this->disableLink = Common::getRequestVar('disableLink', 0, 'int');
             $this->isWidget = Common::getRequestVar('widget', 0, 'int');
             $this->isMultiServerEnvironment = SettingsPiwik::isMultiServerEnvironment();
+            $this->isInternetEnabled = SettingsPiwik::isInternetEnabled();
 
             $piwikAds = StaticContainer::get('Piwik\ProfessionalServices\Advertising');
             $this->areAdsForProfessionalServicesEnabled = $piwikAds->areAdsForProfessionalServicesEnabled();

--- a/plugins/CoreHome/javascripts/corehome.js
+++ b/plugins/CoreHome/javascripts/corehome.js
@@ -19,9 +19,14 @@
 
         // when 'check for updates...' link is clicked, force a check & display the result
         headerMessageParent.on('click', '#updateCheckLinkContainer', function (e) {
-            e.preventDefault();
-
             var headerMessage = $(this).closest('#header_message');
+
+            var $titleElement = headerMessage.find('.title');
+            if ($titleElement.attr('target')) { // if this is an external link, internet access is not available on the server
+                return;
+            }
+
+            e.preventDefault();
 
             var ajaxRequest = new ajaxHelper();
             ajaxRequest.setLoadingElement('#header_message .loadingPiwik');
@@ -32,7 +37,6 @@
 
             ajaxRequest.withTokenInUrl();
 
-            var $titleElement = headerMessage.find('.title');
             $titleElement.addClass('activityIndicator');
 
             ajaxRequest.setCallback(function (response) {

--- a/plugins/CoreHome/lang/en.json
+++ b/plugins/CoreHome/lang/en.json
@@ -101,6 +101,7 @@
         "ExpandSubtables": "Expand subtables",
         "StandardReport": "Standard report",
         "FlattenReport": "Flatten report",
-        "ReportWithMetadata": "Report with metadata"
+        "ReportWithMetadata": "Report with metadata",
+        "SeeAvailableVersions": "See Available Versions"
     }
 }

--- a/plugins/CoreHome/templates/_headerMessage.twig
+++ b/plugins/CoreHome/templates/_headerMessage.twig
@@ -22,9 +22,15 @@
             <span class="icon-warning"></span>
           </a>
         {% elseif isSuperUser and isAdminArea is defined and isAdminArea %}
-        <a class="title">
-            {{ updateCheck|raw }}
-          </a>
+            {% if isInternetEnabled %}
+            <a class="title">{{ updateCheck|raw }}</a>
+            {% else %}
+            <a class="title" href="https://matomo.org/changelog/" target="_blank" rel="noreferrer noopener">
+                <span id="updateCheckLinkContainer">
+                    {{ 'CoreHome_SeeAvailableVersions'|translate }}
+                </span>
+            </a>
+            {% endif %}
         {% endif %}
 
     <div class="dropdown positionInViewport">


### PR DESCRIPTION
This is the last change required after @sgiehl's changes. When server side internet access is unavailable, this replaces the "update check" button to a link to https://matomo.org/changelog/:

![image](https://user-images.githubusercontent.com/125140/43434466-961eeb60-9430-11e8-900f-f398a0ccacee.png)

Note: I think we could also do the check in the browser, but that would be a bigger change.

Fixes #6324 