### PR TITLE
Provide possibility to force not using a subquery

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -249,7 +249,7 @@ class LogAggregator
 
             $logQueryBuilder = StaticContainer::get('Piwik\DataAccess\LogQueryBuilder');
             $forceGroupByBackup = $logQueryBuilder->getForcedInnerGroupBySubselect();
-            $logQueryBuilder->forceInnerGroupBySubselect('');
+            $logQueryBuilder->forceInnerGroupBySubselect(LogQueryBuilder::FORCE_INNER_GROUP_BY_NO_SUBSELECT);
             $segmentSql = $this->segment->getSelectQuery('distinct log_visit.idvisit as idvisit', 'log_visit', $segmentWhere, $segmentBind, 'log_visit.idvisit ASC');
             $logQueryBuilder->forceInnerGroupBySubselect($forceGroupByBackup);
 

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -274,7 +274,7 @@ class LogAggregator
                         if (stripos($where, 'and ') === 0) {
                             $where = substr($where, strlen('and '));
                         }
-                        $bind = array_slice($bind, 3);
+                        $bind = array();
                         break;
                     }
                 }

--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -78,7 +78,7 @@ class LogQueryBuilder
             && strpos($from, 'log_link_visit_action') !== false);
 
         if (!empty($this->forcedInnerGroupBy)) {
-            if ($this->forcedInnerGroupBy) {
+            if ($this->forcedInnerGroupBy === self::FORCE_INNER_GROUP_BY_NO_SUBSELECT) {
                 $sql = $this->buildSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset);
             } else {
                 $sql = $this->buildWrappedSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset, $tables, $this->forcedInnerGroupBy);

--- a/core/DataAccess/LogQueryBuilder.php
+++ b/core/DataAccess/LogQueryBuilder.php
@@ -17,6 +17,8 @@ use Piwik\Segment\SegmentExpression;
 
 class LogQueryBuilder
 {
+    const FORCE_INNER_GROUP_BY_NO_SUBSELECT = '__##nosubquery##__';
+
     /**
      * @var LogTablesProvider
      */
@@ -76,7 +78,11 @@ class LogQueryBuilder
             && strpos($from, 'log_link_visit_action') !== false);
 
         if (!empty($this->forcedInnerGroupBy)) {
-            $sql = $this->buildWrappedSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset, $tables, $this->forcedInnerGroupBy);
+            if ($this->forcedInnerGroupBy) {
+                $sql = $this->buildSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset);
+            } else {
+                $sql = $this->buildWrappedSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset, $tables, $this->forcedInnerGroupBy);
+            }
         } elseif ($useSpecialConversionGroupBy) {
             $innerGroupBy = "CONCAT(log_conversion.idvisit, '_' , log_conversion.idgoal, '_', log_conversion.buster)";
             $sql = $this->buildWrappedSelectQuery($select, $from, $where, $groupBy, $orderBy, $limitAndOffset, $tables, $innerGroupBy);


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/pull/14761

Avoids generating queries like this:

```sql
CREATE TEMPORARY TABLE IF NOT EXISTS logtmpsegmente5bfbc1f135a495c4f5aad6d8047199c (idvisit  BIGINT(10) UNSIGNED NOT NULL) 
            SELECT
                distinct log_inner.idvisit as idvisit
            FROM
                
        (
            
            SELECT
                log_visit.idvisit
            FROM
                log_visit AS log_visit LEFT JOIN log_link_visit_action AS log_link_visit_action ON log_link_visit_action.idvisit = log_visit.idvisit
            WHERE
                ( log_visit.visit_last_action_time >= '2019-04-30 14:00:00'
                AND log_visit.visit_last_action_time <= '2019-05-31 13:59:59'
                AND log_visit.idsite IN ('1') )
                AND
                ( ( log_link_visit_action.idaction_url IN (SELECT idaction FROM log_action WHERE ( name LIKE CONCAT('%', '/admin', '%')  AND type = 1 )) ) )
            GROUP BY
                log_visit.idvisit
            ORDER BY
                NULL
        ) AS log_inner
            ORDER BY
                log_inner.idvisit ASC
```

where we don't need the subquery anymore for create temp table statements anymore as we always do a `distinct idvisit` anyway. 

Also fixes an issue where the bind was wrongly set for roll up reporting