### PR TITLE
In Overlay do not call API directly since it does not have access to the token auth.

### DIFF
--- a/plugins/Overlay/Controller.php
+++ b/plugins/Overlay/Controller.php
@@ -12,15 +12,12 @@ use Piwik\API\CORSHandler;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Config;
-use Piwik\FrontController;
 use Piwik\Metrics;
 use Piwik\Piwik;
-use Piwik\Plugin\Report;
 use Piwik\Plugins\Actions\ArchivingHelper;
 use Piwik\Plugins\SegmentEditor\SegmentFormatter;
 use Piwik\Plugins\SitesManager\API as APISitesManager;
 use Piwik\ProxyHttp;
-use Piwik\Segment;
 use Piwik\Tracker\Action;
 use Piwik\Tracker\PageUrl;
 use Piwik\View;
@@ -254,7 +251,7 @@ class Controller extends \Piwik\Plugin\Controller
 
     private function apiRequest($methodName)
     {
-        $_GET['method'] = $_POST['method'] = 'Overlay.' . $methodName;
-        return FrontController::getInstance()->dispatch('API', 'index');
+        $request = new Request('method=Overlay.'.$methodName);
+        return $request->process();
     }
 }

--- a/plugins/Overlay/Controller.php
+++ b/plugins/Overlay/Controller.php
@@ -12,6 +12,7 @@ use Piwik\API\CORSHandler;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\FrontController;
 use Piwik\Metrics;
 use Piwik\Piwik;
 use Piwik\Plugin\Report;
@@ -35,6 +36,21 @@ class Controller extends \Piwik\Plugin\Controller
     {
         $this->segmentFormatter = $segmentFormatter;
         parent::__construct();
+    }
+
+    public function getTranslations()
+    {
+        return $this->apiRequest('getTranslations');
+    }
+
+    public function getExcludedQueryParameters()
+    {
+        return $this->apiRequest('getExcludedQueryParameters');
+    }
+
+    public function getFollowingPages()
+    {
+        return $this->apiRequest('getFollowingPages');
     }
 
     /** The index of the plugin */
@@ -234,5 +250,11 @@ class Controller extends \Piwik\Plugin\Controller
     {
         $corsHandler = new CORSHandler();
         $corsHandler->handle();
+    }
+
+    private function apiRequest($methodName)
+    {
+        $_GET['method'] = $_POST['method'] = 'Overlay.' . $methodName;
+        return FrontController::getInstance()->dispatch('API', 'index');
     }
 }

--- a/plugins/Overlay/client/client.js
+++ b/plugins/Overlay/client/client.js
@@ -143,9 +143,8 @@ var Piwik_Overlay_Client = (function () {
         },
 
         /** Piwik Overlay API Request */
-        api: function (method, callback, additionalParams) {
-            var url = piwikRoot + 'index.php?module=API&method=Overlay.' + method
-                + '&idSite=' + idSite + '&period=' + period + '&date=' + date + '&format=JSON&filter_limit=-1';
+        controller: function (method, callback, additionalParams) {
+            var url = piwikRoot + 'index.php?module=Overlay&action=' + method + '&idSite=' + idSite + '&period=' + period + '&date=' + date + '&format=JSON&filter_limit=-1';
 
             if (segment) {
                 url += '&segment=' + segment;

--- a/plugins/Overlay/client/followingpages.js
+++ b/plugins/Overlay/client/followingpages.js
@@ -29,7 +29,7 @@ var Piwik_Overlay_FollowingPages = (function () {
         var followingPagesLoaded = false;
 
         // load excluded params
-        Piwik_Overlay_Client.api('getExcludedQueryParameters', function (data) {
+        Piwik_Overlay_Client.controller('getExcludedQueryParameters', function (data) {
             for (var i = 0; i < data.length; i++) {
                 if (typeof data[i] == 'object') {
                     data[i] = data[i][0];
@@ -44,7 +44,7 @@ var Piwik_Overlay_FollowingPages = (function () {
         });
 
         // load following pages
-        Piwik_Overlay_Client.api('getFollowingPages', function (data) {
+        Piwik_Overlay_Client.controller('getFollowingPages', function (data) {
             followingPages = data;
             processFollowingPages();
 

--- a/plugins/Overlay/client/translations.js
+++ b/plugins/Overlay/client/translations.js
@@ -11,7 +11,7 @@ var Piwik_Overlay_Translations = (function () {
          */
         initialize: function (callback) {
             // Load translation data
-            Piwik_Overlay_Client.api('getTranslations', function (data) {
+            Piwik_Overlay_Client.controller('getTranslations', function (data) {
                 translations = data[0];
                 callback();
             });


### PR DESCRIPTION
Fixes #13406 

Authenticating via UI session in API requests is no longer supported.