### PR TITLE
When displaying unprocessed segment message, check for urlencoded segment.

### DIFF
--- a/plugins/SegmentEditor/SegmentEditor.php
+++ b/plugins/SegmentEditor/SegmentEditor.php
@@ -199,7 +199,13 @@ class SegmentEditor extends \Piwik\Plugin
         // data does not exist. this means the data will be processed later. we let the user know so they will not
         // be confused.
         $model = new Model();
-        $storedSegment = $model->getSegmentByDefinition($segment->getString()) ?: null;
+        $storedSegment = $model->getSegmentByDefinition($segment->getString());
+        if (empty($storedSegment)) {
+            $storedSegment = $model->getSegmentByDefinition(urldecode($segment->getString()));
+        }
+        if (empty($storedSegment)) {
+            $storedSegment = null;
+        }
 
         return [$segment, $storedSegment, $isSegmentToPreprocess];
     }

--- a/plugins/SegmentEditor/tests/System/UnprocessedSegmentsTest.php
+++ b/plugins/SegmentEditor/tests/System/UnprocessedSegmentsTest.php
@@ -87,6 +87,26 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         ]);
     }
 
+    public function test_apiOutput_whenUnprocessedAutoArchiveSegmentUsed_WithBrowserArchivingDisabled_AndEncodedSegment()
+    {
+        $idSegment = API::getInstance()->add('testsegment', self::TEST_SEGMENT, self::$fixture->idSite, $autoArchive = true);
+
+        $storedSegment = API::getInstance()->get($idSegment);
+        $this->assertNotEmpty($storedSegment);
+
+        Rules::setBrowserTriggerArchiving(false);
+
+        $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
+        $this->assertContains(self::TEST_SEGMENT, $segments);
+
+        $this->runAnyApiTest('VisitsSummary.get', 'autoArchiveSegmentUnprocessedEncoded', [
+            'idSite' => self::$fixture->idSite,
+            'date' => Date::factory(self::$fixture->dateTime)->toString(),
+            'period' => 'week',
+            'segment' => urlencode(self::TEST_SEGMENT),
+        ]);
+    }
+
     public function test_apiOutput_whenPreprocessedSegmentUsed_WithBrowserArchivingDisabled()
     {
         $idSegment = API::getInstance()->add('testsegment', self::TEST_SEGMENT, self::$fixture->idSite, $autoArchive = true);

--- a/plugins/SegmentEditor/tests/System/expected/test___VisitsSummary.get_autoArchiveSegmentUnprocessedEncoded.xml
+++ b/plugins/SegmentEditor/tests/System/expected/test___VisitsSummary.get_autoArchiveSegmentUnprocessedEncoded.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<error message="These reports have no data, because the Segment you requested (testsegment) has not yet been processed by the system. Data for this Segment should become available in a few hours when processing completes. (If it does not, there may be a problem.) Please note that you can test whether your segment will work without having to wait for it to be processed by using the Live.getLastVisitsDetails API. When using this API method, you will see which users and actions were matched by your &amp;segment= parameter. This can help you confirm your Segment matches the users and actions you expect it to." />
+</result>


### PR DESCRIPTION
Export link, eg, has urlencoded segment value.