### PR TITLE
Do not regenerate tracker files after core archiving

### DIFF
--- a/plugins/CustomPiwikJs/CustomPiwikJs.php
+++ b/plugins/CustomPiwikJs/CustomPiwikJs.php
@@ -18,7 +18,6 @@ class CustomPiwikJs extends Plugin
     {
         return array(
             'CoreUpdater.update.end' => 'updateTracker',
-            'CronArchive.end' => 'updateTracker',
             'PluginManager.pluginActivated' => 'updateTracker',
             'PluginManager.pluginDeactivated' => 'updateTracker',
             'PluginManager.pluginInstalled' => 'updateTracker',


### PR DESCRIPTION
Not sure why I added it there considering they are being regenerated in a task every hour or so anyway.
Also see https://github.com/matomo-org/tag-manager/pull/184