### PR TITLE
On API call error, remove loading gif in transitions report.

### DIFF
--- a/plugins/Transitions/javascripts/transitions.js
+++ b/plugins/Transitions/javascripts/transitions.js
@@ -1564,6 +1564,8 @@ Piwik_Transitions_Ajax.prototype.callApi = function (method, params, callback) {
                     } else {
                         Piwik_Popover.showError(errorTitle, errorMessage, errorBack);
                     }
+
+                    $('#transitions_inline_loading').hide();
                 };
 
                 if (typeof Piwik_Transitions_Translations == 'undefined') {


### PR DESCRIPTION
Currently on error, the loading gif is never removed. This PR removes it.