### PR TITLE
Sparkline: Fix value sanitizing 

### DIFF
--- a/core/Visualization/Sparkline.php
+++ b/core/Visualization/Sparkline.php
@@ -53,33 +53,29 @@ class Sparkline implements ViewInterface
 
         $sparkline = new \Davaxi\Sparkline();
 
-        $seconds = Piwik::translate('Intl_NSecondsShort');
-        $percent = Piwik::translate('Intl_NumberSymbolPercent');
         $thousandSeparator = Piwik::translate('Intl_NumberSymbolGroup');
         $decimalSeparator = Piwik::translate('Intl_NumberSymbolDecimal');
-        $toRemove = array('%', $percent, str_replace('%s', '', $seconds));
+
         $values = [];
+        $hasFloat = false;
         foreach ($this->values as $value) {
-            // 50% and 50s should be plotted as 50
-            $value = str_replace($toRemove, '', $value);
+
             // replace localized decimal separator
             $value = str_replace($thousandSeparator, '', $value);
             $value = str_replace($decimalSeparator, '.', $value);
-            // remove spaces and tabs 
-            $value = trim($value);
-            if ($value == '') {
+
+            // sanitize value
+            $value = filter_var($value, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION | FILTER_FLAG_ALLOW_SCIENTIFIC);
+
+            if (empty($value) || !is_numeric($value)) {
                 $value = 0;
             }
-            $values[] = $value;
-        }
 
-        $hasFloat = false;
-        foreach ($values as $value) {
-            if (is_numeric($value)
-                && is_float($value + 0) // coerce to int/float type before checking
+            $values[] = $value;
+
+            if (is_float($value + 0) // coerce to int/float type before checking
             ) {
                 $hasFloat = true;
-                break;
             }
         }
 


### PR DESCRIPTION
My last pull request (https://github.com/matomo-org/matomo/pull/14901) tried to fix the problem of values with spaces at the end in the Sparkline class (making the values "non-numeric").

While doing some more debugging I also encountered "non-breaking" spaces in some values, which the trim() function (my previous fix) does not remove.

These special spaces are hard to remove, because they sometimes are encoded in ISO/ASCII (hex 0xA0) as well as UTF-8 (hex 0xC2 0xA0). Without making use of the mb_* functions it will be hard to remove all of them while not damaging utf-8 strings.

This PR tries to solve the problem by making use of filter_var() to sanitize the value and remove all non-numeric characters.

See also https://github.com/matomo-org/matomo/issues/14662#issuecomment-534505048