### PR TITLE
Unify logo usage

### DIFF
--- a/plugins/CoreHome/templates/_logo.twig
+++ b/plugins/CoreHome/templates/_logo.twig
@@ -1,13 +1,17 @@
-<span id="logo" class="brand-logo">
-    <a href="index.php" tabindex="-1"
+<span id="logo" class="logo brand-logo {% if centeredLogo is defined and centeredLogo %}center{% endif %}">
+    {% if logoLink is not defined or logoLink is not empty %}
+    <a href="{{ logoLink|default('index.php') }}" tabindex="-1"
        title="{% if isCustomLogo %}{{ 'General_PoweredBy'|translate }} {% endif %}Matomo # {{ 'General_OpenSourceWebAnalytics'|translate }}"
     >
+    {% endif %}
     {% if hasSVGLogo %}
         <img src='{{ logoSVG }}?matomo' tabindex="3"
              alt="{% if isCustomLogo %}{{ 'General_PoweredBy'|translate }} {% endif %}Matomo"
              class="{% if not isCustomLogo %}default-piwik-logo{% endif %}" />
     {% else %}
-        <img src='{{ logoHeader }}?matomo' alt="{% if isCustomLogo %}{{ 'General_PoweredBy'|translate }} {% endif %}Matomo" />
+        <img src='{% if useLargeLogo|default(false) %}{{ logoLarge }}{% else %}{{ logoHeader }}{% endif %}?matomo' alt="{% if isCustomLogo %}{{ 'General_PoweredBy'|translate }} {% endif %}Matomo" />
     {% endif %}
-</a>
+        {% if logoLink is not defined or logoLink is not empty %}
+    </a>
+    {% endif %}
 </span>

--- a/plugins/CoreUpdater/stylesheets/updateLayout.css
+++ b/plugins/CoreUpdater/stylesheets/updateLayout.css
@@ -43,3 +43,11 @@ p strong {
 strong {
     font-weight: 700 !important;
 }
+
+#logo {
+    display: block;
+}
+
+#logo img {
+    height: 40px;
+}

--- a/plugins/CoreUpdater/templates/layout.twig
+++ b/plugins/CoreUpdater/templates/layout.twig
@@ -17,17 +17,7 @@
 </head>
 <body id="simple" ng-app="app">
 
-
-<div class="logo">
-    {% if hasSVGLogo %}
-        <img src='{{ logoSVG }}' tabindex="3"
-             style="height: 40px;"
-             alt="{% if isCustomLogo %}{{ 'General_PoweredBy'|translate }} {% endif %}Matomo"
-             class="{% if not isCustomLogo %}default-piwik-logo{% endif %}" />
-    {% else %}
-        <img src='{{ logoHeader }}' alt="{% if isCustomLogo %}{{ 'General_PoweredBy'|translate }} {% endif %}Matomo" />
-    {% endif %}
-</div>
+{% include "@CoreHome/_logo.twig" with { 'logoLink': false } %}
 
 <div class="box">
     {% block content %}

--- a/plugins/Login/templates/login.twig
+++ b/plugins/Login/templates/login.twig
@@ -27,22 +27,7 @@
     </div>
     <nav>
         <div class="nav-wrapper">
-            <span id="logo" class="brand-logo center">
-
-                {% if isCustomLogo == false %}
-                    <a href="https://matomo.org" title="{{ linkTitle }}">
-                {% endif %}
-                {% if hasSVGLogo %}
-                    <img src='{{ logoSVG }}' class="{% if not isCustomLogo %}default-piwik-logo{% endif %}" title="{{ linkTitle }}" alt="Matomo"/>
-                {% else %}
-                    <img src='{{ logoLarge }}' title="{{ linkTitle }}" alt="Matomo" />
-                {% endif %}
-
-                {% if isCustomLogo == false %}
-                    </a>
-                {% endif %}
-
-            </span>
+            {% include "@CoreHome/_logo.twig" with { 'logoLink': 'https://matomo.org', 'centeredLogo': true, 'useLargeLogo': true } %}
         </div>
     </nav>
 

--- a/plugins/ScheduledReports/templates/unsubscribe.twig
+++ b/plugins/ScheduledReports/templates/unsubscribe.twig
@@ -19,22 +19,7 @@
     </div>
     <nav>
         <div class="nav-wrapper">
-            <span id="logo" class="brand-logo center">
-
-                {% if isCustomLogo == false %}
-                    <a href="https://matomo.org" title="{{ linkTitle }}">
-                {% endif %}
-                {% if hasSVGLogo %}
-                    <img src='{{ logoSVG }}' class="{% if not isCustomLogo %}default-piwik-logo{% endif %}" title="{{ linkTitle }}" alt="Matomo"/>
-                {% else %}
-                    <img src='{{ logoLarge }}' title="{{ linkTitle }}" alt="Matomo" />
-                {% endif %}
-
-                {% if isCustomLogo == false %}
-                    </a>
-                {% endif %}
-
-            </span>
+            {% include "@CoreHome/_logo.twig" with { 'logoLink': 'https://matomo.org', 'centeredLogo': true, 'useLargeLogo': true } %}
         </div>
     </nav>
 


### PR DESCRIPTION
The inclusion of the logo was handled in many templates. This PR aims to move that to one file only, so it looks the same everywhere...

fixes #13287 