### PR TITLE
Fix download issues via cURL with HTTP/2

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -182,9 +182,11 @@ class Http
             . ($userAgent ? " ($userAgent)" : '');
 
         // range header
+        $rangeBytes = '';
         $rangeHeader = '';
         if (!empty($byteRange)) {
-            $rangeHeader = 'Range: bytes=' . $byteRange[0] . '-' . $byteRange[1] . "\r\n";
+            $rangeBytes = $byteRange[0] . '-' . $byteRange[1];
+            $rangeHeader = 'Range: bytes=' . $rangeBytes . "\r\n";
         }
 
         list($proxyHost, $proxyPort, $proxyUser, $proxyPassword) = self::getProxyConfiguration($aUrl);
@@ -517,7 +519,6 @@ class Http
                 CURLOPT_HTTPHEADER     => array_merge(array(
                     $xff,
                     $via,
-                    $rangeHeader,
                     $acceptLanguage
                 ), $additionalHeaders),
                 // only get header info if not saving directly to file
@@ -525,6 +526,11 @@ class Http
                 CURLOPT_CONNECTTIMEOUT => $timeout,
                 CURLOPT_TIMEOUT        => $timeout,
             );
+
+            if ($rangeBytes) {
+                curl_setopt($ch, CURLOPT_RANGE, $rangeBytes);
+            }
+
             // Case core:archive command is triggering archiving on https:// and the certificate is not valid
             if ($acceptInvalidSslCertificate) {
                 $curl_options += array(
@@ -852,7 +858,17 @@ class Http
         }
 
         list($name, $value) = $parts;
-        $headers[trim($name)] = trim($value);
+        $name = trim($name);
+        $headers[$name] = trim($value);
+
+        /**
+         * With HTTP/2 Cloudflare is passing headers in lowercase (e.g. 'content-type' instead of 'Content-Type') 
+         * which breaks any code which uses the header data. 
+         */
+        $camelName = ucwords($name, '-');
+        if ($camelName !== $name) {
+            $headers[$camelName] = trim($value);
+        }
     }
 
     /**

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -292,4 +292,29 @@ class HttpTest extends \PHPUnit_Framework_TestCase
         $result = Http::sendHttpRequestBy('socket', 'https://piwik.org/', 10);
         $this->assertNotEmpty($result);
     }
+
+    /**
+     * @dataProvider getMethodsToTest
+     */
+    public function testHttpDownloadChunk_responseSizeLimitedToChunk($method)
+    {
+        $result = Http::sendHttpRequestBy(
+            $method,
+            'https://tools.ietf.org/html/rfc7233',
+            300,
+            null,
+            null,
+            null,
+            0,
+            '',
+            false,
+            array(0, 50)
+        );
+        /**
+         * The last arg above asked the server to limit the response sent back to bytes 0->50.
+         * The RFC for HTTP Range Requests says that these headers can be ignored, so the test
+         * depends on a server that will respect it - we are requesting the RFC itself, which does.
+         */
+        $this->assertEquals(51, strlen($result));
+    }
 }


### PR DESCRIPTION
Fix two issues observed when downloading the GeoIP database via cURL with HTTP/2:

- The response headers are returned in lowercase e.g. 'content-length' instead of 'Content-Length'
- Work around an apparent bug in libcurl where sending a `Range` header via `CURLOPT_HTTPHEADER` causes curl to error "Failed sending HTTP request". Sending it via `CURLOPT_RANGE` instead has been tested with HTTP/1.1 and HTTP/2 and works with both.

Fixes #14339 