### PR TITLE
Prevent unserialization error in DataTableFactory

### DIFF
--- a/core/Archive/DataTableFactory.php
+++ b/core/Archive/DataTableFactory.php
@@ -397,7 +397,7 @@ class DataTableFactory
             }
 
             $blobName = $dataName . "_" . $sid;
-            if (isset($blobRow[$blobName])) {
+            if (!empty($blobRow[$blobName])) {
                 $subtable = DataTable::fromSerializedArray($blobRow[$blobName]);
                 $this->setSubtables($subtable, $blobRow, $treeLevel + 1);
 


### PR DESCRIPTION
Sometimes $blobRow[$blobName] is set but its value is false and
DataTable::fromSerializedArray will throw an exception if called with a
false value

This patch prevents this by verifying that the value is not 'empty'
instead