### PR TITLE
Support tideways profiler

### DIFF
--- a/core/Profiler.php
+++ b/core/Profiler.php
@@ -210,7 +210,7 @@ class Profiler
         }
 
         $hasXhprof = function_exists('xhprof_enable');
-        $hasTidewaysXhprof = function_exists('tideways_xhprof_enable');
+        $hasTidewaysXhprof = function_exists('tideways_xhprof_enable') || function_exists('tideways_enable');
 
         if (!$hasXhprof && !$hasTidewaysXhprof) {
             $xhProfPath = PIWIK_INCLUDE_PATH . '/vendor/facebook/xhprof/extension/modules/xhprof.so';
@@ -248,6 +248,8 @@ class Profiler
 
         if (function_exists('xhprof_enable')) {
             xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);
+        } elseif (function_exists('tideways_enable')) {
+            tideways_enable(TIDEWAYS_FLAGS_MEMORY | TIDEWAYS_FLAGS_CPU);
         } elseif (function_exists('tideways_xhprof_enable')) {
             tideways_xhprof_enable(TIDEWAYS_XHPROF_FLAGS_MEMORY | TIDEWAYS_XHPROF_FLAGS_CPU);
         }
@@ -257,8 +259,12 @@ class Profiler
                 $xhprofData = xhprof_disable();
                 $xhprofRuns = new XHProfRuns_Default();
                 $runId = $xhprofRuns->save_run($xhprofData, $profilerNamespace);
-            } elseif (function_exists('tideways_xhprof_disable')) {
-                $xhprofData = tideways_xhprof_disable();
+            } elseif (function_exists('tideways_xhprof_disable') || function_exists('tideways_disable')) {
+                if (function_exists('tideways_xhprof_disable')) {
+                    $xhprofData = tideways_xhprof_disable();
+                } else {
+                    $xhprofData = tideways_disable();
+                }
                 $runId = uniqid();
                 file_put_contents(
                     $outputDir . DIRECTORY_SEPARATOR . $runId . '.' . $profilerNamespace . '.xhprof',


### PR DESCRIPTION
I was just installing a different tideways extension where it only worked when removing the `_xhprof` in the middle. IN https://github.com/tideways/php-xhprof-extension it's still documented differently though. So best to support both maybe.