### PR TITLE
Fix user path was not working as it should (allow placing config file outside webroot)

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -8,7 +8,7 @@ use Piwik\Config;
 
 return array(
 
-    'path.root' => PIWIK_USER_PATH,
+    'path.root' => PIWIK_DOCUMENT_ROOT,
 
     'path.tmp' => function (ContainerInterface $c) {
         $root = $c->get('path.root');

--- a/core/Config.php
+++ b/core/Config.php
@@ -108,7 +108,7 @@ class Config
      */
     public static function getGlobalConfigPath()
     {
-        return PIWIK_USER_PATH . self::DEFAULT_GLOBAL_CONFIG_PATH;
+        return PIWIK_DOCUMENT_ROOT . self::DEFAULT_GLOBAL_CONFIG_PATH;
     }
 
     /**

--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -72,7 +72,7 @@ class ContainerFactory
         $builder->addDefinitions(new IniConfigDefinitionSource($this->settings));
 
         // Global config
-        $builder->addDefinitions(PIWIK_USER_PATH . '/config/global.php');
+        $builder->addDefinitions(PIWIK_DOCUMENT_ROOT . '/config/global.php');
 
         // Plugin configs
         $this->addPluginConfigs($builder);

--- a/core/Filechecks.php
+++ b/core/Filechecks.php
@@ -23,7 +23,7 @@ class Filechecks
         if (!is_writable(PIWIK_INCLUDE_PATH . '/') ||
             !is_writable(PIWIK_DOCUMENT_ROOT . '/index.php') ||
             !is_writable(PIWIK_INCLUDE_PATH . '/core') ||
-            !is_writable(PIWIK_USER_PATH . '/config/global.ini.php')
+            !is_writable(PIWIK_DOCUMENT_ROOT . '/config/global.ini.php')
         ) {
             return false;
         }
@@ -40,7 +40,9 @@ class Filechecks
     {
         $resultCheck = array();
         foreach ($directoriesToCheck as $directoryToCheck) {
-            if (!preg_match('/^' . preg_quote(PIWIK_USER_PATH, '/') . '/', $directoryToCheck)) {
+	        if (!preg_match('/^' . preg_quote(PIWIK_USER_PATH, '/') . '/', $directoryToCheck)
+	            && !preg_match('/^' . preg_quote(PIWIK_DOCUMENT_ROOT, '/') . '/', $directoryToCheck)
+	            && !preg_match('/^' . preg_quote(PIWIK_INCLUDE_PATH, '/') . '/', $directoryToCheck)) {
                 $directoryToCheck = PIWIK_USER_PATH . $directoryToCheck;
             }
 

--- a/js/tracker.php
+++ b/js/tracker.php
@@ -22,9 +22,19 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST'
  *
  * @see core/Piwik.php
  */
-define('PIWIK_INCLUDE_PATH', '..');
 define('PIWIK_DOCUMENT_ROOT', '..');
-define('PIWIK_USER_PATH', '..');
+
+if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
+    require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
+}
+
+if (!defined('PIWIK_INCLUDE_PATH')) {
+    define('PIWIK_INCLUDE_PATH', PIWIK_DOCUMENT_ROOT);
+}
+
+if (!defined('PIWIK_USER_PATH')) {
+    define('PIWIK_USER_PATH', PIWIK_DOCUMENT_ROOT);
+}
 
 require_once PIWIK_INCLUDE_PATH . '/libs/upgradephp/upgrade.php';
 

--- a/misc/cron/updatetoken.php
+++ b/misc/cron/updatetoken.php
@@ -15,12 +15,8 @@ use Piwik\Application\Environment;
 use Piwik\Tests\Framework\TestingEnvironmentManipulator;
 use Piwik\Tests\Framework\TestingEnvironmentVariables;
 
-if (!defined('PIWIK_INCLUDE_PATH')) {
-    define('PIWIK_INCLUDE_PATH', realpath(dirname(__FILE__) . "/../.."));
-}
-
-if (!defined('PIWIK_USER_PATH')) {
-    define('PIWIK_USER_PATH', PIWIK_INCLUDE_PATH);
+if (!defined('PIWIK_DOCUMENT_ROOT')) {
+    define('PIWIK_DOCUMENT_ROOT', realpath(dirname(__FILE__) . "/../.."));
 }
 
 define('PIWIK_ENABLE_DISPATCH', false);

--- a/misc/cron/updatetoken.php
+++ b/misc/cron/updatetoken.php
@@ -23,7 +23,7 @@ define('PIWIK_ENABLE_DISPATCH', false);
 define('PIWIK_ENABLE_ERROR_HANDLER', false);
 define('PIWIK_ENABLE_SESSION_START', false);
 
-require_once PIWIK_INCLUDE_PATH . "/index.php";
+require_once PIWIK_DOCUMENT_ROOT . "/index.php";
 
 if (!Common::isPhpCliMode()) {
     return;

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -298,11 +298,6 @@ class Updater
             $model->removeGoneFiles($extractedArchiveDirectory, PIWIK_DOCUMENT_ROOT);
         }
 
-        // Config files may be user (account) specific
-        if (PIWIK_INCLUDE_PATH !== PIWIK_USER_PATH) {
-            Filesystem::copyRecursive($extractedArchiveDirectory . '/config', PIWIK_USER_PATH . '/config');
-        }
-
         Filesystem::unlinkRecursive($extractedArchiveDirectory, true);
 
         Filesystem::clearPhpCaches();

--- a/tests/PHPUnit/Integration/AssetManager/UIAssetMinifierTest.php
+++ b/tests/PHPUnit/Integration/AssetManager/UIAssetMinifierTest.php
@@ -45,7 +45,7 @@ class UIAssetMinifierTest extends \PHPUnit_Framework_TestCase
      */
     public function test_isMinifiedJs($scriptFileName, $isMinified)
     {
-        $scriptFile = new OnDiskUIAsset(PIWIK_USER_PATH, $scriptFileName);
+        $scriptFile = new OnDiskUIAsset(PIWIK_DOCUMENT_ROOT, $scriptFileName);
 
         $this->assertEquals(
             $isMinified,

--- a/tests/PHPUnit/Integration/AssetManagerTest.php
+++ b/tests/PHPUnit/Integration/AssetManagerTest.php
@@ -336,7 +336,7 @@ class AssetManagerTest extends IntegrationTestCase
      */
     private function getExpectedMergedJs($filename)
     {
-        $expectedMergeResult = new OnDiskUIAsset(PIWIK_USER_PATH, self::ASSET_MANAGER_TEST_DIR .'scripts/' . $filename);
+        $expectedMergeResult = new OnDiskUIAsset(PIWIK_DOCUMENT_ROOT, self::ASSET_MANAGER_TEST_DIR .'scripts/' . $filename);
 
         $expectedContent = $expectedMergeResult->getContent();
 
@@ -357,7 +357,7 @@ class AssetManagerTest extends IntegrationTestCase
      */
     private function getExpectedMergedStylesheet()
     {
-        $expectedMergeResult = new OnDiskUIAsset(PIWIK_USER_PATH, self::ASSET_MANAGER_TEST_DIR .'stylesheets/ExpectedMergeResult.css');
+        $expectedMergeResult = new OnDiskUIAsset(PIWIK_DOCUMENT_ROOT, self::ASSET_MANAGER_TEST_DIR .'stylesheets/ExpectedMergeResult.css');
 
         $expectedContent = $expectedMergeResult->getContent();
 

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -41,7 +41,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     public function testFetchApiLatestVersion()
     {
-        $destinationPath = PIWIK_USER_PATH . '/tmp/latest/LATEST';
+        $destinationPath = PIWIK_DOCUMENT_ROOT . '/tmp/latest/LATEST';
         Http::fetchRemoteFile(Fixture::getRootUrl(), $destinationPath, 3);
         $this->assertFileExists($destinationPath);
         $this->assertGreaterThan(0, filesize($destinationPath));
@@ -49,7 +49,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
 
     public function testFetchLatestZip()
     {
-        $destinationPath = PIWIK_USER_PATH . '/tmp/latest/latest.zip';
+        $destinationPath = PIWIK_DOCUMENT_ROOT . '/tmp/latest/latest.zip';
         Http::fetchRemoteFile(Fixture::getRootUrl() . 'tests/PHPUnit/Integration/Http/fixture.zip', $destinationPath, 3, 30);
         $this->assertFileExists($destinationPath);
         $this->assertGreaterThan(0, filesize($destinationPath));


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/13037

As user described in the issue the user path behaviour didn't quite make sense. For example in an update we copied over `config/global.php` and `config/global.ini.php` to the user path. This may fail though due to write permission and is generally not needed cause the only files it should load from there is `config/config.php` and `config/config.ini.php` and `config/common.config.ini.php`. 

This makes things a lot simpler and now there is an easy way to put the config file outside Matomo webroot.

Should probably also create an FAQ for this afterwards.