### PR TITLE
Prevent error related report may not be defined

### DIFF
--- a/core/Plugin/ViewDataTable.php
+++ b/core/Plugin/ViewDataTable.php
@@ -211,6 +211,10 @@ abstract class ViewDataTable implements ViewInterface
             $relatedReports = $report->getRelatedReports();
             if (!empty($relatedReports)) {
                 foreach ($relatedReports as $relatedReport) {
+                    if (!$relatedReport) {
+                        continue;
+                    }
+                    
                     $relatedReportName = $relatedReport->getName();
 
                     $this->config->addRelatedReport($relatedReport->getModule() . '.' . $relatedReport->getAction(),


### PR DESCRIPTION
Prevents eg error message ` {"message":"Call to a member function getName() on null","file":"...\/core\/Plugin\/ViewDataTable.php","line":214}`

Maybe related report cannot be found when a report is disabled or when a plugin is disabled.