### PR TITLE
revert readme badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Matomo (formerly Piwik) - matomo.org
 
-[![Latest Stable Version](https://poser.pugx.org/matomo-org/matomo/v/stable)](https://matomo.org/download/)
-[![Latest Unstable Version](https://poser.pugx.org/matomo-org/matomo/v/unstable)](https://packagist.org/packages/piwik/piwik)
-[![License](https://poser.pugx.org/matomo-org/matomo/license)](https://matomo.org/free-software/)
+[![Latest Stable Version](https://poser.pugx.org/piwik/piwik/v/stable)](https://matomo.org/download/)
+[![Latest Unstable Version](https://poser.pugx.org/piwik/piwik/v/unstable)](https://packagist.org/packages/piwik/piwik)
+[![License](https://poser.pugx.org/piwik/piwik/license)](https://matomo.org/free-software/)
 
 ## Code Status
 


### PR DESCRIPTION
related to https://github.com/matomo-org/matomo/pull/14627
As this service uses packagist where the name is still `piwik/piwik`, this can only be changed after Matomo 4