### PR TITLE
Improves keyboard navigation for segment editor

### DIFF
--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -414,6 +414,14 @@ Segmentation = (function($) {
                 showAddNewSegmentForm();
             });
 
+            // emulate a click when pressing enter on one of the segments or the add button
+            self.target.on("keyup", ".segmentList li, .add_new_segment", function (event) {
+                var keycode = (event.keyCode ? event.keyCode : (event.which ? event.which : event.key));
+                if(keycode == '13'){
+                    $(this).trigger('click');
+                }
+            });
+
             // attach event that will clear segment list filtering input after clicking x
             self.target.on('click', ".segmentFilterContainer span", function (e) {
                 $(e.target).parent().find(".segmentFilter").val(self.translations['General_Search']).trigger('keyup');

--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -147,8 +147,8 @@ Segmentation = (function($) {
             var html = self.editorTemplate.find("> .listHtml").clone();
             var segment, injClass;
             var listHtml = '<li data-idsegment="" ' +
-                (self.currentSegmentStr == "" ? " class='segmentSelected' tabindex='4' " : "")
-                + ' data-definition=""><span class="segname">' + self.translations['SegmentEditor_DefaultAllVisits']
+                (self.currentSegmentStr == "" ? " class='segmentSelected'" : "")
+                + ' data-definition=""><span class="segname" tabindex="4">' + self.translations['SegmentEditor_DefaultAllVisits']
                 + ' ' + self.translations['General_DefaultAppended']
                 + '</span></li> ';
 

--- a/plugins/SegmentEditor/stylesheets/segmentation.less
+++ b/plugins/SegmentEditor/stylesheets/segmentation.less
@@ -206,9 +206,16 @@ div.scrollable {
     cursor: pointer;
 }
 
-.segmentationContainer .submenu ul li:hover {
+.segmentationContainer .submenu ul li:hover,
+.segmentationContainer .submenu ul li:focus,
+.segmentationContainer .submenu ul li:focus-within {
     color: #255792;
     background: @color-silver-l95;
+    outline: none;
+
+    > * {
+        outline: none;
+    }
 }
 
 .segmentationContainer ul.submenu {
@@ -384,7 +391,11 @@ a.metric_category {
     margin: 8px;
 }
 
-.segmentSelected, .segmentSelected:hover, .segmentEditorPanel .segmentationContainer .submenu li .segmentSelected {
+.segmentSelected,
+.segmentSelected:hover,
+.segmentEditorPanel .segmentationContainer .submenu li .segmentSelected,
+.segmentEditorPanel .segmentationContainer .submenu li:focus,
+.segmentEditorPanel .segmentationContainer .submenu li:focus-within {
     font-weight: bold;
 }
 


### PR DESCRIPTION
Pressing enter should now work. Additionally the segments in the list, will be highlighted when focus with tab (not in IE, as it doesn't support `:focus-within`) and the "All visits" segment is now selectable using tab as well.

tested the changes in Chrome, Firefox and IE

fixes #14755