### PR TITLE
Allow custom DB adapter in tracker mode

### DIFF
--- a/core/Tracker/Db.php
+++ b/core/Tracker/Db.php
@@ -261,18 +261,13 @@ abstract class Db
          */
         Piwik::postEvent('Tracker.getDatabaseConfig', array(&$configDb));
 
-        switch ($configDb['adapter']) {
-            case 'PDO\MYSQL':
-            case 'PDO_MYSQL': // old format pre Piwik 2
-                require_once PIWIK_INCLUDE_PATH . '/core/Tracker/Db/Pdo/Mysql.php';
-                return new Mysql($configDb);
+        $className = 'Piwik\Tracker\Db\\' . str_replace(' ', '\\', ucwords(str_replace(array('_', '\\'), ' ', strtolower($configDb['adapter']))));
 
-            case 'MYSQLI':
-                require_once PIWIK_INCLUDE_PATH . '/core/Tracker/Db/Mysqli.php';
-                return new Mysqli($configDb);
+        if (!class_exists($className)) {
+           throw new Exception('Unsupported database adapter ' . $configDb['adapter']);
         }
 
-        throw new Exception('Unsupported database adapter ' . $configDb['adapter']);
+        return new $className($configDb);
     }
 
     public static function connectPiwikTrackerDb()


### PR DESCRIPTION
In regular mode we already use the above logic see https://github.com/matomo-org/matomo/blob/3.x-dev/core/Db/Adapter.php#L68-L74

This means in regular mode any plugin can already define a custom adapter and configure it. This was not working in tracking mode where the two PDO and MySQLI modes were hard coded. This was likely because back in the days we weren't using auto loading in tracker mode which we are doing now already for many years.