### PR TITLE
Remove not needed angular mocks library from release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -56,3 +56,4 @@ tests/ export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
 PULL_REQUEST_TEMPLATE export-ignore
+/libs/bower_components/angular-mocks export-ignore


### PR DESCRIPTION
It seems this is only needed for tests but we actually exclude the tests from the release so we can also exclude this in the package.