### PR TITLE
don't consider .swf files safe

### DIFF
--- a/plugins/Installation/ServerFilesGenerator.php
+++ b/plugins/Installation/ServerFilesGenerator.php
@@ -47,7 +47,7 @@ class ServerFilesGenerator
             "</IfModule>\n\n" .
 
             "# Allow to serve static files which are safe\n" .
-            "<Files ~ \"\\.(gif|ico|jpg|png|svg|js|css|htm|html|swf|mp3|mp4|wav|ogg|avi|ttf|eot|woff|woff2|json)$\">\n" .
+            "<Files ~ \"\\.(gif|ico|jpg|png|svg|js|css|htm|html|mp3|mp4|wav|ogg|avi|ttf|eot|woff|woff2|json)$\">\n" .
             $allow . "\n" .
             "</Files>\n";
 


### PR DESCRIPTION
While writing a better nginx config I noticed that swf doesn't fit in the list, as I wouldn't consider accessing random swf files safe (https://github.com/matomo-org/github-issues-mirror/issues/5).

This shouldn't break anything as there is no reason for swf files in Matomo.