### PR TITLE
Tooltips appear all over the place but shouldn't

### DIFF
--- a/plugins/CoreHome/angularjs/widget/widget.directive.js
+++ b/plugins/CoreHome/angularjs/widget/widget.directive.js
@@ -100,10 +100,16 @@
                     $(element).tooltip({
                         track: true,
                         content: function() {
+                            var $this = $(this);
+                            if ($this.attr('piwik-field') === '') {
+                                // do not show it for form fields
+                                return '';
+                            }
+
                             var title = $(this).attr('title');
                             return piwikHelper.escape(title.replace(/\n/g, '<br />'));
                         },
-                        show: false,
+                        show: {delay: 700, duration: 200},
                         hide: false
                     });
 

--- a/plugins/Live/templates/_dataTableViz_visitorLog.twig
+++ b/plugins/Live/templates/_dataTableViz_visitorLog.twig
@@ -6,7 +6,7 @@
         <div class="card row hoverable">
 
             {% if visitor.getColumn('visitorId') is not empty and not clientSideParameters.hideProfileLink %}
-                <a class="visitor-log-visitor-profile-link visitorLogTooltip" title="{{ 'Live_ViewVisitorProfile'|translate }}" data-visitor-id="{{ visitor.getColumn("visitorId") }}">
+                <a class="visitor-log-visitor-profile-link visitorLogTooltip" data-visitor-id="{{ visitor.getColumn("visitorId") }}">
                     <img src="plugins/Live/images/visitorProfileLaunch.png"/> <span>{{ 'Live_ViewVisitorProfile'|translate }}
                         {%- if visitor.getColumn('userId') is not empty %}: {{ visitor.getColumn('userId')|raw }}{% endif %}</span>
                 </a>


### PR DESCRIPTION
fix #13305 

Add a delay so tooltips don't appear immediately. Do not show any tooltip for any form field.

In visitor log the titles are still shown immediately but there it is wanted maybe?

I clicked through couple of pages and looked a bit in the code but it is hard to find all the places where a title attribute should be removed. Maybe we do this better over time.