### PR TITLE
Let plugins modify the JS tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ### New APIs
 
 * Added new event `Access.modifyUserAccess` which lets plugins modify current user's access levels/permissions.
+* Added new event `CustomMatomoJs.manipulateJsTracker` which lets plugins modify the JavaScript tracker.
 
 ### New Developer Features
 

--- a/plugins/CustomPiwikJs/TrackingCode/PiwikJsManipulator.php
+++ b/plugins/CustomPiwikJs/TrackingCode/PiwikJsManipulator.php
@@ -8,6 +8,8 @@
 
 namespace Piwik\Plugins\CustomPiwikJs\TrackingCode;
 
+use Piwik\Piwik;
+
 class PiwikJsManipulator
 {
     const HOOK = '/*!!! pluginTrackerHook */';
@@ -35,6 +37,24 @@ class PiwikJsManipulator
             // for some reasons it is /*!!! in piwik.js minified and /*!! in js/piwik.js unminified
             $this->content = str_replace(array(self::HOOK, '/*!! pluginTrackerHook */'), self::HOOK . $trackerExtension, $this->content);
         }
+
+        $content = $this->content;
+
+        /**
+         * Triggered after the Matomo JavaScript tracker has been generated and shortly before the tracker file
+         * is written to disk. You can listen to this event to for example automatically append some code to the JS
+         * tracker file.
+         *
+         * **Example**
+         *
+         *     function onManipulateJsTracker (&$content) {
+         *         $content .= "\nPiwik.DOM.onLoad(function () { console.log('loaded'); });";
+         *     }
+         *
+         * @param string $content the generated JavaScript tracker code
+         */
+        Piwik::postEvent('CustomMatomoJs.manipulateJsTracker', array(&$content));
+        $this->content = $content;
 
         return $this->content;
     }


### PR DESCRIPTION
Plugins can already modify the JS tracker by creating a `tracker.js` in their plugin but it is not really a supported or documented API yet. The problem with `tracker.js` is that this file gets added in all cases as long as the plugin that contains it is enabled. But sometimes you want to control when a certain functionality is added to tracker.js. For example you want to only add it after enabling a certain feature etc.