### PR TITLE
Prevent double slash in URL when loading a script

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -483,7 +483,7 @@ class Manager
             $path = $dir . $pluginName;
             if (is_dir($path)) {
                 self::$pluginsToPathCache[$pluginName] = self::getPluginRealPath($path);
-                self::$pluginsToWebRootDirCache[$pluginName] = $relative;
+                self::$pluginsToWebRootDirCache[$pluginName] = rtrim($relative, '/');
                 return $path;
             }
         }


### PR DESCRIPTION
Otherwise generates a URL like `https://example.com/additional-plugins//AbTesting/angularjs/manage/manage.directive.html?cb=303`

In https://github.com/matomo-org/matomo/blob/3.13.1-b2/plugins/CoreHome/angularjs/http404check.js#L29 there will be otherwise `['./additional=plugins/', 'AbTesting', '...'].join()`. The `pluginsToWebRootDirCache ` is only used for that purpose. 

refs https://github.com/matomo-org/matomo/issues/15340
This should not fix the referenced issue as a double slash should not cause any issue AFAIK but be still good to make that right. The `$pluginsToWebRootDirCache ` is only used for that purpose to load these files through http404check