### PR TITLE
Fix broken dashboard when a new version available and when multi_server_environment = 1

### DIFF
--- a/plugins/CoreHome/templates/_headerMessage.twig
+++ b/plugins/CoreHome/templates/_headerMessage.twig
@@ -35,7 +35,8 @@
 
     <div class="dropdown positionInViewport">
         {% if latest_version_available and isSuperUser %}
-            {% if isMultiServerEnvironment %}{{ 'CoreHome_OneClickUpdateNotPossibleAsMultiServerEnvironment'|translate("<a rel='noreferrer noopener' href='https://builds.matomo.org/piwik-" ~ latest_version_available ~ ".zip'>https://builds.matomo.org/piwik-" ~ latest_version_available ~ ".zip</a>")|raw }}
+            {% if isMultiServerEnvironment %}
+                {{ 'CoreHome_OneClickUpdateNotPossibleAsMultiServerEnvironment'|translate("<a rel='noreferrer noopener' href='https://builds.matomo.org/piwik-" ~ latest_version_available ~ ".zip'>builds.matomo.org</a>")|raw }}
             {% else %}
                 {{ 'General_PiwikXIsAvailablePleaseUpdateNow'|translate(latest_version_available,"<br /><a href='index.php?module=CoreUpdater&amp;action=newVersionAvailable'>","</a>","<a target='_blank' rel='noreferrer noopener' href='https://matomo.org/changelog/'>","</a>")|raw }}
             {% endif %}


### PR DESCRIPTION
Without this patch, the dashboard is broken when there is a new version available and when `multi_server_environment = 1`

Before:
![Screenshot from 2019-11-22 16-46-05](https://user-images.githubusercontent.com/466765/69396635-c9574400-0d47-11ea-9bbb-7b3150c8de91.png)
