### PR TITLE
Adds links to online guides in reports help

### DIFF
--- a/core/Plugin/Report.php
+++ b/core/Plugin/Report.php
@@ -75,6 +75,12 @@ class Report
     protected $documentation;
 
     /**
+     * URL linking to an online guide for this report or plugin.
+     * @var string
+     */
+    protected $onlineGuideUrl;
+
+    /**
      * The translation key of the category the report belongs to.
      * @var string
      * @api
@@ -598,6 +604,10 @@ class Report
 
         if (!empty($this->documentation)) {
             $report['documentation'] = $this->documentation;
+        }
+
+        if (!empty($this->onlineGuideUrl)) {
+            $report['onlineGuideUrl'] = $this->onlineGuideUrl;
         }
 
         if (true === $this->isSubtableReport) {

--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -304,6 +304,12 @@ class   Config
     public $documentation = false;
 
     /**
+     * URL linking to an online guide for this report (or plugin).
+     * @var string
+     */
+    public $onlineGuideUrl = false;
+
+    /**
      * Array property containing custom data to be saved in JSON in the data-params HTML attribute
      * of a data table div. This data can be used by JavaScript DataTable classes.
      *
@@ -621,6 +627,10 @@ class   Config
 
         if (isset($report['documentation'])) {
             $this->documentation = $report['documentation'];
+        }
+
+        if (isset($report['onlineGuideUrl'])) {
+            $this->onlineGuideUrl = $report['onlineGuideUrl'];
         }
     }
 

--- a/plugins/API/Glossary.php
+++ b/plugins/API/Glossary.php
@@ -27,10 +27,16 @@ class Glossary
         $reports = array();
         foreach ($metadata as $report) {
             if (isset($report['documentation'])) {
-                $reports[] = array(
+                $docReport = array(
                     'name' => sprintf("%s (%s)", $report['name'], $report['category']),
                     'documentation' => $report['documentation']
                 );
+
+                if (isset($report['onlineGuideUrl'])) {
+                    $docReport['onlineGuideUrl'] = $report['onlineGuideUrl'];
+                }
+
+                $reports[] = $docReport;
             }
         }
 

--- a/plugins/Actions/Reports/GetSiteSearchKeywords.php
+++ b/plugins/Actions/Reports/GetSiteSearchKeywords.php
@@ -23,8 +23,7 @@ class GetSiteSearchKeywords extends SiteSearchBase
         parent::init();
         $this->dimension     = new Keyword();
         $this->name          = Piwik::translate('Actions_WidgetSearchKeywords');
-        $this->documentation = Piwik::translate('Actions_SiteSearchKeywordsDocumentation') . '<br/><br/>' . Piwik::translate('Actions_SiteSearchIntro') . '<br/><br/>'
-                             . '<a href="https://matomo.org/docs/site-search/" rel="noreferrer noopener" target="_blank">' . Piwik::translate('Actions_LearnMoreAboutSiteSearchLink') . '</a>';
+        $this->documentation = Piwik::translate('Actions_SiteSearchKeywordsDocumentation') . '<br/><br/>' . Piwik::translate('Actions_SiteSearchIntro');
         $this->metrics       = array('nb_visits', 'nb_pages_per_search');
         $this->processedMetrics = array(
             new AverageTimeOnPage(),

--- a/plugins/Actions/Reports/SiteSearchBase.php
+++ b/plugins/Actions/Reports/SiteSearchBase.php
@@ -19,6 +19,7 @@ abstract class SiteSearchBase extends Base
     {
         parent::init();
         $this->categoryId = 'General_Actions';
+        $this->onlineGuideUrl = 'https://matomo.org/docs/site-search/';
     }
 
     public function isEnabled()

--- a/plugins/Actions/lang/en.json
+++ b/plugins/Actions/lang/en.json
@@ -40,7 +40,6 @@
         "ExitPagesReportDocumentation": "This report contains information about the exit pages that occurred during the specified period. An exit page is the last page that a user views during their visit. %s The exit URLs are displayed as a folder structure.",
         "ExitPageTitles": "Exit page titles",
         "ExitPageTitlesReportDocumentation": "This report contains information about the titles of exit pages that occurred during the specified period.",
-        "LearnMoreAboutSiteSearchLink": "Learn more about Tracking how your visitors use your Search engine.",
         "OneSearch": "1 search",
         "OutlinkDocumentation": "An outlink is a link that leads the visitor away from your website (to another domain).",
         "OutlinksReportDocumentation": "This report shows a hierarchical list of outlink URLs that were clicked by your visitors.",

--- a/plugins/Contents/Reports/Base.php
+++ b/plugins/Contents/Reports/Base.php
@@ -22,6 +22,7 @@ abstract class Base extends Report
     {
         $this->categoryId = 'General_Actions';
         $this->subcategoryId = 'Contents_Contents';
+        $this->onlineGuideUrl = 'https://matomo.org/docs/content-tracking/';
     }
 
     public function configureWidgets(WidgetsList $widgetsList, ReportWidgetFactory $factory)

--- a/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentNames_lastN__API.getProcessedReport_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentNames_lastN__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Contents</module>
 		<action>getContentNames</action>
 		<dimension>Content Name</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/content-tracking/</onlineGuideUrl>
 		<metrics>
 			<nb_impressions>Impressions</nb_impressions>
 			<nb_interactions>Content Interactions</nb_interactions>

--- a/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentPieces_lastN__API.getProcessedReport_day.xml
+++ b/plugins/Contents/tests/System/expected/test_Contents_Contents.getContentPieces_lastN__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Contents</module>
 		<action>getContentPieces</action>
 		<dimension>Content Piece</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/content-tracking/</onlineGuideUrl>
 		<metrics>
 			<nb_impressions>Impressions</nb_impressions>
 			<nb_interactions>Content Interactions</nb_interactions>

--- a/plugins/CoreHome/angularjs/enrichedheadline/enrichedheadline.directive.less
+++ b/plugins/CoreHome/angularjs/enrichedheadline/enrichedheadline.directive.less
@@ -27,6 +27,7 @@
         display: block;
         background: #F7F7F7;
         font-size: 12px;
+        line-height: 1.1;
         font-weight: normal;
         border: 1px solid #E4E5E4;
         margin: 10px 0 10px 0;

--- a/plugins/CoreHome/lang/en.json
+++ b/plugins/CoreHome/lang/en.json
@@ -106,7 +106,7 @@
         "StandardReport": "Standard report",
         "FlattenReport": "Flatten report",
         "ReportWithMetadata": "Report with metadata",
-        "ReadMoreOnlineGuide": "Read more about this topic in the online guide",
+        "ReadMoreOnlineGuide": "Read more about this topic in the online guide.",
         "SeeAvailableVersions": "See Available Versions",
         "QuickLinks": "Quick Links"
     }

--- a/plugins/CoreHome/lang/en.json
+++ b/plugins/CoreHome/lang/en.json
@@ -106,6 +106,7 @@
         "StandardReport": "Standard report",
         "FlattenReport": "Flatten report",
         "ReportWithMetadata": "Report with metadata",
+        "ReadMoreOnlineGuide": "Read more about this topic in the online guide",
         "SeeAvailableVersions": "See Available Versions",
         "QuickLinks": "Quick Links"
     }

--- a/plugins/CoreHome/templates/_dataTable.twig
+++ b/plugins/CoreHome/templates/_dataTable.twig
@@ -42,7 +42,7 @@
 
     <div class="reportDocumentation">
         {% if properties.documentation|default is not empty %}<p ng-bind-html="{{ properties.documentation|json_encode|e('html_attr') }}"></p>{% endif %}
-        {% if properties.onlineGuideUrl|default is not empty %}<a href="?module=Proxy&action=redirect&url={{ properties.onlineGuideUrl|e('html_attr') }}" target="_blank" class="onlineGuide">{{ 'CoreHome_ReadMoreOnlineGuide'|translate }}</a>{% endif %}
+        {% if properties.onlineGuideUrl|default is not empty %}<a href="{{ properties.onlineGuideUrl|safelink|e('html_attr') }}" target="_blank" rel="noreferrer noopener" class="onlineGuide">{{ 'CoreHome_ReadMoreOnlineGuide'|translate }}</a>{% endif %}
         {% if reportLastUpdatedMessage is defined and reportLastUpdatedMessage %}<span class="helpDate">{{ reportLastUpdatedMessage|raw }}</span>{% endif %}
     </div>
 

--- a/plugins/CoreHome/templates/_dataTable.twig
+++ b/plugins/CoreHome/templates/_dataTable.twig
@@ -42,7 +42,8 @@
 
     <div class="reportDocumentation">
         {% if properties.documentation|default is not empty %}<p ng-bind-html="{{ properties.documentation|json_encode|e('html_attr') }}"></p>{% endif %}
-        {% if reportLastUpdatedMessage is defined and reportLastUpdatedMessage %}<span class='helpDate'>{{ reportLastUpdatedMessage|raw }}</span>{% endif %}
+        {% if properties.onlineGuideUrl|default is not empty %}<a href="?module=Proxy&action=redirect&url={{ properties.onlineGuideUrl|e('html_attr') }}" target="_blank" class="onlineGuide">{{ 'CoreHome_ReadMoreOnlineGuide'|translate }}</a>{% endif %}
+        {% if reportLastUpdatedMessage is defined and reportLastUpdatedMessage %}<span class="helpDate">{{ reportLastUpdatedMessage|raw }}</span>{% endif %}
     </div>
 
     <div class="dataTableWrapper">

--- a/plugins/CustomVariables/Reports/Base.php
+++ b/plugins/CustomVariables/Reports/Base.php
@@ -15,6 +15,7 @@ abstract class Base extends \Piwik\Plugin\Report
     protected function init()
     {
         $this->categoryId = 'General_Visitors';
+        $this->onlineGuideUrl = 'https://matomo.org/docs/custom-variables/';
     }
 
 }

--- a/plugins/Ecommerce/Reports/Base.php
+++ b/plugins/Ecommerce/Reports/Base.php
@@ -19,6 +19,7 @@ abstract class Base extends Report
     {
         $this->module   = 'Goals';
         $this->categoryId = 'Goals_Ecommerce';
+        $this->onlineGuideUrl = 'https://matomo.org/docs/ecommerce-analytics/';
     }
 
     public function isEnabled()

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_Goals.Get_AbandonedCart__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_Goals.Get_AbandonedCart__API.getProcessedReport_day.xml
@@ -10,6 +10,7 @@
 		<parameters>
 			<idGoal>ecommerceAbandonedCart</idGoal>
 		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Abandoned Carts</nb_conversions>
 			<conversion_rate>Conversion Rate</conversion_rate>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_Goals.Get_NormalGoal__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_Goals.Get_NormalGoal__API.getProcessedReport_day.xml
@@ -10,6 +10,7 @@
 		<parameters>
 			<idGoal>1</idGoal>
 		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 			<nb_visits_converted>Visits with Conversions</nb_visits_converted>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_Goals.Get_Order__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_Goals.Get_Order__API.getProcessedReport_day.xml
@@ -10,6 +10,7 @@
 		<parameters>
 			<idGoal>ecommerceOrder</idGoal>
 		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Ecommerce Orders</nb_conversions>
 			<nb_visits_converted>Visits with Conversions</nb_visits_converted>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_ItemsCategory__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_ItemsCategory__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Goals</module>
 		<action>getItemsCategory</action>
 		<dimension>Product Category</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<revenue>Product Revenue</revenue>
 			<quantity>Quantity</quantity>

--- a/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_ItemsSku__API.getProcessedReport_day.xml
+++ b/plugins/Ecommerce/tests/System/expected/test_ecommerceOrderWithItems_Metadata_ItemsSku__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Goals</module>
 		<action>getItemsSku</action>
 		<dimension>Product SKU</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<revenue>Product Revenue</revenue>
 			<quantity>Quantity</quantity>

--- a/plugins/Events/Reports/Base.php
+++ b/plugins/Events/Reports/Base.php
@@ -22,6 +22,7 @@ abstract class Base extends \Piwik\Plugin\Report
     {
         $this->categoryId = 'General_Actions';
         $this->subcategoryId = 'Events_Events';
+        $this->onlineGuideUrl = 'https://matomo.org/docs/event-tracking/';
 
         $this->processedMetrics = array(
             new AverageEventValue()

--- a/plugins/Goals/Reports/Base.php
+++ b/plugins/Goals/Reports/Base.php
@@ -21,6 +21,7 @@ abstract class Base extends \Piwik\Plugin\Report
     protected function init()
     {
         $this->categoryId = 'Goals_Goals';
+        $this->onlineGuideUrl = 'https://matomo.org/docs/tracking-goals-web-analytics/';
     }
 
     protected function addReportMetadataForEachGoal(&$availableReports, $infos, $goalNameFormatter, $isGoalSummaryReport = false)

--- a/plugins/Referrers/Reports/GetCampaigns.php
+++ b/plugins/Referrers/Reports/GetCampaigns.php
@@ -20,8 +20,8 @@ class GetCampaigns extends Base
         parent::init();
         $this->dimension     = new Campaign();
         $this->name          = Piwik::translate('Referrers_Campaigns');
-        $this->documentation = Piwik::translate('Referrers_CampaignsReportDocumentation',
-                               array('<br />', '<a href="https://matomo.org/docs/tracking-campaigns/" rel="noreferrer noopener" target="_blank">', '</a>'));
+        $this->documentation = Piwik::translate('Referrers_CampaignsReportDocumentation');
+        $this->onlineGuideUrl = 'https://matomo.org/docs/tracking-campaigns/';
         $this->actionToLoadSubTables = 'getKeywordsFromCampaignId';
         $this->hasGoalMetrics = true;
         $this->order = 9;

--- a/plugins/Referrers/lang/en.json
+++ b/plugins/Referrers/lang/en.json
@@ -3,7 +3,7 @@
         "AllReferrersReportDocumentation": "This report shows all your Referrers in one unified report, listing all Websites, Search keywords and Campaigns used by your visitors to find your website.",
         "Campaigns": "Campaigns",
         "CampaignsDocumentation": "Visitors that came to your website as the result of a campaign. %1$s See the %2$s report for more details.",
-        "CampaignsReportDocumentation": "This report shows which campaigns led visitors to your website. %1$s For more information about tracking campaigns, read the %2$scampaigns documentation on matomo.org%3$s",
+        "CampaignsReportDocumentation": "This report shows which campaigns led visitors to your website.",
         "ColumnCampaign": "Campaign",
         "CampaignPageUrlHelp": "The URL of the page that this campaign goes to, for example 'http://example.org/offer.html'.",
         "CampaignNameHelp": "Choose a name that describes what the campaign is created for and that distinguishes your campaign from your other campaigns. For example 'Email-SummerDeals' or 'PaidAds-SummerDeals'.",

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_flat__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Events</module>
 		<action>getAction</action>
 		<dimension>Event Action</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/event-tracking/</onlineGuideUrl>
 		<dimensions>
 			<Events_EventAction>Event Action</Events_EventAction>
 			<Events_EventName>Event Name</Events_EventName>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getAction_lastN__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Events</module>
 		<action>getAction</action>
 		<dimension>Event Action</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/event-tracking/</onlineGuideUrl>
 		<dimensions>
 			<Events_EventAction>Event Action</Events_EventAction>
 			<Events_EventName>Event Name</Events_EventName>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Events</module>
 		<action>getCategory</action>
 		<dimension>Event Category</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/event-tracking/</onlineGuideUrl>
 		<dimensions>
 			<Events_EventCategory>Event Category</Events_EventCategory>
 			<Events_EventAction>Event Action</Events_EventAction>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Events</module>
 		<action>getCategory</action>
 		<dimension>Event Category</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/event-tracking/</onlineGuideUrl>
 		<dimensions>
 			<Events_EventCategory>Event Category</Events_EventCategory>
 			<Events_EventAction>Event Action</Events_EventAction>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Events</module>
 		<action>getName</action>
 		<dimension>Event Name</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/event-tracking/</onlineGuideUrl>
 		<dimensions>
 			<Events_EventName>Event Name</Events_EventName>
 			<Events_EventAction>Event Action</Events_EventAction>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<module>Events</module>
 		<action>getName</action>
 		<dimension>Event Name</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/event-tracking/</onlineGuideUrl>
 		<dimensions>
 			<Events_EventName>Event Name</Events_EventName>
 			<Events_EventAction>Event Action</Events_EventAction>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
@@ -10,6 +10,7 @@
 		<action>getPageTitlesFollowingSiteSearch</action>
 		<dimension>Destination Page</dimension>
 		<documentation>When visitors search on your website, they are looking for a particular page, content, product, or service. This report lists the pages that were clicked the most after an internal search. In other words, the list of pages the most searched for by visitors already on your website.&lt;br/&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_hits_following_search>Clicked in search results</nb_hits_following_search>
 			<nb_hits>Pageviews</nb_hits>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageTitlesFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
@@ -10,6 +10,7 @@
 		<action>getPageTitlesFollowingSiteSearch</action>
 		<dimension>Destination Page</dimension>
 		<documentation>When visitors search on your website, they are looking for a particular page, content, product, or service. This report lists the pages that were clicked the most after an internal search. In other words, the list of pages the most searched for by visitors already on your website.&lt;br/&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_hits_following_search>Clicked in search results</nb_hits_following_search>
 			<nb_hits>Pageviews</nb_hits>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_day.xml
@@ -10,6 +10,7 @@
 		<action>getPageUrlsFollowingSiteSearch</action>
 		<dimension>Destination Page</dimension>
 		<documentation>When visitors search on your website, they are looking for a particular page, content, product, or service. This report lists the pages that were clicked the most after an internal search. In other words, the list of pages the most searched for by visitors already on your website.&lt;br/&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_hits_following_search>Clicked in search results</nb_hits_following_search>
 			<nb_hits>Pageviews</nb_hits>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getPageUrlsFollowingSiteSearch_firstSite_lastN__API.getProcessedReport_month.xml
@@ -10,6 +10,7 @@
 		<action>getPageUrlsFollowingSiteSearch</action>
 		<dimension>Destination Page</dimension>
 		<documentation>When visitors search on your website, they are looking for a particular page, content, product, or service. This report lists the pages that were clicked the most after an internal search. In other words, the list of pages the most searched for by visitors already on your website.&lt;br/&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_hits_following_search>Clicked in search results</nb_hits_following_search>
 			<nb_hits>Pageviews</nb_hits>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchCategories_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchCategories_firstSite_lastN__API.getProcessedReport_day.xml
@@ -10,6 +10,7 @@
 		<action>getSiteSearchCategories</action>
 		<dimension>Search Category</dimension>
 		<documentation>This report lists the Categories that visitors selected when they made a Search on your website.&lt;br/&gt;For example, Ecommerce websites typically have a &quot;Category&quot; selector so that visitors can restrict their searches to all products in a specific Category.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_visits>Searches</nb_visits>
 			<nb_pages_per_search>Search Results pages</nb_pages_per_search>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchCategories_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchCategories_firstSite_lastN__API.getProcessedReport_month.xml
@@ -10,6 +10,7 @@
 		<action>getSiteSearchCategories</action>
 		<dimension>Search Category</dimension>
 		<documentation>This report lists the Categories that visitors selected when they made a Search on your website.&lt;br/&gt;For example, Ecommerce websites typically have a &quot;Category&quot; selector so that visitors can restrict their searches to all products in a specific Category.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_visits>Searches</nb_visits>
 			<nb_pages_per_search>Search Results pages</nb_pages_per_search>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_day.xml
@@ -9,7 +9,8 @@
 		<module>Actions</module>
 		<action>getSiteSearchKeywords</action>
 		<dimension>Keyword</dimension>
-		<documentation>This report lists the Search Keywords that visitors searched for on your internal Search Engine.&lt;br/&gt;&lt;br/&gt;Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.&lt;br/&gt;&lt;br/&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about Tracking how your visitors use your Search engine.&lt;/a&gt;</documentation>
+		<documentation>This report lists the Search Keywords that visitors searched for on your internal Search Engine.&lt;br/&gt;&lt;br/&gt;Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_visits>Searches</nb_visits>
 			<nb_pages_per_search>Search Results pages</nb_pages_per_search>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchKeywords_firstSite_lastN__API.getProcessedReport_month.xml
@@ -9,7 +9,8 @@
 		<module>Actions</module>
 		<action>getSiteSearchKeywords</action>
 		<dimension>Keyword</dimension>
-		<documentation>This report lists the Search Keywords that visitors searched for on your internal Search Engine.&lt;br/&gt;&lt;br/&gt;Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.&lt;br/&gt;&lt;br/&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about Tracking how your visitors use your Search engine.&lt;/a&gt;</documentation>
+		<documentation>This report lists the Search Keywords that visitors searched for on your internal Search Engine.&lt;br/&gt;&lt;br/&gt;Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_visits>Searches</nb_visits>
 			<nb_pages_per_search>Search Results pages</nb_pages_per_search>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_day.xml
@@ -10,6 +10,7 @@
 		<action>getSiteSearchNoResultKeywords</action>
 		<dimension>Keyword with No Search Result</dimension>
 		<documentation>Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.&lt;br /&gt;&lt;br /&gt;This report lists the Search Keywords that did not return any Search result: maybe the search engine algorithm can be improved, or maybe your visitors are looking for content that is not (yet) on your website?</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_visits>Searches</nb_visits>
 		</metrics>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_Actions.getSiteSearchNoResultKeywords_firstSite_lastN__API.getProcessedReport_month.xml
@@ -10,6 +10,7 @@
 		<action>getSiteSearchNoResultKeywords</action>
 		<dimension>Keyword with No Search Result</dimension>
 		<documentation>Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.&lt;br /&gt;&lt;br /&gt;This report lists the Search Keywords that did not return any Search result: maybe the search engine algorithm can be improved, or maybe your visitors are looking for content that is not (yet) on your website?</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_visits>Searches</nb_visits>
 		</metrics>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_day.xml
@@ -10,6 +10,7 @@
 		<action>getCustomVariables</action>
 		<dimension>Custom Variable name</dimension>
 		<documentation>This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values. &lt;br /&gt; For more information about Custom Variables in general, read the &lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Custom Variables documentation on matomo.org&lt;/a&gt;</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/custom-variables/</onlineGuideUrl>
 		<dimensions>
 			<CustomVariables_CustomVariableName>Custom Variable name</CustomVariables_CustomVariableName>
 			<CustomVariables_CustomVariableValue>Custom Variable value</CustomVariables_CustomVariableValue>

--- a/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_month.xml
+++ b/tests/PHPUnit/System/expected/test_SiteSearch_CustomVariables.getCustomVariables_firstSite_lastN__API.getProcessedReport_month.xml
@@ -10,6 +10,7 @@
 		<action>getCustomVariables</action>
 		<dimension>Custom Variable name</dimension>
 		<documentation>This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values. &lt;br /&gt; For more information about Custom Variables in general, read the &lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Custom Variables documentation on matomo.org&lt;/a&gt;</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/custom-variables/</onlineGuideUrl>
 		<dimensions>
 			<CustomVariables_CustomVariableName>Custom Variable name</CustomVariables_CustomVariableName>
 			<CustomVariables_CustomVariableValue>Custom Variable value</CustomVariables_CustomVariableValue>

--- a/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_Goals.getDaysToConversion_firstSite_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_TwoVisitors_twoWebsites_differentDays_Conversions_Goals.getDaysToConversion_firstSite_lastN__API.getProcessedReport_day.xml
@@ -8,6 +8,7 @@
 		<module>Goals</module>
 		<action>getDaysToConversion</action>
 		<dimension>Days to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getGlossaryReports.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getGlossaryReports.xml
@@ -19,6 +19,7 @@
 	<row>
 		<name>Campaigns (Referrers)</name>
 		<documentation>This report shows which campaigns led visitors to your website.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-campaigns/</onlineGuideUrl>
 	</row>
 	<row>
 		<name>Channel Type (Referrers)</name>
@@ -43,6 +44,7 @@
 	<row>
 		<name>Custom Variables (Visitors)</name>
 		<documentation>This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values. &lt;br /&gt; For more information about Custom Variables in general, read the &lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Custom Variables documentation on matomo.org&lt;/a&gt;</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/custom-variables/</onlineGuideUrl>
 	</row>
 	<row>
 		<name>Downloads (Actions)</name>
@@ -79,6 +81,7 @@
 	<row>
 		<name>Page Titles Following a Site Search (Actions)</name>
 		<documentation>When visitors search on your website, they are looking for a particular page, content, product, or service. This report lists the pages that were clicked the most after an internal search. In other words, the list of pages the most searched for by visitors already on your website.&lt;br/&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 	</row>
 	<row>
 		<name>Page URLs (Actions)</name>
@@ -91,6 +94,7 @@
 	<row>
 		<name>Pages Following a Site Search (Actions)</name>
 		<documentation>When visitors search on your website, they are looking for a particular page, content, product, or service. This report lists the pages that were clicked the most after an internal search. In other words, the list of pages the most searched for by visitors already on your website.&lt;br/&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 	</row>
 	<row>
 		<name>Pages per Visit (Actions)</name>
@@ -103,6 +107,7 @@
 	<row>
 		<name>Search Categories (Actions)</name>
 		<documentation>This report lists the Categories that visitors selected when they made a Search on your website.&lt;br/&gt;For example, Ecommerce websites typically have a &quot;Category&quot; selector so that visitors can restrict their searches to all products in a specific Category.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 	</row>
 	<row>
 		<name>Search Engines (Referrers)</name>
@@ -111,10 +116,12 @@
 	<row>
 		<name>Search Keywords with No Results (Actions)</name>
 		<documentation>Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.&lt;br /&gt;&lt;br /&gt;This report lists the Search Keywords that did not return any Search result: maybe the search engine algorithm can be improved, or maybe your visitors are looking for content that is not (yet) on your website?</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 	</row>
 	<row>
 		<name>Site Search Keywords (Actions)</name>
 		<documentation>This report lists the Search Keywords that visitors searched for on your internal Search Engine.&lt;br/&gt;&lt;br/&gt;Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 	</row>
 	<row>
 		<name>Social Networks (Referrers)</name>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getGlossaryReports.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getGlossaryReports.xml
@@ -18,7 +18,7 @@
 	</row>
 	<row>
 		<name>Campaigns (Referrers)</name>
-		<documentation>This report shows which campaigns led visitors to your website. &lt;br /&gt; For more information about tracking campaigns, read the &lt;a href=&quot;https://matomo.org/docs/tracking-campaigns/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;campaigns documentation on matomo.org&lt;/a&gt;</documentation>
+		<documentation>This report shows which campaigns led visitors to your website.</documentation>
 	</row>
 	<row>
 		<name>Channel Type (Referrers)</name>
@@ -114,7 +114,7 @@
 	</row>
 	<row>
 		<name>Site Search Keywords (Actions)</name>
-		<documentation>This report lists the Search Keywords that visitors searched for on your internal Search Engine.&lt;br/&gt;&lt;br/&gt;Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.&lt;br/&gt;&lt;br/&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about Tracking how your visitors use your Search engine.&lt;/a&gt;</documentation>
+		<documentation>This report lists the Search Keywords that visitors searched for on your internal Search Engine.&lt;br/&gt;&lt;br/&gt;Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.</documentation>
 	</row>
 	<row>
 		<name>Social Networks (Referrers)</name>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportMetadata_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportMetadata_day.xml
@@ -904,6 +904,7 @@
 		<action>getCustomVariables</action>
 		<dimension>Custom Variable name</dimension>
 		<documentation>This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values. &lt;br /&gt; For more information about Custom Variables in general, read the &lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Custom Variables documentation on matomo.org&lt;/a&gt;</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/custom-variables/</onlineGuideUrl>
 		<dimensions>
 			<CustomVariables_CustomVariableName>Custom Variable name</CustomVariables_CustomVariableName>
 			<CustomVariables_CustomVariableValue>Custom Variable value</CustomVariables_CustomVariableValue>
@@ -1216,7 +1217,8 @@
 		<module>Actions</module>
 		<action>getSiteSearchKeywords</action>
 		<dimension>Keyword</dimension>
-		<documentation>This report lists the Search Keywords that visitors searched for on your internal Search Engine.&lt;br/&gt;&lt;br/&gt;Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.&lt;br/&gt;&lt;br/&gt;&lt;a href=&quot;https://matomo.org/docs/site-search/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Learn more about Tracking how your visitors use your Search engine.&lt;/a&gt;</documentation>
+		<documentation>This report lists the Search Keywords that visitors searched for on your internal Search Engine.&lt;br/&gt;&lt;br/&gt;Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_visits>Searches</nb_visits>
 			<nb_pages_per_search>Search Results pages</nb_pages_per_search>
@@ -1241,6 +1243,7 @@
 		<action>getPageUrlsFollowingSiteSearch</action>
 		<dimension>Destination Page</dimension>
 		<documentation>When visitors search on your website, they are looking for a particular page, content, product, or service. This report lists the pages that were clicked the most after an internal search. In other words, the list of pages the most searched for by visitors already on your website.&lt;br/&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_hits_following_search>Clicked in search results</nb_hits_following_search>
 			<nb_hits>Pageviews</nb_hits>
@@ -1268,6 +1271,7 @@
 		<action>getSiteSearchNoResultKeywords</action>
 		<dimension>Keyword with No Search Result</dimension>
 		<documentation>Tracking searches that visitors make on your website is a very effective way to learn more about what your audience is looking for, it can help find ideas for new content, new Ecommerce products that potential customers might be searching for, and generally improve the visitors' experience on your website.&lt;br /&gt;&lt;br /&gt;This report lists the Search Keywords that did not return any Search result: maybe the search engine algorithm can be improved, or maybe your visitors are looking for content that is not (yet) on your website?</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_visits>Searches</nb_visits>
 		</metrics>
@@ -1290,6 +1294,7 @@
 		<action>getPageTitlesFollowingSiteSearch</action>
 		<dimension>Destination Page</dimension>
 		<documentation>When visitors search on your website, they are looking for a particular page, content, product, or service. This report lists the pages that were clicked the most after an internal search. In other words, the list of pages the most searched for by visitors already on your website.&lt;br/&gt;Use the plus and minus icons on the left to navigate.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_hits_following_search>Clicked in search results</nb_hits_following_search>
 			<nb_hits>Pageviews</nb_hits>
@@ -1317,6 +1322,7 @@
 		<action>getSiteSearchCategories</action>
 		<dimension>Search Category</dimension>
 		<documentation>This report lists the Categories that visitors selected when they made a Search on your website.&lt;br/&gt;For example, Ecommerce websites typically have a &quot;Category&quot; selector so that visitors can restrict their searches to all products in a specific Category.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/site-search/</onlineGuideUrl>
 		<metrics>
 			<nb_visits>Searches</nb_visits>
 			<nb_pages_per_search>Search Results pages</nb_pages_per_search>
@@ -1380,6 +1386,7 @@
 		<module>Events</module>
 		<action>getCategory</action>
 		<dimension>Event Category</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/event-tracking/</onlineGuideUrl>
 		<dimensions>
 			<Events_EventCategory>Event Category</Events_EventCategory>
 			<Events_EventAction>Event Action</Events_EventAction>
@@ -1414,6 +1421,7 @@
 		<module>Events</module>
 		<action>getAction</action>
 		<dimension>Event Action</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/event-tracking/</onlineGuideUrl>
 		<dimensions>
 			<Events_EventAction>Event Action</Events_EventAction>
 			<Events_EventName>Event Name</Events_EventName>
@@ -1448,6 +1456,7 @@
 		<module>Events</module>
 		<action>getName</action>
 		<dimension>Event Name</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/event-tracking/</onlineGuideUrl>
 		<dimensions>
 			<Events_EventName>Event Name</Events_EventName>
 			<Events_EventAction>Event Action</Events_EventAction>
@@ -1482,6 +1491,7 @@
 		<module>Contents</module>
 		<action>getContentNames</action>
 		<dimension>Content Name</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/content-tracking/</onlineGuideUrl>
 		<metrics>
 			<nb_impressions>Impressions</nb_impressions>
 			<nb_interactions>Content Interactions</nb_interactions>
@@ -1506,6 +1516,7 @@
 		<module>Contents</module>
 		<action>getContentPieces</action>
 		<dimension>Content Piece</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/content-tracking/</onlineGuideUrl>
 		<metrics>
 			<nb_impressions>Impressions</nb_impressions>
 			<nb_interactions>Content Interactions</nb_interactions>
@@ -1901,7 +1912,8 @@
 		<module>Referrers</module>
 		<action>getCampaigns</action>
 		<dimension>Campaign</dimension>
-		<documentation>This report shows which campaigns led visitors to your website. &lt;br /&gt; For more information about tracking campaigns, read the &lt;a href=&quot;https://matomo.org/docs/tracking-campaigns/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;campaigns documentation on matomo.org&lt;/a&gt;</documentation>
+		<documentation>This report shows which campaigns led visitors to your website.</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-campaigns/</onlineGuideUrl>
 		<dimensions>
 			<Referrers_Campaign>Campaign</Referrers_Campaign>
 			<Referrers_Keyword>Keyword</Referrers_Keyword>
@@ -1947,6 +1959,7 @@
 		<parameters>
 			<idGoal>ecommerceOrder</idGoal>
 		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Ecommerce Orders</nb_conversions>
 			<nb_visits_converted>Visits with Conversions</nb_visits_converted>
@@ -1977,6 +1990,7 @@
 			<idGoal>ecommerceOrder</idGoal>
 		</parameters>
 		<dimension>Visits to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -1993,6 +2007,7 @@
 			<idGoal>ecommerceOrder</idGoal>
 		</parameters>
 		<dimension>Days to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2008,6 +2023,7 @@
 		<parameters>
 			<idGoal>ecommerceAbandonedCart</idGoal>
 		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Abandoned Carts</nb_conversions>
 			<conversion_rate>Conversion Rate</conversion_rate>
@@ -2033,6 +2049,7 @@
 			<idGoal>ecommerceAbandonedCart</idGoal>
 		</parameters>
 		<dimension>Visits to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2049,6 +2066,7 @@
 			<idGoal>ecommerceAbandonedCart</idGoal>
 		</parameters>
 		<dimension>Days to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2063,6 +2081,7 @@
 		<module>Goals</module>
 		<action>getItemsName</action>
 		<dimension>Product Name</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<revenue>Product Revenue</revenue>
 			<quantity>Quantity</quantity>
@@ -2085,6 +2104,7 @@
 		<module>Goals</module>
 		<action>getItemsSku</action>
 		<dimension>Product SKU</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<revenue>Product Revenue</revenue>
 			<quantity>Quantity</quantity>
@@ -2107,6 +2127,7 @@
 		<module>Goals</module>
 		<action>getItemsCategory</action>
 		<dimension>Product Category</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/ecommerce-analytics/</onlineGuideUrl>
 		<metrics>
 			<revenue>Product Revenue</revenue>
 			<quantity>Quantity</quantity>
@@ -2127,6 +2148,7 @@
 		<name>Goals</name>
 		<module>Goals</module>
 		<action>get</action>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 			<nb_visits_converted>Visits with Conversions</nb_visits_converted>
@@ -2148,6 +2170,7 @@
 		<module>Goals</module>
 		<action>getVisitsUntilConversion</action>
 		<dimension>Visits to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2168,6 +2191,7 @@
 		<module>Goals</module>
 		<action>getDaysToConversion</action>
 		<dimension>Days to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2190,6 +2214,7 @@
 		<parameters>
 			<idGoal>0</idGoal>
 		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 			<nb_visits_converted>Visits with Conversions</nb_visits_converted>
@@ -2214,6 +2239,7 @@
 			<idGoal>0</idGoal>
 		</parameters>
 		<dimension>Visits to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2230,6 +2256,7 @@
 			<idGoal>0</idGoal>
 		</parameters>
 		<dimension>Days to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2245,6 +2272,7 @@
 		<parameters>
 			<idGoal>1</idGoal>
 		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 			<nb_visits_converted>Visits with Conversions</nb_visits_converted>
@@ -2269,6 +2297,7 @@
 			<idGoal>1</idGoal>
 		</parameters>
 		<dimension>Visits to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2285,6 +2314,7 @@
 			<idGoal>1</idGoal>
 		</parameters>
 		<dimension>Days to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2300,6 +2330,7 @@
 		<parameters>
 			<idGoal>2</idGoal>
 		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 			<nb_visits_converted>Visits with Conversions</nb_visits_converted>
@@ -2324,6 +2355,7 @@
 			<idGoal>2</idGoal>
 		</parameters>
 		<dimension>Visits to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2340,6 +2372,7 @@
 			<idGoal>2</idGoal>
 		</parameters>
 		<dimension>Days to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2355,6 +2388,7 @@
 		<parameters>
 			<idGoal>3</idGoal>
 		</parameters>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 			<nb_visits_converted>Visits with Conversions</nb_visits_converted>
@@ -2379,6 +2413,7 @@
 			<idGoal>3</idGoal>
 		</parameters>
 		<dimension>Visits to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>
@@ -2395,6 +2430,7 @@
 			<idGoal>3</idGoal>
 		</parameters>
 		<dimension>Days to Conversion</dimension>
+		<onlineGuideUrl>https://matomo.org/docs/tracking-goals-web-analytics/</onlineGuideUrl>
 		<metrics>
 			<nb_conversions>Conversions</nb_conversions>
 		</metrics>

--- a/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables__subtable__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_twoVisitsWithCustomVariables__subtable__API.getProcessedReport_day.xml
@@ -9,6 +9,7 @@
 		<action>getCustomVariablesValuesFromNameId</action>
 		<dimension>Custom Variable value</dimension>
 		<documentation>This report contains information about your Custom Variables. Click on a variable name to see the distribution of the values. &lt;br /&gt; For more information about Custom Variables in general, read the &lt;a href=&quot;https://matomo.org/docs/custom-variables/&quot; rel=&quot;noreferrer noopener&quot; target=&quot;_blank&quot;&gt;Custom Variables documentation on matomo.org&lt;/a&gt;</documentation>
+		<onlineGuideUrl>https://matomo.org/docs/custom-variables/</onlineGuideUrl>
 		<isSubtableReport>1</isSubtableReport>
 		<metrics>
 			<nb_visits>Visits</nb_visits>


### PR DESCRIPTION
In order to show links to the online guide in all reports where one is available, I've implemented a new report property `onlineGuideUrl`. If it's defined for a report, a link will be shown in the report help.
In addition that url will also be available in the metadata and thus when fetch all reports meta data through API.

Would currently look like this if a documentation and a archive date is set for the report:

![image](https://user-images.githubusercontent.com/1579355/67194959-61d07080-f3f8-11e9-8ccb-4325670e5b87.png)

refs #4481