### PR TITLE
When checking if directory is writable, do not prepend user path or include path

### DIFF
--- a/core/Filechecks.php
+++ b/core/Filechecks.php
@@ -40,12 +40,6 @@ class Filechecks
     {
         $resultCheck = array();
         foreach ($directoriesToCheck as $directoryToCheck) {
-	        if (!preg_match('/^' . preg_quote(PIWIK_USER_PATH, '/') . '/', $directoryToCheck)
-	            && !preg_match('/^' . preg_quote(PIWIK_DOCUMENT_ROOT, '/') . '/', $directoryToCheck)
-	            && !preg_match('/^' . preg_quote(PIWIK_INCLUDE_PATH, '/') . '/', $directoryToCheck)) {
-                $directoryToCheck = PIWIK_USER_PATH . $directoryToCheck;
-            }
-
             Filesystem::mkdir($directoryToCheck);
 
             $directory = Filesystem::realpath($directoryToCheck);


### PR DESCRIPTION
This fixes eg when `path.tmp` in DI is pointing to a different path outside the user path, and outside the document root / include path.

I checked all usages call it with absolute paths anyway.