### PR TITLE
Improve speed of serving unreadable files

### DIFF
--- a/core/ProxyHttp.php
+++ b/core/ProxyHttp.php
@@ -73,6 +73,11 @@ class ProxyHttp
             return;
         }
 
+        if (!is_readable($file)) {
+            Common::sendResponseCode(500);
+            return;
+        }
+
         $modifiedSince = Http::getModifiedSinceHeader();
 
         $fileModifiedTime = @filemtime($file);


### PR DESCRIPTION
While looking for long running Integration tests (#12691) I saw, that the test `Piwik\Tests\Integration\ServeStaticFileTest:test_nonReadableFile` takes around 65s on travis, as reading the file without permission seems to take a long time.
Adding a check for `is_readable` speeds up the test to less than 10 seconds (guess even less, but I used 10 seconds for reporting slow tests).

Not sure if that might decrease the speed for existing files as there is another file operation to be done...