### PR TITLE
Flattened "entry page" and "exit page" take a long time to be generated

### DIFF
--- a/plugins/Actions/API.php
+++ b/plugins/Actions/API.php
@@ -167,11 +167,11 @@ class API extends \Piwik\Plugin\API
      * Returns a DataTable with analytics information for every unique entry page URL, for
      * the specified site, period & segment.
      */
-    public function getEntryPageUrls($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false)
+    public function getEntryPageUrls($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false, $flat = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $dataTable = $this->getPageUrls($idSite, $period, $date, $segment, $expanded, $idSubtable);
+        $dataTable = $this->getPageUrls($idSite, $period, $date, $segment, $expanded, $idSubtable, false, $flat);
         $this->filterNonEntryActions($dataTable);
         return $dataTable;
     }
@@ -180,11 +180,11 @@ class API extends \Piwik\Plugin\API
      * Returns a DataTable with analytics information for every unique exit page URL, for
      * the specified site, period & segment.
      */
-    public function getExitPageUrls($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false)
+    public function getExitPageUrls($idSite, $period, $date, $segment = false, $expanded = false, $idSubtable = false, $flat = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $dataTable = $this->getPageUrls($idSite, $period, $date, $segment, $expanded, $idSubtable);
+        $dataTable = $this->getPageUrls($idSite, $period, $date, $segment, $expanded, $idSubtable, false, $flat);
         $this->filterNonExitActions($dataTable);
         return $dataTable;
     }
@@ -216,11 +216,11 @@ class API extends \Piwik\Plugin\API
      * for the given site, time period & segment.
      */
     public function getEntryPageTitles($idSite, $period, $date, $segment = false, $expanded = false,
-                                       $idSubtable = false)
+                                       $idSubtable = false, $flat = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $dataTable = $this->getPageTitles($idSite, $period, $date, $segment, $expanded, $idSubtable);
+        $dataTable = $this->getPageTitles($idSite, $period, $date, $segment, $expanded, $idSubtable, $flat);
         $this->filterNonEntryActions($dataTable);
         return $dataTable;
     }
@@ -230,11 +230,11 @@ class API extends \Piwik\Plugin\API
      * for the given site, time period & segment.
      */
     public function getExitPageTitles($idSite, $period, $date, $segment = false, $expanded = false,
-                                      $idSubtable = false)
+                                      $idSubtable = false, $flat = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        $dataTable = $this->getPageTitles($idSite, $period, $date, $segment, $expanded, $idSubtable);
+        $dataTable = $this->getPageTitles($idSite, $period, $date, $segment, $expanded, $idSubtable, $flat);
         $this->filterNonExitActions($dataTable);
         return $dataTable;
     }


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/11645

Debugged this on demo.matomo.org.... 

Wasn't as guessed https://github.com/matomo-org/matomo/blame/3.5.1/plugins/Actions/DataTable/Filter/Actions.php#L65-L67  but the flat parameter. After applying it the performance improved from minutes to less than a second.