### PR TITLE
Prevent notice in installer enable_ssl not defined

### DIFF
--- a/plugins/Installation/FormDatabaseSetup.php
+++ b/plugins/Installation/FormDatabaseSetup.php
@@ -131,7 +131,8 @@ class FormDatabaseSetup extends QuickForm2
             'adapter'       => $adapter,
             'port'          => $port,
             'schema'        => Config::getInstance()->database['schema'],
-            'type'          => $this->getSubmitValue('type')
+            'type'          => $this->getSubmitValue('type'),
+            'enable_ssl'    => false
         );
 
         if (($portIndex = strpos($dbInfos['host'], '/')) !== false) {


### PR DESCRIPTION
Installed Matomo on cli and got this notice
/core/Db/Adapter/Pdo/Mysql.php(38): Notice - Undefined index: enable_ssl - Matomo 3.13.0 -