### PR TITLE
Only refresh engagement widget when it is on the page

### DIFF
--- a/plugins/Tour/templates/engagement.twig
+++ b/plugins/Tour/templates/engagement.twig
@@ -50,7 +50,9 @@
         <p class="tourSuperUserNote">{{ 'Tour_OnlyVisibleToSuperUser'|translate('<a href="https://matomo.org/faq/general/faq_35/" target="_blank" rel="noreferrer noopener">', '</a>')|raw }}</p>
         <script>
             jQuery(window).off('focus.tourEngagement').on('focus.tourEngagement', function () {
-                tourEngagement.goToPage({{ currentPage|e('js') }});
+                if (jQuery('#widgetTourgetEngagement').size()) {
+                    tourEngagement.goToPage({{ currentPage|e('js') }});
+                }
             });
         </script>
     {% endif %}


### PR DESCRIPTION
I double checked it should have been only refreshing when the tour widget in the dashboard was loaded/viewed at least once, and only when focusing the window again (eg switching between developer tools and the browser window or between different tabs). It wasn't loaded on every page load within Matomo.

fixes #14648 