### PR TITLE
Add option to archiver to not create archives for segments for today

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -649,6 +649,15 @@ class Archive implements ArchiveQuery
             foreach ($this->params->getIdSites() as $idSite) {
                 $site = new Site($idSite);
 
+                 if ($period->getLabel() === 'day'
+                    && !$this->params->getSegment()->isEmpty()
+                    && Common::getRequestVar('skipArchiveSegmentToday', 0, 'int')
+                    && $period->getDateStart()->toString() == Date::factory('now', $site->getTimezone())->toString()) {
+
+                    Log::debug("Skipping archive %s for %s as segment today is disabled", $period->getLabel(), $period->getPrettyString());
+                    continue;
+                }
+
                 // if the END of the period is BEFORE the website creation date
                 // we already know there are no stats for this period
                 // we add one day to make sure we don't miss the day of the website creation

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1772,12 +1772,16 @@ class CronArchive
         return $url;
     }
 
-    protected function wasSegmentCreatedRecently($definition, $allSegments)
+    protected function wasSegmentChangedRecently($definition, $allSegments)
     {
         foreach ($allSegments as $segment) {
             if ($segment['definition'] === $definition) {
                 $twentyFourHoursAgo = Date::now()->subHour(24);
-                return Date::factory($segment['ts_created'])->isLater($twentyFourHoursAgo);
+                $segmentDate = $segment['ts_created'];
+                if (!empty($segment['ts_last_edit'])) {
+                    $segmentDate = $segment['ts_last_edit'];
+                }
+                return Date::factory($segmentDate)->isLater($twentyFourHoursAgo);
             }
         }
 
@@ -1817,7 +1821,7 @@ class CronArchive
         }
 
         foreach ($segments as $segment) {
-            $shouldSkipToday = $this->skipSegmentsToday && !$this->wasSegmentCreatedRecently($segment, $allSegmentsFullInfo);
+            $shouldSkipToday = $this->skipSegmentsToday && !$this->wasSegmentChangedRecently($segment, $allSegmentsFullInfo);
 
             if ($this->skipSegmentsToday && !$shouldSkipToday) {
                 $this->logger->info(sprintf('Segment "%s" was created recently and will therefore archive today', $segment));

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1824,7 +1824,7 @@ class CronArchive
             $shouldSkipToday = $this->skipSegmentsToday && !$this->wasSegmentChangedRecently($segment, $allSegmentsFullInfo);
 
             if ($this->skipSegmentsToday && !$shouldSkipToday) {
-                $this->logger->info(sprintf('Segment "%s" was created recently and will therefore archive today', $segment));
+                $this->logger->info(sprintf('Segment "%s" was created or changed recently and will therefore archive today', $segment));
             }
 
             $dateParamForSegment = $this->segmentArchivingRequestUrlProvider->getUrlParameterDateString($idSite, $period, $date, $segment);

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -367,6 +367,10 @@ class CronArchive
             $this->logger->info('Will ignore websites and help finish a previous started queue instead. IDs: ' . implode(', ', $this->websites->getInitialSiteIds()));
         }
 
+        if ($this->skipSegmentsToday) {
+            $this->logger->info('Will skip segments archiving for today unless they were created recently');
+        }
+
         $this->logForcedSegmentInfo();
 
         /**
@@ -1768,7 +1772,7 @@ class CronArchive
         return $url;
     }
 
-    private function wasSegmentCreatedRecently($definition, $allSegments)
+    protected function wasSegmentCreatedRecently($definition, $allSegments)
     {
         foreach ($allSegments as $segment) {
             if ($segment['definition'] === $definition) {
@@ -1814,6 +1818,10 @@ class CronArchive
 
         foreach ($segments as $segment) {
             $shouldSkipToday = $this->skipSegmentsToday && !$this->wasSegmentCreatedRecently($segment, $allSegmentsFullInfo);
+
+            if ($this->skipSegmentsToday && !$shouldSkipToday) {
+                $this->logger->info(sprintf('Segment "%s" was created recently and will therefore archive today', $segment));
+            }
 
             $dateParamForSegment = $this->segmentArchivingRequestUrlProvider->getUrlParameterDateString($idSite, $period, $date, $segment);
 

--- a/core/CronArchive/SegmentArchivingRequestUrlProvider.php
+++ b/core/CronArchive/SegmentArchivingRequestUrlProvider.php
@@ -14,6 +14,7 @@ use Piwik\Date;
 use Piwik\Period\Factory as PeriodFactory;
 use Piwik\Period\Range;
 use Piwik\Plugins\SegmentEditor\Model;
+use Piwik\Site;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -59,10 +60,42 @@ class SegmentArchivingRequestUrlProvider
         $this->logger = $logger ?: StaticContainer::get('Psr\Log\LoggerInterface');
     }
 
-    public function getUrlParameterDateString($idSite, $period, $date, $segment)
+    private function ignoreToday($date, $idSite)
+    {
+        if (strpos($date, 'last') === 0) {
+            return str_replace('last', 'previous', $date);
+        }
+
+        $timezone = Site::getTimezoneFor($idSite);
+        $nowInTimezone = Date::now()->setTimezone($timezone);
+
+        $today = $nowInTimezone->toString();
+        $yesterday = $nowInTimezone->subDay(1)->toString();
+
+        if (strpos($date, ',') !== false) {
+            $parts = explode(',', $date);
+            if (count($parts) === 2 && $parts[1] === $today) {
+                return $parts[0] . ',' . $yesterday;
+            }
+            if (count($parts) === 2 && $parts[0] === $today) {
+                return $yesterday . ',' . $yesterday;
+            }
+            return $date;
+        }
+
+        if ($date === $today) {
+            return $yesterday;
+        }
+        return $date;
+    }
+
+    public function getUrlParameterDateString($idSite, $period, $date, $segment, $shouldIncludeToday)
     {
         $oldestDateToProcessForNewSegment = $this->getOldestDateToProcessForNewSegment($idSite, $segment);
         if (empty($oldestDateToProcessForNewSegment)) {
+            if ($shouldIncludeToday) {
+                return $this->ignoreToday($date, $idSite);
+            }
             return $date;
         }
 
@@ -90,6 +123,10 @@ class SegmentArchivingRequestUrlProvider
             $date = $oldestDateToProcessForNewSegment->toString().','.$endDate;
 
             $this->logger->debug("Archiving request date range changed to {date} w/ period {period}.", array('date' => $date, 'period' => $period));
+        }
+
+        if ($shouldIncludeToday) {
+            return $this->ignoreToday($date, $idSite);
         }
 
         return $date;

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -103,7 +103,7 @@ class CoreArchiver extends ConsoleCommand
         $command->addOption('force-idsites', null, InputOption::VALUE_OPTIONAL,
             'If specified, archiving will be processed only for these Sites Ids (comma separated)');
         $command->addOption('skip-segments-today', null, InputOption::VALUE_NONE,
-            'If specified, segments will be only archived for yesterday, but not today. If the segment was created recently, then it will still be archived for today and the setting will be ignored for this segment.');
+            'If specified, segments will be only archived for yesterday, but not today. If the segment was created or changed recently, then it will still be archived for today and the setting will be ignored for this segment.');
         $command->addOption('force-periods', null, InputOption::VALUE_OPTIONAL,
             "If specified, archiving will be processed only for these Periods (comma separated eg. day,week,month,year,range)");
         $command->addOption('force-date-last-n', null, InputOption::VALUE_REQUIRED,

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -52,6 +52,7 @@ class CoreArchiver extends ConsoleCommand
         $archiver->maxConcurrentArchivers = $input->getOption('concurrent-archivers');
 
         $archiver->disableSegmentsArchiving = $input->getOption('skip-all-segments');
+        $archiver->skipSegmentsToday = $input->getOption('skip-segments-today');
 
         $segmentIds = $input->getOption('force-idsegments');
         $segmentIds = explode(',', $segmentIds);
@@ -101,6 +102,8 @@ class CoreArchiver extends ConsoleCommand
             'If specified, all segments will be skipped during archiving.');
         $command->addOption('force-idsites', null, InputOption::VALUE_OPTIONAL,
             'If specified, archiving will be processed only for these Sites Ids (comma separated)');
+        $command->addOption('skip-segments-today', null, InputOption::VALUE_OPTIONAL,
+            'If specified, segments will be only archived for yesterday, but not today. If the segment was created recently, then it will still be archived for today and the setting will be ignored for this segment.');
         $command->addOption('force-periods', null, InputOption::VALUE_OPTIONAL,
             "If specified, archiving will be processed only for these Periods (comma separated eg. day,week,month,year,range)");
         $command->addOption('force-date-last-n', null, InputOption::VALUE_REQUIRED,

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -102,7 +102,7 @@ class CoreArchiver extends ConsoleCommand
             'If specified, all segments will be skipped during archiving.');
         $command->addOption('force-idsites', null, InputOption::VALUE_OPTIONAL,
             'If specified, archiving will be processed only for these Sites Ids (comma separated)');
-        $command->addOption('skip-segments-today', null, InputOption::VALUE_OPTIONAL,
+        $command->addOption('skip-segments-today', null, InputOption::VALUE_NONE,
             'If specified, segments will be only archived for yesterday, but not today. If the segment was created recently, then it will still be archived for today and the setting will be ignored for this segment.');
         $command->addOption('force-periods', null, InputOption::VALUE_OPTIONAL,
             "If specified, archiving will be processed only for these Periods (comma separated eg. day,week,month,year,range)");

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -75,13 +75,13 @@ class CronArchiveTest extends IntegrationTestCase
         $allSegments = $segments->getSegmentsToAutoArchive(1);
 
         $cronarchive = new TestCronArchive(Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php');
-        $this->assertTrue($cronarchive->wasSegmentCreatedRecently('actions>=1', $allSegments));
+        $this->assertTrue($cronarchive->wasSegmentChangedRecently('actions>=1', $allSegments));
 
         // created 30 hours ago...
-        $this->assertFalse($cronarchive->wasSegmentCreatedRecently('actions>=2', $allSegments));
+        $this->assertFalse($cronarchive->wasSegmentChangedRecently('actions>=2', $allSegments));
 
         // not configured segment
-        $this->assertFalse($cronarchive->wasSegmentCreatedRecently('actions>=999', $allSegments));
+        $this->assertFalse($cronarchive->wasSegmentChangedRecently('actions>=999', $allSegments));
     }
 
     public function test_skipSegmentsToday()
@@ -232,8 +232,8 @@ class TestCronArchive extends CronArchive
     {
     }
 
-    public function wasSegmentCreatedRecently($definition, $allSegments)
+    public function wasSegmentChangedRecently($definition, $allSegments)
     {
-        return parent::wasSegmentCreatedRecently($definition, $allSegments);
+        return parent::wasSegmentChangedRecently($definition, $allSegments);
     }
 }

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -8,13 +8,11 @@
 
 namespace Piwik\Tests\Integration;
 
-use Piwik\CliMulti;
 use Piwik\Container\StaticContainer;
 use Piwik\CronArchive;
-use Piwik\Archive\ArchiveInvalidator;
 use Piwik\Date;
-use Piwik\Db;
 use Piwik\Plugins\CoreAdminHome\tests\Framework\Mock\API;
+use Piwik\Plugins\SegmentEditor\Model;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeLogger;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -63,6 +61,54 @@ class CronArchiveTest extends IntegrationTestCase
 
         $expectedSegments = array('actions>=2', 'actions>=4');
         $this->assertEquals($expectedSegments, array_values($cronarchive->segmentsToForce));
+    }
+
+    public function test_wasSegmentCreatedRecently()
+    {
+        Fixture::createWebsite('2014-12-12 00:01:02');
+        SegmentAPI::getInstance()->add('foo', 'actions>=1', 1, true, true);
+        $id = SegmentAPI::getInstance()->add('barb', 'actions>=2', 1, true, true);
+
+        $segments = new Model();
+        $segments->updateSegment($id, array('ts_created' => Date::now()->subHour(30)->getDatetime()));
+
+        $allSegments = $segments->getSegmentsToAutoArchive(1);
+
+        $cronarchive = new TestCronArchive(Fixture::getRootUrl() . 'tests/PHPUnit/proxy/index.php');
+        $this->assertTrue($cronarchive->wasSegmentCreatedRecently('actions>=1', $allSegments));
+
+        // created 30 hours ago...
+        $this->assertFalse($cronarchive->wasSegmentCreatedRecently('actions>=2', $allSegments));
+
+        // not configured segment
+        $this->assertFalse($cronarchive->wasSegmentCreatedRecently('actions>=999', $allSegments));
+    }
+
+    public function test_skipSegmentsToday()
+    {
+        \Piwik\Tests\Framework\Mock\FakeCliMulti::$specifiedResults = array(
+            '/method=API.get/' => serialize(array(array('nb_visits' => 1)))
+        );
+        
+        Fixture::createWebsite('2014-12-12 00:01:02');
+        SegmentAPI::getInstance()->add('foo', 'actions>=1', 1, true, true);
+        $id = SegmentAPI::getInstance()->add('barb', 'actions>=2', 1, true, true);
+
+        $segments = new Model();
+        $segments->updateSegment($id, array('ts_created' => Date::now()->subHour(30)->getDatetime()));
+
+        $logger = new FakeLogger();
+
+        $archiver = new CronArchive(null, $logger);
+        $archiver->skipSegmentsToday = true;
+        $archiver->shouldArchiveAllSites = true;
+        $archiver->shouldArchiveAllPeriodsSince = true;
+        $archiver->init();
+        $archiver->run();
+
+        $this->assertContains('Will skip segments archiving for today unless they were created recently', $logger->output);
+        $this->assertContains('Segment "actions>=1" was created recently and will therefore archive today', $logger->output);
+        $this->assertNotContains('Segment "actions>=2" was created recently', $logger->output);
     }
 
     public function test_output()
@@ -184,5 +230,10 @@ class TestCronArchive extends CronArchive
 
     protected function initPiwikHost($piwikUrl = false)
     {
+    }
+
+    public function wasSegmentCreatedRecently($definition, $allSegments)
+    {
+        return parent::wasSegmentCreatedRecently($definition, $allSegments);
     }
 }


### PR DESCRIPTION
Unless the segment was created recently (in the last 24 hours).

At first I had a different implementation only in `CronArchiver` and it worked but problem was that when it archives current week, month, year it would still archive today again. This is why a mixed implementation was needed.

It can be triggered using `core:archive --skip-segments-today`

@mattab could you have a look at this?