### PR TITLE
Ensure insight reports uses the correct compare period number for periods other than day

### DIFF
--- a/plugins/Insights/Visualizations/Insight.php
+++ b/plugins/Insights/Visualizations/Insight.php
@@ -49,7 +49,7 @@ class Insight extends Visualization
             'reportUniqueId' => $report,
             'minImpactPercent' => $this->requestConfig->min_impact_percent,
             'minGrowthPercent' => $this->requestConfig->min_growth_percent,
-            'comparedToXPeriods' => $this->requestConfig->compared_to_x_periods_ago,
+            'comparedToXPeriods' => $this->getComparedToXPeriodsAgo(),
             'orderBy'  => $this->requestConfig->order_by,
             'filterBy' => $this->requestConfig->filter_by,
             'pivotBy' => false,
@@ -57,6 +57,21 @@ class Insight extends Visualization
             'limitIncreaser' => $this->getLimitIncrease(),
             'limitDecreaser' => $this->getLimitDecrease(),
         );
+    }
+
+    private function getComparedToXPeriodsAgo()
+    {
+        $period = Common::getRequestVar('period', null, 'string');
+
+        if ($period === 'month' && $this->requestConfig->compared_to_x_periods_ago > 1) {
+            return 12;
+        }
+
+        if ($period !== 'day') {
+            return 1;
+        }
+
+        return $this->requestConfig->compared_to_x_periods_ago;
     }
 
     private function getLimitIncrease()


### PR DESCRIPTION
When viewing a insight report for a period other than day it might happen, that the report shows an error like this:

![image](https://user-images.githubusercontent.com/1579355/68128556-3bdabe00-ff18-11e9-89f9-702f73d340bd.png)

This happens when someone chooses to compare to same day in last year when viewing a day report and switching to another period afterwards.

When switching the compared date this setting is stored in the report options. When switching to another period like month, it tries to compare the current month to the month 365 months ago, as the stored option will be used.

As all periods except day should always compare to the last period before. This fix should solve this issue.
