### PR TITLE
Improved CORSHandler

### DIFF
--- a/core/API/CORSHandler.php
+++ b/core/API/CORSHandler.php
@@ -25,8 +25,22 @@ class CORSHandler
 
     public function handle()
     {
+        if (empty($this->domains)) {
+            return;
+        }
+        
+        Common::sendHeader('Vary: Origin');
+        
         // allow Piwik to serve data to all domains
         if (in_array("*", $this->domains)) {
+            
+            Common::sendHeader('Access-Control-Allow-Credentials: true');
+            
+            if (!empty($_SERVER['HTTP_ORIGIN'])) {
+                Common::sendHeader('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+                return;
+            }
+            
             Common::sendHeader('Access-Control-Allow-Origin: *');
             return;
         }
@@ -35,6 +49,7 @@ class CORSHandler
         if (!empty($_SERVER['HTTP_ORIGIN'])) {
             $origin = $_SERVER['HTTP_ORIGIN'];
             if (in_array($origin, $this->domains, true)) {
+                Common::sendHeader('Access-Control-Allow-Credentials: true');
                 Common::sendHeader('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
             }
         }


### PR DESCRIPTION
When using the 3rd party cookie, and tracking to piwik with AJAX, the request will (must) include the 3rd party cookie (see https://github.com/matomo-org/matomo/pull/13159 ).

It is already possible to set "cors_domains[] = *" in config.ini.php to allow this.
However "The value of * is special in that it does not allow requests to supply credentials, meaning it does not allow HTTP authentication, client-side SSL certificates, or cookies to be sent in the cross-domain request." (see https://en.wikipedia.org/wiki/Cross-origin_resource_sharing ).

Thus this change avoids the "*" value and also adds the 'Vary: Origin' header.