### PR TITLE
fix magic quotes deprecation warning

### DIFF
--- a/libs/HTML/QuickForm2.php
+++ b/libs/HTML/QuickForm2.php
@@ -106,7 +106,7 @@ class HTML_QuickForm2 extends HTML_QuickForm2_Container
                               'post' == $method && (!empty($_POST) || !empty($_FILES))))
         {
             $this->addDataSource(new HTML_QuickForm2_DataSource_SuperGlobal(
-                $method, get_magic_quotes_gpc()
+                $method, False
             ));
         }
         if ($trackSubmit) {

--- a/tests/javascript/matomo.php
+++ b/tests/javascript/matomo.php
@@ -106,7 +106,7 @@ if (isset($_GET['requests'])) {
 
         $input    = file_get_contents("php://input");
         $requests = @json_decode($input, true);
-        $data     = json_decode(get_magic_quotes_gpc() ? stripslashes($_REQUEST['data']) : $_REQUEST['data'], true);
+        $data     = json_decode($_REQUEST['data'], true);
 
         if (!empty($requests) && isPost()) {
             $query = true;


### PR DESCRIPTION
reported in https://forum.matomo.org/t/quickform2-php-109-deprecated-function-get-magic-quotes-gpc-is-deprecated/34121
related to https://github.com/matomo-org/matomo/issues/6339
related to https://github.com/matomo-org/matomo/issues/14821 (deprecation warning is new in 7.4)

`get_magic_quotes_gpc()` seems to return if magic quotes are enabled. As it has been removed with PHP 5.4 it can be simply replaced with a hardcoded `False`.