### PR TITLE
Add Movers And Shakers widget to default dashboard

### DIFF
--- a/plugins/Dashboard/Dashboard.php
+++ b/plugins/Dashboard/Dashboard.php
@@ -141,15 +141,21 @@ class Dashboard extends \Piwik\Plugin
         $defaultLayout = $this->getLayoutForUser('', 1);
 
         if (empty($defaultLayout)) {
+            $pluginManager = Plugin\Manager::getInstance();
+
             $advertisingWidget = '';
             $advertising = StaticContainer::get('Piwik\ProfessionalServices\Advertising');
-            if ($advertising->areAdsForProfessionalServicesEnabled() && Plugin\Manager::getInstance()->isPluginActivated('ProfessionalServices')) {
+            if ($advertising->areAdsForProfessionalServicesEnabled() && $pluginManager->isPluginActivated('ProfessionalServices')) {
                 $advertisingWidget = '{"uniqueId":"widgetProfessionalServicespromoServices","parameters":{"module":"ProfessionalServices","action":"promoServices"}},';
             }
             if (Piwik::hasUserSuperUserAccess()) {
                 $piwikPromoWidget = '{"uniqueId":"widgetCoreHomegetDonateForm","parameters":{"module":"CoreHome","action":"getDonateForm"}}';
             } else {
                 $piwikPromoWidget = '{"uniqueId":"widgetCoreHomegetPromoVideo","parameters":{"module":"CoreHome","action":"getPromoVideo"}}';
+            }
+            $insightsWidget = '';
+            if ($pluginManager->isPluginActivated('Insights')) {
+                $insightsWidget = '{"uniqueId":"widgetInsightsgetOverallMoversAndShakers","parameters":{"module":"Insights","action":"getOverallMoversAndShakers"}},';
             }
             $defaultLayout = '[
                 [
@@ -163,6 +169,7 @@ class Dashboard extends \Piwik\Plugin
                 ],
                 [
                     {"uniqueId":"widgetUserCountryMapvisitorMap","parameters":{"module":"UserCountryMap","action":"visitorMap"}},
+                    ' . $insightsWidget . '
                     {"uniqueId":"widgetReferrersgetReferrerType","parameters":{"module":"Referrers","action":"getReferrerType"}},
                     {"uniqueId":"widgetRssWidgetrssPiwik","parameters":{"module":"RssWidget","action":"rssPiwik"}}
                 ]


### PR DESCRIPTION
Could also move it to top left even before the "Visitors in real time widget"? @mattab any preference? As it may be quite useful to see it first, but not needed.

fixes #13153