### PR TITLE
Make private method getIndividualJsIncludesFromAssetFetcher in AssetManager protected

### DIFF
--- a/core/AssetManager.php
+++ b/core/AssetManager.php
@@ -323,7 +323,7 @@ class AssetManager extends Singleton
      * @param UIAssetFetcher $assetFetcher
      * @return string
      */
-    private function getIndividualJsIncludesFromAssetFetcher($assetFetcher)
+    protected function getIndividualJsIncludesFromAssetFetcher($assetFetcher)
     {
         $jsIncludeString = '';
 


### PR DESCRIPTION
following up from https://github.com/matomo-org/matomo/pull/15009 noticed this one should be protected now as well for WordPress. Needed for https://github.com/matomo-org/wp-matomo/pull/17