### PR TITLE
No config reload on save

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -405,16 +405,9 @@ class Config
     /**
      * Write user configuration file
      *
-     * @param array $configLocal
-     * @param array $configGlobal
-     * @param array $configCommon
-     * @param array $configCache
-     * @param string $pathLocal
-     * @param bool $clear
-     *
      * @throws \Exception if config file not writable
      */
-    protected function writeConfig($clear = true)
+    protected function writeConfig()
     {
         $output = $this->dumpConfig();
         if ($output !== null
@@ -441,10 +434,6 @@ class Config
              * @param string $localPath Absolute path to the changed file on the server.
              */
             Piwik::postEvent('Core.configFileChanged', [$localPath]);
-        }
-
-        if ($clear) {
-            $this->reload();
         }
     }
 


### PR DESCRIPTION
Found an interesting issue today re config... when the config is saved, we reload the config afterwards in https://github.com/matomo-org/matomo/blob/3.12.0-b2/core/Config.php#L447 

The problem is, that any `plugins/*/config/config.php` or `config/config.php` that is changing the config using DI is then ignored when reloading the config. Looks like something like this:

```
'Piwik\Config' => DI\decorate(function ($previous) {
        $general = $previous->General;
        $general['force_ssl'] = 1;
        $previous->General = $general;

        return $previous;
    }),
```

We're using this quite intensively in various places. I wonder in that case how to best re-initialise the config to make sure DI is executed again. Like removing it from DI, and then initialising it again using DI... would that work somehow? Problem is that maybe there could be still outdated references to the old config instance... I wonder maybe by default we should not reload the config simply? Not sure why we do it. It was likely not really an issue before since it would have simply saved all changes in `Config` to the local config and then reloaded it again.

However, in a new plugin I will have an event to not save some config parameters to the config file. I will have an event `postEvent('Config.beforeSave', array(&$config))` where I then do something like `unset($config['General']['force_ssl'])` to avoid saving some values in the config. Eg to not save DB credentials in the config etc.