### PR TITLE
Visitor profile: do not load next/previous visitor when ALT key is pressed

### DIFF
--- a/plugins/Live/javascripts/visitorProfile.js
+++ b/plugins/Live/javascripts/visitorProfile.js
@@ -119,9 +119,9 @@
             });
 
             $element.on('keydown', function (e) {
-                if (e.which == 37) { // on <- key press, load previous visitor
+                if (e.which == 37 && !e.altKey) { // on <- key press, load previous visitor
                     self._loadPreviousVisitor();
-                } else if (e.which == 39) { // on -> key press, load next visitor
+                } else if (e.which == 39 && !e.altKey) { // on -> key press, load next visitor
                     self._loadNextVisitor();
                 }
             });


### PR DESCRIPTION
ALT+Left or Alt+Right is a keyboard shortcut to go back/forward in the browser, so do not go previous/next visitor when ALT+left/right is pressed, so that we keep the Back/Forward browser feature working