### PR TITLE
Revert umlaut icons

### DIFF
--- a/plugins/DevicesDetection/functions.php
+++ b/plugins/DevicesDetection/functions.php
@@ -17,7 +17,7 @@ use DeviceDetector\Parser\Client\Browser AS BrowserParser;
 function getBrandLogo($label)
 {
     $path = 'plugins/Morpheus/icons/dist/brand/%s.png';
-    $label = preg_replace("/[^a-z0-9_\-äöü]+/i", "_", $label);
+    $label = preg_replace("/[^a-z0-9_\-]+/i", "_", $label);
     if (!file_exists(PIWIK_INCLUDE_PATH . '/' . sprintf($path, $label))) {
         $label = "unk";
     }


### PR DESCRIPTION
fixes #15078 
reported in https://forum.matomo.org/t/matomo-3-11-0-3-12-0-missing-files/34765
partly reverts #14765

It seems like using umlauts in filenames was a pretty bad idea.