### PR TITLE
add Themes to System Menu

### DIFF
--- a/plugins/CorePluginsAdmin/Menu.php
+++ b/plugins/CorePluginsAdmin/Menu.php
@@ -67,7 +67,10 @@ class Menu extends \Piwik\Plugin\Menu
         if ($hasSuperUserAcess) {
             $menu->addSystemItem(Piwik::translate('General_Plugins') . $pluginsUpdateMessage,
                 $this->urlForAction('plugins', array('activated' => '')),
-                $order = 20);
+                $order = 18);
+            $menu->addSystemItem(Piwik::translate('CorePluginsAdmin_Themes'),
+                $this->urlForAction('themes'),
+                $order = 19);
         }
     }
 

--- a/plugins/Marketplace/Plugins.php
+++ b/plugins/Marketplace/Plugins.php
@@ -172,7 +172,6 @@ class Plugins
     }
 
     /**
-     * @param bool $themesOnly
      * @return array
      */
     public function getPluginsHavingUpdate()


### PR DESCRIPTION
fixes #13211

I created a PR to get the discussion about #13211 rolling. 
Personally I think most Matomo users are not aware of the fact that you can really easily change the style of Matomo just by switching out a handful of color.
My Matomo plugins that are only useful to a really small amount of people have more downloads than [a theme](https://themes.matomo.org/ClassicTheme) that could be interesting to many Matomo users.

This would also allow creating more Matomo Themes as they would then be seen by more people.
(I think a high contrast accessibility and a dark/night theme would be quite useful)

Regarding the Change: Updates would still be shown in the Plugins menu, but I am not sure if showing them twice is easy to do.