### PR TITLE
Don't allow update 0 plugin

### DIFF
--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -10,7 +10,7 @@
         <tr>
             <th>
                 <span class="checkbox-container">
-                    <input type="checkbox" id="select-plugin-all" onclick="boxes_selected()"/>
+                    <input type="checkbox" id="select-plugin-all"/>
                     <label for="select-plugin-all"></label>
                 </span>
             </th>
@@ -74,6 +74,11 @@
 
     <script>
         $(function () {
+            $('span.checkbox-container input').on('click', function() {
+                var isAtLeastOneChecked = $('span.checkbox-container > input[checked]').length >= 1;
+                $('#update-selected-plugins').prop('disabled', !isAtLeastOneChecked);
+            });
+
             $('#update-selected-plugins').on('click', function () {
                 var pluginsToUpdate = [];
                 $('tbody#plugins td.select-cell input').each(function () {
@@ -101,21 +106,6 @@
                 });
             });
         });
-        
-        function boxes_selected(){
-            var checked_boxes = 0;
-            var boxes = document.querySelectorAll('span.checkbox-container > input');
-            
-            for (var i = 0; i < boxes.length; i++){
-                if (boxes[i].checked)
-                    checked_boxes += 1
-            }
-            if (checked_boxes >= 1) {
-                document.getElementById('update-selected-plugins').classList.remove('disabled');
-            } else if (checked_boxes === 0) {
-                document.getElementById('update-selected-plugins').classList.add('disabled');
-            }
-        }
     </script>
 
 {% endmacro %}

--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -26,7 +26,7 @@
             <tr {% if plugin.isActivated|default(false) %}class="active-plugin"{% else %}class="inactive-plugin"{% endif %}>
                 <td class="select-cell">
                     <span class="checkbox-container">
-                        <input type="checkbox" id="select-plugin-{{ plugin.name|e('html_attr') }}" onclick="boxes_selected()" {% if plugin.isDownloadable is defined and not plugin.isDownloadable %}disabled="disabled"{% endif %} />
+                        <input type="checkbox" id="select-plugin-{{ plugin.name|e('html_attr') }}" {% if plugin.isDownloadable is defined and not plugin.isDownloadable %}disabled="disabled"{% endif %} />
                         <label for="select-plugin-{{ plugin.name|e('html_attr') }}"></label>
                     </span>
                 </td>
@@ -74,7 +74,7 @@
 
     <script>
         $(function () {
-            $('span.checkbox-container input').on('click', function() {
+            $('span.checkbox-container').on('click', function() {
                 var isAtLeastOneChecked = $('span.checkbox-container > input[checked]').length >= 1;
                 $('#update-selected-plugins').prop('disabled', !isAtLeastOneChecked);
             });

--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -74,9 +74,9 @@
 
     <script>
         $(function () {
-            $('span.checkbox-container').on('click', function() {
-                var isAtLeastOneChecked = $('span.checkbox-container > input[checked]').length >= 1;
-                $('#update-selected-plugins').prop('disabled', !isAtLeastOneChecked);
+            $('span.checkbox-container').on('change', function() {
+                var isAtLeastOneChecked = $('span.checkbox-container > input:checked').length >= 1;
+                isAtLeastOneChecked ? $('#update-selected-plugins').removeClass('disabled') : $('#update-selected-plugins').addClass('disabled');
             });
 
             $('#update-selected-plugins').on('click', function () {

--- a/plugins/CorePluginsAdmin/templates/macros.twig
+++ b/plugins/CorePluginsAdmin/templates/macros.twig
@@ -3,14 +3,14 @@
     {% import '@Marketplace/macros.twig' as marketplaceMacro %}
 
     <div>
-        <a id="update-selected-plugins" href="javascript:" class="btn">{{ 'CorePluginsAdmin_UpdateSelected'|translate }}</a>
+        <a id="update-selected-plugins" href="javascript:" class="btn disabled">{{ 'CorePluginsAdmin_UpdateSelected'|translate }}</a>
     </div>
     <table piwik-content-table>
         <thead>
         <tr>
             <th>
                 <span class="checkbox-container">
-                    <input type="checkbox" id="select-plugin-all" />
+                    <input type="checkbox" id="select-plugin-all" onclick="boxes_selected()"/>
                     <label for="select-plugin-all"></label>
                 </span>
             </th>
@@ -26,7 +26,7 @@
             <tr {% if plugin.isActivated|default(false) %}class="active-plugin"{% else %}class="inactive-plugin"{% endif %}>
                 <td class="select-cell">
                     <span class="checkbox-container">
-                        <input type="checkbox" id="select-plugin-{{ plugin.name|e('html_attr') }}" {% if plugin.isDownloadable is defined and not plugin.isDownloadable %}disabled="disabled"{% endif %} />
+                        <input type="checkbox" id="select-plugin-{{ plugin.name|e('html_attr') }}" onclick="boxes_selected()" {% if plugin.isDownloadable is defined and not plugin.isDownloadable %}disabled="disabled"{% endif %} />
                         <label for="select-plugin-{{ plugin.name|e('html_attr') }}"></label>
                     </span>
                 </td>
@@ -101,6 +101,21 @@
                 });
             });
         });
+        
+        function boxes_selected(){
+            var checked_boxes = 0;
+            var boxes = document.querySelectorAll('span.checkbox-container > input');
+            
+            for (var i = 0; i < boxes.length; i++){
+                if (boxes[i].checked)
+                    checked_boxes += 1
+            }
+            if (checked_boxes >= 1) {
+                document.getElementById('update-selected-plugins').classList.remove('disabled');
+            } else if (checked_boxes === 0) {
+                document.getElementById('update-selected-plugins').classList.add('disabled');
+            }
+        }
     </script>
 
 {% endmacro %}


### PR DESCRIPTION
Fix for issue #14785 

Button for updating plugins is now disabled by default, enabled if at least one plugin is selected