### PR TITLE
Fix possible error in rowevolution for reports with fixed view types

### DIFF
--- a/core/ViewDataTable/Factory.php
+++ b/core/ViewDataTable/Factory.php
@@ -145,7 +145,7 @@ class Factory
                 $type = $defaultType ?: self::DEFAULT_VIEW;
             }
         } else {
-            $type = $defaultViewType;
+            $type = $defaultType ?: $defaultViewType;
         }
 
         $params['viewDataTable'] = $type;


### PR DESCRIPTION
When a report has a fixed view type (by implementing `alwaysUseDefaultViewDataTable`) the row evolution popover might throw an error as it tries to render this default view type instead of the rowevolution graph.

fixes DEV-81