### PR TITLE
Ignore SSL errors in UI tests

### DIFF
--- a/tests/lib/screenshot-testing/run-tests.js
+++ b/tests/lib/screenshot-testing/run-tests.js
@@ -20,7 +20,7 @@ require('./support/fs-extras');
 main();
 
 async function main() {
-    const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+    const browser = await puppeteer.launch({ args: ['--no-sandbox', '--ignore-certificate-errors'] });
     const webpage = await browser.newPage();
     await webpage._client.send('Animation.setPlaybackRate', { playbackRate: 50 }); // make animations run 50 times faster, so we don't have to wait as much
 


### PR DESCRIPTION
Most of our UI tests are running on http but sometimes some actions may require HTTPS and redirect to HTTPS automatically. 

I had this issue locally and got ` Error: net::ERR_CERT_AUTHORITY_INVALID at http://example.com/tests/PHPUnit/proxy/?idSite=1&period=day&date=2010-01-03&module=MobileMessaging&action=inde`

I reckon there shouldn't be a down side to ignoring SSL errors in our tests?