### PR TITLE
Ensure incompatible visualization entries are still shown as footer icons when they are selected

### DIFF
--- a/core/ViewDataTable/Manager.php
+++ b/core/ViewDataTable/Manager.php
@@ -184,7 +184,7 @@ class Manager
         $nonCoreVisualizations = static::getNonCoreViewDataTables();
 
         foreach ($nonCoreVisualizations as $id => $klass) {
-            if ($klass::canDisplayViewDataTable($view)) {
+            if ($klass::canDisplayViewDataTable($view) || $view::ID == $id) {
                 $footerIcon = static::getFooterIconFor($id);
                 if (Insight::ID == $footerIcon['id']) {
                     $insightsViewIcons['buttons'][] = static::getFooterIconFor($id);


### PR DESCRIPTION
When viewing for example a insights report for a unsupported date/period combination, the report currently won't show any visualization icons to switch to another one.

That is caused by the fact that the currently enabled visualization isn't available (`canDisplayViewDataTable` returns `false`). With the current visualization absent the view won't show any visualization icons (caused by https://github.com/matomo-org/matomo/blob/3.x-dev/plugins/CoreHome/templates/_dataTableActions.twig#L9-L34 and https://github.com/matomo-org/matomo/blob/3.x-dev/plugins/CoreHome/templates/_dataTableActions.twig#L54)

Imho it's makes most sense to add the current visualization to the icons even if wouldn't be present anymore. That way it will be shown as active, and it's possible again to switch to another one.

fixes #14071