### PR TITLE
In LogAggregator, allow the use of a complex dimension w/ an already defined select as.

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -423,6 +423,7 @@ class LogAggregator
      * @param $dimensions
      * @param $tableName
      * @param bool $appendSelectAs
+     * @param bool $parseSelectAs
      * @return mixed
      */
     protected function getSelectDimensions($dimensions, $tableName, $appendSelectAs = true)
@@ -432,11 +433,15 @@ class LogAggregator
 
             if (!is_numeric($selectAs)) {
                 $selectAsString = $selectAs;
-            } else {
-                // if function, do not alias or prefix
-                if ($this->isFieldFunctionOrComplexExpression($field)) {
-                    $selectAsString = $appendSelectAs = false;
+            } else if ($this->isFieldFunctionOrComplexExpression($field)) {
+                // if complex expression has a select as, use it
+                if (!$appendSelectAs && preg_match('/\s+AS\s+(.*?)\s*$/', $field, $matches)) {
+                    $field = $matches[1];
+                    continue;
                 }
+
+                // if function w/o select as, do not alias or prefix
+                $selectAsString = $appendSelectAs = false;
             }
 
             $isKnownField = !in_array($field, array('referrer_data'));

--- a/core/DataTable/Map.php
+++ b/core/DataTable/Map.php
@@ -158,6 +158,15 @@ class Map implements DataTableInterface
     }
 
     /**
+     * @param string $label
+     * @return bool
+     */
+    public function hasTable($label)
+    {
+        return isset($this->array[$label]);
+    }
+
+    /**
      * Returns the first element in the Map's array.
      *
      * @return DataTable|Map|false

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -14,7 +14,7 @@ use Piwik\Date;
 use Piwik\Period;
 use Piwik\Segment;
 use Piwik\Site;
-use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Fixtures\OneVisitorTwoVisits;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
@@ -26,6 +26,11 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 class LogAggregatorTest extends IntegrationTestCase
 {
     /**
+     * @var OneVisitorTwoVisits
+     */
+    public static $fixture;
+
+    /**
      * @var LogAggregator
      */
     private $logAggregator;
@@ -36,12 +41,8 @@ class LogAggregatorTest extends IntegrationTestCase
 
         $idSite = 1;
 
-        if (!Fixture::siteCreated($idSite)) {
-            Fixture::createWebsite('2014-01-01 00:00:00');
-        }
-
         $site = new Site($idSite);
-        $date = Date::factory('2012-01-01');
+        $date = Date::factory('2010-03-06');
         $period = Period\Factory::build('month', $date);
         $segment = new Segment('', array($site->getId()));
 
@@ -65,8 +66,8 @@ class LogAggregatorTest extends IntegrationTestCase
 			ORDER BY
 				5',
             'bind' => array (
-                0 => '2012-01-01 00:00:00',
-                1 => '2012-01-31 23:59:59',
+                0 => '2010-03-01 00:00:00',
+                1 => '2010-03-31 23:59:59',
                 2 => 1
             )
         );
@@ -88,12 +89,52 @@ class LogAggregatorTest extends IntegrationTestCase
 			ORDER BY
 				5',
             'bind' => array (
-                0 => '2012-01-01 00:00:00',
-                1 => '2012-01-31 23:59:59',
+                0 => '2010-03-01 00:00:00',
+                1 => '2010-03-31 23:59:59',
                 2 => 1
             )
         );
         $this->assertSame($expected, $query);
     }
 
+    public function test_queryVisitsByDimension_withComplexDimensionSelect()
+    {
+        $dimensions = [
+            'CASE WHEN HOUR(log_visit.visit_first_action_time) <= 11 THEN \'l\'' .
+            'ELSE \'r\'' .
+            'END AS label',
+        ];
+
+        /** @var \Zend_Db_Statement $query */
+        $query = $this->logAggregator->queryVisitsByDimension($dimensions);
+        $result = $query->fetchAll();
+
+        $expected = [
+            [
+                'label' => 'l',
+                1 => '1',
+                2 => '1',
+                3 => '7',
+                4 => '7',
+                5 => '1621',
+                6 => '0',
+                7 => '1',
+                39 => '0',
+            ],
+            [
+                'label' => 'r',
+                1 => '1',
+                2 => '1',
+                3 => '1',
+                4 => '1',
+                5 => '0',
+                6 => '1',
+                7 => '1',
+                39 => '0',
+            ],
+        ];
+        $this->assertEquals($expected, $result);
+    }
 }
+
+LogAggregatorTest::$fixture = new OneVisitorTwoVisits();


### PR DESCRIPTION
This change allows the use of complex expressions as dimensions. Currently if someone uses, eg, a complex `CASE WHEN ... END` statement as a dimension, it will be duplicated in the select and in the group by of the query. This will allow users to add their own alias like `CASE WHEN ... END AS blahblah`, which will appear in the select as the entire `CASE WHEN ...` but as `blahblah` in the group by.

Also includes a `hasTable($table)` method addition to DataTable\Map so we can check if a table exists w/o triggering an error w/ getTable.