### PR TITLE
Use current segment also in Segmented Visitorlog

### DIFF
--- a/plugins/Live/javascripts/rowaction.js
+++ b/plugins/Live/javascripts/rowaction.js
@@ -67,6 +67,10 @@
     DataTable_RowActions_SegmentVisitorLog.prototype.trigger = function (tr, e, subTableLabel) {
         var segment = getRawSegmentValueFromRow(tr);
 
+        if (this.dataTable.param.segment) {
+            segment = decodeURIComponent(this.dataTable.param.segment) + ';' + segment;
+        }
+
         this.performAction(segment, tr, e);
     };
 


### PR DESCRIPTION
this simple change should be enough so append the current (global) segment to the segment of the segmented visitor log.

fixes #13344