### PR TITLE
send Referrer-Policy header

### DIFF
--- a/core/View.php
+++ b/core/View.php
@@ -282,6 +282,8 @@ class View implements ViewInterface
         if(!empty($this->xFrameOptions)) {
             Common::sendHeader('X-Frame-Options: ' . (string)$this->xFrameOptions);
         }
+        // don't send Referer-Header for outgoing links
+        Common::sendHeader('Referrer-Policy: strict-origin');
 
         return $this->renderTwigTemplate();
     }

--- a/core/View.php
+++ b/core/View.php
@@ -283,7 +283,7 @@ class View implements ViewInterface
             Common::sendHeader('X-Frame-Options: ' . (string)$this->xFrameOptions);
         }
         // don't send Referer-Header for outgoing links
-        Common::sendHeader('Referrer-Policy: strict-origin');
+        Common::sendHeader('Referrer-Policy: same-origin');
 
         return $this->renderTwigTemplate();
     }


### PR DESCRIPTION
See also #13479, https://github.com/matomo-org/matomo/issues/13204 and https://github.com/matomo-org/matomo/pull/12780

`strict-origin` only sends a header to the same domain AND origin (so only to HTTPS if Matomo is HTTPS) and no Referer to all other origins.

This does not work in the email report as it seems to be setting headers somewhere else