### PR TITLE
When you are logged out, the URL gets lost when you log in

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -221,6 +221,19 @@ class Controller extends \Piwik\Plugin\Controller
         $this->passwordResetter->removePasswordResetInfo($login);
 
         if (empty($urlToRedirect)) {
+            $referrer = Url::getReferrer();
+            $module = Common::getRequestVar('module', '', 'string');
+            // when module is login, we redirect to home...
+            if ($module !== 'Login' && $module !== Piwik::getLoginPluginName() && $referrer) {
+                $host = Url::getHostFromUrl($referrer);
+                // we only redirect to a trusted host
+                if ($host && Url::isValidHost($host)) {
+                    $urlToRedirect = $referrer;
+                }
+            }
+        }
+
+        if (empty($urlToRedirect)) {
             $urlToRedirect = Url::getCurrentUrlWithoutQueryString();
         }
 


### PR DESCRIPTION
It won't remember any hash as the hash won't be visible in the referrer etc but it would work for most other pages.

To make it work for hash it would get likely way more complicated like we would need to persist it through JS, temporarily store it somewhere and redirect accordingly. It fixes the case mentioned in the issue.

fix https://github.com/matomo-org/matomo/issues/13328