### PR TITLE
Avoid 'Trying to add two strings in DataTable\Row::sumRowArray' warning in SEO API

### DIFF
--- a/plugins/SEO/API.php
+++ b/plugins/SEO/API.php
@@ -43,7 +43,18 @@ class API extends \Piwik\Plugin\API
         $domain = Url::getHostFromUrl($url);
         $metrics = $metricProvider->getMetrics($domain);
 
-        return $this->toDataTable($metrics);
+        $dataTable = $this->toDataTable($metrics);
+        $dataTable->setMetadata(DataTable::COLUMN_AGGREGATION_OPS_METADATA_NAME, [
+            'id'           => 'skip',
+            'rank'         => 'skip',
+            'logo'         => 'skip',
+            'logo_link'    => 'skip',
+            'logo_tooltip' => 'skip',
+            'rank_suffix'  => 'skip',
+        ]);
+        $dataTable->disableFilter('Limit');
+
+        return $dataTable;
     }
 
     /**


### PR DESCRIPTION
When `SEO.getRank` is called with a `filter_limit` a warning is currently triggered, as a summary row is being built, causing errors in sumRowArray.

As a limit doesn't make much sense for that method at all, I decided to also deactivate the `Limit` filter, so all row are always returned.

fixes DEV-1803