### PR TITLE
Make sure tag manager can only be deactivated, not uninstalled

### DIFF
--- a/core/Application/Kernel/PluginList.php
+++ b/core/Application/Kernel/PluginList.php
@@ -41,7 +41,8 @@ class PluginList
         'ExampleTracker',
         'ExampleReport',
         'MobileAppMeasurable',
-        'Provider'
+        'Provider',
+        'TagManager'
     );
 
     // Themes bundled with core package, disabled by default


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/13835