### PR TITLE
Don't tell people to run chmod -R 755 on their install if update fails

### DIFF
--- a/core/Filechecks.php
+++ b/core/Filechecks.php
@@ -111,8 +111,9 @@ class Filechecks
     {
         $realpath = Filesystem::realpath(PIWIK_INCLUDE_PATH . '/');
         $message = '';
-        $message .= "<code>" . self::getCommandToChangeOwnerOfPiwikFiles() . "</code><br />";
-        $message .= "<code>chmod -R 0755 " . $realpath . "</code><br />";
+        $message .= "<br /><code>" . self::getCommandToChangeOwnerOfPiwikFiles() . "</code><br />";
+        $message .= self::getMakeWritableCommand($realpath);
+        $message .= '<code>chmod 755 '.$realpath.'/console</code><br />';
         $message .= 'After you execute these commands (or change permissions via your FTP software), refresh the page and you should be able to use the "Automatic Update" feature.';
         return $message;
     }
@@ -183,7 +184,7 @@ class Filechecks
         if (SettingsServer::isWindows()) {
             return "<code>cacls $realpath /t /g " . Common::sanitizeInputValue(self::getUser()) . ":f</code><br />\n";
         }
-        return "<code>chmod -R 0755 $realpath</code><br />";
+        return "<code>find $realpath -type f -exec chmod 644 {} \;</code><br /><code>find $realpath -type d -exec chmod 755 {} \;</code><br />";
     }
 
     /**


### PR DESCRIPTION
fix #13628

For not writable directory it generated eg this:
```
chown -R foo:localaccounts /var/www/matomo
find /var/www/matomo/tmp -type f -exec chmod 644 {} \;
find /var/www/matomo/tmp -type d -exec chmod 755 {} \;
```

for auto update it also adds execute permission for `console`

```
chmod 755 /var/www/matomo/console
```

Not sure if any other file needs permission to execute? Couldn't think of any right now. Of course the find commands above they don't change the permission of any symlinks or so. Not sure what users possibly have in there and if it could create some issue. Could extend the find command to something like `-type f or -type l`.

Also generally not sure if `find` is compatible like this on all *nix.

@Findus23 maybe any thoughts?