### PR TITLE
No longer use reader to get archives

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -48,7 +48,6 @@ charset = utf8
 ; If configured, the following queries will be executed on the reader instead of the writer.
 ; * archiving queries that hit a log table
 ; * live queries that hit a log table
-; * fetching of archives when viewing a report
 ; You only want to enable a reader if you can ensure there is minimal replication lag / delay on the reader.
 ; Otherwise you might get corrupt data in the reports.
 [database_reader]

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -453,31 +453,6 @@ class Archive implements ArchiveQuery
         return $dataTable;
     }
 
-    private function canUseDbReader()
-    {
-        if (Common::isPhpCliMode() ) {
-            // we are likely archiving or we are in CronArchive class etc. where it is important to detect if a
-            // specific archive already exist or not to possibly prevent triggering an unneeded archive request...
-            // also we only want to read archives from the reader for requests from the web
-            return false;
-        }
-
-        if (SettingsServer::isArchivePhpTriggered()) {
-            // when archiving is triggered, we want to make sure to read archives from master to ensure most recent
-            // archives are read etc
-            return false;
-        }
-
-        if (Rules::isArchivingDisabledFor($this->params->getIdSites(), $this->params->getSegment(), $this->getPeriodLabel())) {
-            // in this case we know we won't be creating any archives and we will only want to read archives in order
-            // to present the data in Matomo. We want to use the reader in this case
-            return true;
-        }
-
-        // archiving could be triggered during this request, better not use the reader
-        return false;
-    }
-
     private function getSiteIdsThatAreRequestedInThisArchiveButWereNotInvalidatedYet()
     {
         if (is_null(self::$cache)) {
@@ -581,7 +556,7 @@ class Archive implements ArchiveQuery
             return $result;
         }
 
-        $archiveData = ArchiveSelector::getArchiveData($archiveIds, $archiveNames, $archiveDataType, $idSubtable, $this->canUseDbReader());
+        $archiveData = ArchiveSelector::getArchiveData($archiveIds, $archiveNames, $archiveDataType, $idSubtable);
 
         $isNumeric = $archiveDataType == 'numeric';
 
@@ -705,7 +680,7 @@ class Archive implements ArchiveQuery
     private function cacheArchiveIdsWithoutLaunching($plugins)
     {
         $idarchivesByReport = ArchiveSelector::getArchiveIds(
-            $this->params->getIdSites(), $this->params->getPeriods(), $this->params->getSegment(), $plugins, $this->canUseDbReader());
+            $this->params->getIdSites(), $this->params->getPeriods(), $this->params->getSegment(), $plugins);
 
         // initialize archive ID cache for each report
         foreach ($plugins as $plugin) {

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -138,7 +138,6 @@ class ArchiveSelector
      * @param array $periods
      * @param Segment $segment
      * @param array $plugins List of plugin names for which data is being requested.
-     * @param bool $canUseReaderDb if enabled, will try to read archive from reader
      * @return array Archive IDs are grouped by archive name and period range, ie,
      *               array(
      *                   'VisitsSummary.done' => array(
@@ -147,7 +146,7 @@ class ArchiveSelector
      *               )
      * @throws
      */
-    public static function getArchiveIds($siteIds, $periods, $segment, $plugins, $canUseReaderDb)
+    public static function getArchiveIds($siteIds, $periods, $segment, $plugins)
     {
         if (empty($siteIds)) {
             throw new \Exception("Website IDs could not be read from the request, ie. idSite=");
@@ -174,11 +173,7 @@ class ArchiveSelector
             $monthToPeriods[$table][] = $period;
         }
 
-        if ($canUseReaderDb) {
-            $db = Db::getReader();
-        } else {
-            $db = Db::get();
-        }
+        $db = Db::get();
 
         // for every month within the archive query, select from numeric table
         $result = array();
@@ -235,19 +230,14 @@ class ArchiveSelector
      * @param string $archiveDataType The archive data type (either, 'blob' or 'numeric').
      * @param int|null|string $idSubtable  null if the root blob should be loaded, an integer if a subtable should be
      *                                     loaded and 'all' if all subtables should be loaded.
-     * @param bool $canUseReaderDb if enabled, will try to read archive from reader DB
      * @return array
      *@throws Exception
      */
-    public static function getArchiveData($archiveIds, $recordNames, $archiveDataType, $idSubtable, $canUseReaderDb)
+    public static function getArchiveData($archiveIds, $recordNames, $archiveDataType, $idSubtable)
     {
         $chunk = new Chunk();
 
-        if ($canUseReaderDb) {
-            $db = Db::getReader();
-        } else {
-            $db = Db::get();
-        }
+        $db = Db::get();
 
         // create the SQL to select archive data
         $loadAllSubtables = $idSubtable == Archive::ID_SUBTABLE_LOAD_ALL_SUBTABLES;


### PR DESCRIPTION
Instead use the writer/master DB. As discussed @mattab 

Usually there's more load on the reader than writer so it makes sense to make UI more stable by sending these simple queries to the writer.