### PR TITLE
fix Unsupported pivot dimension when switching between related event reports

### DIFF
--- a/plugins/Events/Reports/Base.php
+++ b/plugins/Events/Reports/Base.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\Events\Reports;
 
 use Piwik\EventDispatcher;
+use Piwik\Common;
 use Piwik\Plugin\ViewDataTable;
 use Piwik\Plugins\Events\API;
 use Piwik\Plugins\Events\Columns\Metrics\AverageEventValue;
@@ -40,6 +41,16 @@ abstract class Base extends \Piwik\Plugin\Report
 
     public function configureView(ViewDataTable $view)
     {
+        if (Common::getRequestVar('secondaryDimension')) {
+            foreach (['pivotBy', 'pivotByColumn'] as $property) {
+                $index = array_search($property, $view->requestConfig->overridableProperties);
+                if ($index) {
+                    unset($view->requestConfig->overridableProperties[$index]);
+                }
+            }
+            $view->requestConfig->overridableProperties = array_values($view->requestConfig->overridableProperties);
+        }
+
         $this->configureFooterMessage($view);
     }
 


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/9716

I actually tried to fix it by changing eg 
```php

class GetCategoryFromNameId extends Base
{
    protected function init()
    {
        parent::init();

        $this->dimension     = new EventCategory();
        $this->name          = Piwik::translate('Events_EventCategories');
        $this->isSubtableReport = true;
    }
}
```

to 
```php
class GetCategoryFromNameId extends Base
{
    protected function init()
    {
        parent::init();

        $this->dimension     = new EventCategory();
        $this->name          = Piwik::translate('Events_EventCategories');
        $this->isSubtableReport = true;
        $this->parameters = array('secondaryDimension' => 'eventName')
    }
}
```

so the report has its own unique id and the viewDataTables will be only applied to this report. The problem though is that this doesn't quite work with our report factory which would always use the `GetCategory` report etc.

The easy workaround is to simply not store the pivoted view data table option when switching between related reports.