### PR TITLE
Bump lodash from 4.17.11 to 4.17.14 in /tests/lib/screenshot-testing

### DIFF
--- a/tests/lib/screenshot-testing/package-lock.json
+++ b/tests/lib/screenshot-testing/package-lock.json
@@ -1096,9 +1096,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lru-cache": {
       "version": "4.1.5",


### PR DESCRIPTION
Automated fix by dependabot.