### PR TITLE
Stop urlencoding dashboard names before sending to API

### DIFF
--- a/plugins/Dashboard/javascripts/dashboard.js
+++ b/plugins/Dashboard/javascripts/dashboard.js
@@ -21,7 +21,7 @@ function createDashboard() {
             format: 'json'
         }, 'get');
         ajaxRequest.addParams({
-            dashboardName: encodeURIComponent(dashboardName),
+            dashboardName: dashboardName,
             addDefaultWidgets: addDefaultWidgets,
             login: piwik.userLogin
         }, 'post');


### PR DESCRIPTION
When sent as plain text, the dashboard names are passed through `htmlspecialchars` before they are written to the DB, so they can still be used in their raw form in the UI.
Fixes #14820 
