### PR TITLE
Ensure named character references without a tailing semicolon won't be replaced in transition urls

### DIFF
--- a/plugins/Actions/javascripts/rowactions.js
+++ b/plugins/Actions/javascripts/rowactions.js
@@ -23,6 +23,9 @@ $(function () {
         tr = getRealRowIfComparisonRow(tr);
 
         var link = tr.find('> td:first > a').attr('href');
+        // replace all &, that are not part of a named character reference with a tailing semicolon, with a &amp;
+        // otherwise named character references without a tailing , (like &reg) would be replaced
+        link = link.replace(/&([a-z]+[^a-z;])/, '&amp;$1');
         link = $('<textarea>').html(link).val(); // remove html entities
         return link;
     }


### PR DESCRIPTION
I've debugged the issue of #10733 for a while now, and the real issue is here: 
https://github.com/matomo-org/matomo/blob/3f26e785f015d30d0aeea66aaf7484111b0dbfa9/plugins/Actions/javascripts/rowactions.js#L21-L28

Decoding the html entities also converts stuff like `&reg` into `®`. That also happens without the tailing `;` as various named references don't need it. See https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references