### PR TITLE
Change mysql column type for new installs for log_action.name and log_conversion.url

### DIFF
--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -154,7 +154,7 @@ class Mysql implements SchemaInterface
 
             'log_action'          => "CREATE TABLE {$prefixTables}log_action (
                                       idaction INTEGER(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-                                      name TEXT,
+                                      name VARCHAR(65000),
                                       hash INTEGER(10) UNSIGNED NOT NULL,
                                       type TINYINT UNSIGNED NULL,
                                       url_prefix TINYINT(2) NULL,
@@ -209,7 +209,7 @@ class Mysql implements SchemaInterface
                                       buster int unsigned NOT NULL,
                                       idorder varchar(100) default NULL,
                                       items SMALLINT UNSIGNED DEFAULT NULL,
-                                      url text NOT NULL,
+                                      url VARCHAR(65000) NOT NULL,
                                         PRIMARY KEY (idvisit, idgoal, buster),
                                         UNIQUE KEY unique_idsite_idorder (idsite, idorder),
                                         INDEX index_idsite_datetime ( idsite, server_time )

--- a/core/Updates/4.0.0-b1.php
+++ b/core/Updates/4.0.0-b1.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+/**
+ * Update for version 4.0.0-b1.
+ */
+class Updates_4_0_0_b1 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migration1 = $this->migration->db->changeColumnType('log_action', 'name', 'VARCHAR(65000)');
+        $migration2 = $this->migration->db->changeColumnType('log_conversion', 'url', 'VARCHAR(65000) NOT NULL');
+
+        return array(
+            $migration1,
+            $migration2,
+        );
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+}


### PR DESCRIPTION
from TEXT to VARCHAR
refs https://github.com/matomo-org/matomo/issues/14535

Already includes the update for Matomo 4.

This is part 1 for issue #14535 . The other PR needs to be created for Matomo 4 only as we can't change it for new installs but not for old installs: https://github.com/matomo-org/matomo/pull/14847

We're changing it for new installs already now as it saves us running an alter table on log_action later for heaps of installations. The less changes there will be later the better :) 