### PR TITLE
prefer Gzip to Deflate

### DIFF
--- a/core/ProxyHttp.php
+++ b/core/ProxyHttp.php
@@ -239,11 +239,10 @@ class ProxyHttp
     private static function getCompressionEncodingAcceptedByClient()
     {
         $acceptEncoding = $_SERVER['HTTP_ACCEPT_ENCODING'];
-
-        if (preg_match(self::DEFLATE_ENCODING_REGEX, $acceptEncoding, $matches)) {
-            return array('deflate', '.deflate');
-        } elseif (preg_match(self::GZIP_ENCODING_REGEX, $acceptEncoding, $matches)) {
+        if (preg_match(self::GZIP_ENCODING_REGEX, $acceptEncoding, $matches)) {
             return array('gzip', '.gz');
+        } elseif (preg_match(self::DEFLATE_ENCODING_REGEX, $acceptEncoding, $matches)) {
+            return array('deflate', '.deflate');
         } else {
             return array(false, false);
         }


### PR DESCRIPTION
Hi,

This is a really minor fix I found when taking a closer look at the `js/tracker.php`.

While gzip isn't smaller (in fact it is deflate with a better error checking and therefore is even 18 bytes larger), nearly every website nowadays uses gzip and I think it would be worth it to by default use the established and more robust compression method and only use deflate as a fallback (that would probably never occur as every browser suports gzip).
Only disadvantage would be that it is a tiny bit slower, but as it is cached it shouldn't matter.

Maybe we could also support brotli, even though it would require manually pre-compressing the file.
But I expected a bit more improvement (both with `-9`)
```
-rw-r--r--  1 lukas lukas    65458 Okt 20 20:41  piwik.js
-rw-r--r--  1 lukas lukas    21280 Okt 20 20:41  piwik.js.br
-rw-r--r--  1 lukas lukas    22312 Okt 20 20:41  piwik.js.gz
```