### PR TITLE
Prevent possible fatal error when report not found

### DIFF
--- a/plugins/Goals/Pages.php
+++ b/plugins/Goals/Pages.php
@@ -295,6 +295,9 @@ class Pages
                 }
 
                 $widget = $this->createWidgetForReport($report['module'], $report['action']);
+                if (!$widget) {
+                    continue;
+                }
                 if (!empty($report['name'])) {
                     $widget->setName($report['name']);
                 }
@@ -342,8 +345,10 @@ class Pages
     private function createWidgetForReport($module, $action)
     {
         $report = ReportsProvider::factory($module, $action);
-        $factory = new ReportWidgetFactory($report);
-        return $factory->createWidget();
+        if ($report) {
+            $factory = new ReportWidgetFactory($report);
+            return $factory->createWidget();
+        }
     }
 
 }


### PR DESCRIPTION
fix #13883 

I've tried to debug locally and reproduce the issue locally as well as on the actual instance but couldn't reproduce it. Seems some race conditions or so. Happens like once a day only. Also didn't quite understand where the `deep` URL parameter comes from in ` ?module=API&method=API.getWidgetMetadata&filter_limit=-1&format=JSON&deep=1&idSite=2`