### PR TITLE
Use PHP_BINDIR if other environment variables/constants are not present when looking for the PHP binary.

### DIFF
--- a/core/CliMulti/CliPhp.php
+++ b/core/CliMulti/CliPhp.php
@@ -34,7 +34,7 @@ class CliPhp
             $bin = $this->getPhpCommandIfValid($_SERVER['argv'][0]);
         }
 
-        if (defined('PHP_BINDIR')) {
+        if (empty($bin)) {
             $possiblePhpPath = PHP_BINDIR . ('\\' === \DIRECTORY_SEPARATOR ? '\\php.exe' : '/php');
             $bin = $this->getPhpCommandIfValid($possiblePhpPath);
         }

--- a/core/CliMulti/CliPhp.php
+++ b/core/CliMulti/CliPhp.php
@@ -34,6 +34,11 @@ class CliPhp
             $bin = $this->getPhpCommandIfValid($_SERVER['argv'][0]);
         }
 
+        if (defined('PHP_BINDIR')) {
+            $possiblePhpPath = PHP_BINDIR . ('\\' === \DIRECTORY_SEPARATOR ? '\\php.exe' : '/php');
+            $bin = $this->getPhpCommandIfValid($possiblePhpPath);
+        }
+
         if (!$this->isValidPhpType($bin)) {
             $bin = shell_exec('which php');
         }


### PR DESCRIPTION
h/t https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Process/PhpExecutableFinder.php