### PR TITLE
Noindex, nofollow for login page and tracker default output

### DIFF
--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -79,7 +79,7 @@ class Response
                 Common::sendResponseCode(400);
             }
             Common::printDebug("Empty request => Matomo page");
-            echo "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer'>web analytics & conversion optimisation platform</a>.";
+            echo "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer nofollow'>web analytics & conversion optimisation platform</a>.";
         } else {
             $this->outputApiResponse($tracker);
             Common::printDebug("Nothing to notice => default behaviour");

--- a/plugins/Actions/tests/UI/expected-screenshots/ActionsDataTable_segmented_visitor_log.png
+++ b/plugins/Actions/tests/UI/expected-screenshots/ActionsDataTable_segmented_visitor_log.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:916916f487f5c52405e8a04d434b184d379dc716b45ea8e7a85426fbbacb6937
-size 429798
+oid sha256:1616bdb56100040edc75ffa834ef8afa246331dd001f57af64dee7f5a5c96e61
+size 430070

--- a/plugins/Login/templates/loginLayout.twig
+++ b/plugins/Login/templates/loginLayout.twig
@@ -1,7 +1,7 @@
 {% extends '@Morpheus/layout.twig' %}
 
 {% block meta %}
-    <meta name="robots" content="index,follow">
+    <meta name="robots" content="noindex,nofollow">
 {% endblock %}
 
 {% block head %}

--- a/tests/PHPUnit/Integration/TrackerTest.php
+++ b/tests/PHPUnit/Integration/TrackerTest.php
@@ -250,7 +250,7 @@ class TrackerTest extends IntegrationTestCase
 
         $response = $this->tracker->main($this->getDefaultHandler(), $requestSet);
 
-        $expected = "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer'>web analytics & conversion optimisation platform</a>.";
+        $expected = "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer nofollow'>web analytics & conversion optimisation platform</a>.";
         $this->assertEquals($expected, $response);
     }
 

--- a/tests/PHPUnit/System/TrackerResponseTest.php
+++ b/tests/PHPUnit/System/TrackerResponseTest.php
@@ -125,7 +125,7 @@ class TrackerResponseTest extends SystemTestCase
         $response = Http::sendHttpRequest($url, 10, null, null, 0, false, false, true);
         $this->assertEquals(200, $response['status']);
 
-        $expected = "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer'>web analytics & conversion optimisation platform</a>.";
+        $expected = "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer nofollow'>web analytics & conversion optimisation platform</a>.";
         $this->assertEquals($expected, $response['data']);
     }
 
@@ -136,7 +136,7 @@ class TrackerResponseTest extends SystemTestCase
         $this->assertEquals(400, $response['status']);
 
         $response = $this->sendHttpRequest($url);
-        $expected = "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer'>web analytics & conversion optimisation platform</a>.";
+        $expected = "This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer nofollow'>web analytics & conversion optimisation platform</a>.";
         $this->assertEquals($expected, $response['data']);
     }
 

--- a/tests/PHPUnit/Unit/Tracker/ResponseTest.php
+++ b/tests/PHPUnit/Unit/Tracker/ResponseTest.php
@@ -127,7 +127,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $tracker->setCountOfLoggedRequests(0);
         $this->response->outputResponse($tracker);
 
-        $this->assertEquals("This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer'>web analytics & conversion optimisation platform</a>.",
+        $this->assertEquals("This resource is part of Matomo. Keep full control of your data with the leading free and open source <a href='https://matomo.org' target='_blank' rel='noopener noreferrer nofollow'>web analytics & conversion optimisation platform</a>.",
             $this->response->getOutput());
     }
 

--- a/tests/UI/expected-screenshots/UIIntegrationTest_segmented_visitorlog.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_segmented_visitorlog.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4869df78b4da994ed7c8b1fc999d2a0da71eb176efa9b5c7aa7b874d2afad782
-size 446255
+oid sha256:89354b1ab2f72c9bb5f54b8b1aba8c2b696d1f499be4a10ec85bd9879bcd49ac
+size 446558


### PR DESCRIPTION
Also increases security as less matomo instances will be found on search engines. 

fix https://github.com/matomo-org/matomo/issues/6552