### PR TITLE
Check if widget is enabled in admin home before checking it, fix system summary

### DIFF
--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -62,6 +62,8 @@ class Controller extends ControllerAdmin
         $hasNewPlugins = $widgetsList->isDefined('Marketplace', 'getNewPlugins');
         $hasDiagnostics = $widgetsList->isDefined('Installation', 'getSystemCheck');
         $hasTrackingFailures = $widgetsList->isDefined('CoreAdminHome', 'getTrackingFailures');
+        $hasQuickLinks = $widgetsList->isDefined('CoreHome', 'quickLinks');
+        $hasSystemSummary = $widgetsList->isDefined('CoreHome', 'getSystemSummary');
 
         return $this->renderTemplate('home', array(
             'isInternetEnabled' => $isInternetEnabled,
@@ -73,6 +75,8 @@ class Controller extends ControllerAdmin
             'hasPiwikBlog' => $hasPiwikBlog,
             'hasDiagnostics' => $hasDiagnostics,
             'hasTrackingFailures' => $hasTrackingFailures,
+            'hasQuickLinks' => $hasQuickLinks,
+            'hasSystemSummary' => $hasSystemSummary,
         ));
     }
 

--- a/plugins/CoreAdminHome/templates/home.twig
+++ b/plugins/CoreAdminHome/templates/home.twig
@@ -18,10 +18,12 @@
 
     {% if isSuperUser %}
         <div class="row">
-            <div class="col s12 {% if isFeedbackEnabled %}m4{% else %}m6{% endif %}">
-                <div piwik-widget-loader='{"module":"CoreHome","action":"quickLinks"}'></div>
-                <div piwik-widget-loader='{"module":"CoreHome","action":"getSystemSummary"}'></div>
-            </div>
+            {% if hasQuickLinks or hasSystemSummary %}
+                <div class="col s12 {% if isFeedbackEnabled %}m4{% else %}m6{% endif %}">
+                    {% if hasQuickLinks %}<div piwik-widget-loader='{"module":"CoreHome","action":"quickLinks"}'></div>{% endif %}
+                    {% if hasSystemSummary %}<div piwik-widget-loader='{"module":"CoreHome","action":"getSystemSummary"}'></div>{% endif %}
+                </div>
+            {% endif %}
             {% if hasDiagnostics or hasTrackingFailures %}
                 <div class="col s12 {% if isFeedbackEnabled %}m4{% else %}m6{% endif %}">
                     {% if hasDiagnostics %}

--- a/plugins/CoreHome/Widgets/QuickLinks.php
+++ b/plugins/CoreHome/Widgets/QuickLinks.php
@@ -5,6 +5,8 @@ namespace Piwik\Plugins\CoreHome\Widgets;
 
 
 use Piwik\Piwik;
+use Piwik\Plugins\SitesManager\SitesManager;
+use Piwik\Plugins\UsersManager\UsersManager;
 use Piwik\Widget\Widget;
 use Piwik\Widget\WidgetConfig;
 
@@ -20,7 +22,13 @@ class QuickLinks extends Widget
 
     public function render()
     {
-        return $this->renderTemplate('quickLinks');
+        $hasUsersAdmin = UsersManager::isUsersAdminEnabled();
+        $hasSitesAdmin = SitesManager::isSitesAdminEnabled();
+
+        return $this->renderTemplate('quickLinks', array(
+            'hasUsersAdmin' => $hasUsersAdmin,
+            'hasSitesAdmin' => $hasSitesAdmin,
+        ));
     }
 
 }

--- a/plugins/CoreHome/templates/quickLinks.twig
+++ b/plugins/CoreHome/templates/quickLinks.twig
@@ -1,15 +1,19 @@
 <div class="widgetBody quickLinks">
+    {% if hasSitesAdmin %}
     <div class="quickLink">
         <span class="icon icon-open-source">&nbsp;</span>
         <a href="{{ linkTo({'module': 'SitesManager', 'action': 'index', 'showaddsite': '1'}) }}" class="itemLabel">
             {{ 'SitesManager_AddSite'|translate|e }}
         </a>
     </div>
+    {% endif %}
+    {% if hasUsersAdmin %}
     <div class="quickLink">
         <span class="icon icon-user-add">&nbsp;</span>
         <a href="{{ linkTo({'module': 'UsersManager', 'action': 'index', 'showadduser': '1'}) }}" class="itemLabel">
             {{ 'UsersManager_AddUser'|translate|e }}
         </a>
     </div>
+    {% endif %}
     <br />
 </div>

--- a/plugins/CoreHome/templates/quickLinks.twig
+++ b/plugins/CoreHome/templates/quickLinks.twig
@@ -1,5 +1,5 @@
 <div class="widgetBody quickLinks">
-    {% if hasSitesAdmin %}
+    {% if not hasSitesAdmin %}
     <div class="quickLink">
         <span class="icon icon-open-source">&nbsp;</span>
         <a href="{{ linkTo({'module': 'SitesManager', 'action': 'index', 'showaddsite': '1'}) }}" class="itemLabel">
@@ -7,7 +7,7 @@
         </a>
     </div>
     {% endif %}
-    {% if hasUsersAdmin %}
+    {% if not hasUsersAdmin %}
     <div class="quickLink">
         <span class="icon icon-user-add">&nbsp;</span>
         <a href="{{ linkTo({'module': 'UsersManager', 'action': 'index', 'showadduser': '1'}) }}" class="itemLabel">

--- a/plugins/CoreHome/templates/quickLinks.twig
+++ b/plugins/CoreHome/templates/quickLinks.twig
@@ -1,5 +1,5 @@
 <div class="widgetBody quickLinks">
-    {% if not hasSitesAdmin %}
+    {% if hasSitesAdmin %}
     <div class="quickLink">
         <span class="icon icon-open-source">&nbsp;</span>
         <a href="{{ linkTo({'module': 'SitesManager', 'action': 'index', 'showaddsite': '1'}) }}" class="itemLabel">
@@ -7,7 +7,7 @@
         </a>
     </div>
     {% endif %}
-    {% if not hasUsersAdmin %}
+    {% if hasUsersAdmin %}
     <div class="quickLink">
         <span class="icon icon-user-add">&nbsp;</span>
         <a href="{{ linkTo({'module': 'UsersManager', 'action': 'index', 'showadduser': '1'}) }}" class="itemLabel">

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -63,9 +63,11 @@ class SitesManager extends \Piwik\Plugin
 
     public function addSystemSummaryItems(&$systemSummary)
     {
-        $websites = Request::processRequest('SitesManager.getAllSites', array('filter_limit' => '-1'));
-        $numWebsites = count($websites);
-        $systemSummary[] = new SystemSummary\Item($key = 'websites', Piwik::translate('CoreHome_SystemSummaryNWebsites', $numWebsites), $value = null, $url = array('module' => 'SitesManager', 'action' => 'index'), $icon = '', $order = 10);
+        if (self::isSitesAdminEnabled()) {
+            $websites = Request::processRequest('SitesManager.getAllSites', array('filter_limit' => '-1'));
+            $numWebsites = count($websites);
+            $systemSummary[] = new SystemSummary\Item($key = 'websites', Piwik::translate('CoreHome_SystemSummaryNWebsites', $numWebsites), $value = null, $url = array('module' => 'SitesManager', 'action' => 'index'), $icon = '', $order = 10);
+        }
     }
 
     public function redirectDashboardToWelcomePage(&$module, &$action)

--- a/plugins/Tour/Engagement/Challenges.php
+++ b/plugins/Tour/Engagement/Challenges.php
@@ -12,8 +12,10 @@ use Piwik\Container\StaticContainer;
 use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Plugins\CoreAdminHome\Controller;
+use Piwik\Plugins\SitesManager\SitesManager;
 use Piwik\Plugins\Tour\Dao\DataFinder;
 use Piwik\Plugins\UserCountry\UserCountry;
+use Piwik\Plugins\UsersManager\UsersManager;
 
 class Challenges
 {
@@ -45,10 +47,10 @@ class Challenges
 
         $challenges[] = StaticContainer::get(ChallengeCustomLogo::class);
 
-        if ($this->isActivePlugin('UsersManager')) {
+        if ($this->isActivePlugin('UsersManager') && UsersManager::isUsersAdminEnabled()) {
             $challenges[] = StaticContainer::get(ChallengeAddedUser::class);
         }
-        if ($this->isActivePlugin('SitesManager')) {
+        if ($this->isActivePlugin('SitesManager') && SitesManager::isSitesAdminEnabled()) {
             $challenges[] = StaticContainer::get(ChallengeAddedWebsite::class);
         }
 

--- a/plugins/UsersManager/UsersManager.php
+++ b/plugins/UsersManager/UsersManager.php
@@ -62,6 +62,10 @@ class UsersManager extends \Piwik\Plugin
 
     public function addSystemSummaryItems(&$systemSummary)
     {
+        if (!self::isUsersAdminEnabled()) {
+            return;
+        }
+
         $userLogins = Request::processRequest('UsersManager.getUsersLogin', array('filter_limit' => '-1'));
 
         $numUsers = count($userLogins);


### PR DESCRIPTION
The new users / sites setting we added as part of this release. We should only show the system summary items and quick links when those features are enabled. Quick links will now show an empty widget when both users and sites admin is disabled but that's fine for now as it's very much edge case. The widget itself could be always removed.

Another issue this PR fixes is that in CoreAdminHome there were 2 widgets we didn't check if another plugin maybe disabled them and where still showing them