### PR TITLE
During installation allow to prefill DB form from environment variables

### DIFF
--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -80,12 +80,26 @@ class FormDatabaseSetup extends QuickForm2
         $defaultDatabaseType = Config::getInstance()->database['type'];
         $this->addElement( 'hidden', 'type')->setLabel('Database engine');
 
+
+        $defaults = array(
+            'host'          => '127.0.0.1',
+            'type'          => $defaultDatabaseType,
+            'tables_prefix' => 'matomo_',
+        );
+
+        $defaultsEnvironment = array('host', 'adapter', 'tables_prefix', 'username', 'password', 'dbname');
+        foreach ($defaultsEnvironment as $name) {
+            $envName = 'DATABASE_' . strtoupper($name); // fyi getenv is case insensitive
+            $envNameMatomo = 'MATOMO_' . $envName;
+            if (getenv($envNameMatomo)) {
+                $defaults[$name] = getenv($envNameMatomo);
+            } elseif (getenv($envName)) {
+                $defaults[$name] = getenv($envName);
+            }
+        }
+
         // default values
-        $this->addDataSource(new HTML_QuickForm2_DataSource_Array(array(
-                                                                       'host'          => '127.0.0.1',
-                                                                       'type'          => $defaultDatabaseType,
-                                                                       'tables_prefix' => 'matomo_',
-                                                                  )));
+        $this->addDataSource(new HTML_QuickForm2_DataSource_Array($defaults));
     }
 
     /**


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/10914

@mattab as discussed pre-filling DB values from environment optionally. Supported are:
* MATOMO_DATABASE_HOST
* MATOMO_DATABASE_ADAPTER
* MATOMO_DATABASE_TABLES_PREFIX
* MATOMO_DATABASE_USERNAME
* MATOMO_DATABASE_PASSWORD
* MATOMO_DATABASE_DBNAME

and as fallback if that is not defined (we could also remove that fallback)
* DATABASE_HOST
* DATABASE_ADAPTER
* DATABASE_TABLES_PREFIX
* DATABASE_USERNAME
* DATABASE_PASSWORD
* DATABASE_DBNAME

The structure being taken from the global ini as in `MATOMO_$CATEGORY_$SETTINGNAME`.

I'm not going to implement that it overrides the config and that Matomo could be basically even used without config etc. Some settings will need to be writable I suppose and won't be possible to be set through environment variables. I wouldn't want it in core actually, and to overwrite / configure any environment setting I suggest this will be implemented in a separate plugin which can be put on the marketplace. For performance etc I wouldn't want to check environment variables for heaps of settings etc.