### PR TITLE
Support email address in getTokenAuth

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1361,7 +1361,7 @@ class API extends \Piwik\Plugin\API
 
         $user = $this->model->getUser($userLogin);
 
-        if (empty($user)) {
+        if (empty($user) && Piwik::isValidEmailString($userLogin)) {
             $user = $this->model->getUserByEmail($userLogin);
             
             if (!empty($user['login'])) {

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1351,7 +1351,7 @@ class API extends \Piwik\Plugin\API
      *
      * If the username/password combination is incorrect an invalid token will be returned.
      *
-     * @param string $userLogin Login
+     * @param string $userLogin Login or Email address
      * @param string $md5Password hashed string of the password (using current hash function; MD5-named for historical reasons)
      * @return string
      */
@@ -1361,6 +1361,14 @@ class API extends \Piwik\Plugin\API
 
         $user = $this->model->getUser($userLogin);
 
+        if (empty($user)) {
+            $user = $this->model->getUserByEmail($userLogin);
+            
+            if (!empty($user['login'])) {
+                $userLogin = $user['login'];
+            }
+        }
+        
         if (empty($user) || !$this->password->verify($md5Password, $user['password'])) {
             /**
              * @ignore


### PR DESCRIPTION
Fix https://github.com/matomo-org/matomo-mobile-2/issues/5404

Not writing a test for it as I'm removing this API method as part of #6559 anyway.

Not sure we can have this as part of Matomo 3.13.1? Feel free to close the PR as the method will be removed anyway in Matomo 4 so can also just close the PR