### PR TITLE
No longer manually include SEO JS in twig file

### DIFF
--- a/plugins/SEO/SEO.php
+++ b/plugins/SEO/SEO.php
@@ -18,8 +18,14 @@ class SEO extends \Piwik\Plugin
     public function registerEvents()
     {
         return [
-            'Widget.filterWidgets' => 'filterWidgets'
+            'Widget.filterWidgets' => 'filterWidgets',
+            'AssetManager.getJavaScriptFiles' => 'getJsFiles',
         ];
+    }
+
+    public function getJsFiles(&$jsFiles)
+    {
+        $jsFiles[] = "plugins/SEO/javascripts/rank.js";
     }
 
     /**

--- a/plugins/SEO/javascripts/rank.js
+++ b/plugins/SEO/javascripts/rank.js
@@ -4,9 +4,8 @@
  * @link http://piwik.org
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
-
-$(document).ready(function () {
-    function getRank() {
+var SEOWidget = {
+    getRank: function () {
         var ajaxRequest = new ajaxHelper();
         ajaxRequest.setLoadingElement('#ajaxLoadingSEO');
         ajaxRequest.addParams({
@@ -22,10 +21,4 @@ $(document).ready(function () {
         ajaxRequest.setFormat('html');
         ajaxRequest.send();
     }
-
-    // click on Rank button
-    $('#rankbutton').on('click', function () {
-        getRank();
-        return false;
-    });
-});
+}

--- a/plugins/SEO/templates/getRank.twig
+++ b/plugins/SEO/templates/getRank.twig
@@ -1,52 +1,51 @@
 <div id='SeoRanks'>
-    <script type="text/javascript" src="plugins/SEO/javascripts/rank.js"></script>
 
-    <form method="post" style="padding: 8px;">
-        <div align="left" class="row">
-            <div class="col s8 input-field">
-                <label for="seoUrl" class="active">{{ 'Installation_SetupWebSiteURL'|translate|capitalize }}</label>
-                <input type="text" id="seoUrl" size="15" value="{{ urlToRank }}" class="textbox "/>
-            </div>
-            <div class="col s4">
-                <input type="submit" class="btn btn-small" style='margin-top: 2em' id="rankbutton" value="{{ 'SEO_Rank'|translate }}"/>
-            </div>
+    <div align="left" class="row">
+        <div class="col s8 input-field">
+            <label for="seoUrl" class="active">{{ 'Installation_SetupWebSiteURL'|translate|capitalize }}</label>
+            <input type="text" id="seoUrl" size="15" value="{{ urlToRank }}" class="textbox "/>
         </div>
-
-        {% import "ajaxMacros.twig" as ajax %}
-        {{ ajax.LoadingDiv('ajaxLoadingSEO') }}
-
-        <div id="rankStats" align="left" style="margin-top:10px;margin-left: 5px;font-size:14px;">
-            {% if ranks is empty %}
-                {{ 'General_Error'|translate }}
-            {% else %}
-                {% set cleanUrl %}
-                    <a href="http://{{ urlToRank }}" rel="noreferrer noopener" target="_blank">{{ urlToRank }}</a>
-                {% endset %}
-                {{ 'SEO_SEORankingsFor'|translate(cleanUrl)|raw }}
-                <table cellspacing="2" style="margin:auto;line-height:3.5em !important;margin-top:20px;">
-
-                    {% for rank in ranks %}
-                        <tr>
-                            {% set seoLink %}{% if rank.logo_link is not empty %}<a class="linkContent" href="{{ rank.logo_link }}"
-                                                                                    target="_blank" rel="noreferrer noopener"
-                                                                                    {% if rank.logo_tooltip is not empty %}title="{{ rank.logo_tooltip }}"{% endif %}>{% endif %}{% endset %}
-                                <td>{% if rank.logo_link is not empty %}{{ seoLink|raw }}{% endif %}<img width="24px" height="24px"
-                                                                                                         style='vertical-align:middle;margin-right:6px;' src='{{ rank.logo }}' border='0'
-                                                                                                         alt="{{ rank.label }}">{% if rank.logo_link is not empty %}</a>{% endif %} {{ rank.label|raw }}
-                            </td>
-                            <td>
-                                <div style="margin-left:15px;">
-                                    {% if rank.logo_link is not empty %}{{ seoLink|raw }}{% endif %}
-                                    {% if rank.rank %}{{ rank.rank|raw }}{% else %}-{% endif %}
-                                    {{ rank.rank_suffix }}
-                                    {% if rank.logo_link is not empty %}</a>{% endif %}
-                                </div>
-                            </td>
-                        </tr>
-                    {% endfor %}
-
-                </table>
-            {% endif %}
+        <div class="col s4">
+            <input type="button"
+                   onclick="SEOWidget.getRank()"
+                   class="btn btn-small" style='margin-top: 2em' id="rankbutton" value="{{ 'SEO_Rank'|translate }}"/>
         </div>
-    </form>
+    </div>
+
+    {% import "ajaxMacros.twig" as ajax %}
+    {{ ajax.LoadingDiv('ajaxLoadingSEO') }}
+
+    <div id="rankStats" align="left" style="margin-top:10px;margin-left: 5px;font-size:14px;">
+        {% if ranks is empty %}
+            {{ 'General_Error'|translate }}
+        {% else %}
+            {% set cleanUrl %}
+                <a href="http://{{ urlToRank }}" rel="noreferrer noopener" target="_blank">{{ urlToRank }}</a>
+            {% endset %}
+            {{ 'SEO_SEORankingsFor'|translate(cleanUrl)|raw }}
+            <table cellspacing="2" style="margin:auto;line-height:3.5em !important;margin-top:20px;">
+
+                {% for rank in ranks %}
+                    <tr>
+                        {% set seoLink %}{% if rank.logo_link is not empty %}<a class="linkContent" href="{{ rank.logo_link }}"
+                                                                                target="_blank" rel="noreferrer noopener"
+                                                                                {% if rank.logo_tooltip is not empty %}title="{{ rank.logo_tooltip }}"{% endif %}>{% endif %}{% endset %}
+                            <td>{% if rank.logo_link is not empty %}{{ seoLink|raw }}{% endif %}<img width="24px" height="24px"
+                                                                                                     style='vertical-align:middle;margin-right:6px;' src='{{ rank.logo }}' border='0'
+                                                                                                     alt="{{ rank.label }}">{% if rank.logo_link is not empty %}</a>{% endif %} {{ rank.label|raw }}
+                        </td>
+                        <td>
+                            <div style="margin-left:15px;">
+                                {% if rank.logo_link is not empty %}{{ seoLink|raw }}{% endif %}
+                                {% if rank.rank %}{{ rank.rank|raw }}{% else %}-{% endif %}
+                                {{ rank.rank_suffix }}
+                                {% if rank.logo_link is not empty %}</a>{% endif %}
+                            </div>
+                        </td>
+                    </tr>
+                {% endfor %}
+
+            </table>
+        {% endif %}
+    </div>
 </div>


### PR DESCRIPTION
We shouldn't manually load JS files in a twig template but make sure the file is in the general assets core JS file. This was needed for some project we're working on.