### PR TITLE
Delete config cache only after the cache file was written

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -11,6 +11,8 @@ namespace Piwik;
 
 use Exception;
 use Piwik\Application\Kernel\GlobalSettingsProvider;
+use Piwik\Config\Cache;
+use Piwik\Config\IniFileChain;
 use Piwik\Container\StaticContainer;
 use Piwik\Exception\MissingFilePermissionException;
 use Piwik\ProfessionalServices\Advertising;
@@ -430,6 +432,8 @@ class Config
             if ($success === false) {
                 throw $this->getConfigNotWritableException();
             }
+
+            $this->settings->getIniFileChain()->deleteConfigCache();
 
             /**
              * Triggered when a INI config file is changed on disk.

--- a/core/Config/IniFileChain.php
+++ b/core/Config/IniFileChain.php
@@ -11,7 +11,6 @@ use Piwik\Common;
 use Piwik\Ini\IniReader;
 use Piwik\Ini\IniReadingException;
 use Piwik\Ini\IniWriter;
-use Piwik\Url;
 
 /**
  * Manages a list of INI files where the settings in each INI file merge with or override the
@@ -213,6 +212,7 @@ class IniFileChain
         if (!empty($userSettingsFile) && !empty($GLOBALS['ENABLE_CONFIG_PHP_CACHE'])) {
             $cache = new Cache();
             $values = $cache->doFetch(self::CONFIG_CACHE_KEY);
+            
             if (!empty($values)
                 && isset($values['mergedSettings'])
                 && isset($values['settingsChain'])) {
@@ -253,6 +253,14 @@ class IniFileChain
                 $data = array('mergedSettings' => $this->mergedSettings, 'settingsChain' => $this->settingsChain);
                 $cache->doSave(self::CONFIG_CACHE_KEY, $data, $ttlOneHour);
             }
+        }
+    }
+
+    public function deleteConfigCache()
+    {
+        if (!empty($GLOBALS['ENABLE_CONFIG_PHP_CACHE'])) {
+            $cache = new Cache();
+            $cache->doDelete(IniFileChain::CONFIG_CACHE_KEY);
         }
     }
 
@@ -502,11 +510,6 @@ class IniFileChain
 
     private function dumpSettings($values, $header)
     {
-        if (!empty($GLOBALS['ENABLE_CONFIG_PHP_CACHE'])) {
-            $cache = new Cache();
-            $cache->doDelete(self::CONFIG_CACHE_KEY);
-        }
-
         $values = $this->encodeValues($values);
 
         $writer = new IniWriter();

--- a/tests/PHPUnit/Unit/Config/IniFileChainCacheTest.php
+++ b/tests/PHPUnit/Unit/Config/IniFileChainCacheTest.php
@@ -152,8 +152,9 @@ class IniFileChainCacheTest extends IniFileChainTest
         $this->assertNotEmpty($value);
 
         // dumping the cache should delete it
+
         $fileChain = new TestIniFileChain($defaultSettingFiles, $userSettingsFile);
-        $fileChain->dump('');
+        $fileChain->deleteConfigCache();
 
         $value = $this->cache->doFetch(IniFileChain::CONFIG_CACHE_KEY);
         $this->assertEquals(false, $value);


### PR DESCRIPTION
I noticed we deleted the config cache in `IniFileChain` when we `dumpChanges()` but the actual cache file is not yet overwritten. This actually happens in the config class. We need to make sure to delete the config cache only after we have written the config file. Otherwise there could be race conditions where the outdated config gets cached again, and if the user made two changes within one hour (that's how long the cache is active), then a previous change would be potentially undone.

I was going to use the `Core.configFileChanged` event to listen to config file changes, however, at the time I would listen to the event using `Piwik::addAction('Core.configFileChanged', ...)` the DI container might not exist yet etc. Therefore I figured it's best to invalidate the cache specifically by calling the delete method within the config to ensure it'll work and not cause any trouble to something so critical.