### PR TITLE
Allow DataTables to disable generic filters gthrough a datatable metadata.

### DIFF
--- a/core/API/DataTableGenericFilter.php
+++ b/core/API/DataTableGenericFilter.php
@@ -155,6 +155,7 @@ class DataTableGenericFilter
             return;
         }
 
+        $tableDisabledFilters = $datatable->getMetadata(DataTable::GENERIC_FILTERS_TO_DISABLE_METADATA_NAME) ?: [];
         $genericFilters = $this->getGenericFiltersHavingDefaultValues();
 
         $filterApplied = false;
@@ -164,7 +165,9 @@ class DataTableGenericFilter
             $filterParameters = array();
             $exceptionRaised = false;
 
-            if (in_array($filterName, $this->disabledFilters)) {
+            if (in_array($filterName, $this->disabledFilters)
+                || in_array($filterName, $tableDisabledFilters)
+            ) {
                 continue;
             }
 

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -192,6 +192,11 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
      */
     const COLUMN_AGGREGATION_OPS_METADATA_NAME = 'column_aggregation_ops';
 
+    /**
+     * Name for metadata that stores array of generic filters that should not be run on the table.
+     */
+    const GENERIC_FILTERS_TO_DISABLE_METADATA_NAME = 'generic_filters_to_disable';
+
     /** The ID of the Summary Row. */
     const ID_SUMMARY_ROW = -1;
 

--- a/tests/PHPUnit/Unit/API/DataTableGenericFilterTest.php
+++ b/tests/PHPUnit/Unit/API/DataTableGenericFilterTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Tests\Unit\API;
+
+use Piwik\API\DataTableGenericFilter;
+use Piwik\DataTable;
+
+class DataTableGenericFilterTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_genericFiltersToDisableMetadata_shouldBeRespected()
+    {
+        $dataTable = new DataTable();
+        $dataTable->addRowsFromSimpleArray([
+            ['nb_visits' => 2, 'nb_actions' => 3],
+            ['nb_visits' => 4, 'nb_actions' => 5],
+        ]);
+        $dataTable->setMetadata(DataTable::GENERIC_FILTERS_TO_DISABLE_METADATA_NAME, ['Limit']);
+
+        $genericFilter = new DataTableGenericFilter(['filter_limit' => 1], null);
+        $genericFilter->filter($dataTable);
+
+        $this->assertEquals(2, $dataTable->getRowsCount());
+    }
+}


### PR DESCRIPTION
This is specifically for ProxySite where reports will request a filter_limit/offset, and the target instance will apply it once, and we don't want to apply it a second time in the proxy instance.

The alternative is to always send filter_limit=-1 and apply the limit in the proxy instance, but that would mean a lot of data transfer. Especially for Live APIs, which just time out for me (of course they would).