### PR TITLE
Change session cookie name to MATOMO_SESSID

### DIFF
--- a/core/Session.php
+++ b/core/Session.php
@@ -19,16 +19,11 @@ use Zend_Session;
  */
 class Session extends Zend_Session
 {
-    const SESSION_NAME = 'PIWIK_SESSID';
+    const SESSION_NAME = 'MATOMO_SESSID';
 
     public static $sessionName = self::SESSION_NAME;
 
     protected static $sessionStarted = false;
-
-    /**
-     * @var string
-     */
-    private static $originalCookiePath;
 
     /**
      * Are we using file-based session store?
@@ -86,7 +81,6 @@ class Session extends Zend_Session
         // the session data won't be deleted until the cookie expires.
         @ini_set('session.gc_maxlifetime', $config->General['login_cookie_expire']);
 
-        self::$originalCookiePath = ini_get('session.cookie_path');
         @ini_set('session.cookie_path', empty($config->General['login_cookie_path']) ? '/' : $config->General['login_cookie_path']);
 
         $currentSaveHandler = ini_get('session.save_handler');
@@ -177,16 +171,5 @@ class Session extends Zend_Session
     public static function isSessionStarted()
     {
         return self::$sessionStarted;
-    }
-
-    public static function isIniConfigCookiePathSameAsPhpCookiePath()
-    {
-        return ini_get('session.cookie_path') == self::$originalCookiePath;
-    }
-
-    public static function clearExistingSessionCookie()
-    {
-        $cookie = new Cookie(self::SESSION_NAME, $expire = null, self::$originalCookiePath);
-        $cookie->delete();
     }
 }

--- a/core/Session.php
+++ b/core/Session.php
@@ -26,6 +26,11 @@ class Session extends Zend_Session
     protected static $sessionStarted = false;
 
     /**
+     * @var string
+     */
+    private static $originalCookiePath;
+
+    /**
      * Are we using file-based session store?
      *
      * @return bool  True if file-based; false otherwise
@@ -81,6 +86,7 @@ class Session extends Zend_Session
         // the session data won't be deleted until the cookie expires.
         @ini_set('session.gc_maxlifetime', $config->General['login_cookie_expire']);
 
+        self::$originalCookiePath = ini_get('session.cookie_path');
         @ini_set('session.cookie_path', empty($config->General['login_cookie_path']) ? '/' : $config->General['login_cookie_path']);
 
         $currentSaveHandler = ini_get('session.save_handler');
@@ -171,5 +177,16 @@ class Session extends Zend_Session
     public static function isSessionStarted()
     {
         return self::$sessionStarted;
+    }
+
+    public static function isIniConfigCookiePathSameAsPhpCookiePath()
+    {
+        return Config::getInstance()->General['login_cookie_path'] == self::$originalCookiePath;
+    }
+
+    public static function clearExistingSessionCookie()
+    {
+        $cookie = new Cookie(self::SESSION_NAME, $expire = null, self::$originalCookiePath);
+        $cookie->delete();
     }
 }

--- a/core/Session.php
+++ b/core/Session.php
@@ -181,7 +181,7 @@ class Session extends Zend_Session
 
     public static function isIniConfigCookiePathSameAsPhpCookiePath()
     {
-        return Config::getInstance()->General['login_cookie_path'] == self::$originalCookiePath;
+        return ini_get('session.cookie_path') == self::$originalCookiePath;
     }
 
     public static function clearExistingSessionCookie()

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -125,12 +125,6 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
      */
     function login($messageNoAccess = null, $infoMessage = false)
     {
-        if ($_SERVER['REQUEST_METHOD'] != 'POST'
-            && !Session::isIniConfigCookiePathSameAsPhpCookiePath()
-        ) {
-            Session::clearExistingSessionCookie();
-        }
-
         $form = new FormLogin();
         $form->removeAttribute('action'); // remove action attribute, otherwise hash part will be lost
         if ($form->validate()) {

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -125,7 +125,9 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
      */
     function login($messageNoAccess = null, $infoMessage = false)
     {
-        if (!Session::isIniConfigCookiePathSameAsPhpCookiePath()) {
+        if ($_SERVER['REQUEST_METHOD'] != 'POST'
+            && !Session::isIniConfigCookiePathSameAsPhpCookiePath()
+        ) {
             Session::clearExistingSessionCookie();
         }
 

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -125,6 +125,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
      */
     function login($messageNoAccess = null, $infoMessage = false)
     {
+        if (!Session::isIniConfigCookiePathSameAsPhpCookiePath()) {
+            Session::clearExistingSessionCookie();
+        }
+
         $form = new FormLogin();
         $form->removeAttribute('action'); // remove action attribute, otherwise hash part will be lost
         if ($form->validate()) {


### PR DESCRIPTION
Only done in the Login controller so should not be done on every request.

Tested w/ a PHP INI config that set the cookie path to a subdirectory and was able to verify this fixed the issue.

h/t to @GreenReaper for identifying the issue (at least it seems likely this is the case).