### PR TITLE
Ignore config files placed in misc folder in fileintegrity check

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -111,6 +111,7 @@ return array(
         'misc/user/*png',
         'misc/user/*svg',
         'misc/user/*js',
+        'misc/user/*/config.ini.php',
         'misc/package',
         'misc/package/WebAppGallery/*.xml',
         'misc/package/WebAppGallery/install.sql',


### PR DESCRIPTION
Follow up from https://github.com/matomo-org/matomo/pull/13999 where we allowed to place config files in misc/user directory. These need to be ignored in the file check