### PR TITLE
Fix dashboard copy to user with special chars

### DIFF
--- a/plugins/Dashboard/API.php
+++ b/plugins/Dashboard/API.php
@@ -126,7 +126,7 @@ class API extends \Piwik\Plugin\API
         }
 
         if (!$userFound) {
-            throw new \Exception(sprintf('Cannot copy dashboard to user %s, user not found or user does not have access to same site.', $copyToUser));
+            throw new \Exception(sprintf('Cannot copy dashboard to user %s, user not found.', $copyToUser));
         }
 
         $login  = Piwik::getCurrentUserLogin();

--- a/plugins/Dashboard/javascripts/dashboard.js
+++ b/plugins/Dashboard/javascripts/dashboard.js
@@ -136,7 +136,7 @@ function copyDashboardToUser() {
             ajaxRequest.addParams({
                 dashboardName: encodeURIComponent(copyDashboardName),
                 idDashboard: $('#dashboardWidgetsArea').dashboard('getDashboardId'),
-                copyToUser: encodeURIComponent(copyDashboardUser)
+                copyToUser: copyDashboardUser
             }, 'post');
             ajaxRequest.setCallback(
                 function (response) {


### PR DESCRIPTION
encoding the user name in the request causes problems as soon as any special chars are included because they won't be decoded on server side.

fixes #14191 