### PR TITLE
Start delete log task hourly

### DIFF
--- a/plugins/PrivacyManager/Tasks.php
+++ b/plugins/PrivacyManager/Tasks.php
@@ -40,7 +40,7 @@ class Tasks extends \Piwik\Plugin\Tasks
     public function schedule()
     {
         $this->daily('deleteReportData', null, self::LOW_PRIORITY);
-        $this->daily('deleteLogData', null, self::LOW_PRIORITY);
+        $this->hourly('deleteLogData', null, self::LOW_PRIORITY);
         $this->hourly('anonymizePastData', null, self::LOW_PRIORITY);
         $this->weekly('deleteLogDataForDeletedSites', null, self::LOW_PRIORITY);
     }


### PR DESCRIPTION
This allows plugins to better randomise when a log deletion task should be executed by eg overwriting config ( eg setting `delete_logs_schedule_lowest_interval = "7.1"`.

It won't execute the task any more often otherwise by changing it to hourly because the `deleteLogData` checks when it was last executed. It's super fast this check (reading an option entry) so there is no performance problem by that.