### PR TITLE
rename composer dependency to avoid deprecation warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "twig/twig": "~1.0",
         "leafo/lessphp": "~0.5.0",
         "symfony/console": "~2.6.0",
-        "JShrink": "=1.3.1",
         "mustangostang/spyc": "~0.5.0",
         "piwik/device-detector": "~3.0",
         "piwik/decompress": "~1.0",
@@ -48,7 +47,8 @@
         "composer/semver": "~1.3.0",
         "szymach/c-pchart": "^2.0",
         "geoip2/geoip2": "^2.8",
-        "davaxi/sparkline": "^1.1"
+        "davaxi/sparkline": "^1.1",
+        "matomo-org/jshrink": "1.3.1"
     },
     "require-dev": {
         "aws/aws-sdk-php": "2.7.1",
@@ -88,7 +88,7 @@
         {
             "type": "package",
             "package": {
-                "name": "JShrink",
+                "name": "matomo-org/jshrink",
                 "description": "Javascript Minifier built in PHP",
                 "keywords": ["minifier","javascript"],
                 "homepage": "http://github.com/tedious/JShrink",

--- a/composer.lock
+++ b/composer.lock
@@ -4,41 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c55b34f7e7a42a8670a831bcaf31972e",
+    "content-hash": "93fb13394d1cb02f14d3e74ab475702b",
     "packages": [
-        {
-            "name": "JShrink",
-            "version": "1.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tedious/JShrink",
-                "reference": "v1.3.1"
-            },
-            "require": {
-                "php": "*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "JShrink": "src/"
-                }
-            },
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Robert Hafner",
-                    "email": "tedivm@tedivm.com"
-                }
-            ],
-            "description": "Javascript Minifier built in PHP",
-            "homepage": "http://github.com/tedious/JShrink",
-            "keywords": [
-                "javascript",
-                "minifier"
-            ]
-        },
         {
             "name": "composer/ca-bundle",
             "version": "1.1.3",
@@ -407,6 +374,39 @@
             "description": "lessphp is a compiler for LESS written in PHP.",
             "homepage": "http://leafo.net/lessphp/",
             "time": "2014-11-24T18:39:20+00:00"
+        },
+        {
+            "name": "matomo-org/jshrink",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tedious/JShrink",
+                "reference": "v1.3.1"
+            },
+            "require": {
+                "php": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JShrink": "src/"
+                }
+            },
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Hafner",
+                    "email": "tedivm@tedivm.com"
+                }
+            ],
+            "description": "Javascript Minifier built in PHP",
+            "homepage": "http://github.com/tedious/JShrink",
+            "keywords": [
+                "javascript",
+                "minifier"
+            ]
         },
         {
             "name": "matomo/referrer-spam-blacklist",


### PR DESCRIPTION
I just updated composer to 1.8.3 and it seems like the never versions are more pedantic about the names of dependencies. It doesn't like uppercase letters and the current composer.json shows the following warning
> Deprecation warning: require.JShrink is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*". Make sure you fix this as Composer 2.0 will error.

To fix this I ran

```
composer remove jshrink
```
renamed it in the composer.json and ran
```
composer require matomo-org/jshrink=1.3.1
```