### PR TITLE
Adds new ViewDataTable.configure.end event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ### New APIs
 * A new tracker method `ping` has been added to send a ping request manually instead of using the heart beat timer.
+* Added new event `ViewDataTable.configure.end`, triggered after view configuration properties have been overwritten by saved settings and query parameters.
 
 ## Matomo 3.9.0
 

--- a/core/Plugin/ViewDataTable.php
+++ b/core/Plugin/ViewDataTable.php
@@ -239,6 +239,9 @@ abstract class ViewDataTable implements ViewInterface
          * Triggered during {@link ViewDataTable} construction. Subscribers should customize
          * the view based on the report that is being displayed.
          *
+         * This event is triggered before view configuration properties are overwritten by saved settings or request
+         * parameters. Use this to define default values.
+         *
          * Plugins that define their own reports must subscribe to this event in order to
          * specify how the Piwik UI should display the report.
          *
@@ -275,6 +278,31 @@ abstract class ViewDataTable implements ViewInterface
 
         $this->overrideViewPropertiesWithParams($overrideParams);
         $this->overrideViewPropertiesWithQueryParams();
+
+        /**
+         * Triggered after {@link ViewDataTable} construction. Subscribers should customize
+         * the view based on the report that is being displayed.
+         *
+         * This event is triggered after all view configuration values have been overwritten by saved settings or
+         * request parameters. Use this if you need to work with the final configuration values.
+         *
+         * Plugins that define their own reports can subscribe to this event in order to
+         * specify how the Piwik UI should display the report.
+         *
+         * **Example**
+         *
+         *     // event handler
+         *     public function configureViewDataTableEnd(ViewDataTable $view)
+         *     {
+         *         if ($view->requestConfig->apiMethodToRequestDataTable == 'VisitTime.getVisitInformationPerServerTime'
+         *             && $view->requestConfig->flat == 1) {
+         *                 $view->config->show_header_message = 'You are viewing this report flattened';
+         *         }
+         *     }
+         *
+         * @param ViewDataTable $view The instance to configure.
+         */
+        Piwik::postEvent('ViewDataTable.configure.end', array($this));
     }
 
     private function assignRelatedReportsTitle()


### PR DESCRIPTION
While developing a plugin I tried to add a footer message to an existing report when the report is shown flattened. I tried that using the event `ViewDataTable.configure` with following code.

```php
if ('Plugin.method' === $view->requestConfig->apiMethodToRequestDataTable && $view->requestConfig->flat) {
    $view->config->show_footer_message = $message;
}
```

I wondered why that worked when switching to the flattened view, but not after reloading the page (having the report still flattened).
The reason is, that the saved viewdata parameters are injected after the event is posted. That means that  `$view->requestConfig->flat` holds the default value `false` until then.

My expectations would have been, that the event already gets the final parameters. If that's wrong maybe we could add a new event `ViewDataTable.configure.end` or similar that works with the final parameters?

ping @tsteur @diosmosis @mattab 