### PR TITLE
Only print warning if locking failed, fixes #14167

### DIFF
--- a/plugins/PrivacyManager/LogDataPurger.php
+++ b/plugins/PrivacyManager/LogDataPurger.php
@@ -71,11 +71,13 @@ class LogDataPurger
         $logTables = self::getDeleteTableLogTables();
 
         // delete unused actions from the log_action table (but only if we can lock tables)
-        if ($deleteUnusedLogActions && Db::isLockPrivilegeGranted()) {
-            $this->rawLogDao->deleteUnusedLogActions();
-        } else {
-            $logMessage = get_class($this) . ": LOCK TABLES privilege not granted; skipping unused actions purge";
-            Log::warning($logMessage);
+        if ($deleteUnusedLogActions) {
+            if (Db::isLockPrivilegeGranted()) {
+                $this->rawLogDao->deleteUnusedLogActions();
+            } else {
+                $logMessage = get_class($this) . ": LOCK TABLES privilege not granted; skipping unused actions purge";
+                Log::warning($logMessage);
+            }
         }
 
         /**


### PR DESCRIPTION
Hi,
I think I found the reason for #14167 (the PrivacyManager\LogDataPurger prints a warning which leads to a non-zero exit code of the console process).
I didn’t get any failure in the last 6 days (normally it happens every 5 days) so it seems to work.