### PR TITLE
improve RSS fetching

### DIFF
--- a/plugins/RssWidget/RssRenderer.php
+++ b/plugins/RssWidget/RssRenderer.php
@@ -8,6 +8,7 @@
  */
 
 namespace Piwik\Plugins\RssWidget;
+use Piwik\Cache;
 use Piwik\Http;
 
 /**
@@ -19,10 +20,16 @@ class RssRenderer
     protected $count = 3;
     protected $showDescription = false;
     protected $showContent = false;
+    /**
+     * @var Cache\Lazy
+     */
+    private $cache;
+
 
     public function __construct($url)
     {
         $this->url = $url;
+        $this->cache = Cache::getLazyCache();
     }
 
     public function showDescription($bool)
@@ -42,42 +49,50 @@ class RssRenderer
 
     public function get()
     {
-        try {
-            $content = Http::fetchRemoteFile($this->url);
-            $rss = simplexml_load_string($content);
-        } catch (\Exception $e) {
-            throw new \Exception("Error while importing feed: {$e->getMessage()}\n");
-        }
+        $cacheId = 'RSS_' . md5($this->url);
 
-        $output = '<div style="padding:10px 15px;"><ul class="rss">';
-        $i = 0;
+        $output = $this->cache->fetch($cacheId);
 
-        $items = array();
-        if (!empty($rss->channel->item)) {
-            $items = $rss->channel->item;
-        }
-        foreach ($items as $post) {
-            $title = $post->title;
-            $date = @strftime("%B %e, %Y", strtotime($post->pubDate));
-            $link = $post->link;
-
-            $output .= '<li><a class="rss-title" title="" target="_blank" rel="noreferrer noopener" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '">' . $title . '</a>' .
-                '<span class="rss-date">' . $date . '</span>';
-            if ($this->showDescription) {
-                $output .= '<div class="rss-description">' . $post->description . '</div>';
+        if (!$output) {
+            try {
+                $content = Http::fetchRemoteFile($this->url);
+                $rss = simplexml_load_string($content);
+            } catch (\Exception $e) {
+                throw new \Exception("Error while importing feed: {$e->getMessage()}\n");
             }
 
-            if ($this->showContent) {
-                $output .= '<div class="rss-content">' . $post->content . '</div>';
-            }
-            $output .= '</li>';
+            $output = '<div style="padding:10px 15px;"><ul class="rss">';
+            $i = 0;
 
-            if (++$i == $this->count) {
-                break;
+            $items = array();
+            if (!empty($rss->channel->item)) {
+                $items = $rss->channel->item;
             }
+            foreach ($items as $post) {
+                $title = $post->title;
+                $date = @strftime("%B %e, %Y", strtotime($post->pubDate));
+                $link = $post->link;
+
+                $output .= '<li><a class="rss-title" title="" target="_blank" rel="noreferrer noopener" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '">' . $title . '</a>' .
+                    '<span class="rss-date">' . $date . '</span>';
+                if ($this->showDescription) {
+                    $descriptionParts = explode('<p>The post', $post->description); // remove "appeared first on" appendix
+                    $output .= '<div class="rss-description">' . $descriptionParts[0] . '</div>';
+                }
+
+                if ($this->showContent) {
+                    $output .= '<div class="rss-content">' . $post->content . '</div>';
+                }
+                $output .= '</li>';
+
+                if (++$i == $this->count) {
+                    break;
+                }
+            }
+
+            $output .= '</ul></div>';
+            $this->cache->save($cacheId, $output, 60 * 60 * 24);
         }
-
-        $output .= '</ul></div>';
         return $output;
     }
 }

--- a/plugins/RssWidget/RssRenderer.php
+++ b/plugins/RssWidget/RssRenderer.php
@@ -76,8 +76,7 @@ class RssRenderer
                 $output .= '<li><a class="rss-title" title="" target="_blank" rel="noreferrer noopener" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '">' . $title . '</a>' .
                     '<span class="rss-date">' . $date . '</span>';
                 if ($this->showDescription) {
-                    $descriptionParts = explode('<p>The post', $post->description); // remove "appeared first on" appendix
-                    $output .= '<div class="rss-description">' . $descriptionParts[0] . '</div>';
+                    $output .= '<div class="rss-description">' . $post->description . '</div>';
                 }
 
                 if ($this->showContent) {

--- a/plugins/RssWidget/RssRenderer.php
+++ b/plugins/RssWidget/RssRenderer.php
@@ -76,11 +76,11 @@ class RssRenderer
                 $output .= '<li><a class="rss-title" title="" target="_blank" rel="noreferrer noopener" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '">' . $title . '</a>' .
                     '<span class="rss-date">' . $date . '</span>';
                 if ($this->showDescription) {
-                    $output .= '<div class="rss-description">' . $post->description . '</div>';
+                    $output .= '<div class="rss-description">' . $this->addTargetBlankAndNoReferrerToLinks($post->description) . '</div>';
                 }
 
                 if ($this->showContent) {
-                    $output .= '<div class="rss-content">' . $post->content . '</div>';
+                    $output .= '<div class="rss-content">' . $this->addTargetBlankAndNoReferrerToLinks($post->content) . '</div>';
                 }
                 $output .= '</li>';
 
@@ -93,5 +93,10 @@ class RssRenderer
             $this->cache->save($cacheId, $output, 60 * 60 * 24);
         }
         return $output;
+    }
+
+    private function addTargetBlankAndNoReferrerToLinks($content)
+    {
+        return str_replace('<a ', '<a target="_blank" rel="noreferrer noopener"', $content);
     }
 }

--- a/plugins/RssWidget/Widgets/RssChangelog.php
+++ b/plugins/RssWidget/Widgets/RssChangelog.php
@@ -41,13 +41,9 @@ class RssChangelog extends \Piwik\Widget\Widget
     public function render()
     {   
         try {
-            return $this->getFeed('https://feeds.feedburner.com/PiwikReleases');
+            return $this->getFeed('https://matomo.org/changelog/feed');
         } catch (\Exception $e) {
-            try {
-            return $this->getFeed('http://feeds.feedburner.com/PiwikReleases');
-            } catch (\Exception $e) {
-                return $this->error($e);
-            }
+            return $this->error($e);
         }  
     }
 

--- a/plugins/RssWidget/Widgets/RssPiwik.php
+++ b/plugins/RssWidget/Widgets/RssPiwik.php
@@ -39,13 +39,9 @@ class RssPiwik extends \Piwik\Widget\Widget
     public function render()
     {
         try {
-            return $this->getFeed('https://feeds.feedburner.com/Piwik');
+            return $this->getFeed('https://matomo.org/feed/');
         } catch (\Exception $e) {
-            try {
-                return $this->getFeed('http://feeds.feedburner.com/Piwik');
-            } catch (\Exception $e) {
-                return $this->error($e);
-            }
+            return $this->error($e);
         }  
     }
 

--- a/plugins/RssWidget/stylesheets/rss.less
+++ b/plugins/RssWidget/stylesheets/rss.less
@@ -30,6 +30,9 @@
     line-height: 1.5em;
     font-size: 13px;
     color: #333333;
+    .screen-reader-text {
+        display: none;
+    }
 }
 
 /* hide changing blog post title and date in UI test */


### PR DESCRIPTION
Fixes #5214

While we are on the topic of improving old widgets:
- The Matomo RSS feed now includes a `.screen-reader-text` summary directly after `Read More`, which needs to be hidden
- Always use HTTPS
    - it's better to fail than show possibly mitm-ed HTML
- Don't use feedburner
    - this has the huge advantage of not sending data to Google
    - but this means many requests will reach wordpress, and the endpoint would probably need to be cached
    - speaking of caching: I think Matomo should also cache this data locally so that not every reload fetches the data freshly

Semi-related: https://matomo.org/faq/how-to/faq_99/ should also be removed, archived or updated.

BTW: Feedburner adds tracking-pixels to the feed, but only to the content, so Matomo isn't affected