### PR TITLE
Add new property to store un-encoded site name for use in JS.

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -15,6 +15,7 @@ use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Config as PiwikConfig;
 use Piwik\Container\StaticContainer;
+use Piwik\DataTable\Filter\SafeDecodeLabel;
 use Piwik\Date;
 use Piwik\Exception\NoPrivilegesException;
 use Piwik\Exception\NoWebsiteFoundException;
@@ -614,6 +615,7 @@ abstract class Controller
         $this->setPeriodVariablesView($view);
 
         $view->siteName = $this->site->getName();
+        $view->siteNameDecoded = Common::unsanitizeInputValue($view->siteName);
         $view->siteMainUrl = $this->site->getMainUrl();
 
         $siteTimezone = $this->site->getTimezone();

--- a/plugins/Morpheus/templates/_jsGlobalVariables.twig
+++ b/plugins/Morpheus/templates/_jsGlobalVariables.twig
@@ -20,7 +20,10 @@
 
     {% if idSite is defined %}piwik.idSite = "{{ idSite }}";{% endif %}
 
-    {% if siteName is defined %}piwik.siteName = "{{ siteName|e('js') }}";{% endif %}
+    {% if siteName is defined %}
+    // NOTE: siteName is currently considered deprecated, use piwik.currentSiteName instead, which will not contain HTML entities
+    piwik.siteName = "{{ siteName|e('js') }}";
+    piwik.currentSiteName = {{ siteNameDecoded|json_encode|raw }};{% endif %}
 
     {% if siteMainUrl is defined %}piwik.siteMainUrl = "{{ siteMainUrl|e('js') }}";{% endif %}
 


### PR DESCRIPTION
So plugins can use `piwik.currentSiteName || piwik.siteName` when accessing the current site name.