### PR TITLE
Use Python 2.7 for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,7 @@ services:
 
 addons:
   apt:
-    sources:
-      - deadsnakes
-
     packages:
-      - python2.6
-      - python2.6-dev
       - nginx
       - realpath
       - lftp

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -140,7 +140,7 @@ class Fixture extends \PHPUnit_Framework_Assert
         }
 
         if (SystemTestCase::isTravisCI()) {
-            return 'python2.6';
+            return 'python2.7';
         }
 
         return 'python';


### PR DESCRIPTION
Atm travis is having more and more problems with installing Python 2.6 and all builds are failing randomly.
As Python 2.7 is preinstalled we should use that instead. That will allow us to remove the dependency for `deadsnakes` apt source and helps to fix the random failures.

Personally I don't see any advantage in using the old 2.6 here, as the log importer itself runs it's tests on 2.6 to prove it works...

After merging we need to update all `.travis.yml` files of all our plugins...