### PR TITLE
Prevent warning array to string conversion in console renderer

### DIFF
--- a/core/DataTable/Renderer/Console.php
+++ b/core/DataTable/Renderer/Console.php
@@ -148,6 +148,8 @@ class Console extends Renderer
                     foreach ($metadataIn as $name => $value) {
                         if (is_object($value) && !method_exists( $value, '__toString' )) {
                             $value = 'Object [' . get_class($value) . ']';
+                        } elseif (is_array($value)) {
+                            $value = 'Array ' . json_encode($value);
                         }
                         $output .= $prefix . $prefix . "$name => $value";
                     }


### PR DESCRIPTION
See https://forum.matomo.org/t/notice-array-to-string-conversion-matomo-3-11-0/34644

As we don't have more information yet I couldn't reproduce it. Looking at the code it seems though like some metadata has an array in there. I didn't even quite know we had this renderer and from what I can see we're using it to convert a dataTableMap to a string. Not sure when and why. It should fix the warning though.