### PR TITLE
Add method to get errors in Cron archive

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -554,6 +554,11 @@ class CronArchive
         $this->logger->info($timer->__toString());
     }
 
+    public function getErrors()
+    {
+    	return $this->errors;
+    }
+
     /**
      * End of the script
      */


### PR DESCRIPTION
Needing it in Matomo for WordPress to print any error that happens during a manual archive test run