### PR TITLE
fix URL to JavaScript tracking guide

### DIFF
--- a/plugins/CoreAdminHome/templates/trackingCodeGenerator.twig
+++ b/plugins/CoreAdminHome/templates/trackingCodeGenerator.twig
@@ -43,7 +43,7 @@
             <br/><br/>
             {{ 'CoreAdminHome_JSTrackingIntro4'|translate('<a href="#image-tracking-link">','</a>')|raw }}
             <br/><br/>
-            {{ 'CoreAdminHome_JSTrackingIntro5'|translate('<a rel="noreferrer noopener" target="_blank" href="https://matomo.org/docs/javascript-tracking/">','</a>')|raw }}
+            {{ 'CoreAdminHome_JSTrackingIntro5'|translate('<a rel="noreferrer noopener" target="_blank" href="https://developer.matomo.org/guides/tracking-javascript-guide">','</a>')|raw }}
         </p>
 
         <div piwik-field uicontrol="site" name="js-tracker-website"

--- a/plugins/SitesManager/templates/_displayJavascriptCode.twig
+++ b/plugins/SitesManager/templates/_displayJavascriptCode.twig
@@ -11,7 +11,7 @@
 
     <pre piwik-select-on-focus>{{ jsTag|raw }}</pre>
 
-    <p>{{ 'CoreAdminHome_JSTrackingIntro5'|translate('<a rel="noreferrer noopener" target="_blank" href="https://matomo.org/docs/javascript-tracking/">','</a>')|raw }}</p>
+    <p>{{ 'CoreAdminHome_JSTrackingIntro5'|translate('<a rel="noreferrer noopener" target="_blank" href="https://developer.matomo.org/guides/tracking-javascript-guide">','</a>')|raw }}</p>
 
     {% if isInstall is defined %}
         <p>{{ 'Installation_JSTracking_EndNote'|translate('', '')|raw }}</p>


### PR DESCRIPTION
The docs seem to be long gone and I'm not even sure which ones are meant.

I would recommend to also set up a redirect as this link is quite prominently on the "no data yet" page.