### PR TITLE
Set backtrace on error object and check Piwik_ShouldPrintBackTraceWithMessage()

### DIFF
--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -107,12 +107,10 @@ class FrontController extends Singleton
         $error = array(
             'message' => $e->getMessage(),
             'file' => $e->getFile(),
-            'line' => $e->getLine()
+            'line' => $e->getLine(),
         );
 
-        if (\Piwik_ShouldPrintBackTraceWithMessage()) {
-            $error['backtrace'] = ' on ' . $error['file'] . '(' . $error['line'] . ")\n" . $e->getTraceAsString();
-        }
+        $error['backtrace'] = ' on ' . $error['file'] . '(' . $error['line'] . ")\n" . $e->getTraceAsString();
 
         return self::generateSafeModeOutputFromError($error);
     }
@@ -235,10 +233,8 @@ class FrontController extends Singleton
     {
         $lastError = error_get_last();
         if (!empty($lastError) && $lastError['type'] == E_ERROR) {
-            if (\Piwik_ShouldPrintBackTraceWithMessage()) {
-                $lastError['backtrace'] = ' on ' . $lastError['file'] . '(' . $lastError['line'] . ")\n"
-                    . ErrorHandler::getFatalErrorPartialBacktrace();
-            }
+            $lastError['backtrace'] = ' on ' . $lastError['file'] . '(' . $lastError['line'] . ")\n"
+                . ErrorHandler::getFatalErrorPartialBacktrace();
 
             $message = self::generateSafeModeOutputFromError($lastError);
             echo $message;

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -316,7 +316,9 @@ class Controller extends Plugin\ControllerAdmin
 
             $errorMessage = $lastError['message'];
 
-            if (!empty($lastError['backtrace'])) {
+            if (!empty($lastError['backtrace'])
+                && \Piwik_ShouldPrintBackTraceWithMessage()
+            ) {
                 $errorMessage .= $lastError['backtrace'];
             }
 

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -335,6 +335,11 @@ class Controller extends Plugin\ControllerAdmin
         if (Common::isPhpCliMode()) {
             throw new Exception("Error: " . var_export($lastError, true));
         }
+
+        if (!\Piwik_ShouldPrintBackTraceWithMessage()) {
+            unset($lastError['backtrace']);
+        }
+
         $view = new View('@CorePluginsAdmin/safemode');
         $view->lastError   = $lastError;
         $view->isAllowedToTroubleshootAsSuperUser = $this->isAllowedToTroubleshootAsSuperUser();

--- a/plugins/CorePluginsAdmin/templates/safemode.twig
+++ b/plugins/CorePluginsAdmin/templates/safemode.twig
@@ -34,9 +34,9 @@
             <p>
                 The following error just broke Matomo{% if showVersion %} (v{{ piwikVersion }}){% endif %}:
             </p>
-            <pre>{{ lastError.message }}</pre>
-            <p>in</p>
-            <pre>{{ lastError.file }} line {{ lastError.line }}</pre>
+            <pre>{{ lastError.message }}
+{% if lastError.backtrace is defined %}{{ lastError.backtrace }}{% else %}in {{ lastError.file }} line {{ lastError.line }}{% endif %}
+            </pre>
 
             <hr>
             <h3>Troubleshooting</h3>

--- a/tests/PHPUnit/Integration/FrontControllerTest.php
+++ b/tests/PHPUnit/Integration/FrontControllerTest.php
@@ -47,7 +47,7 @@ FORMAT;
         $this->assertEquals('error', $response['result']);
 
         $expectedFormat = <<<FORMAT
-test message on {includePath}/tests/resources/trigger-fatal-exception.php(23)#0 [internal function]: {closure}('CoreHome', 'index', Array)#1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array)#2 {includePath}/core/Piwik.php(780): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, NULL)#3 {includePath}/core/FrontController.php(540): Piwik\Piwik::postEvent('Request.dispatc...', Array)#4 {includePath}/core/FrontController.php(146): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', NULL)#5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index')#6 {main}
+test message on {includePath}/tests/resources/trigger-fatal-exception.php(23)#0 [internal function]: {closure}('CoreHome', 'index', Array)#1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array)#2 {includePath}/core/Piwik.php(780): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, NULL)#3 {includePath}/core/FrontController.php(536): Piwik\Piwik::postEvent('Request.dispatc...', Array)#4 {includePath}/core/FrontController.php(144): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', NULL)#5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index')#6 {main}
 FORMAT;
 
         $this->assertStringMatchesFormat($expectedFormat, $response['message']);

--- a/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:203d662f996eecbf60209166202cafa1df90f735895b781cf1e288ece427ddb2
-size 204208
+oid sha256:68503ef9dafa19792aba12552ab81872b25247b619851d0ba1b743b31a51c919
+size 203273


### PR DESCRIPTION
… in controller instead of FrontController in case plugins decide to create their own safemode.