### PR TITLE
Add line break to email footer when whitelabel plugin active

### DIFF
--- a/plugins/CoreHome/templates/_htmlEmailFooter.twig
+++ b/plugins/CoreHome/templates/_htmlEmailFooter.twig
@@ -5,6 +5,8 @@
 
 {% if hasHorizontalRule %}
     <hr style=" border: 0; margin-top: 50px;  height: 1px; background-image: linear-gradient(to right, rgba(231, 231, 231, 0), rgba(231, 231, 231, 1), rgba(2311, 2311, 231, 0));">
+{% else %}
+    <br/>
 {% endif %}
 
 {% if not hasWhiteLabel %}


### PR DESCRIPTION
Fixes #14120 

![image](https://user-images.githubusercontent.com/4185912/54316237-1c1f1e80-4645-11e9-94a4-a1981c47a36e.png)
