### PR TITLE
Avoid warning from passing 2 args to ucwords() on older PHP versions

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -865,9 +865,11 @@ class Http
          * With HTTP/2 Cloudflare is passing headers in lowercase (e.g. 'content-type' instead of 'Content-Type') 
          * which breaks any code which uses the header data. 
          */
-        $camelName = ucwords($name, '-');
-        if ($camelName !== $name) {
-            $headers[$camelName] = trim($value);
+        if (version_compare(PHP_VERSION, '5.5.16', '>=')) {
+            $camelName = ucwords($name, '-');
+            if ($camelName !== $name) {
+                $headers[$camelName] = trim($value);
+            }
         }
     }
 

--- a/core/Http.php
+++ b/core/Http.php
@@ -866,6 +866,7 @@ class Http
          * which breaks any code which uses the header data. 
          */
         if (version_compare(PHP_VERSION, '5.5.16', '>=')) {
+            // Passing a second arg to ucwords is not supported by older versions of PHP
             $camelName = ucwords($name, '-');
             if ($camelName !== $name) {
                 $headers[$camelName] = trim($value);


### PR DESCRIPTION
Fixes #14694 