### PR TITLE
Mention at least 7.2 is required in next major release

### DIFF
--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -212,7 +212,7 @@ abstract class ControllerAdmin extends Controller
      */
     private static function getNextRequiredMinimumPHP()
     {
-        return '7.1';
+        return '7.2';
     }
 
     private static function isUsingPhpVersionCompatibleWithNextPiwik()


### PR DESCRIPTION
We might actually require 7.3 but there will be likely another release for 3.X anyway where we can correct this.
Edit: closing... need to activate this check only closer to the 4.x release