### PR TITLE
fix incorrect number of translation strings

### DIFF
--- a/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
+++ b/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
@@ -58,7 +58,8 @@ class CronArchivingLastRunCheck implements Diagnostic
         $lastRunTime = (int)Option::get(CronArchive::OPTION_ARCHIVING_FINISHED_TS);
         if (empty($lastRunTime)) {
             $comment = $this->translator->translate('Diagnostics_CronArchivingHasNotRun')
-                . '<br/><br/>' . $this->translator->translate('Diagnostics_CronArchivingRunDetails', [$coreArchiveShort, $mailto, $commandToRerun]);;
+                . '<br/><br/>' . $this->translator->translate('Diagnostics_CronArchivingRunDetails',
+                    [$coreArchiveShort, $mailto, $commandToRerun, '<a href="https://matomo.org/docs/setup-auto-archiving/" target="_blank" rel="noreferrer noopener">', '</a>']);;
             return [DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_ERROR, $comment)];
         }
 


### PR DESCRIPTION
fix found by @peterbo 
reported in https://forum.matomo.org/t/fehler-systemprufung-nach-update-auf-3-10-0/33491 and a few other forum posts

#14284 only changed one of the usages of the `Diagnostics_CronArchivingRunDetails` string.