### PR TITLE
Add config setting to disable sending emails.

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -450,6 +450,9 @@ noreply_email_address = "noreply@{DOMAIN}"
 ; standard email name displayed when sending emails. If not set, a default name will be used.
 noreply_email_name = ""
 
+; set to 0 to disable sending of all emails. useful for testing.
+emails_enabled = 1
+
 ; feedback email address;
 ; when testing, use your own email address or "nobody"
 feedback_email_address = "feedback@matomo.org"

--- a/core/Mail.php
+++ b/core/Mail.php
@@ -213,6 +213,10 @@ class Mail extends Zend_Mail
 
     private function shouldSendMail()
     {
+        if (!Config::getInstance()->General['emails_enabled']) {
+            return false;
+        }
+
         $shouldSendMail = true;
 
         $mail = $this;


### PR DESCRIPTION
Tiny change to allow users to make sure no emails are sent out from an instance. Useful if your testing w/ a DB dump that has other people's email addresses, and you don't want to send them spam from the test instance.