### PR TITLE
Write correct output when a process is skipped

### DIFF
--- a/core/Archiver/Request.php
+++ b/core/Archiver/Request.php
@@ -10,7 +10,12 @@ namespace Piwik\Archiver;
 
 class Request
 {
+    /**
+     * If a request is aborted, the response of a CliMutli job will be a serialized array containing the
+     * key/value "aborted => 1".
+     */
     const ABORT = 'abort';
+
     /**
      * @var string
      */

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -142,7 +142,7 @@ class CliMulti
             if ($shouldStart === Request::ABORT) {
                 // output is needed to ensure same order of url to response
                 $output = new Output($cmdId);
-                $output->write(serialize(array('skipped' => '1', 'nb_visits' => 0)));
+                $output->write(serialize(array('aborted' => '1')));
                 $this->outputs[] = $output;
             } else {
                 $this->executeUrlCommand($cmdId, $url);

--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -142,7 +142,7 @@ class CliMulti
             if ($shouldStart === Request::ABORT) {
                 // output is needed to ensure same order of url to response
                 $output = new Output($cmdId);
-                $output->write('Skipped');
+                $output->write(serialize(array('skipped' => '1', 'nb_visits' => 0)));
                 $this->outputs[] = $output;
             } else {
                 $this->executeUrlCommand($cmdId, $url);


### PR DESCRIPTION
Prevents errors like ` Error unserializing the following response from ?module=API&method=API.get&idSite=1&period=year&date=last3&format=php&trigger=archivephp: Skipped`

When I tested locally it also avoided the message `WARNING [2018-12-16 22:40:18] 5677  piwik/core/Common.php(271): Notice - unserialize(): Error at offset 0 of 7 bytes `

refs DEV-1521

It is unserialized eg here: https://github.com/matomo-org/matomo/blob/3.x-dev/core/CronArchive.php#L867 and then evaluated here: https://github.com/matomo-org/matomo/blob/3.x-dev/core/CronArchive.php#L1433-L1463 (the other one expects an array of array but still works cause of `empty` check)