### PR TITLE
Don't show feedback prompt when user does not exist

### DIFF
--- a/plugins/Feedback/Feedback.php
+++ b/plugins/Feedback/Feedback.php
@@ -93,6 +93,9 @@ class Feedback extends \Piwik\Plugin
         if ($nextReminderDate === false) {
             $model = new Model();
             $user = $model->getUser($login);
+            if (empty($user['date_registered'])) {
+                return false;
+            }
             $nextReminderDate = Date::factory($user['date_registered'])->addDay(90)->getStartOfDay();
         } else {
             $nextReminderDate = Date::factory($nextReminderDate);


### PR DESCRIPTION
Prevents an error in the UI that said

```
Date format must be: YYYY-MM-DD, or 'today' or 'yesterday' or any keyword supported by the strtotime function (see http://php.net/strtotime for more information):
``` 

when the user did not exist. Eg when you have "virtual" users that aren't actually existing in the user table.