### PR TITLE
Add method to detect if we are running within Matomo for WordPress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 ## Matomo 3.13.1
 
 ### Deprecations
-The methods `\Piwik\Plugins\SitesManager\isSiteSpecificUserAgentExcludeEnabled()` and `\Piwik\Plugins\SitesManager\setSiteSpecificUserAgentExcludeEnabled()` have been deprecated.
+* The methods `\Piwik\Plugins\SitesManager\isSiteSpecificUserAgentExcludeEnabled()` and `\Piwik\Plugins\SitesManager\setSiteSpecificUserAgentExcludeEnabled()` have been deprecated.
+* The method `\Piwik\SettingsServer::isMatomoForWordPress()` has been added so plugins can detect if the plugin is being executed within Matomo for WordPress or Matomo On-Premise 
 
 ## Matomo 3.13.0
 

--- a/core/SettingsServer.php
+++ b/core/SettingsServer.php
@@ -57,6 +57,17 @@ class SettingsServer
     }
 
     /**
+     * Returns true if Matomo is running within Matomo for WordPress.
+     *
+     * @return bool  true if Matomo is running in WordPress, false if Matomo is running as part of On-Premise
+     * @api
+     */
+    public static function isMatomoForWordPress()
+    {
+        return defined( 'ABSPATH') && function_exists('\add_action');
+    }
+
+    /**
      * Returns `true` if running on Microsoft IIS 7 (or above), `false` if otherwise.
      *
      * @return bool


### PR DESCRIPTION
This allows plugins to change behavior when they are running within WordPress.