### PR TITLE
fix for array value handling in sumRowArray()

### DIFF
--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -602,6 +602,10 @@ class Row extends \ArrayObject
      */
     protected function sumRowArray($thisColumnValue, $columnToSumValue, $columnName = null)
     {
+        if (is_array($thisColumnValue) && !is_array($columnToSumValue)) {
+            $columnToSumValue = array($columnToSumValue);
+        }
+
         if (is_numeric($columnToSumValue)) {
             if ($thisColumnValue === false) {
                 $thisColumnValue = 0;
@@ -623,7 +627,13 @@ class Row extends \ArrayObject
         }
 
         if (is_array($columnToSumValue)) {
-            $newValue = $thisColumnValue;
+            
+            if (is_array($thisColumnValue)) {
+                $newValue = $thisColumnValue;
+            } else {
+                $newValue = array($thisColumnValue);
+            }
+
             foreach ($columnToSumValue as $arrayIndex => $arrayValue) {
                 if (!isset($newValue[$arrayIndex])) {
                     $newValue[$arrayIndex] = false;


### PR DESCRIPTION
Since some time the archive job crashes in my setup with 

> Trying to sum unsupported operands for column nb_conversions_stddev_samp in row with label = 35: NULL + string - in plugin AbTesting

What I found out after some debuging:

The AbTesting plugin causes sumRowArray($thisColumnValue, $columnToSumValue) to be called

a) with a float value in $thisColumnValue and an array in $columnToSumValue
In this case the `if (!isset($newValue[$arrayIndex])) {` check is triggered, however, because $newValue is a float, PHP will not convert $newValue to an array, and the $newValue[$arrayIndex] will pass a value of "null" to the recursive sumRowArray() call. This will trigger the above exception.

Because the documentation of sumRowArray() allows $columnToSumValue to be an array, this is most likely a bug.

b) with an array  $thisColumnValue and a float value in $columnToSumValue
This case is not allowed by the function documentation, but maybe it makes sense to handle this case, too?

These changes should be reviewed with care, as I do not yet fully understand why the AbTesting plugin is causing these problems.



