### PR TITLE
Remove no longer existing translation key

### DIFF
--- a/plugins/PrivacyManager/templates/privacySettings.twig
+++ b/plugins/PrivacyManager/templates/privacySettings.twig
@@ -98,7 +98,6 @@
                 </div>
 
                 <div class="alert alert-warning deleteOldLogsWarning" style="width: 50%;" ng-show="deleteOldLogs.enabled">
-                    {{ 'PrivacyManager_DeleteLogDescription2'|translate|raw }}
                     <a href="https://matomo.org/faq/general/#faq_125" rel="noreferrer noopener" target="_blank">
                         {{ 'General_ClickHere'|translate }}
                     </a>


### PR DESCRIPTION
This translation key was removed in https://github.com/matomo-org/matomo/pull/13464/files#diff-a15deb47c9d549824970d1ee811cf124L16 as part of #13464 but forgotten to be removed here as well.