### PR TITLE
Use "if not exists" when trying to create table

### DIFF
--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -450,7 +450,7 @@ class Mysql implements SchemaInterface
      */
     public function createTable($nameWithoutPrefix, $createDefinition)
     {
-        $statement = sprintf("CREATE TABLE `%s` ( %s ) ENGINE=%s DEFAULT CHARSET=utf8 ;",
+        $statement = sprintf("CREATE TABLE IF NOT EXISTS `%s` ( %s ) ENGINE=%s DEFAULT CHARSET=utf8 ;",
                              Common::prefixTable($nameWithoutPrefix),
                              $createDefinition,
                              $this->getTableEngine());


### PR DESCRIPTION
This can avoid some error logs depending on the used database adapter etc. In theory we can then remove catching the error a few lines below but should be fine to keep it as well.

If not exists should be safe to use, was even supported in old versions: http://ftp.nchu.edu.tw/MySQL/doc/refman/4.1/en/create-table.html

Not sure why it wasn't used right away. A comment in the code refers to https://github.com/piwik/piwik/issues/153 but looks like that ID wasn't 100% correctly migrated from the old trac. In any way, using if not exists should be fine... 