### PR TITLE
do not check licenses in development mode since it has no cache

### DIFF
--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -56,6 +56,10 @@ abstract class ControllerAdmin extends Controller
             return;
         }
 
+        if (Development::isEnabled()) {
+            return;
+        }
+
         $expired = StaticContainer::get('Piwik\Plugins\Marketplace\Plugins\InvalidLicenses');
 
         $messageLicenseMissing = $expired->getMessageNoLicense();


### PR DESCRIPTION
Doesn't make it faster w/ Marketplace enabled in development mode since there are other places that trigger an HTTP request though.