### PR TITLE
Fix XML parser warning handling in RssWidget

### DIFF
--- a/plugins/RssWidget/RssRenderer.php
+++ b/plugins/RssWidget/RssRenderer.php
@@ -56,7 +56,21 @@ class RssRenderer
         if (!$output) {
             try {
                 $content = Http::fetchRemoteFile($this->url);
+
+                $promoteWarningToException = function ($errno, $errstr, $errfile, $errline, $errcontext) {
+                    // if the error has been suppressed by the @ we don't handle the error
+                    if (error_reporting() == 0) {
+                        return false;
+                    }
+                    if ($errno !== E_WARNING) {
+                        return false;
+                    }
+                    throw new \Exception($errstr, $errno);
+                };
+                set_error_handler($promoteWarningToException, E_WARNING);
                 $rss = simplexml_load_string($content);
+                restore_error_handler();
+
             } catch (\Exception $e) {
                 throw new \Exception("Error while importing feed: {$e->getMessage()}\n");
             }

--- a/plugins/RssWidget/RssRenderer.php
+++ b/plugins/RssWidget/RssRenderer.php
@@ -57,20 +57,10 @@ class RssRenderer
             try {
                 $content = Http::fetchRemoteFile($this->url);
 
-                $promoteWarningToException = function ($errno, $errstr, $errfile, $errline, $errcontext) {
-                    // if the error has been suppressed by the @ we don't handle the error
-                    if (error_reporting() == 0) {
-                        return false;
-                    }
-                    if ($errno !== E_WARNING) {
-                        return false;
-                    }
-                    throw new \Exception($errstr, $errno);
-                };
-                set_error_handler($promoteWarningToException, E_WARNING);
-                $rss = simplexml_load_string($content);
-                restore_error_handler();
-
+                $rss = @simplexml_load_string($content);
+                if ($rss === false) {
+                    throw new \Exception("Failed to parse XML.");
+                }
             } catch (\Exception $e) {
                 throw new \Exception("Error while importing feed: {$e->getMessage()}\n");
             }


### PR DESCRIPTION
Hi! This should fix #14814.

I had to temporarily set an error handler to promote the warnings generated by `simplexml_load_string()` to exceptions. That way, they're handled gracefully.

Please let me know if this can be improved.