### PR TITLE
Better detection of a succesfull start of a session

### DIFF
--- a/libs/Zend/Session.php
+++ b/libs/Zend/Session.php
@@ -479,14 +479,14 @@ class Zend_Session extends Zend_Session_Abstract
                 restore_error_handler();
             }
 
-            if (!$startedCleanly || Zend_Session_Exception::$sessionStartError != null) {
+            if (!$startedCleanly || !empty(Zend_Session_Exception::$sessionStartError)) {
                 if (self::$_throwStartupExceptions) {
                     set_error_handler(array('Zend_Session_Exception', 'handleSilentWriteClose'), $errorLevel);
                 }
                 session_write_close();
                 if (self::$_throwStartupExceptions) {
                     restore_error_handler();
-                    throw new Zend_Session_Exception(__CLASS__ . '::' . __FUNCTION__ . '() - ' . Zend_Session_Exception::$sessionStartError);
+                    throw new Zend_Session_Exception(__CLASS__ . '::' . __FUNCTION__ . '() - ' . Zend_Session_Exception::$sessionStartError . ' Warnings: ' . Zend_Session_Exception::$sessionStartWarning);
                 }
             }
         }

--- a/libs/Zend/Session/Exception.php
+++ b/libs/Zend/Session/Exception.php
@@ -43,7 +43,8 @@ class Zend_Session_Exception extends Zend_Exception
      * @see http://framework.zend.com/issues/browse/ZF-1325
      * @var string PHP Error Message
      */
-    static public $sessionStartError = null;
+    static public $sessionStartError = '';
+    static public $sessionStartWarning = '';
 
     /**
      * handleSessionStartError() - interface for set_error_handler()
@@ -55,10 +56,12 @@ class Zend_Session_Exception extends Zend_Exception
      */
     static public function handleSessionStartError($errno, $errstr, $errfile, $errline, $errcontext)
     {
-        if (!isset(self::$sessionStartError)) {
-            self::$sessionStartError = '';
+        $message = $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr;
+        if (E_ERROR === $errno || E_CORE_ERROR === $errno || E_COMPILE_ERROR === $errno) {
+            self::$sessionStartError .= $message . ' ';
+        } else {
+            self::$sessionStartWarning .= $message . ' ';
         }
-        self::$sessionStartError .= $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr . ' ';
     }
 
     /**


### PR DESCRIPTION
Differentiate between errors and warnings in session error handler and only assume session was not started if there was an error triggered. It should not throw an exception if there was only a notice or a warning.

Needed for WordPress. Eg there a caching plugin was trying to delete some cache after we executed a DB query, and did cache deletion on the file system triggered a warning. Then Zend_Session assumed the session was not started correctly even though it was and the warning was not related to session_start at all

![image](https://user-images.githubusercontent.com/273120/68238784-aef64880-006e-11ea-846a-fdc7e0343853.png)
