### PR TITLE
Do not perform unprocessed segment check in CLI mode.

### DIFF
--- a/plugins/SegmentEditor/SegmentEditor.php
+++ b/plugins/SegmentEditor/SegmentEditor.php
@@ -97,7 +97,9 @@ class SegmentEditor extends \Piwik\Plugin
         }
 
         // don't do check during cron archiving
-        if (SettingsServer::isArchivePhpTriggered()) {
+        if (SettingsServer::isArchivePhpTriggered()
+            || Common::isPhpCliMode()
+        ) {
             return null;
         }
 


### PR DESCRIPTION
Might fix #13466, which I still can't reproduce.