### PR TITLE
If user is already super user, no need to set super user flag

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -631,6 +631,10 @@ class Access
     {
         $isSuperUser = self::getInstance()->hasSuperUserAccess();
 
+        if ($isSuperUser) {
+            return $function();
+        }
+
         $access = self::getInstance();
         $login = $access->getLogin();
         $shouldResetLogin = empty($login); // make sure to reset login if a login was set by "makeSureLoginNameIsSet()"


### PR DESCRIPTION
It shouldn't change any logic. While debugging noticed some nested `doAsSuperUser` calls and was wondering if this could cause random issues...  Also if actually logged in user is already super user, we don't need to fake anything... 