### PR TITLE
Avoid using getmypid

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -171,11 +171,7 @@ class ArchiveInvalidator
     private function buildRememberArchivedReportIdProcessSafe($idSite, $date)
     {
         $id  = $this->buildRememberArchivedReportIdForSiteAndDate($idSite, $date);
-        if (Process::isMethodDisabled('getmypid')) {
-	        $id .= '_' . Common::getRandomString();
-        } else {
-	        $id .= '_' . getmypid();
-        }
+        $id .= '_' . Common::getProcessId();
         return $id;
     }
 

--- a/core/ArchiveProcessor/ArchivingStatus.php
+++ b/core/ArchiveProcessor/ArchivingStatus.php
@@ -41,7 +41,7 @@ class ArchivingStatus
     {
         $this->lockBackend = $lockBackend;
         $this->archivingTTLSecs = $archivingTTLSecs;
-        $this->pid = Common::getRandomInt(8);
+        $this->pid = Common::getProcessId();
     }
 
     public function archiveStarted(Parameters $params)

--- a/core/ArchiveProcessor/ArchivingStatus.php
+++ b/core/ArchiveProcessor/ArchivingStatus.php
@@ -9,7 +9,6 @@
 
 namespace Piwik\ArchiveProcessor;
 
-use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Concurrency\Lock;
 use Piwik\Concurrency\LockBackend;
@@ -42,12 +41,7 @@ class ArchivingStatus
     {
         $this->lockBackend = $lockBackend;
         $this->archivingTTLSecs = $archivingTTLSecs;
-
-        $cache = Cache::getTransientCache();
-        if (!$cache->contains('ArchivingStatusPid')) {
-            $cache->save('ArchivingStatusPid', Common::getRandomInt(8));
-        }
-        $this->pid = $cache->fetch('ArchivingStatusPid');
+        $this->pid = Common::getRandomInt(8);
     }
 
     public function archiveStarted(Parameters $params)

--- a/core/ArchiveProcessor/ArchivingStatus.php
+++ b/core/ArchiveProcessor/ArchivingStatus.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\ArchiveProcessor;
 
+use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Concurrency\Lock;
 use Piwik\Concurrency\LockBackend;
@@ -41,7 +42,12 @@ class ArchivingStatus
     {
         $this->lockBackend = $lockBackend;
         $this->archivingTTLSecs = $archivingTTLSecs;
-        $this->pid = Common::getRandomInt(8);
+
+        $cache = Cache::getTransientCache();
+        if (!$cache->contains('ArchivingStatusPid')) {
+            $cache->save('ArchivingStatusPid', Common::getRandomInt(8));
+        }
+        $this->pid = $cache->fetch('ArchivingStatusPid');
     }
 
     public function archiveStarted(Parameters $params)

--- a/core/ArchiveProcessor/ArchivingStatus.php
+++ b/core/ArchiveProcessor/ArchivingStatus.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\ArchiveProcessor;
 
+use Piwik\Common;
 use Piwik\Concurrency\Lock;
 use Piwik\Concurrency\LockBackend;
 use Piwik\Container\StaticContainer;
@@ -34,10 +35,13 @@ class ArchivingStatus
      */
     private $lockStack = [];
 
+    private $pid;
+
     public function __construct(LockBackend $lockBackend, $archivingTTLSecs = self::DEFAULT_ARCHIVING_TTL)
     {
         $this->lockBackend = $lockBackend;
         $this->archivingTTLSecs = $archivingTTLSecs;
+        $this->pid = Common::getRandomInt(8);
     }
 
     public function archiveStarted(Parameters $params)
@@ -102,6 +106,6 @@ class ArchivingStatus
 
     private function getInstanceProcessId()
     {
-        return SettingsPiwik::getPiwikInstanceId() . '.' . getmypid();
+        return SettingsPiwik::getPiwikInstanceId() . '.' . $this->pid;
     }
 }

--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -208,6 +208,10 @@ class Process
 
     public static function isMethodDisabled($command)
     {
+        if (!function_exists($command)) {
+            return true;
+        }
+
         $disabled = explode(',', ini_get('disable_functions'));
         $disabled = array_map('trim', $disabled);
         return in_array($command, $disabled)  || !function_exists($command);

--- a/core/Common.php
+++ b/core/Common.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Exception;
+use Piwik\CliMulti\Process;
 use Piwik\Container\StaticContainer;
 use Piwik\Intl\Data\Provider\LanguageDataProvider;
 use Piwik\Intl\Data\Provider\RegionDataProvider;
@@ -198,6 +199,31 @@ class Common
         }
 
         return substr($string, $start, $length);
+    }
+
+    /**
+     * Gets the current process ID.
+     * Note: If getmypid is disabled, a random ID will be generated once and used throughout the request. There is a
+     * small chance that two processes at the same time may generated the same random ID. If you need to rely on the
+     * value being 100% unique, then you may need to use `getmypid` directly or some other logic. Eg in CliMulti it is
+     * fine to use `getmypid` directly as the logic won't be used if getmypid is disabled...
+     * If you are wanting to use the pid to check if the process is running eg using `ps`, then you also have to use
+     * getmypid directly.
+     *
+     * @return int|null
+     */
+    public static function getProcessId()
+    {
+        static $pid;
+        if (!isset($pid)) {
+            if (Process::isMethodDisabled('getmypid')) {
+                $pid = Common::getRandomInt(12);
+            } else {
+                $pid = getmypid();
+            }
+        }
+
+        return $pid;
     }
 
     /**

--- a/libs/Zend/Mail.php
+++ b/libs/Zend/Mail.php
@@ -1100,7 +1100,7 @@ class Zend_Mail extends Zend_Mime_Message
         } elseif (isset($_SERVER['REMOTE_ADDR'])) {
             $user = $_SERVER['REMOTE_ADDR'];
         } else {
-            $user = getmypid();
+            $user = \Piwik\Common::getProcessId();
         }
 
         $rand = mt_rand();

--- a/tests/PHPUnit/Integration/ArchiveProcessor/ArchivingStatusTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/ArchivingStatusTest.php
@@ -44,7 +44,7 @@ class ArchivingStatusTest extends IntegrationTestCase
 
         $this->assertEquals([
             [
-                'key' => 'Archiving.1.fab0afcc3a068ecd91b14d50f3bc911d.' . getmypid(),
+                'key' => 'Archiving.1.fab0afcc3a068ecd91b14d50f3bc911d.' . Common::getProcessId(),
                 'expiry_time' => time() + ArchivingStatus::DEFAULT_ARCHIVING_TTL,
             ],
         ], $this->getLockKeysAndTtls());

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -24,6 +24,13 @@ use Piwik\Tests\Framework\Mock\FakeLogger;
  */
 class CommonTest extends PHPUnit_Framework_TestCase
 {
+    public function test_getProcessId()
+    {
+        $this->assertEquals(getmypid(), Common::getProcessId());
+        //assure always returns same value
+        $this->assertEquals(getmypid(), Common::getProcessId());
+    }
+
     /**
      * Dataprovider for testSanitizeInputValues
      */


### PR DESCRIPTION
@diosmosis was getting this error a few times:

![image](https://user-images.githubusercontent.com/273120/72036747-ae915c80-3300-11ea-88a0-fe661e404d15.png)

I wonder if we could simply generate a random number instead of using `getmypid`? I noticed the class is always used through DI so in the end the instance should be only created once and therefore the `pid` should always be the same even though the property is not static. Could also make it static though if that helps and only set it once? 

Not too important for 3.13.1 but be good. We can move it to 4.0 though and I patch later Matomo for WordPress after the 3.13.1 release