### PR TITLE
Fixes a couple segment handling regressions in the UI

### DIFF
--- a/core/Segment.php
+++ b/core/Segment.php
@@ -123,7 +123,7 @@ class Segment
             // ignore
         }
 
-        if ($subexpressionsRaw > $subexpressionsDecoded) {
+        if ($subexpressionsRaw >= $subexpressionsDecoded) {
             $this->initializeSegment($segmentCondition, $idSites);
             $this->isSegmentEncoded = false;
         } else {

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -66,6 +66,11 @@ class Segment
     protected $string = null;
 
     /**
+     * @var string
+     */
+    protected $originalString = null;
+
+    /**
      * @var array
      */
     protected $idSites = null;
@@ -104,6 +109,8 @@ class Segment
             throw new Exception("The Super User has disabled the Segmentation feature.");
         }
 
+        $this->originalString = $segmentCondition;
+
         // The segment expression can be urlencoded. Unfortunately, both the encoded and decoded versions
         // can usually be parsed successfully. To pick the right one, we try both and pick the one w/ more
         // successfully parsed subexpressions.
@@ -123,7 +130,7 @@ class Segment
             // ignore
         }
 
-        if ($subexpressionsRaw >= $subexpressionsDecoded) {
+        if ($subexpressionsRaw > $subexpressionsDecoded) {
             $this->initializeSegment($segmentCondition, $idSites);
             $this->isSegmentEncoded = false;
         } else {
@@ -464,6 +471,10 @@ class Segment
             if ($storedSegment['definition'] == $segment
                 || $storedSegment['definition'] == urldecode($segment)
                 || $storedSegment['definition'] == urlencode($segment)
+
+                || $storedSegment['definition'] == $this->originalString
+                || $storedSegment['definition'] == urldecode($this->originalString)
+                || $storedSegment['definition'] == urlencode($this->originalString)
             ) {
                 $foundStoredSegment = $storedSegment;
             }

--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -447,7 +447,7 @@ var broadcast = {
             return (str+'').replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
         };
 
-        if (valFromUrl != '') {
+        if (valFromUrl != '' || urlStr.indexOf(paramName + '=') !== -1) {
             // replacing current param=value to newParamValue;
             valFromUrl = getQuotedRegex(valFromUrl);
             var regToBeReplace = new RegExp(paramName + '=' + valFromUrl, 'ig');

--- a/plugins/SegmentEditor/javascripts/Segmentation.js
+++ b/plugins/SegmentEditor/javascripts/Segmentation.js
@@ -939,10 +939,10 @@ $(document).ready(function() {
             segmentDefinition = this.uriEncodeSegmentDefinition(segmentDefinition);
 
             if (piwikHelper.isAngularRenderingThePage()) {
-                return broadcast.propagateNewPage('', true, 'addSegmentAsNew=&segment=' + segmentDefinition);
+                return broadcast.propagateNewPage('', true, 'addSegmentAsNew=&segment=' + segmentDefinition, ['compareSegments', 'comparePeriods']);
             } else {
                 // eg in case of exported dashboard
-                return broadcast.propagateNewPage('segment=' + segmentDefinition, true, 'addSegmentAsNew=&segment=' + segmentDefinition);
+                return broadcast.propagateNewPage('segment=' + segmentDefinition, true, 'addSegmentAsNew=&segment=' + segmentDefinition, ['compareSegments', 'comparePeriods']);
             }
         };
 

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -1806,6 +1806,48 @@ log_visit.visit_total_actions
         ];
     }
 
+    /**
+     * @dataProvider getTestDataForGetStoredSegmentName
+     */
+    public function test_getStoredSegmentName($segment, $expectedName)
+    {
+        SegmentEditorApi::getInstance()->add('test segment 1', 'browserCode==ff');
+        SegmentEditorApi::getInstance()->add('test segment 2', urlencode('browserCode==ch'));
+        SegmentEditorApi::getInstance()->add('test segment 3', 'pageUrl=@' . urlencode('/a/b?d=blahfty'));
+        SegmentEditorApi::getInstance()->add('test segment 4', 'pageUrl=@' . urlencode(urlencode('/a/b?d=wafty')));
+        SegmentEditorApi::getInstance()->add('test segment 5', urlencode('pageUrl=@' . urlencode(urlencode('/a/b?d=woo'))));
+
+        $segmentObj = new Segment($segment, [1]);
+        $this->assertEquals($expectedName, $segmentObj->getStoredSegmentName(1));
+    }
+
+    public function getTestDataForGetStoredSegmentName()
+    {
+        return [
+            ['browserCode==ff', 'test segment 1'],
+            [urlencode('browserCode==ff'), 'test segment 1'],
+
+            ['browserCode==ch', 'test segment 2'],
+            [urlencode('browserCode==ch'), 'test segment 2'],
+
+            ['pageUrl=@' . urlencode('/a/b?d=blahfty'), 'test segment 3'],
+            ['pageUrl=@' . urlencode(urlencode('/a/b?d=blahfty')), 'test segment 3'],
+
+            ['pageUrl=@' . urlencode(urlencode('/a/b?d=wafty')), 'test segment 4'],
+            [urlencode('pageUrl=@' . urlencode(urlencode('/a/b?d=wafty'))), 'test segment 4'],
+
+            ['pageUrl=@' . urlencode(urlencode('/a/b?d=woo')), 'test segment 5'],
+            [urlencode('pageUrl=@' . urlencode(urlencode('/a/b?d=woo'))), 'test segment 5'],
+
+            // these test cases won't pass because the value is encoded, but the operator isn't in one of the segments. kept here just
+            // so there's a `record that they won't work
+            // ['pageUrl=@' . urlencode('/a/b?d=wafty'), 'test segment 4'],
+            // [urlencode('pageUrl=@' . urlencode('/a/b?d=wafty')), 'test segment 4'],
+            // [urlencode('pageUrl=@' . urlencode('/a/b?d=woo')), 'test segment 5'],
+            // ['pageUrl=@' . urlencode('/a/b?d=woo'), 'test segment 5'],
+        ];
+    }
+
     private function assertWillBeArchived($segmentString)
     {
         $this->assertTrue($this->willSegmentByArchived($segmentString));

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_processedReportSingle__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_processedReportSingle__API.getProcessedReport_day.xml
@@ -277,7 +277,7 @@
 			<code>South America</code>
 		</row>
 		<row>
-			<label>Unknown</label>
+			<label>Europe</label>
 			<nb_uniq_visitors>1</nb_uniq_visitors>
 			<nb_visits>1</nb_visits>
 			<nb_actions>1</nb_actions>
@@ -337,22 +337,22 @@
 					<idsubdatatable>-1</idsubdatatable>
 				</row>
 				<row>
-					<nb_visits>2</nb_visits>
-					<nb_actions>2</nb_actions>
-					<revenue>$10</revenue>
-					<nb_actions_per_visit>1</nb_actions_per_visit>
-					<avg_time_on_site>00:00:00</avg_time_on_site>
-					<bounce_rate>100%</bounce_rate>
-					<nb_visits_change>+100%</nb_visits_change>
-					<nb_actions_change>+100%</nb_actions_change>
-					<revenue_change>+100%</revenue_change>
-					<nb_actions_per_visit_change>+0%</nb_actions_per_visit_change>
-					<avg_time_on_site_change>+0%</avg_time_on_site_change>
-					<bounce_rate_change>+0%</bounce_rate_change>
-					<label>0</label>
 					<nb_uniq_visitors>0</nb_uniq_visitors>
+					<nb_visits>0</nb_visits>
+					<nb_actions>0</nb_actions>
+					<revenue>$0</revenue>
+					<nb_actions_per_visit>0</nb_actions_per_visit>
+					<avg_time_on_site>00:00:00</avg_time_on_site>
+					<bounce_rate>0%</bounce_rate>
+					<nb_uniq_visitors_change>-100%</nb_uniq_visitors_change>
+					<nb_visits_change>-100%</nb_visits_change>
+					<nb_actions_change>-100%</nb_actions_change>
+					<revenue_change>-100%</revenue_change>
+					<nb_actions_per_visit_change>-100%</nb_actions_per_visit_change>
+					<avg_time_on_site_change>+0%</avg_time_on_site_change>
+					<bounce_rate_change>-100%</bounce_rate_change>
+					<label>0</label>
 					<label_change>+0%</label_change>
-					<nb_uniq_visitors_change>+0%</nb_uniq_visitors_change>
 					<compareSegment />
 					<compareSegmentPretty>All visits</compareSegmentPretty>
 					<comparePeriod>week</comparePeriod>
@@ -362,22 +362,22 @@
 					<idsubdatatable>-1</idsubdatatable>
 				</row>
 				<row>
-					<nb_visits>1</nb_visits>
-					<nb_actions>1</nb_actions>
-					<revenue>$5</revenue>
-					<nb_actions_per_visit>1</nb_actions_per_visit>
-					<avg_time_on_site>00:00:00</avg_time_on_site>
-					<bounce_rate>100%</bounce_rate>
-					<nb_visits_change>+0%</nb_visits_change>
-					<nb_actions_change>+0%</nb_actions_change>
-					<revenue_change>+0%</revenue_change>
-					<nb_actions_per_visit_change>+0%</nb_actions_per_visit_change>
-					<avg_time_on_site_change>+0%</avg_time_on_site_change>
-					<bounce_rate_change>+0%</bounce_rate_change>
-					<label>0</label>
 					<nb_uniq_visitors>0</nb_uniq_visitors>
+					<nb_visits>0</nb_visits>
+					<nb_actions>0</nb_actions>
+					<revenue>$0</revenue>
+					<nb_actions_per_visit>0</nb_actions_per_visit>
+					<avg_time_on_site>00:00:00</avg_time_on_site>
+					<bounce_rate>0%</bounce_rate>
+					<nb_uniq_visitors_change>-100%</nb_uniq_visitors_change>
+					<nb_visits_change>-100%</nb_visits_change>
+					<nb_actions_change>-100%</nb_actions_change>
+					<revenue_change>-100%</revenue_change>
+					<nb_actions_per_visit_change>-100%</nb_actions_per_visit_change>
+					<avg_time_on_site_change>+0%</avg_time_on_site_change>
+					<bounce_rate_change>-100%</bounce_rate_change>
+					<label>0</label>
 					<label_change>+0%</label_change>
-					<nb_uniq_visitors_change>+0%</nb_uniq_visitors_change>
 					<compareSegment>browserCode%3D%3Die</compareSegment>
 					<compareSegmentPretty>browserCode==ie</compareSegmentPretty>
 					<comparePeriod>week</comparePeriod>
@@ -387,7 +387,7 @@
 					<idsubdatatable>-1</idsubdatatable>
 				</row>
 			</comparisons>
-			<code>Unknown</code>
+			<code>Europe</code>
 		</row>
 	</reportData>
 	<reportMetadata>
@@ -398,7 +398,7 @@
 			<code>South America</code>
 		</row>
 		<row>
-			<code>Unknown</code>
+			<code>Europe</code>
 		</row>
 	</reportMetadata>
 	<reportTotal>

--- a/tests/PHPUnit/System/expected/test_DataComparisonTest_processedReportSingle__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_DataComparisonTest_processedReportSingle__API.getProcessedReport_day.xml
@@ -277,7 +277,7 @@
 			<code>South America</code>
 		</row>
 		<row>
-			<label>Europe</label>
+			<label>Unknown</label>
 			<nb_uniq_visitors>1</nb_uniq_visitors>
 			<nb_visits>1</nb_visits>
 			<nb_actions>1</nb_actions>
@@ -337,22 +337,22 @@
 					<idsubdatatable>-1</idsubdatatable>
 				</row>
 				<row>
-					<nb_uniq_visitors>0</nb_uniq_visitors>
-					<nb_visits>0</nb_visits>
-					<nb_actions>0</nb_actions>
-					<revenue>$0</revenue>
-					<nb_actions_per_visit>0</nb_actions_per_visit>
+					<nb_visits>2</nb_visits>
+					<nb_actions>2</nb_actions>
+					<revenue>$10</revenue>
+					<nb_actions_per_visit>1</nb_actions_per_visit>
 					<avg_time_on_site>00:00:00</avg_time_on_site>
-					<bounce_rate>0%</bounce_rate>
-					<nb_uniq_visitors_change>-100%</nb_uniq_visitors_change>
-					<nb_visits_change>-100%</nb_visits_change>
-					<nb_actions_change>-100%</nb_actions_change>
-					<revenue_change>-100%</revenue_change>
-					<nb_actions_per_visit_change>-100%</nb_actions_per_visit_change>
+					<bounce_rate>100%</bounce_rate>
+					<nb_visits_change>+100%</nb_visits_change>
+					<nb_actions_change>+100%</nb_actions_change>
+					<revenue_change>+100%</revenue_change>
+					<nb_actions_per_visit_change>+0%</nb_actions_per_visit_change>
 					<avg_time_on_site_change>+0%</avg_time_on_site_change>
-					<bounce_rate_change>-100%</bounce_rate_change>
+					<bounce_rate_change>+0%</bounce_rate_change>
 					<label>0</label>
+					<nb_uniq_visitors>0</nb_uniq_visitors>
 					<label_change>+0%</label_change>
+					<nb_uniq_visitors_change>+0%</nb_uniq_visitors_change>
 					<compareSegment />
 					<compareSegmentPretty>All visits</compareSegmentPretty>
 					<comparePeriod>week</comparePeriod>
@@ -362,22 +362,22 @@
 					<idsubdatatable>-1</idsubdatatable>
 				</row>
 				<row>
-					<nb_uniq_visitors>0</nb_uniq_visitors>
-					<nb_visits>0</nb_visits>
-					<nb_actions>0</nb_actions>
-					<revenue>$0</revenue>
-					<nb_actions_per_visit>0</nb_actions_per_visit>
+					<nb_visits>1</nb_visits>
+					<nb_actions>1</nb_actions>
+					<revenue>$5</revenue>
+					<nb_actions_per_visit>1</nb_actions_per_visit>
 					<avg_time_on_site>00:00:00</avg_time_on_site>
-					<bounce_rate>0%</bounce_rate>
-					<nb_uniq_visitors_change>-100%</nb_uniq_visitors_change>
-					<nb_visits_change>-100%</nb_visits_change>
-					<nb_actions_change>-100%</nb_actions_change>
-					<revenue_change>-100%</revenue_change>
-					<nb_actions_per_visit_change>-100%</nb_actions_per_visit_change>
+					<bounce_rate>100%</bounce_rate>
+					<nb_visits_change>+0%</nb_visits_change>
+					<nb_actions_change>+0%</nb_actions_change>
+					<revenue_change>+0%</revenue_change>
+					<nb_actions_per_visit_change>+0%</nb_actions_per_visit_change>
 					<avg_time_on_site_change>+0%</avg_time_on_site_change>
-					<bounce_rate_change>-100%</bounce_rate_change>
+					<bounce_rate_change>+0%</bounce_rate_change>
 					<label>0</label>
+					<nb_uniq_visitors>0</nb_uniq_visitors>
 					<label_change>+0%</label_change>
+					<nb_uniq_visitors_change>+0%</nb_uniq_visitors_change>
 					<compareSegment>browserCode%3D%3Die</compareSegment>
 					<compareSegmentPretty>browserCode==ie</compareSegmentPretty>
 					<comparePeriod>week</comparePeriod>
@@ -387,7 +387,7 @@
 					<idsubdatatable>-1</idsubdatatable>
 				</row>
 			</comparisons>
-			<code>Europe</code>
+			<code>Unknown</code>
 		</row>
 	</reportData>
 	<reportMetadata>
@@ -398,7 +398,7 @@
 			<code>South America</code>
 		</row>
 		<row>
-			<code>Europe</code>
+			<code>Unknown</code>
 		</row>
 	</reportMetadata>
 	<reportTotal>


### PR DESCRIPTION
FIxes #15080

Changes:
* When trying to see whether we should decode a segment, favor encoded segment since it appears to be more common. (This fixes issue in #15080)
* Replace existing param in URL if it exists but empty (eg, segment=). (this fixes issue that occurs when on All Visits and editing/adding a segment, the URL ends up containing `&segment=&segment=...`).
* If editing segment during comparison, remove comparison in case edited segment is one being compared.