### PR TITLE
Skip downloading discontinued GeoLite databases without an error

### DIFF
--- a/plugins/UserCountry/GeoIPAutoUpdater.php
+++ b/plugins/UserCountry/GeoIPAutoUpdater.php
@@ -137,6 +137,11 @@ class GeoIPAutoUpdater extends Task
     {
         $url = trim($url);
 
+        if (strpos($url, 'GeoLite')) {
+            Log::info('GeoLite databases have been discontinued. Skipping download of '.$url.'. Consider switching to GeoIP 2.');
+            return;
+        }
+
         $ext = GeoIPAutoUpdater::getGeoIPUrlExtension($url);
 
         // NOTE: using the first item in $dbNames[$dbType] makes sure GeoLiteCity will be renamed to GeoIPCity


### PR DESCRIPTION
As the databases are now longer available the Task will always fail if configured to download a GeoLite database, This would also cause `core:archive` to exit with an error.

For the next release we should guide users still using GeoLite to use GeoIP 2 instead in the UI.

refs #13957