### PR TITLE
Fix build for failing integration test purger

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -368,7 +368,7 @@ class Model
             // segments are md5 hashes and such not a problem re sql injection. for performance etc we don't want to use
             // bound parameters for the query
             foreach ($segments as $segment) {
-                if (!ctype_xdigit($segment)) {
+                if (!preg_match('/^[a-z0-9A-Z]+$/', $segment)) {
                     throw new Exception($segment . ' expected to be an md5 hash');
                 }
             }


### PR DESCRIPTION
I added a ctype_xdigit test to 100% prevent injections but then noticed the tests use also some other letters. Could restrict the preg_match to `a-f` but using `A-Z` makes the tests a bit more readable and is as safe