### PR TITLE
Do not render until form is initialized

### DIFF
--- a/plugins/ScheduledReports/angularjs/manage-scheduled-report/manage-scheduled-report.controller.js
+++ b/plugins/ScheduledReports/angularjs/manage-scheduled-report/manage-scheduled-report.controller.js
@@ -79,12 +79,14 @@
             report.hour = adjustHourToTimezone(report.hour, getTimeZoneDifferenceInHours());
             updateReportHourUtc(report);
 
-            $('[name=reportsList] input').prop('checked', false);
+            setTimeout(function() {
+              $('[name=reportsList] input').prop('checked', false);
 
-            var key;
-            for (key in report.reports) {
-                $('.' + report.type + ' [report-unique-id=' + report.reports[key] + ']').prop('checked', 'checked');
-            }
+              var key;
+              for (key in report.reports) {
+                  $('.' + report.type + ' [report-unique-id=' + report.reports[key] + ']').prop('checked', 'checked');
+              }
+            });
 
             report['format' + report.type] = report.format;
 

--- a/plugins/ScheduledReports/templates/_addReport.twig
+++ b/plugins/ScheduledReports/templates/_addReport.twig
@@ -1,7 +1,7 @@
 <div piwik-content-block
      content-title="{{ 'ScheduledReports_CreateAndScheduleReport'|translate|e('html_attr') }}"
      class="entityAddContainer"
-     ng-show="manageScheduledReport.showReportForm">
+     ng-if="manageScheduledReport.showReportForm">
     <div class='clear'></div>
     <form id='addEditReport' piwik-form ng-submit="manageScheduledReport.submitReport()">
 

--- a/tests/UI/expected-screenshots/UIIntegrationTest_email_reports_editor.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_email_reports_editor.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6f0fe13093cb06d1050f5bfae9466fa61e30215e9789082f43fbfe11832c00c
-size 422332
+oid sha256:ea78e575be04020ba6d1f8fe232020c425794a558e3ccbd28fdc8400eaa8d0f2
+size 421862


### PR DESCRIPTION
The email report list page throws a lot of JS errors:

![image](https://user-images.githubusercontent.com/111346/51640482-e1add500-1f63-11e9-8ac1-1a25e261dedb.png)


The reason is that the add report form is rendered (though not visibly), but it is not initialised until it is opened.