### PR TITLE
Added API endpoint to return the php version info

### DIFF
--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -90,6 +90,23 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
+     * Get PHP version
+     * @return array
+     */
+    public function getPhpVersion()
+    {
+        Piwik::checkUserHasSomeViewAccess();
+        return array(
+            'version' => PHP_VERSION,
+            'major' => PHP_MAJOR_VERSION,
+            'minor' => PHP_MINOR_VERSION,
+            'release' => PHP_RELEASE_VERSION,
+            'versionId' => PHP_VERSION_ID,
+            'extra' => PHP_EXTRA_VERSION,
+        );
+    }
+
+    /**
      * Get Matomo version
      * @return string
      * @deprecated

--- a/plugins/API/API.php
+++ b/plugins/API/API.php
@@ -95,7 +95,7 @@ class API extends \Piwik\Plugin\API
      */
     public function getPhpVersion()
     {
-        Piwik::checkUserHasSomeViewAccess();
+        Piwik::checkUserHasSuperUserAccess();
         return array(
             'version' => PHP_VERSION,
             'major' => PHP_MAJOR_VERSION,

--- a/tests/PHPUnit/Framework/TestRequest/Collection.php
+++ b/tests/PHPUnit/Framework/TestRequest/Collection.php
@@ -338,6 +338,7 @@ class Collection
                 $this->apiNotToCall = array(
                                             'API.getMatomoVersion',
                                             'API.getPiwikVersion',
+                                            'API.getPhpVersion',
                                             'UserCountry.getLocationFromIP',
                                             'UserCountry.getCountryCodeMapping');
             } else {

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:66967d36349ece90779e0620c0edc17b661f6998803d9ec114920ca3f1dc4cf2
-size 4556222
+oid sha256:d2edd2e71b8ba4a176034f74649ccd791ecdfdec4b169be0ca1ef7c4d325772f
+size 4560424


### PR DESCRIPTION
Hey everybody,

I'm using the `getMatomoVersion` endpoint to see if my Matomo setups are all up-to-date. I would like to also know if the PHP version they're all running on are maintained. Unfortunately there's no endpoint yet for that.

I'm very new to the code base of Matomo but actually very experienced in php and testing. Also followed your setup guide for the tests but when trying to run `./console tests:run unit` it tried to connect to the db (which is very strange to me for unit tests) so I didn't explore more on it.

Feel free to guide me to the things I need to do to have this tested, I'll happily update the PR if you like this addition 😄 