### PR TITLE
Ignore option inserts if they fail at MySQL level

### DIFF
--- a/core/Option.php
+++ b/core/Option.php
@@ -195,7 +195,7 @@ class Option
 
         if (! $rowsUpdated) {
             try {
-                $sql  = 'INSERT INTO `' . Common::prefixTable('option') . '` (option_name, option_value, autoload) ' .
+                $sql  = 'INSERT IGNORE INTO `' . Common::prefixTable('option') . '` (option_name, option_value, autoload) ' .
                         'VALUES (?, ?, ?) ';
                 $bind = array($name, $value, $autoLoad);
 


### PR DESCRIPTION
Problem I'm having is that I'm using a different DB backend which logs/shows errors in their DB layer. In this case what happens is that we're often calling `Option::set()` and the value doesn't actually change. In this case because no row changed, the update `$result` will be `0` and therefore it will try to insert the value which will fail because of duplicate entry.
 I know we're catching the exception but in this case we can as well IGNORE any failure when we catch any exception anyway. This way there will be no more errors shown in the UI when using a different DB layer. I know the same problem can happen in other queries we do as well but it's particularly annoying with the option queries currently.