### PR TITLE
Disable Transitions feature for totals row

### DIFF
--- a/plugins/Transitions/javascripts/transitions.js
+++ b/plugins/Transitions/javascripts/transitions.js
@@ -129,7 +129,7 @@ DataTable_RowActions_Registry.register({
     },
 
     isAvailableOnRow: function (dataTableParams, tr) {
-        if (tr.hasClass('subDataTable')) {
+        if (tr.hasClass('subDataTable') || tr.hasClass('totalsRow')) {
             // not available on groups (i.e. folders)
             return false;
         }


### PR DESCRIPTION
The page title reports currently display the transitions icon for the totals row.