### PR TITLE
Metric value not included in some map overlays

### DIFF
--- a/plugins/UserCountryMap/Controller.php
+++ b/plugins/UserCountryMap/Controller.php
@@ -87,7 +87,7 @@ class Controller extends \Piwik\Plugin\Controller
         $view->defaultMetric = 'nb_visits';
 
         // some translations
-        $view->localeJSON = json_encode(array(
+        $translations = array(
              'nb_visits'            => $this->translator->translate('General_NVisits'),
              'one_visit'            => $this->translator->translate('General_OneVisit'),
              'no_visit'             => $this->translator->translate('UserCountryMap_NoVisit'),
@@ -99,7 +99,15 @@ class Controller extends \Piwik\Plugin\Controller
              'no_data'              => $this->translator->translate('CoreHome_ThereIsNoDataForThisReport'),
              'nb_uniq_visitors'     => $this->translator->translate('General_NUniqueVisitors'),
              'nb_users'             => $this->translator->translate('VisitsSummary_NbUsers'),
-        ));
+        );
+
+        foreach ($translations as &$translation) {
+            if (false === strpos($translation, '%s')) {
+                $translation = '%s ' . $translation;
+            }
+        }
+
+        $view->localeJSON = json_encode($translations);
 
         $view->reqParamsJSON = $this->getEnrichedRequest($params = array(
             'period'                      => $period,


### PR DESCRIPTION
Some of the metric translations used for the visitor map overlay do not include a `%s`, which causes the tooltips to only show the translation text without the actual value.
