### PR TITLE
Improve segments tests

### DIFF
--- a/plugins/API/tests/System/AutoSuggestAPITest.php
+++ b/plugins/API/tests/System/AutoSuggestAPITest.php
@@ -148,6 +148,12 @@ class AutoSuggestAPITest extends SystemTestCase
                 case 'operatingSystemName':
                     $topSegmentValue = 'Android';
                     break;
+                case 'visitEndServerYear':
+                    $topSegmentValue = '2018';
+                    break;
+                case 'visitLocalMinute':
+                    $topSegmentValue = '34';
+                    break;
             }
 
             // Now build the segment request

--- a/plugins/API/tests/System/AutoSuggestAPITest.php
+++ b/plugins/API/tests/System/AutoSuggestAPITest.php
@@ -136,6 +136,20 @@ class AutoSuggestAPITest extends SystemTestCase
             if (is_numeric($topSegmentValue) || is_float($topSegmentValue) || preg_match('/^\d*?,\d*$/', $topSegmentValue)) {
                 $topSegmentValue = Common::forceDotAsSeparatorForDecimalPoint($topSegmentValue);
             }
+
+            // use some specific test values for special segments
+            switch ($params['segmentToComplete']) {
+                case 'countryName':
+                    $topSegmentValue = 'France';
+                    break;
+                case 'browserName':
+                    $topSegmentValue = 'Chrome';
+                    break;
+                case 'operatingSystemName':
+                    $topSegmentValue = 'Android';
+                    break;
+            }
+
             // Now build the segment request
             $segmentValue = rawurlencode(html_entity_decode($topSegmentValue, ENT_COMPAT | ENT_HTML401, 'UTF-8'));
             $params['segment'] = $params['segmentToComplete'] . '==' . $segmentValue;

--- a/plugins/API/tests/System/AutoSuggestAPITest.php
+++ b/plugins/API/tests/System/AutoSuggestAPITest.php
@@ -137,7 +137,7 @@ class AutoSuggestAPITest extends SystemTestCase
                 $topSegmentValue = Common::forceDotAsSeparatorForDecimalPoint($topSegmentValue);
             }
 
-            // use some specific test values for special segments
+            // use some specific test values for segments where auto suggest returns list of values that might not occur
             switch ($params['segmentToComplete']) {
                 case 'countryName':
                     $topSegmentValue = 'France';
@@ -147,6 +147,12 @@ class AutoSuggestAPITest extends SystemTestCase
                     break;
                 case 'operatingSystemName':
                     $topSegmentValue = 'Android';
+                    break;
+                case 'visitEndServerDate':
+                    $topSegmentValue = '2018-01-03';
+                    break;
+                case 'visitEndServerDayOfMonth':
+                    $topSegmentValue = '03';
                     break;
                 case 'visitEndServerYear':
                     $topSegmentValue = '2018';

--- a/plugins/API/tests/System/expected/test_AutoSuggestAPITest_browserName__VisitsSummary.get_range.xml
+++ b/plugins/API/tests/System/expected/test_AutoSuggestAPITest_browserName__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>4</nb_visits>
+	<nb_actions>11</nb_actions>
+	<nb_visits_converted>4</nb_visits_converted>
+	<bounce_count>2</bounce_count>
+	<sum_visit_length>3247</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>50%</bounce_rate>
+	<nb_actions_per_visit>2.8</nb_actions_per_visit>
+	<avg_time_on_site>812</avg_time_on_site>
 </result>

--- a/plugins/API/tests/System/expected/test_AutoSuggestAPITest_countryName__VisitsSummary.get_range.xml
+++ b/plugins/API/tests/System/expected/test_AutoSuggestAPITest_countryName__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>2</nb_visits>
+	<nb_actions>6</nb_actions>
+	<nb_visits_converted>2</nb_visits_converted>
+	<bounce_count>1</bounce_count>
+	<sum_visit_length>1623</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>50%</bounce_rate>
+	<nb_actions_per_visit>3</nb_actions_per_visit>
+	<avg_time_on_site>812</avg_time_on_site>
 </result>

--- a/plugins/API/tests/System/expected/test_AutoSuggestAPITest_operatingSystemName__VisitsSummary.get_range.xml
+++ b/plugins/API/tests/System/expected/test_AutoSuggestAPITest_operatingSystemName__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>6</nb_visits>
+	<nb_actions>17</nb_actions>
+	<nb_visits_converted>6</nb_visits_converted>
+	<bounce_count>3</bounce_count>
+	<sum_visit_length>4870</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>50%</bounce_rate>
+	<nb_actions_per_visit>2.8</nb_actions_per_visit>
+	<avg_time_on_site>812</avg_time_on_site>
 </result>

--- a/plugins/API/tests/System/expected/test_AutoSuggestAPITest_visitEndServerDate__VisitsSummary.get_range.xml
+++ b/plugins/API/tests/System/expected/test_AutoSuggestAPITest_visitEndServerDate__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>4</nb_visits>
+	<nb_actions>12</nb_actions>
+	<nb_visits_converted>4</nb_visits_converted>
+	<bounce_count>2</bounce_count>
+	<sum_visit_length>3242</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>50%</bounce_rate>
+	<nb_actions_per_visit>3</nb_actions_per_visit>
+	<avg_time_on_site>811</avg_time_on_site>
 </result>

--- a/plugins/API/tests/System/expected/test_AutoSuggestAPITest_visitEndServerDayOfMonth__VisitsSummary.get_range.xml
+++ b/plugins/API/tests/System/expected/test_AutoSuggestAPITest_visitEndServerDayOfMonth__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>4</nb_visits>
+	<nb_actions>12</nb_actions>
+	<nb_visits_converted>4</nb_visits_converted>
+	<bounce_count>2</bounce_count>
+	<sum_visit_length>3242</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>50%</bounce_rate>
+	<nb_actions_per_visit>3</nb_actions_per_visit>
+	<avg_time_on_site>811</avg_time_on_site>
 </result>

--- a/plugins/API/tests/System/expected/test_AutoSuggestAPITest_visitEndServerYear__VisitsSummary.get_range.xml
+++ b/plugins/API/tests/System/expected/test_AutoSuggestAPITest_visitEndServerYear__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>35</nb_visits>
+	<nb_actions>95</nb_actions>
+	<nb_visits_converted>35</nb_visits_converted>
+	<bounce_count>18</bounce_count>
+	<sum_visit_length>27579</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>51%</bounce_rate>
+	<nb_actions_per_visit>2.7</nb_actions_per_visit>
+	<avg_time_on_site>788</avg_time_on_site>
 </result>

--- a/plugins/API/tests/System/expected/test_AutoSuggestAPITest_visitLocalMinute__VisitsSummary.get_range.xml
+++ b/plugins/API/tests/System/expected/test_AutoSuggestAPITest_visitLocalMinute__VisitsSummary.get_range.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>0</nb_visits>
-	<nb_actions>0</nb_actions>
-	<nb_visits_converted>0</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>0</sum_visit_length>
-	<max_actions>0</max_actions>
-	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>0</nb_actions_per_visit>
-	<avg_time_on_site>0</avg_time_on_site>
+	<nb_visits>35</nb_visits>
+	<nb_actions>95</nb_actions>
+	<nb_visits_converted>35</nb_visits_converted>
+	<bounce_count>18</bounce_count>
+	<sum_visit_length>27579</sum_visit_length>
+	<max_actions>5</max_actions>
+	<bounce_rate>51%</bounce_rate>
+	<nb_actions_per_visit>2.7</nb_actions_per_visit>
+	<avg_time_on_site>788</avg_time_on_site>
 </result>


### PR DESCRIPTION
Some of the segments tests actually didn't test with a valid value, as the autosuggest returns a full list of possible values instead of a list of occurring values. I've changed the test to use some specific values instead for those segments.  The tests for`customVariablePageName4` and `eventValue` are still returning empty visitsummaries. Maybe we should check if that is correct, as they are using values that seems valid...