### PR TITLE
Search for visitor IDs over whole table not just last 30 mins

### DIFF
--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -357,23 +357,26 @@ class Model
         // 		this page view to the wrong visitor, but this is better than creating artificial visits.
         // 2) there is a visitor ID and we trust it (config setting trust_visitors_cookies, OR it was set using &cid= in tracking API),
         //      and in these cases, we force to look up this visitor id
-        $whereCommon = "visit_last_action_time >= ? AND visit_last_action_time <= ? AND idsite = ?";
-        $bindSql = array(
+        $configIdWhere = "visit_last_action_time >= ? AND visit_last_action_time <= ? AND idsite = ?";
+        $configIdbindSql = array(
             $timeLookBack,
             $timeLookAhead,
             $idSite
         );
 
+        $visitorIdWhere = 'idsite = ?';
+        $visitorIdbindSql = [$idSite];
+
         if ($shouldMatchOneFieldOnly && $isVisitorIdToLookup) {
-            $visitRow = $this->findVisitorByVisitorId($idVisitor, $select, $from, $whereCommon, $bindSql);
+            $visitRow = $this->findVisitorByVisitorId($idVisitor, $select, $from, $visitorIdWhere, $visitorIdbindSql);
         } elseif ($shouldMatchOneFieldOnly) {
-            $visitRow = $this->findVisitorByConfigId($configId, $select, $from, $whereCommon, $bindSql);
+            $visitRow = $this->findVisitorByConfigId($configId, $select, $from, $configIdWhere, $configIdbindSql);
         } else {
-            $visitRow = $this->findVisitorByVisitorId($idVisitor, $select, $from, $whereCommon, $bindSql);
+            $visitRow = $this->findVisitorByVisitorId($idVisitor, $select, $from, $visitorIdWhere, $visitorIdbindSql);
 
             if (empty($visitRow)) {
-                $whereCommon .= ' AND user_id IS NULL ';
-                $visitRow = $this->findVisitorByConfigId($configId, $select, $from, $whereCommon, $bindSql);
+                $configIdWhere .= ' AND user_id IS NULL ';
+                $visitRow = $this->findVisitorByConfigId($configId, $select, $from, $configIdWhere, $configIdbindSql);
             }
         }
 


### PR DESCRIPTION
In the tracker when searching by visitor ID, search through entire log_visit table instead of just in the last 30 mins.

Should be fast thanks to already existing index (h/t @tsteur)

CC @mattab can you take a look at this re any possible privacy implications?