### PR TITLE
Always fail during tracking when authentication is required but invalid token is used

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -862,7 +862,7 @@ class Request
 
         if (!$this->isAuthenticated()) {
             Common::printDebug("WARN: Tracker API 'cip' was used with invalid token_auth");
-            return IP::getIpFromHeader();
+            throw new InvalidRequestParameterException("Tracker API 'cip' was used, requires valid token_auth");
         }
 
         return $cip;

--- a/plugins/UserCountry/Columns/Base.php
+++ b/plugins/UserCountry/Columns/Base.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\UserCountry\Columns;
 
 use Piwik\Common;
+use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Network\IPUtils;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\UserCountry\VisitorGeolocator;
@@ -27,12 +28,14 @@ abstract class Base extends VisitDimension
 
     protected function getUrlOverrideValueIfAllowed($urlParamToOverride, Request $request)
     {
-        if (!$request->isAuthenticated()) {
-            return false;
-        }
-
         $value = Common::getRequestVar($urlParamToOverride, false, 'string', $request->getParams());
+
         if (!empty($value)) {
+            if (!$request->isAuthenticated()) {
+                Common::printDebug("WARN: Tracker API '$urlParamToOverride' was used with invalid token_auth");
+                throw new InvalidRequestParameterException("Tracker API '$urlParamToOverride' was used, requires valid token_auth");
+            }
+
             return $value;
         }
 

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -34,6 +34,7 @@ class VisitTest extends IntegrationTestCase
         // setup the access layer
         FakeAccess::$superUser = true;
 
+        Fixture::createSuperUser(true);
         Manager::getInstance()->loadTrackerPlugins();
         $pluginNames = array_keys(Manager::getInstance()->getLoadedPlugins());
         $pluginNames[] = 'SitesManager';

--- a/tests/PHPUnit/Unit/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestTest.php
@@ -9,6 +9,7 @@
 namespace Piwik\Tests\Unit\Tracker;
 
 use Piwik\Cookie;
+use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Network\IPUtils;
 use Piwik\Piwik;
 use Piwik\Plugins\CustomVariables\CustomVariables;
@@ -524,6 +525,10 @@ class RequestTest extends UnitTestCase
         $this->assertEquals($_SERVER['REMOTE_ADDR'], $this->request->getIpString());
     }
 
+    /**
+     * @expectedException \Piwik\Exception\InvalidRequestParameterException
+     * @expectedException requires valid token_auth
+     */
     public function test_getIpString_ShouldDefaultToServerAddress_IfCustomIpIsSetButNotAuthenticated()
     {
         $request = $this->buildRequest(array('cip' => '192.192.192.192'));


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/13471

Don't think a  test is needed for the location ones.