### PR TITLE
Two small changes for GA importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Matomo 3.12.0
+
+### New API
+* Added new event `Visualization.beforeRender`, triggered after immediately before rendering a visualization.
+
 ## Matomo 3.10.0
 
 ### Breaking Changes

--- a/core/Archive/DataTableFactory.php
+++ b/core/Archive/DataTableFactory.php
@@ -271,7 +271,7 @@ class DataTableFactory
         }
 
         // set table metadata
-        $table->setAllTableMetadata(array_merge(DataCollection::getDataRowMetadata($blobRow), $keyMetadata));
+        $table->setAllTableMetadata(array_merge($table->getAllTableMetadata(), DataCollection::getDataRowMetadata($blobRow), $keyMetadata));
 
         if ($this->expandDataTable) {
             $table->enableRecursiveFilters();
@@ -297,7 +297,7 @@ class DataTableFactory
 
         foreach ($blobRow as $name => $blob) {
             $newTable = DataTable::fromSerializedArray($blob);
-            $newTable->setAllTableMetadata($tableMetadata);
+            $newTable->setAllTableMetadata(array_merge($newTable->getAllTableMetadata(), $tableMetadata));
 
             $table->addTable($newTable, $name);
         }
@@ -452,7 +452,7 @@ class DataTableFactory
         $table = new DataTable\Simple();
 
         if (!empty($data)) {
-            $table->setAllTableMetadata(array_merge(DataCollection::getDataRowMetadata($data), $keyMetadata));
+            $table->setAllTableMetadata(array_merge($table->getAllTableMetadata(), DataCollection::getDataRowMetadata($data), $keyMetadata));
 
             DataCollection::removeMetadataFromDataRow($data);
 
@@ -470,7 +470,7 @@ class DataTableFactory
                 $table->addRow(new Row(array(Row::COLUMNS => array($name => 0))));
             }
 
-            $table->setAllTableMetadata($keyMetadata);
+            $table->setAllTableMetadata(array_merge($table->getAllTableMetadata(), $keyMetadata));
         }
 
         $result = $table;
@@ -496,7 +496,7 @@ class DataTableFactory
                 $table = new DataTable();
             }
 
-            $table->setAllTableMetadata($metadata);
+            $table->setAllTableMetadata(array_merge($table->getAllTableMetadata(), $metadata));
             $map->addTable($table, $this->prettifyIndexLabel(self::TABLE_METADATA_PERIOD_INDEX, $range));
 
             $tables[$range] = $table;

--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -190,7 +190,9 @@ class Visualization extends ViewDataTable
             $this->applyFilters();
             $this->addVisualizationInfoFromMetricMetadata();
             $this->afterAllFiltersAreApplied();
+
             $this->beforeRender();
+            $this->fireBeforeRenderHook();
 
             $this->logMessageIfRequestPropertiesHaveChanged($requestPropertiesAfterLoadDataTable);
         } catch (NoAccessException $e) {
@@ -721,6 +723,14 @@ class Visualization extends ViewDataTable
     public function beforeRender()
     {
         // eg $this->config->showFooterColumns = true;
+    }
+
+    private function fireBeforeRenderHook()
+    {
+        /**
+         * @ignore
+         */
+        Piwik::postEvent('Visualization.beforeRender', [$this]);
     }
 
     private function makeDataTablePostProcessor()

--- a/core/Plugin/Visualization.php
+++ b/core/Plugin/Visualization.php
@@ -728,7 +728,10 @@ class Visualization extends ViewDataTable
     private function fireBeforeRenderHook()
     {
         /**
-         * @ignore
+         * Posted immediately before rendering the view. Plugins can use this event to perform last minute
+         * configuration of the view based on it's data or the report being viewed.
+         *
+         * @param Visualization $view The instance to configure.
          */
         Piwik::postEvent('Visualization.beforeRender', [$this]);
     }


### PR DESCRIPTION
* Add Visualization.beforeRender event. I need to add a footer message after the datatable is loaded, so I can't use VIewDataTable.configure (since it's posted in the constructor).
* Don't overwrite existing table metadata entries when loading datatables from blobs so metadata that is archived is returned through the API.