### PR TITLE
CustomVariables: Fix frontend display of value 0

### DIFF
--- a/plugins/CustomVariables/DataTable/Filter/CustomVariablesValuesFromNameId.php
+++ b/plugins/CustomVariables/DataTable/Filter/CustomVariablesValuesFromNameId.php
@@ -34,9 +34,9 @@ class CustomVariablesValuesFromNameId extends BaseFilter
         $notDefinedLabel = Piwik::translate('General_NotDefined', Piwik::translate('CustomVariables_ColumnCustomVariableValue'));
 
         $table->queueFilter('ColumnCallbackReplace', array('label', function ($label) use ($notDefinedLabel) {
-            return $label == \Piwik\Plugins\CustomVariables\Archiver::LABEL_CUSTOM_VALUE_NOT_DEFINED
+            return $label === \Piwik\Plugins\CustomVariables\Archiver::LABEL_CUSTOM_VALUE_NOT_DEFINED
                 ? $notDefinedLabel
-                : $label;
+                : strval($label);
         }));
     }
 }


### PR DESCRIPTION
Line 37:
The value of 0 is wrongly displayed as "not defined" because in PHP the statement "0 == 'string value'" equals true. This is because, if you compare an integer with a string in PHP, it converts the string to an integer first (will always be 0 in this case).

Line 39:
After the fix for line 37, the value 0 will be displayed as '-'. with the strval conversion, we will see the real value of '0' in the frontend.