### PR TITLE
Add new parameter to Live.getLastVisitsDetails API to request more detailed information

### DIFF
--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -157,9 +157,10 @@ class API extends \Piwik\Plugin\API
      * @param bool|int $minTimestamp (optional) Minimum timestamp to restrict the query to (useful when paginating or refreshing visits)
      * @param bool $flat
      * @param bool $doNotFetchActions
+     * @param bool $enhanced for plugins that want to expose additional information
      * @return DataTable
      */
-    public function getLastVisitsDetails($idSite, $period = false, $date = false, $segment = false, $countVisitorsToFetch = false, $minTimestamp = false, $flat = false, $doNotFetchActions = false)
+    public function getLastVisitsDetails($idSite, $period = false, $date = false, $segment = false, $countVisitorsToFetch = false, $minTimestamp = false, $flat = false, $doNotFetchActions = false, $enhanced = false)
     {
         Piwik::checkUserHasViewAccess($idSite);
         $idSite = Site::getIdSitesFromIdSitesString($idSite);


### PR DESCRIPTION
I know it looks funny that parameter isn't used.

In Media Analytics we're adding a new feature around heatmaps and we do not want to expose this information by default through the `Live.getLastVisitsDetails` API because it is a wee bit slower and could return a lot of data. However, it can be useful to request it and we have users that ask specifically for that. I figured it be good to only return this information in the API when an additional flag is set. I named it `enhanced` as we use this already in `MultiSites` API and be good for consistency.

In order for this parameter to still appear in the documentation I've added it to the method here and eventually other plugins could do similar based on this. 

We don't have to merge it if it's a problem that the parameter isn't used in core. Be good to have it though maybe.