### PR TITLE
Do not calculate report totals if totals metadata is found.

### DIFF
--- a/core/API/DataTableManipulator/ReportTotalsCalculator.php
+++ b/core/API/DataTableManipulator/ReportTotalsCalculator.php
@@ -87,7 +87,8 @@ class ReportTotalsCalculator extends DataTableManipulator
         $firstLevelTable = $this->makeSureToWorkOnFirstLevelDataTable($dataTable);
 
         if (!$firstLevelTable->getRowsCount()
-            || $firstLevelTable->getTotalsRow()
+            || $dataTable->getTotalsRow()
+            || $dataTable->getMetadata('totals')
         ) {
             return $dataTable;
         }


### PR DESCRIPTION
Otherwise, it will request the totals row when it doesn't need to.

(This was causing an issue w/ ProxySite since the target would no longer keep the totals row, causing the proxy to try to compute it.)