### PR TITLE
Disable pivot by if comparison is enabled.

### DIFF
--- a/plugins/CoreHome/templates/_dataTableActions.twig
+++ b/plugins/CoreHome/templates/_dataTableActions.twig
@@ -146,7 +146,7 @@
                     <div class="configItem dataTableExcludeLowPopulation"></div>
                 </li>
             {% endif %}
-            {% if properties.show_pivot_by_subtable|default is not empty %}
+            {% if properties.show_pivot_by_subtable|default is not empty and not isComparing|default(false) %}
                 <li>
                     <div class="configItem dataTablePivotBySubtable"></div>
                 </li>


### PR DESCRIPTION
Pivoting can sometimes try to access subtables, and in comparison mode subtables must be obtained from various other reports. Currently it's not a simple task to make it work in this case so we should disable it.