### PR TITLE
Disable update of some resources when auto update is disabled

### DIFF
--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -74,7 +74,7 @@ class Tasks extends \Piwik\Plugin\Tasks
         $this->daily('cleanupTrackingFailures', null, self::LOWEST_PRIORITY);
         $this->weekly('notifyTrackingFailures', null, self::LOWEST_PRIORITY);
 
-        if(SettingsPiwik::isInternetEnabled() === true){
+        if(SettingsPiwik::isInternetEnabled() && SettingsPiwik::isAutoUpdateEnabled()){
             $this->weekly('updateSpammerBlacklist');
         }
 

--- a/plugins/Referrers/Tasks.php
+++ b/plugins/Referrers/Tasks.php
@@ -17,7 +17,8 @@ class Tasks extends \Piwik\Plugin\Tasks
 {
     public function schedule()
     {
-        if(SettingsPiwik::isInternetEnabled() === true){
+        if(SettingsPiwik::isInternetEnabled()
+            && SettingsPiwik::isAutoUpdateEnabled()){
             $this->weekly('updateSearchEngines');
             $this->weekly('updateSocials');
         }


### PR DESCRIPTION
When auto update is disabled, we probably also don't want to update these resources from GitHub.

If needed I can also introduce a new config setting but reckon auto update also kind of falls into this category maybe? Can also create a new config setting...  If so, any thoughts on the wording?

