### PR TITLE
Better check whether report is cached

### DIFF
--- a/core/Plugin/ReportsProvider.php
+++ b/core/Plugin/ReportsProvider.php
@@ -83,9 +83,9 @@ class ReportsProvider
         $lazyCacheId = CacheId::pluginAware($cacheKey);
 
         $cache = PiwikCache::getLazyCache();
-        if ($cache->contains($lazyCacheId)) {
-            $mapApiToReport = $cache->fetch($lazyCacheId);
-        } else {
+        $mapApiToReport = $cache->fetch($lazyCacheId);
+
+        if (empty($mapApiToReport)) {
             $reports = new static();
             $reports = $reports->getAllReports();
 


### PR DESCRIPTION
refs #13883 and #13892

Checking for `$cache->contains($lazyCacheId)` and then `$cache->fetch($lazyCacheId)` can run into race conditions when the cache expires just in between. I reckon this might be the case for #13892 which we see happening like once a day or every other day.

We would possibly also need to check for other usages. Might not actually be an issue cause the transient is used in the lazy cache as well and it should keep the entry during the same request. It could come to this issue though the first time a cache entry is read.