### PR TITLE
Fix error number is detected wrongly in tracker mode

### DIFF
--- a/core/Db/Adapter/Mysqli.php
+++ b/core/Db/Adapter/Mysqli.php
@@ -185,14 +185,26 @@ class Mysqli extends Zend_Db_Adapter_Mysqli implements AdapterInterface
      */
     public function isErrNo($e, $errno)
     {
-        if (is_null($this->_connection)) {
+        return self::isMysqliErrorNumber($e, $this->_connection, $errno);
+    }
+
+    /**
+     * Test error number
+     *
+     * @param Exception $e
+     * @param string $errno
+     * @return bool
+     */
+    public static function isMysqliErrorNumber($e, $connection, $errno)
+    {
+        if (is_null($connection)) {
             if (preg_match('/(?:\[|\s)([0-9]{4})(?:\]|\s)/', $e->getMessage(), $match)) {
                 return $match[1] == $errno;
             }
             return mysqli_connect_errno() == $errno;
         }
 
-        return mysqli_errno($this->_connection) == $errno;
+        return mysqli_errno($connection) == $errno;
     }
 
     /**

--- a/core/Db/Adapter/Pdo/Mysql.php
+++ b/core/Db/Adapter/Pdo/Mysql.php
@@ -209,6 +209,19 @@ class Mysql extends Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      */
     public function isErrNo($e, $errno)
     {
+        return self::isPdoErrorNumber($e, $errno);
+    }
+
+
+    /**
+     * Test error number
+     *
+     * @param Exception $e
+     * @param string $errno
+     * @return bool
+     */
+    public static function isPdoErrorNumber($e, $errno)
+    {
         if (preg_match('/(?:\[|\s)([0-9]{4})(?:\]|\s)/', $e->getMessage(), $match)) {
             return $match[1] == $errno;
         }

--- a/core/Tracker/Db/Mysqli.php
+++ b/core/Tracker/Db/Mysqli.php
@@ -305,15 +305,15 @@ class Mysqli extends Db
         }
     }
 
-    /**
-     * Test error number
-     *
-     * @param Exception $e
-     * @param string $errno
-     * @return bool
-     */
     public function isErrNo($e, $errno)
     {
+        if (is_null($this->connection)) {
+            if (preg_match('/(?:\[|\s)([0-9]{4})(?:\]|\s)/', $e->getMessage(), $match)) {
+                return $match[1] == $errno;
+            }
+            return mysqli_connect_errno() == $errno;
+        }
+
         return mysqli_errno($this->connection) == $errno;
     }
 

--- a/core/Tracker/Db/Mysqli.php
+++ b/core/Tracker/Db/Mysqli.php
@@ -307,14 +307,7 @@ class Mysqli extends Db
 
     public function isErrNo($e, $errno)
     {
-        if (is_null($this->connection)) {
-            if (preg_match('/(?:\[|\s)([0-9]{4})(?:\]|\s)/', $e->getMessage(), $match)) {
-                return $match[1] == $errno;
-            }
-            return mysqli_connect_errno() == $errno;
-        }
-
-        return mysqli_errno($this->connection) == $errno;
+        return \Piwik\Db\Adapter\Mysqli::isMysqliErrorNumber($e, $this->connection, $errno);
     }
 
     /**

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -260,9 +260,10 @@ class Mysql extends Db
      */
     public function isErrNo($e, $errno)
     {
-        if (preg_match('/([0-9]{4})/', $e->getMessage(), $match)) {
+        if (preg_match('/(?:\[|\s)([0-9]{4})(?:\]|\s)/', $e->getMessage(), $match)) {
             return $match[1] == $errno;
         }
+
         return false;
     }
 

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -260,11 +260,7 @@ class Mysql extends Db
      */
     public function isErrNo($e, $errno)
     {
-        if (preg_match('/(?:\[|\s)([0-9]{4})(?:\]|\s)/', $e->getMessage(), $match)) {
-            return $match[1] == $errno;
-        }
-
-        return false;
+        return \Piwik\Db\Adapter\Pdo\Mysql::isPdoErrorNumber($e, $errno);
     }
 
     /**

--- a/tests/PHPUnit/Integration/Db/Adapter/MysqliTest.php
+++ b/tests/PHPUnit/Integration/Db/Adapter/MysqliTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Db\Adapter;
+
+use Piwik\Db\Adapter\Mysqli;
+use Exception;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+class MysqliTest extends IntegrationTestCase
+{
+    public function test_isMysqliErrorNumber_whenNoConnectionIsSet()
+    {
+        $e = new Exception('Error query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry');
+        $connection = null;
+        $this->assertTrue(Mysqli::isMysqliErrorNumber($e, $connection, 1062));
+        $this->assertTrue(Mysqli::isMysqliErrorNumber($e, $connection, '1062'));
+
+        $this->assertFalse(Mysqli::isMysqliErrorNumber($e, $connection, '2300'));
+        $this->assertFalse(Mysqli::isMysqliErrorNumber($e, $connection, '23000'));
+    }
+}

--- a/tests/PHPUnit/Integration/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/PHPUnit/Integration/Db/Adapter/Pdo/MysqlTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Db\Adapter\Pdo;
+
+use Piwik\Db\Adapter\Pdo\Mysql;
+use Exception;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+class MysqlTest extends IntegrationTestCase
+{
+    public function test_isPdoErrorNumber()
+    {
+        $e = new Exception('Error query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry');
+        $this->assertTrue(Mysql::isPdoErrorNumber($e, 1062));
+        $this->assertTrue(Mysql::isPdoErrorNumber($e, '1062'));
+
+        $this->assertFalse(Mysql::isPdoErrorNumber($e, '2300'));
+        $this->assertFalse(Mysql::isPdoErrorNumber($e, '23000'));
+    }
+}


### PR DESCRIPTION
Eg when the error is `Error query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry`, it would detect 2300 instead of 1062.
fix DEV-1683