### PR TITLE
It is not possible to record more than one conversion per second for the same visit

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -691,14 +691,9 @@ class GoalManager
     
     private function makeRandomMySqlUnsignedInt($length)
     {
-        // mysql int unsgined max value is 4294967295 so we cannot start with a 5 or higher
-        $randomInt = Common::getRandomString(1, '1234');
-        if ($length >= 2) {
-            $randomInt .= Common::getRandomString(1, '012');
-        }
-        if ($length > 2) {
-            $randomInt .= Common::getRandomString($length - 2, '0123456789');
-        }
+        // mysql int unsgined max value is 4294967295 so we want to allow max 39999...
+        $randomInt = Common::getRandomString(1, '123');
+        $randomInt .= Common::getRandomString($length - 1, '0123456789');
         return $randomInt;
     }
 

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -671,15 +671,28 @@ class GoalManager
             }
 
             // If multiple Goal conversions per visit, set a cache buster
-            $conversion['buster'] = $convertedGoal['allow_multiple'] == 0
-                ? '0'
-                : $visitProperties->getProperty('visit_last_action_time');
+            if ($convertedGoal['allow_multiple'] == 0) {
+                $conversion['buster'] = 0;
+            } else {
+                $lastActionTime = $visitProperties->getProperty('visit_last_action_time');
+                if (empty($lastActionTime)) {
+                    $conversion['buster'] = $this->makeRandomMySqlUnsignedInt(10);
+                } else {
+                    $conversion['buster'] = $this->makeRandomMySqlUnsignedInt(2) . Common::mb_substr($visitProperties->getProperty('visit_last_action_time'), 2);
+                }
+            }
 
             $conversionDimensions = ConversionDimension::getAllDimensions();
             $conversion = $this->triggerHookOnDimensions($request, $conversionDimensions, 'onGoalConversion', $visitor, $action, $conversion);
 
             $this->insertNewConversion($conversion, $visitProperties->getProperties(), $request, $action, $convertedGoal);
         }
+    }
+
+    private function makeRandomMySqlUnsignedInt($length)
+    {
+        // mysql int unsgined max value is 4294967295 so we cannot start with a 5 or higher
+        return Common::getRandomString(1, '1234') . Common::getRandomString($length - 1, '0123456789');
     }
 
     /**

--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -688,11 +688,18 @@ class GoalManager
             $this->insertNewConversion($conversion, $visitProperties->getProperties(), $request, $action, $convertedGoal);
         }
     }
-
+    
     private function makeRandomMySqlUnsignedInt($length)
     {
         // mysql int unsgined max value is 4294967295 so we cannot start with a 5 or higher
-        return Common::getRandomString(1, '1234') . Common::getRandomString($length - 1, '0123456789');
+        $randomInt = Common::getRandomString(1, '1234');
+        if ($length >= 2) {
+            $randomInt .= Common::getRandomString(1, '012');
+        }
+        if ($length > 2) {
+            $randomInt .= Common::getRandomString($length - 2, '0123456789');
+        }
+        return $randomInt;
     }
 
     /**


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/9916

we randomize the first 2 numbers increasing the chances to record multiple goal conversions per second per visit.