### PR TITLE
Tweak live queries when they query current week, month, or year where end date is in the future

### DIFF
--- a/plugins/Live/Model.php
+++ b/plugins/Live/Model.php
@@ -454,7 +454,13 @@ class Model
                 }
                 $processedPeriod = Period\Factory::build($period, $processedDate);
             }
+
             $dateStart = $processedPeriod->getDateStart()->setTimezone($currentTimezone);
+
+            $now = Date::now();
+            if ($dateStart->isLater($now)) {
+                $dateStart = $now;
+            }
 
             if (!in_array($date, array('now', 'today', 'yesterdaySameTime'))
                 && strpos($date, 'last') === false
@@ -463,8 +469,14 @@ class Model
             ) {
                 $dateEnd = $processedPeriod->getDateEnd()->setTimezone($currentTimezone);
                 $dateEnd = $dateEnd->addDay(1);
+
+                if ($dateEnd->isLater(Date::now())) {
+                    // making sure dateEnd is bit higher than start date plus in case a second past by now ...
+                    $dateEnd = $now->addPeriod(1, 'second');
+                }
             }
         }
+
         return [$dateStart, $dateEnd];
     }
 

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -32,6 +32,51 @@ class ModelTest extends IntegrationTestCase
         Fixture::createWebsite('2010-01-01');
     }
 
+    public function test_getStandAndEndDate_usesNowWhenDateOutOfRange()
+    {
+        $model = new Model();
+        list($dateStart, $dateEnd) = $model->getStartAndEndDate($idSite = 1, 'year', '2025-01-01');
+
+        $validDates = $this->getValidNowDates();
+
+        $this->assertTrue(in_array($dateStart->getDatetime(), $validDates));
+        $this->assertTrue(in_array($dateEnd->getDatetime(), $validDates));
+        $this->assertNotEquals($dateStart->getDatetime(), $dateEnd->getDatetime());
+    }
+
+    public function test_getStandAndEndDate_usesNowWhenEndDateOutOfRange()
+    {
+        $model = new Model();
+        list($dateStart, $dateEnd) = $model->getStartAndEndDate($idSite = 1, 'year', date('Y').'-01-01');
+
+        $validDates = $this->getValidNowDates();
+
+        $this->assertEquals(date('Y') . '-01-01 00:00:00', $dateStart->getDatetime());
+        $this->assertTrue(in_array($dateEnd->getDatetime(), $validDates));
+        $this->assertNotEquals($dateStart->getDatetime(), $dateEnd->getDatetime());
+    }
+
+    private function getValidNowDates()
+    {
+        $now = Date::now();
+        $validDates = [$now->getDatetime()];
+        $validDates[] = $now->subSeconds(1)->getDatetime();
+        $validDates[] = $now->subSeconds(2)->getDatetime();
+        $validDates[] = $now->addPeriod(1, 'second')->getDatetime();
+        $validDates[] = $now->addPeriod(2, 'second')->getDatetime();
+
+        return $validDates;
+    }
+
+    public function test_getStandAndEndDate()
+    {
+        $model = new Model();
+        list($dateStart, $dateEnd) = $model->getStartAndEndDate($idSite = 1, 'year', '2018-02-01');
+
+        $this->assertEquals('2018-01-01 00:00:00', $dateStart->getDatetime());
+        $this->assertEquals('2019-01-01 00:00:00', $dateEnd->getDatetime());
+    }
+
     public function test_makeLogVisitsQueryString()
     {
         $model = new Model();


### PR DESCRIPTION
To make use of the query performance tweak we added in https://github.com/matomo-org/matomo/pull/14700

Otherwise we query eg 

```
2019-12-30-2019-12-31
then 2019-12-23-2019-12-30
then 2019-11-23-2019-12-23
then the rest of the year
```

instead of say

```
2019-08-12 - 2019-08-11
2019-08-04 - 2019-08-11
...
```

if today was `2019-08-12` preventing full table scans