### PR TITLE
If URL starts with // in sites manager, only prepend http: instead of… http://

### DIFF
--- a/plugins/WebsiteMeasurable/Settings/Urls.php
+++ b/plugins/WebsiteMeasurable/Settings/Urls.php
@@ -115,7 +115,11 @@ class Urls extends \Piwik\Settings\Measurable\MeasurableProperty
             if (empty($scheme)
                 && strpos($url, '://') === false
             ) {
-                $url = 'http://' . $url;
+                if (strpos($url, '//') === 0) {
+                    $url = 'http:' . $url;
+                } else {
+                    $url = 'http://' . $url;
+                }
             }
             $url = trim($url);
             $url = Common::sanitizeInputValue($url);


### PR DESCRIPTION

fix https://github.com/matomo-org/matomo/issues/14615

alternatively we could throw an exception if URL starts with `//`. Configuring a URL with `//` is not supported currently.