### PR TITLE
Determine in file class if the file content is the same

### DIFF
--- a/plugins/CustomPiwikJs/File.php
+++ b/plugins/CustomPiwikJs/File.php
@@ -43,6 +43,8 @@ class File
 
     public function isFileContentSame($content)
     {
+        // we determine if file content is the same in here in case a different "file" implementation needs to check
+        // whether multiple files are up to date
         return $this->getContent() === $content;
     }
 
@@ -51,6 +53,8 @@ class File
         if (false === file_put_contents($this->file, $content, LOCK_EX)) {
             throw new AccessDeniedException(sprintf("Could not write to %s", $this->file));
         }
+        // we need to return an array of files in case some other "File" implementation actually updates multiple files
+        // eg one file per trusted host
         return [$this->getPath()];
     }
 

--- a/plugins/CustomPiwikJs/File.php
+++ b/plugins/CustomPiwikJs/File.php
@@ -41,9 +41,14 @@ class File
         }
     }
 
+    public function isFileContentSame($content)
+    {
+        return $this->getContent() === $content;
+    }
+
     public function save($content)
     {
-        if(false === file_put_contents($this->file, $content, LOCK_EX)) {
+        if (false === file_put_contents($this->file, $content, LOCK_EX)) {
             throw new AccessDeniedException(sprintf("Could not write to %s", $this->file));
         }
     }

--- a/plugins/CustomPiwikJs/File.php
+++ b/plugins/CustomPiwikJs/File.php
@@ -51,6 +51,7 @@ class File
         if (false === file_put_contents($this->file, $content, LOCK_EX)) {
             throw new AccessDeniedException(sprintf("Could not write to %s", $this->file));
         }
+        return [$this->getPath()];
     }
 
     public function getContent()

--- a/plugins/CustomPiwikJs/TrackerUpdater.php
+++ b/plugins/CustomPiwikJs/TrackerUpdater.php
@@ -131,14 +131,17 @@ class TrackerUpdater
         $newContent = $this->getUpdatedTrackerFileContent();
 
         if (!$this->toFile->isFileContentSame($newContent)) {
-            $this->toFile->save($newContent);
+            $savedFiles = $this->toFile->save($newContent);
+            foreach ($savedFiles as $savedFile) {
 
-            /**
-             * Triggered after the tracker JavaScript content (the content of the piwik.js file) is changed.
-             *
-             * @param string $absolutePath The path to the new piwik.js file.
-             */
-            Piwik::postEvent('CustomPiwikJs.piwikJsChanged', [$this->toFile->getPath()]);
+                /**
+                 * Triggered after the tracker JavaScript content (the content of the piwik.js file) is changed.
+                 *
+                 * @param string $absolutePath The path to the new piwik.js file.
+                 */
+                Piwik::postEvent('CustomPiwikJs.piwikJsChanged', [$savedFile]);
+            }
+
         }
 
         // we need to make sure to sync matomo.js / piwik.js
@@ -152,8 +155,10 @@ class TrackerUpdater
             $alternativeFilename = dirname($this->toFile->getPath()) . DIRECTORY_SEPARATOR . $toFile;
             $file = $this->toFile->setFile($alternativeFilename);
             if ($file->hasWriteAccess() && !$file->isFileContentSame($newContent)) {
-                $file->save($newContent);
-                Piwik::postEvent('CustomPiwikJs.piwikJsChanged', [$file->getPath()]);
+                $savedFiles = $file->save($newContent);
+                foreach ($savedFiles as $savedFile) {
+                    Piwik::postEvent('CustomPiwikJs.piwikJsChanged', [$savedFile]);
+                }
             }
         }
     }

--- a/plugins/CustomPiwikJs/TrackerUpdater.php
+++ b/plugins/CustomPiwikJs/TrackerUpdater.php
@@ -130,7 +130,7 @@ class TrackerUpdater
 
         $newContent = $this->getUpdatedTrackerFileContent();
 
-        if ($newContent !== $this->getCurrentTrackerFileContent()) {
+        if (!$this->toFile->isFileContentSame($newContent)) {
             $this->toFile->save($newContent);
 
             /**
@@ -151,7 +151,7 @@ class TrackerUpdater
         if (Common::stringEndsWith($this->toFile->getName(), $fromFile)) {
             $alternativeFilename = dirname($this->toFile->getPath()) . DIRECTORY_SEPARATOR . $toFile;
             $file = $this->toFile->setFile($alternativeFilename);
-            if ($file->hasWriteAccess() && $file->getContent() !== $newContent) {
+            if ($file->hasWriteAccess() && !$file->isFileContentSame($newContent)) {
                 $file->save($newContent);
                 Piwik::postEvent('CustomPiwikJs.piwikJsChanged', [$file->getPath()]);
             }

--- a/plugins/CustomPiwikJs/tests/Integration/FileTest.php
+++ b/plugins/CustomPiwikJs/tests/Integration/FileTest.php
@@ -180,6 +180,14 @@ class FileTest extends IntegrationTestCase
         $this->assertSame("// Hello world\nvar fooBar = 'test';", $this->makeFile()->getContent());
     }
 
+    public function test_isFileContentSame()
+    {
+        $this->assertTrue($this->makeFile()->isFileContentSame("// Hello world\nvar fooBar = 'test';"));
+        $this->assertFalse($this->makeFile()->isFileContentSame("// Hello world\nvar foBar = 'test';"));
+        $this->assertFalse($this->makeFile()->isFileContentSame("// Hello world\nvar foBar = 'test'"));
+        $this->assertFalse($this->makeFile()->isFileContentSame("Hello world\nvar foBar = 'test'"));
+    }
+
     public function test_getContent_returnsNull_IfFileIsNotReadableOrNotExists()
     {
         $this->assertNull($this->makeNotReadableFile()->getContent());

--- a/plugins/CustomPiwikJs/tests/Integration/FileTest.php
+++ b/plugins/CustomPiwikJs/tests/Integration/FileTest.php
@@ -199,8 +199,9 @@ class FileTest extends IntegrationTestCase
         $this->assertFalse($notExistingFile->hasReadAccess());
         $this->assertTrue($notExistingFile->hasWriteAccess());
 
-        $notExistingFile->save('myTestContent');
+        $updatedFile =  $notExistingFile->save('myTestContent');
 
+        $this->assertEquals([$this->dir . 'notExisTinGFile.js'], $updatedFile);
         $this->assertEquals('myTestContent', $notExistingFile->getContent());
         $this->assertTrue($notExistingFile->hasReadAccess());
         $this->assertTrue($notExistingFile->hasWriteAccess());

--- a/plugins/CustomPiwikJs/tests/resources/file-made-non-writable.js
+++ b/plugins/CustomPiwikJs/tests/resources/file-made-non-writable.js
@@ -1,0 +1,1 @@
+will be saved OK, and then we make it non writable.

--- a/plugins/CustomPiwikJs/tests/resources/file-made-non-writable.js
+++ b/plugins/CustomPiwikJs/tests/resources/file-made-non-writable.js
@@ -1,1 +1,0 @@
-will be saved OK, and then we make it non writable.


### PR DESCRIPTION
I will need this one in 3.11.0 ideally. 

Moved the detection whether the file is up to date to a new method `isFileContentSame()`. It looks unneeded, but is useful when you have eg a ` class CdnFile {}` and need to update the content of that file not only on one path, but also for other trusted hosts. Then you need to save the content basically again if just one of the files is out of date. This happens only when using a custom directory for tracker files.

eg /matomo/foo/$trustedHost/matomo.js
eg /matomo/foo/trusted.host.one/matomo.js
eg /matomo/foo/trusted.host.two/matomo.js
eg /matomo/foo/trusted.host.three/matomo.js

Then we don't just need to read/update/delete one file, but multiple times for each host.

For the same reason we need to return an array of which files were actually updated in the `save()` method. We might not just update the file in one path, but actually in multiple paths. And then we need to trigger an event for each updated file.

Ideally we would have this logic better in core somehow, but the way we use it is quite special and usually you wouldn't have a file per trusted host.