### PR TITLE
Do not show plugins notice when plugins admin is disabled

### DIFF
--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -17,6 +17,7 @@ use Piwik\Menu\MenuTop;
 use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Plugin\ControllerAdmin;
+use Piwik\Plugins\CorePluginsAdmin\CorePluginsAdmin;
 use Piwik\Plugins\Marketplace\Marketplace;
 use Piwik\Plugins\CustomVariables\CustomVariables;
 use Piwik\Plugins\LanguagesManager\LanguagesManager;
@@ -245,6 +246,7 @@ class Controller extends ControllerAdmin
     {
         // Whether to display or not the general settings (cron, beta, smtp)
         $view->isGeneralSettingsAdminEnabled = self::isGeneralSettingsAdminEnabled();
+        $view->isPluginsAdminEnabled = CorePluginsAdmin::isPluginsAdminEnabled();
         if ($view->isGeneralSettingsAdminEnabled) {
             $this->displayWarningIfConfigFileNotWritable();
         }

--- a/plugins/CoreAdminHome/templates/generalSettings.twig
+++ b/plugins/CoreAdminHome/templates/generalSettings.twig
@@ -156,7 +156,8 @@
              ng-model="brandingSettings.enabled"
              ng-change="brandingSettings.toggleCustomLogo()"
              title="{{ 'CoreAdminHome_UseCustomLogo'|translate|e('html_attr') }}"
-             value="{% if branding.use_custom_logo == 1 %}1{% endif %}" inline-help="{{ help|e('html_attr') }}">
+             value="{% if branding.use_custom_logo == 1 %}1{% endif %}"
+             {% if isPluginsAdminEnabled %}inline-help="{{ help|e('html_attr') }}"{% endif %}>
         </div>
 
         <div id="logoSettings" ng-show="brandingSettings.enabled">


### PR DESCRIPTION
The help text currently reads "If you customize the Matomo logo, you might also be interested to hide the "Give us Feedback!" link in the top menu. To do so, you can disable the Feedback plugin in the Manage Plugins page." but this should not be shown when the plugins admin is disabled.