### PR TITLE
Only add site to list of sites to reprocess if only date being processed is today.

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -71,15 +71,13 @@ class Model
         $rows = Db::fetchAll($sql);
         foreach ($rows as $row) {
             $duplicateArchives = explode(',', $row['archives']);
+            $countOfArchives = count($duplicateArchives);
 
             $firstArchive = array_shift($duplicateArchives);
             list($firstArchiveId, $firstArchiveValue) = explode('.', $firstArchive);
 
-            // if the first archive (ie, the newest) is an 'ok' or 'ok temporary' archive, then
-            // all invalidated archives after it can be deleted
-            if ($firstArchiveValue == ArchiveWriter::DONE_OK
-                || $firstArchiveValue == ArchiveWriter::DONE_OK_TEMPORARY
-            ) {
+            // if there is more than one archive, the older invalidated ones can be deleted
+            if ($countOfArchives > 1) {
                 foreach ($duplicateArchives as $pair) {
                     if (strpos($pair, '.') === false) {
                         $this->logger->info("GROUP_CONCAT cut off the query result, you may have to purge archives again.");

--- a/tests/PHPUnit/Fixtures/TwoSitesVisitsInPast.php
+++ b/tests/PHPUnit/Fixtures/TwoSitesVisitsInPast.php
@@ -42,6 +42,22 @@ class TwoSitesVisitsInPast extends Fixture
         if (!self::siteCreated($idSite = 2)) {
             self::createWebsite($this->dateTimeCreationWebsite2);
         }
+
+        if (!self::siteCreated($idSite = 3)) {
+            self::createWebsite($this->dateTimeCreationWebsite2);
+        }
+
+        if (!self::siteCreated($idSite = 4)) {
+            self::createWebsite($this->dateTimeCreationWebsite2);
+        }
+
+        if (!self::siteCreated($idSite = 5)) {
+            self::createWebsite($this->dateTimeCreationWebsite2);
+        }
+
+        if (!self::siteCreated($idSite = 6)) {
+            self::createWebsite($this->dateTimeCreationWebsite2);
+        }
     }
 
     protected function trackVisits()

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -19,6 +19,7 @@ use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugins\CoreAdminHome\Tasks\ArchivesToPurgeDistributedList;
 use Piwik\Plugins\PrivacyManager\PrivacyManager;
+use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Archive\ArchiveInvalidator;
 use Piwik\Segment;
@@ -55,6 +56,15 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
         // these are static because it takes a long time to create new Segment instances (for some reason)
         self::$segment1 = new Segment(self::TEST_SEGMENT_1, array());
         self::$segment2 = new Segment(self::TEST_SEGMENT_2, array());
+    }
+
+    protected static function beforeTableDataCached()
+    {
+        parent::beforeTableDataCached();
+
+        for ($i = 0; $i != 10; ++$i) {
+            Fixture::createWebsite('2012-03-04');
+        }
     }
 
     public function setUp()

--- a/tests/PHPUnit/System/VisitsInPastInvalidateOldReportsTest.php
+++ b/tests/PHPUnit/System/VisitsInPastInvalidateOldReportsTest.php
@@ -79,7 +79,7 @@ class VisitsInPastInvalidateOldReportsTest extends SystemTestCase
 
         // 1) Invalidate old reports for the 2 websites
         // Test invalidate 1 date only
-        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=4,5,6,55,-1,s',1&dates=2010-01-03");
+        $r = new Request("module=API&method=CoreAdminHome.invalidateArchivedReports&idSites=4,5,6,-1,s',1&dates=2010-01-03");
         $this->assertApiResponseHasNoError($r->process());
 
         // Test invalidate comma separated dates


### PR DESCRIPTION
Quick fix for #15086 ... and fix for archive purging logic now that today dates are invalidated and temporary archives do not exist.

Fixes #15086 
Fixes #10439