### PR TITLE
Add new method to register a plugin auto loader when plugin is installed outside Matomo plugin dir

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -35,8 +35,6 @@ use Piwik\Theme;
 use Piwik\Translation\Translator;
 use Piwik\Updater;
 
-require_once PIWIK_INCLUDE_PATH . '/core/EventDispatcher.php';
-
 /**
  * The singleton that manages plugin loading/unloading and installation/uninstallation.
  */
@@ -369,17 +367,7 @@ class Manager
 
             $pluginDirs = self::getPluginsDirectories();
             if (count($pluginDirs) > 1) {
-                spl_autoload_register(function ($className) use ($pluginDirs) {
-                    if (strpos($className, 'Piwik\Plugins\\') === 0) {
-                        $withoutPrefix = str_replace('Piwik\Plugins\\', '', $className);
-                        $path = str_replace('\\', DIRECTORY_SEPARATOR, $withoutPrefix) . '.php';
-                        foreach ($pluginDirs as $pluginsDirectory) {
-                            if (file_exists($pluginsDirectory . $path)) {
-                                require_once $pluginsDirectory . $path;
-                            }
-                        }
-                    }
-                });
+                self::registerPluginDirAutoload($pluginDirs);
             }
         }
 
@@ -393,6 +381,26 @@ class Manager
         ) {
             throw new \Exception('"MATOMO_PLUGIN_COPY_DIR" dir must be one of "MATOMO_PLUGIN_DIRS" directories');
         }
+    }
+
+    /**
+     * Registers a new autoloader to support the loading of Matomo plugin classes when the plugins are installed
+     * outside the Matomo plugins folder.
+     * @param array $pluginDirs
+     */
+    public static function registerPluginDirAutoload($pluginDirs)
+    {
+        spl_autoload_register(function ($className) use ($pluginDirs) {
+            if (strpos($className, 'Piwik\Plugins\\') === 0) {
+                $withoutPrefix = str_replace('Piwik\Plugins\\', '', $className);
+                $path = str_replace('\\', DIRECTORY_SEPARATOR, $withoutPrefix) . '.php';
+                foreach ($pluginDirs as $pluginsDirectory) {
+                    if (file_exists($pluginsDirectory . $path)) {
+                        require_once $pluginsDirectory . $path;
+                    }
+                }
+            }
+        });
     }
 
     public static function getAlternativeWebRootDirectories()


### PR DESCRIPTION
Potentially needed for https://github.com/matomo-org/wp-matomo/compare/autoload_matomo?expand=1#diff-7f39b61770654ba934a26dd97681c7c3R97

Not sure yet if I will merge the referenced branch but be good to have this logic in a separate method anyway. The initial included is not needed and is from many many years ago when we didn't use the autoloader in tracking.