### PR TITLE
Show the CORS settings in the UI when enable_general_settings_admin=0

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -640,9 +640,10 @@ enable_geolocation_admin = 1
 enable_delete_old_data_settings_admin = 1
 
 ; By setting this option to 0, the following settings will be hidden and disabled from being set in the UI:
-; - "Archiving Settings"
-; - "Update settings"
-; - "Email server settings"
+; - Archiving settings
+; - Update settings
+; - Email server settings
+; - Trusted Matomo Hostname
 enable_general_settings_admin = 1
 
 ; Disabling this will disable features like automatic updates for Matomo,

--- a/plugins/CoreAdminHome/SystemSettings.php
+++ b/plugins/CoreAdminHome/SystemSettings.php
@@ -25,9 +25,11 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     {
         $this->title = ' '; // intentionally left blank as it's hidden with css
 
-        $isWritable = Piwik::hasUserSuperUserAccess();
+        $isWritable = Piwik::hasUserSuperUserAccess() && CoreAdminController::isGeneralSettingsAdminEnabled();
         $this->trustedHostnames = $this->createTrustedHostnames();
         $this->trustedHostnames->setIsWritableByCurrentUser($isWritable);
+
+        $isWritable = Piwik::hasUserSuperUserAccess();
         $this->corsDomains = $this->createCorsDomains();
         $this->corsDomains->setIsWritableByCurrentUser($isWritable);
     }

--- a/plugins/CoreAdminHome/SystemSettings.php
+++ b/plugins/CoreAdminHome/SystemSettings.php
@@ -25,7 +25,7 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
     {
         $this->title = ' '; // intentionally left blank as it's hidden with css
 
-        $isWritable = Piwik::hasUserSuperUserAccess() && CoreAdminController::isGeneralSettingsAdminEnabled();
+        $isWritable = Piwik::hasUserSuperUserAccess();
         $this->trustedHostnames = $this->createTrustedHostnames();
         $this->trustedHostnames->setIsWritableByCurrentUser($isWritable);
         $this->corsDomains = $this->createCorsDomains();


### PR DESCRIPTION
The INI setting description does not mean to include CORS:
```ini

; By setting this option to 0, the following settings will be hidden and disabled from being set in the UI:
; - "Archiving Settings"
; - "Update settings"
; - "Email server settings"
enable_general_settings_admin = 1
```