### PR TITLE
When running cron jobs or console commands, and 2FA is forced for everyone, do not fail

### DIFF
--- a/plugins/TwoFactorAuth/Validator.php
+++ b/plugins/TwoFactorAuth/Validator.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\TwoFactorAuth;
 
+use Piwik\Common;
 use Piwik\Piwik;
 use Piwik\Session\SessionFingerprint;
 use Exception;

--- a/plugins/TwoFactorAuth/Validator.php
+++ b/plugins/TwoFactorAuth/Validator.php
@@ -27,6 +27,11 @@ class Validator
 
     public function canUseTwoFa()
     {
+        if (Common::isPhpCliMode() && (!defined('PIWIK_TEST_MODE') || !PIWIK_TEST_MODE)) {
+            // eg when archiving or executing other commands
+            return false;
+        }
+
         if (!SettingsPiwik::isPiwikInstalled()) {
             return false;
         }


### PR DESCRIPTION
For tests we still enable 2FA as otherwise things wouldn't really be testable.

fixes https://forum.matomo.org/t/global-2fa-prevents-cron-task-to-finish/31367