### PR TITLE
Use new exception in PluginsArchiver & add previous exceptions to backtrace in fatal error report

### DIFF
--- a/core/API/ResponseBuilder.php
+++ b/core/API/ResponseBuilder.php
@@ -165,10 +165,19 @@ class ResponseBuilder
      */
     private function formatExceptionMessage($exception)
     {
-        $message = $exception->getMessage();
-        if ($this->shouldPrintBacktrace) {
-            $message .= "\n" . $exception->getTraceAsString();
-        }
+        $message = "";
+
+        $e = $exception;
+        do {
+            if ($e !== $exception) {
+                $message .= ",\ncaused by: ";
+            }
+
+            $message .= $e->getMessage();
+            if ($this->shouldPrintBacktrace) {
+                $message .= "\n" . $e->getTraceAsString();
+            }
+        } while ($e = $e->getPrevious());
 
         return Renderer::formatValueXml($message);
     }

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -177,7 +177,7 @@ class PluginsArchiver
                         $this->params->getSegment() ? sprintf("(for segment = '%s')", $this->params->getSegment()->getString()) : ''
                     );
                 } catch (Exception $e) {
-                    throw new PluginsArchiverException($e->getMessage() . " - caused by plugin $pluginName", $e->getCode(), $e);
+                    throw new PluginsArchiverException($e->getMessage() . " - in plugin $pluginName", $e->getCode(), $e);
                 }
             } else {
                 Log::debug("PluginsArchiver::%s: Not archiving reports for plugin '%s'.", __FUNCTION__, $pluginName);

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -177,15 +177,7 @@ class PluginsArchiver
                         $this->params->getSegment() ? sprintf("(for segment = '%s')", $this->params->getSegment()->getString()) : ''
                     );
                 } catch (Exception $e) {
-                    $className = get_class($e);
-
-                    if ($className === 'PHPUnit_Framework_Exception' || (class_exists('PHPUnit_Framework_Exception', false) &&  is_subclass_of($className, 'PHPUnit_Framework_Exception'))) {
-                        $exception = new $className($e->getMessage() . " - caused by plugin $pluginName", $e->getCode(), $e->getFile(), $e->getLine(), $e);
-                    } else {
-                        $exception = new $className($e->getMessage() . " - caused by plugin $pluginName", $e->getCode(), $e);
-                    }
-
-                    throw $exception;
+                    throw new PluginsArchiverException($e->getMessage() . " - caused by plugin $pluginName", $e->getCode(), $e);
                 }
             } else {
                 Log::debug("PluginsArchiver::%s: Not archiving reports for plugin '%s'.", __FUNCTION__, $pluginName);

--- a/core/ArchiveProcessor/PluginsArchiverException.php
+++ b/core/ArchiveProcessor/PluginsArchiverException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\ArchiveProcessor;
+
+
+class PluginsArchiverException extends \Exception
+{
+}

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -110,7 +110,7 @@ class FrontController extends Singleton
             'line' => $e->getLine(),
         );
 
-        $error['backtrace'] = 'on ' . $error['file'] . '(' . $error['line'] . ")\n";
+        $error['backtrace'] = ' on ' . $error['file'] . '(' . $error['line'] . ")\n";
         $error['backtrace'] .= $e->getTraceAsString();
 
         $exception = $e;
@@ -241,7 +241,7 @@ class FrontController extends Singleton
     {
         $lastError = error_get_last();
         if (!empty($lastError) && $lastError['type'] == E_ERROR) {
-            $lastError['backtrace'] = 'on ' . $lastError['file'] . '(' . $lastError['line'] . ")\n"
+            $lastError['backtrace'] = ' on ' . $lastError['file'] . '(' . $lastError['line'] . ")\n"
                 . ErrorHandler::getFatalErrorPartialBacktrace();
 
             $message = self::generateSafeModeOutputFromError($lastError);

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -110,7 +110,15 @@ class FrontController extends Singleton
             'line' => $e->getLine(),
         );
 
-        $error['backtrace'] = ' on ' . $error['file'] . '(' . $error['line'] . ")\n" . $e->getTraceAsString();
+        $error['backtrace'] = 'on ' . $error['file'] . '(' . $error['line'] . ")\n";
+        $error['backtrace'] .= $e->getTraceAsString();
+
+        $exception = $e;
+        while ($exception = $exception->getPrevious()) {
+            $error['backtrace'] .= "\ncaused by: " . $exception->getMessage();
+            $error['backtrace'] .= ' on ' . $exception->getFile() . '(' . $exception->getLine() . ")\n";
+            $error['backtrace'] .= $exception->getTraceAsString();
+        }
 
         return self::generateSafeModeOutputFromError($error);
     }
@@ -233,7 +241,7 @@ class FrontController extends Singleton
     {
         $lastError = error_get_last();
         if (!empty($lastError) && $lastError['type'] == E_ERROR) {
-            $lastError['backtrace'] = ' on ' . $lastError['file'] . '(' . $lastError['line'] . ")\n"
+            $lastError['backtrace'] = 'on ' . $lastError['file'] . '(' . $lastError['line'] . ")\n"
                 . ErrorHandler::getFatalErrorPartialBacktrace();
 
             $message = self::generateSafeModeOutputFromError($lastError);

--- a/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
@@ -82,8 +82,8 @@ class PluginsArchiverTest extends IntegrationTestCase
     }
 
     /**
-     * @expectedException \Piwik\Tracker\Db\DbException
-     * @expectedExceptionMessage Failed query foo bar - caused by plugin MyPluginName
+     * @expectedException \Piwik\ArchiveProcessor\PluginsArchiverException
+     * @expectedExceptionMessage Failed query foo bar - in plugin MyPluginName
      * @expectedExceptionCode 42
      */
     public function test_purgeOutdatedArchives_PurgesCorrectTemporaryArchives_WhileKeepingNewerTemporaryArchives_WithBrowserTriggeringEnabled()

--- a/tests/PHPUnit/Integration/FrontControllerTest.php
+++ b/tests/PHPUnit/Integration/FrontControllerTest.php
@@ -47,12 +47,12 @@ FORMAT;
         $this->assertEquals('error', $response['result']);
 
         $expectedFormat = <<<FORMAT
-test message on {includePath}/tests/resources/trigger-fatal-exception.php(23)#0 [internal function]: {closure}('CoreHome', 'index', Array)#1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array)#2 {includePath}/core/Piwik.php(780): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, NULL)#3 {includePath}/core/FrontController.php(536): Piwik\Piwik::postEvent('Request.dispatc...', Array)#4 {includePath}/core/FrontController.php(144): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', NULL)#5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index')#6 {main}
+test message on {includePath}/tests/resources/trigger-fatal-exception.php(23)#0 [internal function]: {closure}('CoreHome', 'index', Array)#1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array)#2 {includePath}/core/Piwik.php(780): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, NULL)#3 {includePath}/core/FrontController.php(544): Piwik\Piwik::postEvent('Request.dispatc...', Array)#4 {includePath}/core/FrontController.php(152): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', NULL)#5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index')#6 {main}
 FORMAT;
 
         if (PHP_MAJOR_VERSION >= 7) {
             $expectedFormat = <<<FORMAT
-test message on {includePath}/tests/resources/trigger-fatal-exception.php(23)#0 [internal function]: {closure}('CoreHome', 'index', Array)#1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array)#2 {includePath}/core/Piwik.php(780): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, Array)#3 {includePath}/core/FrontController.php(536): Piwik\Piwik::postEvent('Request.dispatc...', Array)#4 {includePath}/core/FrontController.php(144): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', Array)#5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index')#6 {main}
+test message on {includePath}/tests/resources/trigger-fatal-exception.php(23)#0 [internal function]: {closure}('CoreHome', 'index', Array)#1 {includePath}/core/EventDispatcher.php(141): call_user_func_array(Object(Closure), Array)#2 {includePath}/core/Piwik.php(780): Piwik\EventDispatcher-&gt;postEvent('Request.dispatc...', Array, false, Array)#3 {includePath}/core/FrontController.php(544): Piwik\Piwik::postEvent('Request.dispatc...', Array)#4 {includePath}/core/FrontController.php(152): Piwik\FrontController-&gt;doDispatch('CoreHome', 'index', Array)#5 {includePath}/tests/resources/trigger-fatal-exception.php(31): Piwik\FrontController-&gt;dispatch('CoreHome', 'index')#6 {main}
 FORMAT;
         }
 


### PR DESCRIPTION
Refs #13466 

Changes:
* When wrapping thrown exception, use custom exception class since thrown exception may not have compatible constructor.
* Add previous exceptions to fatal error info's backtrace property.
* Recongize previous exceptions in API responses as well (so they will appear in core:archive output).