### PR TITLE
don't allow SEO plugin to make non-HTTPS requests

### DIFF
--- a/plugins/SEO/Metric/Alexa.php
+++ b/plugins/SEO/Metric/Alexa.php
@@ -17,8 +17,8 @@ use Psr\Log\LoggerInterface;
  */
 class Alexa implements MetricsProvider
 {
-    const URL = 'http://data.alexa.com/data?cli=10&url=';
-    const LINK = 'http://www.alexa.com/siteinfo/';
+    const URL = 'https://data.alexa.com/data?cli=10&url=';
+    const LINK = 'https://www.alexa.com/siteinfo/';
 
     /**
      * @var LoggerInterface

--- a/plugins/SEO/Metric/Bing.php
+++ b/plugins/SEO/Metric/Bing.php
@@ -17,7 +17,7 @@ use Psr\Log\LoggerInterface;
  */
 class Bing implements MetricsProvider
 {
-    const URL = 'http://www.bing.com/search?setlang=en-US&rdr=1&q=site%3A';
+    const URL = 'https://www.bing.com/search?setlang=en-US&rdr=1&q=site%3A';
 
     /**
      * @var LoggerInterface

--- a/plugins/SEO/Metric/DomainAge.php
+++ b/plugins/SEO/Metric/DomainAge.php
@@ -131,12 +131,6 @@ class DomainAge implements MetricsProvider
         try {
             return $this->getHttpResponse($url);
         } catch (\Exception $e) {
-        }
-
-        $httpUrl = str_replace('https://', 'http://', $url);
-        try {
-            return $this->getHttpResponse($httpUrl);
-        } catch (\Exception $e) {
             $this->logger->warning('Error while getting SEO stats (domain age): {message}', array('message' => $e->getMessage()));
             return '';
         }


### PR DESCRIPTION
While I think the SEO plugin needs to be improved in general (opt-in, fix all requests), this PR at least makes sure the domain is never sent in clear text.