### PR TITLE
don't send referrer to plugin authors website

### DIFF
--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -165,7 +165,7 @@
                                                 <a class="donation-link paypal" target="_blank" rel="noreferrer noopener" href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&item_name=Matomo%20Plugin%20{{ name|escape('url') }}&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted&business={{ plugin.info.donate.paypal|escape('url') }}"><img src="plugins/CorePluginsAdmin/images/paypal_donate.png" height="30"/></a>
                                             {% endif %}
                                             {% if plugin.info.donate.flattr is defined and plugin.info.donate.flattr %}
-                                                <a class="donation-link flattr" target="_blank" href="{{ plugin.info.donate.flattr }}"><img class="alignnone" title="Flattr" alt="" src="plugins/CorePluginsAdmin/images/flattr.png" height="29" /></a>
+                                                <a class="donation-link flattr" target="_blank" rel="noreferrer noopener" href="{{ plugin.info.donate.flattr }}"><img class="alignnone" title="Flattr" alt="" src="plugins/CorePluginsAdmin/images/flattr.png" height="29" /></a>
                                             {% endif %}
                                             {% if plugin.info.donate.bitcoin is defined and plugin.info.donate.bitcoin %}
                                                 <div class="donation-link bitcoin">

--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -150,7 +150,7 @@
                                 'https://matomo.org', 'https://www.matomo.org', 'https://matomo.org/', 'https://www.matomo.org/'
                             ] %}
                                 <span class="plugin-homepage">
-                            <a target="_blank" href="{{ plugin.info.homepage }}">({{ 'CorePluginsAdmin_PluginHomepage'|translate|replace({' ': '&nbsp;'})|raw }})</a>
+                            <a target="_blank" rel="noreferrer noopener" href="{{ plugin.info.homepage }}">({{ 'CorePluginsAdmin_PluginHomepage'|translate|replace({' ': '&nbsp;'})|raw }})</a>
                         </span>
                             {% endif %}
 
@@ -162,7 +162,7 @@
                                         <p>{{ 'CorePluginsAdmin_ConsiderDonatingCreatorOf'|translate("<b>" ~ name ~ "</b>")|raw }}</p>
                                         <div class="donation-links">
                                             {% if plugin.info.donate.paypal is defined and plugin.info.donate.paypal %}
-                                                <a class="donation-link paypal" target="_blank" href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&item_name=Matomo%20Plugin%20{{ name|escape('url') }}&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted&business={{ plugin.info.donate.paypal|escape('url') }}"><img src="plugins/CorePluginsAdmin/images/paypal_donate.png" height="30"/></a>
+                                                <a class="donation-link paypal" target="_blank" rel="noreferrer noopener" href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&item_name=Matomo%20Plugin%20{{ name|escape('url') }}&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted&business={{ plugin.info.donate.paypal|escape('url') }}"><img src="plugins/CorePluginsAdmin/images/paypal_donate.png" height="30"/></a>
                                             {% endif %}
                                             {% if plugin.info.donate.flattr is defined and plugin.info.donate.flattr %}
                                                 <a class="donation-link flattr" target="_blank" href="{{ plugin.info.donate.flattr }}"><img class="alignnone" title="Flattr" alt="" src="plugins/CorePluginsAdmin/images/flattr.png" height="29" /></a>


### PR DESCRIPTION
Followup to https://github.com/matomo-org/matomo/pull/12780 and related to #13204

I noticed seeing foreign Matomo domains in my reports which seems to be caused by this missing `noreferrer`.