### PR TITLE
Fix cli archiving might not work when using litespeed

### DIFF
--- a/core/CliMulti/CliPhp.php
+++ b/core/CliMulti/CliPhp.php
@@ -80,7 +80,8 @@ class CliPhp
         return !empty($path)
         && false === strpos($path, 'fpm')
         && false === strpos($path, 'cgi')
-        && false === strpos($path, 'phpunit');
+        && false === strpos($path, 'phpunit')
+        && false === strpos($path, 'lsphp');
     }
 
     private function getPhpCommandIfValid($path)


### PR DESCRIPTION
replaces https://github.com/matomo-org/matomo/pull/15283

Noticed the user's instance was using listespeed https://www.php.net/manual/en/install.unix.litespeed.php which returned following

``` 
phpbinary: /usr/local/bin/lsphp
phpbindir: /opt/alt/php72/usr/bin
which php: /usr/local/bin/php
```

We would have used lsphp but this seems to print the hashbang and have other issues. see #15283