### PR TITLE
Apply AddSegmentBySegmentValue filter recursive

### DIFF
--- a/core/DataTable/Filter/AddSegmentBySegmentValue.php
+++ b/core/DataTable/Filter/AddSegmentBySegmentValue.php
@@ -62,6 +62,8 @@ class AddSegmentBySegmentValue extends BaseFilter
             return;
         }
 
+        $this->enableRecursive(true);
+
         /** @var \Piwik\Plugin\Segment $segment */
         $segment     = reset($segments);
         $segmentName = $segment->getSegment();
@@ -73,6 +75,8 @@ class AddSegmentBySegmentValue extends BaseFilter
             if ($value !== false && $filter === false) {
                 $row->setMetadata('segment', sprintf('%s==%s', $segmentName, urlencode($value)));
             }
+
+            $this->filterSubTable($row);
         }
     }
 }


### PR DESCRIPTION
When a datatable is loaded expanded the `segmentValue` metadata won't be converted into `segment` metadata for all subtables. This is also the case when search in action subtables as described in #11849.

fixes #11849 
