### PR TITLE
Check site permission should check if site actually exists

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -1035,6 +1035,7 @@ abstract class Controller
     {
         if (!empty($this->idSite)) {
             Access::getInstance()->checkUserHasViewAccess($this->idSite);
+            new Site($this->idSite);
         } elseif (empty($this->site) || empty($this->idSite)) {
             throw new Exception("The requested website idSite is not found in the request, or is invalid.
 				Please check that you are logged in Matomo and have permission to access the specified website.");


### PR DESCRIPTION
Noticed this error in the logs:

> Error: {"message":"Call to a member function getName() on null","file":"\/core\/Plugin\/Controller.php","line":622,"request_id":"57488","backtrace":" on l\/core\/Plugin\/Controller.php(622)\n#0 l\/core\/Plugin\/Controller.php(607): Piwik\\Plugin\\Controller->setGeneralVariablesViewAs(Object(Piwik\\View), 'basic')\n#1

The request was like this:

> /index.php?module=Widgetize&action=iframe&moduleToWidgetize=Dashboard&actionToWidgetize=index&idSite=254&period=week&date=today&token_auth=XYZANONYMIZED

So you'd think the `checkSitePermission` should have failed but it didn't because it was requested by a super user and `checkUserHasViewAccess` does not actually check if the site exists for a super user.