### PR TITLE
Make sure test constant exists in feedback

### DIFF
--- a/plugins/Feedback/Feedback.php
+++ b/plugins/Feedback/Feedback.php
@@ -114,7 +114,7 @@ class Feedback extends \Piwik\Plugin
     // needs to be protected not private for testing purpose
     protected function isDisabledInTestMode()
     {
-        return PIWIK_TEST_MODE && !Common::getRequestVar('forceFeedbackTest', false);
+        return defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE && !Common::getRequestVar('forceFeedbackTest', false);
     }
 
 }


### PR DESCRIPTION
Not quite sure how this did not fail earlier or how this usually works but seeing an error around this in my logs:

> www/piwik/plugins/Feedback/Feedback.php(117): Notice - Use of undefined constant PIWIK_TEST_MODE - assumed 'PIWIK_TEST_MODE' - Matomo 3.12.0-b1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)