### PR TITLE
In piwik.updatePeriodParamsFromUrl() get period/date values from hash or URL.

### DIFF
--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -151,6 +151,10 @@ abstract class ControllerAdmin extends Controller
             return;
         }
 
+        if (defined('PIWIK_TEST_MODE')) {
+            return;
+        }
+
         $message = Piwik::translate('General_CurrentlyUsingUnsecureHttp');
 
         $message .= " ";

--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -151,10 +151,6 @@ abstract class ControllerAdmin extends Controller
             return;
         }
 
-        if (defined('PIWIK_TEST_MODE')) {
-            return;
-        }
-
         $message = Piwik::translate('General_CurrentlyUsingUnsecureHttp');
 
         $message .= " ";

--- a/core/Url.php
+++ b/core/Url.php
@@ -572,7 +572,14 @@ class Url
             return false;
         }
 
-        return in_array($host, Url::getLocalHostnames(), true);
+        // remove port
+        $hostWithoutPort = explode(':', $host);
+        array_pop($hostWithoutPort);
+        $hostWithoutPort = implode(':', $hostWithoutPort);
+
+        $localHostnames = Url::getLocalHostnames();
+        return in_array($host, $localHostnames, true)
+            || in_array($hostWithoutPort, $localHostnames, true);
     }
 
     public static function getTrustedHostsFromConfig()

--- a/plugins/CoreHome/angularjs/common/services/piwik.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik.js
@@ -23,9 +23,8 @@
         }
 
         function updatePeriodParamsFromUrl() {
-            var date = piwik.broadcast.getValueFromHash('date');
-            var period = piwik.broadcast.getValueFromHash('period');
-
+            var date = piwik.broadcast.getValueFromHash('date') || piwik.broadcast.getValueFromUrl('date');
+            var period = piwik.broadcast.getValueFromHash('period') || piwik.broadcast.getValueFromUrl('period');
             if (!isValidPeriod(period, date)) {
                 // invalid data in URL
                 return;

--- a/plugins/CoreHome/angularjs/common/services/piwik.spec.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik.spec.js
@@ -35,7 +35,7 @@
             });
         });
 
-        describe.only('#updatePeriodParamsFromUrl()', function() {
+        describe('#updatePeriodParamsFromUrl()', function() {
             DATE_PERIODS_TO_TEST = [
                 {
                     date: '2012-01-02',

--- a/plugins/CoreHome/angularjs/common/services/piwik.spec.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik.spec.js
@@ -34,5 +34,143 @@
                 expect(piwikService.piwik_url).to.eql('http://localhost/');
             });
         });
+
+        describe.only('#updatePeriodParamsFromUrl()', function() {
+            DATE_PERIODS_TO_TEST = [
+                {
+                    date: '2012-01-02',
+                    period: 'day',
+                    expected: {
+                        currentDateString: '2012-01-02',
+                        period: 'day',
+                        startDateString: '2012-01-02',
+                        endDateString: '2012-01-02'
+                    }
+                },
+                {
+                    date: '2012-01-02',
+                    period: 'week',
+                    expected: {
+                        currentDateString: '2012-01-02',
+                        period: 'week',
+                        startDateString: '2012-01-02',
+                        endDateString: '2012-01-08'
+                    }
+                },
+                {
+                    date: '2012-01-02',
+                    period: 'month',
+                    expected: {
+                        currentDateString: '2012-01-02',
+                        period: 'month',
+                        startDateString: '2012-01-01',
+                        endDateString: '2012-01-31'
+                    }
+                },
+                {
+                    date: '2012-01-02',
+                    period: 'year',
+                    expected: {
+                        currentDateString: '2012-01-02',
+                        period: 'year',
+                        startDateString: '2012-01-01',
+                        endDateString: '2012-12-31'
+                    }
+                },
+                {
+                    date: '2012-01-02,2012-02-03',
+                    period: 'range',
+                    expected: {
+                        currentDateString: '2012-01-02,2012-02-03',
+                        period: 'range',
+                        startDateString: '2012-01-02',
+                        endDateString: '2012-02-03'
+                    }
+                },
+                // invalid
+                {
+                    date: '2012-01-02',
+                    period: 'range',
+                    expected: {
+                        currentDateString: undefined,
+                        period: undefined,
+                        startDateString: undefined,
+                        endDateString: undefined
+                    }
+                },
+                {
+                    date: 'sldfjkdslkfj',
+                    period: 'month',
+                    expected: {
+                        currentDateString: undefined,
+                        period: undefined,
+                        startDateString: undefined,
+                        endDateString: undefined
+                    }
+                },
+                {
+                    date: '2012-01-02',
+                    period: 'sflkjdslkfj',
+                    expected: {
+                        currentDateString: undefined,
+                        period: undefined,
+                        startDateString: undefined,
+                        endDateString: undefined
+                    }
+                }
+            ];
+
+            DATE_PERIODS_TO_TEST.forEach(function (test) {
+                var date = test.date,
+                    period = test.period,
+                    expected = test.expected;
+
+                it('should parse the period in the URL correctly when date=' + date + ' and period=' + period, function () {
+                    delete piwikService.currentDateString;
+                    delete piwikService.period;
+                    delete piwikService.startDateString;
+                    delete piwikService.endDateString;
+
+                    history.pushState(null, null, '?date=' + date + '&period=' + period);
+
+                    piwikService.updatePeriodParamsFromUrl();
+
+                    expect(piwikService.currentDateString).to.equal(expected.currentDateString);
+                    expect(piwikService.period).to.equal(expected.period);
+                    expect(piwikService.startDateString).to.equal(expected.startDateString);
+                    expect(piwikService.endDateString).to.equal(expected.endDateString);
+                });
+
+                it('should parse the period in the URL hash correctly when date=' + date + ' and period=' + period, function () {
+                    delete piwikService.currentDateString;
+                    delete piwikService.period;
+                    delete piwikService.startDateString;
+                    delete piwikService.endDateString;
+
+                    history.pushState(null, null, '?someparam=somevalue#?date=' + date + '&period=' + period);
+
+                    piwikService.updatePeriodParamsFromUrl();
+
+                    expect(piwikService.currentDateString).to.equal(expected.currentDateString);
+                    expect(piwikService.period).to.equal(expected.period);
+                    expect(piwikService.startDateString).to.equal(expected.startDateString);
+                    expect(piwikService.endDateString).to.equal(expected.endDateString);
+                });
+            });
+
+            it('should not change object values if the current date/period is the same as the URL date/period', function () {
+                piwik.period = 'range';
+                piwik.currentDateString = '2012-01-01,2012-01-02';
+                piwik.startDateString = 'shouldnotchange';
+                piwik.endDateString = 'shouldnotchangeeither';
+
+                history.pushState(null, null, '?someparam=somevalue#?date=' + piwik.currentDateString + '&period=' + piwik.period);
+
+                piwikService.updatePeriodParamsFromUrl();
+
+                expect(piwikService.startDateString).to.equal('shouldnotchange');
+                expect(piwikService.endDateString).to.equal('shouldnotchangeeither');
+            });
+        });
     });
 })();

--- a/plugins/Morpheus/javascripts/ajaxHelper.js
+++ b/plugins/Morpheus/javascripts/ajaxHelper.js
@@ -532,7 +532,6 @@ function ajaxHelper() {
         var defaultParams = {
             idSite:  piwik.idSite || broadcast.getValueFromUrl('idSite'),
             period:  piwik.period || broadcast.getValueFromUrl('period'),
-            date: piwik.date || broadcast.getValueFromUrl('date'),
             segment: broadcast.getValueFromHash('segment', window.location.href.split('#')[1])
         };
 

--- a/plugins/MultiSites/tests/UI/MultiSites_spec.js
+++ b/plugins/MultiSites/tests/UI/MultiSites_spec.js
@@ -11,6 +11,7 @@ describe("MultiSitesTest", function () {
     this.timeout(0);
 
     var generalParams = 'idSite=1&period=year&date=2012-08-09';
+    var rangeParams = 'idSite=1&period=range&date=2012-08-05,2012-08-15';
     var selector = '#multisites,.expandDataTableFooterDrawer';
 
     var createdSiteId = null;
@@ -66,6 +67,15 @@ describe("MultiSitesTest", function () {
     it('should toggle sort order when click on current metric', function (done) {
         expect.screenshot('all_websites_changed_sort_order').to.be.captureSelector(selector, function (page) {
             page.click('#visits .heading');
+        }, done);
+    });
+
+    it('should load the all websites dashboard correctly when period is range', function (done) {
+        this.retries(3);
+
+        expect.screenshot('all_websites').to.be.captureSelector(selector, function (page) {
+            page.load("?" + rangeParams + "&module=MultiSites&action=index");
+            page.wait(3000);
         }, done);
     });
 

--- a/plugins/MultiSites/tests/UI/MultiSites_spec.js
+++ b/plugins/MultiSites/tests/UI/MultiSites_spec.js
@@ -70,10 +70,10 @@ describe("MultiSitesTest", function () {
         }, done);
     });
 
-    it('should load the all websites dashboard correctly when period is range', function (done) {
+    it.only('should load the all websites dashboard correctly when period is range', function (done) {
         this.retries(3);
 
-        expect.screenshot('all_websites').to.be.captureSelector(selector, function (page) {
+        expect.screenshot('all_websites_range').to.be.captureSelector(selector, function (page) {
             page.load("?" + rangeParams + "&module=MultiSites&action=index");
             page.wait(3000);
         }, done);

--- a/plugins/MultiSites/tests/UI/MultiSites_spec.js
+++ b/plugins/MultiSites/tests/UI/MultiSites_spec.js
@@ -70,7 +70,7 @@ describe("MultiSitesTest", function () {
         }, done);
     });
 
-    it.only('should load the all websites dashboard correctly when period is range', function (done) {
+    it('should load the all websites dashboard correctly when period is range', function (done) {
         this.retries(3);
 
         expect.screenshot('all_websites_range').to.be.captureSelector(selector, function (page) {

--- a/plugins/MultiSites/tests/UI/expected-screenshots/MultiSitesTest_all_websites_range.png
+++ b/plugins/MultiSites/tests/UI/expected-screenshots/MultiSitesTest_all_websites_range.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c36b8421ccb17493ee3563008864f91ec6a36ef1ce22d3e07b892957c367c249
+size 63159

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -185,6 +185,14 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             array($isLocal = true, '127.0.0.1'),
             array($isLocal = true, '::1'),
             array($isLocal = true, '[::1]'),
+
+            // with port
+            array($isLocal = false, '172.30.1.1:80'),
+            array($isLocal = false, '3ffe:1900:4545:3:200:f8ff:fe21:67cf:1005'),
+            array($isLocal = true, 'localhost:3000'),
+            array($isLocal = true, '127.0.0.1:213424'),
+            array($isLocal = true, '::1:345'),
+            array($isLocal = true, '[::1]:443'),
         );
     }
 


### PR DESCRIPTION
MultiSites dashboard does not use a hash so the date/period values were not found. So the currentDateString was not set correctly but only for range periods.

UI tests did not pick this up because MultiSites isn't tested w/ every type of period in the URL (doing so would add a lot of time to the tests). I added unit tests for the function in question in this PR.

Fixes #13266 
Fixes #13271