### PR TITLE
Sparkline for Single Metric Widget might not show for period year

### DIFF
--- a/plugins/CoreHome/angularjs/common/services/periods.js
+++ b/plugins/CoreHome/angularjs/common/services/periods.js
@@ -224,6 +224,25 @@
             endDate = endPeriod.getDateRange()[1];
         }
 
+        var firstWebsiteDate = new Date(1991, 7, 6);
+        if (startDate - firstWebsiteDate < 0) {
+            switch (childPeriodType) {
+                case 'year':
+                    startDate = new Date(1992, 0, 1);
+                    break;
+                case 'month':
+                    startDate = new Date(1991, 8, 1);
+                    break;
+                case 'week':
+                    startDate = new Date(1991, 8, 12);
+                    break;
+                case 'day':
+                default:
+                    startDate = firstWebsiteDate;
+                    break;
+            }
+        }
+
         return new RangePeriod(startDate, endDate, childPeriodType);
     };
 


### PR DESCRIPTION
The sparkline for single metric widget by default tries to show a sparkline for the last 30 units of the current period. If the period year is chosen, the start date for that period would be 1989-01-01 (or even earlier if another year than 2018 is chosen). That date throws an error in Matomo as dates before 1991-08-06 are not allowed.
The changes will automatically use the first allowed date for the given period...