### PR TITLE
Show correct message why plugin was deactivated when it has a missing license

### DIFF
--- a/plugins/Marketplace/Plugins/InvalidLicenses.php
+++ b/plugins/Marketplace/Plugins/InvalidLicenses.php
@@ -193,7 +193,7 @@ class InvalidLicenses
                     continue;
                 }
                 $pluginName = $plugin['name'];
-                if ($this->isPluginActivated($pluginName)) {
+                if ($this->isPluginInActivatedPluginsList($pluginName)) {
                     if (empty($plugin['consumer']['license'])) {
                         $pluginNames['noLicense'][] = $pluginName;
                     } elseif (!empty($plugin['consumer']['license']['isExceeded'])) {
@@ -223,7 +223,7 @@ class InvalidLicenses
         $this->activatedPluginNames = $pluginNames;
     }
 
-    protected function isPluginActivated($pluginName)
+    protected function isPluginInActivatedPluginsList($pluginName)
     {
         if (empty($this->activatedPluginNames)){
             $this->activatedPluginNames = $this->pluginManager->getActivatedPluginsFromConfig();

--- a/plugins/Marketplace/Plugins/InvalidLicenses.php
+++ b/plugins/Marketplace/Plugins/InvalidLicenses.php
@@ -223,22 +223,13 @@ class InvalidLicenses
         $this->activatedPluginNames = $pluginNames;
     }
 
-    protected function isPluginInstalled($pluginName)
-    {
-        if (in_array($pluginName, $this->activatedPluginNames)) {
-            return true;
-        }
-
-        return $this->pluginManager->isPluginInstalled($pluginName);
-    }
-
     protected function isPluginActivated($pluginName)
     {
-        if (in_array($pluginName, $this->activatedPluginNames)) {
-            return true;
+        if (empty($this->activatedPluginNames)){
+            $this->activatedPluginNames = $this->pluginManager->getActivatedPluginsFromConfig();
         }
 
-        return $this->pluginManager->isPluginActivated($pluginName);
+        return is_array($this->activatedPluginNames) && in_array($pluginName, $this->activatedPluginNames);
     }
 
 }


### PR DESCRIPTION
… license

I was never able to reproduce this issue until I disabled development mode. 
With the old code, when no valid license in the Marketplace was configured and development mode is disabled, it would show a message "Plugin XYZ could not be loaded" where it should have said "Plugin was not loaded because the license is missing".

This was regressed in https://github.com/matomo-org/matomo/blob/3.10.0-b1/core/Plugin/Manager.php#L1058-L1086 where we unloaded plugin when the license is missing, so that logic failed to determine that the plugin was activated. By looking at the config we can ensure to correctly detect if plugin is still activated or not and now shows correct message.

A test is not really easily possible to write as some logic is disabled for tests etc and might not be actually needed.