### PR TITLE
Add more debug info to archiving queries

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -366,6 +366,11 @@ class LogAggregator
             $query['sql'] = 'SELECT /* ' . $this->queryOriginHint . ' */' . substr($query['sql'], strlen($select));
         }
 
+        if (!$segment->isEmpty() && is_array($query) && 0 === strpos(trim($query['sql']), $select)) {
+            $query['sql'] = trim($query['sql']);
+            $query['sql'] = 'SELECT /* ' . $this->dateStart->toString() . ',' . $this->dateEnd->toString() . ':' . implode(array_map('intval', $this->sites)). ' */' . substr($query['sql'], strlen($select));
+        }
+ 
     	// Log on DEBUG level all SQL archiving queries
         $this->logger->debug($query['sql']);
 

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -366,9 +366,10 @@ class LogAggregator
             $query['sql'] = 'SELECT /* ' . $this->queryOriginHint . ' */' . substr($query['sql'], strlen($select));
         }
 
-        if (!$segment->isEmpty() && is_array($query) && 0 === strpos(trim($query['sql']), $select)) {
+        if (empty($bind) && is_array($query) && 0 === strpos(trim($query['sql']), $select)) {
+            // bind is empty when a segment table was applied...
             $query['sql'] = trim($query['sql']);
-            $query['sql'] = 'SELECT /* ' . $this->dateStart->toString() . ',' . $this->dateEnd->toString() . ':' . implode(array_map('intval', $this->sites)). ' */' . substr($query['sql'], strlen($select));
+            $query['sql'] = 'SELECT /* ' . $this->dateStart->toString() . ',' . $this->dateEnd->toString() . ' ' . implode(',', array_map('intval', $this->sites)). ' */' . substr($query['sql'], strlen($select));
         }
  
     	// Log on DEBUG level all SQL archiving queries

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -366,10 +366,9 @@ class LogAggregator
             $query['sql'] = 'SELECT /* ' . $this->queryOriginHint . ' */' . substr($query['sql'], strlen($select));
         }
 
-        if (empty($bind) && is_array($query) && 0 === strpos(trim($query['sql']), $select)) {
-            // bind is empty when a segment table was applied...
+        if (!$this->getSegment()->isEmpty() && is_array($query) && 0 === strpos(trim($query['sql']), $select)) {
             $query['sql'] = trim($query['sql']);
-            $query['sql'] = 'SELECT /* ' . $this->dateStart->toString() . ',' . $this->dateEnd->toString() . ' ' . implode(',', array_map('intval', $this->sites)). ' */' . substr($query['sql'], strlen($select));
+            $query['sql'] = 'SELECT /* ' . $this->dateStart->toString() . ',' . $this->dateEnd->toString() . ' sites ' . implode(',', array_map('intval', $this->sites)) . ' segmenthash ' . $this->getSegment()->getHash(). ' */' . substr($query['sql'], strlen($select));
         }
  
     	// Log on DEBUG level all SQL archiving queries


### PR DESCRIPTION
Otherwise it is hard to find out  for what  period etc the query was. Ideally we would add segmentId instead of segmentHash but would need to refactor some code from segmentQueryDecorator to the segmentClass (the method that finds the segmentId for a segment)... 

example:
```sql
SELECT /* 2019-11-25,2019-11-26 sites 1 segmenthash 6fb490cfce17323e01f4d11d61ea9679 */ /* Core */
				count(distinct log_visit.idvisitor) AS `1`, 
			count(*) AS `2`, 
			sum(log_visit.visit_total_actions) AS `3`, 
			max(log_visit.visit_total_actions) AS `4`, 
			sum(log_visit.visit_total_time) AS `5`, 
			sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) AS `6`, 
			sum(case log_visit.visit_goal_converted when 1 then 1 else 0 end) AS `7`, 
			count(distinct log_visit.user_id) AS `39`
			FROM
				piwik_logtmpsegmentde86627ef24972fd077a35a9eb0dc563 AS logtmpsegmentde86627ef24972fd077a35a9eb0dc563 INNER JOIN piwik_log_visit AS log_visit ON log_visit.idvisit = logtmpsegmentde86627ef24972fd077a35a9eb0dc563.idvisit 
```