### PR TITLE
fix SEO bing count

### DIFF
--- a/plugins/SEO/Metric/Bing.php
+++ b/plugins/SEO/Metric/Bing.php
@@ -35,6 +35,7 @@ class Bing implements MetricsProvider
 
         try {
             $response = str_replace('&nbsp;', ' ', Http::sendHttpRequest($url, $timeout = 10, @$_SERVER['HTTP_USER_AGENT']));
+            $response = str_replace('&#160;', '', $response); // number uses nbsp as thousand seperator
 
             if (preg_match('#([0-9,\.]+) results#i', $response, $p)) {
                 $pageCount = NumberFormatter::getInstance()->formatNumber((int)str_replace(array(',', '.'), '', $p[1]));


### PR DESCRIPTION
And another SEO fix: `67 700 000 results` on bing.com seems to be separated by `&#160;`