### PR TITLE
Make Visitor Log live query more performant

### DIFF
--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -89,6 +89,7 @@ class Model
             }
 
             if ($virtualDateStart->isEarlier($virtualDateEnd)) {
+                // need to use ",endDate" in case startDate is not set in which case we do not want to have any limit
                 $queries[] = array($dateStart, $virtualDateEnd->subSeconds(1));
             }
         } else {

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -61,8 +61,13 @@ class Model
             $virtualDateEnd = Date::now()->addDay(1); // matomo always adds one day for some reason
         }
 
+        $virtualDateStart = $dateStart;
+        if (empty($virtualDateStart)) {
+            $virtualDateStart = Date::factory('1990-01-01'); // matomo always adds one day for some reason
+        }
+
         $queries = [];
-        $hasStartEndDateMoreThanOneDayInBetween = $dateStart && $dateStart->addDay(1)->isEarlier($virtualDateEnd);
+        $hasStartEndDateMoreThanOneDayInBetween = $virtualDateStart && $virtualDateStart->addDay(1)->isEarlier($virtualDateEnd);
         if ($limit
             && $hasStartEndDateMoreThanOneDayInBetween
         ) {
@@ -70,20 +75,20 @@ class Model
                 $virtualDateEnd = $virtualDateEnd->subDay(1);
                 $queries[] = array($virtualDateEnd, $dateEnd); // need to use ",endDate" in case endDate is not set
             }
-            if ($dateStart->addDay(7)->isEarlier($virtualDateEnd)) {
+            if ($virtualDateStart->addDay(7)->isEarlier($virtualDateEnd)) {
                 $queries[] = array($virtualDateEnd->subDay(7), $virtualDateEnd->subSeconds(1));
                 $virtualDateEnd = $virtualDateEnd->subDay(7);
             }
-            if ($dateStart->addDay(30)->isEarlier($virtualDateEnd)) {
+            if ($virtualDateStart->addDay(30)->isEarlier($virtualDateEnd)) {
                 $queries[] = array($virtualDateEnd->subDay(30), $virtualDateEnd->subSeconds(1));
                 $virtualDateEnd = $virtualDateEnd->subDay(30);
             }
-            if ($dateStart->addPeriod(1, 'year')->isEarlier($virtualDateEnd)) {
+            if ($virtualDateStart->addPeriod(1, 'year')->isEarlier($virtualDateEnd)) {
                 $queries[] = array($virtualDateEnd->subYear(1), $virtualDateEnd->subSeconds(1));
                 $virtualDateEnd = $virtualDateEnd->subYear(1);
             }
 
-            if ($dateStart->isEarlier($virtualDateEnd)) {
+            if ($virtualDateStart->isEarlier($virtualDateEnd)) {
                 $queries[] = array($dateStart, $virtualDateEnd->subSeconds(1));
             }
         } else {

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -62,8 +62,10 @@ class Model
         }
 
         $queries = [];
-        $hasStartEndDateMoreThanOneDayInBetween = $dateStart->addDay(1)->isEarlier($virtualDateEnd);
-        if ($limit && $hasStartEndDateMoreThanOneDayInBetween) {
+        $hasStartEndDateMoreThanOneDayInBetween = $dateStart && $dateStart->addDay(1)->isEarlier($virtualDateEnd);
+        if ($limit
+            && $hasStartEndDateMoreThanOneDayInBetween
+        ) {
             if ($hasStartEndDateMoreThanOneDayInBetween) {
                 $virtualDateEnd = $virtualDateEnd->subDay(1);
                 $queries[] = array($virtualDateEnd, $dateEnd); // need to use ",endDate" in case endDate is not set
@@ -88,7 +90,8 @@ class Model
             $queries[] = array($dateStart, $dateEnd);
         }
 
-        $deb = array_map(function ($query) { return $query[0]->getDatetime() . ' ' . $query[1]->getDatetime(); }, $queries);
+        // uncomment to see the dateTimes that have been generated.
+        // $debugDateTime = array_map(function ($query) { return $query[0]->getDatetime() . ' ' . $query[1]->getDatetime(); }, $queries);
 
         $foundVisits = array();
         foreach ($queries as $queryRange) {

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -69,6 +69,7 @@ class Model
         $queries = [];
         $hasStartEndDateMoreThanOneDayInBetween = $virtualDateStart && $virtualDateStart->addDay(1)->isEarlier($virtualDateEnd);
         if ($limit
+            && !$offset
             && $hasStartEndDateMoreThanOneDayInBetween
         ) {
             if ($hasStartEndDateMoreThanOneDayInBetween) {
@@ -106,12 +107,8 @@ class Model
             if (!empty($limit)) {
                 $updatedLimit = $limit - count($foundVisits);
             }
-            $updatedOffset = $offset;
-            if (!empty($offset)) {
-                $updatedOffset = $offset - count($foundVisits);
-            }
 
-            list($sql, $bind) = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $updatedOffset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder);
+            list($sql, $bind) = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $offset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder);
 
             $visits = Db::getReader()->fetchAll($sql, $bind);
             $foundVisits = array_merge($foundVisits, $visits);

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -102,9 +102,16 @@ class Model
         $foundVisits = array();
 
         foreach ($queries as $queryRange) {
-            $updatedLimit = $limit - count($foundVisits);
+            $updatedLimit = $limit;
+            if (!empty($limit)) {
+                $updatedLimit = $limit - count($foundVisits);
+            }
+            $updatedOffset = $offset;
+            if (!empty($offset)) {
+                $updatedOffset = $offset - count($foundVisits);
+            }
 
-            list($sql, $bind) = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $offset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder);
+            list($sql, $bind) = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $updatedOffset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder);
 
             $visits = Db::getReader()->fetchAll($sql, $bind);
             $foundVisits = array_merge($foundVisits, $visits);

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -100,13 +100,14 @@ class Model
         // $debugDateTime = array_map(function ($query) { return $query[0]->getDatetime() . ' ' . $query[1]->getDatetime(); }, $queries);
 
         $foundVisits = array();
+
         foreach ($queries as $queryRange) {
             $updatedLimit = $limit - count($foundVisits);
 
             list($sql, $bind) = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $offset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder);
 
             $visits = Db::getReader()->fetchAll($sql, $bind);
-            $foundVisits += $visits;
+            $foundVisits = array_merge($foundVisits, $visits);
 
             if ($limit && count($foundVisits) >= $limit) {
                 $foundVisits = array_slice($foundVisits, 0, $limit);

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -117,7 +117,9 @@ class Model
             $foundVisits = array_merge($foundVisits, $visits);
 
             if ($limit && count($foundVisits) >= $limit) {
-                $foundVisits = array_slice($foundVisits, 0, $limit);
+                if (count($foundVisits) > $limit) {
+                    $foundVisits = array_slice($foundVisits, 0, $limit);
+                }
                 break;
             }
         }

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -98,7 +98,7 @@ class Model
         }
 
         // uncomment to see the dateTimes that have been generated.
-        // $debugDateTime = array_map(function ($query) { return $query[0]->getDatetime() . ' ' . $query[1]->getDatetime(); }, $queries);
+        //$debugDateTime = array_map(function ($query) { return ($query[0] ? $query[0]->getDatetime() : '') . ' ' . ($query[1] ? $query[1]->getDatetime() : ''); }, $queries);
 
         $foundVisits = array();
 
@@ -111,7 +111,9 @@ class Model
             list($sql, $bind) = $this->makeLogVisitsQueryString($idSite, $queryRange[0], $queryRange[1], $segment, $offset, $updatedLimit, $visitorId, $minTimestamp, $filterSortOrder);
 
             $visits = Db::getReader()->fetchAll($sql, $bind);
-            $foundVisits = array_merge($foundVisits, $visits);
+            if (!empty($visits)) {
+                $foundVisits = array_merge($foundVisits, $visits);
+            }
 
             if ($limit && count($foundVisits) >= $limit) {
                 if (count($foundVisits) > $limit) {
@@ -471,10 +473,11 @@ class Model
             $where[] = "log_visit.visit_last_action_time >= ?";
             $whereBind[] = $startDate->toString('Y-m-d H:i:s');
 
-            if (!empty($endDate)) {
-                $where[] = " log_visit.visit_last_action_time <= ?";
-                $whereBind[] = $endDate->toString('Y-m-d H:i:s');
-            }
+        }
+
+        if (!empty($endDate)) {
+            $where[] = " log_visit.visit_last_action_time <= ?";
+            $whereBind[] = $endDate->toString('Y-m-d H:i:s');
         }
 
         if (count($where) > 0) {

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -425,7 +425,6 @@ class Model
                 && Date::factory($dateString)->toString('Y-m-d') != Date::factory('now', $currentTimezone)->toString()
             ) {
                 $dateEnd = $processedPeriod->getDateEnd()->setTimezone($currentTimezone);
-                $where[] = " log_visit.visit_last_action_time <= ?";
                 $dateEnd = $dateEnd->addDay(1);
             }
         }

--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -63,7 +63,7 @@ class Model
 
         $virtualDateStart = $dateStart;
         if (empty($virtualDateStart)) {
-            $virtualDateStart = Date::factory('1990-01-01'); // matomo always adds one day for some reason
+            $virtualDateStart = Date::factory(Date::FIRST_WEBSITE_TIMESTAMP); // matomo always adds one day for some reason
         }
 
         $queries = [];

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -34,10 +34,11 @@ class ModelTest extends IntegrationTestCase
     public function test_makeLogVisitsQueryString()
     {
         $model = new Model();
+        list($dateStart, $dateEnd) = $model->getStartAndEndDate($idSite = 1, 'month', '2010-01-01');
         list($sql, $bind) = $model->makeLogVisitsQueryString(
                 $idSite = 1,
-                $period = 'month',
-                $date = '2010-01-01',
+                $dateStart,
+                $dateEnd,
                 $segment = false,
                 $offset = 0,
                 $limit = 100,
@@ -75,10 +76,11 @@ class ModelTest extends IntegrationTestCase
         });
 
         $model = new Model();
+        list($dateStart, $dateEnd) = $model->getStartAndEndDate($idSite = 1, 'month', '2010-01-01');
         list($sql, $bind) = $model->makeLogVisitsQueryString(
                 $idSite = 1,
-                $period = 'month',
-                $date = '2010-01-01',
+                $dateStart,
+                $dateEnd,
                 $segment = false,
                 $offset = 0,
                 $limit = 100,
@@ -114,10 +116,12 @@ class ModelTest extends IntegrationTestCase
     public function test_makeLogVisitsQueryStringWithOffset()
     {
         $model = new Model();
+
+        list($dateStart, $dateEnd) = $model->getStartAndEndDate($idSite = 1, 'month', '2010-01-01');
         list($sql, $bind) = $model->makeLogVisitsQueryString(
                 $idSite = 1,
-                $period = 'month',
-                $date = '2010-01-01',
+                $dateStart,
+                $dateEnd,
                 $segment = false,
                 $offset = 15,
                 $limit = 100,
@@ -152,10 +156,11 @@ class ModelTest extends IntegrationTestCase
     public function test_makeLogVisitsQueryString_whenSegment()
     {
         $model = new Model();
+        list($dateStart, $dateEnd) = $model->getStartAndEndDate($idSite = 1, 'month', '2010-01-01');
         list($sql, $bind) = $model->makeLogVisitsQueryString(
             $idSite = 1,
-            $period = 'month',
-            $date = '2010-01-01',
+            $dateStart,
+            $dateEnd,
             $segment = 'customVariablePageName1==Test',
             $offset = 10,
             $limit = 100,


### PR DESCRIPTION
Sometimes the live query can be really slow (like many minutes). It could even end up using all database resources when there is a lot of data in the log tables. Especially when using segments on top. Often the system ends up doing queries like these: 

```sql
SELECT sub.* FROM (
            SELECT
                log_inner.*
            FROM     
        (
            SELECT
                log_visit.*
            FROM
                log_visit AS log_visit LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
            WHERE
                ( log_visit.idsite in ('1') 
                AND log_visit.visit_last_action_time >= '2019-05-25 23:00:00' )
                AND
                ( ( log_link_visit_action.idaction_url IS NOT NULL AND log_link_visit_action.idaction_url <> '' AND log_link_visit_action.idaction_url <> '0' ) )
            ORDER BY
                idsite DESC, visit_last_action_time DESC LIMIT 0, 4010
        ) AS log_inner
            ORDER BY
                idsite DESC, visit_last_action_time DESC
            ) AS sub
            GROUP BY sub.idvisit
            ORDER BY sub.visit_last_action_time DESC
        LIMIT 401
```

Where it fetches data over several months. This obviously can take a very long time, and it might create big temporary tables, full table scans, etc. As we're only wanting the most recent results, it be smarter to first look only at the last day and if this query returns enough results, then we can directly return the result making it a LOT faster.

In this PR I'm executing up to 5 queries to get the result instead of doing it in one query:
* Look one day back
* Look another 1 week back (without fetching first day again)
* Look 1 month back (without looking at the 1week + 1day we already fetched again)
* Look 1 year back (without looking at the data we already requested)
* Remaining time 

If only 1 week is being requested, it would only execute 2 queries. If 2 years are requested, it would execute up to 5 queries but stop as soon as the requested data has been found. So we might be actually only looking at one day compared to 2 years! 

The logic can be only done if there is a data limit. Otherwise we need to return all results anyway and this can still be a problem fyi @mattab 

It cannot be executed when there is a limit plus an offset @mattab . So it won't solve too many problems possibly. Unless we executed each query twice see this logic:

```
Imagine we have `Limit 5 Offset 5`
Query 1 finds: 2 rows  => should use Limit 5, Offset 5. The result of the method would return an empty array. Because of the offset, we can't know that 2 rows have been skipped unless we executed every query twice when no result has been returned? First we would need to execute `Limit 5, Offset 5`, then we would need to execute `Limit $offset, Offset 0` to find out how many rows were skipped
Query 2 finds: 0 rows  => should use Limit 5, Offset 3 
Query 3 finds: 7 rows  => should use Limit 5, Offset 3 and basically should skip the first 3 rows and then return the next 4
Query 4 finds: 0 rows: => should use Limit 1, Offset 0: that one is easy... as soon as at least one row has been found we use offset => 0 and limit can be calculated easily too (originalLimit - foundRows).
```
Another workaround for offset that slightly improves it could be that when `Offset <= 3 * LIMIT` then we apply the offset in PHP and not in MySQL. Means we fetch a lot more rows but then discard them in PHP. Would make this logic work for a few more pages.

And another workaround be, if there's an offset, we simply check if the first day gives results and if not fetch all other days.