### PR TITLE
Fix check if the difference between start and end date is a day

### DIFF
--- a/core/ArchiveProcessor/Parameters.php
+++ b/core/ArchiveProcessor/Parameters.php
@@ -211,7 +211,7 @@ class Parameters
     {
         $period = $this->getPeriod();
         $secondsInPeriod = $period->getDateEnd()->getTimestampUTC() - $period->getDateStart()->getTimestampUTC();
-        $oneDay = $secondsInPeriod <= Date::NUM_SECONDS_IN_DAY;
+        $oneDay = $secondsInPeriod <= Date::NUM_SECONDS_IN_DAY && $period->getLabel() !== 'range';
 
         return $oneDay;
     }


### PR DESCRIPTION
This fixes issue #13047

The check does not take into consideration `range` period, where if you have two adjacent days, the difference is `47h59m59s` and not a day.
Example: If I want to get archived data from `2018-06-10` to `2018-06-11`, I need to check everything between `2018-06-10 00:00:00` and `2018-06-11 23:59:59`. The check disregards the time part of the date.
I think this bug was introduced when functions `Date::getDateStartUTC` and `Date::getDateEndUTC` were deprecated. In the code they are replaced with `getTimestampUTC` which doesn't return the same format as the other two. The tests in `ArchiveProcessorTest` still use the deprecated functions though.

p.s. Apologies for not providing unit tests for this but I couldn't set up phpunit for this project. I also realize this is not the most elegant solution but I didn't want to change too many parts of the code.