### PR TITLE
fix theme.less include

### DIFF
--- a/plugins/Morpheus/stylesheets/base.less
+++ b/plugins/Morpheus/stylesheets/base.less
@@ -1,8 +1,6 @@
 /* base.less is a standalone Less file */
 
 @import "base/colors";
-@import "theme";
-@import "theme-advanced";
 @import "base/mixins";
 
 /* General styles */


### PR DESCRIPTION
Fix minor regression of #13250 

`plugins/Morpheus/stylesheets/theme-advanced.less` and `plugins/Morpheus/stylesheets/theme.less` got deleted, but only the include in `plugins/Morpheus/stylesheets/main.less` has been removed.

Because of this less keeps a `@import "theme";` in the CSS file and the browser tries to fetch `https://demo.matomo.org/theme` which causes a 404.