### PR TITLE
Don't lock log_visit table to check if privilege is granted

### DIFF
--- a/core/Db.php
+++ b/core/Db.php
@@ -786,7 +786,7 @@ class Db
     {
         if (is_null(self::$lockPrivilegeGranted)) {
             try {
-                Db::lockTables(Common::prefixTable('log_visit'));
+                Db::lockTables(Common::prefixTable('site_url'));
                 Db::unlockAllTables();
 
                 self::$lockPrivilegeGranted = true;


### PR DESCRIPTION
Instead use a table we write to less frequently. Otherwise, whenever we over privacy settings or when it is trying to delete unused actions it will lock the log_visit table for a short time that could cause random tracking issues (eg heap of requests piling up trying to write to the log_visit table).

It's only a read lock but according to MySQL it still blocks other sessions from writing

from http://www.mysqltutorial.org/mysql-table-locking/: 
> The session that holds the READ lock can only read data from the table, but cannot write. And other sessions cannot write data to the table until the READ lock is released. The write operations from another session will be put into the waiting states until the READ lock is released.

This method is rarely executed so I don't think it was any big issue and it should be quickly unlocked again.