### PR TITLE
Catch error if tx_isolation is not available

### DIFF
--- a/core/Db/TransactionLevel.php
+++ b/core/Db/TransactionLevel.php
@@ -40,7 +40,16 @@ class TransactionLevel
 
     public function setUncommitted()
     {
-        $backup = $this->db->fetchOne('SELECT @@TX_ISOLATION');
+        try {
+            $backup = $this->db->fetchOne('SELECT @@TX_ISOLATION');
+        } catch (\Exception $e) {
+            try {
+                $backup = $this->db->fetchOne('SELECT @@transaction_isolation');
+            } catch (\Exception $e) {
+                return false;
+            }
+        }
+
         try {
             $this->db->query('SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED');
             $this->statusBackup = $backup;


### PR DESCRIPTION
follow up from https://github.com/matomo-org/matomo/pull/14920/files

![image](https://user-images.githubusercontent.com/273120/65925921-3688e000-e44f-11e9-8e60-8c982a262205.png)


Starting from MySQL 5.7.20 tx_isolation is deprecated and starting from MySQL 8 the variable was completely removed.


fyi @diosmosis 