### PR TITLE
Revert "Support alternative matomo bootstrap file"

### DIFF
--- a/console
+++ b/console
@@ -6,8 +6,6 @@ if (!defined('PIWIK_DOCUMENT_ROOT')) {
 
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
-} elseif (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
-    require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
 }
 
 if (!defined('PIWIK_INCLUDE_PATH')) {

--- a/index.php
+++ b/index.php
@@ -13,8 +13,6 @@ if (!defined('PIWIK_DOCUMENT_ROOT')) {
 }
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
-} elseif (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
-    require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
 }
 if (!defined('PIWIK_INCLUDE_PATH')) {
     define('PIWIK_INCLUDE_PATH', PIWIK_DOCUMENT_ROOT);

--- a/piwik.php
+++ b/piwik.php
@@ -24,8 +24,6 @@ if (!defined('PIWIK_DOCUMENT_ROOT')) {
 }
 if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
     require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
-} elseif (file_exists(PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php')) {
-    require_once PIWIK_DOCUMENT_ROOT . '/../matomo_bootstrap.php';
 }
 if (!defined('PIWIK_INCLUDE_PATH')) {
     define('PIWIK_INCLUDE_PATH', PIWIK_DOCUMENT_ROOT);


### PR DESCRIPTION
Reverts matomo-org/matomo#14887

fix https://github.com/matomo-org/matomo/issues/15070

I had added this for WP-Matomo but I can try to find a workaround by copying the bootstrap file into the app directory