### PR TITLE
Don't sum row columns

### DIFF
--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -32,6 +32,7 @@ class Row extends \ArrayObject
      */
     private static $unsummableColumns = array(
         'label'    => true,
+        'url'      => true,
         'full_url' => true // column used w/ old Piwik versions,
     );
 


### PR DESCRIPTION
Not sure what side effects this may have. Was first solving this in MediaAnayltics to prevent notices such as:

> WARNING MediaAnalytics[2019-09-23 19:22:13 UTC] [3489 ...] Trying to add two strings in DataTable\Row::sumRowArray: https:/... + https://...) for column url in row # ['label' => -1, 'nb_plays' => 8, 'nb_unique_visitors_plays' => 3, 'nb_impressions' => 80, 'nb_unique_visitors_impressions' => 47, 'nb_finishes' => 5, 'sum_media_length' => 120, 'sum_time_watched' => 87, 'sum_time_to_play' => 10, 'sum_time_progress' => 84, 'nb_plays_with_tip' => 8, 'nb_plays_with_ml' => 8, 'sum_fullscreen_plays' => 0, 'url' => 'https://...'] [] [idsubtable = ]<br />

but then also noticed this problem in other plugins such as Funnels. Maybe that fixes it for all plugins considering `url` is a common column maybe in Matomo and it shouldn't be summable?