### PR TITLE
fix diagnostics template

### DIFF
--- a/plugins/Diagnostics/stylesheets/configfile.less
+++ b/plugins/Diagnostics/stylesheets/configfile.less
@@ -7,6 +7,10 @@
     font-style: italic;
   }
 
+  .pre {
+    white-space: pre-wrap;
+  }
+
   td.name {
     max-width: 330px;
     word-wrap: break-word;

--- a/plugins/Diagnostics/templates/configfile.twig
+++ b/plugins/Diagnostics/templates/configfile.twig
@@ -8,6 +8,10 @@
     {% elseif value is null %}
     {% elseif value is emptyString %}
         ''
+    {% elseif value is empty %}
+        []
+    {% elseif value is iterable %}
+        <div class="pre">{{ value|json_encode(constant('JSON_PRETTY_PRINT')) }}</div>
     {% else %}
         {{ value|join(', ') }}
     {% endif %}


### PR DESCRIPTION
I have been seeing this error quite often on my instance in Sentry
```
ErrorException: Array to string conversion
#33 vendor/twig/twig/lib/Twig/Extension/Core.php(740): handleError
```

It seems to be caused by my CustomiseTranslations plugin. Because when you are viewing the "Config File" Diagnostic page it tries to display the following data (as the plugin stores a list of dictionaries in the config)
```php
[{$$hashKey: object:457, translationKey: CorePluginsAdmin_PluginsManagement, translationText: This is text!!}, {$$hashKey: object:467, translationKey: , translationText: }]
```

My fix isn't great and I can't promise it works well, but maybe someone else can think of something more simple.