### PR TITLE
Check $defaultLayout is an array when generating default dashboard

### DIFF
--- a/plugins/Tour/Tour.php
+++ b/plugins/Tour/Tour.php
@@ -123,9 +123,9 @@ class Tour extends \Piwik\Plugin
     public function changeDefaultDashboardLayout(&$defaultLayout)
     {
         if (Piwik::hasUserSuperUserAccess()) {
-            $defaultLayout = json_decode($defaultLayout);
+            $defaultLayout = json_decode($defaultLayout, true);
             $engagementWidget = array('uniqueId' => 'widgetTourgetEngagement', 'parameters' => array('module' => 'Tour', 'action' => 'getEngagement'));
-            if (isset($defaultLayout[2])) {
+            if (is_array($defaultLayout) && isset($defaultLayout[2]) && is_array($defaultLayout[2])) {
                 array_unshift($defaultLayout[2], $engagementWidget);
             }
             $defaultLayout = json_encode($defaultLayout);


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/14595

Not sure why it wouldn't be an array. Even when using ` json_decode($defaultLayout);` compared to ` json_decode($defaultLayout, true);` it is an array on my instance and works nicely. Just in case there is some other plugin installed that changes it maybe, check if it is an array