### PR TITLE
Fix error session already started

### DIFF
--- a/libs/Zend/Session.php
+++ b/libs/Zend/Session.php
@@ -424,6 +424,13 @@ class Zend_Session extends Zend_Session_Abstract
             return; // already started
         }
 
+        if (session_status() === PHP_SESSION_ACTIVE) {
+	        parent::$_readable = true;
+	        parent::$_writable = true;
+	        self::$_sessionStarted = true;
+	        return;
+        }
+
         // make sure our default options (at the least) have been set
         if (!self::$_defaultOptionsSet) {
             self::setOptions(is_array($options) ? $options : array());

--- a/tests/resources/sessionStarter.php
+++ b/tests/resources/sessionStarter.php
@@ -10,6 +10,8 @@
  * serverStaticFile.test.php has been created to avoid making too many modifications to /tests/core/Piwik.test.php
  */
 use Piwik\FrontController;
+use Piwik\Nonce;
+
 session_start(); // matomo should not fail if session was started by someone else
 define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__).'/../../');
 if(file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
@@ -28,5 +30,7 @@ try {
     die($e->getMessage());
 }
 FrontController::getInstance()->init();
+
+Nonce::getNonce('test');
 
 echo 'ok';


### PR DESCRIPTION
Got this error when going on eg  `index.php?module=PrivacyManager&action=privacySettings&idSite=1&period=week&date=2019-09-20` and a session was started by another tool. That page uses NONCE which then uses SessionNamespace which then wants to start the session even though it was already started.