### PR TITLE
Add new translation keys for mobile app

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -566,7 +566,13 @@
         "VerifyAccount": "Verifying Account",
         "ValidateSslCertificate": "Validate SSL Certificate",
         "VerifyLoginData": "Make sure your username and password combination is correct.",
-        "YouAreOffline": "Sorry, you are currently offline"
+        "YouAreOffline": "Sorry, you are currently offline",
+        "ExceptionNoViewAccess": "Please check your username and password and make sure you have %s access for at least one website.",
+        "Mobile_HowtoExitAndroid": "Please click BACK again to exit",
+        "PiwikMarketplace": "Matomo Marketplace",
+        "EnterAuthCode": "Enter authentication code",
+        "EnterCorrectAuthCode": "Enter correct authentication code",
+        "EnterAuthCodeExplanation": "It looks like you may be using two-factor authentication. Please enter the six-digit code to log in to your account."
     },
     "RowEvolution": {
         "AvailableMetrics": "Available metrics",

--- a/lang/en.json
+++ b/lang/en.json
@@ -569,7 +569,7 @@
         "YouAreOffline": "Sorry, you are currently offline",
         "ExceptionNoViewAccess": "Please check your username and password and make sure you have %s access for at least one website.",
         "Mobile_HowtoExitAndroid": "Please click BACK again to exit",
-        "PiwikMarketplace": "Matomo Marketplace",
+        "MatomoMarketplace": "Matomo Marketplace",
         "EnterAuthCode": "Enter authentication code",
         "EnterCorrectAuthCode": "Enter correct authentication code",
         "EnterAuthCodeExplanation": "It looks like you may be using two-factor authentication. Please enter the six-digit code to log in to your account."


### PR DESCRIPTION
See https://github.com/matomo-org/matomo-mobile-2/pull/5344#issuecomment-503764394 except for `Mobile_PossibleSslErrorExplanation2 ` which isn't used  currently