### PR TITLE
Fix error core JS proxy couldn't be decoded when gzipped

### DIFF
--- a/core/ProxyHttp.php
+++ b/core/ProxyHttp.php
@@ -170,7 +170,13 @@ class ProxyHttp
             Common::sendHeader('Content-Encoding: ' . $encoding);
         }
 
-        @ob_get_clean();
+        // in case any notices were triggered before this point (eg in WordPress) etc.
+        // it would break the gzipped response since it would have mixed regular notice/string plus gzipped content
+        // and would not be able to decode the response
+        $levels = ob_get_level();
+        for ( $i = 0; $i < $levels; $i++ ) {
+            ob_end_clean();
+        }
 
         if (!_readfile($file, $byteStart, $byteEnd)) {
             Common::sendResponseCode(500);

--- a/core/ProxyHttp.php
+++ b/core/ProxyHttp.php
@@ -170,6 +170,8 @@ class ProxyHttp
             Common::sendHeader('Content-Encoding: ' . $encoding);
         }
 
+        @ob_get_clean();
+
         if (!_readfile($file, $byteStart, $byteEnd)) {
             Common::sendResponseCode(500);
         }


### PR DESCRIPTION
refs https://github.com/matomo-org/wp-matomo/pull/40

This happens when eg WordPress might be triggering a notice before we do the "readfile" in which case the notice will be mixed with the gzipped content in the response and therefore the browser cannot read the gzipped JS/CSS. You can easily reproduce this by eg replacing the `ob_get_clean` with an `echo 'foobar';`

Something I don't quite understand yet is why it works when echoing something after the `_readfile`. In theory we would need to exit right away.