### PR TITLE
Truncate referrer name & keyword in Base class so the value used there matches what is in the DB.

### DIFF
--- a/plugins/Referrers/Columns/Keyword.php
+++ b/plugins/Referrers/Columns/Keyword.php
@@ -33,11 +33,6 @@ class Keyword extends Base
     public function onNewVisit(Request $request, Visitor $visitor, $action)
     {
         $information = $this->getReferrerInformationFromRequest($request, $visitor);
-
-        if (!empty($information['referer_keyword'])) {
-            return Common::mb_substr($information['referer_keyword'], 0, 255);
-        }
-
         return $information['referer_keyword'];
     }
 

--- a/plugins/Referrers/Columns/ReferrerName.php
+++ b/plugins/Referrers/Columns/ReferrerName.php
@@ -34,10 +34,6 @@ class ReferrerName extends Base
     public function onNewVisit(Request $request, Visitor $visitor, $action)
     {
         $information = $this->getReferrerInformationFromRequest($request, $visitor);
-
-        if (!empty($information['referer_name'])) {
-            return Common::mb_substr($information['referer_name'], 0, 70);
-        }
         return $information['referer_name'];
     }
 


### PR DESCRIPTION
Prevents creating new visits when referrer is the same but is cut off in the DB because it is too long.

refs https://github.com/matomo-org/matomo/pull/13469