### PR TITLE
Consistent detection of HTTPS

### DIFF
--- a/core/Url.php
+++ b/core/Url.php
@@ -727,6 +727,14 @@ class Url
      */
     protected static function getCurrentSchemeFromRequestHeader()
     {
+        if (isset($_SERVER['HTTP_X_FORWARDED_SCHEME']) && strtolower($_SERVER['HTTP_X_FORWARDED_SCHEME']) === 'https') {
+            return 'https';
+        }
+
+        if (isset($_SERVER['HTTP_X_URL_SCHEME']) && strtolower($_SERVER['HTTP_X_URL_SCHEME']) === 'https') {
+            return 'https';
+        }
+
         if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'http') {
             return 'http';
         }


### PR DESCRIPTION
see https://github.com/matomo-org/matomo/blob/3.9.0-b3/core/ProxyHeaders.php#L22-L40 where we recognise these headers already