### PR TITLE
Fix visitors overview ui test

### DIFF
--- a/tests/UI/expected-screenshots/UIIntegrationTest_visitors_overview_columns.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_visitors_overview_columns.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5797c570a3eff9aa550442eedfa692a89865da9b9081245c08672f6bf6324b92
+size 71706

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -137,7 +137,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         await page.waitForNetworkIdle();
 
         pageWrap = await page.$('.pageWrap');
-        expect(await pageWrap.screenshot()).to.matchImage('visitors_overview');
+        expect(await pageWrap.screenshot()).to.matchImage('visitors_overview_columns');
     });
 
     it('should reload the visitors > overview page when clicking on the visitors overview page element again', async function () {


### PR DESCRIPTION
The two tests using the same screenshot actually differ, as the first test adds a `columns` parameter to the url, which is lost when reloading the reports through the menu.

Not 100% sure if the passed column value should be stored in user settings, but afaik it's expected behavior that it's not stored and so lost on reload.

Note: The test seems to be failing for a long time. But as the result was overwritten by the second test, the UI viewer always showed 0% difference...