### PR TITLE
Log stack traces for PHP warnings etc

### DIFF
--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -161,22 +161,14 @@ class ErrorHandler
             case E_DEPRECATED:
             case E_USER_DEPRECATED:
             default:
-                // Need to create and throw an Exception so that we can get the stack trace
-                $e = new \Exception();
-                $message = self::getHtmlMessage($errno, $errstr, $errfile, $errline, $e->getTraceAsString());
+                $context = array('trace' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
                 try {
-                    throw new ErrorException($message, 0, $errno, $errfile, $errline);
-                } catch (ErrorException $outerEx) {
-                    // But we'll catch it and put it straight into the logs rather than propagating up
-                    try {
-                        $context = array('trace' => $outerEx->getTraceAsString());
-                        StaticContainer::get(LoggerInterface::class)->warning(
-                            self::createLogMessage($errno, $errstr, $errfile, $errline),
-                            $context
-                        );
-                    } catch (\Exception $ex) {
-                        // ignore (it's possible for this to happen if the StaticContainer hasn't been created yet)
-                    }
+                    StaticContainer::get(LoggerInterface::class)->warning(
+                        self::createLogMessage($errno, $errstr, $errfile, $errline),
+                        $context
+                    );
+                } catch (\Exception $ex) {
+                    // ignore (it's possible for this to happen if the StaticContainer hasn't been created yet)
                 }
 
                 break;

--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -161,7 +161,7 @@ class ErrorHandler
             case E_DEPRECATED:
             case E_USER_DEPRECATED:
             default:
-                $context = array('trace' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
+                $context = array('trace' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 15));
                 try {
                     StaticContainer::get(LoggerInterface::class)->warning(
                         self::createLogMessage($errno, $errstr, $errfile, $errline),

--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -78,7 +78,7 @@ class LineMessageFormatter implements FormatterInterface
         for ($i = 0; $i < $numLevels; $i++) {
             $level = $trace[$i];
             if (isset($level['file'], $level['line'])) {
-                $levelTrace = '#' . $i . $level['file'] . '(' . $level['line'] . ')';
+                $levelTrace = '#' . $i . (str_replace(PIWIK_DOCUMENT_ROOT, '', $level['file'])) . '(' . $level['line'] . ')';
             } else {
                 $levelTrace = '[internal function]: ' . $level['class'] . $level['type'] . $level['function'] . '()';
             }

--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -61,9 +61,10 @@ class LineMessageFormatter implements FormatterInterface
 
     private function formatMessage($class, $message, $date, $record)
     {
+        $trace = $record['context']['trace'] ?: '';
         $message = str_replace(
-            array('%tag%', '%message%', '%datetime%', '%level%'),
-            array($class, $message, $date, $record['level_name']),
+            array('%tag%', '%message%', '%datetime%', '%level%', '%trace%'),
+            array($class, $message, $date, $record['level_name'], $trace),
             $this->logMessageFormat
         );
 

--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -61,14 +61,14 @@ class LineMessageFormatter implements FormatterInterface
 
     private function formatMessage($class, $message, $date, $record)
     {
-        $trace = $record['context']['trace'] ? self::formatTrace($record['context']['trace']) : '';
+        $trace = isset($record['context']['trace']) ? self::formatTrace($record['context']['trace']) : '';
         $message = str_replace(
             array('%tag%', '%message%', '%datetime%', '%level%', '%trace%'),
             array($class, $message, $date, $record['level_name'], $trace),
             $this->logMessageFormat
         );
 
-        $message .= "\n";
+        $message = trim($message) . "\n";
         return $message;
     }
 
@@ -82,9 +82,9 @@ class LineMessageFormatter implements FormatterInterface
             } else {
                 $levelTrace = '[internal function]: ' . $level['class'] . $level['type'] . $level['function'] . '()';
             }
-            $strTrace .= $levelTrace . "\n";
+            $strTrace .= $levelTrace . ",";
         }
-        return trim($strTrace);
+        return trim($strTrace, ",");
     }
 
     public function formatBatch(array $records)

--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -61,7 +61,7 @@ class LineMessageFormatter implements FormatterInterface
 
     private function formatMessage($class, $message, $date, $record)
     {
-        $trace = $record['context']['trace'] ?: '';
+        $trace = $record['context']['trace'] ? self::formatTrace($record['context']['trace']) : '';
         $message = str_replace(
             array('%tag%', '%message%', '%datetime%', '%level%', '%trace%'),
             array($class, $message, $date, $record['level_name'], $trace),
@@ -70,6 +70,21 @@ class LineMessageFormatter implements FormatterInterface
 
         $message .= "\n";
         return $message;
+    }
+
+    private static function formatTrace(array $trace, $numLevels = 10)
+    {
+        $strTrace = '';
+        for ($i = 0; $i < $numLevels; $i++) {
+            $level = $trace[$i];
+            if (isset($level['file'], $level['line'])) {
+                $levelTrace = '#' . $i . $level['file'] . '(' . $level['line'] . ')';
+            } else {
+                $levelTrace = '[internal function]: ' . $level['class'] . $level['type'] . $level['function'] . '()';
+            }
+            $strTrace .= $levelTrace . "\n";
+        }
+        return trim($strTrace);
     }
 
     public function formatBatch(array $records)

--- a/plugins/Monolog/config/config.php
+++ b/plugins/Monolog/config/config.php
@@ -97,16 +97,13 @@ return array(
         ->constructor(DI\get('log.file.filename'), DI\get('log.level.file'))
         ->method('setFormatter', DI\get('log.lineMessageFormatter.file')),
 
-    'log.lineMessageFormatter.file' => DI\object('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter')
-        ->constructorParameter('allowInlineLineBreaks', false),
-
     'Piwik\Plugins\Monolog\Handler\DatabaseHandler' => DI\object()
         ->constructor(DI\get('log.level.database'))
-        ->method('setFormatter', DI\get('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter')),
+        ->method('setFormatter', DI\get('log.lineMessageFormatter')),
 
     'Piwik\Plugins\Monolog\Handler\WebNotificationHandler' => DI\object()
         ->constructor(DI\get('log.level.screen'))
-        ->method('setFormatter', DI\get('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter')),
+        ->method('setFormatter', DI\get('log.lineMessageFormatter')),
 
     'log.level' => DI\factory(function (ContainerInterface $c) {
         if ($c->has('ini.log.log_level')) {
@@ -175,14 +172,25 @@ return array(
         return $logPath;
     }),
 
-    'Piwik\Plugins\Monolog\Formatter\LineMessageFormatter' => DI\object()
-        ->constructor(DI\get('log.format')),
+    'log.lineMessageFormatter' => DI\object('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter')
+        ->constructor(DI\get('log.short.format')),
 
-    'log.format' => DI\factory(function (ContainerInterface $c) {
+    'log.lineMessageFormatter.file' => DI\object('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter')
+        ->constructor(DI\get('log.trace.format'))
+        ->constructorParameter('allowInlineLineBreaks', false),
+
+    'log.short.format' => DI\factory(function (ContainerInterface $c) {
         if ($c->has('ini.log.string_message_format')) {
             return $c->get('ini.log.string_message_format');
         }
         return '%level% %tag%[%datetime%] %message%';
+    }),
+
+    'log.trace.format' => DI\factory(function (ContainerInterface $c) {
+        if ($c->has('ini.log.string_message_format_trace')) {
+            return $c->get('ini.log.string_message_format_trace');
+        }
+        return '%level% %tag%[%datetime%] %message% %trace%';
     }),
 
     'archiving.performance.handlers' => function (ContainerInterface $c) {

--- a/plugins/Monolog/tests/Integration/LogTest.php
+++ b/plugins/Monolog/tests/Integration/LogTest.php
@@ -257,6 +257,7 @@ class LogTest extends IntegrationTestCase
             'ini.log.log_writers' => array($backend),
             'ini.log.log_level' => $level,
             'ini.log.string_message_format' => self::STRING_MESSAGE_FORMAT,
+            'ini.log.string_message_format_trace' => self::STRING_MESSAGE_FORMAT,
             'ini.log.logger_file_path' => self::getLogFileLocation(),
             'Psr\Log\LoggerInterface' => \DI\get('Monolog\Logger'),
             'Tests.log.allowAllHandlers' => true,


### PR DESCRIPTION
Includes the full stack in the log message when writing to file only.  The log message for other handlers (web notifications and database) will not be changed.