### PR TITLE
Let plugins change the report type in sendReport event

### DIFF
--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -616,6 +616,8 @@ class API extends \Piwik\Plugin\API
                 Log::warning("Scheduled report file '%s' exists but is empty!", $outputFilename);
             }
 
+            $reportType = $report['type'];
+
             /**
              * Triggered when sending scheduled reports.
              *
@@ -644,7 +646,7 @@ class API extends \Piwik\Plugin\API
             Piwik::postEvent(
                 self::SEND_REPORT_EVENT,
                 array(
-                    $report['type'],
+                    &$reportType,
                     $report,
                     $contents,
                     $filename = basename($outputFilename),


### PR DESCRIPTION
This way I can set the `reportType` to eg `foobar` so it won't be handled and won't be sent. Needing this feature... Was going to add otherwise another parameter or another event but having two events with similar `sendReport` name may be confusing and another parameter could cause issues. No need to document this any further I would say.

@diosmosis can you have a quick look?