### PR TITLE
Trust cookie only when visitorId is set

### DIFF
--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -143,7 +143,7 @@ class VisitorRecognizer
 
         // This setting would be enabled for Intranet websites, to ensure that visitors using all the same computer config, same IP
         // are not counted as 1 visitor. In this case, we want to enforce and trust the visitor ID from the cookie.
-        if (($isVisitorIdToLookup || $isForcedUserIdMustMatch) && $this->trustCookiesOnly) {
+        if ($isVisitorIdToLookup && $this->trustCookiesOnly) {
             return true;
         }
 


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/15205

Since we no longer use the UserId as VisitorId I reckon this needs changing. I haven't tested anything but it seems logical to me. Otherwise there might be issues where no visitorId is set but a userId and then it always creates new visits.