### PR TITLE
Remove no longer needed require statement

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -14,11 +14,6 @@ use Piwik\Plugin\Manager;
 use Piwik\Plugin\MetadataLoader;
 
 /**
- * @see Piwik\Plugin\MetadataLoader
- */
-require_once PIWIK_INCLUDE_PATH . '/core/Plugin/MetadataLoader.php';
-
-/**
  * Base class of all Plugin Descriptor classes.
  *
  * Any plugin that wants to add event observers to one of Piwik's {@hook # hooks},


### PR DESCRIPTION
Was probably still there from the old days where includes were done manually eg in tracker mode maybe.