### PR TITLE
If session was already started, do not start it again

### DIFF
--- a/core/Session.php
+++ b/core/Session.php
@@ -174,7 +174,11 @@ class Session extends Zend_Session
 
     public static function close()
     {
-        parent::writeClose();
+        if (self::isSessionStarted()) {
+            // only write/close session if the session was actually started by us
+            // otherwise we will set the session values to base64 encoded and whoever the session started might not expect the values in that way
+            parent::writeClose();
+        }
     }
 
     public static function isSessionStarted()

--- a/core/Session.php
+++ b/core/Session.php
@@ -50,6 +50,7 @@ class Session extends Zend_Session
         if (headers_sent()
             || self::$sessionStarted
             || (defined('PIWIK_ENABLE_SESSION_START') && !PIWIK_ENABLE_SESSION_START)
+            || session_status() == PHP_SESSION_ACTIVE
         ) {
             return;
         }

--- a/core/bootstrap.php
+++ b/core/bootstrap.php
@@ -29,7 +29,9 @@ if (!defined('PIWIK_VENDOR_PATH')) {
 // NOTE: the code above must be PHP 4 compatible
 require_once PIWIK_INCLUDE_PATH . '/core/testMinimumPhpVersion.php';
 
-session_cache_limiter('nocache');
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_cache_limiter('nocache');
+}
 
 define('PIWIK_DEFAULT_TIMEZONE', @date_default_timezone_get());
 @date_default_timezone_set('UTC');

--- a/tests/PHPUnit/Integration/SessionTest.php
+++ b/tests/PHPUnit/Integration/SessionTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration;
+
+use Piwik\Http;
+use Piwik\Piwik;
+use Piwik\Session;
+use Piwik\Tests\Framework\Fixture;
+
+/**
+ * @group Core
+ * @group Session
+ * @group SessionTest
+ */
+class SessionTest extends \PHPUnit_Framework_TestCase
+{
+	public function test_session_should_not_be_started_if_it_was_already_started()
+	{
+        $url = Fixture::getRootUrl() . '/tests/resources/sessionStarter.php';
+	    $result = Http::sendHttpRequest($url, 5);
+	    $this->assertSame('ok', trim($result));
+	}
+
+}

--- a/tests/resources/sessionStarter.php
+++ b/tests/resources/sessionStarter.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This php file is used to unit test Piwik::serverStaticFile()
+ * To make a comprehensive test suit for Piwik::serverStaticFile() (ie. being able to test combinations of request
+ * headers, being able to test response headers and so on) we need to simulate static file requests in a controlled
+ * environment
+ * The php code which simulates requests using Piwik::serverStaticFile() is provided in the same file (ie. this one)
+ * as the unit testing code for Piwik::serverStaticFile()
+ * This decision has a structural impact on the usual unit test file structure
+ * serverStaticFile.test.php has been created to avoid making too many modifications to /tests/core/Piwik.test.php
+ */
+use Piwik\FrontController;
+session_start(); // matomo should not fail if session was started by someone else
+define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__).'/../../');
+if(file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
+    require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
+}
+if (!defined('PIWIK_INCLUDE_PATH')) {
+    define('PIWIK_INCLUDE_PATH', PIWIK_DOCUMENT_ROOT);
+}
+
+require_once PIWIK_INCLUDE_PATH . '/core/bootstrap.php';
+
+$environment = new \Piwik\Application\Environment(null);
+try {
+    $environment->init();
+} catch(\Piwik\Exception\NotYetInstalledException $e) {
+    die($e->getMessage());
+}
+FrontController::getInstance()->init();
+
+echo 'ok';


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/12963
refs https://forum.matomo.org/t/an-error-occurred/32500

A session may be already started by some other platform when Matomo is embedded like this: https://developer.matomo.org/guides/querying-the-reporting-api