### PR TITLE
Page title in Tag Manager, Help page, Admin pages show the date but there is no calendar in the page

### DIFF
--- a/plugins/CoreHome/angularjs/common/services/piwik.js
+++ b/plugins/CoreHome/angularjs/common/services/piwik.js
@@ -62,6 +62,10 @@
         }
 
         function updateDateInTitle( date, period ) {
+            if (!$('.top_controls #periodString').length) {
+                return;
+            }
+
             // Cache server-rendered page title
             originalTitle = originalTitle || document.title;
             var titleParts = originalTitle.split('-');


### PR DESCRIPTION


fix https://github.com/matomo-org/matomo/issues/13353