### PR TITLE
Fix site selector shows undefined in custom dimensions 

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -753,6 +753,10 @@ abstract class Controller
         $view->relativePluginWebDirs = (object) $pluginManager->getWebRootDirectoriesForCustomPluginDirs();
         $view->isMultiSitesEnabled = Manager::getInstance()->isPluginActivated('MultiSites');
 
+        if (isset($this->site) && is_object($this->site) && $this->site instanceof Site) {
+            $view->siteName = $this->site->getName();
+        }
+
         self::setHostValidationVariablesView($view);
     }
 


### PR DESCRIPTION
fix DEV-1827

Needed because otherwise the sites selector shows  otherwise undefined as site name when https://github.com/matomo-org/plugin-CustomDimensions/pull/136/files is merged