### PR TITLE
Replace unsupported characters in all tracking request params

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -88,12 +88,23 @@ class Request
 
         // check for 4byte utf8 characters in all tracking params and replace them with �
         // @TODO Remove as soon as our database tables use utf8mb4 instead of utf8
-        array_walk_recursive ($this->params, function(&$value, $key){
-            if (is_string($value) && preg_match('/[\x{10000}-\x{10FFFF}]/u', $value)) {
-                Common::printDebug("Unsupport character detected in $key. Replacing with \xEF\xBF\xBD");
-                $value = preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $value);
-            }
-        });
+        $this->params = $this->replaceUnsupportedUtf8Chars($this->params);
+    }
+
+    protected function replaceUnsupportedUtf8Chars($value, $key=false)
+    {
+        if (is_string($value) && preg_match('/[\x{10000}-\x{10FFFF}]/u', $value)) {
+            Common::printDebug("Unsupport character detected in $key. Replacing with \xEF\xBF\xBD");
+            return preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $value);
+        }
+
+        if (is_array($value)) {
+            array_walk_recursive ($value, function(&$value, $key){
+                $value = $this->replaceUnsupportedUtf8Chars($value, $key);
+            });
+        }
+
+        return $value;
     }
 
     /**
@@ -402,7 +413,7 @@ class Request
         $paramType = $supportedParams[$name][1];
 
         if ($this->hasParam($name)) {
-            $this->paramsCache[$name] = Common::getRequestVar($name, $paramDefaultValue, $paramType, $this->params);
+            $this->paramsCache[$name] = $this->replaceUnsupportedUtf8Chars(Common::getRequestVar($name, $paramDefaultValue, $paramType, $this->params), $name);
         } else {
             $this->paramsCache[$name] = $paramDefaultValue;
         }

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -86,12 +86,14 @@ class Request
             }
         }
 
-        // check for 4byte utf8 characters in url and replace them with �
+        // check for 4byte utf8 characters in all tracking params and replace them with �
         // @TODO Remove as soon as our database tables use utf8mb4 instead of utf8
-        if (array_key_exists('url', $this->params) && preg_match('/[\x{10000}-\x{10FFFF}]/u', $this->params['url'])) {
-            Common::printDebug("Unsupport character detected. Replacing with \xEF\xBF\xBD");
-            $this->params['url'] = preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $this->params['url']);
-        }
+        array_walk_recursive ($this->params, function(&$value, $key){
+            if (is_string($value) && preg_match('/[\x{10000}-\x{10FFFF}]/u', $value)) {
+                Common::printDebug("Unsupport character detected in $key. Replacing with \xEF\xBF\xBD");
+                $value = preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $value);
+            }
+        });
     }
 
     /**

--- a/tests/PHPUnit/Fixtures/Utf8mb4.php
+++ b/tests/PHPUnit/Fixtures/Utf8mb4.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link    http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\Fixtures;
+
+use Piwik\Date;
+use Piwik\Tests\Framework\Fixture;
+
+/**
+ *
+ */
+class Utf8mb4 extends Fixture
+{
+    public $idSite = 1;
+    public $dateTime = '2010-01-04 00:11:42';
+
+    public $trackInvalidRequests = true;
+
+    public function setUp()
+    {
+        $this->setUpWebsitesAndGoals();
+        $this->trackVisits();
+    }
+
+    public function tearDown()
+    {
+        // empty
+    }
+
+    private function setUpWebsitesAndGoals()
+    {
+        if (!self::siteCreated($idSite = 1)) {
+            self::createWebsite($this->dateTime);
+        }
+    }
+
+    private function trackVisits()
+    {
+        $t = self::getTracker($this->idSite, $this->dateTime, $defaultInit = true);
+        $t->setForceVisitDateTime(Date::factory($this->dateTime)->addHour(1)->getDatetime());
+        $t->setUrlReferrer('http://www.google.com/search?q=😡');
+        $t->setUrl('http://example.org/foo/🙙.html');
+        self::checkResponse($t->doTrackPageView('incredible 🚜'));
+
+        $t->addEcommerceItem('sku 🛸', 'name 🛩', 'category 🛤', 95);
+        self::checkResponse($t->doTrackEcommerceCartUpdate(100));
+    }
+}

--- a/tests/PHPUnit/System/Utf8mb4Test.php
+++ b/tests/PHPUnit/System/Utf8mb4Test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\System;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\Tests\Fixtures\Utf8mb4;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tracker\Action;
+use Piwik\Tests\Framework\TestCase\SystemTestCase;
+use Piwik\Tests\Fixtures\OneVisitWithAbnormalPageviewUrls;
+
+/**
+ * Tests for tracking parameters containing 4 byte UTF8 chars.
+ *
+ * @group Core
+ * @group Utf8mb4Test
+ */
+class Utf8mb4Test extends SystemTestCase
+{
+    /** @var Utf8mb4 */
+    public static $fixture = null; // initialized below class definition
+
+    public function testApi()
+    {
+        $this->runApiTests(['Live.getLastVisitsDetails'], [
+            'idSite'            => self::$fixture->idSite,
+            'date'              => '2010-01-04',
+            'period'            => 'year'
+        ]);
+    }
+
+
+    public static function getOutputPrefix()
+    {
+        return 'Utf8mb4';
+    }
+}
+
+Utf8mb4Test::$fixture = new Utf8mb4();

--- a/tests/PHPUnit/System/expected/test_Utf8mb4__Live.getLastVisitsDetails_year.xml
+++ b/tests/PHPUnit/System/expected/test_Utf8mb4__Live.getLastVisitsDetails_year.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<row>
+		<idSite>1</idSite>
+		<idVisit>1</idVisit>
+		<visitIp>156.5.3.2</visitIp>
+		
+		<actionDetails>
+			<row>
+				<type>ecommerceAbandonedCart</type>
+				<revenue>100</revenue>
+				<items>1</items>
+				
+				<itemDetails>
+					<row>
+						<itemSKU>sku �</itemSKU>
+						<itemName>name �</itemName>
+						<itemCategory>category �</itemCategory>
+						<price>95</price>
+						<quantity>1</quantity>
+					</row>
+				</itemDetails>
+				<icon>plugins/Morpheus/images/ecommerceAbandonedCart.png</icon>
+				
+			</row>
+			<row>
+				<type>action</type>
+				<url>http://example.org/foo/�.html</url>
+				<pageTitle>incredible �</pageTitle>
+				<pageIdAction>2</pageIdAction>
+				
+				
+				<pageId>1</pageId>
+				<bandwidth />
+				<interactionPosition>1</interactionPosition>
+				<icon />
+				
+				<bandwidth_pretty>0 M</bandwidth_pretty>
+			</row>
+		</actionDetails>
+		<goalConversions>0</goalConversions>
+		<siteCurrency>USD</siteCurrency>
+		<siteCurrencySymbol>$</siteCurrencySymbol>
+		
+		
+		
+		
+		<siteName>Piwik test</siteName>
+		
+		
+		
+		
+		
+		
+		<userId />
+		<visitorType>new</visitorType>
+		<visitorTypeIcon />
+		<visitConverted>0</visitConverted>
+		<visitConvertedIcon />
+		<visitCount>1</visitCount>
+		<visitEcommerceStatus>abandonedCart</visitEcommerceStatus>
+		<visitEcommerceStatusIcon>plugins/Morpheus/images/ecommerceAbandonedCart.png</visitEcommerceStatusIcon>
+		<daysSinceFirstVisit>0</daysSinceFirstVisit>
+		<daysSinceLastEcommerceOrder>0</daysSinceLastEcommerceOrder>
+		<visitDuration>1</visitDuration>
+		<visitDurationPretty>1s</visitDurationPretty>
+		<searches>0</searches>
+		<actions>1</actions>
+		<interactions>1</interactions>
+		<referrerType>search</referrerType>
+		<referrerTypeName>Search Engines</referrerTypeName>
+		<referrerName>Google</referrerName>
+		<referrerKeyword>�</referrerKeyword>
+		<referrerKeywordPosition />
+		<referrerUrl>http://www.google.com/search?q=�</referrerUrl>
+		<referrerSearchEngineUrl>http://google.com</referrerSearchEngineUrl>
+		<referrerSearchEngineIcon>plugins/Morpheus/icons/dist/searchEngines/google.com.png</referrerSearchEngineIcon>
+		<referrerSocialNetworkUrl />
+		<referrerSocialNetworkIcon />
+		<languageCode>fr</languageCode>
+		<language>French</language>
+		<deviceType>Desktop</deviceType>
+		<deviceTypeIcon>plugins/Morpheus/icons/dist/devices/desktop.png</deviceTypeIcon>
+		<deviceBrand>Unknown</deviceBrand>
+		<deviceModel>Generic Desktop</deviceModel>
+		<operatingSystem>Windows XP</operatingSystem>
+		<operatingSystemName>Windows</operatingSystemName>
+		<operatingSystemIcon>plugins/Morpheus/icons/dist/os/WIN.png</operatingSystemIcon>
+		<operatingSystemCode>WIN</operatingSystemCode>
+		<operatingSystemVersion>XP</operatingSystemVersion>
+		<browserFamily>Gecko</browserFamily>
+		<browserFamilyDescription>Gecko (Firefox)</browserFamilyDescription>
+		<browser>Firefox 3.6</browser>
+		<browserName>Firefox</browserName>
+		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
+		<browserCode>FF</browserCode>
+		<browserVersion>3.6</browserVersion>
+		<totalEcommerceRevenue>0</totalEcommerceRevenue>
+		<totalEcommerceConversions>0</totalEcommerceConversions>
+		<totalEcommerceItems>0</totalEcommerceItems>
+		<totalAbandonedCartsRevenue>100</totalAbandonedCartsRevenue>
+		<totalAbandonedCarts>1</totalAbandonedCarts>
+		<totalAbandonedCartsItems>1</totalAbandonedCartsItems>
+		<events>0</events>
+		<continent>Europe</continent>
+		<continentCode>eur</continentCode>
+		<country>France</country>
+		<countryCode>fr</countryCode>
+		<countryFlag>plugins/Morpheus/icons/dist/flags/fr.png</countryFlag>
+		<region />
+		<regionCode />
+		<city />
+		<location>France</location>
+		<latitude />
+		<longitude />
+		<visitLocalTime>12:34:06</visitLocalTime>
+		<visitLocalHour>12</visitLocalHour>
+		<daysSinceLastVisit>0</daysSinceLastVisit>
+		<customVariables>
+		</customVariables>
+		<resolution>1024x768</resolution>
+		<plugins>cookie, flash, java</plugins>
+		<pluginsIcons>
+			<row>
+				<pluginIcon>plugins/Morpheus/icons/dist/plugins/cookie.png</pluginIcon>
+				<pluginName>cookie</pluginName>
+			</row>
+			<row>
+				<pluginIcon>plugins/Morpheus/icons/dist/plugins/flash.png</pluginIcon>
+				<pluginName>flash</pluginName>
+			</row>
+			<row>
+				<pluginIcon>plugins/Morpheus/icons/dist/plugins/java.png</pluginIcon>
+				<pluginName>java</pluginName>
+			</row>
+		</pluginsIcons>
+	</row>
+</result>


### PR DESCRIPTION
ping @mattab @tsteur 

When tracking emojis in e.g. page titles, the page title currently will result in an empty value (or maybe an error, depending on mysql config)

Not sure why we currently replace those characters only for the url and not all params...

refs #8790

also kind of fixes #13148