### PR TITLE
fix domain age from archive.org

### DIFF
--- a/plugins/SEO/Metric/DomainAge.php
+++ b/plugins/SEO/Metric/DomainAge.php
@@ -74,16 +74,12 @@ class DomainAge implements MetricsProvider
      */
     private function getAgeArchiveOrg($domain)
     {
-        $data = $this->getUrl('https://wayback.archive.org/web/*/' . urlencode($domain));
-        preg_match('#<a href=\"([^>]*)' . preg_quote($domain) . '/\">([^<]*)<\/a>#', $data, $p);
-        if (!empty($p[2])) {
-            $value = strtotime($p[2]);
-            if ($value === false) {
-                return 0;
-            }
-            return $value;
+        $response = $this->getUrl('https://archive.org/wayback/available?timestamp=19900101&url=' . urlencode($domain));
+        $data = json_decode($response, true);
+        if (empty($data["archived_snapshots"])) {
+            return 0;
         }
-        return 0;
+        return strtotime($data["archived_snapshots"]["closest"]["timestamp"]);
     }
 
     /**

--- a/plugins/SEO/Metric/DomainAge.php
+++ b/plugins/SEO/Metric/DomainAge.php
@@ -76,7 +76,7 @@ class DomainAge implements MetricsProvider
     {
         $response = $this->getUrl('https://archive.org/wayback/available?timestamp=19900101&url=' . urlencode($domain));
         $data = json_decode($response, true);
-        if (empty($data["archived_snapshots"])) {
+        if (empty($data["archived_snapshots"]["closest"]["timestamp"])) {
             return 0;
         }
         return strtotime($data["archived_snapshots"]["closest"]["timestamp"]);

--- a/plugins/SEO/tests/Integration/SEOTest.php
+++ b/plugins/SEO/tests/Integration/SEOTest.php
@@ -55,11 +55,10 @@ class SEOTest extends \PHPUnit_Framework_TestCase
         $renderer->setSerialize(false);
         $ranks = $renderer->render($dataTable);
         foreach ($ranks as $rank) {
-            $message = $rank['id'] . ' expected non-zero rank, got [' . $rank['rank'] . ']';
-            if(empty($rank['rank'])) {
-                $this->markTestSkipped("Skipped to avoid random build failure: " . $message);
+            if ($rank["id"] == "alexa") { // alexa is broken at the moment
+                continue;
             }
-            $this->assertNotEmpty($rank['rank'], $message);
+            $this->assertNotEmpty($rank['rank'], $rank['id'] . ' expected non-zero rank, got [' . $rank['rank'] . ']');
         }
     }
 


### PR DESCRIPTION
https://wayback.archive.org doesn't seem to exist anymore and the new website loads the content dynamically via react. But there is no need to parse the archive.org website, because they provide an API, that's perfect for this use case as it returns the closest match to a timestamp.

https://archive.org/help/wayback_api.php