### PR TITLE
Show url and page title on different lines in realtime visits widget & show tooltip more quickly

### DIFF
--- a/plugins/CoreHome/angularjs/widget/widget.directive.js
+++ b/plugins/CoreHome/angularjs/widget/widget.directive.js
@@ -109,7 +109,7 @@
                             var title = $(this).attr('title');
                             return piwikHelper.escape(title.replace(/\n/g, '<br />'));
                         },
-                        show: {delay: 700, duration: 200},
+                        show: {delay: 100, duration: 200},
                         hide: false
                     });
 

--- a/plugins/CoreHome/angularjs/widget/widget.directive.js
+++ b/plugins/CoreHome/angularjs/widget/widget.directive.js
@@ -109,7 +109,7 @@
                             var title = $(this).attr('title');
                             return piwikHelper.escape(title.replace(/\n/g, '<br />'));
                         },
-                        show: {delay: 100, duration: 200},
+                        show: {delay: 700, duration: 200},
                         hide: false
                     });
 

--- a/plugins/Live/templates/getLastVisitsStart.twig
+++ b/plugins/Live/templates/getLastVisitsStart.twig
@@ -85,7 +85,7 @@
 {{ action.serverTimePretty }}
 {% if action.timeSpentPretty is defined %}{{ 'General_TimeOnPage'|translate }}: {{ action.timeSpentPretty|raw }}{% endif %}
 {%- endset %}
-                                    <img src="plugins/Live/images/file{{ col }}.png" title="{{ action.url|e('html_attr') }}&mdash;{{- title -}}"/>
+                                    <img src="plugins/Live/images/file{{ col }}.png" title="{{ action.url|truncate(120)|e('html_attr') }}<br/>{{- title -}}"/>
                                 {% elseif action.type == 'outlink' or action.type == 'download' %}
                                     <img class='iconPadding' src="{{ action.icon }}"
                                          title="{% if action.url is defined %}{{ action.url }} - {% endif %}{{ action.serverTimePretty }}"/>

--- a/plugins/Live/templates/getLastVisitsStart.twig
+++ b/plugins/Live/templates/getLastVisitsStart.twig
@@ -85,7 +85,7 @@
 {{ action.serverTimePretty }}
 {% if action.timeSpentPretty is defined %}{{ 'General_TimeOnPage'|translate }}: {{ action.timeSpentPretty|raw }}{% endif %}
 {%- endset %}
-                                    <img src="plugins/Live/images/file{{ col }}.png" title="{{ action.url|e('html_attr') }}<br/>{{- title -}}"/>
+                                    <img src="plugins/Live/images/file{{ col }}.png" title="{% if action.url|trim is not empty %}{{ action.url|e('html_attr') }}<br/>{% endif %}{{- title -}}"/>
                                 {% elseif action.type == 'outlink' or action.type == 'download' %}
                                     <img class='iconPadding' src="{{ action.icon }}"
                                          title="{% if action.url is defined %}{{ action.url }} - {% endif %}{{ action.serverTimePretty }}"/>

--- a/plugins/Live/templates/getLastVisitsStart.twig
+++ b/plugins/Live/templates/getLastVisitsStart.twig
@@ -85,7 +85,7 @@
 {{ action.serverTimePretty }}
 {% if action.timeSpentPretty is defined %}{{ 'General_TimeOnPage'|translate }}: {{ action.timeSpentPretty|raw }}{% endif %}
 {%- endset %}
-                                    <img src="plugins/Live/images/file{{ col }}.png" title="{{ action.url|truncate(120)|e('html_attr') }}<br/>{{- title -}}"/>
+                                    <img src="plugins/Live/images/file{{ col }}.png" title="{{ action.url|e('html_attr') }}<br/>{{- title -}}"/>
                                 {% elseif action.type == 'outlink' or action.type == 'download' %}
                                     <img class='iconPadding' src="{{ action.icon }}"
                                          title="{% if action.url is defined %}{{ action.url }} - {% endif %}{{ action.serverTimePretty }}"/>

--- a/plugins/Live/templates/getLastVisitsStart.twig
+++ b/plugins/Live/templates/getLastVisitsStart.twig
@@ -115,9 +115,19 @@
     {% endfor %}
 </ul>
 <script type="text/javascript">
-$('#visitsLive').on('click', '.visits-live-launch-visitor-profile', function (e) {
-    e.preventDefault();
-    broadcast.propagateNewPopoverParameter('visitorProfile', $(this).attr('data-visitor-id'));
-    return false;
+$(function () {
+    $('#visitsLive').on('click', '.visits-live-launch-visitor-profile', function (e) {
+        e.preventDefault();
+        broadcast.propagateNewPopoverParameter('visitorProfile', $(this).attr('data-visitor-id'));
+        return false;
+    }).tooltip({
+        track: true,
+        content: function() {
+            var title = $(this).attr('title');
+            return piwikHelper.escape(title.replace(/\n/g, '<br />'));
+        },
+        show: {delay: 100, duration: 0},
+        hide: false
+    });
 });
 </script>


### PR DESCRIPTION
Also truncates url to 120 chars.

The tooltip delay is reduced to 100ms. I couldn't reproduce the stuck tooltip issue yhat the delay fixed, so hoping it will be ok.

Fixes #13991 