### PR TITLE
When installer is disabled and any module is requested, also show the not set up yet message

### DIFF
--- a/core/Application/Kernel/EnvironmentValidator.php
+++ b/core/Application/Kernel/EnvironmentValidator.php
@@ -9,6 +9,7 @@
 namespace Piwik\Application\Kernel;
 
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\Exception\NotYetInstalledException;
 use Piwik\Filechecks;
 use Piwik\Piwik;
@@ -73,6 +74,12 @@ class EnvironmentValidator
     {
         if (is_readable($path)) {
             return;
+        }
+
+        $general = Config::getInstance()->General;
+
+        if (!$general['enable_installer']) {
+            throw new \Exception('Matomo is not set up yet');
         }
 
         $message = $this->getSpecificMessageWhetherFileExistsOrNot($path);

--- a/core/Application/Kernel/EnvironmentValidator.php
+++ b/core/Application/Kernel/EnvironmentValidator.php
@@ -76,7 +76,7 @@ class EnvironmentValidator
             return;
         }
 
-        $general = Config::getInstance()->General;
+        $general = $this->settingsProvider->getSection('General');
 
         if (!$general['enable_installer']) {
             throw new \Exception('Matomo is not set up yet');


### PR DESCRIPTION
Expected (already working when requesting https://analytics.domain.com )

![image](https://user-images.githubusercontent.com/273120/60720648-b45e4d80-9f2b-11e9-8402-dfd982cc415c.png)

but doesn't work when eg requesting https://analytics.domain.com/index.php?module=API&action=home&idSite=1&period=day&date=yesterday

which was showing eg this

![image](https://user-images.githubusercontent.com/273120/60720701-de177480-9f2b-11e9-8f36-41d60fa134ba.png)

Adding another check for this case when a module is specified...  In the past we didn't want find a need to fix it but it's easy to do. A test for this special case shouldn't be needed.