### PR TITLE
Keep a copy of triggered event names for better debugging

### DIFF
--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -30,6 +30,27 @@ class EventDispatcher
     const EVENT_CALLBACK_GROUP_SECOND = 1;
     const EVENT_CALLBACK_GROUP_THIRD = 2;
 
+    private static $lastEventNames = array();
+
+    /**
+     * A list of triggered event names, useful to debug problems and to better understand how something happens
+     * @param  int $limit if a value is set, will return only the last X triggered events
+     * @return string[]
+     */
+    public static function getTriggeredEventNames($limit = 0)
+    {
+        if (empty($limit)) {
+            return self::$lastEventNames;
+        } else {
+            return array_slice(self::$lastEventNames, -1 * $limit, $limit);
+        }
+    }
+
+    private static function logLastEvent($eventName)
+    {
+        self::$lastEventNames[] = $eventName;
+    }
+
     /**
      * Array of observers (callbacks attached to events) that are not methods
      * of plugin classes.
@@ -90,6 +111,8 @@ class EventDispatcher
         if ($pending) {
             $this->pendingEvents[] = array($eventName, $params);
         }
+
+        self::logLastEvent($eventName);
 
         $manager = $this->pluginManager;
 


### PR DESCRIPTION
Sometimes you are in a method that can be triggered through many different events and you want to know which event triggered the method or which events happened before this as the event might be triggered by another event etc. Not keeping any params re possible memory issues.

Might be even useful to log like the last X occurred events in some places on top of a backtrace or so... (be something maybe for another PR). Refs DEV-1456