### PR TITLE
Improve total report values calculation

### DIFF
--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -717,7 +717,7 @@ class ProcessedReport
         foreach ($simpleTotals as $metric => $value) {
             if (!array_key_exists($metric, $totals)) {
                 $totals[$metric] = $value;
-            } else {
+            } else if(is_numeric($value)) {
                 $totals[$metric] += $value;
             }
         }

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -715,8 +715,8 @@ class ProcessedReport
         $simpleTotals = $this->hideShowMetrics($metadataTotals);
 
         foreach ($simpleTotals as $metric => $value) {
-            if (0 === strpos($metric, 'avg_') || '_rate' === substr($metric, -5)) {
-                continue; // skip average and rate metrics
+            if (0 === strpos($metric, 'avg_') || '_rate' === substr($metric, -5) || '_evolution' === substr($metric, -10)) {
+                continue; // skip average, rate and evolution metrics
             }
             if (is_array($value) ) {
                 continue; // skip totals for nested metrics

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -718,8 +718,8 @@ class ProcessedReport
             if (0 === strpos($metric, 'avg_') || '_rate' === substr($metric, -5) || '_evolution' === substr($metric, -10)) {
                 continue; // skip average, rate and evolution metrics
             }
-            if (is_array($value) ) {
-                continue; // skip totals for nested metrics
+            if (is_array($value) || !is_numeric($value)) {
+                continue; // skip totals for nested or not numeric metrics
             }
 
             if (!array_key_exists($metric, $totals)) {
@@ -728,7 +728,7 @@ class ProcessedReport
                 $totals[$metric] = min($totals[$metric], $value);
             } else if(0 === strpos($metric, 'max_')) {
                 $totals[$metric] = max($totals[$metric], $value);
-            } else if(is_numeric($value)) {
+            } else {
                 $totals[$metric] += $value;
             }
         }

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -715,6 +715,13 @@ class ProcessedReport
         $simpleTotals = $this->hideShowMetrics($metadataTotals);
 
         foreach ($simpleTotals as $metric => $value) {
+            if (0 === strpos($metric, 'avg_') || '_rate' === substr($metric, -5)) {
+                continue; // skip average and rate metrics
+            }
+            if (is_array($value) ) {
+                continue; // skip totals for nested metrics
+            }
+
             if (!array_key_exists($metric, $totals)) {
                 $totals[$metric] = $value;
             } else if(is_numeric($value)) {

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -714,12 +714,26 @@ class ProcessedReport
 
         $simpleTotals = $this->hideShowMetrics($metadataTotals);
 
+        return $this->calculateTotals($simpleTotals, $totals);
+    }
+
+    private function calculateTotals($simpleTotals, $totals)
+    {
         foreach ($simpleTotals as $metric => $value) {
             if (0 === strpos($metric, 'avg_') || '_rate' === substr($metric, -5) || '_evolution' === substr($metric, -10)) {
                 continue; // skip average, rate and evolution metrics
             }
-            if (is_array($value) || !is_numeric($value)) {
-                continue; // skip totals for nested or not numeric metrics
+
+            if (!is_numeric($value) && !is_array($value)) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $currentValue = array_key_exists($metric, $totals) ? $totals[$metric] : [];
+                $newValue = $this->calculateTotals($value, $currentValue);
+                if (!empty($newValue)) {
+                    $totals[$metric] = $newValue;
+                }
             }
 
             if (!array_key_exists($metric, $totals)) {
@@ -728,7 +742,7 @@ class ProcessedReport
                 $totals[$metric] = min($totals[$metric], $value);
             } else if(0 === strpos($metric, 'max_')) {
                 $totals[$metric] = max($totals[$metric], $value);
-            } else {
+            } else if($value) {
                 $totals[$metric] += $value;
             }
         }

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -724,6 +724,10 @@ class ProcessedReport
 
             if (!array_key_exists($metric, $totals)) {
                 $totals[$metric] = $value;
+            } else if(0 === strpos($metric, 'min_')) {
+                $totals[$metric] = min($totals[$metric], $value);
+            } else if(0 === strpos($metric, 'max_')) {
+                $totals[$metric] = max($totals[$metric], $value);
             } else if(is_numeric($value)) {
                 $totals[$metric] += $value;
             }

--- a/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentNames_lastN__API.getProcessedReport_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentNames_lastN__API.getProcessedReport_day.xml
@@ -90,6 +90,5 @@
 		<nb_visits>16</nb_visits>
 		<nb_impressions>18</nb_impressions>
 		<nb_interactions>6</nb_interactions>
-		<interaction_rate>33.33%</interaction_rate>
 	</reportTotal>
 </result>

--- a/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentPieces_lastN__API.getProcessedReport_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentPieces_lastN__API.getProcessedReport_day.xml
@@ -133,6 +133,5 @@
 		<nb_visits>16</nb_visits>
 		<nb_impressions>18</nb_impressions>
 		<nb_interactions>6</nb_interactions>
-		<interaction_rate>33.33%</interaction_rate>
 	</reportTotal>
 </result>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_ItemsCategory__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_ItemsCategory__API.getProcessedReport_day.xml
@@ -115,8 +115,5 @@
 		<nb_uniq_visitors>8</nb_uniq_visitors>
 		<nb_visits>12</nb_visits>
 		<nb_actions>17</nb_actions>
-		<avg_price>513.9</avg_price>
-		<avg_quantity>2.3</avg_quantity>
-		<conversion_rate>66.67%</conversion_rate>
 	</reportTotal>
 </result>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_ItemsSku__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_ItemsSku__API.getProcessedReport_day.xml
@@ -85,8 +85,5 @@
 		<nb_uniq_visitors>3</nb_uniq_visitors>
 		<nb_visits>6</nb_visits>
 		<nb_actions>11</nb_actions>
-		<avg_price>527.81</avg_price>
-		<avg_quantity>2.5</avg_quantity>
-		<conversion_rate>66.67%</conversion_rate>
 	</reportTotal>
 </result>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
@@ -401,35 +401,9 @@
 		<max_actions>6</max_actions>
 		<sum_visit_length>5403</sum_visit_length>
 		<bounce_count>0</bounce_count>
-		<goals>
-			<row idgoal="1">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>10</revenue>
-			</row>
-			<row idgoal="ecommerceAbandonedCart">
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>2</nb_visits_converted>
-				<revenue>5020.22</revenue>
-				<items>8</items>
-			</row>
-			<row idgoal="ecommerceOrder">
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111.11</revenue>
-				<revenue_subtotal>2500</revenue_subtotal>
-				<revenue_tax>511</revenue_tax>
-				<revenue_shipping>100.11</revenue_shipping>
-				<revenue_discount>666</revenue_discount>
-				<items>10</items>
-			</row>
-		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>3121.11</revenue>
 		<nb_visits_converted>1</nb_visits_converted>
-		<conversion_rate>33.33%</conversion_rate>
 		<nb_actions_per_visit>4.3</nb_actions_per_visit>
-		<avg_time_on_site>1801</avg_time_on_site>
-		<bounce_rate>0%</bounce_rate>
 	</reportTotal>
 </result>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_VisitTime.getVisitInformationPerServerTime__API.getProcessedReport_day.xml
@@ -401,6 +401,29 @@
 		<max_actions>6</max_actions>
 		<sum_visit_length>5403</sum_visit_length>
 		<bounce_count>0</bounce_count>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>10</revenue>
+			</row>
+			<row idgoal="ecommerceAbandonedCart">
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>2</nb_visits_converted>
+				<revenue>5020.22</revenue>
+				<items>8</items>
+			</row>
+			<row idgoal="ecommerceOrder">
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>3111.11</revenue>
+				<revenue_subtotal>2500</revenue_subtotal>
+				<revenue_tax>511</revenue_tax>
+				<revenue_shipping>100.11</revenue_shipping>
+				<revenue_discount>666</revenue_discount>
+				<items>10</items>
+			</row>
+		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>3121.11</revenue>
 		<nb_visits_converted>1</nb_visits_converted>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
@@ -94,34 +94,8 @@
 		<max_actions>6</max_actions>
 		<sum_visit_length>5403</sum_visit_length>
 		<bounce_count>0</bounce_count>
-		<goals>
-			<row idgoal="1">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>10</revenue>
-			</row>
-			<row idgoal="ecommerceAbandonedCart">
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>2</nb_visits_converted>
-				<revenue>5020.22</revenue>
-				<items>8</items>
-			</row>
-			<row idgoal="ecommerceOrder">
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>3111.11</revenue>
-				<revenue_subtotal>2500</revenue_subtotal>
-				<revenue_tax>511</revenue_tax>
-				<revenue_shipping>100.11</revenue_shipping>
-				<revenue_discount>666</revenue_discount>
-				<items>10</items>
-			</row>
-		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>3121.11</revenue>
-		<conversion_rate>0%</conversion_rate>
 		<nb_actions_per_visit>4.3</nb_actions_per_visit>
-		<avg_time_on_site>1801</avg_time_on_site>
-		<bounce_rate>0%</bounce_rate>
 	</reportTotal>
 </result>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems__API.getProcessedReport_day.xml
@@ -94,6 +94,29 @@
 		<max_actions>6</max_actions>
 		<sum_visit_length>5403</sum_visit_length>
 		<bounce_count>0</bounce_count>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>10</revenue>
+			</row>
+			<row idgoal="ecommerceAbandonedCart">
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>2</nb_visits_converted>
+				<revenue>5020.22</revenue>
+				<items>8</items>
+			</row>
+			<row idgoal="ecommerceOrder">
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>3111.11</revenue>
+				<revenue_subtotal>2500</revenue_subtotal>
+				<revenue_tax>511</revenue_tax>
+				<revenue_shipping>100.11</revenue_shipping>
+				<revenue_discount>666</revenue_discount>
+				<items>10</items>
+			</row>
+		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>3121.11</revenue>
 		<nb_actions_per_visit>4.3</nb_actions_per_visit>

--- a/plugins/Referrers/tests/System/expected/test_Referrers_getReferrerType__API.getProcessedReport_day.xml
+++ b/plugins/Referrers/tests/System/expected/test_Referrers_getReferrerType__API.getProcessedReport_day.xml
@@ -1197,6 +1197,18 @@
 		<sum_visit_length>11315</sum_visit_length>
 		<bounce_count>62</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>31</nb_conversions>
+				<nb_visits_converted>31</nb_visits_converted>
+				<revenue>0</revenue>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>62</nb_conversions>
+				<nb_visits_converted>31</nb_visits_converted>
+				<revenue>0</revenue>
+			</row>
+		</goals>
 		<nb_conversions>93</nb_conversions>
 		<revenue>0</revenue>
 		<nb_actions_per_visit>31</nb_actions_per_visit>

--- a/plugins/Referrers/tests/System/expected/test_Referrers_getReferrerType__API.getProcessedReport_day.xml
+++ b/plugins/Referrers/tests/System/expected/test_Referrers_getReferrerType__API.getProcessedReport_day.xml
@@ -1193,27 +1193,12 @@
 		<nb_visits>62</nb_visits>
 		<nb_actions>62</nb_actions>
 		<nb_users>0</nb_users>
-		<max_actions>31</max_actions>
+		<max_actions>1</max_actions>
 		<sum_visit_length>11315</sum_visit_length>
 		<bounce_count>62</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
-		<goals>
-			<row idgoal="1">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>0</revenue>
-			</row>
-			<row idgoal="2">
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>0</revenue>
-			</row>
-		</goals>
 		<nb_conversions>93</nb_conversions>
 		<revenue>0</revenue>
-		<conversion_rate>0</conversion_rate>
 		<nb_actions_per_visit>31</nb_actions_per_visit>
-		<avg_time_on_site>5673</avg_time_on_site>
-		<bounce_rate>3100</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_flat__API.getProcessedReport_day.xml
@@ -577,8 +577,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>37.32</min_event_value>
-		<max_event_value>62.32</max_event_value>
-		<avg_event_value>19.54</avg_event_value>
+		<min_event_value>18.66</min_event_value>
+		<max_event_value>42.66</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
@@ -417,8 +417,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>37.32</min_event_value>
-		<max_event_value>62.32</max_event_value>
-		<avg_event_value>19.54</avg_event_value>
+		<min_event_value>18.66</min_event_value>
+		<max_event_value>42.66</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
@@ -528,8 +528,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>19.32</min_event_value>
-		<max_event_value>81.64</max_event_value>
-		<avg_event_value>19.54</avg_event_value>
+		<min_event_value>9.66</min_event_value>
+		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
@@ -171,8 +171,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>19.32</min_event_value>
-		<max_event_value>81.64</max_event_value>
-		<avg_event_value>19.54</avg_event_value>
+		<min_event_value>9.66</min_event_value>
+		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
@@ -606,8 +606,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>19.32</min_event_value>
-		<max_event_value>81.64</max_event_value>
-		<avg_event_value>19.54</avg_event_value>
+		<min_event_value>9.66</min_event_value>
+		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
@@ -267,8 +267,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>19.32</min_event_value>
-		<max_event_value>81.64</max_event_value>
-		<avg_event_value>19.54</avg_event_value>
+		<min_event_value>9.66</min_event_value>
+		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric__API.getProcessedReport_day.xml
@@ -74,8 +74,6 @@
 		<sum_time_spent>1440</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<entry_nb_visits>8</entry_nb_visits>
 		<entry_nb_actions>24</entry_nb_actions>
 		<entry_sum_visit_length>6484</entry_sum_visit_length>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric__API.getProcessedReport_day.xml
@@ -81,9 +81,5 @@
 		<entry_sum_visit_length>6484</entry_sum_visit_length>
 		<entry_bounce_count>4</entry_bounce_count>
 		<exit_nb_visits>4</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>180</avg_time_on_page>
-		<bounce_rate>50%</bounce_rate>
-		<exit_rate>50%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric_constantRowsCountShouldKeepEmptyRows__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric_constantRowsCountShouldKeepEmptyRows__API.getProcessedReport_day.xml
@@ -402,23 +402,8 @@
 		<sum_visit_length>6484</sum_visit_length>
 		<bounce_count>4</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
-		<goals>
-			<row idgoal="1">
-				<nb_conversions>8</nb_conversions>
-				<nb_visits_converted>8</nb_visits_converted>
-				<revenue>40</revenue>
-			</row>
-			<row idgoal="2">
-				<nb_conversions>4</nb_conversions>
-				<nb_visits_converted>4</nb_visits_converted>
-				<revenue>20</revenue>
-			</row>
-		</goals>
 		<nb_conversions>12</nb_conversions>
 		<revenue>60</revenue>
-		<conversion_rate>0%</conversion_rate>
 		<nb_actions_per_visit>3</nb_actions_per_visit>
-		<avg_time_on_site>811</avg_time_on_site>
-		<bounce_rate>50%</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric_constantRowsCountShouldKeepEmptyRows__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_ManyVisitorsOneWebsiteTest_sortByProcessedMetric_constantRowsCountShouldKeepEmptyRows__API.getProcessedReport_day.xml
@@ -402,6 +402,18 @@
 		<sum_visit_length>6484</sum_visit_length>
 		<bounce_count>4</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>8</nb_conversions>
+				<nb_visits_converted>8</nb_visits_converted>
+				<revenue>40</revenue>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>4</nb_conversions>
+				<nb_visits_converted>4</nb_visits_converted>
+				<revenue>20</revenue>
+			</row>
+		</goals>
 		<nb_conversions>12</nb_conversions>
 		<revenue>60</revenue>
 		<nb_actions_per_visit>3</nb_actions_per_visit>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__subtable__API.getProcessedReport_week.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__subtable__API.getProcessedReport_week.xml
@@ -71,14 +71,7 @@
 		<min_bandwidth />
 		<max_bandwidth />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
-		<avg_bandwidth>0</avg_bandwidth>
-		<conversion_rate>0%</conversion_rate>
 		<nb_actions_per_visit>0</nb_actions_per_visit>
-		<avg_time_on_site>0</avg_time_on_site>
-		<bounce_rate>100%</bounce_rate>
-		<avg_time_on_page>1080</avg_time_on_page>
-		<exit_rate>200%</exit_rate>
-		<avg_time_generation>0.615</avg_time_generation>
 		<exit_nb_visits>2</exit_nb_visits>
 		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
 		<entry_nb_visits>2</entry_nb_visits>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__subtable__API.getProcessedReport_week.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits__subtable__API.getProcessedReport_week.xml
@@ -68,8 +68,6 @@
 		<max_time_generation>0.615</max_time_generation>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<nb_actions_per_visit>0</nb_actions_per_visit>
 		<exit_nb_visits>2</exit_nb_visits>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
@@ -87,7 +87,5 @@
 		<nb_uniq_visitors>3</nb_uniq_visitors>
 		<entry_nb_uniq_visitors>1</entry_nb_uniq_visitors>
 		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
-		<avg_bandwidth>0</avg_bandwidth>
-		<exit_rate>50%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_hideColumns___API.getProcessedReport_day.xml
@@ -78,8 +78,6 @@
 		<max_time_generation>0.615</max_time_generation>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<entry_nb_actions>8</entry_nb_actions>
 		<entry_sum_visit_length>1621</entry_sum_visit_length>
 		<entry_bounce_count>1</entry_bounce_count>

--- a/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumns___API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_OneVisitorTwoVisits_showColumns___API.getProcessedReport_day.xml
@@ -83,6 +83,5 @@
 	<reportTotal>
 		<nb_hits>4</nb_hits>
 		<entry_nb_visits>2</entry_nb_visits>
-		<bounce_rate>50%</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
@@ -71,7 +71,5 @@
 		<nb_hits_following_search>2</nb_hits_following_search>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
@@ -73,9 +73,5 @@
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
 		<max_bandwidth />
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>84</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>0%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
@@ -73,9 +73,5 @@
 		<min_bandwidth />
 		<max_bandwidth />
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>84</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>0%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
@@ -70,8 +70,6 @@
 		<nb_hits_following_search>2</nb_hits_following_search>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
@@ -117,9 +117,5 @@
 		<max_bandwidth />
 		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>63</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>33%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
@@ -113,8 +113,6 @@
 		<nb_hits_following_search>2</nb_hits_following_search>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
 	</reportTotal>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_month.xml
@@ -112,8 +112,6 @@
 		<nb_hits_following_search>2</nb_hits_following_search>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
 		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_month.xml
@@ -117,9 +117,5 @@
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
 		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>63</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>33%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
@@ -78,7 +78,5 @@
 		<nb_hits_following_search>2</nb_hits_following_search>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
@@ -80,9 +80,5 @@
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
 		<max_bandwidth />
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>84</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>0%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
@@ -77,8 +77,6 @@
 		<nb_hits_following_search>2</nb_hits_following_search>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
@@ -80,9 +80,5 @@
 		<min_bandwidth />
 		<max_bandwidth />
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>84</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>0%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
@@ -108,9 +108,5 @@
 		<max_bandwidth />
 		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>63</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>33%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
@@ -104,8 +104,6 @@
 		<nb_hits_following_search>2</nb_hits_following_search>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
 	</reportTotal>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_month.xml
@@ -103,8 +103,6 @@
 		<nb_hits_following_search>2</nb_hits_following_search>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
 		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_month.xml
@@ -108,9 +108,5 @@
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<exit_nb_visits>1</exit_nb_visits>
 		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>63</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>33%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_day.xml
@@ -114,13 +114,9 @@
 		<sum_time_spent>882</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth>0</min_bandwidth>
-		<max_bandwidth>0</max_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
 		<nb_pages_per_search>9</nb_pages_per_search>
 		<exit_nb_visits>2</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>141</avg_time_on_page>
-		<bounce_rate>0</bounce_rate>
-		<exit_rate>53</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_day.xml
@@ -114,8 +114,6 @@
 		<sum_time_spent>882</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<nb_pages_per_search>9</nb_pages_per_search>
 		<exit_nb_visits>2</exit_nb_visits>
 	</reportTotal>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_month.xml
@@ -103,8 +103,6 @@
 		<sum_time_spent>882</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<nb_pages_per_search>8</nb_pages_per_search>
 		<exit_nb_visits>2</exit_nb_visits>
 	</reportTotal>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_month.xml
@@ -107,9 +107,5 @@
 		<max_bandwidth />
 		<nb_pages_per_search>8</nb_pages_per_search>
 		<exit_nb_visits>2</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>68</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>25%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_day.xml
@@ -73,12 +73,8 @@
 		<sum_time_spent>288</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth>0</min_bandwidth>
-		<max_bandwidth>0</max_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
 		<nb_pages_per_search>2</nb_pages_per_search>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>288</avg_time_on_page>
-		<bounce_rate>0</bounce_rate>
-		<exit_rate>0</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_day.xml
@@ -73,8 +73,6 @@
 		<sum_time_spent>288</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<nb_pages_per_search>2</nb_pages_per_search>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_month.xml
@@ -63,8 +63,6 @@
 		<sum_time_spent>288</sum_time_spent>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<nb_pages_per_search>1</nb_pages_per_search>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_month.xml
@@ -66,9 +66,5 @@
 		<min_bandwidth />
 		<max_bandwidth />
 		<nb_pages_per_search>1</nb_pages_per_search>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>144</avg_time_on_page>
-		<bounce_rate>0%</bounce_rate>
-		<exit_rate>0%</exit_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_day.xml
@@ -172,9 +172,6 @@
 		<nb_uniq_visitors>11</nb_uniq_visitors>
 		<nb_visits>11</nb_visits>
 		<nb_actions>14</nb_actions>
-		<conversion_rate>0</conversion_rate>
 		<nb_actions_per_visit>2.5</nb_actions_per_visit>
-		<avg_time_on_site>0</avg_time_on_site>
-		<bounce_rate>0</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_month.xml
@@ -118,9 +118,6 @@
 		<nb_visits>11</nb_visits>
 		<nb_actions>14</nb_actions>
 		<sum_daily_nb_uniq_visitors>11</sum_daily_nb_uniq_visitors>
-		<conversion_rate>0%</conversion_rate>
 		<nb_actions_per_visit>1.3</nb_actions_per_visit>
-		<avg_time_on_site>0</avg_time_on_site>
-		<bounce_rate>0%</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
@@ -297,12 +297,12 @@
 		<sum_time_spent>4500</sum_time_spent>
 		<sum_time_generation>5.239</sum_time_generation>
 		<nb_hits_with_time_generation>18</nb_hits_with_time_generation>
-		<min_time_generation>5.086</min_time_generation>
-		<max_time_generation>5.116</max_time_generation>
+		<min_time_generation>0.123</min_time_generation>
+		<max_time_generation>0.948</max_time_generation>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth>0</min_bandwidth>
-		<max_bandwidth>0</max_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
 		<entry_nb_uniq_visitors>7</entry_nb_uniq_visitors>
 		<entry_nb_visits>7</entry_nb_visits>
 		<entry_nb_actions>27</entry_nb_actions>
@@ -310,10 +310,5 @@
 		<entry_bounce_count>2</entry_bounce_count>
 		<exit_nb_uniq_visitors>7</exit_nb_uniq_visitors>
 		<exit_nb_visits>7</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>1500</avg_time_on_page>
-		<bounce_rate>100</bounce_rate>
-		<exit_rate>265</exit_rate>
-		<avg_time_generation>1.941</avg_time_generation>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageTitles_firstSite_lastN__API.getProcessedReport_day.xml
@@ -301,8 +301,6 @@
 		<max_time_generation>0.948</max_time_generation>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<entry_nb_uniq_visitors>7</entry_nb_uniq_visitors>
 		<entry_nb_visits>7</entry_nb_visits>
 		<entry_nb_actions>27</entry_nb_actions>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
@@ -313,8 +313,6 @@
 		<max_time_generation>0.775</max_time_generation>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
 		<entry_nb_uniq_visitors>7</entry_nb_uniq_visitors>
 		<entry_nb_visits>7</entry_nb_visits>
 		<entry_nb_actions>27</entry_nb_actions>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Actions.getPageUrls_firstSite_lastN__API.getProcessedReport_day.xml
@@ -309,12 +309,12 @@
 		<sum_time_spent>4500</sum_time_spent>
 		<sum_time_generation>5.239</sum_time_generation>
 		<nb_hits_with_time_generation>18</nb_hits_with_time_generation>
-		<min_time_generation>2.979</min_time_generation>
-		<max_time_generation>4.374</max_time_generation>
+		<min_time_generation>0.223</min_time_generation>
+		<max_time_generation>0.775</max_time_generation>
 		<sum_bandwidth>0</sum_bandwidth>
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth>0</min_bandwidth>
-		<max_bandwidth>0</max_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
 		<entry_nb_uniq_visitors>7</entry_nb_uniq_visitors>
 		<entry_nb_visits>7</entry_nb_visits>
 		<entry_nb_actions>27</entry_nb_actions>
@@ -322,10 +322,5 @@
 		<entry_bounce_count>2</entry_bounce_count>
 		<exit_nb_uniq_visitors>7</exit_nb_uniq_visitors>
 		<exit_nb_visits>7</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>900</avg_time_on_page>
-		<bounce_rate>100</bounce_rate>
-		<exit_rate>265</exit_rate>
-		<avg_time_generation>1.941</avg_time_generation>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_MultiSites.getAll_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_MultiSites.getAll_firstSite_lastN__API.getProcessedReport_day.xml
@@ -265,9 +265,5 @@
 		<nb_actions>31</nb_actions>
 		<nb_pageviews>31</nb_pageviews>
 		<revenue>35</revenue>
-		<visits_evolution>700</visits_evolution>
-		<actions_evolution>700</actions_evolution>
-		<pageviews_evolution>700</pageviews_evolution>
-		<revenue_evolution>600</revenue_evolution>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Referrers.getWebsites_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Referrers.getWebsites_firstSite_lastN__API.getProcessedReport_day.xml
@@ -153,13 +153,10 @@
 		<nb_visits>4</nb_visits>
 		<nb_actions>12</nb_actions>
 		<nb_users>0</nb_users>
-		<max_actions>12</max_actions>
+		<max_actions>5</max_actions>
 		<sum_visit_length>1802</sum_visit_length>
 		<bounce_count>2</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
-		<conversion_rate>0</conversion_rate>
 		<nb_actions_per_visit>12</nb_actions_per_visit>
-		<avg_time_on_site>1802</avg_time_on_site>
-		<bounce_rate>200</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getProcessedReport_day.xml
@@ -78,6 +78,13 @@
 		<max_actions>1</max_actions>
 		<sum_visit_length>1086</sum_visit_length>
 		<bounce_count>1</bounce_count>
+		<goals>
+			<row idgoal="3">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>42.26</revenue>
+			</row>
+		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>42.26</revenue>
 		<nb_actions_per_visit>1</nb_actions_per_visit>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getProcessedReport_day.xml
@@ -78,18 +78,8 @@
 		<max_actions>1</max_actions>
 		<sum_visit_length>1086</sum_visit_length>
 		<bounce_count>1</bounce_count>
-		<goals>
-			<row idgoal="3">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>42.26</revenue>
-			</row>
-		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>42.26</revenue>
-		<conversion_rate>0%</conversion_rate>
 		<nb_actions_per_visit>1</nb_actions_per_visit>
-		<avg_time_on_site>1086</avg_time_on_site>
-		<bounce_rate>100%</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_showRawMetrics__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_showRawMetrics__API.getProcessedReport_day.xml
@@ -91,6 +91,13 @@
 		<max_actions>1</max_actions>
 		<sum_visit_length>1086</sum_visit_length>
 		<bounce_count>1</bounce_count>
+		<goals>
+			<row idgoal="3">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>42.26</revenue>
+			</row>
+		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>42.26</revenue>
 		<nb_actions_per_visit>1</nb_actions_per_visit>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_showRawMetrics__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_showRawMetrics__API.getProcessedReport_day.xml
@@ -91,18 +91,8 @@
 		<max_actions>1</max_actions>
 		<sum_visit_length>1086</sum_visit_length>
 		<bounce_count>1</bounce_count>
-		<goals>
-			<row idgoal="3">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>42.26</revenue>
-			</row>
-		</goals>
 		<nb_conversions>1</nb_conversions>
 		<revenue>42.26</revenue>
-		<conversion_rate>0%</conversion_rate>
 		<nb_actions_per_visit>1</nb_actions_per_visit>
-		<avg_time_on_site>1086</avg_time_on_site>
-		<bounce_rate>100%</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__API.getProcessedReport_range.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__API.getProcessedReport_range.xml
@@ -73,6 +73,18 @@
 		<max_actions>3</max_actions>
 		<sum_visit_length>725</sum_visit_length>
 		<bounce_count>2</bounce_count>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>2</nb_visits_converted>
+				<revenue>1000</revenue>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>0</revenue>
+			</row>
+		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>1000</revenue>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__API.getProcessedReport_range.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI__API.getProcessedReport_range.xml
@@ -73,25 +73,10 @@
 		<max_actions>3</max_actions>
 		<sum_visit_length>725</sum_visit_length>
 		<bounce_count>2</bounce_count>
-		<goals>
-			<row idgoal="1">
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>2</nb_visits_converted>
-				<revenue>1000</revenue>
-			</row>
-			<row idgoal="2">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>0</revenue>
-			</row>
-		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>1000</revenue>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
-		<conversion_rate>0%</conversion_rate>
 		<nb_actions_per_visit>1.7</nb_actions_per_visit>
-		<avg_time_on_site>242</avg_time_on_site>
-		<bounce_rate>67%</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__API.getProcessedReport_range.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__API.getProcessedReport_range.xml
@@ -73,6 +73,18 @@
 		<max_actions>3</max_actions>
 		<sum_visit_length>725</sum_visit_length>
 		<bounce_count>2</bounce_count>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>2</nb_conversions>
+				<nb_visits_converted>2</nb_visits_converted>
+				<revenue>1000</revenue>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>0</revenue>
+			</row>
+		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>1000</revenue>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>

--- a/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__API.getProcessedReport_range.xml
+++ b/tests/PHPUnit/System/expected/test_periodIsRange_dateIsLastN_MetadataAndNormalAPI_pagesegment__API.getProcessedReport_range.xml
@@ -73,25 +73,10 @@
 		<max_actions>3</max_actions>
 		<sum_visit_length>725</sum_visit_length>
 		<bounce_count>2</bounce_count>
-		<goals>
-			<row idgoal="1">
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>2</nb_visits_converted>
-				<revenue>1000</revenue>
-			</row>
-			<row idgoal="2">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>0</revenue>
-			</row>
-		</goals>
 		<nb_conversions>3</nb_conversions>
 		<revenue>1000</revenue>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
-		<conversion_rate>0%</conversion_rate>
 		<nb_actions_per_visit>1.7</nb_actions_per_visit>
-		<avg_time_on_site>242</avg_time_on_site>
-		<bounce_rate>67%</bounce_rate>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables__subtable__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables__subtable__API.getProcessedReport_day.xml
@@ -79,6 +79,18 @@
 		<max_actions>13</max_actions>
 		<sum_visit_length>1805</sum_visit_length>
 		<bounce_count>4</bounce_count>
+		<goals>
+			<row idgoal="1">
+				<nb_conversions>5</nb_conversions>
+				<nb_visits_converted>5</nb_visits_converted>
+				<revenue>2000</revenue>
+			</row>
+			<row idgoal="2">
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
+				<revenue>0</revenue>
+			</row>
+		</goals>
 		<nb_conversions>6</nb_conversions>
 		<revenue>2000</revenue>
 		<nb_actions_per_visit>11</nb_actions_per_visit>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables__subtable__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables__subtable__API.getProcessedReport_day.xml
@@ -79,23 +79,8 @@
 		<max_actions>13</max_actions>
 		<sum_visit_length>1805</sum_visit_length>
 		<bounce_count>4</bounce_count>
-		<goals>
-			<row idgoal="1">
-				<nb_conversions>5</nb_conversions>
-				<nb_visits_converted>5</nb_visits_converted>
-				<revenue>2000</revenue>
-			</row>
-			<row idgoal="2">
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>0</revenue>
-			</row>
-		</goals>
 		<nb_conversions>6</nb_conversions>
 		<revenue>2000</revenue>
-		<conversion_rate>0%</conversion_rate>
 		<nb_actions_per_visit>11</nb_actions_per_visit>
-		<avg_time_on_site>1144</avg_time_on_site>
-		<bounce_rate>167%</bounce_rate>
 	</reportTotal>
 </result>


### PR DESCRIPTION
While checking tests for PHP 7.3 in #14148 it turned out that in many tests a `A non well formed numeric value encountered` error occurs.
This happens as the total report calculation tries to sum up any values regardless of their type.
To prevent that I've added a check for `is_numeric`
Also I thought it might be good to deactivate the total calculation for minimum, maximum, rate or nested metrics, as it doesn't make sense to sum up those values at all.