### PR TITLE
Fix Malformed URL in real-time-visitors module

### DIFF
--- a/plugins/Actions/VisitorDetails.php
+++ b/plugins/Actions/VisitorDetails.php
@@ -138,10 +138,12 @@ class VisitorDetails extends VisitorDetailsAbstract
 
         // Reconstruct url from prefix
         if (array_key_exists('url', $action) && array_key_exists('url_prefix', $action)) {
-            $url = PageUrl::reconstructNormalizedUrl($action['url'], $action['url_prefix']);
-            $url = Common::unsanitizeInputValue($url);
+            if (stripos($action['url'], 'http://') !== 0 && stripos($action['url'], 'https://') !== 0) {
+                $url = PageUrl::reconstructNormalizedUrl($action['url'], $action['url_prefix']);
+                $url = Common::unsanitizeInputValue($url);
+                $action['url'] = $url;
+            }
 
-            $action['url'] = $url;
             unset($action['url_prefix']);
         }
 


### PR DESCRIPTION
This issue was created in WP Matomo so was investigating and could reproduce this eg by tracking

```js
_paq.push(['trackLink', 'http://mydomain.co.uk/mailto/Agent', 'download']);
```

It adds the http:// prefix twice causing the links to not work. Maybe this was a regression from when refactoring things into visitorDetails? It's probably more a workaround since the actual issue might be that it shouldn't set the url prefix when it keeps the http url, or maybe it should remove the http in the action when it sets a url prefix... 

This might be a more proper fix but not sure if it would regress anything

```diff
--- a/app/plugins/Actions/Actions/ActionDownloadUrl.php
+++ b/app/plugins/Actions/Actions/ActionDownloadUrl.php
@@ -34,7 +34,7 @@ class ActionDownloadUrl extends Action
     {
         return array(
             // Note: we do not normalize download URL
-            'idaction_url' => array($this->getActionUrl(), $this->getActionType())
+               'idaction_url'  => $this->getUrlAndType()
         );
     }
 ```

(it would actually use the wrong type Page URL and would need to adjust this...) I reckon we better don't change this in a minor/patch release.

fix https://github.com/matomo-org/matomo/issues/15232