### PR TITLE
Only permit scalar values for custom variables

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -620,7 +620,8 @@ class Request
             if ($id < 1
                 || $id > $maxCustomVars
                 || count($keyValue) != 2
-                || (!is_string($keyValue[0]) && !is_numeric($keyValue[0]))
+                || (!is_string($keyValue[0]) && !is_numeric($keyValue[0])
+                || (!is_string($keyValue[1]) && !is_numeric($keyValue[1])))
             ) {
                 Common::printDebug("Invalid custom variables detected (id=$id)");
                 continue;

--- a/tests/PHPUnit/Integration/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Integration/Tracker/RequestTest.php
@@ -229,6 +229,15 @@ class RequestTest extends IntegrationTestCase
         $this->assertCustomVariablesInPageScope($expected, $customVars);
     }
 
+    public function test_getCustomVariables_inputArrayOfMixedType()
+    {
+        $input = array('mykey' => array('myarraykey' => 'myvalue'));
+        $customVars = $this->buildCustomVars($input);
+        $expected = $this->buildExpectedCustomVars($input);
+
+        $this->assertCustomVariablesInPageScope($expected, $customVars);
+    }
+
     public function test_isAuthenticated_ShouldBeNotAuthenticatedInTestsByDefault()
     {
         $this->assertFalse($this->request->isAuthenticated());

--- a/tests/PHPUnit/Integration/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Integration/Tracker/RequestTest.php
@@ -229,11 +229,12 @@ class RequestTest extends IntegrationTestCase
         $this->assertCustomVariablesInPageScope($expected, $customVars);
     }
 
-    public function test_getCustomVariables_inputArrayOfMixedType()
+    public function test_getCustomVariables_nonStringInput()
     {
-        $input = array('mykey' => array('myarraykey' => 'myvalue'));
+        $input = array('mykey' => array('myarraykey' => 'myvalue'), 'myotherkey' => 2);
         $customVars = $this->buildCustomVars($input);
-        $expected = $this->buildExpectedCustomVars($input);
+        // Int value should come through; array value is invalid so should be discarded
+        $expected = array('custom_var_k2' => 'myotherkey', 'custom_var_v2' => 2);
 
         $this->assertCustomVariablesInPageScope($expected, $customVars);
     }


### PR DESCRIPTION
Fixes #14580 (a PHP warning that happens when an array is passed)