### PR TITLE
Remove user-agent checking code in SessionAuth.

### DIFF
--- a/core/Session/SessionAuth.php
+++ b/core/Session/SessionAuth.php
@@ -99,11 +99,6 @@ class SessionAuth implements Auth
             return $this->makeAuthFailure();
         }
 
-        if (!$sessionFingerprint->isMatchingCurrentRequest()) {
-            $this->initNewBlankSession($sessionFingerprint);
-            return $this->makeAuthFailure();
-        }
-
         $tsPasswordModified = !empty($user['ts_password_modified']) ? $user['ts_password_modified'] : null;
         if ($this->isSessionStartedBeforePasswordChange($sessionFingerprint, $tsPasswordModified)) {
             $this->destroyCurrentSession($sessionFingerprint);

--- a/core/Session/SessionFingerprint.php
+++ b/core/Session/SessionFingerprint.php
@@ -56,12 +56,11 @@ class SessionFingerprint
         return null;
     }
 
-    public function initialize($userName, $time = null, $userAgent = null)
+    public function initialize($userName, $time = null)
     {
         $_SESSION[self::USER_NAME_SESSION_VAR_NAME] = $userName;
         $_SESSION[self::SESSION_INFO_SESSION_VAR_NAME] = [
             'ts' => $time ?: Date::now()->getTimestampUTC(),
-            'ua' => $userAgent ?: $this->getUserAgent(),
         ];
     }
 
@@ -69,18 +68,6 @@ class SessionFingerprint
     {
         unset($_SESSION[self::USER_NAME_SESSION_VAR_NAME]);
         unset($_SESSION[self::SESSION_INFO_SESSION_VAR_NAME]);
-    }
-
-    public function isMatchingCurrentRequest()
-    {
-        $requestUa = $this->getUserAgent();
-
-        $userInfo = $this->getUserInfo();
-        if (empty($userInfo)) {
-            return false;
-        }
-
-        return $userInfo['ua'] == $requestUa;
     }
 
     public function getSessionStartTime()
@@ -93,10 +80,5 @@ class SessionFingerprint
         }
 
         return $userInfo['ts'];
-    }
-
-    private function getUserAgent()
-    {
-        return array_key_exists('HTTP_USER_AGENT', $_SERVER) ? $_SERVER['HTTP_USER_AGENT'] : null;
     }
 }

--- a/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
+++ b/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
@@ -43,7 +43,6 @@ class SessionFingerprintTest extends \PHPUnit_Framework_TestCase
     {
         $sessionVarValue = [
             'ip' => 'someip',
-            'ua' => 'someua',
         ];
 
         $_SESSION[SessionFingerprint::SESSION_INFO_SESSION_VAR_NAME] = $sessionVarValue;
@@ -57,24 +56,11 @@ class SessionFingerprintTest extends \PHPUnit_Framework_TestCase
 
     public function test_initialize_SetsSessionVarsToCurrentRequest()
     {
-        $_SERVER['HTTP_USER_AGENT'] = 'test-user-agent';
         $this->testInstance->initialize('testuser', self::TEST_TIME_VALUE);
 
         $this->assertEquals('testuser', $_SESSION[SessionFingerprint::USER_NAME_SESSION_VAR_NAME]);
         $this->assertEquals(
-            ['ts' => self::TEST_TIME_VALUE, 'ua' => 'test-user-agent'],
-            $_SESSION[SessionFingerprint::SESSION_INFO_SESSION_VAR_NAME]
-        );
-    }
-
-    public function test_initialize_DoesNotSetUserAgent_IfUserAgentIsNotInHttpRequest()
-    {
-        unset($_SERVER['HTTP_USER_AGENT']);
-        $this->testInstance->initialize('testuser', self::TEST_TIME_VALUE);
-
-        $this->assertEquals('testuser', $_SESSION[SessionFingerprint::USER_NAME_SESSION_VAR_NAME]);
-        $this->assertEquals(
-            ['ts' => self::TEST_TIME_VALUE, 'ua' => null],
+            ['ts' => self::TEST_TIME_VALUE],
             $_SESSION[SessionFingerprint::SESSION_INFO_SESSION_VAR_NAME]
         );
     }

--- a/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
+++ b/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
@@ -79,46 +79,6 @@ class SessionFingerprintTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @dataProvider getTestDataForIsMatchingCurrentRequest
-     */
-    public function test_isMatchingCurrentRequest_ChecksIfSessionVarsMatchRequest(
-        $sessionUa, $requestUa, $expectedResult
-    ) {
-        $_SESSION[SessionFingerprint::SESSION_INFO_SESSION_VAR_NAME] = [
-            'ua' => $sessionUa,
-        ];
-
-        $_SERVER['HTTP_USER_AGENT'] = $requestUa;
-
-        $this->assertEquals($expectedResult, $this->testInstance->isMatchingCurrentRequest());
-    }
-
-    public function getTestDataForIsMatchingCurrentRequest()
-    {
-        return [
-            ['test ua', 'test ua', true],
-            ['nontest ua', 'test ua', false],
-            [null, 'test ua', false],
-        ];
-    }
-
-    public function test_isMatchingCurrentRequest_ReturnsFalse_IfUserInfoSessionVarDoesNotExist()
-    {
-        $_SERVER['HTTP_USER_AGENT'] = 'test-ua';
-
-        $this->assertEquals(false, $this->testInstance->isMatchingCurrentRequest());
-    }
-
-    public function test_isMatchingCurrentRequest_ReturnsFalse_IfRequestDetailsDoNotExist()
-    {
-        $_SESSION[SessionFingerprint::SESSION_INFO_SESSION_VAR_NAME] = [
-            'ua' => 'test-ua',
-        ];
-
-        $this->assertEquals(false, $this->testInstance->isMatchingCurrentRequest());
-    }
-
     public function test_getSessionStartTime_()
     {
         $_SESSION[SessionFingerprint::SESSION_INFO_SESSION_VAR_NAME] = [

--- a/tests/PHPUnit/Unit/Session/SessionInitializerTest.php
+++ b/tests/PHPUnit/Unit/Session/SessionInitializerTest.php
@@ -40,7 +40,7 @@ class SessionInitializerTest extends \PHPUnit_Framework_TestCase
     public function test_initSession_Throws_IfAuthenticationFailed($rememberMe)
     {
         $sessionInitializer = new TestSessionInitializer();
-        $sessionInitializer->initSession($this->makeMockAuth(AuthResult::SUCCESS), $rememberMe);
+        $sessionInitializer->initSession($this->makeMockAuth(AuthResult::SUCCESS));
     }
 
     /**
@@ -49,7 +49,7 @@ class SessionInitializerTest extends \PHPUnit_Framework_TestCase
     public function test_initSession_InitializesTheSessionCorrectly_IfAuthenticationSucceeds($rememberMe)
     {
         $sessionInitializer = new TestSessionInitializer();
-        $sessionInitializer->initSession($this->makeMockAuth(AuthResult::SUCCESS), $rememberMe);
+        $sessionInitializer->initSession($this->makeMockAuth(AuthResult::SUCCESS));
 
         $this->assertSessionCreatedCorrectly();
     }
@@ -72,7 +72,7 @@ class SessionInitializerTest extends \PHPUnit_Framework_TestCase
         $fingerprint = new SessionFingerprint();
         $this->assertEquals('testlogin', $fingerprint->getUser());
         $this->assertNotEmpty($fingerprint->getSessionStartTime());
-        $this->assertEquals(['ts', 'ua'], array_keys($fingerprint->getUserInfo()));
+        $this->assertEquals(['ts'], array_keys($fingerprint->getUserInfo()));
     }
 }
 


### PR DESCRIPTION
Given the user agent can change for normal use cases like switching from mobile => desktop view on a mobile device, seems more inconvenient to have it.