### PR TITLE
Implements a rate limit for password resets

### DIFF
--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -462,7 +462,7 @@ class PasswordResetter
      */
     private function savePasswordResetInfo($login, $newPassword, $keySuffix)
     {
-        $optionName = $this->getPasswordResetInfoOptionName($login);
+        $optionName = self::getPasswordResetInfoOptionName($login);
 
         $existingResetInfo = Option::get($optionName);
 

--- a/plugins/Login/lang/en.json
+++ b/plugins/Login/lang/en.json
@@ -36,7 +36,7 @@
         "PasswordChanged": "Your password has been changed.",
         "PasswordRepeat": "Password (repeat)",
         "PasswordsDoNotMatch": "Passwords do not match.",
-        "PasswordResetAlreadySent": "A password reset was already requested shortly. A new request can be made in one hour. If you have problems resetting your password, please contact you administrator for help.",
+        "PasswordResetAlreadySent": "You have requested too many password resets shortly. A new request can be made in one hour. If you have problems resetting your password, please contact you administrator for help.",
         "WrongPasswordEntered": "Please enter your correct password.",
         "ConfirmPasswordToContinue": "Confirm your password to continue",
         "PluginDescription": "Provides authentication via username and password as well as password reset functionality. Authentication method can be changed by using another Login plugin such as LoginLdap available on the Marketplace.",

--- a/plugins/Login/lang/en.json
+++ b/plugins/Login/lang/en.json
@@ -36,7 +36,7 @@
         "PasswordChanged": "Your password has been changed.",
         "PasswordRepeat": "Password (repeat)",
         "PasswordsDoNotMatch": "Passwords do not match.",
-        "PasswordResetAlreadySent": "A password reset was already requested shortly. If you have problems resetting your password, please contact you administrator for help.",
+        "PasswordResetAlreadySent": "A password reset was already requested shortly. A new request can be made in one hour. If you have problems resetting your password, please contact you administrator for help.",
         "WrongPasswordEntered": "Please enter your correct password.",
         "ConfirmPasswordToContinue": "Confirm your password to continue",
         "PluginDescription": "Provides authentication via username and password as well as password reset functionality. Authentication method can be changed by using another Login plugin such as LoginLdap available on the Marketplace.",

--- a/plugins/Login/lang/en.json
+++ b/plugins/Login/lang/en.json
@@ -36,6 +36,7 @@
         "PasswordChanged": "Your password has been changed.",
         "PasswordRepeat": "Password (repeat)",
         "PasswordsDoNotMatch": "Passwords do not match.",
+        "PasswordResetAlreadySent": "A password reset was already requested shortly. If you have problems resetting your password, please contact you administrator for help.",
         "WrongPasswordEntered": "Please enter your correct password.",
         "ConfirmPasswordToContinue": "Confirm your password to continue",
         "PluginDescription": "Provides authentication via username and password as well as password reset functionality. Authentication method can be changed by using another Login plugin such as LoginLdap available on the Marketplace.",


### PR DESCRIPTION
currently only prevents from requesting new password resets within one hour. Maybe we could even increase the time limit.

fixes #13813 