### PR TITLE
Ensure first sparkline is highlighted after switching periods in row evolution overlay

### DIFF
--- a/plugins/CoreVisualizations/javascripts/jqplot.js
+++ b/plugins/CoreVisualizations/javascripts/jqplot.js
@@ -761,6 +761,7 @@ RowEvolutionSeriesToggle.prototype.attachEvents = function () {
             // show the active series
             // if initiallyShowAll, all are active; otherwise only the first one
             self.activated.push(true);
+            el.find('td').css('opacity', '');
         } else {
             // fade out the others
             el.find('td').css('opacity', .5);


### PR DESCRIPTION
When switching the periods in the evolution chart in the row evolution overlay, the selected metrics are unset. If another metric than the first one was selected at this point, no metric is highlighted in the sparkline list below afterwards.

Note: This is just a quick fix for the current behavior. Imho it would be a lot better to actually restore the selected metrics when switching the period

refs #14208