### PR TITLE
Disable range select until overlay is fully loaded.

### DIFF
--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -122,6 +122,7 @@ var Piwik_Overlay = (function () {
     /** Hide the loading message */
     function hideLoading() {
         $loading.hide();
+        $('#overlayDateRangeSelect').prop('disabled', false).material_select();
     }
 
     function getOverlaySegment(url) {

--- a/plugins/Overlay/javascripts/Piwik_Overlay.js
+++ b/plugins/Overlay/javascripts/Piwik_Overlay.js
@@ -146,7 +146,8 @@ var Piwik_Overlay = (function () {
     }
 
     function setIframeOrigin(location) {
-        iframeOrigin = location.match(ORIGIN_PARSE_REGEX)[0];
+        var m = location.match(ORIGIN_PARSE_REGEX);
+        iframeOrigin = m ? m[0] : null;
 
         // unset iframe origin if it is not one of the site URLs
         var validSiteOrigins = Piwik_Overlay.siteUrls.map(function (url) {

--- a/plugins/Overlay/templates/index.twig
+++ b/plugins/Overlay/templates/index.twig
@@ -16,7 +16,7 @@
         <div id="overlayDateRangeSelection">
 
             <span class="icon icon-calendar"></span>
-            <select id="overlayDateRangeSelect" name="overlayDateRangeSelect">
+            <select id="overlayDateRangeSelect" name="overlayDateRangeSelect" disabled>
                 <option value="day;today">{{ 'Intl_Today'|translate }}</option>
                 <option value="day;yesterday">{{ 'Intl_Yesterday'|translate }}</option>
                 <option value="week;today">{{ 'General_CurrentWeek'|translate }}</option>


### PR DESCRIPTION
Fixes #14835 