### PR TITLE
Removed closing PHP tag due to PSR-2 definition

### DIFF
--- a/plugins/API/config/config.php
+++ b/plugins/API/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/API/config/tracker.php
+++ b/plugins/API/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Actions/config/config.php
+++ b/plugins/Actions/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Actions/config/tracker.php
+++ b/plugins/Actions/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Annotations/config/config.php
+++ b/plugins/Annotations/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Annotations/config/tracker.php
+++ b/plugins/Annotations/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/BulkTracking/config/config.php
+++ b/plugins/BulkTracking/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/BulkTracking/config/tracker.php
+++ b/plugins/BulkTracking/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Contents/config/config.php
+++ b/plugins/Contents/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Contents/config/tracker.php
+++ b/plugins/Contents/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/CoreAdminHome/config/config.php
+++ b/plugins/CoreAdminHome/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/CoreAdminHome/config/tracker.php
+++ b/plugins/CoreAdminHome/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/CoreConsole/config/config.php
+++ b/plugins/CoreConsole/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/CoreConsole/config/tracker.php
+++ b/plugins/CoreConsole/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/CoreHome/config/tracker.php
+++ b/plugins/CoreHome/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/CorePluginsAdmin/config/config.php
+++ b/plugins/CorePluginsAdmin/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/CorePluginsAdmin/config/tracker.php
+++ b/plugins/CorePluginsAdmin/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/CoreUpdater/config/tracker.php
+++ b/plugins/CoreUpdater/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/CoreVisualizations/config/config.php
+++ b/plugins/CoreVisualizations/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/CoreVisualizations/config/tracker.php
+++ b/plugins/CoreVisualizations/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/CustomPiwikJs/config/tracker.php
+++ b/plugins/CustomPiwikJs/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/CustomVariables/config/tracker.php
+++ b/plugins/CustomVariables/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/DBStats/config/config.php
+++ b/plugins/DBStats/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/DBStats/config/tracker.php
+++ b/plugins/DBStats/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Dashboard/config/config.php
+++ b/plugins/Dashboard/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Dashboard/config/tracker.php
+++ b/plugins/Dashboard/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/DevicePlugins/config/config.php
+++ b/plugins/DevicePlugins/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/DevicePlugins/config/tracker.php
+++ b/plugins/DevicePlugins/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/DevicesDetection/config/config.php
+++ b/plugins/DevicesDetection/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/DevicesDetection/config/tracker.php
+++ b/plugins/DevicesDetection/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Diagnostics/config/tracker.php
+++ b/plugins/Diagnostics/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Ecommerce/config/config.php
+++ b/plugins/Ecommerce/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Ecommerce/config/tracker.php
+++ b/plugins/Ecommerce/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Events/config/config.php
+++ b/plugins/Events/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Events/config/tracker.php
+++ b/plugins/Events/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExampleAPI/config/config.php
+++ b/plugins/ExampleAPI/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExampleAPI/config/tracker.php
+++ b/plugins/ExampleAPI/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExampleCommand/config/config.php
+++ b/plugins/ExampleCommand/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExampleCommand/config/tracker.php
+++ b/plugins/ExampleCommand/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExampleLogTables/config/config.php
+++ b/plugins/ExampleLogTables/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExampleLogTables/config/tracker.php
+++ b/plugins/ExampleLogTables/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExamplePlugin/config/config.php
+++ b/plugins/ExamplePlugin/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExamplePlugin/config/tracker.php
+++ b/plugins/ExamplePlugin/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExampleReport/config/config.php
+++ b/plugins/ExampleReport/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExampleReport/config/tracker.php
+++ b/plugins/ExampleReport/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExampleSettingsPlugin/config/config.php
+++ b/plugins/ExampleSettingsPlugin/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExampleSettingsPlugin/config/tracker.php
+++ b/plugins/ExampleSettingsPlugin/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExampleTheme/config/config.php
+++ b/plugins/ExampleTheme/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExampleTheme/config/tracker.php
+++ b/plugins/ExampleTheme/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExampleTracker/config/config.php
+++ b/plugins/ExampleTracker/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExampleTracker/config/tracker.php
+++ b/plugins/ExampleTracker/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExampleUI/config/config.php
+++ b/plugins/ExampleUI/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExampleUI/config/tracker.php
+++ b/plugins/ExampleUI/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ExampleVisualization/config/config.php
+++ b/plugins/ExampleVisualization/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ExampleVisualization/config/tracker.php
+++ b/plugins/ExampleVisualization/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Feedback/config/tracker.php
+++ b/plugins/Feedback/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/GeoIp2/config/tracker.php
+++ b/plugins/GeoIp2/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Goals/config/config.php
+++ b/plugins/Goals/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Goals/config/tracker.php
+++ b/plugins/Goals/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Heartbeat/config/config.php
+++ b/plugins/Heartbeat/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Heartbeat/config/tracker.php
+++ b/plugins/Heartbeat/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ImageGraph/config/config.php
+++ b/plugins/ImageGraph/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ImageGraph/config/tracker.php
+++ b/plugins/ImageGraph/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Insights/config/config.php
+++ b/plugins/Insights/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Insights/config/tracker.php
+++ b/plugins/Insights/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Installation/config/config.php
+++ b/plugins/Installation/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Installation/config/tracker.php
+++ b/plugins/Installation/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Intl/config/tracker.php
+++ b/plugins/Intl/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/IntranetMeasurable/config/config.php
+++ b/plugins/IntranetMeasurable/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/IntranetMeasurable/config/tracker.php
+++ b/plugins/IntranetMeasurable/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/LanguagesManager/config/config.php
+++ b/plugins/LanguagesManager/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/LanguagesManager/config/tracker.php
+++ b/plugins/LanguagesManager/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Live/config/tracker.php
+++ b/plugins/Live/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Login/config/tracker.php
+++ b/plugins/Login/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Marketplace/config/tracker.php
+++ b/plugins/Marketplace/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/MobileAppMeasurable/config/config.php
+++ b/plugins/MobileAppMeasurable/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/MobileAppMeasurable/config/tracker.php
+++ b/plugins/MobileAppMeasurable/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/MobileMessaging/config/config.php
+++ b/plugins/MobileMessaging/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/MobileMessaging/config/tracker.php
+++ b/plugins/MobileMessaging/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Morpheus/config/config.php
+++ b/plugins/Morpheus/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Morpheus/config/tracker.php
+++ b/plugins/Morpheus/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/MultiSites/config/config.php
+++ b/plugins/MultiSites/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/MultiSites/config/tracker.php
+++ b/plugins/MultiSites/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Overlay/config/config.php
+++ b/plugins/Overlay/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Overlay/config/tracker.php
+++ b/plugins/Overlay/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/PrivacyManager/config/config.php
+++ b/plugins/PrivacyManager/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/PrivacyManager/config/tracker.php
+++ b/plugins/PrivacyManager/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ProfessionalServices/config/config.php
+++ b/plugins/ProfessionalServices/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/ProfessionalServices/config/tracker.php
+++ b/plugins/ProfessionalServices/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Provider/config/config.php
+++ b/plugins/Provider/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Provider/config/tracker.php
+++ b/plugins/Provider/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Proxy/config/config.php
+++ b/plugins/Proxy/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Proxy/config/tracker.php
+++ b/plugins/Proxy/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Referrers/config/config.php
+++ b/plugins/Referrers/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Referrers/config/tracker.php
+++ b/plugins/Referrers/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Resolution/config/config.php
+++ b/plugins/Resolution/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Resolution/config/tracker.php
+++ b/plugins/Resolution/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/RssWidget/config/config.php
+++ b/plugins/RssWidget/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/RssWidget/config/tracker.php
+++ b/plugins/RssWidget/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/SEO/config/config.php
+++ b/plugins/SEO/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/SEO/config/tracker.php
+++ b/plugins/SEO/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/ScheduledReports/config/tracker.php
+++ b/plugins/ScheduledReports/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/SegmentEditor/config/tracker.php
+++ b/plugins/SegmentEditor/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/SitesManager/config/config.php
+++ b/plugins/SitesManager/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/SitesManager/config/tracker.php
+++ b/plugins/SitesManager/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/TestRunner/config/config.php
+++ b/plugins/TestRunner/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/TestRunner/config/tracker.php
+++ b/plugins/TestRunner/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Tour/config/config.php
+++ b/plugins/Tour/config/config.php
@@ -1,3 +1,3 @@
 <?php
 return array();
-?> 
+

--- a/plugins/Tour/config/tracker.php
+++ b/plugins/Tour/config/tracker.php
@@ -1,3 +1,3 @@
 <?php
 return array();
-?> 
+

--- a/plugins/Transitions/config/config.php
+++ b/plugins/Transitions/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Transitions/config/tracker.php
+++ b/plugins/Transitions/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/TwoFactorAuth/config/config.php
+++ b/plugins/TwoFactorAuth/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/TwoFactorAuth/config/tracker.php
+++ b/plugins/TwoFactorAuth/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/UserCountry/config/tracker.php
+++ b/plugins/UserCountry/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/UserCountryMap/config/config.php
+++ b/plugins/UserCountryMap/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/UserCountryMap/config/tracker.php
+++ b/plugins/UserCountryMap/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/UserId/config/config.php
+++ b/plugins/UserId/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/UserId/config/tracker.php
+++ b/plugins/UserId/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/UserLanguage/config/config.php
+++ b/plugins/UserLanguage/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/UserLanguage/config/tracker.php
+++ b/plugins/UserLanguage/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/UsersManager/config/config.php
+++ b/plugins/UsersManager/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/UsersManager/config/tracker.php
+++ b/plugins/UsersManager/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/VisitFrequency/config/config.php
+++ b/plugins/VisitFrequency/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/VisitFrequency/config/tracker.php
+++ b/plugins/VisitFrequency/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/VisitTime/config/config.php
+++ b/plugins/VisitTime/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/VisitTime/config/tracker.php
+++ b/plugins/VisitTime/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/VisitorInterest/config/config.php
+++ b/plugins/VisitorInterest/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/VisitorInterest/config/tracker.php
+++ b/plugins/VisitorInterest/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/VisitsSummary/config/config.php
+++ b/plugins/VisitsSummary/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/VisitsSummary/config/tracker.php
+++ b/plugins/VisitsSummary/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/WebsiteMeasurable/config/config.php
+++ b/plugins/WebsiteMeasurable/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/WebsiteMeasurable/config/tracker.php
+++ b/plugins/WebsiteMeasurable/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>

--- a/plugins/Widgetize/config/config.php
+++ b/plugins/Widgetize/config/config.php
@@ -1,3 +1,2 @@
 <?php
 return array();
-?>

--- a/plugins/Widgetize/config/tracker.php
+++ b/plugins/Widgetize/config/tracker.php
@@ -1,3 +1,2 @@
 <?php 
 return array(); 
-?>


### PR DESCRIPTION
While reading your Matomos contributing guide, I saw, that Matomo is sticking to PSR-1, PSR-2 and PSR-4. I digged into the code and saw some closing PHP tags, which must be omitted (see: https://www.php-fig.org/psr/psr-2/#22-files).

There are also closing PHP tags in `libs/HTML` but I wasn't sure, if these should be touched.