### PR TITLE
Add a CACHEDIR.TAG file to tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ php_errors.log
 /robots.txt
 /tmp/*
 !/tmp/.gitkeep
+!/tmp/CACHEDIR.TAG
 /vendor/
 /.cache
 /.externalToolBuilders

--- a/tmp/CACHEDIR.TAG
+++ b/tmp/CACHEDIR.TAG
@@ -1,0 +1,4 @@
+Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by Matomo.
+# For information about cache directory tags, see:
+#	http://www.bford.info/cachedir/


### PR DESCRIPTION
### Ellipsis
This PR adds a simple `CACHEDIR.TAG` file, as recognised by some backup solutions. This originated in issue #12754, which I assume is accepting PRs.

Note that I have modified the URL: The original `http://www.brynosaurus.com/cachedir/` is now showing an error page (blocked by Yale for malware?), but http://www.bford.info/cachedir/ seems to be an alias.

### Caveats
This assumes that users would not just go and delete the entire `tmp/` directory. A periodic check for the `CACHEDIR.TAG` would fix this, but I wasn't sure where to put it in the code. It's probably not something we want to do at every request. Also, this might be considered unnecessary overhead for most use cases. It might be sensible to assume that users relying on this file would take care, but I don't think that is a very safe assumption to make.

It could also be considered to include a check for `CACHEDIR.TAG` in the `System Check` page, but again, only very few users will probably care about that.

This PR does not add any tests because it does not add any code.

Fixes #12754 