### PR TITLE
Fix "PHP Deprecated:  strpos(): Non-string needles will be interprete…

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -713,8 +713,9 @@ class Access
         }
         // Try to detect whether user was previously logged in so that we can display a different message
         $referrer = Url::getReferrer();
-        if ($referrer && Url::isValidHost(Url::getHostFromUrl($referrer)) &&
-            strpos($_SERVER['HTTP_REFERER'], SettingsPiwik::getPiwikUrl()) === 0
+        $matomoUrl = SettingsPiwik::getPiwikUrl();
+        if ($referrer && $matomoUrl && Url::isValidHost(Url::getHostFromUrl($referrer)) &&
+            strpos($referrer, $matomoUrl) === 0
         ) {
             $message = Piwik::translate('General_YourSessionHasExpired');
         }


### PR DESCRIPTION
…d as strings in the future." in Access class

refs https://github.com/matomo-org/wp-matomo/issues/72

[10-Nov-2019 16:43:37 UTC] PHP Deprecated:  strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in htdocs/wp-content/plugins/matomo/app/core/Access.php on line 717