### PR TITLE
Makes flushSpools public available

### DIFF
--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -239,7 +239,7 @@ class ArchiveWriter
         return true;
     }
 
-    protected function flushSpools()
+    public function flushSpools()
     {
         $this->flushSpool('numeric');
         $this->flushSpool('blob');


### PR DESCRIPTION
Required for some plugins to add historical archives until #11974 is implemented