### PR TITLE
Small performance tweak for MultiSites requests

### DIFF
--- a/plugins/MultiSites/Controller.php
+++ b/plugins/MultiSites/Controller.php
@@ -115,6 +115,7 @@ class Controller extends \Piwik\Plugin\Controller
             $api = "Goals.get";
         }
         $view = $this->getLastUnitGraph($this->pluginName, __FUNCTION__, $api);
+        $view->requestConfig->totals = 0;
         return $this->renderView($view);
     }
 }

--- a/plugins/MultiSites/Dashboard.php
+++ b/plugins/MultiSites/Dashboard.php
@@ -59,6 +59,7 @@ class Dashboard
             'disable_queued_filters' => '1',
             'filter_limit' => '-1',
             'filter_offset' => '0',
+            'totals' => 0
         ], $default = []);
 
         $sites->deleteRow(DataTable::ID_SUMMARY_ROW);


### PR DESCRIPTION
By not processing the totals the report should load a bit faster.

Noticed it while looking into #13839 