### PR TITLE
Couple changes to visitor log for proxysite

### DIFF
--- a/plugins/Live/VisitorDetails.php
+++ b/plugins/Live/VisitorDetails.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\Live;
 
 use Piwik\API\Request;
+use Piwik\Common;
 use Piwik\Config;
 use Piwik\Date;
 use Piwik\DataTable;
@@ -155,7 +156,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 
     function getIdSite()
     {
-        return $this->details['idsite'];
+        return isset($this->details['idsite']) ? $this->details['idsite'] : Common::getRequestVar('idSite');
     }
 
     function getFingerprint()

--- a/plugins/Live/templates/_actionEcommerce.twig
+++ b/plugins/Live/templates/_actionEcommerce.twig
@@ -40,7 +40,7 @@
                         {% for product in action.itemDetails %}
                             <li>
                                 {{ product.itemSKU }}{% if product.itemName is not empty %}: {{ product.itemName }}{% endif -%}
-                                {%- if product.categories is not empty %} ({% for category in product.categories %}{{ category }}{% if not loop.last %}, {% endif %}{% endfor %}){% endif %},
+                                {%- if product.categories is defined and product.categories is not empty %} ({% for category in product.categories %}{{ category }}{% if not loop.last %}, {% endif %}{% endfor %}){% endif %},
                                 {{ 'General_Quantity'|translate }}: {{ product.quantity }},
                                 {{ 'General_Price'|translate }}: {{ product.price|money(visitInfo.idSite)|raw }}
                             </li>


### PR DESCRIPTION
Three fixes:
- CustomDimensions must use API in one instance.
- If product categories not present, don't display.
- idSite query parameter is not present in visitor details when proxysite is used, since VisitorDetailsAbstract::setDetails() is only called in the API. So when the visitor log visualization tries to use it through the Live event, the idSite is absent and an error occurs.