### PR TITLE
Remove duplicate decodeURIComponent call in segmentcontroller

### DIFF
--- a/plugins/SegmentEditor/angularjs/segment-generator/segmentgenerator.controller.js
+++ b/plugins/SegmentEditor/angularjs/segment-generator/segmentgenerator.controller.js
@@ -47,7 +47,6 @@
             }
         }
 
-        newMetric.value = decodeURIComponent(newMetric.value);
         return newMetric;
     };
 

--- a/plugins/SegmentEditor/angularjs/segment-generator/segmentgenerator.controller.js
+++ b/plugins/SegmentEditor/angularjs/segment-generator/segmentgenerator.controller.js
@@ -47,6 +47,13 @@
             }
         }
 
+        try {
+            // Decode again to deal with double-encoded segments in database
+            newMetric.value = decodeURIComponent(newMetric.value);
+        } catch (e) {
+            // Expected if the segment was not double-encoded
+        }
+
         return newMetric;
     };
 


### PR DESCRIPTION
Fixes #14943
This line is not needed as the `decodeURIComponent` is already done whenever `newmetric.value` is set.