### PR TITLE
[NumberFormatter] Support changing translation after instantiation

### DIFF
--- a/core/NumberFormatter.php
+++ b/core/NumberFormatter.php
@@ -17,38 +17,14 @@ use Piwik\Translation\Translator;
  */
 class NumberFormatter
 {
-    /** @var string language specific patterns for numbers */
-    protected $patternNumber;
+    /** @var Translator */
+    protected $translator;
 
-    /** @var string language specific pattern for percent numbers */
-    protected $patternPercent;
+    /** @var array cached patterns per language */
+    protected $patterns;
 
-    /** @var string language specific pattern for currency numbers */
-    protected $patternCurrency;
-
-    /** @var string language specific plus sign */
-    protected $symbolPlus;
-
-    /** @var string language specific minus sign */
-    protected $symbolMinus;
-
-    /** @var string language specific percent sign */
-    protected $symbolPercent;
-
-    /** @var string language specific symbol used as decimal separator */
-    protected $symbolDecimal;
-
-    /** @var string language specific symbol used as group separator */
-    protected $symbolGroup;
-
-    /** @var bool indicates if language uses grouping for numbers */
-    protected $usesGrouping;
-
-    /** @var int language specific size for primary group numbers */
-    protected $primaryGroupSize;
-
-    /** @var int language specific size for secondary group numbers */
-    protected $secondaryGroupSize;
+    /** @var array cached symbols per language */
+    protected $symbols;
 
     /**
      * Loads all required data from Intl plugin
@@ -62,30 +38,7 @@ class NumberFormatter
      */
     public function __construct(Translator $translator)
     {
-        $this->patternNumber = $translator->translate('Intl_NumberFormatNumber');
-        $this->patternCurrency = $translator->translate('Intl_NumberFormatCurrency');
-        $this->patternPercent = $translator->translate('Intl_NumberFormatPercent');
-        $this->symbolPlus = $translator->translate('Intl_NumberSymbolPlus');
-        $this->symbolMinus = $translator->translate('Intl_NumberSymbolMinus');
-        $this->symbolPercent = $translator->translate('Intl_NumberSymbolPercent');
-        $this->symbolGroup = $translator->translate('Intl_NumberSymbolGroup');
-        $this->symbolDecimal = $translator->translate('Intl_NumberSymbolDecimal');
-    }
-
-    /**
-     * Parses the given pattern and returns patterns for positive and negative numbers
-     *
-     * @param string $pattern
-     * @return array
-     */
-    protected function parsePattern($pattern)
-    {
-        $patterns = explode(';', $pattern);
-        if (!isset($patterns[1])) {
-            // No explicit negative pattern was provided, construct it.
-            $patterns[1] = '-' . $patterns[0];
-        }
-        return $patterns;
+        $this->translator = $translator;
     }
 
     /**
@@ -119,14 +72,7 @@ class NumberFormatter
      */
     public function formatNumber($value, $maximumFractionDigits=0, $minimumFractionDigits=0)
     {
-
-        static $positivePattern, $negativePattern;
-
-        if (empty($positivePatter) || empty($negativePattern)) {
-            list($positivePattern, $negativePattern) = $this->parsePattern($this->patternNumber);
-        }
-        $negative = $this->isNegative($value);
-        $pattern = $negative ? $negativePattern : $positivePattern;
+        $pattern = $this->getPattern($value, 'Intl_NumberFormatNumber');
 
         return $this->formatNumberWithPattern($pattern, $value, $maximumFractionDigits, $minimumFractionDigits);
     }
@@ -140,19 +86,12 @@ class NumberFormatter
      */
     public function formatPercent($value, $maximumFractionDigits=0, $minimumFractionDigits=0)
     {
-        static $positivePattern, $negativePattern;
-
-        if (empty($positivePatter) || empty($negativePattern)) {
-            list($positivePattern, $negativePattern) = $this->parsePattern($this->patternPercent);
-        }
-
-        $newValue =  trim($value, " \0\x0B%");
+        $newValue = trim($value, " \0\x0B%");
         if (!is_numeric($newValue)) {
             return $value;
         }
 
-        $negative = $this->isNegative($value);
-        $pattern = $negative ? $negativePattern : $positivePattern;
+        $pattern = $this->getPattern($value, 'Intl_NumberFormatPercent');
 
         return $this->formatNumberWithPattern($pattern, $newValue, $maximumFractionDigits, $minimumFractionDigits);
     }
@@ -170,8 +109,10 @@ class NumberFormatter
 
         $formatted = self::formatPercent($value);
 
-        if($isPositiveEvolution) {
-            return $this->symbolPlus . $formatted;
+        if ($isPositiveEvolution) {
+            // $this->symbols has already been initialized from formatPercent().
+            $language = $this->translator->getCurrentLanguage();
+            return $this->symbols[$language]['+'] . $formatted;
         }
         return $formatted;
     }
@@ -185,19 +126,12 @@ class NumberFormatter
      */
     public function formatCurrency($value, $currency, $precision=2)
     {
-        static $positivePattern, $negativePattern;
-
-        if (empty($positivePatter) || empty($negativePattern)) {
-            list($positivePattern, $negativePattern) = $this->parsePattern($this->patternCurrency);
-        }
-
-        $newValue =  trim($value, " \0\x0B$currency");
+        $newValue = trim($value, " \0\x0B$currency");
         if (!is_numeric($newValue)) {
             return $value;
         }
 
-        $negative = $this->isNegative($value);
-        $pattern = $negative ? $negativePattern : $positivePattern;
+        $pattern = $this->getPattern($value, 'Intl_NumberFormatCurrency');
 
         if ($newValue == round($newValue)) {
             // if no fraction digits available, don't show any
@@ -208,6 +142,43 @@ class NumberFormatter
         }
 
         return str_replace('¤', $currency, $value);
+    }
+
+    /**
+     * Returns the relevant pattern for the given number.
+     *
+     * @param string $value
+     * @param string $translationId
+     * @return string
+     */
+    protected function getPattern($value, $translationId)
+    {
+        $language = $this->translator->getCurrentLanguage();
+
+        if (!isset($this->patterns[$language][$translationId])) {
+            $this->patterns[$language][$translationId] = $this->parsePattern($this->translator->translate($translationId));
+        }
+
+        list($positivePattern, $negativePattern) = $this->patterns[$language][$translationId];
+        $negative = $this->isNegative($value);
+
+        return $negative ? $negativePattern : $positivePattern;
+    }
+
+    /**
+     * Parses the given pattern and returns patterns for positive and negative numbers
+     *
+     * @param string $pattern
+     * @return array
+     */
+    protected function parsePattern($pattern)
+    {
+        $patterns = explode(';', $pattern);
+        if (!isset($patterns[1])) {
+            // No explicit negative pattern was provided, construct it.
+            $patterns[1] = '-' . $patterns[0];
+        }
+        return $patterns;
     }
 
     /**
@@ -225,15 +196,15 @@ class NumberFormatter
             return $value;
         }
 
-        $this->usesGrouping = (strpos($pattern, ',') !== false);
+        $usesGrouping = (strpos($pattern, ',') !== false);
         // if pattern has number groups, parse them.
-        if ($this->usesGrouping) {
+        if ($usesGrouping) {
             preg_match('/#+0/', $pattern, $primaryGroupMatches);
-            $this->primaryGroupSize = $this->secondaryGroupSize = strlen($primaryGroupMatches[0]);
+            $primaryGroupSize = $secondaryGroupSize = strlen($primaryGroupMatches[0]);
             $numberGroups = explode(',', $pattern);
             // check for distinct secondary group size.
             if (count($numberGroups) > 2) {
-                $this->secondaryGroupSize = strlen($numberGroups[1]);
+                $secondaryGroupSize = strlen($numberGroups[1]);
             }
         }
 
@@ -248,14 +219,14 @@ class NumberFormatter
         // Account for maximumFractionDigits = 0, where the number won't
         // have a decimal point, and $valueParts[1] won't be set.
         $minorDigits = isset($valueParts[1]) ? $valueParts[1] : '';
-        if ($this->usesGrouping) {
+        if ($usesGrouping) {
             // Reverse the major digits, since they are grouped from the right.
             $majorDigits = array_reverse(str_split($majorDigits));
             // Group the major digits.
             $groups = array();
-            $groups[] = array_splice($majorDigits, 0, $this->primaryGroupSize);
+            $groups[] = array_splice($majorDigits, 0, $primaryGroupSize);
             while (!empty($majorDigits)) {
-                $groups[] = array_splice($majorDigits, 0, $this->secondaryGroupSize);
+                $groups[] = array_splice($majorDigits, 0, $secondaryGroupSize);
             }
             // Reverse the groups and the digits inside of them.
             $groups = array_reverse($groups);
@@ -295,14 +266,19 @@ class NumberFormatter
      */
     protected function replaceSymbols($value)
     {
-        $replacements = array(
-            '.' => $this->symbolDecimal,
-            ',' => $this->symbolGroup,
-            '+' => $this->symbolPlus,
-            '-' => $this->symbolMinus,
-            '%' => $this->symbolPercent,
-        );
-        return strtr($value, $replacements);
+        $language = $this->translator->getCurrentLanguage();
+
+        if (!isset($this->symbols[$language])) {
+            $this->symbols[$language] = array(
+                '.' => $this->translator->translate('Intl_NumberSymbolDecimal'),
+                ',' => $this->translator->translate('Intl_NumberSymbolGroup'),
+                '+' => $this->translator->translate('Intl_NumberSymbolPlus'),
+                '-' => $this->translator->translate('Intl_NumberSymbolMinus'),
+                '%' => $this->translator->translate('Intl_NumberSymbolPercent'),
+            );
+        }
+
+        return strtr($value, $this->symbols[$language]);
     }
 
     /**

--- a/tests/PHPUnit/Integration/NumberFormatterTest.php
+++ b/tests/PHPUnit/Integration/NumberFormatterTest.php
@@ -154,4 +154,27 @@ class NumberFormatterTest extends \PHPUnit_Framework_TestCase
             array('en', -5000000, '-5,000,000%'),
         );
     }
+
+    public function testChangeLanguage()
+    {
+        $this->translator->setCurrentLanguage('en');
+        $numberFormatter = new NumberFormatter($this->translator);
+      
+        $this->assertEquals('5,000.1', $numberFormatter->formatNumber(5000.1, 1));
+        $this->assertEquals('50.1%', $numberFormatter->formatPercent(50.1, 1));
+        $this->assertEquals('+50%', $numberFormatter->formatPercentEvolution(50));
+        $this->assertEquals('$5,000.1', $numberFormatter->formatCurrency(5000.1, '$'));
+      
+        $this->translator->setCurrentLanguage('de');
+        $this->assertEquals('5.000,1', $numberFormatter->formatNumber(5000.1, 1));
+        $this->assertEquals('50,1 %', $numberFormatter->formatPercent(50.1, 1));
+        $this->assertEquals('+50 %', $numberFormatter->formatPercentEvolution(50));
+        $this->assertEquals('5.000,1 €', $numberFormatter->formatCurrency(5000.1, '€'));
+
+        $this->translator->setCurrentLanguage('ar');
+        $this->assertEquals('5٬000٫1٪؜', $numberFormatter->formatPercent(5000.1, 1));
+
+        $this->translator->setCurrentLanguage('bn');
+        $this->assertEquals('50,00,000', $numberFormatter->formatNumber(5000000));
+    }
 }


### PR DESCRIPTION
The `NumberFormatter` reads its translations in the constructor and ignores later changes to the translation language.

This caused the scheduled reports to sometimes use a different number format than the one defined for the recipient user's locale.