### PR TITLE
Improve GeoIP2 re-scheduling

### DIFF
--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -352,7 +352,7 @@ class GeoIP2AutoUpdater extends Task
             /** @var Scheduler $scheduler */
             $scheduler = StaticContainer::getContainer()->get('Piwik\Scheduler\Scheduler');
 
-            $scheduler->rescheduleTask(new GeoIP2AutoUpdater());
+            $scheduler->rescheduleTaskAndRunTomorrow(new GeoIP2AutoUpdater());
         }
 
         // clear option for GeoIP as not needed if GeoIP2 is set up


### PR DESCRIPTION
In #11659 only GeoIP Legacy updater has been adjusted. As this one is deprecated and GeoIP2 should be used in the future, we should improve the re-scheduling there as well.