### PR TITLE
Use correct NotYetInstalledException when Matomo is not yet installed

### DIFF
--- a/core/Application/Kernel/EnvironmentValidator.php
+++ b/core/Application/Kernel/EnvironmentValidator.php
@@ -82,7 +82,7 @@ class EnvironmentValidator
         if (isset($general['enable_installer'])
             && !$general['enable_installer']
         ) {
-            throw new InvalidRequestParameterException('Matomo is not set up yet');
+            throw new NotYetInstalledException('Matomo is not set up yet');
         }
 
         $message = $this->getSpecificMessageWhetherFileExistsOrNot($path);

--- a/core/Exception/NotYetInstalledException.php
+++ b/core/Exception/NotYetInstalledException.php
@@ -8,6 +8,6 @@
  */
 namespace Piwik\Exception;
 
-class NotYetInstalledException extends Exception
+class NotYetInstalledException extends InvalidRequestParameterException
 {
 }

--- a/plugins/Installation/Installation.php
+++ b/plugins/Installation/Installation.php
@@ -11,7 +11,7 @@ namespace Piwik\Plugins\Installation;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Config;
-use Piwik\Exception\InvalidRequestParameterException;
+use Piwik\Exception\NotYetInstalledException;
 use Piwik\FrontController;
 use Piwik\Piwik;
 use Piwik\Plugins\Installation\Exception\DatabaseConnectionFailedException;
@@ -65,7 +65,7 @@ class Installation extends \Piwik\Plugin
         $general = Config::getInstance()->General;
 
         if (!SettingsPiwik::isPiwikInstalled() && !$general['enable_installer']) {
-            throw new InvalidRequestParameterException('Matomo is not set up yet');
+            throw new NotYetInstalledException('Matomo is not set up yet');
         }
 
         if (empty($general['installation_in_progress'])) {

--- a/plugins/TwoFactorAuth/Validator.php
+++ b/plugins/TwoFactorAuth/Validator.php
@@ -9,7 +9,7 @@
 namespace Piwik\Plugins\TwoFactorAuth;
 
 use Piwik\Common;
-use Piwik\Exception\InvalidRequestParameterException;
+use Piwik\Exception\NotYetInstalledException;
 use Piwik\Piwik;
 use Piwik\Session\SessionFingerprint;
 use Exception;
@@ -46,7 +46,7 @@ class Validator
         Piwik::checkUserIsNotAnonymous();
 
         if (!SettingsPiwik::isPiwikInstalled()) {
-            throw new InvalidRequestParameterException('Matomo is not set up yet');
+            throw new NotYetInstalledException('Matomo is not set up yet');
         }
     }
 


### PR DESCRIPTION
Otherwise it can become impossible to catch this exception.