### PR TITLE
HTTP method needs to return true when a destination path is given

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -244,16 +244,19 @@ class Http
 		     * described below
 		     * @ignore
 		     */
-		    Piwik::postEvent('Http.sendHttpRequest.end', array($aUrl, $httpEventParams, &$response, &$status, &$headers));
-
-		    if ($getExtendedInfo) {
-			    return array(
-				    'status'  => $status,
-				    'headers' => $headers,
-				    'data'    => $response
-			    );
+                    Piwik::postEvent('Http.sendHttpRequest.end', array($aUrl, $httpEventParams, &$response, &$status, &$headers));
+ 
+                    if ($destinationPath && file_exists($destinationPath)) {
+                        return true;
+                    }
+                    if ($getExtendedInfo) {
+                        return array(
+                            'status'  => $status,
+                            'headers' => $headers,
+                            'data'    => $response
+                        );
 		    } else {
-			    return trim($response);
+                        return trim($response);
 		    }
 	    }
 


### PR DESCRIPTION
In https://github.com/matomo-org/matomo/pull/14877 I added a new feature so plugins can hook into HTTP. Now noticed the GeoIP download was not working because it didn't return true when the response was loaded into a file.