### PR TITLE
Fixes warning for newer PHP versions

### DIFF
--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -43,9 +43,9 @@ class Mysql extends Db
      */
     public function __construct($dbInfo, $driverName = 'mysql')
     {
-        if (isset($dbInfo['unix_socket']) && $dbInfo['unix_socket'][0] == '/') {
+        if (isset($dbInfo['unix_socket']) && substr($dbInfo['unix_socket'], 0, 1) == '/') {
             $this->dsn = $driverName . ':dbname=' . $dbInfo['dbname'] . ';unix_socket=' . $dbInfo['unix_socket'];
-        } elseif (!empty($dbInfo['port']) && $dbInfo['port'][0] == '/') {
+        } elseif (!empty($dbInfo['port']) && substr($dbInfo['port'], 0, 1) == '/') {
             $this->dsn = $driverName . ':dbname=' . $dbInfo['dbname'] . ';unix_socket=' . $dbInfo['port'];
         } else {
             $this->dsn = $driverName . ':dbname=' . $dbInfo['dbname'] . ';host=' . $dbInfo['host'] . ';port=' . $dbInfo['port'];


### PR DESCRIPTION
Change should be safe. MySQLi Adapter already checks it that way:

See https://github.com/matomo-org/matomo/blob/3.x-dev/core/Tracker/Db/Mysqli.php#L46-L50