### PR TITLE
Support configuration of a reader database

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -45,6 +45,19 @@ ssl_no_verify =
 ; Matomo should work correctly without this setting but we recommend to have a charset set.
 charset = utf8
 
+; If configured, the following queries will be executed on the reader instead of the writer.
+; * archiving queries that hit a log table
+; * live queries that hit a log table
+; * fetching of archives when viewing a report
+; You only want to enable a reader if you can ensure there is minimal replication lag / delay on the reader.
+; Otherwise you might get corrupt data in the reports.
+[database_reader]
+host =
+username =
+password =
+dbname =
+port = 3306
+
 [database_tests]
 host = localhost
 username = "@USERNAME@"

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -453,6 +453,31 @@ class Archive implements ArchiveQuery
         return $dataTable;
     }
 
+    private function canUseDbReader()
+    {
+        if (Common::isPhpCliMode() ) {
+            // we are likely archiving or we are in CronArchive class etc. where it is important to detect if a
+            // specific archive already exist or not to possibly prevent triggering an unneeded archive request...
+            // also we only want to read archives from the reader for requests from the web
+            return false;
+        }
+
+        if (SettingsServer::isArchivePhpTriggered()) {
+            // when archiving is triggered, we want to make sure to read archives from master to ensure most recent
+            // archives are read etc
+            return false;
+        }
+
+        if (Rules::isArchivingDisabledFor($this->params->getIdSites(), $this->params->getSegment(), $this->getPeriodLabel())) {
+            // in this case we know we won't be creating any archives and we will only want to read archives in order
+            // to present the data in Matomo. We want to use the reader in this case
+            return true;
+        }
+
+        // archiving could be triggered during this request, better not use the reader
+        return false;
+    }
+
     private function getSiteIdsThatAreRequestedInThisArchiveButWereNotInvalidatedYet()
     {
         if (is_null(self::$cache)) {
@@ -556,7 +581,7 @@ class Archive implements ArchiveQuery
             return $result;
         }
 
-        $archiveData = ArchiveSelector::getArchiveData($archiveIds, $archiveNames, $archiveDataType, $idSubtable);
+        $archiveData = ArchiveSelector::getArchiveData($archiveIds, $archiveNames, $archiveDataType, $idSubtable, $this->canUseDbReader());
 
         $isNumeric = $archiveDataType == 'numeric';
 
@@ -680,7 +705,7 @@ class Archive implements ArchiveQuery
     private function cacheArchiveIdsWithoutLaunching($plugins)
     {
         $idarchivesByReport = ArchiveSelector::getArchiveIds(
-            $this->params->getIdSites(), $this->params->getPeriods(), $this->params->getSegment(), $plugins);
+            $this->params->getIdSites(), $this->params->getPeriods(), $this->params->getSegment(), $plugins, $this->canUseDbReader());
 
         // initialize archive ID cache for each report
         foreach ($plugins as $plugin) {

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -138,6 +138,7 @@ class ArchiveSelector
      * @param array $periods
      * @param Segment $segment
      * @param array $plugins List of plugin names for which data is being requested.
+     * @param bool $canUseReaderDb if enabled, will try to read archive from reader
      * @return array Archive IDs are grouped by archive name and period range, ie,
      *               array(
      *                   'VisitsSummary.done' => array(
@@ -146,7 +147,7 @@ class ArchiveSelector
      *               )
      * @throws
      */
-    public static function getArchiveIds($siteIds, $periods, $segment, $plugins)
+    public static function getArchiveIds($siteIds, $periods, $segment, $plugins, $canUseReaderDb)
     {
         if (empty($siteIds)) {
             throw new \Exception("Website IDs could not be read from the request, ie. idSite=");
@@ -171,6 +172,12 @@ class ArchiveSelector
             }
             $table = ArchiveTableCreator::getNumericTable($period->getDateStart());
             $monthToPeriods[$table][] = $period;
+        }
+
+        if ($canUseReaderDb) {
+            $db = Db::getReader();
+        } else {
+            $db = Db::get();
         }
 
         // for every month within the archive query, select from numeric table
@@ -204,7 +211,8 @@ class ArchiveSelector
 
             $sql = sprintf($getArchiveIdsSql, $table, $dateCondition);
 
-            $archiveIds = Db::fetchAll($sql, $bind);
+
+            $archiveIds = $db->fetchAll($sql, $bind);
 
             // get the archive IDs
             foreach ($archiveIds as $row) {
@@ -227,12 +235,19 @@ class ArchiveSelector
      * @param string $archiveDataType The archive data type (either, 'blob' or 'numeric').
      * @param int|null|string $idSubtable  null if the root blob should be loaded, an integer if a subtable should be
      *                                     loaded and 'all' if all subtables should be loaded.
-     * @throws Exception
+     * @param bool $canUseReaderDb if enabled, will try to read archive from reader DB
      * @return array
+     *@throws Exception
      */
-    public static function getArchiveData($archiveIds, $recordNames, $archiveDataType, $idSubtable)
+    public static function getArchiveData($archiveIds, $recordNames, $archiveDataType, $idSubtable, $canUseReaderDb)
     {
         $chunk = new Chunk();
+
+        if ($canUseReaderDb) {
+            $db = Db::getReader();
+        } else {
+            $db = Db::get();
+        }
 
         // create the SQL to select archive data
         $loadAllSubtables = $idSubtable == Archive::ID_SUBTABLE_LOAD_ALL_SUBTABLES;
@@ -293,7 +308,7 @@ class ArchiveSelector
             }
 
             $sql      = sprintf($getValuesSql, $table, implode(',', $ids));
-            $dataRows = Db::fetchAll($sql, $bind);
+            $dataRows = $db->fetchAll($sql, $bind);
 
             foreach ($dataRows as $row) {
                 if ($isNumeric) {

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -963,6 +963,6 @@ class LogAggregator
 
     public function getDb()
     {
-        return Db::get();
+        return Db::getReader();
     }
 }

--- a/core/Db.php
+++ b/core/Db.php
@@ -36,6 +36,7 @@ class Db
     const SQL_MODE = 'NO_AUTO_VALUE_ON_ZERO';
 
     private static $connection = null;
+    private static $readerConnection = null;
 
     private static $logQueries = true;
 
@@ -55,6 +56,39 @@ class Db
         }
 
         return self::$connection;
+    }
+
+    /**
+     * @internal
+     * @ignore
+     * @return bool
+     */
+    public static function hasReaderConfigured()
+    {
+        $readerConfig = Config::getInstance()->database_reader;
+
+        return !empty($readerConfig['host']);
+    }
+
+    /**
+     * Returns the database connection and creates it if it hasn't been already. Make sure to not write any data on
+     * the reader and only use the connection to read data.
+     *
+     * @since Matomo 3.12
+     *
+     * @return \Piwik\Tracker\Db|\Piwik\Db\AdapterInterface|\Piwik\Db
+     */
+    public static function getReader()
+    {
+        if (!self::hasReaderConfigured()) {
+            return self::get();
+        }
+
+        if (!self::hasReaderDatabaseObject()) {
+            self::createReaderDatabaseObject();
+        }
+
+        return self::$readerConnection;
     }
 
     /**
@@ -125,6 +159,34 @@ class Db
     }
 
     /**
+     * Connects to the reader database.
+     *
+     * Shouldn't be called directly, use {@link get()} instead.
+     *
+     * @param array|null $dbConfig Connection parameters in an array. Defaults to the `[database]`
+     *                             INI config section.
+     *
+     * @since Matomo 3.12
+     */
+    public static function createReaderDatabaseObject($dbConfig = null)
+    {
+        if (!isset($dbConfig)) {
+            $dbConfig = Config::getInstance()->database_reader;
+        }
+
+        $masterDbConfig = self::getDatabaseConfig();
+        $dbConfig = self::getDatabaseConfig($dbConfig);
+        $dbConfig['adapter'] = $masterDbConfig['adapter'];
+        $dbConfig['schema'] = $masterDbConfig['schema'];
+        $dbConfig['type'] = $masterDbConfig['type'];
+        $dbConfig['tables_prefix'] = $masterDbConfig['tables_prefix'];
+
+        $db = @Adapter::factory($dbConfig['adapter'], $dbConfig);
+
+        self::$readerConnection = $db;
+    }
+
+    /**
      * Detect whether a database object is initialized / created or not.
      *
      * @internal
@@ -132,6 +194,16 @@ class Db
     public static function hasDatabaseObject()
     {
         return isset(self::$connection);
+    }
+
+    /**
+     * Detect whether a database object is initialized / created or not.
+     *
+     * @internal
+     */
+    public static function hasReaderDatabaseObject()
+    {
+        return isset(self::$readerConnection);
     }
 
     /**
@@ -145,6 +217,11 @@ class Db
             DbHelper::disconnectDatabase();
         }
         self::$connection = null;
+
+        if (self::hasReaderDatabaseObject()) {
+            self::$readerConnection->closeConnection();
+        }
+        self::$readerConnection = null;
     }
 
     /**

--- a/plugins/Actions/VisitorDetails.php
+++ b/plugins/Actions/VisitorDetails.php
@@ -271,7 +271,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 				WHERE log_link_visit_action.idvisit IN ('" . implode("','", $idVisits) . "')
 				ORDER BY log_link_visit_action.idvisit, server_time ASC
 				 ";
-        $actionDetails = Db::fetchAll($sql);
+        $actionDetails = $this->getDb()->fetchAll($sql);
         return $actionDetails;
     }
 

--- a/plugins/Diagnostics/ConfigReader.php
+++ b/plugins/Diagnostics/ConfigReader.php
@@ -88,7 +88,7 @@ class ConfigReader
     private function shouldSkipCategory($category)
     {
         $category = strtolower($category);
-        if ($category === 'database') {
+        if ($category === 'database' || $category === 'database_reader') {
             return true;
         }
 

--- a/plugins/Diagnostics/Diagnostic/DbReaderCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DbReaderCheck.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Plugins\Diagnostics\Diagnostic;
+
+use Piwik\Common;
+use Piwik\Config;
+use Piwik\Db;
+use Piwik\Piwik;
+use Piwik\Translation\Translator;
+
+/**
+ * Check if Piwik can use LOAD DATA INFILE.
+ */
+class DbReaderCheck implements Diagnostic
+{
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    public function __construct(Translator $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function execute()
+    {
+        $isPiwikInstalling = !Config::getInstance()->existsLocalConfig();
+        if ($isPiwikInstalling) {
+            // Skip the diagnostic if Piwik is being installed
+            return array();
+        }
+
+        if (!Db::hasReaderConfigured()) {
+            // only show an entry when reader is actually configured
+            return array();
+        }
+
+        $label = $this->translator->translate('Diagnostics_DatabaseReaderConnection');
+
+        try {
+            Db::getReader();
+            return array(DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_OK, ''));
+        } catch (\Exception $e) {
+
+        }
+
+        $comment = Piwik::translate('Installation_CannotConnectToDb');
+        return array(DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_WARNING, $comment));
+    }
+}

--- a/plugins/Diagnostics/config/config.php
+++ b/plugins/Diagnostics/config/config.php
@@ -7,6 +7,7 @@ return array(
     'diagnostics.required' => array(
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\PhpVersionCheck'),
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\DbAdapterCheck'),
+        DI\get('Piwik\Plugins\Diagnostics\Diagnostic\DbReaderCheck'),
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\PhpExtensionsCheck'),
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\PhpFunctionsCheck'),
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\PhpSettingsCheck'),

--- a/plugins/Diagnostics/lang/en.json
+++ b/plugins/Diagnostics/lang/en.json
@@ -6,6 +6,7 @@
         "ConfigFileIntroduction": "Here you can view the Matomo configuration. If you are running Matomo in a load balanced environment, the page might be different depending on from which server this page is loaded. Rows with a different background color are changed config values that are specified for example in the %1$s file.",
         "HideUnchanged": "If you want to see only changed values you can %1$shide all unchanged values%2$s.",
         "Sections": "Sections",
+        "DatabaseReaderConnection": "Database Reader Connection",
         "CronArchivingLastRunCheck": "Last Successful Archiving Completion",
         "CronArchivingHasNotRun": "Archiving has not yet run successfully.",
         "CronArchivingHasNotRunInAWhile": "Archiving last ran successfully on %1$s which is %2$s ago.",

--- a/plugins/Ecommerce/VisitorDetails.php
+++ b/plugins/Ecommerce/VisitorDetails.php
@@ -91,10 +91,10 @@ class VisitorDetails extends VisitorDetailsAbstract
     protected function queryEcommerceConversionsVisitorLifeTimeMetricsForVisitor($idSite, $idVisitor)
     {
         $sql             = $this->getSqlEcommerceConversionsLifeTimeMetricsForIdGoal(GoalManager::IDGOAL_ORDER);
-        $ecommerceOrders = Db::fetchRow($sql, array($idSite, @Common::hex2bin($idVisitor)));
+        $ecommerceOrders = $this->getDb()->fetchRow($sql, array($idSite, @Common::hex2bin($idVisitor)));
 
         $sql            = $this->getSqlEcommerceConversionsLifeTimeMetricsForIdGoal(GoalManager::IDGOAL_CART);
-        $abandonedCarts = Db::fetchRow($sql, array($idSite, @Common::hex2bin($idVisitor)));
+        $abandonedCarts = $this->getDb()->fetchRow($sql, array($idSite, @Common::hex2bin($idVisitor)));
 
         return array(
             'totalEcommerceRevenue'      => $ecommerceOrders['lifeTimeRevenue'],
@@ -157,7 +157,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 					WHERE log_conversion.idvisit IN ('" . implode("','", $idVisits) . "')
 						AND idgoal <= " . GoalManager::IDGOAL_ORDER . "
 					ORDER BY log_conversion.idvisit, log_conversion.server_time ASC";
-        $ecommerceDetails = Db::fetchAll($sql);
+        $ecommerceDetails = $this->getDb()->fetchAll($sql);
         return $ecommerceDetails;
     }
 
@@ -201,7 +201,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 
         $bind = array($idVisit, $idOrder);
 
-        $itemsDetails = Db::fetchAll($sql, $bind);
+        $itemsDetails = $this->getDb()->fetchAll($sql, $bind);
 
         // create categories array for each item
         foreach ($itemsDetails as &$item) {

--- a/plugins/Goals/VisitorDetails.php
+++ b/plugins/Goals/VisitorDetails.php
@@ -88,7 +88,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 					AND log_conversion.idgoal > 0
                 ORDER BY log_conversion.idvisit, log_conversion.server_time ASC
 			";
-        return Db::fetchAll($sql);
+        return $this->getDb()->fetchAll($sql);
     }
 
 

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -45,7 +45,7 @@ class Model
 
         list($sql, $bind) = $this->makeLogVisitsQueryString($idSite, $period, $date, $segment, $offset, $limit, $visitorId, $minTimestamp, $filterSortOrder);
 
-        $visits = Db::fetchAll($sql, $bind);
+        $visits = Db::getReader()->fetchAll($sql, $bind);
 
         if ($checkforMoreEntries) {
             if (count($visits) == $limit) {
@@ -161,7 +161,7 @@ class Model
         $segment = new Segment($segment, $idSite);
         $query   = $segment->getSelectQuery($select, $from, $where, $bind);
 
-        $numVisitors = Db::fetchOne($query['sql'], $query['bind']);
+        $numVisitors = Db::getReader()->fetchOne($query['sql'], $query['bind']);
 
         return $numVisitors;
     }
@@ -231,7 +231,7 @@ class Model
                  LIMIT 1";
         $bind = array_merge($queryInfo['bind'], array($visitLastActionTime));
 
-        $visitorId = Db::fetchOne($sql, $bind);
+        $visitorId = Db::getReader()->fetchOne($sql, $bind);
         if (!empty($visitorId)) {
             $visitorId = bin2hex($visitorId);
         }

--- a/plugins/Live/VisitorDetailsAbstract.php
+++ b/plugins/Live/VisitorDetailsAbstract.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\Live;
 
 use Piwik\DataTable;
+use Piwik\Db;
 
 /**
  * Class VisitorDetailsAbstract
@@ -271,5 +272,14 @@ abstract class VisitorDetailsAbstract
      */
     public function finalizeProfile($visits, &$profile)
     {
+    }
+
+    /**
+     * @since Matomo 3.12
+     * @return Db|Db\AdapterInterface
+     */
+    public function getDb()
+    {
+        return Db::getReader();
     }
 }

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -818,6 +818,7 @@ abstract class SystemTestCase extends PHPUnit_Framework_TestCase
     public function assertNotDbConnectionCreated($message = 'A database connection was created but should not.')
     {
         self::assertFalse(Db::hasDatabaseObject(), $message);
+        self::assertFalse(Db::hasReaderDatabaseObject(), $message);
     }
 
     public function assertDbConnectionCreated($message = 'A database connection was not created but should.')

--- a/tests/PHPUnit/Integration/DbTest.php
+++ b/tests/PHPUnit/Integration/DbTest.php
@@ -18,10 +18,84 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class DbTest extends IntegrationTestCase
 {
+    private $dbReaderConfigBackup;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->dbReaderConfigBackup = Config::getInstance()->database_reader;
+    }
+
+    public function tearDown()
+    {
+        Db::destroyDatabaseObject();
+        Config::getInstance()->database_reader = $this->dbReaderConfigBackup;
+        parent::tearDown();
+    }
+
     public function test_getColumnNamesFromTable()
     {
         $this->assertColumnNames('access', array('idaccess', 'login', 'idsite', 'access'));
         $this->assertColumnNames('option', array('option_name', 'option_value', 'autoload'));
+    }
+
+    public function test_getDb()
+    {
+        $db = Db::get();
+        $this->assertNotEmpty($db);
+        $this->assertTrue($db instanceof Db\AdapterInterface);
+    }
+
+    public function test_hasReaderDatabaseObject_byDefaultNotInUse()
+    {
+        $this->assertFalse(Db::hasReaderDatabaseObject());
+    }
+
+    public function test_hasReaderConfigured_byDefaultNotConfigured()
+    {
+        $this->assertFalse(Db::hasReaderConfigured());
+    }
+
+    public function test_getReader_whenNotConfigured_StillReturnsRegularDbConnection()
+    {
+        $this->assertFalse(Db::hasReaderConfigured());// ensure no reader is configured
+        $db = Db::getReader();
+        $this->assertNotEmpty($db);
+        $this->assertTrue($db instanceof Db\AdapterInterface);
+    }
+
+    public function test_withReader()
+    {
+        Config::getInstance()->database_reader = Config::getInstance()->database;
+
+        $this->assertFalse(Db::hasReaderDatabaseObject());
+        $this->assertTrue(Db::hasReaderConfigured());
+
+        $db = Db::getReader();
+        $this->assertNotEmpty($db);
+        $this->assertTrue($db instanceof Db\AdapterInterface);
+
+        $this->assertTrue(Db::hasReaderDatabaseObject());
+        Db::destroyDatabaseObject();
+        $this->assertFalse(Db::hasReaderDatabaseObject());
+    }
+
+    public function test_withReader_createsDifferentConnectionForDb()
+    {
+        Config::getInstance()->database_reader = Config::getInstance()->database;
+
+        $db = Db::getReader();
+        $this->assertNotSame($db->getConnection(), Db::get()->getConnection());
+    }
+
+    public function test_withoutReader_usesSameDbConnection()
+    {
+        $this->assertFalse(Db::hasReaderConfigured());
+        $this->assertFalse(Db::hasReaderDatabaseObject());
+
+        $db = Db::getReader();
+        $this->assertSame($db->getConnection(), Db::get()->getConnection());
     }
 
     private function assertColumnNames($tableName, $expectedColumnNames)


### PR DESCRIPTION
If configured, most archiving, live, and archive reading queries (when browser archiving is disabled) will be read from a reader instead of the master. This means mainly the tracker will hit the master database and when writing archives.

FYI added a system check that connection works if a reader is configured.

fix https://github.com/matomo-org/matomo/issues/7554