### PR TITLE
New implementation of generateUniqId() using random_bytes()

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -603,9 +603,7 @@ class Common
      */
     public static function generateUniqId()
     {
-        $rand = self::getRandomInt();
-
-        return md5(uniqid($rand, true));
+        return bin2hex(random_bytes(16));
     }
 
     /**


### PR DESCRIPTION
Note that the `random_bytes()` function is only available in PHP 7.  As we won't be supporting PHP 5.x in Matomo 4.0 I haven't implemented any backwards compatibility for this and there are many tests failing on PHP 5.6.

Fixes #13357 