### PR TITLE
Serialize scalars and objects in original format.

### DIFF
--- a/plugins/API/Renderer/Original.php
+++ b/plugins/API/Renderer/Original.php
@@ -50,12 +50,12 @@ class Original extends ApiRenderer
 
     public function renderScalar($scalar)
     {
-        return $scalar;
+        return $this->serializeIfNeeded($scalar);
     }
 
     public function renderObject($object)
     {
-        return $object;
+        return $this->serializeIfNeeded($object);
     }
 
     public function renderResource($resource)

--- a/tests/PHPUnit/System/OneVisitorTwoVisitsTest.php
+++ b/tests/PHPUnit/System/OneVisitorTwoVisitsTest.php
@@ -94,6 +94,14 @@ class OneVisitorTwoVisitsTest extends SystemTestCase
                 ),
                 'onlyCheckUnserialize' => true,
             )),
+            array('Live.getMostRecentVisitorId', array('idSite' => $idSite,
+                'date' => $dateTime,
+                'format' => 'original',
+                'otherRequestParameters' => array(
+                    'serialize' => '1',
+                ),
+                'onlyCheckUnserialize' => true,
+            )),
 
             // test API.get (for bug that incorrectly reorders columns of CSV output)
             //   note: bug only affects rows after first


### PR DESCRIPTION
Will change the API for format=original&serialize=1 for scalar values & objects (not sure if that's an issue).