### PR TITLE
use mb_substr wrapper method

### DIFF
--- a/core/Date.php
+++ b/core/Date.php
@@ -744,7 +744,7 @@ class Date
         }
 
         if ($ucfirst) {
-          $out = Common::mb_strtoupper(mb_substr($out, 0, 1)) . mb_substr($out, 1);
+          $out = Common::mb_strtoupper(Common::mb_substr($out, 0, 1)) . Common::mb_substr($out, 1);
         }
 
         return $out;


### PR DESCRIPTION
might otherwise cause problems if mbstring extensions is not installed

This was reported multiple times by mail