### PR TITLE
When loading a template url from a custom plugin directory, prefix the relative directory

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -35,6 +35,7 @@ use Piwik\Plugins\LanguagesManager\LanguagesManager;
 use Piwik\SettingsPiwik;
 use Piwik\Site;
 use Piwik\Url;
+use Piwik\Plugin;
 use Piwik\View;
 use Piwik\View\ViewInterface;
 use Piwik\ViewDataTable\Factory as ViewDataTableFactory;
@@ -745,6 +746,9 @@ abstract class Controller
             $view->setXFrameOptions('sameorigin');
         }
 
+        $pluginManager = Plugin\Manager::getInstance();
+        $view->relativePluginWebDirs = (object) $pluginManager->getWebRootDirectoriesForCustomPluginDirs();
+
         self::setHostValidationVariablesView($view);
     }
 
@@ -1060,3 +1064,4 @@ abstract class Controller
         }
     }
 }
+

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -412,7 +412,7 @@ class Manager
 
     public function getWebRootDirectoriesForCustomPluginDirs()
     {
-        return self::$pluginsToWebRootDirCache;
+        return array_intersect_key(self::$pluginsToWebRootDirCache, array_flip($this->pluginsToLoad));
     }
 
     /**

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -55,6 +55,7 @@ class Manager
     protected $doLoadPlugins = true;
 
     protected static $pluginsToPathCache = array();
+    protected static $pluginsToWebRootDirCache = array();
 
     private $pluginsLoadedAndActivated;
 
@@ -409,6 +410,11 @@ class Manager
         return $dirs;
     }
 
+    public function getWebRootDirectoriesForCustomPluginDirs()
+    {
+        return self::$pluginsToWebRootDirCache;
+    }
+
     /**
      * Returns the path to all plugins directories. Each plugins directory may contain several plugins.
      * All paths have a trailing slash '/'.
@@ -465,10 +471,11 @@ class Manager
             return self::$pluginsToPathCache[$pluginName];
         }
 
-        foreach (self::getPluginsDirectories() as $dir) {
+        foreach (self::getAlternativeWebRootDirectories() as $dir => $relative) {
             $path = $dir . $pluginName;
             if (is_dir($path)) {
                 self::$pluginsToPathCache[$pluginName] = self::getPluginRealPath($path);
+                self::$pluginsToWebRootDirCache[$pluginName] = $relative;
                 return $path;
             }
         }
@@ -1640,3 +1647,4 @@ class Manager
         }
     }
 }
+

--- a/plugins/CoreHome/angularjs/http404check.js
+++ b/plugins/CoreHome/angularjs/http404check.js
@@ -24,7 +24,7 @@
                     var urlParts = config.url.split('/');
                     if (urlParts && urlParts.length > 2 && urlParts[1]) {
                         var pluginName = urlParts[1];
-                        if (pluginName && pluginName in piwik.relativePluginWebDirs) {
+                        if (pluginName && pluginName in piwik.relativePluginWebDirs && piwik.relativePluginWebDirs[pluginName]) {
                             urlParts[0] = piwik.relativePluginWebDirs[pluginName];
                             config.url = urlParts.join('/');
                         }

--- a/plugins/CoreHome/angularjs/http404check.js
+++ b/plugins/CoreHome/angularjs/http404check.js
@@ -16,7 +16,7 @@
 
         return {
             'request': function(config) {
-                if ('object' === typeof matomoRelativeWebDirs
+                if ('object' === typeof piwik.relativePluginWebDirs
                     && config && config.url && config.url.indexOf('plugins/') === 0
                     && config.url.indexOf('.html') > 0
                     && config.url.indexOf('/angularjs/') > 0) {
@@ -24,8 +24,8 @@
                     var urlParts = config.url.split('/');
                     if (urlParts && urlParts.length > 2 && urlParts[1]) {
                         var pluginName = urlParts[1];
-                        if (pluginName && pluginName in matomoRelativeWebDirs) {
-                            config.url = matomoRelativeWebDirs[pluginName] + config.url;
+                        if (pluginName && pluginName in piwik.relativePluginWebDirs) {
+                            config.url = piwik.relativePluginWebDirs[pluginName] + config.url;
                         }
                     }
                 }
@@ -66,3 +66,4 @@
 
 
 })();
+

--- a/plugins/CoreHome/angularjs/http404check.js
+++ b/plugins/CoreHome/angularjs/http404check.js
@@ -25,7 +25,8 @@
                     if (urlParts && urlParts.length > 2 && urlParts[1]) {
                         var pluginName = urlParts[1];
                         if (pluginName && pluginName in piwik.relativePluginWebDirs) {
-                            config.url = piwik.relativePluginWebDirs[pluginName] + config.url;
+                            urlParts[0] = piwik.relativePluginWebDirs[pluginName];
+                            config.url = urlParts.join('/');
                         }
                     }
                 }

--- a/plugins/CoreHome/angularjs/http404check.js
+++ b/plugins/CoreHome/angularjs/http404check.js
@@ -15,6 +15,22 @@
         }
 
         return {
+            'request': function(config) {
+                if ('object' === typeof matomoRelativeWebDirs
+                    && config && config.url && config.url.indexOf('plugins/') === 0
+                    && config.url.indexOf('.html') > 0
+                    && config.url.indexOf('/angularjs/') > 0) {
+
+                    var urlParts = config.url.split('/');
+                    if (urlParts && urlParts.length > 2 && urlParts[1]) {
+                        var pluginName = urlParts[1];
+                        if (pluginName && pluginName in matomoRelativeWebDirs) {
+                            config.url = matomoRelativeWebDirs[pluginName] + config.url;
+                        }
+                    }
+                }
+                return config;
+            },
             'responseError': function(rejection) {
 
                 if (rejection &&

--- a/plugins/Morpheus/templates/_jsGlobalVariables.twig
+++ b/plugins/Morpheus/templates/_jsGlobalVariables.twig
@@ -22,7 +22,11 @@
 
     {% if idSite is defined %}piwik.idSite = "{{ idSite }}";{% endif %}
 
-    {% if siteName is defined %}piwik.siteName = "{{ siteName|e('js') }}";{% endif %}
+    {% if siteName is defined %}
+    // NOTE: siteName is currently considered deprecated, use piwik.currentSiteName instead, which will not contain HTML entities
+    piwik.siteName = "{{ siteName|e('js') }}";
+    piwik.currentSiteName = {{ siteNameDecoded|json_encode|raw }};{% endif %}
+    {% endif %}
 
     {% if siteMainUrl is defined %}piwik.siteMainUrl = "{{ siteMainUrl|e('js') }}";{% endif %}
 

--- a/plugins/Morpheus/templates/_jsGlobalVariables.twig
+++ b/plugins/Morpheus/templates/_jsGlobalVariables.twig
@@ -26,7 +26,6 @@
     // NOTE: siteName is currently considered deprecated, use piwik.currentSiteName instead, which will not contain HTML entities
     piwik.siteName = "{{ siteName|e('js') }}";
     piwik.currentSiteName = {{ siteNameDecoded|json_encode|raw }};{% endif %}
-    {% endif %}
 
     {% if siteMainUrl is defined %}piwik.siteMainUrl = "{{ siteMainUrl|e('js') }}";{% endif %}
 

--- a/plugins/Morpheus/templates/_jsGlobalVariables.twig
+++ b/plugins/Morpheus/templates/_jsGlobalVariables.twig
@@ -16,14 +16,13 @@
         symbolDecimal: "{{ 'Intl_NumberSymbolDecimal'|translate }}"
     };
 
+    piwik.relativePluginWebDirs = {{ relativePluginWebDirs|json_encode|raw }}
+
     {% if userLogin %}piwik.userLogin = "{{ userLogin|e('js')}}";{% endif %}
 
     {% if idSite is defined %}piwik.idSite = "{{ idSite }}";{% endif %}
 
-    {% if siteName is defined %}
-    // NOTE: siteName is currently considered deprecated, use piwik.currentSiteName instead, which will not contain HTML entities
-    piwik.siteName = "{{ siteName|e('js') }}";
-    piwik.currentSiteName = {{ siteNameDecoded|json_encode|raw }};{% endif %}
+    {% if siteName is defined %}piwik.siteName = "{{ siteName|e('js') }}";{% endif %}
 
     {% if siteMainUrl is defined %}piwik.siteMainUrl = "{{ siteMainUrl|e('js') }}";{% endif %}
 
@@ -55,3 +54,4 @@
     piwik.shouldPropagateTokenAuth = {{ shouldPropagateTokenAuth|json_encode|raw }};
     {{ postEvent("Template.jsGlobalVariables") }}
 </script>
+


### PR DESCRIPTION
In https://github.com/matomo-org/matomo/pull/14051 we started supporting multiple plugin paths.

There we already rewrite the path to the JS and CSS assets and load them from a different path. But it looks for some reason that a `directive templateUrl` is not loaded correctly when the plugin is located in a different path. It's still trying to load the template file eg from `$matomoUrl/matomo/plugins/PluginName/angularjs/widgetname/widgetname.html` when instead  it should be maybe loaded from `$matomoUrl/matomo/../extensions/PluginName/angularjs/widgetname/widgetname.html`