### PR TITLE
Don't hardcode plugins directory

### DIFF
--- a/core/API/Proxy.php
+++ b/core/API/Proxy.php
@@ -13,6 +13,7 @@ use Exception;
 use Piwik\Common;
 use Piwik\Context;
 use Piwik\Piwik;
+use Piwik\Plugin\Manager;
 use Piwik\Singleton;
 use ReflectionClass;
 use ReflectionMethod;
@@ -437,7 +438,7 @@ class Proxy extends Singleton
     private function includeApiFile($fileName)
     {
         $module = self::getModuleNameFromClassName($fileName);
-        $path = PIWIK_INCLUDE_PATH . '/plugins/' . $module . '/API.php';
+        $path = Manager::getPluginsDirectory() . $module . '/API.php';
 
         if (is_readable($path)) {
             require_once $path; // prefixed by PIWIK_INCLUDE_PATH

--- a/core/Columns/Updater.php
+++ b/core/Columns/Updater.php
@@ -14,6 +14,7 @@ use Piwik\Plugin\Dimension\ActionDimension;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugin\Dimension\ConversionDimension;
 use Piwik\Db;
+use Piwik\Plugin\Manager;
 use Piwik\Updater as PiwikUpdater;
 use Piwik\Filesystem;
 use Piwik\Cache as PiwikCache;
@@ -341,7 +342,7 @@ class Updater extends \Piwik\Updates
 
     private static function getCurrentDimensionFileChanges()
     {
-        $files = Filesystem::globr(PIWIK_INCLUDE_PATH . '/plugins/*/Columns', '*.php');
+        $files = Filesystem::globr(Manager::getPluginsDirectory() . '*/Columns', '*.php');
 
         $times = array();
         foreach ($files as $file) {

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -160,12 +160,6 @@ class Plugin
         }
     }
 
-    public function getPluginPath()
-    {
-        $class_info = new \ReflectionClass($this);
-        return dirname($class_info->getFileName());
-    }
-
     private function hasDefinedPluginInformationInPluginClass()
     {
         $myClassName = get_class();

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -10,6 +10,7 @@ namespace Piwik;
 
 use Piwik\Container\StaticContainer;
 use Piwik\Plugin\Dependency;
+use Piwik\Plugin\Manager;
 use Piwik\Plugin\MetadataLoader;
 
 /**
@@ -157,6 +158,12 @@ class Plugin
         if (is_null($this->cache)) {
             $this->cache = Cache::getEagerCache();
         }
+    }
+
+    public function getPluginPath()
+    {
+        $class_info = new \ReflectionClass($this);
+        return dirname($class_info->getFileName());
     }
 
     private function hasDefinedPluginInformationInPluginClass()
@@ -354,7 +361,9 @@ class Plugin
 
         $cacheId = 'Plugin' . $this->pluginName . $componentName . $expectedSubclass;
 
-        $componentFile = sprintf('%s/plugins/%s/%s.php', PIWIK_INCLUDE_PATH, $this->pluginName, $componentName);
+        $pluginsDir = Manager::getPluginsDirectory();
+
+        $componentFile = sprintf('%s%s/%s.php', $pluginsDir, $this->pluginName, $componentName);
 
         if ($this->cache->contains($cacheId)) {
             $classname = $this->cache->fetch($cacheId);
@@ -534,7 +543,8 @@ class Plugin
     {
         $components = array();
 
-        $baseDir = PIWIK_INCLUDE_PATH . '/plugins/' . $this->pluginName . '/' . $directoryWithinPlugin;
+        $pluginsDir = Manager::getPluginsDirectory();
+        $baseDir = $pluginsDir . $this->pluginName . '/' . $directoryWithinPlugin;
         $files   = Filesystem::globr($baseDir, '*.php');
 
         foreach ($files as $file) {

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -459,7 +459,8 @@ class Manager
 
     public static function deletePluginFromFilesystem($plugin)
     {
-        Filesystem::unlinkRecursive(PIWIK_INCLUDE_PATH . '/plugins/' . $plugin, $deleteRootToo = true);
+        $pluginDir = self::getPluginsDirectory();
+        Filesystem::unlinkRecursive($pluginDir . $plugin, $deleteRootToo = true);
     }
 
     /**
@@ -693,7 +694,7 @@ class Manager
             return true;
         }
 
-        $path = $this->getPluginsDirectory() . $pluginName;
+        $path = self::getPluginsDirectory() . $pluginName;
         if (!$this->isManifestFileFound($path)) {
             return true;
         }

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -12,6 +12,7 @@ use Exception;
 use Piwik\Container\StaticContainer;
 use Piwik\DataTable\Filter\SafeDecodeLabel;
 use Piwik\Metrics\Formatter;
+use Piwik\Plugin\Manager;
 use Piwik\Tracker\GoalManager;
 use Piwik\View\RenderTokenParser;
 use Piwik\Visualization\Sparkline;
@@ -313,7 +314,7 @@ class Twig
     private function getDefaultThemeLoader()
     {
         $themeLoader = new Twig_Loader_Filesystem(array(
-                                                       sprintf("%s/plugins/%s/templates/", PIWIK_INCLUDE_PATH, \Piwik\Plugin\Manager::DEFAULT_THEME)
+                                                       sprintf("%s%s/templates/", Manager::getPluginsDirectory(), \Piwik\Plugin\Manager::DEFAULT_THEME)
                                                   ), PIWIK_DOCUMENT_ROOT.DIRECTORY_SEPARATOR);
 
         return $themeLoader;
@@ -326,11 +327,12 @@ class Twig
      */
     protected function getCustomThemeLoader(Plugin $theme)
     {
-        if (!file_exists(sprintf("%s/plugins/%s/templates/", PIWIK_INCLUDE_PATH, $theme->getPluginName()))) {
+        $pluginsDir = Manager::getPluginsDirectory();
+        if (!file_exists(sprintf("%s%s/templates/", $pluginsDir, $theme->getPluginName()))) {
             return false;
         }
         $themeLoader = new Twig_Loader_Filesystem(array(
-                                                       sprintf("%s/plugins/%s/templates/", PIWIK_INCLUDE_PATH, $theme->getPluginName())
+                                                       sprintf("%s%s/templates/", $pluginsDir, $theme->getPluginName())
                                                   ), PIWIK_DOCUMENT_ROOT.DIRECTORY_SEPARATOR);
 
         return $themeLoader;
@@ -519,10 +521,12 @@ class Twig
     {
         $pluginManager = \Piwik\Plugin\Manager::getInstance();
         $plugins = $pluginManager->getAllPluginsNames();
+
+        $pluginsDir = Manager::getPluginsDirectory();
         foreach ($plugins as $name) {
-            $path = sprintf("%s/plugins/%s/templates/", PIWIK_INCLUDE_PATH, $name);
+            $path = sprintf("%s%s/templates/", $pluginsDir, $name);
             if (is_dir($path)) {
-                $loader->addPath(PIWIK_INCLUDE_PATH . '/plugins/' . $name . '/templates', $name);
+                $loader->addPath($pluginsDir . $name . '/templates', $name);
             }
         }
     }
@@ -536,10 +540,13 @@ class Twig
     {
         $pluginManager = \Piwik\Plugin\Manager::getInstance();
         $plugins = $pluginManager->getAllPluginsNames();
+
+        $pluginsDir = Manager::getPluginsDirectory();
+
         foreach ($plugins as $name) {
-            $path = sprintf("%s/plugins/%s/templates/plugins/%s/", PIWIK_INCLUDE_PATH, $pluginName, $name);
+            $path = sprintf("%s%s/templates/plugins/%s/", $pluginsDir, $pluginName, $name);
             if (is_dir($path)) {
-                $loader->addPath(PIWIK_INCLUDE_PATH . '/plugins/' . $pluginName . '/templates/plugins/'. $name, $name);
+                $loader->addPath($pluginsDir . $pluginName . '/templates/plugins/'. $name, $name);
             }
         }
     }

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -10,6 +10,7 @@ namespace Piwik;
 
 use Piwik\Columns\Updater as ColumnUpdater;
 use Piwik\Container\StaticContainer;
+use Piwik\Plugin\Manager;
 use Piwik\Plugins\Installation\ServerFilesGenerator;
 use Piwik\Updater\Migration;
 use Piwik\Updater\Migration\Db\Sql;
@@ -62,7 +63,7 @@ class Updater
     public function __construct($pathUpdateFileCore = null, $pathUpdateFilePlugins = null, Columns\Updater $columnsUpdater = null)
     {
         $this->pathUpdateFileCore = $pathUpdateFileCore ?: PIWIK_INCLUDE_PATH . '/core/Updates/';
-        $this->pathUpdateFilePlugins = $pathUpdateFilePlugins ?: PIWIK_INCLUDE_PATH . '/plugins/%s/Updates/';
+        $this->pathUpdateFilePlugins = $pathUpdateFilePlugins ?: Manager::getPluginsDirectory() . '%s/Updates/';
         $this->columnsUpdater = $columnsUpdater ?: new Columns\Updater();
 
         self::$activeInstance = $this;

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -480,7 +480,7 @@ class Controller extends Plugin\ControllerAdmin
         $uninstalled = $this->pluginManager->uninstallPlugin($pluginName);
 
         if (!$uninstalled) {
-            $path = Filesystem::getPathToPiwikRoot() . '/plugins/' . $pluginName . '/';
+            $path = Plugin\Manager::getPluginsDirectory() . $pluginName . '/';
             $messagePermissions = Filechecks::getErrorMessageMissingPermissions($path);
 
             $messageIntro = $this->translator->translate("Warning: \"%s\" could not be uninstalled. Piwik did not have enough permission to delete the files in $path. ",

--- a/plugins/CorePluginsAdmin/PluginInstaller.php
+++ b/plugins/CorePluginsAdmin/PluginInstaller.php
@@ -15,6 +15,7 @@ use Piwik\Filesystem;
 use Piwik\Piwik;
 use Piwik\Plugin\Manager as PluginManager;
 use Piwik\Plugin\Dependency as PluginDependency;
+use Piwik\Plugin\Manager;
 use Piwik\Plugins\Marketplace\Marketplace;
 use Piwik\Unzip;
 use Piwik\Plugins\Marketplace\Api\Client;
@@ -25,7 +26,6 @@ use Piwik\Plugins\Marketplace\Api\Client;
 class PluginInstaller
 {
     const PATH_TO_DOWNLOAD = '/latest/plugins/';
-    const PATH_TO_EXTRACT = '/plugins/';
 
     private $pluginName;
 
@@ -131,7 +131,7 @@ class PluginInstaller
     {
         Filechecks::dieIfDirectoriesNotWritable(array(
             StaticContainer::get('path.tmp') . self::PATH_TO_DOWNLOAD,
-            self::PATH_TO_EXTRACT
+            Manager::getPluginsDirectory()
         ));
     }
 
@@ -294,11 +294,12 @@ class PluginInstaller
 
     private function copyPluginToDestination($tmpPluginFolder)
     {
-        $pluginTargetPath = PIWIK_USER_PATH . self::PATH_TO_EXTRACT . $this->pluginName;
+        $pluginsDir = Manager::getPluginsDirectory();
+        $pluginTargetPath = $pluginsDir . $this->pluginName;
 
         $this->removeFolderIfExists($pluginTargetPath);
 
-        Filesystem::copyRecursive($tmpPluginFolder, PIWIK_USER_PATH . self::PATH_TO_EXTRACT);
+        Filesystem::copyRecursive($tmpPluginFolder, $pluginsDir);
     }
 
     /**

--- a/plugins/LanguagesManager/API.php
+++ b/plugins/LanguagesManager/API.php
@@ -97,7 +97,7 @@ class API extends \Piwik\Plugin\API
         $englishTranslation = json_decode($data, true);
 
         // merge with plugin translations if any
-        $pluginFiles = glob(sprintf('%s/plugins/*/lang/en.json', PIWIK_INCLUDE_PATH));
+        $pluginFiles = glob(sprintf('%s*/lang/en.json', Manager::getPluginsDirectory()));
         foreach ($pluginFiles as $file) {
 
             preg_match('/\/plugins\/([^\/]+)\/lang/i', $file, $matches);
@@ -117,7 +117,7 @@ class API extends \Piwik\Plugin\API
             $translations = json_decode($data, true);
 
             // merge with plugin translations if any
-            $pluginFiles = glob(sprintf('%s/plugins/*/lang/%s.json', PIWIK_INCLUDE_PATH, $filename));
+            $pluginFiles = glob(sprintf('%s*/lang/%s.json', Manager::getPluginsDirectory(), $filename));
             foreach ($pluginFiles as $file) {
 
                 preg_match('/\/plugins\/([^\/]+)\/lang/i', $file, $matches);
@@ -223,7 +223,7 @@ class API extends \Piwik\Plugin\API
             return false;
         }
 
-        $languageFile = PIWIK_INCLUDE_PATH . "/plugins/$pluginName/lang/$languageCode.json";
+        $languageFile = Manager::getPluginsDirectory() . "$pluginName/lang/$languageCode.json";
 
         if (!file_exists($languageFile)) {
             return false;

--- a/plugins/LanguagesManager/Commands/PluginsWithTranslations.php
+++ b/plugins/LanguagesManager/Commands/PluginsWithTranslations.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\LanguagesManager\Commands;
 
+use Piwik\Plugin\Manager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -26,9 +27,9 @@ class PluginsWithTranslations extends TranslationBase
     {
         $output->writeln("Following plugins contain their own translation files:");
 
-        $pluginFiles = glob(sprintf('%s/plugins/*/lang/en.json', PIWIK_INCLUDE_PATH));
+        $pluginFiles = glob(sprintf('%s*/lang/en.json', Manager::getPluginsDirectory()));
         $pluginFiles = array_map(function($elem){
-            return str_replace(array(sprintf('%s/plugins/', PIWIK_INCLUDE_PATH), '/lang/en.json'), '', $elem);
+            return str_replace(array(Manager::getPluginsDirectory(), '/lang/en.json'), '', $elem);
         }, $pluginFiles);
 
         $output->writeln(join("\n", $pluginFiles));

--- a/plugins/LanguagesManager/Commands/Update.php
+++ b/plugins/LanguagesManager/Commands/Update.php
@@ -158,9 +158,9 @@ class Update extends TranslationBase
             return $pluginsWithTranslations;
         }
 
-        $pluginsWithTranslations = glob(sprintf('%s/plugins/*/lang/en.json', PIWIK_INCLUDE_PATH));
+        $pluginsWithTranslations = glob(sprintf('%s*/lang/en.json', Manager::getPluginsDirectory()));
         $pluginsWithTranslations = array_map(function ($elem) {
-            return str_replace(array(sprintf('%s/plugins/', PIWIK_INCLUDE_PATH), '/lang/en.json'), '', $elem);
+            return str_replace(array(Manager::getPluginsDirectory(), '/lang/en.json'), '', $elem);
         }, $pluginsWithTranslations);
 
         return $pluginsWithTranslations;
@@ -189,9 +189,9 @@ class Update extends TranslationBase
 
         $pluginsNotInCore = array_merge($submodulePlugins, $newPlugins);
 
-        $pluginsWithTranslations = glob(sprintf('%s/plugins/*/lang/en.json', PIWIK_INCLUDE_PATH));
+        $pluginsWithTranslations = glob(sprintf('%s*/lang/en.json', Manager::getPluginsDirectory()));
         $pluginsWithTranslations = array_map(function ($elem) {
-            return str_replace(array(sprintf('%s/plugins/', PIWIK_INCLUDE_PATH), '/lang/en.json'), '', $elem);
+            return str_replace(array(Manager::getPluginsDirectory(), '/lang/en.json'), '', $elem);
         }, $pluginsWithTranslations);
 
         $pluginsInCore = array_diff($pluginsWithTranslations, $pluginsNotInCore);

--- a/plugins/LanguagesManager/TranslationWriter/Writer.php
+++ b/plugins/LanguagesManager/TranslationWriter/Writer.php
@@ -12,6 +12,7 @@ use Exception;
 use Piwik\Container\StaticContainer;
 use Piwik\Filesystem;
 use Piwik\Piwik;
+use Piwik\Plugin\Manager;
 use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\FilterAbstract;
 use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\ValidateAbstract;
 
@@ -201,7 +202,7 @@ class Writer
             if ($base == 'tmp') {
                 return sprintf('%s/plugins/%s/lang/%s.json', StaticContainer::get('path.tmp'), $this->pluginName, $lang);
             } else {
-                return sprintf('%s/plugins/%s/lang/%s.json', PIWIK_INCLUDE_PATH, $this->pluginName, $lang);
+                return sprintf('%s%s/lang/%s.json', Manager::getPluginsDirectory(), $this->pluginName, $lang);
             }
         }
 


### PR DESCRIPTION
Instead use the method that defines the plugin dir. No logic should change here. Doing this in preparation to potentially provide a way to define multiple plugin directories. But for this we first need to make sure that all code is using the same method when looking for plugin directory.