### PR TITLE
Long labels in left mobile menu may be shown on the next line

### DIFF
--- a/plugins/CoreHome/angularjs/reporting-menu/reportingmenu.directive.html
+++ b/plugins/CoreHome/angularjs/reporting-menu/reportingmenu.directive.html
@@ -40,7 +40,7 @@
     <li class="no-padding" ng-repeat="category in menuModel.menu">
         <ul class="collapsible collapsible-accordion" piwik-side-nav="nav .activateLeftMenu">
             <li>
-                <a class="collapsible-header">{{ category.name }}<i class="{{ category.icon ? category.icon : 'icon-arrow-bottom' }}"></i></a>
+                <a class="collapsible-header"><i class="{{ category.icon ? category.icon : 'icon-arrow-bottom' }}"></i>{{ category.name }}</a>
                 <div class="collapsible-body">
                     <ul>
                         <li ng-repeat="subcategory in category.subcategories">


### PR DESCRIPTION
refs DEV-1705
See eg session recordings label. Instead session recordings will be now over 2 lines