### PR TITLE
Reconstruct partial stack traces for fatal errors.

### DIFF
--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -28,16 +28,18 @@ class ResponseBuilder
 
     private $apiModule = false;
     private $apiMethod = false;
+    private $shouldPrintBacktrace = false;
 
     /**
      * @param string $outputFormat
      * @param array $request
      */
-    public function __construct($outputFormat, $request = array())
+    public function __construct($outputFormat, $request = array(), $shouldPrintBacktrace = null)
     {
         $this->outputFormat = $outputFormat;
         $this->request      = $request;
         $this->apiRenderer  = ApiRenderer::factory($outputFormat, $request);
+        $this->shouldPrintBacktrace = $shouldPrintBacktrace === null ? \Piwik_ShouldPrintBackTraceWithMessage() : $shouldPrintBacktrace;
     }
 
     public function disableSendHeader()
@@ -164,7 +166,7 @@ class ResponseBuilder
     private function formatExceptionMessage($exception)
     {
         $message = $exception->getMessage();
-        if (\Piwik_ShouldPrintBackTraceWithMessage()) {
+        if ($this->shouldPrintBackTrace) {
             $message .= "\n" . $exception->getTraceAsString();
         }
 

--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -147,7 +147,7 @@ class ResponseBuilder
     {
         // If we are in tests, show full backtrace
         if (defined('PIWIK_PATH_TEST_TO_ROOT')) {
-            if (\Piwik_ShouldPrintBackTraceWithMessage()) {
+            if ($this->shouldPrintBacktrace) {
                 $message = $e->getMessage() . " in \n " . $e->getFile() . ":" . $e->getLine() . " \n " . $e->getTraceAsString();
             } else {
                 $message = $e->getMessage() . "\n \n --> To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php";
@@ -166,7 +166,7 @@ class ResponseBuilder
     private function formatExceptionMessage($exception)
     {
         $message = $exception->getMessage();
-        if ($this->shouldPrintBackTrace) {
+        if ($this->shouldPrintBacktrace) {
             $message .= "\n" . $exception->getTraceAsString();
         }
 

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -16,6 +16,7 @@ use Piwik\CronArchive\Performance\Logger;
 use Piwik\DataAccess\ArchiveWriter;
 use Piwik\DataAccess\LogAggregator;
 use Piwik\DataTable\Manager;
+use Piwik\ErrorHandler;
 use Piwik\Metrics;
 use Piwik\Piwik;
 use Piwik\Plugin\Archiver;
@@ -157,11 +158,11 @@ class PluginsArchiver
                     if ($this->shouldAggregateFromRawData) {
                         Log::debug("PluginsArchiver::%s: Archiving day reports for plugin '%s'.", __FUNCTION__, $pluginName);
 
-                        $archiver->aggregateDayReport();
+                        $archiver->callAggregateDayReport();
                     } else {
                         Log::debug("PluginsArchiver::%s: Archiving period reports for plugin '%s'.", __FUNCTION__, $pluginName);
 
-                        $archiver->aggregateMultipleReports();
+                        $archiver->callAggregateMultipleReports();
                     }
 
                     $this->logAggregator->setQueryOriginHint('');

--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -22,8 +22,9 @@ class ErrorHandler
      */
     public static function pushFatalErrorBreadcrumb($className = null)
     {
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $limit = 1);
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $limit = 2);
         $backtrace[0]['class'] = $className; // knowing the derived class name is far more useful
+        $backtrace[0]['function'] = $backtrace[1]['function']; // $backtrace[0]['function'] is originally pushFatalErrorBreadcrumb()
         array_unshift(self::$fatalErrorStackTrace, $backtrace[0]);
     }
 

--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -15,6 +15,37 @@ use Piwik\Exception\ErrorException;
  */
 class ErrorHandler
 {
+    private static $fatalErrorStackTrace = [];
+
+    /**
+     * TODO: docs
+     */
+    public static function pushFatalErrorBreadcrumb($className = null)
+    {
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $limit = 1);
+        $backtrace[0]['class'] = $className; // knowing the derived class name is far more useful
+        array_unshift(self::$fatalErrorStackTrace, $backtrace[0]);
+    }
+
+    public static function popFatalErrorBreadcrumb()
+    {
+        array_shift(self::$fatalErrorStackTrace);
+    }
+
+    public static function getFatalErrorPartialBacktrace()
+    {
+        $result = '';
+        foreach (self::$fatalErrorStackTrace as $index => $entry) {
+            $function = $entry['function'];
+            if (!empty($entry['class'])) {
+                $function = $entry['class'] . $entry['type'] . $function;
+            }
+
+            $result .= sprintf("#%s %s(%s): %s()\n", $index, $entry['file'], $entry['line'], $function);
+        }
+        return $result;
+    }
+
     /**
      * Returns a string description of a PHP error number.
      *

--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -18,7 +18,26 @@ class ErrorHandler
     private static $fatalErrorStackTrace = [];
 
     /**
-     * TODO: docs
+     * Fatal errors in PHP do not leave behind backtraces, which can make it impossible to determine
+     * the exact cause of one. We can, however, save a partial stack trace by remembering certain execution
+     * points. This method and popFatalErrorBreadcrumb() are used for that purpose.
+     *
+     * To use this method, surround a function call w/ pushFatalErrorBreadcrumb() & popFatalErrorBreadcrumb()
+     * like so:
+     *
+     *     public function theMethodIWantToAppearInFatalErrorStackTraces()
+     *     {
+     *         try {
+     *             ErrorHandler::pushFatalErrorBreadcrumb(static::class);
+     *
+     *             // ...
+     *         } finally {
+     *             ErrorHandler::popFatalErrorBreadcrumb();
+     *         }
+     *     }
+     *
+     * If a fatal error occurs, theMethodIWantToAppearInFatalErrorStackTraces will appear in the stack trace,
+     * if PIWIK_PRINT_ERROR_BACKTRACE is true.
      */
     public static function pushFatalErrorBreadcrumb($className = null)
     {

--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -42,9 +42,8 @@ class ErrorHandler
     public static function pushFatalErrorBreadcrumb($className = null)
     {
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $limit = 2);
-        $backtrace[0]['class'] = $className; // knowing the derived class name is far more useful
-        $backtrace[0]['function'] = $backtrace[1]['function']; // $backtrace[0]['function'] is originally pushFatalErrorBreadcrumb()
-        array_unshift(self::$fatalErrorStackTrace, $backtrace[0]);
+        $backtrace[1]['class'] = $className; // knowing the derived class name is far more useful
+        array_unshift(self::$fatalErrorStackTrace, $backtrace[1]);
     }
 
     public static function popFatalErrorBreadcrumb()

--- a/core/Plugin/Archiver.php
+++ b/core/Plugin/Archiver.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugin;
 
 use Piwik\ArchiveProcessor;
 use Piwik\Config as PiwikConfig;
+use Piwik\ErrorHandler;
 
 /**
  * The base class that should be extended by plugins that compute their own
@@ -75,6 +76,34 @@ abstract class Archiver
         $this->maximumRows = PiwikConfig::getInstance()->General['datatable_archiving_maximum_rows_standard'];
         $this->processor = $processor;
         $this->enabled = true;
+    }
+
+    /**
+     * @ignore
+     */
+    final public function callAggregateDayReport()
+    {
+        try {
+            ErrorHandler::pushFatalErrorBreadcrumb(static::class);
+
+            $this->aggregateDayReport();
+        } finally {
+            ErrorHandler::popFatalErrorBreadcrumb();
+        }
+    }
+
+    /**
+     * @ignore
+     */
+    final public function callAggregateMultipleReports()
+    {
+        try {
+            ErrorHandler::pushFatalErrorBreadcrumb(static::class);
+
+            $this->aggregateMultipleReports();
+        } finally {
+            ErrorHandler::popFatalErrorBreadcrumb();
+        }
     }
 
     /**

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -12,6 +12,7 @@ use Exception;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
+use Piwik\ErrorHandler;
 use Piwik\Exception\MissingFilePermissionException;
 use Piwik\Filechecks;
 use Piwik\Filesystem;
@@ -315,11 +316,15 @@ class Controller extends Plugin\ControllerAdmin
 
             $errorMessage = $lastError['message'];
 
+            if (\Piwik_ShouldPrintBackTraceWithMessage()) {
+                $errorMessage .= "\n" . ErrorHandler::getFatalErrorPartialBacktrace();
+            }
+
             if (Piwik::isUserIsAnonymous()) {
                 $errorMessage = 'A fatal error occurred.';
             }
 
-            $response = new \Piwik\API\ResponseBuilder($outputFormat);
+            $response = new \Piwik\API\ResponseBuilder($outputFormat, [], false); // don't print the exception backtrace since it will be useless
             $message  = $response->getResponseException(new Exception($errorMessage));
 
             return $message;

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -317,7 +317,7 @@ class Controller extends Plugin\ControllerAdmin
             $errorMessage = $lastError['message'];
 
             if (\Piwik_ShouldPrintBackTraceWithMessage()) {
-                $errorMessage .= "\n" . ErrorHandler::getFatalErrorPartialBacktrace();
+                $errorMessage .= ' on ' . $lastError['file'] . '(' . $lastError['line'] . ")\n" . ErrorHandler::getFatalErrorPartialBacktrace();
             }
 
             if (Piwik::isUserIsAnonymous()) {

--- a/tests/PHPUnit/Integration/ErrorHandlerTest.php
+++ b/tests/PHPUnit/Integration/ErrorHandlerTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration;
+
+
+use Piwik\Http;
+use Piwik\Tests\Framework\Fixture;
+
+class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_fatalErrorStackTracesReturned()
+    {
+        $url = Fixture::getRootUrl() . '/tests/resources/trigger-fatal.php?format=json';
+        $response = Http::sendHttpRequest($url, 2);
+
+        $response = json_decode($response, $isAssoc = true);
+        $response['message'] = $this->cleanMessage($response['message']);
+
+        $this->assertEquals('error', $response['result']);
+
+        $expectedFormat = <<<FORMAT
+Allowed memory size of %s bytes exhausted (tried to allocate %s bytes) on {includePath}/tests/resources/trigger-fatal.php(20)#0 {includePath}/tests/resources/trigger-fatal.php(32): MyClass-&gt;triggerError()#1 {includePath}/tests/resources/trigger-fatal.php(48): MyDerivedClass::staticMethod()#2 {includePath}/tests/resources/trigger-fatal.php(54): myFunction()
+FORMAT;
+
+        $this->assertStringMatchesFormat($expectedFormat, $response['message']);
+    }
+
+    private function cleanMessage($message)
+    {
+        return str_replace(PIWIK_INCLUDE_PATH, '{includePath}', $message);
+    }
+}

--- a/tests/PHPUnit/Integration/ErrorHandlerTest.php
+++ b/tests/PHPUnit/Integration/ErrorHandlerTest.php
@@ -11,8 +11,9 @@ namespace Piwik\Tests\Integration;
 
 use Piwik\Http;
 use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
-class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
+class ErrorHandlerTest extends IntegrationTestCase
 {
     public function test_fatalErrorStackTracesReturned()
     {
@@ -25,7 +26,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('error', $response['result']);
 
         $expectedFormat = <<<FORMAT
-Allowed memory size of %s bytes exhausted (tried to allocate %s bytes) on {includePath}/tests/resources/trigger-fatal.php(20)#0 {includePath}/tests/resources/trigger-fatal.php(32): MyClass-&gt;triggerError()#1 {includePath}/tests/resources/trigger-fatal.php(48): MyDerivedClass::staticMethod()#2 {includePath}/tests/resources/trigger-fatal.php(54): myFunction()
+Allowed memory size of %s bytes exhausted (tried to allocate %s bytes) on {includePath}/tests/resources/trigger-fatal.php(22)#0 {includePath}/tests/resources/trigger-fatal.php(35): MyClass-&gt;triggerError()#1 {includePath}/tests/resources/trigger-fatal.php(51): MyDerivedClass::staticMethod()#2 {includePath}/tests/resources/trigger-fatal.php(57): myFunction()
 FORMAT;
 
         $this->assertStringMatchesFormat($expectedFormat, $response['message']);

--- a/tests/resources/trigger-fatal.php
+++ b/tests/resources/trigger-fatal.php
@@ -1,0 +1,54 @@
+<?php
+
+define('PIWIK_PRINT_ERROR_BACKTRACE', true);
+define('PIWIK_ENABLE_DISPATCH', false);
+
+require_once __DIR__ . '/../../index.php';
+
+$environment = new \Piwik\Application\Environment(null);
+$environment->init();
+
+\Piwik\Access::getInstance()->setSuperUserAccess(true);
+
+class MyClass
+{
+    public function triggerError()
+    {
+        try {
+            \Piwik\ErrorHandler::pushFatalErrorBreadcrumb(static::class);
+
+            $val = str_repeat(" ", 1024 * 1024 * 1024 * 1024 * 1024);
+        } finally {
+            \Piwik\ErrorHandler::popFatalErrorBreadcrumb();
+        }
+    }
+
+    public static function staticMethod()
+    {
+        try {
+            \Piwik\ErrorHandler::pushFatalErrorBreadcrumb(static::class);
+
+            $instance = new MyClass();
+            $instance->triggerError();
+        } finally {
+            \Piwik\ErrorHandler::popFatalErrorBreadcrumb();
+        }
+    }
+}
+
+class MyDerivedClass extends MyClass
+{
+}
+
+function myFunction()
+{
+    try {
+        \Piwik\ErrorHandler::pushFatalErrorBreadcrumb();
+
+        MyDerivedClass::staticMethod();
+    } finally {
+        \Piwik\ErrorHandler::popFatalErrorBreadcrumb();
+    }
+}
+
+myFunction();

--- a/tests/resources/trigger-fatal.php
+++ b/tests/resources/trigger-fatal.php
@@ -3,7 +3,7 @@
 define('PIWIK_PRINT_ERROR_BACKTRACE', true);
 define('PIWIK_ENABLE_DISPATCH', false);
 
-require_once __DIR__ . '/../../index.php';
+require_once __DIR__ . '/../../tests/PHPUnit/proxy/index.php';
 
 $environment = new \Piwik\Application\Environment(null);
 $environment->init();
@@ -17,7 +17,10 @@ class MyClass
         try {
             \Piwik\ErrorHandler::pushFatalErrorBreadcrumb(static::class);
 
-            $val = str_repeat(" ", 1024 * 1024 * 1024 * 1024 * 1024);
+            $val = "";
+            while (true) {
+                $val .= str_repeat("*", 1024 * 1024 * 1024);
+            }
         } finally {
             \Piwik\ErrorHandler::popFatalErrorBreadcrumb();
         }


### PR DESCRIPTION
<img width="1440" alt="screen shot 2018-08-01 at 1 34 02 am" src="https://user-images.githubusercontent.com/125140/43510641-1f4d37ac-952b-11e8-9e57-8fa43573bce4.png">

Fixes #13196 
