### PR TITLE
Do not prepend composer autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "config":{
         "platform": {
             "php": "5.5.9"
-        }
+        },
+        "prepend-autoloader": false
     },
     "require": {
         "php": ">=5.5.9",


### PR DESCRIPTION
See https://getcomposer.org/doc/06-config.md#prepend-autoloader to fix https://github.com/matomo-org/wp-matomo/issues/19

Can we not prepend the autoloader? Basically it should pass the argument false  here: https://github.com/matomo-org/wp-matomo/blob/master/app/vendor/composer/autoload_real.php#L52

What is happening is that in this case the composer autoloader from cookiebot is registered, then some PHP-DI files are loaded, then our composer autoloader is registered, and suddenly it starts loading PHP-DI files from our vendor directory and these classes are not compatible. I reckon setting the parameter fixes that issue