### PR TITLE
Avoid creating any archive tables for future dates

### DIFF
--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -166,6 +166,9 @@ class ArchiveSelector
         $monthToPeriods = array();
         foreach ($periods as $period) {
             /** @var Period $period */
+            if ($period->getDateStart()->isLater(Date::now()->addDay(2))) {
+                continue; // avoid creating any archive tables in the future
+            }
             $table = ArchiveTableCreator::getNumericTable($period->getDateStart());
             $monthToPeriods[$table][] = $period;
         }


### PR DESCRIPTION
Under certain circumstances Archiving might create empty `archive_numeric` tables for future dates:
- `enable_browser_archiving_triggering` is set to `0`
- requesting a date range in the future. e.g. something like `&period=range&date=2018-01-01,2019-09-29`