### PR TITLE
Support alternative matomo bootstrap file

### DIFF
--- a/console
+++ b/console
@@ -4,12 +4,10 @@ if (!defined('PIWIK_DOCUMENT_ROOT')) {
     define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__) == '/' ? '' : dirname(__FILE__));
 }
 
-if (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
-	require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
-}
-
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
+} elseif (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
+    require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
 }
 
 if (!defined('PIWIK_INCLUDE_PATH')) {

--- a/console
+++ b/console
@@ -4,6 +4,10 @@ if (!defined('PIWIK_DOCUMENT_ROOT')) {
     define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__) == '/' ? '' : dirname(__FILE__));
 }
 
+if (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
+	require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
+}
+
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
 }

--- a/index.php
+++ b/index.php
@@ -11,11 +11,10 @@
 if (!defined('PIWIK_DOCUMENT_ROOT')) {
     define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__) == '/' ? '' : dirname(__FILE__));
 }
-if (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
-	require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
-}
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
+} elseif (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
+    require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
 }
 if (!defined('PIWIK_INCLUDE_PATH')) {
     define('PIWIK_INCLUDE_PATH', PIWIK_DOCUMENT_ROOT);

--- a/index.php
+++ b/index.php
@@ -11,6 +11,9 @@
 if (!defined('PIWIK_DOCUMENT_ROOT')) {
     define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__) == '/' ? '' : dirname(__FILE__));
 }
+if (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
+	require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
+}
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
 }

--- a/piwik.php
+++ b/piwik.php
@@ -22,11 +22,10 @@ use Piwik\API\CORSHandler;
 if (!defined('PIWIK_DOCUMENT_ROOT')) {
     define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__) == '/' ? '' : dirname(__FILE__));
 }
-if (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
-	require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
-}
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
+} elseif (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
+    require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
 }
 if (!defined('PIWIK_INCLUDE_PATH')) {
     define('PIWIK_INCLUDE_PATH', PIWIK_DOCUMENT_ROOT);

--- a/piwik.php
+++ b/piwik.php
@@ -22,6 +22,9 @@ use Piwik\API\CORSHandler;
 if (!defined('PIWIK_DOCUMENT_ROOT')) {
     define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__) == '/' ? '' : dirname(__FILE__));
 }
+if (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
+	require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
+}
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
 }


### PR DESCRIPTION
Currently, we allow to put a `bootstrap.php` file into the root directory of Matomo and then load it as first thing. This allows for example the configuration of a few things that are needed to be set BEFORE we load any config. Such as

* PIWIK_USER_PATH constant
* Usage of config cache
* PIWIK_ENABLE_ERROR_HANDLER
* PIWIK_PRINT_ERROR_BACKTRACE
* $GLOBALS['PIWIK_TRACKER_DEBUG']
* etc.

This works nicely. The problem is when you would like to use Matomo for example as a submodule, or install it through composer, etc... then having a file in Matomo directory doesn't do the trick and you need to have the bootstrap file outside the Matomo directory. 

That's why I'm now looking for `../matomo_bootstrap.php`. It's not ideal cause what if the next person wants to have it at `../../../matomo_bootstrap.php` etc. Ideally there be an environment variable. However, the project I'm working on I cannot make use of environment variables. 

I will try to workaround it by putting all files into a new endpoint like `my_index.php` which then includes `matomo_bootstrap.php` and `matomo/index.php` for example but likely this won't work since Matomo will then not know the correct paths anymore... 

Also we cannot look for `../bootstrap.php` btw since someone might actually use that file for a completely different project and we don't want to load any file by accident that does not belong to Matomo.

Update: I couldn't find a workaround for this because otherwise Matomo gets completely confused with paths etc when embedding Matomo eg in a file `index.php` by doing like `matomo/index.php` and as I can't use environment variables or anything else will need this solution. Also I noticed that with such a solution we risk that Matomo thinks it is uninstalled and this be a security issue. An attacker could install Matomo using the attacker's DB credentials and this way get super user access which allows to install plugins etc. 