### PR TITLE
Split Integration tests into Core and Plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,10 @@ matrix:
       env: TEST_SUITE=SystemTestsPlugins MYSQL_ADAPTER=PDO_MYSQL
       sudo: required
     - php: 5.6
-      env: TEST_SUITE=IntegrationTests MYSQL_ADAPTER=PDO_MYSQL
+      env: TEST_SUITE=IntegrationTestsCore MYSQL_ADAPTER=PDO_MYSQL
+      sudo: required
+    - php: 5.6
+      env: TEST_SUITE=IntegrationTestsPlugins MYSQL_ADAPTER=PDO_MYSQL
       sudo: required
     - php: 5.6
       env: TEST_SUITE=UnitTests MYSQL_ADAPTER=PDO_MYSQL

--- a/tests/PHPUnit/phpunit.xml.dist
+++ b/tests/PHPUnit/phpunit.xml.dist
@@ -50,6 +50,15 @@
         <directory>../../tests/resources/custompluginsdir/*/tests/Integration</directory>
         <directory>../../tests/resources/custompluginsdir/*/Test/Integration</directory>
     </testsuite>
+    <testsuite name="IntegrationTestsCore">
+        <directory>./Integration</directory>
+        <directory>../../tests/resources/custompluginsdir/*/tests/Integration</directory>
+        <directory>../../tests/resources/custompluginsdir/*/Test/Integration</directory>
+    </testsuite>
+    <testsuite name="IntegrationTestsPlugins">
+        <directory>../../plugins/*/tests/Integration</directory>
+        <directory>../../plugins/*/Test/Integration</directory>
+    </testsuite>
     <testsuite name="UnitTests">
         <directory>./Unit</directory>
         <directory>../../plugins/*/tests/Unit</directory>


### PR DESCRIPTION
As the Integration tests are currently running too long, it might be useful to split them as well.

refs #12691