### PR TITLE
Fix mysql table name too long while archiving a segment

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -195,7 +195,8 @@ class LogAggregator
     private function getSegmentTmpTableName()
     {
         $bind = $this->getGeneralQueryBindParams();
-        return self::LOG_TABLE_SEGMENT_TEMPORARY_PREFIX . md5(json_encode($bind) . $this->segment->getString());
+        $tableName = self::LOG_TABLE_SEGMENT_TEMPORARY_PREFIX . md5(json_encode($bind) . $this->segment->getString());
+        return Common::mb_substr($tableName, 0, 64);
     }
 
     public function cleanup()

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -196,7 +196,7 @@ class LogAggregator
     {
         $bind = $this->getGeneralQueryBindParams();
         $tableName = self::LOG_TABLE_SEGMENT_TEMPORARY_PREFIX . md5(json_encode($bind) . $this->segment->getString());
-        return Common::mb_substr($tableName, 0, 64);
+        return Common::mb_substr($tableName, 0, Db\Schema\Mysql::MAX_TABLE_NAME_LENGTH);
     }
 
     public function cleanup()

--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -24,6 +24,7 @@ use Piwik\Version;
 class Mysql implements SchemaInterface
 {
     const OPTION_NAME_MATOMO_INSTALL_VERSION = 'install_version';
+    const MAX_TABLE_NAME_LENGTH = 64;
 
     private $tablesInstalled = null;
 


### PR DESCRIPTION
fix error 
> WP DB Error: Identifier name 'wp_foooobarrrrrr_matomo_logtmpsegment07171d02820b83eab14316299645c2e9' is too long SQL: CREATE TEMPORARY TABLE wp_foooobarrrrrr_matomo_logtmpsegment07171d02820b83eab14316299645c2e9 (idvisit BIGINT(10) UNSIGNED NOT NULL)