### PR TITLE
Add JS event invoked after a widget is loaded for client side manipulation of widgets.

### DIFF
--- a/core/API/DataTableManipulator/Flattener.php
+++ b/core/API/DataTableManipulator/Flattener.php
@@ -102,8 +102,7 @@ class Flattener extends DataTableManipulator
      * @param string $dimensionName
      * @param bool $parentLogo
      */
-    private function flattenRow
-    (Row $row, $rowId, DataTable $dataTable, $level, $dimensionName,
+    private function flattenRow(Row $row, $rowId, DataTable $dataTable, $level, $dimensionName,
                                 $labelPrefix = '', $parentLogo = false)
     {
         $dimensions = $dataTable->getMetadata('dimensions');

--- a/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.js
+++ b/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.js
@@ -19,9 +19,9 @@
 (function () {
     angular.module('piwikApp').directive('piwikWidgetLoader', piwikWidgetLoader);
 
-    piwikWidgetLoader.$inject = ['piwik', 'piwikUrl', '$http', '$compile', '$q', '$location', 'notifications'];
+    piwikWidgetLoader.$inject = ['piwik', 'piwikUrl', '$http', '$compile', '$q', '$location', 'notifications', '$rootScope', '$timeout'];
 
-    function piwikWidgetLoader(piwik, piwikUrl, $http, $compile, $q, $location, notifications){
+    function piwikWidgetLoader(piwik, piwikUrl, $http, $compile, $q, $location, notifications, $rootScope, $timeout){
         return {
             restrict: 'A',
             transclude: true,
@@ -148,6 +148,13 @@
                             $compile(currentElement)(newScope);
 
                             notifications.parseNotificationDivs();
+
+                            $timeout(function () {
+                                $rootScope.$emit('widget:loaded', {
+                                    parameters: parameters,
+                                    element: currentElement,
+                                });
+                            });
                         })['catch'](function () {
                             if (thisChangeId !== changeCounter) {
                                 // another widget was requested meanwhile, ignore this response


### PR DESCRIPTION
New JS event is used in the google analytics importer to add footer text to reports like transitions or usersflow which aren't viewdatatables