### PR TITLE
Override string trim only if needed to fix performance issue

### DIFF
--- a/plugins/Morpheus/javascripts/piwikHelper.js
+++ b/plugins/Morpheus/javascripts/piwikHelper.js
@@ -567,11 +567,11 @@ var piwikHelper = {
         }
     }
 };
-
-String.prototype.trim = function() {
-    return this.replace(/^\s+|\s+$/g,"");
-};
-
+if (typeof String.prototype.trim !== 'function') {
+    String.prototype.trim = function() {
+        return this.replace(/^\s+|\s+$/g,"");
+    };
+}
 /**
  * Returns true if the event keypress passed in parameter is the ENTER key
  * @param {Event} e   current window event


### PR DESCRIPTION
I had a case where this method took 90s to execute compared to builtin only a ms.