### PR TITLE
Make sure Monolog never adds its default handler.

### DIFF
--- a/plugins/Monolog/config/config.php
+++ b/plugins/Monolog/config/config.php
@@ -37,7 +37,13 @@ return array(
             || \Piwik\CliMulti::isCliMultiRequest();
 
         $writerNames = array_map('trim', $writerNames);
-        $writers = array();
+
+        $writers = [
+            // we always add the null handler to make sure there is at least one handler specified. otherwise Monolog will
+            // add a stream handler to stderr w/ a DEBUG log level, which will cause archiving requests to fail.
+            $c->get(\Monolog\Handler\NullHandler::class),
+        ];
+
         foreach ($writerNames as $writerName) {
             if ($writerName === 'screen' && \Piwik\Common::isPhpCliMode()) {
                 continue; // screen writer is only valid for web requests


### PR DESCRIPTION
Fixes #14229 

This issue was always around, but exposed probably by https://github.com/matomo-org/matomo/blob/3.x-dev/plugins/Monolog/config/config.php#L42-L44, which results in an empty handlers array. Causing the following code in Monolog to be executed:

```
        if (!$this->handlers) {
            $this->pushHandler(new StreamHandler('php://stderr', static::DEBUG));
        }
```

Which resulted in climulti requests always having debug level output.

Note: this code doesn't appear to be in the latest monolog version.