### PR TITLE
"Support & Services" button link updated to new Support Plans

### DIFF
--- a/plugins/CoreUpdater/templates/updateSuccess.twig
+++ b/plugins/CoreUpdater/templates/updateSuccess.twig
@@ -29,7 +29,7 @@
 
         <div class="row">
             <div class="col s5 offset-s1">
-                <a href="https://matomo.org/support/?pk_medium=Update_Success_button&pk_source=Piwik_App&pk_campaign=App_Updated" class="btn btn-block">{{ 'CoreUpdater_ServicesSupport'|translate }}</a>
+                <a href="https://matomo.org/support-plans/?pk_medium=Update_Success_button&pk_source=Piwik_App&pk_campaign=App_Updated" class="btn btn-block">{{ 'CoreUpdater_ServicesSupport'|translate }}</a>
             </div>
             <div class="col s5">
                 <a href="https://matomo.org/hosting/?pk_medium=App_Cloud_button&pk_source=Piwik_App&pk_campaign=App_Updated" class="btn btn-block">{{ 'CoreUpdater_CloudHosting'|translate }}</a>


### PR DESCRIPTION

Links now to https://matomo.org/support-plans/
instead of https://matomo.org/support/