### PR TITLE
Match configId even when userId is found

### DIFF
--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -398,10 +398,13 @@ class Model
         } elseif ($shouldMatchOneFieldOnly) {
             $visitRow = $this->findVisitorByConfigId($configId, $select, $from, $configIdWhere, $configIdbindSql);
         } else {
-            $visitRow = $this->findVisitorByVisitorId($idVisitor, $select, $from, $visitorIdWhere, $visitorIdbindSql);
+            if (!empty($idVisitor)) {
+                $visitRow = $this->findVisitorByVisitorId($idVisitor, $select, $from, $visitorIdWhere, $visitorIdbindSql);
+            } else {
+                $visitRow = false;
+            }
 
             if (empty($visitRow)) {
-                $configIdWhere .= ' AND user_id IS NULL ';
                 $visitRow = $this->findVisitorByConfigId($configId, $select, $from, $configIdWhere, $configIdbindSql);
             }
         }

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -366,7 +366,7 @@ class Model
         return $wasInserted;
     }
 
-    public function findVisitor($idSite, $configId, $idVisitor, $fieldsToRead, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead)
+    public function findVisitor($idSite, $configId, $idVisitor, $userId, $fieldsToRead, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead)
     {
         $selectCustomVariables = '';
 
@@ -405,6 +405,13 @@ class Model
             }
 
             if (empty($visitRow)) {
+                $configIdWhere .= ' AND ( user_id IS NULL ';
+                if (!empty($userId)) {
+                    $configIdWhere .= 'OR user_id = ? )';
+                    $configIdbindSql[] = $userId;
+                } else {
+                    $configIdWhere .= ')';
+                }
                 $visitRow = $this->findVisitorByConfigId($configId, $select, $from, $configIdWhere, $configIdbindSql);
             }
         }

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -405,12 +405,9 @@ class Model
             }
 
             if (empty($visitRow)) {
-                $configIdWhere .= ' AND ( user_id IS NULL ';
                 if (!empty($userId)) {
-                    $configIdWhere .= 'OR user_id = ? )';
+                    $configIdWhere .= 'AND ( user_id IS NULL OR user_id = ? )';
                     $configIdbindSql[] = $userId;
-                } else {
-                    $configIdWhere .= ')';
                 }
                 $visitRow = $this->findVisitorByConfigId($configId, $select, $from, $configIdWhere, $configIdbindSql);
             }

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -83,6 +83,7 @@ class VisitorRecognizer
     {
         $idSite    = $request->getIdSite();
         $idVisitor = $request->getVisitorId();
+        $userId    = $request->getForcedUserId();
 
         $isVisitorIdToLookup = !empty($idVisitor);
 
@@ -98,7 +99,7 @@ class VisitorRecognizer
         $shouldMatchOneFieldOnly  = $this->shouldLookupOneVisitorFieldOnly($isVisitorIdToLookup, $request);
         list($timeLookBack, $timeLookAhead) = $this->getWindowLookupThisVisit($request);
 
-        $visitRow = $this->model->findVisitor($idSite, $configId, $idVisitor, $persistedVisitAttributes, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead);
+        $visitRow = $this->model->findVisitor($idSite, $configId, $idVisitor, $userId, $persistedVisitAttributes, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead);
         $this->visitRow = $visitRow;
 
         if ($visitRow

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__Live.getLastVisitsDetails_month.xml
@@ -103,6 +103,8 @@
 				<serverTimePretty>Mar 6, 2010 13:22:33</serverTimePretty>
 				<pageId>5</pageId>
 				<bandwidth />
+				<timeSpent>360</timeSpent>
+				<timeSpentPretty>6 min 0s</timeSpentPretty>
 				<interactionPosition>2</interactionPosition>
 				<title>incredible title!</title>
 				<subtitle>http://example.org/index.htm</subtitle>
@@ -111,15 +113,6 @@
 				<timestamp>1267881753</timestamp>
 				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
-		</actionDetails>
-		<lastActionDateTime>2010-03-06 13:22:33</lastActionDateTime>
-		<userId>email@example.com</userId>
-		<actions>2</actions>
-	</row>
-	<row>
-		<idVisit>4</idVisit>
-		<visitorId>6ccebef4faef4969</visitorId>
-		<actionDetails>
 			<row>
 				<type>action</type>
 				<url>http://example.org/index.htm</url>
@@ -129,7 +122,7 @@
 				<serverTimePretty>Mar 6, 2010 13:28:33</serverTimePretty>
 				<pageId>6</pageId>
 				<bandwidth />
-				<interactionPosition>1</interactionPosition>
+				<interactionPosition>3</interactionPosition>
 				<title>second page</title>
 				<subtitle>http://example.org/index.htm</subtitle>
 				<icon />
@@ -140,10 +133,10 @@
 		</actionDetails>
 		<lastActionDateTime>2010-03-06 13:28:33</lastActionDateTime>
 		<userId>email@example.com</userId>
-		<actions>1</actions>
+		<actions>3</actions>
 	</row>
 	<row>
-		<idVisit>5</idVisit>
+		<idVisit>4</idVisit>
 		<visitorId>2f16b4d842cc294d</visitorId>
 		<actionDetails>
 			<row>
@@ -169,7 +162,7 @@
 		<actions>1</actions>
 	</row>
 	<row>
-		<idVisit>6</idVisit>
+		<idVisit>5</idVisit>
 		<visitorId>7dcebef4faef4969</visitorId>
 		<actionDetails>
 			<row>
@@ -274,7 +267,7 @@
 		<actions>3</actions>
 	</row>
 	<row>
-		<idVisit>7</idVisit>
+		<idVisit>6</idVisit>
 		<visitorId>7dcebef4faef4325</visitorId>
 		<actionDetails>
 			<row>
@@ -300,7 +293,7 @@
 		<actions>1</actions>
 	</row>
 	<row>
-		<idVisit>8</idVisit>
+		<idVisit>7</idVisit>
 		<visitorId>6ccebef4faef4969</visitorId>
 		<actionDetails>
 			<row>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_day.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_uniq_visitors>6</nb_uniq_visitors>
+	<nb_uniq_visitors>5</nb_uniq_visitors>
 	<nb_users>2</nb_users>
-	<nb_visits>6</nb_visits>
+	<nb_visits>5</nb_visits>
 	<nb_actions>10</nb_actions>
 	<nb_visits_converted>1</nb_visits_converted>
-	<bounce_count>3</bounce_count>
-	<sum_visit_length>1623</sum_visit_length>
+	<bounce_count>2</bounce_count>
+	<sum_visit_length>1983</sum_visit_length>
 	<max_actions>3</max_actions>
-	<bounce_rate>50%</bounce_rate>
-	<nb_actions_per_visit>1.7</nb_actions_per_visit>
-	<avg_time_on_site>271</avg_time_on_site>
+	<bounce_rate>40%</bounce_rate>
+	<nb_actions_per_visit>2</nb_actions_per_visit>
+	<avg_time_on_site>397</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_month.xml
@@ -2,13 +2,13 @@
 <result>
 	<nb_uniq_visitors>7</nb_uniq_visitors>
 	<nb_users>3</nb_users>
-	<nb_visits>8</nb_visits>
+	<nb_visits>7</nb_visits>
 	<nb_actions>12</nb_actions>
 	<nb_visits_converted>1</nb_visits_converted>
-	<bounce_count>5</bounce_count>
-	<sum_visit_length>1623</sum_visit_length>
+	<bounce_count>4</bounce_count>
+	<sum_visit_length>1983</sum_visit_length>
 	<max_actions>3</max_actions>
-	<bounce_rate>63%</bounce_rate>
-	<nb_actions_per_visit>1.5</nb_actions_per_visit>
-	<avg_time_on_site>203</avg_time_on_site>
+	<bounce_rate>57%</bounce_rate>
+	<nb_actions_per_visit>1.7</nb_actions_per_visit>
+	<avg_time_on_site>283</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_week.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_week.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_uniq_visitors>6</nb_uniq_visitors>
+	<nb_uniq_visitors>5</nb_uniq_visitors>
 	<nb_users>2</nb_users>
-	<nb_visits>6</nb_visits>
+	<nb_visits>5</nb_visits>
 	<nb_actions>10</nb_actions>
 	<nb_visits_converted>1</nb_visits_converted>
-	<bounce_count>3</bounce_count>
-	<sum_visit_length>1623</sum_visit_length>
+	<bounce_count>2</bounce_count>
+	<sum_visit_length>1983</sum_visit_length>
 	<max_actions>3</max_actions>
-	<bounce_rate>50%</bounce_rate>
-	<nb_actions_per_visit>1.7</nb_actions_per_visit>
-	<avg_time_on_site>271</avg_time_on_site>
+	<bounce_rate>40%</bounce_rate>
+	<nb_actions_per_visit>2</nb_actions_per_visit>
+	<avg_time_on_site>397</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_year.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_year.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>8</nb_visits>
+	<nb_visits>7</nb_visits>
 	<nb_actions>12</nb_actions>
 	<nb_visits_converted>1</nb_visits_converted>
-	<bounce_count>5</bounce_count>
-	<sum_visit_length>1623</sum_visit_length>
+	<bounce_count>4</bounce_count>
+	<sum_visit_length>1983</sum_visit_length>
 	<max_actions>3</max_actions>
-	<bounce_rate>63%</bounce_rate>
-	<nb_actions_per_visit>1.5</nb_actions_per_visit>
-	<avg_time_on_site>203</avg_time_on_site>
+	<bounce_rate>57%</bounce_rate>
+	<nb_actions_per_visit>1.7</nb_actions_per_visit>
+	<avg_time_on_site>283</avg_time_on_site>
 </result>


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/15320
refs https://github.com/matomo-org/matomo/pull/15337
fyi @mattab @diosmosis 

I wonder if maybe the query should be actually and `user_id is null or user_id = $userIdFromRequestIfGiven`? 

Edit: Added the `or user_id = ?`