### PR TITLE
Fix possible error in charts "[] operator not supported for strings" 

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/Graph/Config.php
+++ b/plugins/CoreVisualizations/Visualizations/Graph/Config.php
@@ -63,7 +63,7 @@ class Config extends VisualizationConfig
      *
      * @see self::ROW_PICKER_VALUE_COLUMN
      */
-    public $selectable_rows = 'selectable_rows';
+    public $selectable_rows = [];
 
     /**
      * Controls whether all ticks & labels are shown on a graph's x-axis or just some.


### PR DESCRIPTION
When loading the evolution chart for acquisition report, I received the following error `[] operator not supported for strings
in /var/www/matomo/plugins/CoreVisualizations/Visualizations/Graph.php line 138`

That seems to happen as the default value for that variable used to be a `string`. Using an empty array instead fixes the issue. Not sure which circumstances lead to that error, as I'm not able to reproduce it on demo. Might also be a regression of #14332 ?

Actually I'm not sure why the default is `selectable_rows`, as I couldn't find any usage of that string anywhere else.

