### PR TITLE
Display a warning if using an EOL version of PHP

### DIFF
--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -207,7 +207,7 @@ abstract class ControllerAdmin extends Controller
      */
     private static function getNextRequiredMinimumPHP()
     {
-        return '5.5.9';
+        return '7.1';
     }
 
     private static function isUsingPhpVersionCompatibleWithNextPiwik()
@@ -240,23 +240,24 @@ abstract class ControllerAdmin extends Controller
 
     private static function notifyWhenPhpVersionIsEOL()
     {
-        return; // no supported version (5.5+) has currently ended support
-        $notifyPhpIsEOL = Piwik::hasUserSuperUserAccess() && self::isPhpVersionAtLeast55();
+        $notifyPhpIsEOL = Piwik::hasUserSuperUserAccess() && ! self::isPhpVersionAtLeast71();
         if (!$notifyPhpIsEOL) {
             return;
         }
 
+        $deprecatedMajorPhpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
         $message = Piwik::translate('General_WarningPiwikWillStopSupportingPHPVersion', array($deprecatedMajorPhpVersion, self::getNextRequiredMinimumPHP()))
-            . "\n "
+            . "<br/> "
             . Piwik::translate('General_WarningPhpVersionXIsTooOld', $deprecatedMajorPhpVersion);
 
         $notification = new Notification($message);
+        $notification->raw = true;
         $notification->title = Piwik::translate('General_Warning');
         $notification->priority = Notification::PRIORITY_LOW;
         $notification->context = Notification::CONTEXT_WARNING;
         $notification->type = Notification::TYPE_TRANSIENT;
         $notification->flags = Notification::FLAG_NO_CLEAR;
-        NotificationManager::notify('PHP54VersionCheck', $notification);
+        NotificationManager::notify('PHP71VersionCheck', $notification);
     }
 
     private static function notifyWhenDebugOnDemandIsEnabled($trackerSetting)
@@ -365,8 +366,8 @@ abstract class ControllerAdmin extends Controller
         return "Matomo " . Version::VERSION;
     }
 
-    private static function isPhpVersionAtLeast55()
+    private static function isPhpVersionAtLeast71()
     {
-        return version_compare(PHP_VERSION, '5.5', '>=');
+        return version_compare(PHP_VERSION, '7.1', '>=');
     }
 }


### PR DESCRIPTION
Warn the user if their version of PHP is < 7.1

![image](https://user-images.githubusercontent.com/4185912/54316422-8df76800-4645-11e9-8a5b-b38299245dac.png)

Fixes #14174 