### PR TITLE
Do not fetch totals for insights

### DIFF
--- a/core/ViewDataTable/Request.php
+++ b/core/ViewDataTable/Request.php
@@ -71,6 +71,7 @@ class Request
             'filter_column',
             'filter_pattern',
             'flat',
+            'totals',
             'expanded',
             'pivotBy',
             'pivotByColumn',

--- a/core/ViewDataTable/RequestConfig.php
+++ b/core/ViewDataTable/RequestConfig.php
@@ -156,7 +156,7 @@ class RequestConfig
      *
      * Default value: false
      */
-    public $totals = false;
+    public $totals = 0;
 
     /**
      * If set to true, the returned data will contain the first level results, as well as all sub-tables.

--- a/core/ViewDataTable/RequestConfig.php
+++ b/core/ViewDataTable/RequestConfig.php
@@ -151,10 +151,10 @@ class RequestConfig
     public $flat = false;
 
     /**
-     * If set to true, the report may calculate totals information and show percentage values for each row in relative
-     * to the total value.
+     * If set to true or "1", the report may calculate totals information and show percentage values for each row in
+     * relative to the total value.
      *
-     * Default value: false
+     * Default value: 0
      */
     public $totals = 0;
 

--- a/core/ViewDataTable/RequestConfig.php
+++ b/core/ViewDataTable/RequestConfig.php
@@ -156,7 +156,7 @@ class RequestConfig
      *
      * Default value: false
      */
-    public $totals = true;
+    public $totals = false;
 
     /**
      * If set to true, the returned data will contain the first level results, as well as all sub-tables.

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -175,6 +175,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             'disable_generic_filters',
             'columns',
             'flat',
+            'totals',
             'include_aggregate_rows',
             'totalRows',
             'pivotBy',
@@ -1959,6 +1960,7 @@ var switchToHtmlTable = function (dataTable, viewDataTable) {
     delete dataTable.param.filter_sort_column;
     delete dataTable.param.filter_sort_order;
     delete dataTable.param.columns;
+    delete dataTable.param.totals;
     dataTable.reloadAjaxDataTable();
     dataTable.notifyWidgetParametersChange(dataTable.$element, {viewDataTable: viewDataTable});
 };

--- a/plugins/CoreVisualizations/Visualizations/HtmlTable/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable/Config.php
@@ -88,7 +88,7 @@ class Config extends VisualizationConfig
     public $highlight_summary_row = false;
 
     /**
-     * If true, the totals row will be hidden
+     * If true, the totals row will be shown
      *
      * Default value: false
      */

--- a/plugins/CoreVisualizations/Visualizations/HtmlTable/RequestConfig.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable/RequestConfig.php
@@ -38,6 +38,7 @@ class RequestConfig extends VisualizationRequestConfig
 
     public function __construct()
     {
+        $this->totals = true;
         $this->filter_limit = PiwikConfig::getInstance()->General['datatable_default_limit'];
 
         if (Common::getRequestVar('enable_filter_excludelowpop', false) == '1') {

--- a/plugins/Insights/API.php
+++ b/plugins/Insights/API.php
@@ -322,6 +322,7 @@ class API extends \Piwik\Plugin\API
             'period' => $period,
             'format' => 'original',
             'reportUniqueId' => $reportId,
+            'totals' => 0
         );
 
         if (!empty($segment)) {

--- a/plugins/Insights/Model.php
+++ b/plugins/Insights/Model.php
@@ -41,7 +41,8 @@ class Model
             'period' => $period,
             'date'   => $date,
             'filter_limit' => 1000,
-            'showColumns'  => $metric
+            'showColumns'  => $metric,
+            'totals' => 0
         );
 
         if (!empty($segment)) {

--- a/plugins/Insights/Visualizations/Insight.php
+++ b/plugins/Insights/Visualizations/Insight.php
@@ -36,6 +36,8 @@ class Insight extends Visualization
             $this->requestConfig->filter_limit = 10;
         }
 
+        $this->requestConfig->totals = 0;
+
         $report = $this->requestConfig->apiMethodToRequestDataTable;
         $report = str_replace('.', '_', $report);
 

--- a/plugins/Insights/Visualizations/Insight.php
+++ b/plugins/Insights/Visualizations/Insight.php
@@ -36,8 +36,6 @@ class Insight extends Visualization
             $this->requestConfig->filter_limit = 10;
         }
 
-        $this->requestConfig->totals = 0;
-
         $report = $this->requestConfig->apiMethodToRequestDataTable;
         $report = str_replace('.', '_', $report);
 


### PR DESCRIPTION
Got this error warning

> WARNING: Trying to add two strings in DataTable\Row::sumRowArray: 35.8% + 48.6% for row # ['label' =&gt; -2, 'nb_visits' =&gt; 379, 'growth_percent' =&gt; '35.8%', 'growth_percent_numeric' =&gt; '35.8', 'grown' =&gt; 1, 'value_old' =&gt; 162, 'value_new' =&gt; 220, 'difference' =&gt; 58, 'importance' =&gt; 58, 'isDisappeared' =&gt; , 'isNew' =&gt; , 'isMover' =&gt; 1] [] [idsubtable = ]&lt;br /&gt;

The totals row should be only needed for HTML table visualisations. Bar and Pie, etc should not need this totals row and therefore disabled it by default so other visualisations don't need to disable it. Makes viewing reports faster...