### PR TITLE
Add a config to disable e-mail notifications on password/email change through API

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -453,6 +453,9 @@ noreply_email_name = ""
 ; set to 0 to disable sending of all emails. useful for testing.
 emails_enabled = 1
 
+; set to 0 to disable sending of emails in API UserManager::updateUser endpoint
+api_update_users_email_notifications = 1
+
 ; feedback email address;
 ; when testing, use your own email address or "nobody"
 feedback_email_address = "feedback@matomo.org"

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -453,8 +453,8 @@ noreply_email_name = ""
 ; set to 0 to disable sending of all emails. useful for testing.
 emails_enabled = 1
 
-; set to 0 to disable sending of emails in API UserManager::updateUser endpoint
-api_update_users_email_notifications = 1
+; set to 0 to disable sending of emails when a password or email is changed
+enable_update_users_email = 1
 
 ; feedback email address;
 ; when testing, use your own email address or "nobody"

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -853,7 +853,7 @@ class API extends \Piwik\Plugin\API
                                $_isPasswordHashed = false, $passwordConfirmation = false)
     {
         $requirePasswordConfirmation = self::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION;
-        $isEmailNotificationOnInConfig = Config::getInstance()->General['api_update_users_email_notifications'];
+        $isEmailNotificationOnInConfig = Config::getInstance()->General['enable_update_users_email'];
         self::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = true;
 
         Piwik::checkUserHasSuperUserAccessOrIsTheUser($userLogin);

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -853,6 +853,7 @@ class API extends \Piwik\Plugin\API
                                $_isPasswordHashed = false, $passwordConfirmation = false)
     {
         $requirePasswordConfirmation = self::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION;
+        $isEmailNotificationOnInConfig = Config::getInstance()->General['api_update_users_email_notifications'];
         self::$UPDATE_USER_REQUIRE_PASSWORD_CONFIRMATION = true;
 
         Piwik::checkUserHasSuperUserAccessOrIsTheUser($userLogin);
@@ -918,13 +919,11 @@ class API extends \Piwik\Plugin\API
 
         Cache::deleteTrackerCache();
 
-        if ($email != $userInfo['email']) {
+        if ($email != $userInfo['email'] && $isEmailNotificationOnInConfig) {
             $this->sendEmailChangedEmail($userInfo, $email);
         }
 
-        if ($passwordHasBeenUpdated
-            && $requirePasswordConfirmation
-        ) {
+        if ($passwordHasBeenUpdated && $requirePasswordConfirmation && $isEmailNotificationOnInConfig) {
             $this->sendPasswordChangedEmail($userInfo);
         }
 

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -157,7 +157,14 @@ class APITest extends IntegrationTestCase
         Fixture::createWebsite('2014-01-01 00:00:00');
         $this->api->addUser($this->login, $this->password, 'userlogin@password.de');
     }
+    
+    public function tearDown()
+    {
+        Config::getInstance()->General['enable_update_users_email'] = 1;
 
+        parent::tearDown(); 
+    }
+    
     public function test_setUserAccess_ShouldTriggerRemoveSiteAccessEvent_IfAccessToAWebsiteIsRemoved()
     {
         $eventTriggered = false;
@@ -338,7 +345,6 @@ class APITest extends IntegrationTestCase
 
         $subjects = array_map(function (Mail $mail) { return $mail->getSubject(); }, $capturedMails);
         $this->assertEquals([], $subjects);
-        Config::getInstance()->General['enable_update_users_email'] = 1;
     }
 
     public function test_updateUser_doesNotChangePasswordIfFalsey()

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -325,7 +325,7 @@ class APITest extends IntegrationTestCase
 
     public function test_updateUser_doesNotSendEmailsIfTurnedOffInConfig()
     {
-        Config::getInstance()->General['api_update_users_email_notifications'] = 0;
+        Config::getInstance()->General['enable_update_users_email'] = 0;
         $capturedMails = [];
         Piwik::addAction('Mail.send', function (Mail $mail) use (&$capturedMails) {
             $capturedMails[] = $mail;
@@ -338,7 +338,7 @@ class APITest extends IntegrationTestCase
 
         $subjects = array_map(function (Mail $mail) { return $mail->getSubject(); }, $capturedMails);
         $this->assertEquals([], $subjects);
-        Config::getInstance()->General['api_update_users_email_notifications'] = 1;
+        Config::getInstance()->General['enable_update_users_email'] = 1;
     }
 
     public function test_updateUser_doesNotChangePasswordIfFalsey()


### PR DESCRIPTION
Adds a new config option `api_update_users_email_notifications` that when set to 0 disables all emails from `UserManager::updateUser` API endpoint. #14267