### PR TITLE
Do not record the stack trace for user input errors

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -12,6 +12,7 @@ use Exception;
 use Piwik\Access\CapabilitiesProvider;
 use Piwik\Access\RolesProvider;
 use Piwik\Container\StaticContainer;
+use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Plugins\SitesManager\API as SitesManagerApi;
 
 /**
@@ -695,6 +696,6 @@ class Access
  *
  * @api
  */
-class NoAccessException extends \Exception
+class NoAccessException extends InvalidRequestParameterException
 {
 }

--- a/core/Application/Kernel/EnvironmentValidator.php
+++ b/core/Application/Kernel/EnvironmentValidator.php
@@ -10,6 +10,7 @@ namespace Piwik\Application\Kernel;
 
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Exception\NotYetInstalledException;
 use Piwik\Filechecks;
 use Piwik\Piwik;
@@ -81,7 +82,7 @@ class EnvironmentValidator
         if (isset($general['enable_installer'])
             && !$general['enable_installer']
         ) {
-            throw new \Exception('Matomo is not set up yet');
+            throw new InvalidRequestParameterException('Matomo is not set up yet');
         }
 
         $message = $this->getSpecificMessageWhetherFileExistsOrNot($path);

--- a/core/Exception/NoWebsiteFoundException.php
+++ b/core/Exception/NoWebsiteFoundException.php
@@ -8,6 +8,6 @@
  */
 namespace Piwik\Exception;
 
-class NoWebsiteFoundException extends Exception
+class NoWebsiteFoundException extends InvalidRequestParameterException
 {
 }

--- a/plugins/Installation/Installation.php
+++ b/plugins/Installation/Installation.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\Installation;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Config;
+use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\FrontController;
 use Piwik\Piwik;
 use Piwik\Plugins\Installation\Exception\DatabaseConnectionFailedException;
@@ -64,7 +65,7 @@ class Installation extends \Piwik\Plugin
         $general = Config::getInstance()->General;
 
         if (!SettingsPiwik::isPiwikInstalled() && !$general['enable_installer']) {
-            throw new \Exception('Matomo is not set up yet');
+            throw new InvalidRequestParameterException('Matomo is not set up yet');
         }
 
         if (empty($general['installation_in_progress'])) {

--- a/plugins/Monolog/Processor/ExceptionToTextProcessor.php
+++ b/plugins/Monolog/Processor/ExceptionToTextProcessor.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\Monolog\Processor;
 
 use Piwik\ErrorHandler;
+use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Log;
 
 /**
@@ -24,6 +25,10 @@ class ExceptionToTextProcessor
 
         /** @var \Exception $exception */
         $exception = $record['context']['exception'];
+
+        if ($exception instanceof InvalidRequestParameterException) {
+            return $record;
+        }
 
         $exceptionStr = sprintf(
             "%s(%d): %s\n%s",

--- a/plugins/TwoFactorAuth/Validator.php
+++ b/plugins/TwoFactorAuth/Validator.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\TwoFactorAuth;
 
 use Piwik\Common;
+use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Piwik;
 use Piwik\Session\SessionFingerprint;
 use Exception;
@@ -45,7 +46,7 @@ class Validator
         Piwik::checkUserIsNotAnonymous();
 
         if (!SettingsPiwik::isPiwikInstalled()) {
-            throw new \Exception('Matomo is not set up yet');
+            throw new InvalidRequestParameterException('Matomo is not set up yet');
         }
     }
 


### PR DESCRIPTION
As the logs are otherwise full of them as they are happening thousands of times every hour and it is quite clear where these errors are happening etc.

This lets you better find actual errors.