### PR TITLE
Acquire an exclusive lock when writing config file

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -387,7 +387,7 @@ class Config
                 // simulate whether it would be successful
                 $success = is_writable($localPath);
             } else {
-                $success = @file_put_contents($localPath, $output);
+                $success = @file_put_contents($localPath, $output, LOCK_EX);
             }
 
             if ($success === false) {


### PR DESCRIPTION
Avoids a config file end up empty under circumstances