### PR TITLE
When exporting data and "Show export URL" is clicked, don't reveal the full token_auth until field is clicked

### DIFF
--- a/plugins/CoreHome/angularjs/report-export/reportexport.popover.html
+++ b/plugins/CoreHome/angularjs/report-export/reportexport.popover.html
@@ -50,12 +50,13 @@
     </div>
 
     <div class="col l12" ng-show="showUrl">
-        <textarea readonly>{{ getExportLink() }}</textarea>
+        <textarea piwik-select-on-focus readonly class="exportFullUrlFull" ng-show="showFullUrl">{{ getExportLink() }}</textarea>
+        <textarea readonly ng-show="!showFullUrl" title="{{ 'CoreHome_ClickToSeeFullInformation'|translate }}" class="exportFullUrlPartial" ng-click="showFullUrl=true">{{ getExportLink()|limitTo:50 }}...</textarea>
     </div>
 
     <div class="col l12">
         <a class="btn" ng-attr-href="{{ getExportLink() }}" target="_new">{{ 'General_Export'|translate }}</a>
-        <a href="javascript:;" ng-click="showUrl=!showUrl" class="toggle-export-url">
+        <a href="javascript:;" ng-click="showUrl=!showUrl;showFullUrl=false;" class="toggle-export-url">
             <span ng-show="!showUrl">{{ 'CoreHome_ShowExportUrl'|translate }}</span>
             <span ng-show="showUrl">{{ 'CoreHome_HideExportUrl'|translate }}</span>
         </a>


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/13413

Seeing there are no UI tests for this feature so far but also don't think it needs any. Logic is simple and otherwise end up with thousands of UI tests :)