### PR TITLE
Adds additional system check for CREATE TEMPORARY TABLES permission

### DIFF
--- a/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
@@ -36,7 +36,11 @@ class DatabaseAbilitiesCheck implements Diagnostic
         }
 
         $result = new DiagnosticResult($this->translator->translate('Installation_DatabaseAbilities'));
-        $result->addItem($this->checkLoadDataInfile());
+
+        if (Config::getInstance()->General['enable_load_data_infile']) {
+            $result->addItem($this->checkLoadDataInfile());
+        }
+
         $result->addItem($this->checkTemporaryTables());
 
         return [$result];

--- a/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
@@ -42,6 +42,7 @@ class DatabaseAbilitiesCheck implements Diagnostic
         }
 
         $result->addItem($this->checkTemporaryTables());
+        $result->addItem($this->checkTransactionLevel());
 
         return [$result];
     }
@@ -124,6 +125,23 @@ class DatabaseAbilitiesCheck implements Diagnostic
             $status = DiagnosticResult::STATUS_ERROR;
             $comment .= '<br/>' . $this->translator->translate('Diagnostics_MysqlTemporaryTablesWarning');
             $comment .= '<br/>Troubleshooting: <a target="_blank" rel="noreferrer noopener" href="https://matomo.org/faq/how-to-install/faq_23484/">FAQ on matomo.org</a>';
+        }
+
+        return new DiagnosticResultItem($status, $comment);
+
+    }
+
+    protected function checkTransactionLevel()
+    {
+        $status = DiagnosticResult::STATUS_OK;
+        $comment = 'Changing transaction isolation level';
+
+        $level = new Db\TransactionLevel(Db::getReader());
+        if (!$level->setUncommitted()) {
+            $status = DiagnosticResult::STATUS_WARNING;
+            $comment .= '<br/>' . $this->translator->translate('Diagnostics_MysqlTransactionLevel');
+        } else {
+            $level->restorePreviousStatus();
         }
 
         return new DiagnosticResultItem($status, $comment);

--- a/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
@@ -109,6 +109,7 @@ class DatabaseAbilitiesCheck implements Diagnostic
         } catch (\Exception $e) {
             $status = DiagnosticResult::STATUS_ERROR;
             $comment .= '<br/>' . $this->translator->translate('Diagnostics_MysqlTemporaryTablesWarning');
+            $comment .= '<br/>Troubleshooting: <a target="_blank" rel="noreferrer noopener" href="https://matomo.org/faq/how-to-install/faq_23484/">FAQ on matomo.org</a>';
         }
 
         return new DiagnosticResultItem($status, $comment);

--- a/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
+++ b/plugins/Diagnostics/Diagnostic/DatabaseAbilitiesCheck.php
@@ -102,10 +102,24 @@ class DatabaseAbilitiesCheck implements Diagnostic
         $comment = 'CREATE TEMPORARY TABLES';
 
         try {
+            // create a temporary table
             Db::exec("CREATE TEMPORARY TABLE `piwik_test_table_temp` (
-                                        id INT AUTO_INCREMENT,
+                                        id INT,
+                                        val VARCHAR(5) NULL,
                                         PRIMARY KEY (id)
                                      )");
+
+            // insert an entry into the new temporary table
+            Db::exec('INSERT INTO `piwik_test_table_temp` (`id`, `val`) VALUES ("1", "val1");');
+
+            for ($i=0; $i < 5; $i++) {
+                // try reading the entry a few times to ensure it doesn't fail, which might be possible when using load balanced databases
+                $result = Db::fetchRow('SELECT * FROM `piwik_test_table_temp` WHERE `id` = 1');
+
+                if (empty($result)) {
+                    throw new \Exception('read failed');
+                }
+            }
         } catch (\Exception $e) {
             $status = DiagnosticResult::STATUS_ERROR;
             $comment .= '<br/>' . $this->translator->translate('Diagnostics_MysqlTemporaryTablesWarning');

--- a/plugins/Diagnostics/config/config.php
+++ b/plugins/Diagnostics/config/config.php
@@ -27,7 +27,7 @@ return array(
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\NfsDiskCheck'),
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\CronArchivingCheck'),
         DI\get(CronArchivingLastRunCheck::class),
-        DI\get('Piwik\Plugins\Diagnostics\Diagnostic\LoadDataInfileCheck'),
+        DI\get('Piwik\Plugins\Diagnostics\Diagnostic\DatabaseAbilitiesCheck'),
         Di\get('Piwik\Plugins\Diagnostics\Diagnostic\DbOverSSLCheck'),
         Di\get('Piwik\Plugins\Diagnostics\Diagnostic\DbMaxPacket'),
         Di\get('Piwik\Plugins\Diagnostics\Diagnostic\ForceSSLCheck'),

--- a/plugins/Diagnostics/lang/en.json
+++ b/plugins/Diagnostics/lang/en.json
@@ -1,6 +1,7 @@
 {
     "Diagnostics": {
         "ConfigFileTitle": "Config file",
+        "MysqlTemporaryTablesWarning": "MySQL Permission CREATE TEMPORARY TABLES is required for Matomo to work properly.",
         "MysqlMaxPacketSize": "Max Packet Size",
         "MysqlMaxPacketSizeWarning": "It is recommended to configure a 'max_allowed_packet' size in your MySQL database of at least %1$s. Configured is currently %2$s.",
         "ConfigFileIntroduction": "Here you can view the Matomo configuration. If you are running Matomo in a load balanced environment, the page might be different depending on from which server this page is loaded. Rows with a different background color are changed config values that are specified for example in the %1$s file.",

--- a/plugins/Diagnostics/lang/en.json
+++ b/plugins/Diagnostics/lang/en.json
@@ -2,6 +2,7 @@
     "Diagnostics": {
         "ConfigFileTitle": "Config file",
         "MysqlTemporaryTablesWarning": "MySQL Permission CREATE TEMPORARY TABLES is required for Matomo to work properly.",
+        "MysqlTransactionLevel": "Changing transaction isolation level not supported. Archiving will still work but it may be slower and it is recommended to change for example the `binlog_format` to `row` if possible.",
         "MysqlMaxPacketSize": "Max Packet Size",
         "MysqlMaxPacketSizeWarning": "It is recommended to configure a 'max_allowed_packet' size in your MySQL database of at least %1$s. Configured is currently %2$s.",
         "ConfigFileIntroduction": "Here you can view the Matomo configuration. If you are running Matomo in a load balanced environment, the page might be different depending on from which server this page is loaded. Rows with a different background color are changed config values that are specified for example in the %1$s file.",

--- a/plugins/Diagnostics/tests/UI/Diagnostics_spec.js
+++ b/plugins/Diagnostics/tests/UI/Diagnostics_spec.js
@@ -1,0 +1,21 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * Screenshot tests for the DBStats plugin.
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe("Diagnostics", function () {
+    this.timeout(0);
+
+    const url = "?module=Installation&action=systemCheckPage&idSite=1&period=day&date=yesterday";
+
+    it("should load correctly", async function() {
+        await page.goto(url);
+
+        const content = await page.$('#content');
+        expect(await content.screenshot()).to.matchImage('page');
+    });
+});

--- a/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
+++ b/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:beac9c4490143385645ba9176a3cb52dc32ce1c46cffd34d4dee642449dd36b2
+size 204429


### PR DESCRIPTION
Also hides the `LOAD DATA INFILE` check if that feature is disabled in config

fixes #15132
fixes #15115
refs #15084