### PR TITLE
When checking if a segment archive table exists, try to read data from an actual column

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -221,7 +221,7 @@ class LogAggregator
     {
         try {
             // using DROP TABLE IF EXISTS would not work on a DB reader if the table doesn't exist...
-            $this->getDb()->fetchOne('SELECT 1 FROM ' . $segmentTablePrefixed . ' LIMIT 1');
+            $this->getDb()->fetchOne('SELECT idvisit FROM ' . $segmentTablePrefixed . ' LIMIT 1');
             $tableExists = true;
         } catch (\Exception $e) {
             $tableExists = false;


### PR DESCRIPTION
I'm trying to update WP-Matomo to 3.12.0 and noticed mysqli is not triggering an error when doing a `select 1`. At least in WordPress. Not sure it's an issue with our mysqli implementation as well but might be (haven't seen anything in tests though)