### PR TITLE
Don't cache tag manager preview files

### DIFF
--- a/plugins/Installation/ServerFilesGenerator.php
+++ b/plugins/Installation/ServerFilesGenerator.php
@@ -54,7 +54,9 @@ class ServerFilesGenerator
         $noCachePreview = "
 # do not cache preview container files
 <Files  ~ \"^container_.*_preview\.js$\">
+<IfModule mod_headers.c>
 Header set Cache-Control \"Cache-Control: private, no-cache, no-store\"
+</IfModule>
 </Files>";
 
         $directoriesToProtect = array(

--- a/plugins/Installation/ServerFilesGenerator.php
+++ b/plugins/Installation/ServerFilesGenerator.php
@@ -51,8 +51,14 @@ class ServerFilesGenerator
             $allow . "\n" .
             "</Files>\n";
 
+        $noCachePreview = "
+# do not cache preview container files
+<Files  ~ \"^container_.*_preview\.js$\">
+Header set Cache-Control \"Cache-Control: private, no-cache, no-store\"
+</Files>";
+
         $directoriesToProtect = array(
-            '/js'        => $allowAny,
+            '/js'        => $allowAny . $noCachePreview,
             '/libs'      => $denyAll . $allowStaticAssets,
             '/vendor'    => $denyAll . $allowStaticAssets,
             '/plugins'   => $denyAll . $allowStaticAssets,


### PR DESCRIPTION
Not sure if this will work across apache versions? Tested on Apache 2.2

Prevents preview files from being cached in the browser and that always the newest version will be served. Otherwise the user will need to use ctrl+r or something to reload a page that includes a preview file to make sure the cache is ignored and many users would not know that.

refs https://github.com/matomo-org/tag-manager/pull/150
for Nginx see https://github.com/matomo-org/matomo-nginx/issues/48