### PR TITLE
Add extra plugins to load to test env manipulators fake plugin list.

### DIFF
--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -147,8 +147,6 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
     {
         $testVarDefinitionSource = new TestingEnvironmentVariablesDefinitionSource();
 
-        $fixturePluginsToLoad = [];
-
         $diConfigs = array($testVarDefinitionSource);
         if ($this->vars->testCaseClass) {
             $testCaseClass = $this->vars->testCaseClass;
@@ -158,7 +156,6 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
                 // Apply DI config from the fixture
                 if (isset($testCaseClass::$fixture)) {
                     $diConfigs[] = $testCaseClass::$fixture->provideContainerConfig();
-                    $fixturePluginsToLoad = $testCaseClass::$fixture->extraPluginsToLoad;
                 }
 
                 if (method_exists($testCaseClass, 'provideContainerConfigBeforeClass')) {
@@ -174,7 +171,6 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
 
             if ($this->classExists($fixtureClass)) {
                 $fixture = new $fixtureClass();
-                $fixturePluginsToLoad = $fixture->extraPluginsToLoad;
 
                 if (method_exists($fixture, 'provideContainerConfig')) {
                     $diConfigs[] = $fixture->provideContainerConfig();
@@ -182,7 +178,7 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
             }
         }
 
-        $plugins = $this->getPluginsToLoadDuringTest($fixturePluginsToLoad);
+        $plugins = $this->getPluginsToLoadDuringTest();
         $diConfigs[] = array(
             'observers.global' => \DI\add($this->globalObservers),
 
@@ -212,10 +208,27 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
         return $result;
     }
 
-    private function getPluginsToLoadDuringTest($fixtureExtraPlugins = [])
+    private function getPluginsToLoadDuringTest()
     {
         $plugins = $this->vars->getCoreAndSupportedPlugins();
         $plugins[] = 'TagManager';
+
+        $fixturePluginsToLoad = [];
+
+        if ($this->vars->testCaseClass) {
+            $testCaseClass = $this->vars->testCaseClass;
+            if ($this->classExists($testCaseClass)) {
+                if (isset($testCaseClass::$fixture)) {
+                    $fixturePluginsToLoad = $testCaseClass::$fixture->extraPluginsToLoad;
+                }
+            }
+        } else if ($this->vars->fixtureClass) {
+            $fixtureClass = $this->vars->fixtureClass;
+            if ($this->classExists($fixtureClass)) {
+                $fixture = new $fixtureClass();
+                $fixturePluginsToLoad = $fixture->extraPluginsToLoad;
+            }
+        }
 
         // make sure the plugin that executed this method is included in the plugins to load
         $extraPlugins = array_merge(
@@ -227,7 +240,7 @@ class TestingEnvironmentManipulator implements EnvironmentManipulator
                 Plugin::getPluginNameFromNamespace($this->vars->fixtureClass),
                 Plugin::getPluginNameFromNamespace(get_called_class())
             ),
-            $fixtureExtraPlugins
+            $fixturePluginsToLoad
         );
 
         foreach ($extraPlugins as $pluginName) {


### PR DESCRIPTION
This way plugins are added to the list when the DI container is created, so DI config for plugins will be loaded during tests when Fixture::$extraPluginsToLoad is set.