### PR TITLE
Only show default number of rows for device type report

### DIFF
--- a/plugins/DevicesDetection/Reports/GetType.php
+++ b/plugins/DevicesDetection/Reports/GetType.php
@@ -8,10 +8,10 @@
  */
 namespace Piwik\Plugins\DevicesDetection\Reports;
 
+use Piwik\Common;
 use Piwik\Piwik;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\DevicesDetection\Columns\DeviceType;
-use DeviceDetector\Parser\Device\DeviceParserAbstract as DeviceParser;
 
 class GetType extends Base
 {
@@ -28,8 +28,6 @@ class GetType extends Base
 
     public function configureView(ViewDataTable $view)
     {
-        $unknownTypeCount = 1;
-        $view->requestConfig->filter_limit = $unknownTypeCount + count(DeviceParser::getAvailableDeviceTypeNames());
         $view->config->show_search = false;
         $view->config->show_exclude_low_population = false;
         $view->config->addTranslation('label', Piwik::translate("DevicesDetection_dataTableLabelTypes"));


### PR DESCRIPTION
fix #12266

fyi @mattab couldn't make it work to show `0` instead of `-`. 
Now all the reports have the same length by default on the devices page. If someone wants to see more, they can increase the limit. Or if many are `-` then they can choose only `5` in the limit selection and it will apply this setting next time.

I reckon this is a good compromise. It lets users also still perform row evolution plus discover all the things/devices we can detect.

![image](https://user-images.githubusercontent.com/273120/46508404-e443cc00-c899-11e8-8ca5-1e24707e1287.png)
