### PR TITLE
Allow bootstrap file to manipulate config settings

### DIFF
--- a/core/Config/IniFileChain.php
+++ b/core/Config/IniFileChain.php
@@ -242,6 +242,10 @@ class IniFileChain
         // on PHP 7+ as they would be always equal
         $this->mergedSettings = $this->copy($merged);
 
+        if (!empty($GLOBALS['MATOMO_MODIFY_CONFIG_SETTINGS']) && !empty($this->mergedSettings)) {
+            $this->mergedSettings = call_user_func($GLOBALS['MATOMO_MODIFY_CONFIG_SETTINGS'], $this->mergedSettings);
+        }
+        
         if (!empty($GLOBALS['ENABLE_CONFIG_PHP_CACHE'])
             && !empty($userSettingsFile)
             && !empty($this->mergedSettings)


### PR DESCRIPTION
Allows a bootstrap file to change config settings like by creating a `bootstrap.php` and then having eg 

```php
// matomo/bootstrap.php
$GLOBALS['MATOMO_MODIFY_CONFIG_SETTINGS'] = function ($settings) {
	$settings['Plugins'][] = 'MyPlugin';
         return $settings;
});
```

It's mainly useful to configure the list of plugins as pretty much all other settings can be configured through DI when the config is being created. I was doing this initially here as well for quite some time until I noticed a problem with an incompatible plugin and had to do it this way. The problem is that when changing the list of activated plugins dynamically through DI, then the plugin config.php files aren't loaded correctly. The order is:

1. Get activated plugins
2. Load plugin config.php files when building DI container
3. Run DI container for config class

This means when adding eg TagManager through DI to the list of activated plugins then the config.php of TagManager will never be loaded and it always results in errors. Instead of in step 3 I needed to make the change in step 1. 

Not documenting this for now as it would usually never be needed and we don't want to support this just yet.