### PR TITLE
Do not ask for 2fa authentication code when CoreUpdater is being requested

### DIFF
--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -150,6 +150,10 @@ class TwoFactorAuth extends \Piwik\Plugin
             return;
         }
 
+        if ($module === 'CoreUpdater') {
+            return;
+        }
+
         if ($module === Piwik::getLoginPluginName() && $action === 'logout') {
             return;
         }


### PR DESCRIPTION
Could fix an edge case where user is logged in, but hasn't confirmed the auth code (so the user is not actually logged in), and then an update appears.

Also prevents if someone is logged in, then another uses force 2FA, and then update appears for the original user. 