### PR TITLE
Support to cache the config file

### DIFF
--- a/core/Config/Cache.php
+++ b/core/Config/Cache.php
@@ -34,14 +34,11 @@ class Cache extends File
 
     private function makeCacheDir($host)
     {
-        return PIWIK_INCLUDE_PATH . '/tmp/' . $host . '/cache/tracker/';
+        return PIWIK_INCLUDE_PATH . '/tmp/' . $host . '/cache/tracker';
     }
 
     public function isValidHost($mergedConfigSettings)
     {
-        if (!$this->host) {
-            return true;
-        }
         if (!isset($mergedConfigSettings['General']['trusted_hosts']) || !is_array($mergedConfigSettings['General']['trusted_hosts'])) {
             return false;
         }
@@ -55,7 +52,10 @@ class Cache extends File
         $host = Url::getHostSanitized($host); // Remove any port number to get actual hostname
         $host = Common::sanitizeInputValue($host);
 
-        if (empty($host) || strpos($host, '..') !== false || strpos($host, '/') !== false) {
+        if (empty($host)
+            || strpos($host, '..') !== false
+            || strpos($host, '\\') !== false
+            || strpos($host, '/') !== false) {
             throw new \Exception('Unsupported host');
         }
 
@@ -69,6 +69,7 @@ class Cache extends File
         // when the config changes, we need to invalidate the config caches for all configured hosts as well, not only
         // the currently trusted host
         $hosts = Url::getTrustedHosts();
+        $initialDir = $this->directory;
 
         foreach ($hosts as $host)
         {
@@ -81,6 +82,8 @@ class Cache extends File
                 }
             }
         }
+
+        $this->directory = $initialDir;
     }
 
 }

--- a/core/Config/Cache.php
+++ b/core/Config/Cache.php
@@ -39,15 +39,14 @@ class Cache extends File
 
     public function isValidHost($mergedConfigSettings)
     {
-        $host = $this->getHost();
-        if (!$host) {
+        if (!$this->host) {
             return true;
         }
         if (!isset($mergedConfigSettings['General']['trusted_hosts']) || !is_array($mergedConfigSettings['General']['trusted_hosts'])) {
             return false;
         }
         // note: we do not support "enable_trusted_host_check" to keep things secure
-        return in_array($host, $mergedConfigSettings['General']['trusted_hosts'], true);
+        return in_array($this->host, $mergedConfigSettings['General']['trusted_hosts'], true);
     }
 
     private function getHost()

--- a/core/Config/Cache.php
+++ b/core/Config/Cache.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Config;
+
+use Piwik\Cache\Backend\File;
+use Piwik\Url;
+
+/**
+ * Exception thrown when the config file doesn't exist.
+ */
+class Cache extends File
+{
+    public function __construct()
+    {
+        $host = Url::getHost($checkIfTrusted = false);
+        $host = Url::getHostSanitized($host); // Remove any port number to get actual hostname
+
+        $dir = PIWIK_INCLUDE_PATH . '/tmp/' . $host . '/cache/tracker/';
+        parent::__construct($dir);
+        $this->setNamespace('');
+    }
+
+}

--- a/core/Config/IniFileChain.php
+++ b/core/Config/IniFileChain.php
@@ -35,7 +35,7 @@ use Piwik\Url;
  */
 class IniFileChain
 {
-    const CONFIG_CACHE_KEY = 'config.ini.php';
+    const CONFIG_CACHE_KEY = 'config.ini';
     /**
      * Maps INI file names with their parsed contents. The order of the files signifies the order
      * in the chain. Files with lower index are overwritten/merged with files w/ a higher index.

--- a/tests/PHPUnit/Integration/Config/CacheTest.php
+++ b/tests/PHPUnit/Integration/Config/CacheTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\Integration\Config\Cache;
+
+use PHPUnit_Framework_TestCase;
+use Piwik\Config;
+use Piwik\Config\Cache;
+use Piwik\Config\IniFileChain;
+use Piwik\Tests\Integration\Settings\IntegrationTestCase;
+
+/**
+ * @group Core
+ */
+class CacheTest extends IntegrationTestCase
+{
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    private $testHost = 'analytics.test.matomo.org';
+
+    public function setUp()
+    {
+        unset($GLOBALS['ENABLE_CONFIG_PHP_CACHE']);
+        $this->setTrustedHosts();
+        $_SERVER['HTTP_HOST'] = $this->testHost;
+        $this->cache = new Cache();
+        $this->cache->doDelete(IniFileChain::CONFIG_CACHE_KEY);
+        parent::setUp();
+    }
+
+    private function setTrustedHosts()
+    {
+        Config::setSetting('General', 'trusted_hosts', array($this->testHost, 'foonot.exists'));
+    }
+
+    public function tearDown()
+    {
+        $this->setTrustedHosts();
+        $this->cache->doDelete(IniFileChain::CONFIG_CACHE_KEY);
+        unset($_SERVER['HTTP_HOST']);
+        parent::tearDown();
+    }
+
+    public function test_doFetch_noValueSaved_shouldReturnFalse()
+    {
+        $noValue = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $this->assertFalse($noValue);
+    }
+
+    /**
+     * @dataProvider getRandmHosts
+     * @expectedException \Exception
+     * @expectedExceptionMessage  Unsupported host
+     */
+    public function test_construct_failsWhenUsingRandomHost($host)
+    {
+        $_SERVER['HTTP_HOST'] = $host;
+        new Cache();
+    }
+
+    public function getRandmHosts()
+    {
+        return [
+            ['foo..test'],
+            ['foo\test'],
+            ['']
+        ];
+    }
+
+    public function test_doSave_doFetch_savesAndReadsData()
+    {
+        $value = array('mergedSettings' => 'foobar', 'settingsChain' => array('bar' => 'baz'));
+        $this->cache->doSave(IniFileChain::CONFIG_CACHE_KEY, $value, 60);
+        $this->assertEquals($value, $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY));
+
+        // also works when creating new instance to ensure it's read from file
+        $this->cache = new Cache();
+        $this->assertEquals($value, $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY));
+    }
+
+    public function test_doDelete()
+    {
+        $value = array('mergedSettings' => 'foobar', 'settingsChain' => array('bar' => 'baz'));
+        $this->cache->doSave(IniFileChain::CONFIG_CACHE_KEY, $value, 60);
+
+        $this->setTrustedHosts();
+
+        $this->assertEquals($value, $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY));
+
+        $this->cache->doDelete(IniFileChain::CONFIG_CACHE_KEY);
+
+        $this->assertFalse($this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY));
+
+        $cache = new Cache();
+        $this->assertFalse($cache->doFetch(IniFileChain::CONFIG_CACHE_KEY));
+    }
+
+    public function test_isValidHost()
+    {
+        $this->assertTrue($this->cache->isValidHost(array('General' => array('trusted_hosts' => array('foo.com', $this->testHost, 'bar.baz')))));
+        $this->assertFalse($this->cache->isValidHost(array('General' => array('trusted_hosts' => array('foo.com', 'bar.baz')))));
+        $this->assertFalse($this->cache->isValidHost(array('General' => array('trusted_hosts' => array()))));
+        $this->assertFalse($this->cache->isValidHost(array()));
+    }
+
+}

--- a/tests/PHPUnit/Unit/Config/IniFileChainCacheTest.php
+++ b/tests/PHPUnit/Unit/Config/IniFileChainCacheTest.php
@@ -7,25 +7,155 @@
  */
 namespace Piwik\Tests\Unit\Config;
 
-use PHPUnit_Framework_TestCase;
+use Piwik\Config;
+use Piwik\Config\Cache;
 use Piwik\Config\IniFileChain;
+
+class TestIniFileChain extends IniFileChain
+{
+    public $addHostInfo = '';
+
+    public function __construct(array $defaultSettingsFiles = array(), $userSettingsFile = null, $addhostInfo = '')
+    {
+        $this->addHostInfo = $addhostInfo;
+        parent::__construct($defaultSettingsFiles, $userSettingsFile);
+    }
+
+    protected function mergeFileSettings()
+    {
+        $settings = parent::mergeFileSettings();
+
+        if (!empty($this->addHostInfo)) {
+            $settings['General'] = ['trusted_hosts'=> [$this->addHostInfo]];
+        }
+
+        return $settings;
+    }
+}
 
 /**
  * @group Core
  */
 class IniFileChainCacheTest extends IniFileChainTest
 {
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    private $testHost = 'mytest.matomo.org';
+
     public function setUp()
     {
         $GLOBALS['ENABLE_CONFIG_PHP_CACHE'] = true;
-        $_SERVER['HTTP_HOST'] = 'mytest.matomo.org';
+        $_SERVER['HTTP_HOST'] = $this->testHost;
+        $this->cache = new Cache();
         parent::setUp();
+        $this->setTrustedHosts();
+    }
+
+    private function setTrustedHosts()
+    {
+        Config::setSetting('General', 'trusted_hosts', array($this->testHost, 'foonot.exists'));
     }
 
     public function tearDown()
     {
+        $this->cache->doDelete(IniFileChain::CONFIG_CACHE_KEY);
         unset($GLOBALS['ENABLE_CONFIG_PHP_CACHE']);
         unset($_SERVER['HTTP_HOST']);
         parent::tearDown();
+    }
+
+    /**
+     * @dataProvider getMergingTestData
+     */
+    public function test_reload_shouldNotPopulateCacheWhenNoTrustedHostIsConfigured($testDescription, $defaultSettingFiles, $userSettingsFile, $expected)
+    {
+        $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $this->assertEquals(false, $value);
+
+        // reading the chain should populate the cache
+        $fileChain = new TestIniFileChain($defaultSettingFiles, $userSettingsFile);
+        $this->assertEquals($expected, $fileChain->getAll(), "'$testDescription' failed");
+
+        $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $this->assertEquals(false, $value);
+    }
+
+    /**
+     * @dataProvider getMergingTestData
+     */
+    public function test_reload_shouldNotPopulateCacheWhenTrustedHostIsNotValid($testDescription, $defaultSettingFiles, $userSettingsFile, $expected)
+    {
+        $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $this->assertEquals(false, $value);
+
+        // reading the chain should populate the cache
+        $fileChain = new TestIniFileChain($defaultSettingFiles, $userSettingsFile, 'foo.bar.com');
+        $expected['General'] = array('trusted_hosts' => array('foo.bar.com'));
+        $this->assertEquals($expected, $fileChain->getAll(), "'$testDescription' failed");
+
+        $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $this->assertEquals(false, $value);
+    }
+
+    /**
+     * @dataProvider getMergingTestData
+     */
+    public function test_reload_shoulPopulateCacheWhenTrustedHostIsValid($testDescription, $defaultSettingFiles, $userSettingsFile, $expected)
+    {
+        $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $this->assertEquals(false, $value);
+
+        // reading the chain should populate the cache
+        $fileChain = new TestIniFileChain($defaultSettingFiles, $userSettingsFile, $this->testHost);
+        $expected['General'] = array('trusted_hosts' => array($this->testHost));
+        $this->assertEquals($expected, $fileChain->getAll(), "'$testDescription' failed");
+
+        $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $settingsChain = $value['settingsChain'];
+        unset($value['settingsChain']);
+        $this->assertEquals(array('mergedSettings' => $expected), $value);
+
+        $this->assertArraySubset($defaultSettingFiles, array_keys($settingsChain));
+        $this->assertNotEmpty(array_keys($settingsChain));
+    }
+    
+    /**
+     * @dataProvider getMergingTestData
+     */
+    public function test_reload_canReadFromCache($testDescription, $defaultSettingFiles, $userSettingsFile, $expected)
+    {
+        $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $this->assertEquals(false, $value);
+
+        // reading the chain should populate the cache
+        $fileChain = new TestIniFileChain($defaultSettingFiles, $userSettingsFile, $this->testHost);
+        $expected['General'] = array('trusted_hosts' => array($this->testHost));
+        $this->assertEquals($expected, $fileChain->getAll(), "'$testDescription' failed");
+
+        // even though the passed config files don't exist it still returns the same result as it is fetched from
+        // cache
+        $testChain = new TestIniFileChain(array('foo'), 'bar');
+        $this->assertEquals($expected, $testChain->getAll(), "'$testDescription' failed");
+    }
+
+    /**
+     * @dataProvider getMergingTestData
+     */
+    public function test_populateCache_DeleteCache($testDescription, $defaultSettingFiles, $userSettingsFile, $expected)
+    {
+        $this->test_reload_shoulPopulateCacheWhenTrustedHostIsValid($testDescription, $defaultSettingFiles, $userSettingsFile, $expected);
+
+        $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $this->assertNotEmpty($value);
+
+        // dumping the cache should delete it
+        $fileChain = new TestIniFileChain($defaultSettingFiles, $userSettingsFile);
+        $fileChain->dump('');
+
+        $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
+        $this->assertEquals(false, $value);
     }
 }

--- a/tests/PHPUnit/Unit/Config/IniFileChainCacheTest.php
+++ b/tests/PHPUnit/Unit/Config/IniFileChainCacheTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Tests\Unit\Config;
+
+use PHPUnit_Framework_TestCase;
+use Piwik\Config\IniFileChain;
+
+/**
+ * @group Core
+ */
+class IniFileChainCacheTest extends IniFileChainTest
+{
+    public function setUp()
+    {
+        $GLOBALS['ENABLE_CONFIG_PHP_CACHE'] = true;
+        $_SERVER['HTTP_HOST'] = 'mytest.matomo.org';
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        unset($GLOBALS['ENABLE_CONFIG_PHP_CACHE']);
+        unset($_SERVER['HTTP_HOST']);
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/14367

This supports caching the config ini file. It would be enabled through `$matomoDir/bootstrap.php` by putting this code in there (we cannot use DI or config file for this because they don't exist at the time of the config loading):

```php
<?php

$GLOBALS['ENABLE_CONFIG_PHP_CACHE'] = true;
$GLOBALS['MATOMO_PLUGIN_DIRS'] = array(); // this line is unrelated... just another setting we added recently by using bootstrap.php
```

It would pretty much only work for single server environments... all others would have the problem that the cache invalidation when the config changes wouldn't be synced. Also we do not want to have to document that users need to invalidate the cache when they make changes to it. It would pretty much only help us and I would probably not even document it. When loaded from a regular filesystem, it should be still very fast with the regular ini. If it works nicely, we could document it eventually.

By caching it, it would come from opcache instead of filesystem... and we would not need to do things like all these decodings etc https://github.com/matomo-org/component-ini/blob/master/src/IniReader.php#L149-L384

Any thoughts on this @mattab 

refs DEV-1692