### PR TITLE
Fixes Ecommerce overview

### DIFF
--- a/plugins/Ecommerce/Controller.php
+++ b/plugins/Ecommerce/Controller.php
@@ -76,13 +76,12 @@ class Controller extends \Piwik\Plugins\Goals\Controller
     {
         $view = new View('@Ecommerce/conversionOverview');
         $idGoal = Common::getRequestVar('idGoal', null, 'string');
-        $idSite = Common::getRequestVar('idSite', null, 'int');
         $period = Common::getRequestVar('period', null, 'string');
         $segment = Common::getRequestVar('segment', '', 'string');
 
         $goalMetrics = Request::processRequest('Goals.get', [
             'idGoal'       => $idGoal,
-            'idSite'       => $idSite,
+            'idSite'       => $this->idSite,
             'date'         => $this->strDate,
             'period'       => $period,
             'segment'      => $segment,
@@ -90,7 +89,7 @@ class Controller extends \Piwik\Plugins\Goals\Controller
         ], $default = []);
         $dataRow = $goalMetrics->getFirstRow();
 
-        $view->idSite = $idSite;
+        $view->idSite = $this->idSite;
         $view->idGoal = $idGoal;
 
         if ($dataRow) {

--- a/plugins/Ecommerce/Controller.php
+++ b/plugins/Ecommerce/Controller.php
@@ -76,11 +76,21 @@ class Controller extends \Piwik\Plugins\Goals\Controller
     {
         $view = new View('@Ecommerce/conversionOverview');
         $idGoal = Common::getRequestVar('idGoal', null, 'string');
+        $idSite = Common::getRequestVar('idSite', null, 'int');
+        $period = Common::getRequestVar('period', null, 'string');
+        $segment = Common::getRequestVar('segment', '', 'string');
 
-        $goalMetrics = Request::processRequest('Goals.get', array('idGoal' => $idGoal, 'filter_limit' => '-1'), $default = []);
+        $goalMetrics = Request::processRequest('Goals.get', [
+            'idGoal'       => $idGoal,
+            'idSite'       => $idSite,
+            'date'         => $this->strDate,
+            'period'       => $period,
+            'segment'      => $segment,
+            'filter_limit' => '-1'
+        ], $default = []);
         $dataRow = $goalMetrics->getFirstRow();
 
-        $view->idSite = Common::getRequestVar('idSite', null, 'int');
+        $view->idSite = $idSite;
         $view->idGoal = $idGoal;
 
         if ($dataRow) {


### PR DESCRIPTION
The ecommerce overview broke with the merge of #13293.
The parameters send to the API method were incomplete. See

![image](https://builds-artifacts.matomo.org/matomo-org/matomo/stablesortactions/29920/processed/UIIntegrationTest_goals_ecommerce.png)