### PR TITLE
Don't render goal when no goal name defined

### DIFF
--- a/plugins/Live/VisitorDetails.php
+++ b/plugins/Live/VisitorDetails.php
@@ -76,6 +76,9 @@ class VisitorDetails extends VisitorDetailsAbstract
                 $template = '@Live/_actionEcommerce.twig';
                 break;
             case 'goal':
+                if (empty($action['goalName'])) {
+                    return; // goal deleted
+                }
                 $template = '@Live/_actionGoal.twig';
                 break;
             case 'action':


### PR DESCRIPTION
I think this prevented in my case some segmentation fault (or it exists without reporting or something weird is happening under circumstances)

My action looks eg like this:

> DEBUG Live[2019-12-22 02:54:11 UTC] [c333b] {"type":"goal","goalName":null,"goalId":null,"idpageview":"3f08db","revenue":"0.1","goalPageId":"18461104","serverTimePretty":"Jul 31, 2019 18:43:12","url":"....\/user-guide\/video-actions-reports-page-views-downloads-clicks\/%3Cspan%20class=","icon":"plugins\/Morpheus\/images\/goal.png","iconSVG":"plugins\/Morpheus\/images\/goal.svg","title":"Goal conversion","subtitle":" (\u20ac0.10 revenue)","timestamp":1564598592}