### PR TITLE
Fix incorrect sort order when scheduled report uses custom report

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -12,6 +12,7 @@ use Exception;
 use Piwik\Access;
 use Piwik\Cache;
 use Piwik\Common;
+use Piwik\Context;
 use Piwik\DataTable;
 use Piwik\Exception\PluginDeactivatedException;
 use Piwik\IP;
@@ -261,7 +262,12 @@ class Request
             // call the method
             $returnedValue = Proxy::getInstance()->call($apiClassName, $method, $this->request);
 
-            $toReturn = $response->getResponse($returnedValue, $module, $method);
+            // get the response with the request query parameters loaded, since DataTablePost processor will use the Report
+            // class instance, which may inspect the query parameters. (eg, it may look for the idCustomReport parameters
+            // which may only exist in $this->request, if the request was called programatically)
+            $toReturn = Context::executeWithQueryParameters($this->request, function () use ($response, $returnedValue, $module, $method) {
+                return $response->getResponse($returnedValue, $module, $method);
+            });
         } catch (Exception $e) {
             Log::debug($e);
 

--- a/core/Context.php
+++ b/core/Context.php
@@ -17,15 +17,18 @@ class Context
     {
         // Temporarily sets the Request array to this API call context
         $saveGET = $_GET;
+        $savePOST = $_POST;
         $saveQUERY_STRING = @$_SERVER['QUERY_STRING'];
         foreach ($parametersRequest as $param => $value) {
             $_GET[$param] = $value;
+            $_POST[$param] = $value;
         }
 
         try {
             return $callback();
         } finally {
             $_GET = $saveGET;
+            $_POST = $savePOST;
             $_SERVER['QUERY_STRING'] = $saveQUERY_STRING;
         }
     }

--- a/core/Context.php
+++ b/core/Context.php
@@ -13,6 +13,23 @@ namespace Piwik;
  */
 class Context
 {
+    public static function executeWithQueryParameters(array $parametersRequest, callable $callback)
+    {
+        // Temporarily sets the Request array to this API call context
+        $saveGET = $_GET;
+        $saveQUERY_STRING = @$_SERVER['QUERY_STRING'];
+        foreach ($parametersRequest as $param => $value) {
+            $_GET[$param] = $value;
+        }
+
+        try {
+            return $callback();
+        } finally {
+            $_GET = $saveGET;
+            $_SERVER['QUERY_STRING'] = $saveQUERY_STRING;
+        }
+    }
+
     /**
      * Temporarily overwrites the idSite parameter so all code executed by `$callback()`
      * will use that idSite.


### PR DESCRIPTION
Make sure request parameters are loaded in superglobals when DataTablePostProcessor gets the Report instance.

DataTablePostProcessor will call `ReportsProvider::factory()`, but it will call it outside of `Piwik\Api\Proxy`, which means the request parameters won't be in `$_GET/$_POST`. So if the Report instance tries to access these in order to configure itself, it may not be able to find them.