### PR TITLE
Add extra processed metrics to list of available metrics in Graph if …

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/Graph.php
+++ b/plugins/CoreVisualizations/Visualizations/Graph.php
@@ -10,6 +10,8 @@ namespace Piwik\Plugins\CoreVisualizations\Visualizations;
 
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
+use Piwik\Plugin\Metric;
+use Piwik\Plugins\AbTesting\Columns\Metrics\ProcessedMetric;
 use Piwik\Plugins\CoreVisualizations\Metrics\Formatter\Numeric;
 use Piwik\Piwik;
 use Piwik\Plugin\Visualization;
@@ -206,6 +208,19 @@ abstract class Graph extends Visualization
             $allColumns = $this->report->getAllMetrics();
         }
         $allColumns = array_merge($allColumns, $this->getDataTable()->getColumns());
+
+        $dataTable = $this->getDataTable();
+        if ($dataTable instanceof DataTable\Map) {
+            $dataTable = $dataTable->getFirstRow();
+        }
+
+        /** @var ProcessedMetric[] $extraProcessedMetrics */
+        $extraProcessedMetrics = $dataTable->getMetadata(DataTable::EXTRA_PROCESSED_METRICS_METADATA_NAME);
+        if (!empty($extraProcessedMetrics)) {
+            $extraProcessedMetricNames = array_map(function (Metric $m) { return $m->getName(); }, $extraProcessedMetrics);
+            $allColumns = array_merge($allColumns, $extraProcessedMetricNames);
+        }
+
         $allColumns = array_unique($allColumns);
 
         // If the datatable has no data, use the default columns (there must be data for evolution graphs or else nothing displays)


### PR DESCRIPTION
…the metadata field exists.

If an evolution graph API request returns no data, and the columns_to_display is for a processed metric that isn't in the Report instance, but the DataTable metadata, then nothing will display in the evolution graph.

Fixed by looking for processed metrics when validating/cleaning the columns_to_display config property.