### PR TITLE
Fix wrapping in menu selectors

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -250,6 +250,8 @@ nav {
           padding: 15px 22px 11px 45px;
           font-size: 13px;
           font-weight: normal;
+          word-wrap: break-word;
+          word-break: break-all;
 
           &:hover, &:focus {
             color: @theme-color-menu-contrast-textActive;


### PR DESCRIPTION
When having a long goal name without spaces the name didn't wrap in the menu selector:

![image](https://user-images.githubusercontent.com/1579355/44330722-07d8c180-a468-11e8-8ce3-47a675cef771.png)

Same should apply for other selectors like dashboads, sessions,...