### PR TITLE
update matomo-icons

### DIFF
--- a/plugins/DevicesDetection/functions.php
+++ b/plugins/DevicesDetection/functions.php
@@ -17,7 +17,7 @@ use DeviceDetector\Parser\Client\Browser AS BrowserParser;
 function getBrandLogo($label)
 {
     $path = 'plugins/Morpheus/icons/dist/brand/%s.png';
-    $label = preg_replace("/[^a-z0-9_-]+/i", "_", $label);
+    $label = preg_replace("/[^a-z0-9_\-äöü]+/i", "_", $label);
     if (!file_exists(PIWIK_INCLUDE_PATH . '/' . sprintf($path, $label))) {
         $label = "unk";
     }


### PR DESCRIPTION
**:warning: Please merge https://github.com/matomo-org/matomo-package/pull/100 before merging this PR :warning:** 

I finally had time to spend an afternoon on updating all icons. There are tons of new brands supported in DeviceDetector. I checked all of them and added icons or added them to the ignore list:
https://github.com/matomo-org/matomo-icons/blob/1a6ab38f4870112603df6bb5a8b16a280e32847a/tests-ignore.yml#L14

I also changed the brand name replacement regex for filename so it accepts dashes and umlauts. 