### PR TITLE
Fix zend session hides actual error when there are two or more errors…

### DIFF
--- a/libs/Zend/Session/Exception.php
+++ b/libs/Zend/Session/Exception.php
@@ -58,7 +58,7 @@ class Zend_Session_Exception extends Zend_Exception
         if (!isset(self::$sessionStartError)) {
             self::$sessionStartError = '';
         }
-        self::$sessionStartError .= $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr;
+        self::$sessionStartError .= $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr . ' ';
     }
 
     /**

--- a/libs/Zend/Session/Exception.php
+++ b/libs/Zend/Session/Exception.php
@@ -55,7 +55,10 @@ class Zend_Session_Exception extends Zend_Exception
      */
     static public function handleSessionStartError($errno, $errstr, $errfile, $errline, $errcontext)
     {
-        self::$sessionStartError = $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr;
+        if (!isset(self::$sessionStartError)) {
+            self::$sessionStartError = '';
+        }
+        self::$sessionStartError .= $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr;
     }
 
     /**


### PR DESCRIPTION
…/notices/warnings

Need to append each warning.