### PR TITLE
fix no data message may not be shown when deleteLogs is enabled

### DIFF
--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -112,7 +112,7 @@ class Tasks extends \Piwik\Plugin\Tasks
     {
         $this->rememberTrackingCodeReminderRan($idSite);
 
-        if (!SitesManager::hasTrackedAnyTraffic($idSite)) {
+        if (SitesManager::hasTrackedAnyTraffic($idSite)) {
             return;
         }
 

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -16,7 +16,6 @@ use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugins\CoreHome\SystemSummary;
-use Piwik\Plugins\PrivacyManager\PrivacyManager;
 use Piwik\Settings\Storage\Backend\MeasurableSettingsTable;
 use Piwik\Tracker\Cache;
 use Piwik\Tracker\Model as TrackerModel;
@@ -66,33 +65,18 @@ class SitesManager extends \Piwik\Plugin
             return;
         }
 
-        // Skip the screen if purging logs is enabled
-        $settings = PrivacyManager::getPurgeDataSettings();
-        if ($settings['delete_logs_enable'] == 1) {
-            $hadTrafficKey = 'SitesManagerHadTrafficInPast_' . (int) $siteId;
-            $hadTrafficBefore = Option::get($hadTrafficKey);
-            if (!empty($hadTrafficBefore)) {
-                // user had traffic at some stage in the past... not needed to show tracking code
-                return;
-            } elseif (self::hasTrackedAnyTraffic($siteId)) {
-                // remember the user had traffic in the past so we won't show the tracking screen again
-                // if all visits are deleted for example
-                Option::set($hadTrafficKey, 1);
-                return;
-            } else {
-                // never had any traffic
-                $session = new SessionNamespace('siteWithoutData');
-                if (!empty($session->ignoreMessage)) {
-                    return;
-                }
-
-                $module = 'SitesManager';
-                $action = 'siteWithoutData';
-            }
+        $hadTrafficKey = 'SitesManagerHadTrafficInPast_' . (int) $siteId;
+        $hadTrafficBefore = Option::get($hadTrafficKey);
+        if (!empty($hadTrafficBefore)) {
+            // user had traffic at some stage in the past... not needed to show tracking code
             return;
-        }
-
-        if (!self::hasTrackedAnyTraffic($siteId)) {
+        } elseif (self::hasTrackedAnyTraffic($siteId)) {
+            // remember the user had traffic in the past so we won't show the tracking screen again
+            // if all visits are deleted for example
+            Option::set($hadTrafficKey, 1);
+            return;
+        } else {
+            // never had any traffic
             $session = new SessionNamespace('siteWithoutData');
             if (!empty($session->ignoreMessage)) {
                 return;

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -13,6 +13,7 @@ use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
+use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugins\CoreHome\SystemSummary;
 use Piwik\Plugins\PrivacyManager\PrivacyManager;
@@ -68,10 +69,30 @@ class SitesManager extends \Piwik\Plugin
         // Skip the screen if purging logs is enabled
         $settings = PrivacyManager::getPurgeDataSettings();
         if ($settings['delete_logs_enable'] == 1) {
+            $hadTrafficKey = 'SitesManagerHadTrafficInPast_' . (int) $siteId;
+            $hadTrafficBefore = Option::get($hadTrafficKey);
+            if (!empty($hadTrafficBefore)) {
+                // user had traffic at some stage in the past... not needed to show tracking code
+                return;
+            } elseif (self::hasTrackedAnyTraffic($siteId)) {
+                // remember the user had traffic in the past so we won't show the tracking screen again
+                // if all visits are deleted for example
+                Option::set($hadTrafficKey, 1);
+                return;
+            } else {
+                // never had any traffic
+                $session = new SessionNamespace('siteWithoutData');
+                if (!empty($session->ignoreMessage)) {
+                    return;
+                }
+
+                $module = 'SitesManager';
+                $action = 'siteWithoutData';
+            }
             return;
         }
 
-        if (self::hasTrackedAnyTraffic($siteId)) {
+        if (!self::hasTrackedAnyTraffic($siteId)) {
             $session = new SessionNamespace('siteWithoutData');
             if (!empty($session->ignoreMessage)) {
                 return;
@@ -98,7 +119,7 @@ class SitesManager extends \Piwik\Plugin
         Piwik::postEvent('SitesManager.shouldPerformEmptySiteCheck', [&$shouldPerformEmptySiteCheck, $siteId]);
 
         $trackerModel = new TrackerModel();
-        return $shouldPerformEmptySiteCheck && $trackerModel->isSiteEmpty($siteId);
+        return $shouldPerformEmptySiteCheck && !$trackerModel->isSiteEmpty($siteId);
     }
 
     public function onSiteDeleted($idSite)

--- a/plugins/SitesManager/tests/Integration/SitesManagerTest.php
+++ b/plugins/SitesManager/tests/Integration/SitesManagerTest.php
@@ -10,8 +10,12 @@ namespace Piwik\Plugins\SitesManager\tests\Integration;
 
 use Piwik\Cache;
 use Piwik\Archive\ArchiveInvalidator;
+use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
+use Piwik\Db;
+use Piwik\Option;
+use Piwik\Piwik;
 use Piwik\Plugins\SitesManager\SitesManager;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -72,6 +76,106 @@ class SitesManagerTest extends IntegrationTestCase
             '2014-04-05' => array(4949)
         );
         $this->assertEquals($expected, $archive->getRememberedArchivedReportsThatShouldBeInvalidated());
+    }
+
+    /**
+     * @dataProvider getTestDataForRedirectDashboard
+     */
+    public function test_redirectDashboardToWelcomePage_doesNothingIfModuleActionAreIncorrect($module, $action)
+    {
+        $originalModule = $module;
+        $originalAction = $action;
+        $params = [];
+
+        Piwik::postEvent('Request.dispatch', [&$module, &$action, &$params]);
+
+        $this->assertEquals($originalModule, $module);
+        $this->assertEquals($originalAction, $action);
+    }
+
+    public function getTestDataForRedirectDashboard()
+    {
+        return [
+            ['CoreHome', 'someothermethod'],
+            ['SitesManager', 'index'],
+        ];
+    }
+
+    public function test_redirectDashboardToWelcomePage_doesNothingIfThereIsNoIdSiteParam()
+    {
+        $module = 'CoreHome';
+        $action = 'index';
+        $params = [];
+
+        Piwik::postEvent('Request.dispatch', [&$module, &$action, &$params]);
+
+        $this->assertEquals('CoreHome', $module);
+        $this->assertEquals('index', $action);
+    }
+
+    public function test_redirectDashboardToWelcomePage_doesNothingIfAVisitWasTrackedInThePast()
+    {
+        $module = 'CoreHome';
+        $action = 'index';
+        $params = [];
+
+        $_GET['idSite'] = $this->siteId;
+
+        $tracker = Fixture::getTracker($this->siteId, '2015-02-04 04:12:35');
+        $tracker->setUrl('http://example.com/');
+        Fixture::checkResponse($tracker->doTrackPageView('a test title'));
+
+        $this->assertEquals(false, Option::get('SitesManagerHadTrafficInPast_' . $this->siteId));
+
+        Piwik::postEvent('Request.dispatch', [&$module, &$action, &$params]);
+
+        $this->assertEquals('1', Option::get('SitesManagerHadTrafficInPast_' . $this->siteId));
+
+        $this->assertEquals('CoreHome', $module);
+        $this->assertEquals('index', $action);
+    }
+
+    public function test_redirectDashboardToWelcomePage_doesNothingIfAVisitWasTrackedAndWasLaterPurged()
+    {
+        $module = 'CoreHome';
+        $action = 'index';
+        $params = [];
+
+        $_GET['idSite'] = $this->siteId;
+
+        $tracker = Fixture::getTracker($this->siteId, '2015-02-04 04:12:35');
+        $tracker->setUrl('http://example.com/');
+        Fixture::checkResponse($tracker->doTrackPageView('a test title'));
+
+        Piwik::postEvent('Request.dispatch', [&$module, &$action, &$params]);
+
+        Db::exec('TRUNCATE ' . Common::prefixTable('log_visit'));
+
+        $module = 'CoreHome';
+        $action = 'index';
+
+        $this->assertEquals('CoreHome', $module);
+        $this->assertEquals('index', $action);
+    }
+
+    public function test_redirectDashboardToWelcomePage_redirectsIfThereIsNoDataAndAppropriateParams()
+    {
+        $module = 'CoreHome';
+        $action = 'index';
+        $params = [];
+
+        $_GET['idSite'] = $this->siteId;
+
+        Piwik::postEvent('Request.dispatch', [&$module, &$action, &$params]);
+
+        $this->assertEquals('SitesManager', $module);
+        $this->assertEquals('siteWithoutData', $action);
+    }
+
+    protected static function configureFixture($fixture)
+    {
+        parent::configureFixture($fixture);
+        $fixture->createSuperUser = true;
     }
 
     public function provideContainerConfig()


### PR DESCRIPTION
* Fixes DEV-1671
* Also fixes `SitesManager::hasTrackedAnyTraffic($idSite)` was returning inverted result. Meaning it was returning true when no traffic was tracked, but the method suggested it should return false in this case.