### PR TITLE
In JS tracker generator make sure to reuse same class when creating new file

### DIFF
--- a/plugins/CustomPiwikJs/File.php
+++ b/plugins/CustomPiwikJs/File.php
@@ -15,11 +15,16 @@ class File
     /**
      * @var string
      */
-    private $file;
+    protected $file;
 
     public function __construct($file)
     {
         $this->file = $file;
+    }
+
+    public function setFile($file)
+    {
+        return new static($file);
     }
 
     public function checkReadable()

--- a/plugins/CustomPiwikJs/TrackerUpdater.php
+++ b/plugins/CustomPiwikJs/TrackerUpdater.php
@@ -150,7 +150,7 @@ class TrackerUpdater
     {
         if (Common::stringEndsWith($this->toFile->getName(), $fromFile)) {
             $alternativeFilename = dirname($this->toFile->getPath()) . DIRECTORY_SEPARATOR . $toFile;
-            $file = new File($alternativeFilename);
+            $file = $this->toFile->setFile($alternativeFilename);
             if ($file->hasWriteAccess() && $file->getContent() !== $newContent) {
                 $file->save($newContent);
                 Piwik::postEvent('CustomPiwikJs.piwikJsChanged', [$file->getPath()]);

--- a/plugins/CustomPiwikJs/tests/Integration/FileTest.php
+++ b/plugins/CustomPiwikJs/tests/Integration/FileTest.php
@@ -11,6 +11,10 @@ namespace Piwik\Plugins\CustomPiwikJs\tests\Integration;
 use Piwik\Plugins\CustomPiwikJs\File;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
+class CustomTestFile extends File {
+
+}
+
 /**
  * @group CustomPiwikJs
  * @group FileTest
@@ -96,6 +100,21 @@ class FileTest extends IntegrationTestCase
     {
         $this->assertSame('test.js', $this->makeFile()->getName());
         $this->assertSame('notExisTinGFile.js', $this->makeNotReadableFile()->getName());
+    }
+
+    public function test_setFile_createsNewObjectLeavesOldUnchanged()
+    {
+        $file = $this->makeFile();
+        $file2 = $file->setFile('foo/bar.png');
+        $this->assertSame('test.js', $file->getName());
+        $this->assertSame('bar.png', $file2->getName());
+    }
+
+    public function test_setFile_returnsObjectOfSameType()
+    {
+        $file = new CustomTestFile('foo/baz.png');
+        $file2 = $file->setFile('foo/bar.png');
+        $this->assertTrue($file2 instanceof CustomTestFile);
     }
 
     public function test_getPath()


### PR DESCRIPTION
Background:
Someone might use DI to set a custom file type like this:

```php
  'Piwik\Plugins\CustomPiwikJs\TrackerUpdater' => DI\decorate(function ($previous) {
 
        $to = new \Piwik\Plugins\MyPlugin\CdnFile('mypath/piwik.js');

        $previous->setToFile($to);

        return $previous;
    }),
```

The tracker updater would then eg update the file content on the CDN instead of locally. However, because we have a `piwik.js` and a `matomo.js` that needs to be updated, the `matomo.js` would have still been updated on the local filesystem because it was using `new File()` hard coded where it should have created basically `new CdnFile()`. 

We need this patch on the cloud fyi.