### PR TITLE
Make sure user is not logged out when settings saved w/ no password change.

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -808,7 +808,7 @@ class API extends \Piwik\Plugin\API
         $passwordHasBeenUpdated = false;
 
         if (empty($password)) {
-            $password = $userInfo['password'];
+            $password = false;
         } else {
             $password = Common::unsanitizeInputValue($password);
 

--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -410,6 +410,7 @@ class Controller extends ControllerAdmin
         $alias = Common::getRequestVar('alias');
         $email = Common::getRequestVar('email');
         $newPassword = false;
+
         $password = Common::getRequestvar('password', false);
         $passwordBis = Common::getRequestvar('passwordBis', false);
         if (!empty($password)
@@ -439,7 +440,7 @@ class Controller extends ControllerAdmin
             $auth = StaticContainer::get('Piwik\Auth');
             $auth->setLogin($userLogin);
             $auth->setPassword($newPassword);
-            $sessionInitializer->initSession($auth, $rememberMe = false);
+            $sessionInitializer->initSession($auth);
         }
     }
 

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -310,12 +310,15 @@ class Model
 
     public function updateUser($userLogin, $hashedPassword, $email, $alias, $tokenAuth)
     {
-        $this->updateUserFields($userLogin, array(
-            'password'   => $hashedPassword,
+        $fields = array(
             'alias'      => $alias,
             'email'      => $email,
             'token_auth' => $tokenAuth
-        ));
+        );
+        if (!empty($hashedPassword)) {
+            $fields['password'] = $hashedPassword;
+        }
+        $this->updateUserFields($userLogin, $fields);
     }
 
     public function updateUserTokenAuth($userLogin, $tokenAuth)

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -304,6 +304,19 @@ class APITest extends IntegrationTestCase
         $this->assertTrue($passwordHelper->verify(UsersManager::getPasswordHash('newPassword'), $user['password']));
     }
 
+    public function test_updateUser_doesNotChangePasswordIfFalsey()
+    {
+        $model = new Model();
+        $userBefore = $model->getUser($this->login);
+
+        $this->api->updateUser($this->login, false, 'email@example.com', 'newAlias', false);
+
+        $user = $model->getUser($this->login);
+
+        $this->assertSame($userBefore['password'], $user['password']);
+        $this->assertSame($userBefore['ts_password_modified'], $user['ts_password_modified']);
+    }
+
     public function test_getSitesAccessFromUser_forSuperUser()
     {
         $user2 = 'userLogin2';


### PR DESCRIPTION
Makes sure when password is not deliberately set through API, ts_password_modified does not change.