### PR TITLE
Speed up integration tests

### DIFF
--- a/core/Console.php
+++ b/core/Console.php
@@ -85,10 +85,19 @@ class Console extends Application
             $this->addCommandIfExists($command);
         }
 
-        $self = $this;
-        $exitCode = Access::doAsSuperUser(function () use ($input, $output, $self) {
-            return call_user_func(array($self, 'Symfony\Component\Console\Application::doRun'), $input, $output);
-        });
+        $exitCode = null;
+
+        /**
+         * @ignore
+         */
+        Piwik::postEvent('Console.doRun', [&$exitCode, $input, $output]);
+
+        if ($exitCode === null) {
+            $self = $this;
+            $exitCode = Access::doAsSuperUser(function () use ($input, $output, $self) {
+                return call_user_func(array($self, 'Symfony\Component\Console\Application::doRun'), $input, $output);
+            });
+        }
 
         $importantLogDetector = StaticContainer::get(FailureLogMessageDetector::class);
         if ($exitCode === 0 && $importantLogDetector->hasEncounteredImportantLog()) {

--- a/core/View.php
+++ b/core/View.php
@@ -224,15 +224,9 @@ class View implements ViewInterface
         unset($this->templateVars[$name]);
     }
 
-    /** @var Twig */
-    static $twigCached = null;
-
     private function initializeTwig()
     {
-        if (empty(static::$twigCached)) {
-            static::$twigCached = new Twig();
-        }
-        $this->twig = static::$twigCached->getTwigEnvironment();
+        $this->twig = StaticContainer::get(Twig::class)->getTwigEnvironment();
     }
 
     /**
@@ -429,7 +423,7 @@ class View implements ViewInterface
      */
     public static function clearCompiledTemplates()
     {
-        $twig = new Twig();
+        $twig = StaticContainer::get(Twig::class);
         $environment = $twig->getTwigEnvironment();
         $environment->clearTemplateCache();
 

--- a/tests/PHPUnit/Integration/ArchiveWebTest.php
+++ b/tests/PHPUnit/Integration/ArchiveWebTest.php
@@ -13,6 +13,8 @@ use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tests\Fixtures\ManySitesImportedLogs;
 use Piwik\Tests\Framework\Fixture;
 use Exception;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Tests to call the archive.php script via web and check there is no error.
@@ -22,8 +24,6 @@ use Exception;
  */
 class ArchiveWebTest extends SystemTestCase
 {
-    public static $fixture = null; // initialized below class definition
-
     public function test_WebArchiving()
     {
         if (self::isMysqli() && self::isTravisCI()) {
@@ -37,20 +37,15 @@ class ArchiveWebTest extends SystemTestCase
         Option::set('piwikUrl', $host . 'tests/PHPUnit/proxy/index.php');
 
         $url    = $host . 'tests/PHPUnit/proxy/archive.php?token_auth=' . $token;
-        $output = Http::sendHttpRequest($url, 600);
+        $output = Http::sendHttpRequest($url, 6);
 
-        // ignore random build issues
-        if (empty($output) || strpos($output, \Piwik\CronArchive::NO_ERROR) === false) {
-            $this->fail("archive web failed: " . $output . "\n\nurl used: $url");
-        }
+        $this->assertEquals("- 1 ['0' => 'mock output'] [] [idsubtable = ]<br />", $output);
 
         if (!empty($urlTmp)) {
             Option::set('piwikUrl', $urlTmp);
         } else {
             Option::delete('piwikUrl');
         }
-
-        $this->assertWebArchivingDone($output);
 
     }
 
@@ -59,24 +54,7 @@ class ArchiveWebTest extends SystemTestCase
         list($returnCode, $output) = $this->runArchivePhpScriptWithPhpCgi();
 
         $this->assertEquals(0, $returnCode, "Output: " . $output);
-        $this->assertWebArchivingDone($output, $checkArchivedSite = false);
-    }
-
-    private function assertWebArchivingDone($output, $checkArchivedSite = true)
-    {
-        $this->assertContains('Starting Matomo reports archiving...', $output);
-        if ($checkArchivedSite) {
-            $this->assertContains('Archived website id = 1', $output);
-        }
-        $this->assertContains('Done archiving!', $output);
-
-        $this->assertNotContains('ERROR', $output);
-        $this->assertNotContains('WARNING', $output);
-
-        // Check there are enough lines in output
-        $minimumLinesInOutput = 30;
-        $linesInOutput = count( explode(PHP_EOL, $output) );
-        $this->assertGreaterThan($minimumLinesInOutput, $linesInOutput);
+        $this->assertStringStartsWith('mock output', $output);
     }
 
     private function runArchivePhpScriptWithPhpCgi()
@@ -95,9 +73,19 @@ class ArchiveWebTest extends SystemTestCase
         return array(
             'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger'),
             'Tests.log.allowAllHandlers' => true,
+            'observers.global' => [
+                ['API.Request.intercept', function (&$returnedValue, $finalParameters, $pluginName, $methodName, $parametersRequest) {
+                    if ($pluginName == 'CoreAdminHome' && $methodName == 'runCronArchiving') {
+                        $returnedValue = 'mock output';
+                    }
+                }],
+                ['Console.doRun', function (&$exitCode, InputInterface $input, OutputInterface $output) {
+                    if ($input->getFirstArgument() == 'core:archive') {
+                        $output->writeln('mock output');
+                        $exitCode = 0;
+                    }
+                }],
+            ],
         );
     }
 }
-
-ArchiveWebTest::$fixture = new ManySitesImportedLogs();
-ArchiveWebTest::$fixture->addSegments = true;


### PR DESCRIPTION
Changes:
- Make ArchiveWebTest.php less intensive, since the archive.php web script is mostly for BC.
  - Added hidden Console.doRun event that tests can use to intercept console execution.
- In View.php, get Twig instance through DI. In `clearCompiledTemplates()` `Twig` was created as a new instance each time. It only took ~.03s, but this function is called on updates and in plugin manager when a plugin is activated/installed/deactivated/uninstalled. Which means it is run multiple times for each plugin every time a Fixture is setup, and since there are many integration tests this means it is run quite a lot.

In total seems to save > 8mins. Will eventually have to split the build between core & plugins, though.