### PR TITLE
Show all sites item only if multi sites is enabled

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -751,6 +751,7 @@ abstract class Controller
 
         $pluginManager = Plugin\Manager::getInstance();
         $view->relativePluginWebDirs = (object) $pluginManager->getWebRootDirectoriesForCustomPluginDirs();
+        $view->isMultiSitesEnabled = Manager::getInstance()->isPluginActivated('MultiSites');
 
         self::setHostValidationVariablesView($view);
     }

--- a/plugins/CoreHome/templates/_siteSelectHeader.twig
+++ b/plugins/CoreHome/templates/_siteSelectHeader.twig
@@ -1,3 +1,3 @@
 <div class="top_bar_sites_selector piwikTopControl">
-    <div piwik-siteselector show-selected-site="true" show-all-sites-item="{{ (isMultiSitesEnabled|default) ? 'true' : 'false' }}" class="sites_autocomplete"></div>
+    <div piwik-siteselector show-selected-site="true" show-all-sites-item="{{ isMultiSitesEnabled ? 'true' : 'false' }}" class="sites_autocomplete"></div>
 </div>

--- a/plugins/CoreHome/templates/_siteSelectHeader.twig
+++ b/plugins/CoreHome/templates/_siteSelectHeader.twig
@@ -1,3 +1,3 @@
 <div class="top_bar_sites_selector piwikTopControl">
-    <div piwik-siteselector show-selected-site="true" class="sites_autocomplete"></div>
+    <div piwik-siteselector show-selected-site="true" show-all-sites-item="{{ (isMultiSitesEnabled|default) ? 'true' : 'false' }}" class="sites_autocomplete"></div>
 </div>


### PR DESCRIPTION
To prevent showing a not working link to the all sites page.

There are a few more usages of siteselector but they aren't as important and visible for now. Also sometimes I think they don't link to the all sites page but handle it differently.