### PR TITLE
Make more links clickable in New releases notification emails

### DIFF
--- a/plugins/CoreUpdater/templates/_updateCommunicationEmail.twig
+++ b/plugins/CoreUpdater/templates/_updateCommunicationEmail.twig
@@ -3,7 +3,7 @@
 <p>{{ 'CoreUpdater_ThereIsNewVersionAvailableForUpdate'|translate }}</p>
 
 <p>{{ 'CoreUpdater_YouCanUpgradeAutomaticallyOrDownloadPackage'|translate(latestVersion) }}<br/>
-<a href="{{ host }}index.php?module=CoreUpdater&action=newVersionAvailable">{{ host }}index.php?module=CoreUpdater&action=newVersionAvailable</a>
+<a href="{{ host|e('html_attr') }}index.php?module=CoreUpdater&action=newVersionAvailable">{{ host }}index.php?module=CoreUpdater&action=newVersionAvailable</a>
 </p>
 
 {% if isStableVersion %}

--- a/plugins/CoreUpdater/templates/_updateCommunicationEmail.twig
+++ b/plugins/CoreUpdater/templates/_updateCommunicationEmail.twig
@@ -3,16 +3,16 @@
 <p>{{ 'CoreUpdater_ThereIsNewVersionAvailableForUpdate'|translate }}</p>
 
 <p>{{ 'CoreUpdater_YouCanUpgradeAutomaticallyOrDownloadPackage'|translate(latestVersion) }}<br/>
-{{ host }}index.php?module=CoreUpdater&action=newVersionAvailable
+<a href="{{ host }}index.php?module=CoreUpdater&action=newVersionAvailable">{{ host }}index.php?module=CoreUpdater&action=newVersionAvailable</a>
 </p>
 
 {% if isStableVersion %}
 <p>
     {{ 'CoreUpdater_ViewVersionChangelog'|translate }}
     <br/>
-    {{ linkToChangeLog }}
+    <a href="{{ linkToChangeLog }}">{{ linkToChangeLog }}</a>
 </p>
 {% endif %}
 
 <p>{{ 'CoreUpdater_ReceiveEmailBecauseIsSuperUser'|translate(host) }}</p>
-<p>{{ 'CoreUpdater_FeedbackRequest'|translate }}<br/>https://matomo.org/contact/</p>
+<p>{{ 'CoreUpdater_FeedbackRequest'|translate }}<br/><a href="https://matomo.org/contact/">https://matomo.org/contact/</a></p>

--- a/plugins/CoreUpdater/templates/_updateCommunicationEmail.twig
+++ b/plugins/CoreUpdater/templates/_updateCommunicationEmail.twig
@@ -10,7 +10,7 @@
 <p>
     {{ 'CoreUpdater_ViewVersionChangelog'|translate }}
     <br/>
-    <a href="{{ linkToChangeLog }}">{{ linkToChangeLog }}</a>
+    <a href="{{ linkToChangeLog|safelink|e('html_attr') }}">{{ linkToChangeLog }}</a>
 </p>
 {% endif %}
 


### PR DESCRIPTION
Links in the (new?) notification email are no longer clickable.