### PR TITLE
Fix possible error in visitor profile when no visit found

### DIFF
--- a/plugins/Live/VisitorProfile.php
+++ b/plugins/Live/VisitorProfile.php
@@ -79,6 +79,11 @@ class VisitorProfile
      */
     private function handleAdjacentVisitorIds(DataTable $visits, $visitorId, $segment)
     {
+        if (!$visits->getRowsCount()) {
+            $this->profile['nextVisitorId'] = false;
+            $this->profile['previousVisitorId'] = false;
+            return;
+        }
         // get visitor IDs that are adjacent to this one in log_visit
         // TODO: make sure order of visitor ids is not changed if a returning visitor visits while the user is
         //       looking at the popup.


### PR DESCRIPTION
Not tested but fix this fatal error
> Error: {"message":"Call to a member function getColumn() on boolean","file":"plugins\/Live\/VisitorProfile.php","line":86}

Happened eg on 
> module=API&method=Live.getVisitorProfile&idSite=1&format=JSON&token_auth=XYZANONYMIZED&visitorId=b06bc6d6274c1244&limitVisits=-1