### PR TITLE
Create directory for processed files if needed when syncing tests

### DIFF
--- a/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
+++ b/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
@@ -107,7 +107,9 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
         foreach($artifacts as $artifact) {
             $artifactName = basename($artifact);
             list($plugin, $file) = explode('~~', $artifactName);
-            Filesystem::copy($artifact, sprintf($targetDir, $plugin) . $file);
+            $pluginTargetDir = sprintf($targetDir, $plugin);
+            Filesystem::mkdir($pluginTargetDir);
+            Filesystem::copy($artifact, $pluginTargetDir . $file);
         }
 
         Filesystem::unlinkRecursive($extractionTarget, true);


### PR DESCRIPTION
I got this message:
                                                                                                                                                                                  
  [Exception]                                                                                                                                                                       
  Error while creating/copying file to <code>plugins/Annotations/tests/System/processed/test_annotations__Annotations.get.xml  
  </code>. <br />Please check that the web server has enough permission to write to these files/directories:<br />For example, on a GNU/Linux server if your Apache httpd user is   
  abc, you can try to execute:<br />                                                                                                                                        
  <code>chown -R abc ...www/piwik</code><br /><code>chmod -R 0755 ...www/piw  
  ik</code><br />