### PR TITLE
Copy downloaded plugin to all plugins directories

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -705,9 +705,6 @@ num_days_before_tracking_code_reminder = 5
 ; breaks and reencrypts SSL connections you can set your custom file here. 
 custom_cacert_pem=
 
-; set to 1 to copy downloaded plugins to all plugins directories including those defined in MATOMO_PLUGIN_DIRS env variable 
-copy_to_plugins_dirs = 0
-
 [Tracker]
 
 ; Matomo uses "Privacy by default" model. When one of your users visit multiple of your websites tracked in this Matomo,

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -705,6 +705,9 @@ num_days_before_tracking_code_reminder = 5
 ; breaks and reencrypts SSL connections you can set your custom file here. 
 custom_cacert_pem=
 
+; set to 1 to copy downloaded plugins to all plugins directories including those defined in MATOMO_PLUGIN_DIRS env variable 
+copy_to_plugins_dirs = 0
+
 [Tracker]
 
 ; Matomo uses "Privacy by default" model. When one of your users visit multiple of your websites tracked in this Matomo,

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -380,6 +380,11 @@ class Manager
                     }
                 });
             }
+            
+            $envCopyDir =  getenv('MATOMO_PLUGIN_COPY_DIR');
+            if (!empty($envCopyDir) && in_array($envCopyDir, $pluginDirs)) {
+                $GLOBALS['MATOMO_PLUGIN_COPY_DIR'] = $envCopyDir;
+            }
         }
     }
 

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -380,14 +380,17 @@ class Manager
                     }
                 });
             }
-            
-            $envCopyDir =  getenv('MATOMO_PLUGIN_COPY_DIR');
-            if (!empty($envCopyDir)) {
-                if (!in_array($envCopyDir, $pluginDirs)) {
-                    throw new \Exception('"MATOMO_PLUGIN_COPY_DIR" dir must be one of "MATOMO_PLUGIN_DIRS" directories');
-                }
-                $GLOBALS['MATOMO_PLUGIN_COPY_DIR'] = $envCopyDir;
-            }
+        }
+
+        $envCopyDir =  getenv('MATOMO_PLUGIN_COPY_DIR');
+        if (!empty($envCopyDir)) {
+            $GLOBALS['MATOMO_PLUGIN_COPY_DIR'] = $envCopyDir;
+        }
+        
+        if (!empty($GLOBALS['MATOMO_PLUGIN_COPY_DIR'])
+            && !in_array($GLOBALS['MATOMO_PLUGIN_COPY_DIR'], self::getPluginsDirectories())
+        ) {
+            throw new \Exception('"MATOMO_PLUGIN_COPY_DIR" dir must be one of "MATOMO_PLUGIN_DIRS" directories');
         }
     }
 

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -382,7 +382,10 @@ class Manager
             }
             
             $envCopyDir =  getenv('MATOMO_PLUGIN_COPY_DIR');
-            if (!empty($envCopyDir) && in_array($envCopyDir, $pluginDirs)) {
+            if (!empty($envCopyDir)) {
+                if (!in_array($envCopyDir, $pluginDirs)) {
+                    throw new \Exception('"MATOMO_PLUGIN_COPY_DIR" dir must be one of "MATOMO_PLUGIN_DIRS" directories');
+                }
                 $GLOBALS['MATOMO_PLUGIN_COPY_DIR'] = $envCopyDir;
             }
         }

--- a/plugins/CorePluginsAdmin/PluginInstaller.php
+++ b/plugins/CorePluginsAdmin/PluginInstaller.php
@@ -19,6 +19,7 @@ use Piwik\Plugin\Manager;
 use Piwik\Plugins\Marketplace\Marketplace;
 use Piwik\Unzip;
 use Piwik\Plugins\Marketplace\Api\Client;
+use Piwik\Config;
 
 /**
  *
@@ -297,12 +298,20 @@ class PluginInstaller
 
     private function copyPluginToDestination($tmpPluginFolder)
     {
-        $pluginsDir = Manager::getPluginsDirectory();
-        $pluginTargetPath = $pluginsDir . $this->pluginName;
-
-        $this->removeFolderIfExists($pluginTargetPath);
-
-        Filesystem::copyRecursive($tmpPluginFolder, $pluginsDir);
+        if (!empty(Config::getInstance()->General['copy_to_plugins_dirs'])) {
+            $pluginsDirs = Manager::getPluginsDirectories();
+            // Copy plugin to all plugins directories
+            foreach ($pluginsDirs as $dir) {
+                $pluginTargetPath = $dir . $this->pluginName;
+                $this->removeFolderIfExists($pluginTargetPath);
+                Filesystem::copyRecursive($tmpPluginFolder, $dir);
+            }
+        } else {
+            $pluginsDir = Manager::getPluginsDirectory();
+            $pluginTargetPath = $pluginsDir . $this->pluginName;
+            $this->removeFolderIfExists($pluginTargetPath);
+            Filesystem::copyRecursive($tmpPluginFolder, $pluginsDir);
+        }
     }
 
     /**

--- a/plugins/CorePluginsAdmin/PluginInstaller.php
+++ b/plugins/CorePluginsAdmin/PluginInstaller.php
@@ -298,19 +298,18 @@ class PluginInstaller
 
     private function copyPluginToDestination($tmpPluginFolder)
     {
-        if (!empty(Config::getInstance()->General['copy_to_plugins_dirs'])) {
-            $pluginsDirs = Manager::getPluginsDirectories();
-            // Copy plugin to all plugins directories
-            foreach ($pluginsDirs as $dir) {
-                $pluginTargetPath = $dir . $this->pluginName;
-                $this->removeFolderIfExists($pluginTargetPath);
-                Filesystem::copyRecursive($tmpPluginFolder, $dir);
-            }
-        } else {
-            $pluginsDir = Manager::getPluginsDirectory();
-            $pluginTargetPath = $pluginsDir . $this->pluginName;
+        // if MATOMO_PLUGIN_COPY_DIR is defined , copy plugin to this directory too
+
+        $pluginsDirs = [Manager::getPluginsDirectory()];
+        
+        if (!empty($GLOBALS['MATOMO_PLUGIN_COPY_DIR'])) {
+            array_push($pluginsDirs, $GLOBALS['MATOMO_PLUGIN_COPY_DIR']);
+        }
+
+        foreach ($pluginsDirs as $dir) {
+            $pluginTargetPath = $dir . $this->pluginName;
             $this->removeFolderIfExists($pluginTargetPath);
-            Filesystem::copyRecursive($tmpPluginFolder, $pluginsDir);
+            Filesystem::copyRecursive($tmpPluginFolder, $dir);
         }
     }
 

--- a/plugins/CorePluginsAdmin/PluginInstaller.php
+++ b/plugins/CorePluginsAdmin/PluginInstaller.php
@@ -19,7 +19,6 @@ use Piwik\Plugin\Manager;
 use Piwik\Plugins\Marketplace\Marketplace;
 use Piwik\Unzip;
 use Piwik\Plugins\Marketplace\Api\Client;
-use Piwik\Config;
 
 /**
  *

--- a/plugins/CorePluginsAdmin/PluginInstaller.php
+++ b/plugins/CorePluginsAdmin/PluginInstaller.php
@@ -297,19 +297,16 @@ class PluginInstaller
 
     private function copyPluginToDestination($tmpPluginFolder)
     {
-        // if MATOMO_PLUGIN_COPY_DIR is defined , copy plugin to this directory too
+        $pluginsDir = Manager::getPluginsDirectory();
 
-        $pluginsDirs = [Manager::getPluginsDirectory()];
-        
         if (!empty($GLOBALS['MATOMO_PLUGIN_COPY_DIR'])) {
-            array_push($pluginsDirs, $GLOBALS['MATOMO_PLUGIN_COPY_DIR']);
+            $pluginsDir = $GLOBALS['MATOMO_PLUGIN_COPY_DIR'];
         }
+        $pluginTargetPath = $pluginsDir . $this->pluginName;
 
-        foreach ($pluginsDirs as $dir) {
-            $pluginTargetPath = $dir . $this->pluginName;
-            $this->removeFolderIfExists($pluginTargetPath);
-            Filesystem::copyRecursive($tmpPluginFolder, $dir);
-        }
+        $this->removeFolderIfExists($pluginTargetPath);
+
+        Filesystem::copyRecursive($tmpPluginFolder, $pluginsDir);
     }
 
     /**


### PR DESCRIPTION
When downloading a plugins from Marketplace UI, it would be useful to copy them also to folders defined in MATOMO_PLUGINS_DIRS . This is useful when Matomo is deployed in env with Persistent Volume like Kubernetes

The PR copies plugin to all directories and not to one of them because in practice `MATOMO_PLUGINS_DIRS` will have only one directory outside Matomo directory.

fixes #14534