### PR TITLE
Mention the --yes flag in core:update description

### DIFF
--- a/plugins/CoreUpdater/lang/en.json
+++ b/plugins/CoreUpdater/lang/en.json
@@ -80,7 +80,7 @@
         "ExecuteDbUpgrade": "A database upgrade is required. Execute update?",
         "DryRun": "Note: this is a Dry Run",
         "DryRunEnd": "End of Dry Run",
-        "ConsoleCommandDescription": "Triggers upgrades. Use it after Matomo core or any plugin files have been updated.",
+        "ConsoleCommandDescription": "Triggers upgrades. Use it after Matomo core or any plugin files have been updated. Append --yes to upgrade without confirmation.",
         "ConsoleParameterDescription": "Directly execute the update without asking for confirmation",
         "VerifyingUnpackedFiles": "Verifying the unpacked files",
         "WarningMessages": "Warning messages:",


### PR DESCRIPTION
The --yes flag is essential if you want to trigger unattended Matomo
upgrades. This is only mentioned in the Debian package post-install
script:

https://github.com/matomo-org/matomo-package/blob/204f845ddbe3527104994788b6beac1ea6190ece/debian/matomo.postinst#L96

This change adds the --yes flag to the core:update description.

---

I had to try different things like `--no-interaction`, which I thought would work with `core:update`, but it didn't. I had to search and find this issue https://github.com/matomo-org/matomo-package/issues/23, which gave me the idea to search the post-install script of the Debian package.

PS. Are translations handled automatically?