### PR TITLE
Slight performance improvement when rendering data table visualisations

### DIFF
--- a/plugins/CoreHome/templates/_dataTable.twig
+++ b/plugins/CoreHome/templates/_dataTable.twig
@@ -2,7 +2,7 @@
     {% include visualizationTemplate %}
 {%- else -%}
 
-{% set isDataTableEmpty = (dataTable is not defined or dataTableHasNoData|default(false)) %}
+{% set isDataTableEmpty = (dataTable is not defined or dataTable is null or dataTableHasNoData|default(false)) %}
 
 {% set showCardAsContentBlock = (properties.show_as_content_block and properties.show_title and not isWidget) %}
 {% set showOnlyTitleWithoutCard = not showCardAsContentBlock and properties.title and properties.show_title %}

--- a/plugins/CoreHome/templates/_dataTable.twig
+++ b/plugins/CoreHome/templates/_dataTable.twig
@@ -2,7 +2,7 @@
     {% include visualizationTemplate %}
 {%- else -%}
 
-{% set isDataTableEmpty = (dataTable is empty or dataTableHasNoData|default(false)) %}
+{% set isDataTableEmpty = (dataTable is not defined or dataTableHasNoData|default(false)) %}
 
 {% set showCardAsContentBlock = (properties.show_as_content_block and properties.show_title and not isWidget) %}
 {% set showOnlyTitleWithoutCard = not showCardAsContentBlock and properties.title and properties.show_title %}


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/pull/15037

Currently it is checking if a data table is empty when means twig will call the toString method of our dataTables

![image](https://user-images.githubusercontent.com/273120/67432015-f2e65800-f641-11e9-95a4-5029855708b4.png)

which means for regular data tables it will use the HTML renderer just to check if the table is empty, for Maps it will use the console renderer. They always return a non empty string though meaning the check is kind of useless and only consumes CPU.