### PR TITLE
Gracefully handle case when row evolution has no data

### DIFF
--- a/plugins/API/RowEvolution.php
+++ b/plugins/API/RowEvolution.php
@@ -55,6 +55,10 @@ class RowEvolution
 
         $dataTable = $this->loadRowEvolutionDataFromAPI($metadata, $idSite, $period, $date, $apiModule, $apiAction, $labels, $segment, $apiParameters);
 
+        if (empty($dataTable->getDataTables())) {
+            return array();
+        }
+
         if (empty($labels)) {
             $labels = $this->getLabelsFromDataTable($dataTable, $labels);
             $dataTable = $this->enrichRowAddMetadataLabelIndex($labels, $dataTable);

--- a/plugins/API/tests/Integration/RowEvolutionTest.php
+++ b/plugins/API/tests/Integration/RowEvolutionTest.php
@@ -43,4 +43,10 @@ class RowEvolutionTest extends IntegrationTestCase
         $this->assertNotEmpty($table);
     }
 
+    public function test_getRowEvolution_shouldReturnEmptyArray_IfNoData()
+    {
+        $rowEvolution = new RowEvolution();
+        $table = $rowEvolution->getRowEvolution(1, 'day', 'last7', 'Actions', 'getSiteSearchCategories');
+        $this->assertEquals(array(), $table);
+    }
 }


### PR DESCRIPTION
Fixes #14499 