### PR TITLE
Remove unused Pagination key

### DIFF
--- a/plugins/MultiSites/lang/en.json
+++ b/plugins/MultiSites/lang/en.json
@@ -3,7 +3,6 @@
         "Evolution": "Evolution",
         "LoadingWebsites": "Loading websites",
         "PluginDescription": "View and compare all your websites and apps in this useful 'All Websites' dashboard. ",
-        "TopLinkTooltip": "Compare Web Analytics stats for all of your Websites.",
-        "Pagination": "%1$s - %2$s of %3$s"
+        "TopLinkTooltip": "Compare Web Analytics stats for all of your Websites."
     }
 }


### PR DESCRIPTION
One more pagination clean-up (follow-up to #14157):

Remove unused translation key. This key is not used, and wasn't used immediately prior to #14157 either.