### PR TITLE
Make sure simple datatable metadata is serialized + some test case changes

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -308,7 +308,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      *
      * @var array
      */
-    private $metadata = array();
+    protected $metadata = array();
 
     /**
      * Maximum number of rows allowed in this datatable (including the summary row).

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -306,6 +306,8 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      *
      * Any data that describes the data held in the table's rows should go here.
      *
+     * Note: this field is protected so derived classes will serialize it.
+     *
      * @var array
      */
     protected $metadata = array();

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -296,11 +296,17 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
     protected function runAnyApiTest($apiMethod, $apiId, $requestParams, $options = array())
     {
         $requestParams['module'] = 'API';
-        $requestParams['format'] = 'XML';
+        if (empty($requestParams['format'])) {
+            $requestParams['format'] = 'XML';
+        }
         $requestParams['method'] = $apiMethod;
 
-        $apiId = $apiMethod . '_' . $apiId . '.xml';
+        $apiId = $apiMethod . '_' . $apiId . '.' . strtolower($requestParams['format']);
         $testName = 'test_' . static::getOutputPrefix();
+
+        if (!empty($options['testSuffix'])) {
+            $testName .= '_' . $options['testSuffix'];
+        }
 
         list($processedFilePath, $expectedFilePath) =
             $this->getProcessedAndExpectedPaths($testName, $apiId, $format = null, $compareAgainst = false);

--- a/tests/PHPUnit/Unit/DataTable/SimpleTest.php
+++ b/tests/PHPUnit/Unit/DataTable/SimpleTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\DataTable;
+
+
+use Piwik\DataTable;
+use Piwik\DataTable\Row;
+use Piwik\DataTable\Simple;
+
+class SimpleTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_serialize_includesAllRequiredData()
+    {
+        $dataTable = new Simple();
+        $dataTable->addRowFromSimpleArray([
+            'column1' => 'value1',
+            'column2' => 'value2',
+        ]);
+        $dataTable->addSummaryRow(new Row([
+            Row::COLUMNS => ['column1' => 'total1', 'column2' => 'total2']
+        ]));
+        $dataTable->setAllTableMetadata([
+            'metadataKey1' => 10,
+            'metadataKey2' => ['a', 'b', 'c'],
+        ]);
+
+        $serialized = serialize($dataTable);
+
+        /** @var Simple $unserialized */
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals(1, $unserialized->getRowsCountWithoutSummaryRow());
+        $this->assertEquals([
+            'column1' => 'value1',
+            'column2' => 'value2',
+        ], $unserialized->getRows()[0]->getColumns());
+
+        $this->assertEquals(2, $unserialized->getRowsCount());
+        $this->assertEquals(['column1' => 'total1', 'column2' => 'total2'], $unserialized->getRows()[DataTable::ID_SUMMARY_ROW]->getColumns());
+
+        $this->assertEquals([
+            'metadataKey1' => 10,
+            'metadataKey2' => ['a', 'b', 'c'],
+        ], $unserialized->getAllTableMetadata());
+    }
+}


### PR DESCRIPTION
Changes:
- Make DataTable::$metadata protected so derived classes will end up serializing that property.
- Allow specifying format in SystemTestCase::runAnyApiTest.
- Allow specifying test suffix in SystemTestCase::runAnyApiTest.