### PR TITLE
Fixing regressions causing UI tests to fail

### DIFF
--- a/plugins/Actions/tests/UI/expected-screenshots/ActionsDataTable_search.png
+++ b/plugins/Actions/tests/UI/expected-screenshots/ActionsDataTable_search.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59288cfeb15c12178d884707cc7ef136a2a47a723b77fbc90cbda1021460c9c7
-size 84535
+oid sha256:60ea147848b428c8ab2ccb14d39ae8f28a3ca0ba437ddc9372877e003ef95be0
+size 84405

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -38,7 +38,7 @@ class CoreHome extends \Piwik\Plugin
             'AssetManager.filterMergedJavaScripts'   => 'filterMergedJavaScripts',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
             'Metric.addComputedMetrics'              => 'addComputedMetrics',
-            'Request.initAuthenticationObject' => 'initAuthenticationObject',
+            'Request.dispatchCoreAndPluginUpdatesScreen' => 'initAuthenticationObject',
         );
     }
 

--- a/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
@@ -281,7 +281,13 @@
                 function formatPrettyDefaultValue(defaultValue, availableOptions) {
                     if (angular.isString(defaultValue) && defaultValue) {
                         // eg default value for multi tuple
-                        var defaultParsed = JSON.parse(defaultValue);
+                        var defaultParsed = null;
+                        try {
+                            defaultParsed = JSON.parse(defaultValue);
+                        } catch (e) {
+                            // invalid JSON
+                        }
+
                         if (angular.isObject(defaultParsed)) {
                             return null;
                         }

--- a/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/form-field.directive.js
@@ -308,7 +308,7 @@
                     }
 
                     angular.forEach(availableOptions, function (value, key) {
-                        if (defaultValue.indexOf(value.key) !== -1) {
+                        if (defaultValue.indexOf(value.key) !== -1 && typeof value.value !== 'undefined') {
                             prettyValues.push(value.value);
                         }
                     });

--- a/plugins/Morpheus/javascripts/ajaxHelper.js
+++ b/plugins/Morpheus/javascripts/ajaxHelper.js
@@ -532,6 +532,7 @@ function ajaxHelper() {
         var defaultParams = {
             idSite:  piwik.idSite || broadcast.getValueFromUrl('idSite'),
             period:  piwik.period || broadcast.getValueFromUrl('period'),
+            date: piwik.date || broadcast.getValueFromUrl('date'),
             segment: broadcast.getValueFromHash('segment', window.location.href.split('#')[1])
         };
 

--- a/tests/UI/expected-screenshots/MeasurableManager_add_measurable_view.png
+++ b/tests/UI/expected-screenshots/MeasurableManager_add_measurable_view.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fb7e68d9b88d65e53fcc6d4bde110dab603379120ce18bf378e6d36559fb11a1
-size 437780
+oid sha256:9a13073cbbfa7c2028707675e609b3994dac7014c2e15f3fa6a8c69b3277bab5
+size 441065


### PR DESCRIPTION
Changes:
- Request.initAuthenticationObject is not always called now so use different event for login whitelist.
- default value for form field may not be valid JSON so deal w/ that case.
- date parameter should be forwarded as default value in ajaxHelper

CC @matomo-org/core-team will be merging if build passes.