### PR TITLE
Acquire an exclusive lock on the tracker file while proceeding to the writing

### DIFF
--- a/plugins/CustomPiwikJs/File.php
+++ b/plugins/CustomPiwikJs/File.php
@@ -38,7 +38,7 @@ class File
 
     public function save($content)
     {
-        if(false === file_put_contents($this->file, $content)) {
+        if(false === file_put_contents($this->file, $content, LOCK_EX)) {
             throw new AccessDeniedException(sprintf("Could not write to %s", $this->file));
         }
     }


### PR DESCRIPTION
In case two processes try to write the file at the same time.