### PR TITLE
Remove output that can be ignored in climulti

### DIFF
--- a/core/CliMulti/Output.php
+++ b/core/CliMulti/Output.php
@@ -8,6 +8,7 @@
 namespace Piwik\CliMulti;
 
 use Piwik\CliMulti;
+use Piwik\Common;
 use Piwik\Filesystem;
 
 class Output
@@ -58,7 +59,14 @@ class Output
 
     public function get()
     {
-        return @file_get_contents($this->tmpFile);
+        $content = @file_get_contents($this->tmpFile);
+        $search = '#!/usr/bin/env php';
+        if (!empty($content)
+            && is_string($content)
+            && Common::mb_substr(trim($content), 0, strlen($search)) === $search) {
+            $content = trim(Common::mb_substr(trim($content), strlen($search)));
+        }
+        return $content;
     }
 
     public function destroy()

--- a/tests/PHPUnit/Integration/CliMulti/OutputTest.php
+++ b/tests/PHPUnit/Integration/CliMulti/OutputTest.php
@@ -114,6 +114,14 @@ class OutputTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($anyContent, $this->output->get());
     }
 
+    public function test_get_write_shouldRemoveHashBang()
+    {
+        $anyContent = "\n#!/usr/bin/env php {}";
+        $this->output->write($anyContent);
+
+        $this->assertEquals('{}', $this->output->get());
+    }
+
     public function test_write_shouldNotAppend_IfWriteIsCalledTwice()
     {
         $anyContent = 'My Actual Content';


### PR DESCRIPTION
Not sure it's really needed and how it happens but I reckon it cannot hurt. We've seen some archiving errors in Matomo for WordPress when CLI archiving is used where the output starts with the console hashbang ... 

Seeing this also in PHPUnit in https://github.com/sebastianbergmann/phpunit/blob/8.5.0/src/Util/PHP/AbstractPhpProcess.php#L268-L273 which was added to fix https://github.com/sebastianbergmann/phpunit/issues/982 but the change doesn't seem related to that.