### PR TITLE
Do not wrap date range label in period selector

### DIFF
--- a/plugins/Morpheus/stylesheets/uibase/_periodSelect.less
+++ b/plugins/Morpheus/stylesheets/uibase/_periodSelect.less
@@ -71,6 +71,7 @@
 
 #periodString .period-type label {
   font-size: 13px;
+  white-space: nowrap;
 }
 
 #periodString label.selected-period-label {


### PR DESCRIPTION
fixes #13954 

Just to point it out. In some languages "date range" is a bit longer and thus the date selector will get a bit wider:

![image](https://user-images.githubusercontent.com/1579355/51102109-007ecf80-17de-11e9-954f-42d596396a45.png)
