### PR TITLE
Update spyc to 0.6.X

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "twig/twig": "~1.0",
         "leafo/lessphp": "dev-php74-compat",
         "symfony/console": "~2.6.0",
-        "mustangostang/spyc": "~0.5.0",
+        "mustangostang/spyc": "~0.6.0",
         "piwik/device-detector": "~3.0",
         "piwik/decompress": "~1.0",
         "piwik/network": "~0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f244a77e8ac6cfb4125e24912c39833d",
+    "content-hash": "1da88efb800e7f42bb70995f59858ac9",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -631,20 +631,23 @@
         },
         {
             "name": "mustangostang/spyc",
-            "version": "0.5.1",
+            "version": "0.6.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mustangostang/spyc.git",
-                "reference": "dc4785b4d7227fd9905e086d499fb8abfadf9977"
+                "url": "git@github.com:mustangostang/spyc.git",
+                "reference": "4627c838b16550b666d15aeae1e5289dd5b77da0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mustangostang/spyc/zipball/dc4785b4d7227fd9905e086d499fb8abfadf9977",
-                "reference": "dc4785b4d7227fd9905e086d499fb8abfadf9977",
+                "url": "https://api.github.com/repos/mustangostang/spyc/zipball/4627c838b16550b666d15aeae1e5289dd5b77da0",
+                "reference": "4627c838b16550b666d15aeae1e5289dd5b77da0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.3.*@dev"
             },
             "type": "library",
             "extra": {
@@ -659,7 +662,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT License"
+                "MIT"
             ],
             "authors": [
                 {
@@ -674,7 +677,7 @@
                 "yaml",
                 "yml"
             ],
-            "time": "2013-02-21T10:52:01+00:00"
+            "time": "2019-09-10T13:16:29+00:00"
         },
         {
             "name": "pear/archive_tar",
@@ -772,18 +775,18 @@
             "authors": [
                 {
                     "name": "Greg Beaver",
-                    "role": "Helper",
-                    "email": "cellog@php.net"
+                    "email": "cellog@php.net",
+                    "role": "Helper"
                 },
                 {
                     "name": "Andrei Zmievski",
-                    "role": "Lead",
-                    "email": "andrei@php.net"
+                    "email": "andrei@php.net",
+                    "role": "Lead"
                 },
                 {
                     "name": "Stig Bakken",
-                    "role": "Developer",
-                    "email": "stig@php.net"
+                    "email": "stig@php.net",
+                    "role": "Developer"
                 }
             ],
             "description": "More info available on: http://pear.php.net/package/Console_Getopt",
@@ -826,8 +829,8 @@
             "authors": [
                 {
                     "name": "Christian Weiske",
-                    "role": "Lead",
-                    "email": "cweiske@php.net"
+                    "email": "cweiske@php.net",
+                    "role": "Lead"
                 }
             ],
             "description": "Minimal set of PEAR core files to be used as composer dependency",


### PR DESCRIPTION
@sgiehl any thoughts on that? I reckon shouldn't be an issue?

I was getting this error in WordPress:

```
Cannot declare class Spyc, because the name is already in use
```

Because it doesn't use the regular autoloader and Spyc's autoloader/class is loaded on every request. Only in 0.6.X they are checking if the class is already loaded and don't redeclare it https://github.com/mustangostang/spyc/blob/0.6.3/Spyc.php#L46 compared to before they always tried to redeclare it https://github.com/mustangostang/spyc/blob/0.5.1/Spyc.php#L57

This is basically needed for WordPress to:
* Have better compatibility with other WP plugins
* Support WP-CLI