### PR TITLE
Always set Auth interface in DI to the correct plugin's Auth implementation

### DIFF
--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -373,6 +373,8 @@ class FrontController extends Singleton
         if (!$loggedIn) {
             $authAdapter = $this->makeAuthenticator();
             Access::getInstance()->reloadAccess($authAdapter);
+        } else {
+            $this->makeAuthenticator($sessionAuth); // Piwik\Auth must be set to the correct Login plugin
         }
 
         // Force the auth to use the token_auth if specified, so that embed dashboard
@@ -632,7 +634,7 @@ class FrontController extends Singleton
         return null;
     }
 
-    private function makeAuthenticator()
+    private function makeAuthenticator(SessionAuth $auth = null)
     {
         /**
          * Triggered before the user is authenticated, when the global authentication object
@@ -662,8 +664,13 @@ class FrontController extends Singleton
             throw $ex;
         }
 
-        $authAdapter->setLogin(self::DEFAULT_LOGIN);
-        $authAdapter->setTokenAuth(self::DEFAULT_TOKEN_AUTH);
+        if ($auth) {
+            $authAdapter->setLogin($auth->getLogin());
+            $authAdapter->setTokenAuth($auth->getTokenAuth());
+        } else {
+            $authAdapter->setLogin(self::DEFAULT_LOGIN);
+            $authAdapter->setTokenAuth(self::DEFAULT_TOKEN_AUTH);
+        }
 
         return $authAdapter;
     }

--- a/core/Session/SessionAuth.php
+++ b/core/Session/SessionAuth.php
@@ -39,7 +39,7 @@ class SessionAuth implements Auth
      *
      * @var string
      */
-    private $token_auth;
+    private $user;
 
     public function __construct(UsersModel $userModel = null, $shouldDestroySession = true)
     {
@@ -54,12 +54,12 @@ class SessionAuth implements Auth
 
     public function setTokenAuth($token_auth)
     {
-        $this->token_auth = $token_auth;
+        // empty
     }
 
     public function getLogin()
     {
-        // empty
+        return $this->user['login'];
     }
 
     public function getTokenAuthSecret()
@@ -136,7 +136,7 @@ class SessionAuth implements Auth
 
     private function makeAuthSuccess($user)
     {
-        $this->setTokenAuth($user['token_auth']);
+        $this->user = $user;
 
         $isSuperUser = (int) $user['superuser_access'];
         $code = $isSuperUser ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
@@ -175,6 +175,6 @@ class SessionAuth implements Auth
 
     public function getTokenAuth()
     {
-        return $this->token_auth;
+        return $this->user['token_auth'];
     }
 }

--- a/core/Session/SessionAuth.php
+++ b/core/Session/SessionAuth.php
@@ -34,6 +34,13 @@ class SessionAuth implements Auth
      */
     private $userModel;
 
+    /**
+     * Set internally so it can be queried in FrontController.
+     *
+     * @var string
+     */
+    private $token_auth;
+
     public function __construct(UsersModel $userModel = null, $shouldDestroySession = true)
     {
         $this->userModel = $userModel ?: new UsersModel();
@@ -47,7 +54,7 @@ class SessionAuth implements Auth
 
     public function setTokenAuth($token_auth)
     {
-        // empty
+        $this->token_auth = $token_auth;
     }
 
     public function getLogin()
@@ -164,5 +171,10 @@ class SessionAuth implements Auth
         if ($this->shouldDestroySession) {
             Session::regenerateId();
         }
+    }
+
+    public function getTokenAuth()
+    {
+        return $this->token_auth;
     }
 }

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -102,7 +102,8 @@ class Auth implements \Piwik\Auth
 
         if (!empty($user['token_auth'])
             // authenticate either with the token or the "hash token"
-            && $user['token_auth'] === $token
+            && ((SessionInitializer::getHashTokenAuth($login, $user['token_auth']) === $token)
+                || $user['token_auth'] === $token)
         ) {
             return $this->authenticationSuccess($user);
         }

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -191,4 +191,10 @@ class Auth implements \Piwik\Auth
 
         $this->hashedPassword = $passwordHash;
     }
+
+    // for tests
+    public function getTokenAuth()
+    {
+        return $this->token_auth;
+    }
 }

--- a/tests/PHPUnit/Integration/FrontControllerTest.php
+++ b/tests/PHPUnit/Integration/FrontControllerTest.php
@@ -47,7 +47,7 @@ FORMAT;
         $this->assertEquals('error', $response['result']);
 
         $expectedFormat = <<<FORMAT
-test message on {includePath}/tests/resources/trigger-fatal-exception.php(23)#0 [internal function]: {closure}('CoreHome', 'index', Array)#1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array)#2 {includePath}/core/Piwik.php(780): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, NULL)#3 {includePath}/core/FrontController.php(538): Piwik\Piwik::postEvent('Request.dispatc...', Array)#4 {includePath}/core/FrontController.php(146): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', NULL)#5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index')#6 {main}
+test message on {includePath}/tests/resources/trigger-fatal-exception.php(23)#0 [internal function]: {closure}('CoreHome', 'index', Array)#1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array)#2 {includePath}/core/Piwik.php(780): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, NULL)#3 {includePath}/core/FrontController.php(540): Piwik\Piwik::postEvent('Request.dispatc...', Array)#4 {includePath}/core/FrontController.php(146): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', NULL)#5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index')#6 {main}
 FORMAT;
 
         $this->assertStringMatchesFormat($expectedFormat, $response['message']);


### PR DESCRIPTION
The Auth interface is used for more than authentication, such as getting the configured Login plugin's name, and it is possible for code to try and re-authenticate using the stored auth. In which case, we would always want this interface set to the real implementation.

This PR does that if the SessionAuth succeeds and sets the token auth to the authenticated user's token auth, so reauthentication w/ plugin auths should work (since all Auth implementations are required to support authenticating by token auth alone).

CC @matomo-org/core-team 