### PR TITLE
Make sure automatic login feature does not result in multiple set-cookie headers.

### DIFF
--- a/core/Session/SessionInitializer.php
+++ b/core/Session/SessionInitializer.php
@@ -88,7 +88,11 @@ class SessionInitializer
 
     protected function regenerateSessionId()
     {
-        Session::regenerateId();
+        if (Session::isStarted()) {
+            Session::regenerateId();
+        } else {
+            Session::start();
+        }
     }
 
     /**

--- a/core/Session/SessionInitializer.php
+++ b/core/Session/SessionInitializer.php
@@ -88,9 +88,14 @@ class SessionInitializer
 
     protected function regenerateSessionId()
     {
-        if (Session::isStarted()) {
+        $isSessionCookieExists = isset($_COOKIE[Session::SESSION_NAME]);
+
+        if (Session::isStarted()) { // session already exist, regenerate ID so old session is still unauthenticated (in case an attacker has it)
             Session::regenerateId();
-        } else {
+        } else if ($isSessionCookieExists) { // session not started, but session cookie exists: start session & regenerate ID
+            Session::start();
+            Session::regenerateId();
+        } else { // session not started and no sesssion cookie exists: start session, which will create a new ID.
             Session::start();
         }
     }

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -172,7 +172,7 @@ class Controller extends \Piwik\Plugin\Controller
         $urlToRedirect = Common::getRequestVar('url', $currentUrl, 'string');
         $urlToRedirect = Common::unsanitizeInputValue($urlToRedirect);
 
-        $this->authenticateAndRedirect($login, $password, $urlToRedirect, $passwordHashed = true);
+        $this->authenticateAndRedirect($login, $password, $urlToRedirect, $passwordHashed = true, $discardNonce = false);
     }
 
     /**
@@ -204,9 +204,11 @@ class Controller extends \Piwik\Plugin\Controller
      * @param bool $passwordHashed indicates if $password is hashed
      * @return string failure message if unable to authenticate
      */
-    protected function authenticateAndRedirect($login, $password, $urlToRedirect = false, $passwordHashed = false)
+    protected function authenticateAndRedirect($login, $password, $urlToRedirect = false, $passwordHashed = false, $discardNonce = true)
     {
-        Nonce::discardNonce('Login.login');
+        if ($discardNonce) { // the nonce is stored in the session, and for "automatic login" we don't want to start a session here
+            Nonce::discardNonce('Login.login');
+        }
 
         $this->auth->setLogin($login);
         if ($passwordHashed === false) {

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -33,6 +33,7 @@ class Login extends \Piwik\Plugin
             'AssetManager.getJavaScriptFiles'  => 'getJsFiles',
             'AssetManager.getStylesheetFiles'  => 'getStylesheetFiles',
             'Session.beforeSessionStart'       => 'beforeSessionStart',
+            'Session.shouldStartSession' => 'shouldStartSession',
         );
         return $hooks;
     }
@@ -42,10 +43,17 @@ class Login extends \Piwik\Plugin
         $jsFiles[] = "plugins/Login/javascripts/login.js";
     }
 
-   public function getStylesheetFiles(&$stylesheetFiles)
+    public function getStylesheetFiles(&$stylesheetFiles)
     {
         $stylesheetFiles[] = "plugins/Login/stylesheets/login.less";
         $stylesheetFiles[] = "plugins/Login/stylesheets/variables.less";
+    }
+
+    public function shouldStartSession(&$shouldStartSession, $module, $action)
+    {
+        if ($module == 'Login' && $action == 'logme') {
+            $shouldStartSession = false;
+        }
     }
 
     public function beforeSessionStart()

--- a/plugins/Login/tests/Integration/LoginTest.php
+++ b/plugins/Login/tests/Integration/LoginTest.php
@@ -15,6 +15,7 @@ use Piwik\DbHelper;
 use Piwik\NoAccessException;
 use Piwik\Plugins\Login\Auth;
 use Piwik\Plugins\UsersManager\API;
+use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
@@ -324,6 +325,26 @@ class LoginTest extends IntegrationTestCase
         // Check that the login + token auth is correct in the result
         $this->assertEquals($user['login'], $rc->getIdentity());
         $this->assertEquals($user['tokenAuth'], $rc->getTokenAuth());
+    }
+
+    public function test_logme_onlyReturnsASingleSessionId()
+    {
+        $this->_setUpUser();
+
+        $url = Fixture::getTestRootUrl() . 'index.php?module=Login&action=logme&login=user&password=' . md5('geqgeagae');
+
+        $context = stream_context_create([
+            'http' => ['ignore_errors' => true, 'follow_location' => false],
+        ]);
+        file_get_contents($url, false, $context);
+
+        $cookies = [];
+        foreach ($http_response_header as $header) {
+            if (preg_match('/^set-cookie:/i', $header)) {
+                $cookies[] = $header;
+            }
+        }
+        $this->assertCount(1, $cookies);
     }
 
     protected function _setUpUser()

--- a/plugins/Login/tests/Integration/LoginTest.php
+++ b/plugins/Login/tests/Integration/LoginTest.php
@@ -347,6 +347,40 @@ class LoginTest extends IntegrationTestCase
         $this->assertCount(1, $cookies);
     }
 
+    public function test_logme_onlyReturnsASingleSessionId_ifSessionInProgress()
+    {
+        $this->_setUpUser();
+
+        $context = stream_context_create([
+            'http' => ['ignore_errors' => true, 'follow_location' => false],
+        ]);
+        file_get_contents(Fixture::getRootUrl() . 'index.php', false, $context); // using non-test URL so it won't auto-login (since FakeAccess is used here)
+
+        $sessionId = $this->findSessionId($http_response_header);
+        $this->assertNotNull($sessionId);
+
+        $url = Fixture::getTestRootUrl() . 'index.php?module=Login&action=logme&login=user&password=' . md5('geqgeagae');
+
+        $context = stream_context_create([
+            'http' => ['ignore_errors' => true, 'follow_location' => false, 'header' => "Cookie: PIWIK_SESSID=$sessionId;"],
+        ]);
+        file_get_contents($url, false, $context);
+
+        $newSessionId = $this->findSessionId($http_response_header);
+        $this->assertNotNull($newSessionId);
+        $this->assertNotEquals($sessionId, $newSessionId);
+    }
+
+    private function findSessionId($headers)
+    {
+        foreach ($headers as $header) {
+            if (preg_match('/^set-cookie:\s*PIWIK_SESSID=([^;]+)/i', $header, $matches)) {
+                return $matches[1];
+            }
+        }
+        return null;
+    }
+
     protected function _setUpUser()
     {
         $user = array('login'    => 'user',


### PR DESCRIPTION
Cause of duplicate headers is due to following workflow:

1. User uses logme API endpoint, w/o having a session already started.
2. FrontController calls Session::start() which notices there's no session currently and creates one.
3. PHP calls setcookie() w/ session id resulting in one set-cookie header.
4. logme() authenticates user & SessionInitializer regenerates the session ID.
5. PHP calls setcookie() to change the session ID. This results in a new set-cookie header (it doesn't change the existing one).
6. the response contains 2 set-cookie headers

Fixed by introducing new hidden event `Session.shouldStartSession`. The Login plugin does not start a session for logme(). Then in SessionInitializer, instead of calling Session::regenerateId() (which will have no effect if the session is not started), we call Session::start() if the session hasn't been started yet, and Session::regenerateId() only if there is already an existing session.

Fixes #13393 