### PR TITLE
Prevent errors if limitVisits is <= 0.

### DIFF
--- a/plugins/Live/API.php
+++ b/plugins/Live/API.php
@@ -211,7 +211,7 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasViewAccess($idSite);
 
-        if ($limitVisits === false) {
+        if ($limitVisits <= 0) {
             $limitVisits = VisitorProfile::VISITOR_PROFILE_MAX_VISITS_TO_SHOW;
         } else {
             $limitVisits = (int) $limitVisits;


### PR DESCRIPTION
If set to 0 or less than 0, all rows will be removed from result set, but the code assumes at least one row exists, which results in errors.