### PR TITLE
Fix fatal when multiple sites are requested in referrers API report

### DIFF
--- a/plugins/Actions/API.php
+++ b/plugins/Actions/API.php
@@ -91,6 +91,8 @@ class API extends \Piwik\Plugin\API
     public function getPageUrls($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false,
                                 $depth = false, $flat = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = Archive::createDataTableFromArchive('Actions_actions_url', $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable, $depth);
 
         $this->filterActionsDataTable($dataTable);
@@ -121,6 +123,8 @@ class API extends \Piwik\Plugin\API
      */
     public function getPageUrlsFollowingSiteSearch($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getPageUrls($idSite, $period, $date, $segment, $expanded, $idSubtable);
         $this->keepPagesFollowingSearch($dataTable);
         return $dataTable;
@@ -138,6 +142,8 @@ class API extends \Piwik\Plugin\API
      */
     public function getPageTitlesFollowingSiteSearch($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getPageTitles($idSite, $period, $date, $segment, $expanded, $idSubtable);
         $this->keepPagesFollowingSearch($dataTable);
         return $dataTable;
@@ -163,6 +169,8 @@ class API extends \Piwik\Plugin\API
      */
     public function getEntryPageUrls($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getPageUrls($idSite, $period, $date, $segment, $expanded, $idSubtable);
         $this->filterNonEntryActions($dataTable);
         return $dataTable;
@@ -174,6 +182,8 @@ class API extends \Piwik\Plugin\API
      */
     public function getExitPageUrls($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getPageUrls($idSite, $period, $date, $segment, $expanded, $idSubtable);
         $this->filterNonExitActions($dataTable);
         return $dataTable;
@@ -181,6 +191,8 @@ class API extends \Piwik\Plugin\API
 
     public function getPageUrl($pageUrl, $idSite, $period, $date, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $callBackParameters = array('Actions_actions_url', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null);
         $dataTable = $this->getFilterPageDatatableSearch($callBackParameters, $pageUrl, Action::TYPE_PAGE_URL);
         $this->addPageProcessedMetrics($dataTable);
@@ -190,6 +202,8 @@ class API extends \Piwik\Plugin\API
 
     public function getPageTitles($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false, $flat = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = Archive::createDataTableFromArchive('Actions_actions', $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable);
 
         $this->filterActionsDataTable($dataTable);
@@ -204,6 +218,8 @@ class API extends \Piwik\Plugin\API
     public function getEntryPageTitles($idSite, $period, $date, $segment = false, $expanded = false,
                                        $idSubtable = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getPageTitles($idSite, $period, $date, $segment, $expanded, $idSubtable);
         $this->filterNonEntryActions($dataTable);
         return $dataTable;
@@ -216,6 +232,8 @@ class API extends \Piwik\Plugin\API
     public function getExitPageTitles($idSite, $period, $date, $segment = false, $expanded = false,
                                       $idSubtable = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getPageTitles($idSite, $period, $date, $segment, $expanded, $idSubtable);
         $this->filterNonExitActions($dataTable);
         return $dataTable;
@@ -223,6 +241,8 @@ class API extends \Piwik\Plugin\API
 
     public function getPageTitle($pageName, $idSite, $period, $date, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $callBackParameters = array('Actions_actions', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null);
         $dataTable = $this->getFilterPageDatatableSearch($callBackParameters, $pageName, Action::TYPE_PAGE_TITLE);
         $this->addPageProcessedMetrics($dataTable);
@@ -232,6 +252,8 @@ class API extends \Piwik\Plugin\API
 
     public function getDownloads($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false, $flat = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = Archive::createDataTableFromArchive('Actions_downloads', $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable);
         $this->filterActionsDataTable($dataTable);
         return $dataTable;
@@ -239,6 +261,8 @@ class API extends \Piwik\Plugin\API
 
     public function getDownload($downloadUrl, $idSite, $period, $date, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $callBackParameters = array('Actions_downloads', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null);
         $dataTable = $this->getFilterPageDatatableSearch($callBackParameters, $downloadUrl, Action::TYPE_DOWNLOAD);
         $this->filterActionsDataTable($dataTable);
@@ -247,6 +271,8 @@ class API extends \Piwik\Plugin\API
 
     public function getOutlinks($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false, $flat = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = Archive::createDataTableFromArchive('Actions_outlink', $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable);
         $this->filterActionsDataTable($dataTable);
         return $dataTable;
@@ -254,6 +280,8 @@ class API extends \Piwik\Plugin\API
 
     public function getOutlink($outlinkUrl, $idSite, $period, $date, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $callBackParameters = array('Actions_outlink', $idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable = null);
         $dataTable = $this->getFilterPageDatatableSearch($callBackParameters, $outlinkUrl, Action::TYPE_OUTLINK);
         $this->filterActionsDataTable($dataTable);
@@ -262,6 +290,8 @@ class API extends \Piwik\Plugin\API
 
     public function getSiteSearchKeywords($idSite, $period, $date, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getSiteSearchKeywordsRaw($idSite, $period, $date, $segment);
         $dataTable->deleteColumn(PiwikMetrics::INDEX_SITE_SEARCH_HAS_NO_RESULT);
         $this->filterActionsDataTable($dataTable);
@@ -289,6 +319,8 @@ class API extends \Piwik\Plugin\API
 
     public function getSiteSearchNoResultKeywords($idSite, $period, $date, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getSiteSearchKeywordsRaw($idSite, $period, $date, $segment);
         // Delete all rows that have some results
         $dataTable->filter('ColumnCallbackDeleteRow',
@@ -316,6 +348,8 @@ class API extends \Piwik\Plugin\API
      */
     public function getSiteSearchCategories($idSite, $period, $date, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         Actions::checkCustomVariablesPluginEnabled();
         $customVariables = APICustomVariables::getInstance()->getCustomVariables($idSite, $period, $date, $segment, $expanded = false, $_leavePiwikCoreVariables = true);
 

--- a/plugins/Annotations/API.php
+++ b/plugins/Annotations/API.php
@@ -41,9 +41,9 @@ class API extends \Piwik\Plugin\API
      */
     public function add($idSite, $date, $note, $starred = 0)
     {
+        $this->checkUserCanAddNotesFor($idSite);
         $this->checkSingleIdSite($idSite, $extraMessage = "Note: Cannot add one note to multiple sites.");
         $this->checkDateIsValid($date);
-        $this->checkUserCanAddNotesFor($idSite);
 
         // add, save & return a new annotation
         $annotations = new AnnotationList($idSite);
@@ -127,8 +127,9 @@ class API extends \Piwik\Plugin\API
      */
     public function deleteAll($idSite)
     {
-        $this->checkSingleIdSite($idSite, $extraMessage = "Note: Cannot delete annotations from multiple sites.");
         Piwik::checkUserHasSuperUserAccess();
+
+        $this->checkSingleIdSite($idSite, $extraMessage = "Note: Cannot delete annotations from multiple sites.");
 
         $annotations = new AnnotationList($idSite);
 
@@ -152,8 +153,9 @@ class API extends \Piwik\Plugin\API
      */
     public function get($idSite, $idNote)
     {
-        $this->checkSingleIdSite($idSite, $extraMessage = "Note: Specify only one site ID when getting ONE note.");
         Piwik::checkUserHasViewAccess($idSite);
+
+        $this->checkSingleIdSite($idSite, $extraMessage = "Note: Specify only one site ID when getting ONE note.");
 
         // get single annotation
         $annotations = new AnnotationList($idSite);

--- a/plugins/CustomVariables/API.php
+++ b/plugins/CustomVariables/API.php
@@ -60,6 +60,8 @@ class API extends \Piwik\Plugin\API
      */
     public function getCustomVariables($idSite, $period, $date, $segment = false, $expanded = false, $_leavePiwikCoreVariables = false, $flat = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getDataTable($idSite, $period, $date, $segment, $expanded, $flat, $idSubtable = null);
 
         if ($dataTable instanceof DataTable
@@ -105,6 +107,8 @@ class API extends \Piwik\Plugin\API
      */
     public function getCustomVariablesValuesFromNameId($idSite, $period, $date, $idSubtable, $segment = false, $_leavePriceViewedColumn = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getDataTable($idSite, $period, $date, $segment, $expanded = false, $flat = false, $idSubtable);
 
         if (!$_leavePriceViewedColumn) {

--- a/plugins/Goals/API.php
+++ b/plugins/Goals/API.php
@@ -86,6 +86,9 @@ class API extends \Piwik\Plugin\API
         $cacheId = self::getCacheId($idSite);
         $cache = $this->getGoalsInfoStaticCache();
         if (!$cache->contains($cacheId)) {
+            // note: the reason this is secure is because the above cache is a static cache and cleared after each request
+            // if we were to use a different cache that persists the result, this would not be secure because when a
+            // result is in the cache, it would just return the result
             $idSite = Site::getIdSitesFromIdSitesString($idSite);
 
             if (empty($idSite)) {

--- a/plugins/Referrers/API.php
+++ b/plugins/Referrers/API.php
@@ -15,6 +15,7 @@ use Piwik\Common;
 use Piwik\DataTable;
 use Piwik\Date;
 use Piwik\Piwik;
+use Piwik\Site;
 
 /**
  * The Referrers API lets you access reports about Websites, Search engines, Keywords, Campaigns used to access your website.
@@ -67,6 +68,10 @@ class API extends \Piwik\Plugin\API
     public function getReferrerType($idSite, $period, $date, $segment = false, $typeReferrer = false,
                                     $idSubtable = false, $expanded = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
+        $this->checkSingleSite($idSite, 'getReferrerType');
+
         // if idSubtable is supplied, interpret idSubtable as referrer type and return correct report
         if ($idSubtable !== false) {
             $result = false;
@@ -122,11 +127,23 @@ class API extends \Piwik\Plugin\API
         return $dataTable;
     }
 
+    private function checkSingleSite($idSite, $method)
+    {
+        $idSites = Site::getIdSitesFromIdSitesString($idSite);
+
+        if (count($idSites) > 1) {
+            throw new Exception("Referrers.$method with multiple sites is not supported (yet).");
+        }
+    }
+
     /**
      * Returns a report that shows
      */
     public function getAll($idSite, $period, $date, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
+        $this->checkSingleSite($idSite, 'getAll');
         $dataTable = $this->getReferrerType($idSite, $period, $date, $segment, $typeReferrer = false, $idSubtable = false, $expanded = true);
 
         if ($dataTable instanceof DataTable\Map) {
@@ -142,6 +159,8 @@ class API extends \Piwik\Plugin\API
 
     public function getKeywords($idSite, $period, $date, $segment = false, $expanded = false, $flat = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = Archive::createDataTableFromArchive(Archiver::KEYWORDS_RECORD_NAME, $idSite, $period, $date, $segment, $expanded, $flat);
 
         if ($flat) {
@@ -227,6 +246,7 @@ class API extends \Piwik\Plugin\API
 
     public function getSearchEnginesFromKeywordId($idSite, $period, $date, $idSubtable, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
         $dataTable = $this->getDataTable(Archiver::KEYWORDS_RECORD_NAME, $idSite, $period, $date, $segment, $expanded = false, $idSubtable);
         $keywords  = $this->getKeywords($idSite, $period, $date, $segment);
         $keyword   = $keywords->getRowFromIdSubDataTable($idSubtable)->getColumn('label');
@@ -240,6 +260,7 @@ class API extends \Piwik\Plugin\API
 
     public function getSearchEngines($idSite, $period, $date, $segment = false, $expanded = false, $flat = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
         $dataTable = Archive::createDataTableFromArchive(Archiver::SEARCH_ENGINES_RECORD_NAME, $idSite, $period, $date, $segment, $expanded, $flat);
 
         if ($flat) {
@@ -258,6 +279,7 @@ class API extends \Piwik\Plugin\API
 
     public function getKeywordsFromSearchEngineId($idSite, $period, $date, $idSubtable, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
         $dataTable = $this->getDataTable(Archiver::SEARCH_ENGINES_RECORD_NAME, $idSite, $period, $date, $segment, $expanded = false, $idSubtable);
 
         // get the search engine and create the URL to the search result page
@@ -274,6 +296,7 @@ class API extends \Piwik\Plugin\API
 
     public function getCampaigns($idSite, $period, $date, $segment = false, $expanded = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
         $dataTable = $this->getDataTable(Archiver::CAMPAIGNS_RECORD_NAME, $idSite, $period, $date, $segment, $expanded);
 
         $dataTable->filter('AddSegmentByLabel', array('referrerName'));
@@ -284,6 +307,7 @@ class API extends \Piwik\Plugin\API
 
     public function getKeywordsFromCampaignId($idSite, $period, $date, $idSubtable, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
         $campaigns = $this->getCampaigns($idSite, $period, $date, $segment);
         $campaigns->applyQueuedFilters();
         $campaign  = $campaigns->getRowFromIdSubDataTable($idSubtable)->getColumn('label');
@@ -296,6 +320,7 @@ class API extends \Piwik\Plugin\API
 
     public function getWebsites($idSite, $period, $date, $segment = false, $expanded = false, $flat = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
         $dataTable = Archive::createDataTableFromArchive(Archiver::WEBSITES_RECORD_NAME, $idSite, $period, $date, $segment, $expanded, $flat, $idSubtable = null);
 
         if ($flat) {
@@ -309,6 +334,7 @@ class API extends \Piwik\Plugin\API
 
     public function getUrlsFromWebsiteId($idSite, $period, $date, $idSubtable, $segment = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
         $dataTable = $this->getDataTable(Archiver::WEBSITES_RECORD_NAME, $idSite, $period, $date, $segment, $expanded = false, $idSubtable);
         $dataTable->filter('Piwik\Plugins\Referrers\DataTable\Filter\UrlsFromWebsiteId');
         $dataTable->filter('AddSegmentByLabel', array('referrerUrl'));
@@ -330,6 +356,8 @@ class API extends \Piwik\Plugin\API
      */
     public function getSocials($idSite, $period, $date, $segment = false, $expanded = false, $flat = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = Archive::createDataTableFromArchive(Archiver::SOCIAL_NETWORKS_RECORD_NAME, $idSite, $period, $date, $segment, $expanded, $flat);
 
         $dataTable->filter('ColumnCallbackAddMetadata', array('label', 'url', function ($name) {
@@ -430,6 +458,8 @@ class API extends \Piwik\Plugin\API
      */
     public function getUrlsForSocial($idSite, $period, $date, $segment = false, $idSubtable = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
+
         $dataTable = $this->getDataTable(Archiver::SOCIAL_NETWORKS_RECORD_NAME, $idSite, $period, $date, $segment, $expanded = true, $idSubtable);
 
         if (!$idSubtable) {

--- a/plugins/Referrers/tests/System/ApiTest.php
+++ b/plugins/Referrers/tests/System/ApiTest.php
@@ -66,6 +66,16 @@ class ApiTest extends SystemTestCase
             ],
         ];
 
+        $apiToTest[] = [
+            array('Referrers.getAll', 'Referrers.getReferrerType'),
+            [
+                'idSite' => 'all',
+                'date' => '2010-01-01',
+                'periods' => 'year',
+                'testSuffix' => 'allSites',
+            ],
+        ];
+
         return $apiToTest;
     }
 

--- a/plugins/Referrers/tests/System/expected/test_allSites__Referrers.getAll_year.xml
+++ b/plugins/Referrers/tests/System/expected/test_allSites__Referrers.getAll_year.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<error message="Referrers.getAll with multiple sites is not supported (yet).
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
+</result>

--- a/plugins/Referrers/tests/System/expected/test_allSites__Referrers.getReferrerType_year.xml
+++ b/plugins/Referrers/tests/System/expected/test_allSites__Referrers.getReferrerType_year.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<result>
+	<error message="Referrers.getReferrerType with multiple sites is not supported (yet).
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php" />
+</result>

--- a/plugins/VisitFrequency/API.php
+++ b/plugins/VisitFrequency/API.php
@@ -35,6 +35,7 @@ class API extends \Piwik\Plugin\API
      */
     public function get($idSite, $period, $date, $segment = false, $columns = false)
     {
+        Piwik::checkUserHasViewAccess($idSite);
         $segment = $this->appendReturningVisitorSegment($segment);
 
         $this->unprefixColumns($columns);


### PR DESCRIPTION
fixes https://github.com/matomo-org/matomo/issues/13438

I know the check user has view access calls are not needed since they are checked in the archive classes that we call and it is safe. I got confused there though for a second and I think it is better to have them there in case things get refactored at some point and forgets to add such calls etc. Can remove them again if wanted.