### PR TITLE
fix implode argument order (php 7.4 compatibility)

### DIFF
--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -313,7 +313,7 @@ class Model
     {
         list($updateParts, $sqlBind) = $this->fieldsToQuery($valuesToUpdate);
 
-        $parts = implode($updateParts, ', ');
+        $parts = implode(', ',$updateParts);
         $table = Common::prefixTable('log_visit');
 
         $sqlQuery = "UPDATE $table SET $parts WHERE idsite = ? AND idvisit = ?";


### PR DESCRIPTION
related to https://github.com/matomo-org/matomo/issues/14821
With PHP 7.4 a lot of incorrect usages of functions have been deprecated.
One of them is that `implode()` will now throw a warning if the glue isn't the first parameter.

I'll update this PR as I come across more warnings.