### PR TITLE
Fix warning Undefined index: host

### DIFF
--- a/core/Tracker/TrackerCodeGenerator.php
+++ b/core/Tracker/TrackerCodeGenerator.php
@@ -247,7 +247,7 @@ class TrackerCodeGenerator
         foreach ($websiteUrls as $site_url) {
             $referrerParsed = parse_url($site_url);
 
-            if (!isset($firstHost)) {
+            if (!isset($firstHost) && isset($referrerParsed['host'])) {
                 $firstHost = $referrerParsed['host'];
             }
 


### PR DESCRIPTION
> WARNING SitesManager [66dd3 ...] core/Tracker/TrackerCodeGenerator.php(251): Notice - Undefined index: host - Matomo 3.11.0 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)