### PR TITLE
Ensure segment param is used from url if no hash available

### DIFF
--- a/plugins/Morpheus/javascripts/ajaxHelper.js
+++ b/plugins/Morpheus/javascripts/ajaxHelper.js
@@ -529,10 +529,16 @@ function ajaxHelper() {
      */
     this._mixinDefaultGetParams = function (params) {
 
+        if (window.location.hash) {
+            var segment = broadcast.getValueFromHash('segment', window.location.href.split('#')[1]);
+        } else {
+            var segment = broadcast.getValueFromUrl('segment');
+        }
+
         var defaultParams = {
             idSite:  piwik.idSite || broadcast.getValueFromUrl('idSite'),
             period:  piwik.period || broadcast.getValueFromUrl('period'),
-            segment: broadcast.getValueFromHash('segment', window.location.href.split('#')[1])
+            segment: segment
         };
 
         // never append token_auth to url


### PR DESCRIPTION
When viewing widgets in widgetize mode, all parameters are directly contained in the query string instead of the hash. When appending a segment to the query string it wasn't automatically added to ongoing ajax request.