### PR TITLE
Couple small additions to glossary generation.

### DIFF
--- a/plugins/API/Controller.php
+++ b/plugins/API/Controller.php
@@ -182,7 +182,8 @@ class Controller extends \Piwik\Plugin\Controller
         foreach ($glossaryItems as &$item) {
             $item['letters'] = array();
             foreach ($item['entries'] as &$entry) {
-                $entry['letter'] = Common::mb_strtoupper(substr($entry['name'], 0, 1));
+                $cleanEntryName = preg_replace('/["\']/', '', $entry['name']);
+                $entry['letter'] = Common::mb_strtoupper(substr($cleanEntryName, 0, 1));
                 $item['letters'][] = $entry['letter'];
             }
 

--- a/plugins/API/templates/glossary.twig
+++ b/plugins/API/templates/glossary.twig
@@ -42,10 +42,11 @@
                                 <div class="section scrollspy" id="{{ keyword }}{{ lastLetter }}">
                             {% endif %}
                                 <h3 style="color:#4183C4;font-weight: bold;">{{ entry.name }}</h3>
+                                {% if entry.subtitle|default is not empty %}<p style="color:#999;text-transform:uppercase;font-weight:normal;margin-top:-16px;">{{ entry.subtitle|translate }}</p>{% endif %}
                                 <p>{{ entry.documentation|raw }}
 
                                     {% if entry.id is defined %}
-                                        <br/><span style="color: #bbb;">{{ entry.id }}{% if keyword == 'metrics' %} (API){% endif %}</span>
+                                        <br/><span style="color: #bbb;">{{ entry.id }}{% if keyword == 'metrics' or entry.is_metric|default %} (API){% endif %}</span>
                                     {% endif %}
                                 </p>
                         {% endfor %}


### PR DESCRIPTION
Changes:
* Allow glossary items to have a subtitle.
* Don't include quotes in legend.
* Recognize `is_metric` property so plugins can add the `(API)` suffix.

Example:
![image](https://user-images.githubusercontent.com/125140/43554463-5facecec-95a9-11e8-9c14-f68c03116386.png)
