### PR TITLE
Add support for up to 4 fields to multipairfield

### DIFF
--- a/plugins/CoreHome/angularjs/multipairfield/multipairfield.controller.js
+++ b/plugins/CoreHome/angularjs/multipairfield/multipairfield.controller.js
@@ -34,8 +34,16 @@
             $scope.field2.templateFile = getTemplate($scope.field2);
         }
 
+        if ($scope.field3 && !$scope.field3.templateFile) {
+            $scope.field3.templateFile = getTemplate($scope.field3);
+        }
+
+        if ($scope.field4 && !$scope.field4.templateFile) {
+            $scope.field4.templateFile = getTemplate($scope.field4);
+        }
+
         var self = this;
-        $scope.$watch('formValue', function () {
+        $scope.$watch('formValue', function () {;
             if (!$scope.formValue || !$scope.formValue.length) {
                 self.addEntry();
             } else {
@@ -50,7 +58,15 @@
                     hasAny = false;
                     return;
                 }
-                if ($scope.field1 && $scope.field2) {
+                if ($scope.field1 && $scope.field2 && $scope.field3 && $scope.field4) {
+                    if (!table[$scope.field1.key] && !table[$scope.field2.key] && !table[$scope.field3.key] && !table[$scope.field4.key]) {
+                        hasAny = false;
+                    }
+                } else if ($scope.field1 && $scope.field2 && $scope.field3) {
+                    if (!table[$scope.field1.key] && !table[$scope.field2.key] && !table[$scope.field3.key]) {
+                        hasAny = false;
+                    }
+                } else if ($scope.field1 && $scope.field2) {
                     if (!table[$scope.field1.key] && !table[$scope.field2.key]) {
                         hasAny = false;
                     }
@@ -63,6 +79,19 @@
                         hasAny = false;
                     }
                 }
+
+                var fieldCount = 0;
+                if ($scope.field1 && $scope.field2 && $scope.field3 && $scope.field4) {
+                    fieldCount = 4;
+                } else if ($scope.field1 && $scope.field2 && $scope.field3) {
+                    fieldCount = 3;
+                } else if ($scope.field1 && $scope.field2) {
+                    fieldCount = 2;
+                } else if ($scope.field1 || $scope.field2) {
+                    fieldCount = 1;
+                }
+                table.fieldCount = fieldCount;
+
             });
             if (hasAny) {
                 this.addEntry();
@@ -72,12 +101,24 @@
         this.addEntry = function () {
             if (angular.isArray($scope.formValue)) {
                 var obj = {};
+                var fieldCount = 0;
                 if ($scope.field1 && $scope.field1.key) {
                     obj[$scope.field1.key] = '';
+                    fieldCount++;
                 }
                 if ($scope.field2 && $scope.field2.key) {
                     obj[$scope.field2.key] = '';
+                    fieldCount++;
                 }
+                if ($scope.field3 && $scope.field3.key) {
+                    obj[$scope.field3.key] = '';
+                    fieldCount++;
+                }
+                if ($scope.field4 && $scope.field4.key) {
+                    obj[$scope.field4.key] = '';
+                    fieldCount++;
+                }
+                obj.fieldCount = fieldCount;
                 $scope.formValue.push(obj);
             }
         };

--- a/plugins/CoreHome/angularjs/multipairfield/multipairfield.directive.html
+++ b/plugins/CoreHome/angularjs/multipairfield/multipairfield.directive.html
@@ -1,13 +1,13 @@
 <div class="multiPairField form-group">
     <div ng-repeat="(index, item) in formValue"
-         class="multiPairFieldTable multiPairFieldTable{{ index }} multiple valign-wrapper">
+         class="multiPairFieldTable multiPairFieldTable{{ index }} has{{ item.fieldCount }}Fields multiple valign-wrapper">
 
         <div piwik-field uicontrol="{{ field1.uiControl }}"
              data-title="{{ field1.title }}"
              full-width="true"
              ng-if="field1.templateFile"
              template-file="{{ field1.templateFile }}"
-             class="fieldUiControl1"
+             class="fieldUiControl fieldUiControl1"
              ng-class="{'hasMultiFields': (field1.templateFile && field2.templateFile)}"
              ng-model="formValue[index][field1.key]"
              options="field1.availableValues"
@@ -19,11 +19,35 @@
              data-title="{{ field2.title }}"
              full-width="true"
              ng-if="field2.templateFile"
-             class="fieldUiControl2"
+             class="fieldUiControl fieldUiControl2"
              template-file="{{ field2.templateFile }}"
              options="field2.availableValues"
              ng-change="multiPairField.onEntryChange()"
              ng-model="formValue[index][field2.key]"
+             placeholder=" ">
+        </div>
+
+        <div piwik-field uicontrol="{{ field3.uiControl }}"
+             data-title="{{ field3.title }}"
+             full-width="true"
+             ng-if="field3.templateFile"
+             class="fieldUiControl fieldUiControl3"
+             template-file="{{ field3.templateFile }}"
+             options="field3.availableValues"
+             ng-change="multiPairField.onEntryChange()"
+             ng-model="formValue[index][field3.key]"
+             placeholder=" ">
+        </div>
+
+        <div piwik-field uicontrol="{{ field4.uiControl }}"
+             data-title="{{ field4.title }}"
+             full-width="true"
+             ng-if="field4.templateFile"
+             class="fieldUiControl fieldUiControl4"
+             template-file="{{ field4.templateFile }}"
+             options="field4.availableValues"
+             ng-change="multiPairField.onEntryChange()"
+             ng-model="formValue[index][field4.key]"
              placeholder=" ">
         </div>
 

--- a/plugins/CoreHome/angularjs/multipairfield/multipairfield.directive.js
+++ b/plugins/CoreHome/angularjs/multipairfield/multipairfield.directive.js
@@ -19,7 +19,9 @@
             restrict: 'A',
             scope: {
                 field1: '=',
-                field2: '='
+                field2: '=',
+                field3: '=',
+                field4: '='
             },
             require: "?ngModel",
             templateUrl: 'plugins/CoreHome/angularjs/multipairfield/multipairfield.directive.html?cb=' + piwik.cacheBuster,

--- a/plugins/CoreHome/angularjs/multipairfield/multipairfield.directive.less
+++ b/plugins/CoreHome/angularjs/multipairfield/multipairfield.directive.less
@@ -18,6 +18,7 @@
     &:not(.has1Fields) {
       .fieldUiControl {
         display: inline-block;
+        padding-right: 0.75rem;
       }
     }
 
@@ -33,7 +34,7 @@
   
     &.has3Fields {
       .fieldUiControl1 {
-        width: 140px;
+        width: 120px;
       }
       .fieldUiControl2,
       .fieldUiControl3 {
@@ -43,12 +44,12 @@
   
     &.has4Fields {
       .fieldUiControl1 {
-        width: 140px;
+        width: 120px;
       }
       .fieldUiControl2,
       .fieldUiControl3,
       .fieldUiControl4 {
-        width: 150px;
+        width: 148px;
       }
     }
   }

--- a/plugins/CoreHome/angularjs/multipairfield/multipairfield.directive.less
+++ b/plugins/CoreHome/angularjs/multipairfield/multipairfield.directive.less
@@ -6,21 +6,53 @@
     margin-bottom: 2px;
   }
 
-  .fieldUiControl1.hasMultiFields {
-    width: 160px;
-    display: inline-block;
+  .multiPairFieldTable {
+    
+    &.has1Fields {
+      .fieldUiControl1{
+        width: ~"calc(100% - 60px)";
+        padding-right: 0.75rem;
+      }
+    }
+  
+    &:not(.has1Fields) {
+      .fieldUiControl {
+        display: inline-block;
+      }
+    }
+
+    &.has2Fields {
+      .fieldUiControl1 {
+        width: 160px;
+      }
+      .fieldUiControl2 {
+        width: ~"calc(100% - 190px)";
+        padding: 0.75rem;
+      }
+    }
+  
+    &.has3Fields {
+      .fieldUiControl1 {
+        width: 140px;
+      }
+      .fieldUiControl2,
+      .fieldUiControl3 {
+        width: 220px;
+      }
+    }
+  
+    &.has4Fields {
+      .fieldUiControl1 {
+        width: 140px;
+      }
+      .fieldUiControl2,
+      .fieldUiControl3,
+      .fieldUiControl4 {
+        width: 150px;
+      }
+    }
   }
 
-  .fieldUiControl1:not(.hasMultiFields) {
-    width: ~"calc(100% - 60px)";
-    padding-right: 0.75rem;
-  }
-
-  .fieldUiControl2 {
-    width: ~"calc(100% - 190px)";
-    padding: 0.75rem;
-    display: inline-block;
-  }
   .icon-minus {
     cursor: pointer;
   }

--- a/plugins/CorePluginsAdmin/angularjs/form-field/field-multituple.html
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/field-multituple.html
@@ -3,7 +3,9 @@
          name="{{ formField.name }}"
          ng-model="formField.value"
          field1="formField.uiControlAttributes.field1"
-         field2="formField.uiControlAttributes.field2">
+         field2="formField.uiControlAttributes.field2"
+         field3="formField.uiControlAttributes.field3"
+         field4="formField.uiControlAttributes.field4">
     </div>
     <label for="{{ formField.name }}" ng-bind-html="formField.title"></label>
 </div>

--- a/plugins/Morpheus/templates/demo.twig
+++ b/plugins/Morpheus/templates/demo.twig
@@ -348,24 +348,66 @@
 </div>
 
 <div piwik-field uicontrol="multituple" name="multitupletext"
-     data-title="Multiple values"
+     data-title="Multiple values (two)"
      value="[]"
      inline-help="Multi Tuple text and text"
      ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"text","availableValues":null},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null}}'>
 </div>
 
 <div piwik-field uicontrol="multituple" name="multitupletextvalue"
-     data-title="Multiple values with values"
+     data-title="Multiple values with values (two)"
      value='[{"index": "test", "value":"myfoo"},{"index": "test 2", "value":"myfoo 2"}]'
      inline-help="Multi Tuple again."
      ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"text","availableValues":null},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null}}'>
 </div>
 
 <div piwik-field uicontrol="multituple" name="multitupleselect"
-     data-title="Multiple values with select"
+     data-title="Multiple values with select (two)"
      value='[{"index": "test", "value": "myfoo"}]'
      inline-help="Multi Tuple select and text"
      ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"select","availableValues":{"test":"test"}},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null}}'>
+</div>
+
+<div piwik-field uicontrol="multituple" name="multitupletext"
+     data-title="Multiple values (three)"
+     value="[]"
+     inline-help="Multi Tuple text and text"
+     ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"text","availableValues":null},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field3":{"key":"value","title":"Value","uiControl":"text","availableValues":null}}'>
+</div>
+
+<div piwik-field uicontrol="multituple" name="multitupletextvalue"
+     data-title="Multiple values with values (three)"
+     value='[{"index": "test", "value":"myfoo"},{"index": "test 2", "value":"myfoo 2"}]'
+     inline-help="Multi Tuple again."
+     ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"text","availableValues":null},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field3":{"key":"value","title":"Value","uiControl":"text","availableValues":null}}'>
+</div>
+
+<div piwik-field uicontrol="multituple" name="multitupleselect"
+     data-title="Multiple values with select (three)"
+     value='[{"index": "test", "value": "myfoo"}]'
+     inline-help="Multi Tuple select and text"
+     ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"select","availableValues":{"test":"test"}},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field3":{"key":"value","title":"Value","uiControl":"text","availableValues":null}}'>
+</div>
+
+<div piwik-field uicontrol="multituple" name="multitupletext"
+     data-title="Multiple values (four)"
+     value="[]"
+     inline-help="Multi Tuple text and text"
+     ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"text","availableValues":null},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field3":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field4":{"key":"value","title":"Value","uiControl":"text","availableValues":null}}'>
+</div>
+
+<div piwik-field uicontrol="multituple" name="multitupletextvalue"
+     data-title="Multiple values with values (four)"
+     value='[{"index": "test", "value":"myfoo"},{"index": "test 2", "value":"myfoo 2"}]'
+     inline-help="Multi Tuple again."
+     ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"text","availableValues":null},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field3":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field4":{"key":"value","title":"Value","uiControl":"text","availableValues":null}}'>
+</div>
+
+<div piwik-field uicontrol="multituple" name="multitupleselect"
+     data-title="Multiple values with select (four)"
+     value='[{"index": "test", "value": "myfoo"}]'
+     inline-help="Multi Tuple select and text"
+     ui-control-attributes='{"field1":{"key":"index","title":"Index","uiControl":"select","availableValues":{"test":"test"}},"field2":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field3":{"key":"value","title":"Value","uiControl":"text","availableValues":null},"field4":{"key":"value","title":"Value","uiControl":"text","availableValues":null}}'>
 </div>
 
 <div piwik-field uicontrol="multituple" name="multituplesingleselect"


### PR DESCRIPTION
Adds support for up to 4 fields in the multipairfield config template.
Needed for another pull requests for Tag Manager (support for Custom Variables https://github.com/matomo-org/tag-manager/pull/201).

Maybe the changes in "plugins/CorePluginsAdmin/angularjs/form-field/field-multituple.html" are not required? I am not 100% sure.