### PR TITLE
Referrer name comparison should be case insensitive …

### DIFF
--- a/plugins/Referrers/Columns/Base.php
+++ b/plugins/Referrers/Columns/Base.php
@@ -425,7 +425,7 @@ abstract class Base extends VisitDimension
 
         $this->detectCampaignKeywordFromReferrerUrl();
 
-        $isCurrentVisitACampaignWithSameName = $visitor->getVisitorColumn('referer_name') == $this->nameReferrerAnalyzed;
+        $isCurrentVisitACampaignWithSameName = Common::mb_strtolower($visitor->getVisitorColumn('referer_name')) == Common::mb_strtolower($this->nameReferrerAnalyzed);
         $isCurrentVisitACampaignWithSameName = $isCurrentVisitACampaignWithSameName && $visitor->getVisitorColumn('referer_type') == Common::REFERRER_TYPE_CAMPAIGN;
 
         // if we detected a campaign but there is still no keyword set, we set the keyword to the Referrer host
@@ -553,6 +553,7 @@ abstract class Base extends VisitDimension
     {
         foreach (array('referer_keyword', 'referer_name', 'referer_type') as $infoName) {
             if ($this->hasReferrerColumnChanged($visitor, $information, $infoName)) {
+                Common::printDebug("Referrers\Base::isReferrerInformationNew: detected change in $infoName.");
                 return true;
             }
         }


### PR DESCRIPTION
… since that is how it is stored in the log table.

Otherwise referrer name's that are not all lowercase will result in new visits being created:

1. upper case referrer url is passed to tracker, tracker saves it as lowercase
2. upper case referrer url is passed again, tracker compares lowercased w/ uppercased, fails
3. tracker sets referrer keyword to host https://github.com/matomo-org/matomo/blob/3.x-dev/plugins/Referrers/Columns/Base.php#L444
4. referrer keyword will be different than before, new visit is created