### PR TITLE
Fix failing SEO test

### DIFF
--- a/plugins/SEO/tests/Integration/SEOTest.php
+++ b/plugins/SEO/tests/Integration/SEOTest.php
@@ -12,13 +12,14 @@ use Piwik\DataTable\Renderer;
 use Piwik\Plugins\SEO\API;
 use Exception;
 use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 /**
  * @group SEO
  * @group SEOTest
  * @group Plugins
  */
-class SEOTest extends \PHPUnit_Framework_TestCase
+class SEOTest extends IntegrationTestCase
 {
     public function setUp()
     {
@@ -32,10 +33,9 @@ class SEOTest extends \PHPUnit_Framework_TestCase
         FakeAccess::$superUser = true;
 
         $user_agents = array(
-            'Mozilla/6.0 (Macintosh; I; Intel Mac OS X 11_7_9; de-LI; rv:1.9b4) Gecko/2012010317 Firefox/10.0a4',
-            'Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0',
-            'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/535.2 (KHTML, like Gecko) Chrome/18.6.872.0 Safari/535.2 UNTRUSTED/1.0 3gpp-gba UNTRUSTED/1.0',
-            'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1',
+            'Mozilla/5.0 (X11; Fedora; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36',
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Safari/605.1.15',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36',
         );
 
         $_SERVER['HTTP_USER_AGENT'] = $user_agents[mt_rand(0, count($user_agents) - 1)];


### PR DESCRIPTION
It seems bing returns the data depending on the detected device (type) of the useragent or something like this. Changing the useragents fixed the tests :man_shrugging: 

fixes #14577