### PR TITLE
Copy geoip archive into temporary folder instead of in the geoip folder

### DIFF
--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -129,7 +129,7 @@ class GeoIP2AutoUpdater extends Task
         // NOTE: using the first item in $dbNames[$dbType] makes sure GeoLiteCity will be renamed to GeoIPCity
         $zippedFilename = LocationProviderGeoIp2::$dbNames[$dbType][0] . '.' . $ext;
 
-        $zippedOutputPath = LocationProviderGeoIp2::getPathForGeoIpDatabase($zippedFilename);
+        $zippedOutputPath = self::getTemporaryFolder($zippedFilename);
 
         $url = self::removeDateFromUrl($url);
 
@@ -156,6 +156,11 @@ class GeoIP2AutoUpdater extends Task
         }
 
         Log::info("GeoIP2AutoUpdater: successfully updated GeoIP 2 database '%s'", $url);
+    }
+
+    protected static function getTemporaryFolder($file)
+    {
+        return \Piwik\Container\StaticContainer::get('path.tmp') . '/latest/' . $file;
     }
 
     /**
@@ -201,7 +206,7 @@ class GeoIP2AutoUpdater extends Task
 
             $dbFilename = basename($fileToExtract);
             $tempFilename = $dbFilename . '.new';
-            $outputPath = LocationProviderGeoIp2::getPathForGeoIpDatabase($tempFilename);
+            $outputPath = self::getTemporaryFolder($tempFilename);
 
             // write unzipped to file
             $fd = fopen($outputPath, 'wb');
@@ -212,7 +217,7 @@ class GeoIP2AutoUpdater extends Task
 
             $dbFilename = basename($path);
             $tempFilename = $dbFilename . '.new';
-            $outputPath = LocationProviderGeoIp2::getPathForGeoIpDatabase($tempFilename);
+            $outputPath = self::getTemporaryFolder($tempFilename);
 
             $success = $unzip->extract($outputPath);
 
@@ -235,7 +240,7 @@ class GeoIP2AutoUpdater extends Task
                 'loc' => array(),
                 'isp' => array()
             );
-            $customDbNames[$dbType] = array($tempFilename);
+            $customDbNames[$dbType] = $outputPath;
 
             $phpProvider = new Php($customDbNames);
 
@@ -258,7 +263,7 @@ class GeoIP2AutoUpdater extends Task
                 unlink($oldDbFile);
             }
 
-            $tempFile = LocationProviderGeoIp2::getPathForGeoIpDatabase($tempFilename);
+            $tempFile = self::getTemporaryFolder($tempFilename);
             if (@rename($tempFile, $oldDbFile) !== true) {
                 //In case the $tempfile cannot be renamed, we copy the file.
                 copy($tempFile, $oldDbFile);

--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -240,7 +240,7 @@ class GeoIP2AutoUpdater extends Task
                 'loc' => array(),
                 'isp' => array()
             );
-            $customDbNames[$dbType] = $outputPath;
+            $customDbNames[$dbType] = array($outputPath);
 
             $phpProvider = new Php($customDbNames);
 

--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -260,7 +260,7 @@ class GeoIP2AutoUpdater extends Task
             // delete the existing GeoIP database (if any) and rename the downloaded file
             $oldDbFile = LocationProviderGeoIp2::getPathForGeoIpDatabase($dbFilename);
             if (file_exists($oldDbFile)) {
-                unlink($oldDbFile);
+                @unlink($oldDbFile);
             }
 
             $tempFile = self::getTemporaryFolder($tempFilename);

--- a/plugins/GeoIp2/LocationProvider/GeoIp2.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2.php
@@ -124,6 +124,10 @@ abstract class GeoIp2 extends LocationProvider
      */
     public static function getPathForGeoIpDatabase($filename)
     {
+        if (strpos($filename, '/') !== false && file_exists($filename)) {
+            return $filename;
+        }
+
         return StaticContainer::get('path.geoip2') . $filename;
     }
 

--- a/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
@@ -320,15 +320,7 @@ class Php extends GeoIp2
     private function getGeoIpInstance($key)
     {
         if (empty($this->readerCache[$key])) {
-            if (is_string($this->customDbNames[$key])
-                && strpos( $this->customDbNames[$key], '/') !== false
-                && @file_exists($this->customDbNames[$key])) {
-                // for performance reason we only check for file exists if the string contains a slash and is not only a
-                // filename
-                $pathToDb = $this->customDbNames[$key];
-            } else {
-                $pathToDb = self::getPathToGeoIpDatabase($this->customDbNames[$key]);
-            }
+            $pathToDb = self::getPathToGeoIpDatabase($this->customDbNames[$key]);
             if ($pathToDb !== false) {
                 try {
                     $this->readerCache[$key] = new Reader($pathToDb);

--- a/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
@@ -320,7 +320,8 @@ class Php extends GeoIp2
     private function getGeoIpInstance($key)
     {
         if (empty($this->readerCache[$key])) {
-            if (strpos( $this->customDbNames[$key], '/') !== false
+            if (is_string($this->customDbNames[$key])
+                && strpos( $this->customDbNames[$key], '/') !== false
                 && @file_exists($this->customDbNames[$key])) {
                 // for performance reason we only check for file exists if the string contains a slash and is not only a
                 // filename

--- a/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
+++ b/plugins/GeoIp2/LocationProvider/GeoIp2/Php.php
@@ -320,7 +320,14 @@ class Php extends GeoIp2
     private function getGeoIpInstance($key)
     {
         if (empty($this->readerCache[$key])) {
-            $pathToDb = self::getPathToGeoIpDatabase($this->customDbNames[$key]);
+            if (strpos( $this->customDbNames[$key], '/') !== false
+                && @file_exists($this->customDbNames[$key])) {
+                // for performance reason we only check for file exists if the string contains a slash and is not only a
+                // filename
+                $pathToDb = $this->customDbNames[$key];
+            } else {
+                $pathToDb = self::getPathToGeoIpDatabase($this->customDbNames[$key]);
+            }
             if ($pathToDb !== false) {
                 try {
                     $this->readerCache[$key] = new Reader($pathToDb);


### PR DESCRIPTION
I noticed the geoip tar.gz archive is downloaded  and extracted into the `misc` directory or whatever is configured eg through ` 'path.geoip2' => DI\string('{path.root}/misc/geoip/'),`. However, only the `misc/GeoLite2-City.mmdb` might have write access but not any other file. This causes the updating of the geodb to fail. Instead, it should be extracted into the `tmp/latest` folder which we use for such cases (eg matomo update, plugin update, ...)