### PR TITLE
When loading templates detect if an ad blocker is active

### DIFF
--- a/plugins/CoreHome/angularjs/http404check.js
+++ b/plugins/CoreHome/angularjs/http404check.js
@@ -7,7 +7,7 @@
 
         function isClientError(rejection)
         {
-            if (rejection.status === 500 || rejection.status === -1) {
+            if (rejection.status === 500 || rejection.status <= -1) {
                 return true;
             }
 

--- a/plugins/CoreHome/angularjs/http404check.js
+++ b/plugins/CoreHome/angularjs/http404check.js
@@ -7,7 +7,7 @@
 
         function isClientError(rejection)
         {
-            if (rejection.status === 500 || rejection.status <= -1) {
+            if (rejection.status === 500 || rejection.status <= 0) {
                 return true;
             }
 

--- a/plugins/CoreHome/angularjs/http404check.js
+++ b/plugins/CoreHome/angularjs/http404check.js
@@ -7,7 +7,7 @@
 
         function isClientError(rejection)
         {
-            if (rejection.status === 500) {
+            if (rejection.status === 500 || rejection.status === -1) {
                 return true;
             }
 
@@ -29,6 +29,10 @@
 
                     var message = 'Please check your server configuration. You may want to whitelist "*.html" files from the "plugins" directory.';
                     message    += ' The HTTP status code is ' + rejection.status + ' for URL "' + url + '"';
+                    
+                    if (rejection.status === -1) {
+                        message = 'Please check if you have an ad blocker or something similar enabled.';
+                    }
 
                     var UI = require('piwik/UI');
                     var notification = new UI.Notification();


### PR DESCRIPTION
fix DEV-1680
The status seems to be -1 when an ad blocker is blocking the loading of an html template (eg HeatmapSessionRecording)

![image](https://user-images.githubusercontent.com/273120/62335703-fc6b9280-b520-11e9-9bcc-4ea25aa9d9ba.png)

Should avoid error like this:

![image](https://user-images.githubusercontent.com/273120/62335712-08575480-b521-11e9-8d48-d197203c262a.png)
