### PR TITLE
Ensure missing GD extension doesn't break some features

### DIFF
--- a/core/Visualization/Sparkline.php
+++ b/core/Visualization/Sparkline.php
@@ -57,7 +57,13 @@ class Sparkline implements ViewInterface
 
     public function main()
     {
-        $sparkline = new \Davaxi\Sparkline();
+        try {
+            $sparkline = new \Davaxi\Sparkline();
+        } catch (\Exception $exception) {
+            // Ignore GD not installed exception
+            return;
+        }
+
 
         $thousandSeparator = Piwik::translate('Intl_NumberSymbolGroup');
         $decimalSeparator = Piwik::translate('Intl_NumberSymbolDecimal');
@@ -205,7 +211,9 @@ class Sparkline implements ViewInterface
     }
 
     public function render() {
-        $this->sparkline->display();
-        $this->sparkline->destroy();
+        if ($this->sparkline instanceof \Davaxi\Sparkline) {
+            $this->sparkline->display();
+            $this->sparkline->destroy();
+        }
     }
 }


### PR DESCRIPTION
Those small changes at least prevent the row evolution popover to only show the GD error. Instead only the sparklines will be shown as broken images. Guess that at least improves the behavior.

Not sure if that's enough to fix the referenced issue, or if we some-when try to find a way to show sparklines even without GD :man_shrugging: 

refs #15112