### PR TITLE
Use absolute path for alternative tracker file

### DIFF
--- a/plugins/CustomPiwikJs/TrackerUpdater.php
+++ b/plugins/CustomPiwikJs/TrackerUpdater.php
@@ -149,7 +149,7 @@ class TrackerUpdater
     private function updateAlternative($fromFile, $toFile, $newContent)
     {
         if (Common::stringEndsWith($this->toFile->getName(), $fromFile)) {
-            $alternativeFilename = dirname($this->toFile->getName()) . DIRECTORY_SEPARATOR . $toFile;
+            $alternativeFilename = dirname($this->toFile->getPath()) . DIRECTORY_SEPARATOR . $toFile;
             $file = new File($alternativeFilename);
             if ($file->hasWriteAccess() && $file->getContent() !== $newContent) {
                 $file->save($newContent);


### PR DESCRIPTION
Currently it resulted in something like `./matomo.js` for example (which causes problems with our file sync).