### PR TITLE
Fix socket configuration not applied in MySQLi

### DIFF
--- a/libs/Zend/Db/Adapter/Mysqli.php
+++ b/libs/Zend/Db/Adapter/Mysqli.php
@@ -346,6 +346,8 @@ class Zend_Db_Adapter_Mysqli extends Zend_Db_Adapter_Abstract
             }
         }
 
+        $socket = !empty($this->_config['unix_socket']) ? $this->_config['unix_socket'] : null;
+
         // Suppress connection warnings here.
         // Throw an exception instead.
         $_isConnected = @mysqli_real_connect(
@@ -355,7 +357,7 @@ class Zend_Db_Adapter_Mysqli extends Zend_Db_Adapter_Abstract
             $this->_config['password'],
             $this->_config['dbname'],
             $port,
-            $socket = null,
+            $socket,
             $enable_ssl ? $flags : null
         );
 


### PR DESCRIPTION
We have a `unix_socket` setting to connect using this setting instead of host & port. It is being used in the Mysqli Tracker DB but by the looks not in the MySQLi core db. Haven't tested it but should work and at least won't make it worse :)