### PR TITLE
Show visitor profile link in realtime widget only for logged in users

### DIFF
--- a/plugins/Live/templates/getLastVisitsStart.twig
+++ b/plugins/Live/templates/getLastVisitsStart.twig
@@ -11,15 +11,17 @@
                 {% set year = visitor.getColumn('serverTimestamp')|date('Y') %}
                 <span class="realTimeWidget_datetime">{{ visitor.getColumn('serverDatePretty')|replace({(year): ' '}) }} - {{ visitor.getColumn('serverTimePretty') }} {% if visitor.getColumn('visitDuration') > 0 %}({{ visitor.getColumn('visitDurationPretty')|raw }}){% endif %}</span>
                 {% if visitor.getColumn('userId')|default(false) is not empty %}
-                  &nbsp;  <a class="visits-live-launch-visitor-profile rightLink" title="{{ 'Live_ViewVisitorProfile'|translate }} {% if visitor.getColumn('userId') is not empty %}{{ visitor.getColumn('userId')|raw }}{% endif %}" data-visitor-id="{{ visitor.getColumn('visitorId') }}">
-                        <span>{{ visitor.getColumn('userId') }}</span>
+                  &nbsp;  <a class="visits-live-launch-visitor-profile rightLink" title="{{ 'Live_ViewVisitorProfile'|translate }} {% if visitor.getColumn('userId') is not empty %}{{ visitor.getColumn('userId') }}{% endif %}" data-visitor-id="{{ visitor.getColumn('visitorId') }}">
+                        <span>{{ visitor.getColumn('userId')|rawSafeDecoded}}</span>
                     </a>
                 {% endif %}
 
                 {{ postEvent('Live.renderVisitorIcons', visitor) }}
-                <a class="visits-live-launch-visitor-profile rightLink" title="{{ 'Live_ViewVisitorProfile'|translate }} {% if visitor.getColumn('userId') is not empty %}{{ visitor.getColumn('userId')|raw }}{% endif %}" data-visitor-id="{{ visitor.getColumn('visitorId') }}">
+                {% if not userIsAnonymous %}
+                <a class="visits-live-launch-visitor-profile rightLink" title="{{ 'Live_ViewVisitorProfile'|translate }} {% if visitor.getColumn('userId') is not empty %}{{ visitor.getColumn('userId') }}{% endif %}" data-visitor-id="{{ visitor.getColumn('visitorId') }}">
                     <span class="icon-visitor-profile"></span>
                 </a>
+                {% endif %}
 
                 <span class="referrer">
                     {% include "@Referrers/_visitorDetails.twig" with {'visitInfo': visitor} %}
@@ -78,7 +80,7 @@
                                 {% if action.type == 'action' %}
 {# white spacing matters as Chrome tooltip display whitespaces #}
 {% set title %}
-{% if action.pageTitle is not empty %}{{ action.pageTitle|rawSafeDecoded }}{% endif %}
+{% if action.pageTitle is not empty %}{{ action.pageTitle }}{% endif %}
 
 {{ action.serverTimePretty }}
 {% if action.timeSpentPretty is defined %}{{ 'General_TimeOnPage'|translate }}: {{ action.timeSpentPretty|raw }}{% endif %}


### PR DESCRIPTION
Only logged in users are able to launch the visitor profile. So showing an icon doesn't make much sense in that case.

Also tweak the encoding/decoding a bit...