### PR TITLE
Show the link to upload a new plugin when enable_plugin_upload=1

### DIFF
--- a/plugins/CorePluginsAdmin/templates/plugins.twig
+++ b/plugins/CorePluginsAdmin/templates/plugins.twig
@@ -17,7 +17,7 @@
         <p>{{ 'CorePluginsAdmin_PluginsExtendPiwik'|translate }}
             {{ 'CorePluginsAdmin_OncePluginIsInstalledYouMayActivateHere'|translate }}
 
-            {% if isMarketplaceEnabled %}
+            {% if isMarketplaceEnabled or isPluginUploadEnabled %}
                 {{ 'CorePluginsAdmin_TeaserExtendPiwikByPlugin'|translate(
                     '<a href="' ~ linkTo({'action':'browsePlugins', 'sort': null, 'activated': null})|e('html_attr') ~ '">',
                     '</a>',


### PR DESCRIPTION
Reproduce:
* Disable Marketplace
* Enable `enable_plugin_upload=1`
* Got: no link to upload the plugin in the top of "Plugins" page.
* Expected to see the link to upload the plugin

Note: with this patch, if Marketplace is disabled and enable_plugin_upload=1 then users will see a link to the Marketplace as well as the zip upload link. When clicked it says "The plugin Marketplace is not enabled. You can activate the plugin on Settings > Plugins page in Matomo." which is fine imho.