### PR TITLE
Skip unnecessary validation on report unsubscribe

### DIFF
--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -194,6 +194,36 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
+     * Updates an existing report.
+     *
+     * @see addReport()
+     */
+    public function unsubscribe($idReport, $idSite, $parameters)
+    {
+        Piwik::checkUserIsNotAnonymous();
+        Piwik::checkUserHasViewAccess($idSite);
+
+        $scheduledReports = $this->getReports($idSite, $periodSearch = false, $idReport);
+        $report   = reset($scheduledReports);
+        $idReport = $report['idreport'];
+
+        $currentUser = Piwik::getCurrentUserLogin();
+        self::ensureLanguageSetForUser($currentUser);
+
+        // We'll only accept changes to two keys related to email subscriptions
+        $paramsToSave = $report['parameters'];
+        $paramsToSave['emailMe'] = $parameters['emailMe'];
+        $paramsToSave['additionalEmails'] = $parameters['additionalEmails'];
+        self::validateReportParameters($report['type'], $paramsToSave);
+
+        $this->getModel()->updateReport($idReport, array(
+            'parameters'  => $paramsToSave
+        ));
+
+        self::$cache = array();
+    }
+
+    /**
      * Deletes a specific report
      *
      * @param int $idReport

--- a/plugins/ScheduledReports/API.php
+++ b/plugins/ScheduledReports/API.php
@@ -194,36 +194,6 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * Updates an existing report.
-     *
-     * @see addReport()
-     */
-    public function unsubscribe($idReport, $idSite, $parameters)
-    {
-        Piwik::checkUserIsNotAnonymous();
-        Piwik::checkUserHasViewAccess($idSite);
-
-        $scheduledReports = $this->getReports($idSite, $periodSearch = false, $idReport);
-        $report   = reset($scheduledReports);
-        $idReport = $report['idreport'];
-
-        $currentUser = Piwik::getCurrentUserLogin();
-        self::ensureLanguageSetForUser($currentUser);
-
-        // We'll only accept changes to two keys related to email subscriptions
-        $paramsToSave = $report['parameters'];
-        $paramsToSave['emailMe'] = $parameters['emailMe'];
-        $paramsToSave['additionalEmails'] = $parameters['additionalEmails'];
-        self::validateReportParameters($report['type'], $paramsToSave);
-
-        $this->getModel()->updateReport($idReport, array(
-            'parameters'  => $paramsToSave
-        ));
-
-        self::$cache = array();
-    }
-
-    /**
      * Deletes a specific report
      *
      * @param int $idReport

--- a/plugins/ScheduledReports/SubscriptionModel.php
+++ b/plugins/ScheduledReports/SubscriptionModel.php
@@ -81,17 +81,10 @@ class SubscriptionModel
 
         if ($emailFound) {
             Access::doAsSuperUser(function() use ($report) {
-                Request::processRequest('ScheduledReports.updateReport', [
+                Request::processRequest('ScheduledReports.unsubscribe', [
                     'idReport'     => $report['idreport'],
                     'idSite'       => $report['idsite'],
-                    'description'  => $report['description'],
-                    'period'       => $report['period'],
-                    'hour'         => $report['hour'],
-                    'reportType'   => $report['type'],
-                    'reportFormat' => $report['format'],
-                    'reports'      => $report['reports'],
                     'parameters'   => $report['parameters'],
-                    'idSegment'    => $report['idsegment'],
                 ]);
             });
 

--- a/plugins/ScheduledReports/SubscriptionModel.php
+++ b/plugins/ScheduledReports/SubscriptionModel.php
@@ -14,6 +14,7 @@ use Piwik\Common;
 use Piwik\Db;
 use Piwik\DbHelper;
 use Piwik\Piwik;
+use Piwik\Plugins\ScheduledReports\API as ScheduledReports;
 
 class SubscriptionModel
 {
@@ -84,6 +85,8 @@ class SubscriptionModel
             $reportModel->updateReport($report['idreport'], array(
                 'parameters' => json_encode($report['parameters'])
             ));
+            // Reset the cache manually since we didn't call the API method which would do it for us
+            ScheduledReports::$cache = array();
 
             Piwik::postEvent('Report.unsubscribe', [$report['idreport'], $email]);
 

--- a/plugins/ScheduledReports/SubscriptionModel.php
+++ b/plugins/ScheduledReports/SubscriptionModel.php
@@ -80,13 +80,10 @@ class SubscriptionModel
         }
 
         if ($emailFound) {
-            Access::doAsSuperUser(function() use ($report) {
-                Request::processRequest('ScheduledReports.unsubscribe', [
-                    'idReport'     => $report['idreport'],
-                    'idSite'       => $report['idsite'],
-                    'parameters'   => $report['parameters'],
-                ]);
-            });
+            $reportModel = new Model();
+            $reportModel->updateReport($report['idreport'], array(
+                'parameters' => json_encode($report['parameters'])
+            ));
 
             Piwik::postEvent('Report.unsubscribe', [$report['idreport'], $email]);
 

--- a/plugins/ScheduledReports/SubscriptionModel.php
+++ b/plugins/ScheduledReports/SubscriptionModel.php
@@ -14,7 +14,7 @@ use Piwik\Common;
 use Piwik\Db;
 use Piwik\DbHelper;
 use Piwik\Piwik;
-use Piwik\Plugins\ScheduledReports\API as ScheduledReports;
+use Piwik\Plugins\ScheduledReports\API as APIScheduledReports;
 
 class SubscriptionModel
 {
@@ -86,7 +86,7 @@ class SubscriptionModel
                 'parameters' => json_encode($report['parameters'])
             ));
             // Reset the cache manually since we didn't call the API method which would do it for us
-            ScheduledReports::$cache = array();
+            APIScheduledReports::$cache = array();
 
             Piwik::postEvent('Report.unsubscribe', [$report['idreport'], $email]);
 


### PR DESCRIPTION
Fixes #14925, which was caused by the subscription containing a report from a plugin which had been deactivated.