### PR TITLE
Prevent possible fatal during update

### DIFF
--- a/core/Updates/3.7.0-b1.php
+++ b/core/Updates/3.7.0-b1.php
@@ -29,8 +29,8 @@ class Updates_3_7_0_b1 extends PiwikUpdates
     public function getMigrations(Updater $updater)
     {
         return [
-            $this->migration->db->addColumn(Model::$rawPrefix, 'evolution_graph_within_period', 'TINYINT(4) NOT NULL DEFAULT 0'),
-            $this->migration->db->addColumn(Model::$rawPrefix, 'evolution_graph_period_n', 'INT(11) NULL'),
+            $this->migration->db->addColumn('report', 'evolution_graph_within_period', 'TINYINT(4) NOT NULL DEFAULT 0'),
+            $this->migration->db->addColumn('report', 'evolution_graph_period_n', 'INT(11) NULL'),
         ];
     }
 


### PR DESCRIPTION
the `$rawPrefix` was only added in the release so if there is some opcache active etc the property might not be available yet.