### PR TITLE
Do not send password changed email for automated use cases.

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -922,7 +922,9 @@ class API extends \Piwik\Plugin\API
             $this->sendEmailChangedEmail($userInfo, $email);
         }
 
-        if ($passwordHasBeenUpdated) {
+        if ($passwordHasBeenUpdated
+            && $requirePasswordConfirmation
+        ) {
             $this->sendPasswordChangedEmail($userInfo);
         }
 


### PR DESCRIPTION
Fixes https://github.com/matomo-org/plugin-LoginLdap/issues/180

Updated since previous solution wouldn't work.