### PR TITLE
Use strict comparison to prevent Cookie Signature Bypass Through PHP Type Confusion

### DIFF
--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -204,7 +204,7 @@ class Cookie
         $signature = substr($content, -40);
 
         if (substr($content, -43, 3) == self::VALUE_SEPARATOR . '_=' &&
-            $signature == sha1(substr($content, 0, -40) . SettingsPiwik::getSalt())
+            $signature === sha1(substr($content, 0, -40) . SettingsPiwik::getSalt())
         ) {
             // strip trailing: VALUE_SEPARATOR '_=' signature"
             return substr($content, 0, -43);


### PR DESCRIPTION
We got a security report, as below, which recommends changing this comparison operator:

# Report

![Screenshot from 2019-08-13 10-17-01](https://user-images.githubusercontent.com/466765/62902418-a36aec80-bdb3-11e9-8a60-fc3a509ae3d0.png)
![Screenshot from 2019-08-13 10-17-16](https://user-images.githubusercontent.com/466765/62902417-a36aec80-bdb3-11e9-81d2-32f1f4766cc9.png)