### PR TITLE
New events + some other misc changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Matomo 3.6.1
+
+### New APIs
+
+* Added new event `Access.modifyUserAccess` which lets plugins modify current user's access levels/permissions.
+
 ## Matomo 3.6.0
 
 ### New Features

--- a/core/Access.php
+++ b/core/Access.php
@@ -221,8 +221,8 @@ class Access
         } elseif (isset($this->login)) {
             if (empty($this->idsitesByAccess['view'])
                 && empty($this->idsitesByAccess['write'])
-                && empty($this->idsitesByAccess['admin'])) {
-
+                && empty($this->idsitesByAccess['admin'])
+            ) {
                 // we join with site in case there are rows in access for an idsite that doesn't exist anymore
                 // (backward compatibility ; before we deleted the site without deleting rows in _access table)
                 $accessRaw = $this->getRawSitesWithSomeViewAccess($this->login);
@@ -243,6 +243,35 @@ class Access
                         }
                     }
                 }
+
+                /**
+                 * Triggered after the initial access levels and permissions for the current user are loaded. Use this
+                 * event to modify the current user's permissions (for example, making sure every user has view access
+                 * to a specific site).
+                 *
+                 * **Example**
+                 *
+                 *     function (&$idsitesByAccess, $login) {
+                 *         if ($login == 'somespecialuser') {
+                 *             return;
+                 *         }
+                 *
+                 *         $idsitesByAccess['view'][] = $mySpecialIdSite;
+                 *     }
+                 *
+                 * @param array[] &$idsitesByAccess The current user's access levels for individual sites. Maps role and
+                 *                                  capability IDs to list of site IDs, eg:
+                 *
+                 *                                  ```
+                 *                                  [
+                 *                                      'view' => [1, 2, 3],
+                 *                                      'write' => [4, 5],
+                 *                                      'admin' => [],
+                 *                                  ]
+                 *                                  ```
+                 * @param string $login The current user's login.
+                 */
+                Piwik::postEvent('Access.modifyUserAccess', [&$this->idsitesByAccess, $this->login]);
             }
         }
     }

--- a/core/Site.php
+++ b/core/Site.php
@@ -136,6 +136,7 @@ class Site
      * @param $idSite
      * @param $infoSite
      * @throws Exception if website or idsite is invalid
+     * @internal
      */
     public static function setSiteFromArray($idSite, $infoSite)
     {
@@ -149,6 +150,10 @@ class Site
     /**
      * Sets the cached Site data with a non-associated array of site data.
      *
+     * This method will trigger the `Sites.setSites` event modifying `$sites` before setting cached
+     * site data. In other words, this method will change the site data before it is cached and then
+     * return the modified array.
+     *
      * @param array $sites The array of sites data. eg,
      *
      *                         array(
@@ -156,6 +161,8 @@ class Site
      *                             array('idsite' => '2', 'name' => 'Site 2', ...),
      *                         )
      * @return array The modified array.
+     * @deprecated
+     * @internal
      */
     public static function setSitesFromArray($sites)
     {

--- a/core/Site.php
+++ b/core/Site.php
@@ -155,6 +155,7 @@ class Site
      *                             array('idsite' => '1', 'name' => 'Site 1', ...),
      *                             array('idsite' => '2', 'name' => 'Site 2', ...),
      *                         )
+     * @return array The modified array.
      */
     public static function setSitesFromArray($sites)
     {
@@ -168,6 +169,8 @@ class Site
 
             self::setSiteFromArray($idSite, $site);
         }
+
+        return $sites;
     }
 
     /**

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -125,9 +125,15 @@ class API extends \Piwik\Plugin\API
 
     private static function ensureLanguageSetForUser($currentUser)
     {
-        $lang = \Piwik\Plugins\LanguagesManager\API::getInstance()->getLanguageForUser($currentUser);
+        $lang = Request::processRequest('LanguagesManager.getLanguageForUser', [
+            'login' => $currentUser,
+        ]);
+
         if (empty($lang)) {
-            \Piwik\Plugins\LanguagesManager\API::getInstance()->setLanguageForUser($currentUser, LanguagesManager::getLanguageCodeForCurrentUser());
+            Request::processRequest('LanguagesManager.setLanguageForUser', [
+                'login' => $currentUser,
+                'languageCode' => LanguagesManager::getLanguageCodeForCurrentUser(),
+            ]);
         }
     }
 

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -454,6 +454,7 @@ class ApiTest extends IntegrationTestCase
                     $result->addRowFromSimpleArray(array('label' => 'referrers label', 'nb_visits' => 1));
                     return $result;
                 case '\Piwik\Plugins\API\API':
+                case '\Piwik\Plugins\LanguagesManager\API':
                     return $realProxy->call($className, $methodName, $parametersRequest);
                 default:
                     throw new \Exception("Unexpected method $className::$methodName.");

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -191,7 +191,7 @@ class API extends \Piwik\Plugin\API
             $this->enrichSite($site);
         }
 
-        Site::setSitesFromArray($sites);
+        $sites = Site::setSitesFromArray($sites);
         return $sites;
     }
 
@@ -272,7 +272,7 @@ class API extends \Piwik\Plugin\API
             $return[$site['idsite']] = $site;
         }
 
-        Site::setSitesFromArray($return);
+        $return = Site::setSitesFromArray($return);
 
         return $return;
     }
@@ -343,7 +343,7 @@ class API extends \Piwik\Plugin\API
                 $this->enrichSite($site);
             }
 
-            Site::setSitesFromArray($sites);
+            $sites = Site::setSitesFromArray($sites);
         }
 
         if ($fetchAliasUrls) {
@@ -472,7 +472,7 @@ class API extends \Piwik\Plugin\API
             $this->enrichSite($site);
         }
 
-        Site::setSitesFromArray($sites);
+        $sites = Site::setSitesFromArray($sites);
 
         return $sites;
     }
@@ -1622,6 +1622,7 @@ class API extends \Piwik\Plugin\API
 
         $sites = $this->getModel()->getPatternMatchSites($ids, $pattern, $limit);
 
+        $sites = Site::setSitesFromArray($sites);
         return $sites;
     }
 

--- a/plugins/SitesManager/templates/siteWithoutData.twig
+++ b/plugins/SitesManager/templates/siteWithoutData.twig
@@ -52,8 +52,11 @@
                class="btn ignoreSitesWithoutData">{{ 'SitesManager_SiteWithoutDataIgnoreMessage'|translate }}</a>
         </p>
 
+        {{ postEvent('Template.siteWithoutData.afterIntro') }}
+
         {{ trackingHelp|raw }}
 
+        {{ postEvent('Template.siteWithoutData.afterTrackingHelp') }}
     </div>
 
 {% endblock %}

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -376,8 +376,15 @@ class Controller extends ControllerAdmin
             $this->processPasswordChange($userLogin);
 
             LanguagesManager::setLanguageForSession($language);
-            APILanguagesManager::getInstance()->setLanguageForUser($userLogin, $language);
-            APILanguagesManager::getInstance()->set12HourClockForUser($userLogin, $timeFormat);
+
+            Request::processRequest('LanguagesManager.setLanguageForUser', [
+                'login' => $userLogin,
+                'languageCode' => $language,
+            ]);
+            Request::processRequest('LanguagesManager.set12HourClockForUser', [
+                'login' => $userLogin,
+                'use12HourClock' => $timeFormat,
+            ]);
 
             APIUsersManager::getInstance()->setUserPreference($userLogin,
                 APIUsersManager::PREFERENCE_DEFAULT_REPORT,


### PR DESCRIPTION
Changes:

* Added event `Access.modifyUserAccess` so plugins can directly edit user access w/o having to go to the DB.
* Add a couple template events.
* Use `Request::process()` for some LanguagesManager API calls so events will execute for it.
* Use the result of `Site.setSites` event in the SitesManager API so the output will change. **(this will change API output)**