### PR TITLE
Fix possible json encoding error

### DIFF
--- a/core/DataTable/Renderer/Json.php
+++ b/core/DataTable/Renderer/Json.php
@@ -74,7 +74,7 @@ class Json extends Renderer
         $str = @json_encode($array);
 
         if ($str === false && json_last_error() === JSON_ERROR_UTF8) {
-            $str = @json_encode(self::makeArrayUtf8($array));
+            $str = json_encode(self::makeArrayUtf8($array));
         }
 
         return $str;

--- a/core/DataTable/Renderer/Json.php
+++ b/core/DataTable/Renderer/Json.php
@@ -73,7 +73,28 @@ class Json extends Renderer
         // silence "Warning: json_encode(): Invalid UTF-8 sequence in argument"
         $str = @json_encode($array);
 
+        if ($str === false && json_last_error() === JSON_ERROR_UTF8) {
+            $str = @json_encode(self::makeArrayUtf8($array));
+        }
+
         return $str;
+    }
+
+    private static function makeArrayUtf8($array)
+    {
+        if (!function_exists('mb_convert_encoding')) {
+            return $array;
+        }
+
+        if (is_array($array)) {
+            foreach ($array as $key => $value) {
+                $array[$key] = self::makeArrayUtf8($value);
+            }
+        } elseif (is_string($array)) {
+            return mb_convert_encoding($array, 'UTF-8', 'UTF-8');
+        }
+
+        return $array;
     }
 
     public static function sendHeaderJSON()

--- a/core/DataTable/Renderer/Json.php
+++ b/core/DataTable/Renderer/Json.php
@@ -73,25 +73,29 @@ class Json extends Renderer
         // silence "Warning: json_encode(): Invalid UTF-8 sequence in argument"
         $str = @json_encode($array);
 
-        if ($str === false && json_last_error() === JSON_ERROR_UTF8) {
-            $str = json_encode(self::makeArrayUtf8($array));
+        if ($str === false
+            && json_last_error() === JSON_ERROR_UTF8
+            && $this->canMakeArrayUtf8()) {
+            $array = $this->makeArrayUtf8($array);
+            $str = json_encode($array);
         }
 
         return $str;
     }
 
-    private static function makeArrayUtf8($array)
+    private function canMakeArrayUtf8()
     {
-        if (!function_exists('mb_convert_encoding')) {
-            return $array;
-        }
+        return function_exists('mb_convert_encoding');
+    }
 
+    private function makeArrayUtf8($array)
+    {
         if (is_array($array)) {
             foreach ($array as $key => $value) {
                 $array[$key] = self::makeArrayUtf8($value);
             }
         } elseif (is_string($array)) {
-            return mb_convert_encoding($array, 'UTF-8', 'UTF-8');
+            return mb_convert_encoding($array, 'UTF-8', 'auto');
         }
 
         return $array;


### PR DESCRIPTION
some API's in tests don't return a response cause they fail to json_encode because of `Malformed UTF-8 characters, possibly incorrectly encoded`. Tested this fix and it worked for me. Would maybe also need to create a general JSON class for this that always takes care of this in case we have same problem somewhere else? Not sure how good a fix it is as the input might not be utf8?

In test case there was eg `/page/index.htm?q=non unicode keyword ��������";s:7:"segment";s:103:"pageUrl==http%3A%2F%2Fexample.org%2Fpage%2Findex.htm%3Fq%3Dnon+unicode+keyword+%EC%E5%F8%EA%EE%E2%FB%E5";}i` and it was converted to `??????`