### PR TITLE
Request different columns when no columns will be available

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/Graph.php
+++ b/plugins/CoreVisualizations/Visualizations/Graph.php
@@ -73,6 +73,19 @@ abstract class Graph extends Visualization
             $this->requestConfig->request_parameters_to_modify['keep_totals_row_label'] = Piwik::translate('General_Total');
         }
 
+        if (!empty($this->config->columns_to_display)) {
+            $metrics = $this->removeUnavailableMetrics($this->config->columns_to_display);
+            if (empty($metrics)) {
+                if (!empty($this->config->selectable_columns)) {
+                    $this->config->columns_to_display = array(reset($this->config->selectable_columns));
+                } else {
+                    $this->config->columns_to_display = array('nb_visit');
+                }
+                $this->requestConfig->request_parameters_to_modify['columns'] = 'nb_visits';
+                $this->requestConfig->request_parameters_to_modify['columns_to_display'] = 'nb_visits';
+            }
+        }
+
         $this->metricsFormatter = new Numeric();
     }
 


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/15033 
it might fix that issue

fixes a regression from https://github.com/matomo-org/matomo/pull/14996

When you have the Visits over time for example in the dashboard, view day period, select unique visitors, then select year period, it will then show visits metric instead of unique visitors because unique visitors is not available for year. The visits metric will not show any data though because it had the `&columns=nb_unique_visitors` param applied and the visits metric was never fetched. That's because in https://github.com/matomo-org/matomo/pull/14996 the metric was replaced after the dataTable was being requested. Trying to do this now before requesting dataTable too. Not sure what other regressions this could potentially introduce...