### PR TITLE
Improve detection of cgi in cli multi

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -239,7 +239,8 @@ class CliMulti
      */
     public function supportsAsync()
     {
-        $supportsAsync = Process::isSupported() && !Common::isPhpCgiType() && $this->findPhpBinary();
+        $phpBinary = $this->findPhpBinary();
+        $supportsAsync = Process::isSupported() && !Common::isPhpCgiType() && $phpBinary && strpos($phpBinary, 'cgi') === false;
 
         /**
          * Triggered to allow plugins to force the usage of async cli multi execution or to disable it.


### PR DESCRIPTION
Not sure if it's possible but maybe a regular request is not using CGI, but then the CLI request is if `findPhpBinary` returns a cgi script?

See https://www.php.net/manual/en/function.shell-exec.php
In Matomo for WordPress seeing various reports where the output starts with `#!/usr/bin/env php`. 

![image](https://user-images.githubusercontent.com/273120/71054230-219e2c00-21b6-11ea-9672-4382b6dc26e5.png)

refs https://github.com/matomo-org/matomo/pull/15277
refs https://github.com/matomo-org/wp-matomo/issues/135#issuecomment-566766633

Trying to reproduce this locally this happens:

```bash
php -r "echo shell_exec(\"php-cgi app/console climulti:request -q  'module=API&method=API.get&idSite=1&period=day&date=last19&format=php&trigger=archivephp' --superuser\");"
X-Powered-By: PHP/7.3.12
Content-type: text/html; charset=UTF-8
```

Where it prints x-powered by etc