### PR TITLE
Removes some methods deprecated for Matomo 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * Deprecated `piwik` font was removed. Use `matomo` font instead
 * The JavaScript AjaxHelper does not longer support synchronous requests. All requests will be sent async instead.
 * The deprecated Platform API method `\Piwik\Plugin::getListHooksRegistered()` has been removed. Use `\Piwik\Plugin::registerEvents()` instead
+* The deprecated Platform API method `\Piwik\Piwik::doAsSuperUser()` has been removed. Use `\Piwik\Access::doAsSuperUser()` instead
 
 ## Matomo 3.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 * Deprecated `piwik` font was removed. Use `matomo` font instead
 * The JavaScript AjaxHelper does not longer support synchronous requests. All requests will be sent async instead.
+* The deprecated Platform API method `\Piwik\Plugin::getListHooksRegistered()` has been removed. Use `\Piwik\Plugin::registerEvents()` instead
 
 ## Matomo 3.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The JavaScript AjaxHelper does not longer support synchronous requests. All requests will be sent async instead.
 * The deprecated Platform API method `\Piwik\Plugin::getListHooksRegistered()` has been removed. Use `\Piwik\Plugin::registerEvents()` instead
 * The deprecated Platform API method `\Piwik\Piwik::doAsSuperUser()` has been removed. Use `\Piwik\Access::doAsSuperUser()` instead
+* The deprecated Platform API method `\Piwik\SettingsPiwik::isPiwikInstalled()` has been removed. Use `\Piwik\SettingsPiwik::isMatomoInstalled()` instead
 
 ## Matomo 3.13.1
 

--- a/config/global.php
+++ b/config/global.php
@@ -56,7 +56,7 @@ return array(
         // If Piwik is not installed yet, it's possible the tmp/ folder is not writable
         // we prevent failing with an unclear message eg. coming from doctrine-cache
         // by forcing to use a cache backend which always works ie. array
-        if(!\Piwik\SettingsPiwik::isPiwikInstalled()) {
+        if(!\Piwik\SettingsPiwik::isMatomoInstalled()) {
             $backend = 'array';
         } else {
             try {

--- a/core/Application/Kernel/EnvironmentValidator.php
+++ b/core/Application/Kernel/EnvironmentValidator.php
@@ -44,7 +44,7 @@ class EnvironmentValidator
     {
         $this->checkConfigFileExists($this->settingsProvider->getPathGlobal());
 
-        if(SettingsPiwik::isPiwikInstalled()) {
+        if(SettingsPiwik::isMatomoInstalled()) {
             $this->checkConfigFileExists($this->settingsProvider->getPathLocal(), $startInstaller = false);
             return;
         }

--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -107,7 +107,7 @@ class EventDispatcher
 
             if (!isset($this->pluginHooks[$pluginName])) {
                 $plugin = $manager->getLoadedPlugin($pluginName);
-                $this->pluginHooks[$pluginName] = $plugin->getListHooksRegistered();
+                $this->pluginHooks[$pluginName] = $plugin->registerEvents();
             }
 
             $hooks = $this->pluginHooks[$pluginName];

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -652,7 +652,7 @@ class FrontController extends Singleton
 
         // the session must be started before using the session authenticator,
         // so we do it here, if this is not an API request.
-        if (SettingsPiwik::isPiwikInstalled()
+        if (SettingsPiwik::isMatomoInstalled()
             && ($module !== 'API' || ($action && $action !== 'index'))
         ) {
             /**

--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -819,19 +819,4 @@ class Piwik
 
         return $translator->translate($translationId, $args, $language);
     }
-
-    /**
-     * Executes a callback with superuser privileges, making sure those privileges are rescinded
-     * before this method exits. Privileges will be rescinded even if an exception is thrown.
-     *
-     * @param callback $function The callback to execute. Should accept no arguments.
-     * @return mixed The result of `$function`.
-     * @throws Exception rethrows any exceptions thrown by `$function`.
-     * @api
-     * @deprecated since Matomo 3.8.0 use `Piwik\Access::doAsSuperUser` instead
-     */
-    public static function doAsSuperUser($function)
-    {
-        return Access::doAsSuperUser($function);
-    }
 }

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -223,16 +223,6 @@ class Plugin
     }
 
     /**
-     * @ignore
-     * @deprecated since 2.15.0 use {@link registerEvents()} instead.
-     * @return array
-     */
-    public function getListHooksRegistered()
-    {
-        return $this->registerEvents();
-    }
-
-    /**
      * This method is executed after a plugin is loaded and translations are registered.
      * Useful for initialization code that uses translated strings.
      */

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1388,7 +1388,7 @@ class Manager
             return true;
         }
 
-        $hooks = $plugin->getListHooksRegistered();
+        $hooks = $plugin->registerEvents();
         $hookNames = array_keys($hooks);
         foreach ($hookNames as $name) {
             if (strpos($name, self::TRACKER_EVENT_PREFIX) === 0) {

--- a/core/Session.php
+++ b/core/Session.php
@@ -91,7 +91,7 @@ class Session extends Zend_Session
 
         $currentSaveHandler = ini_get('session.save_handler');
 
-        if (!SettingsPiwik::isPiwikInstalled()) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             // Note: this handler doesn't work well in load-balanced environments and may have a concurrency issue with locked session files
 
             // for "files", use our own folder to prevent local session file hijacking
@@ -143,7 +143,7 @@ class Session extends Zend_Session
                 'ignoreInScreenWriter' => true,
             ]);
 
-            if (SettingsPiwik::isPiwikInstalled()) {
+            if (SettingsPiwik::isMatomoInstalled()) {
                 $pathToSessions = '';
             } else {
                 $pathToSessions = Filechecks::getErrorMessageMissingPermissions(self::getSessionsDirectory());

--- a/core/SettingsPiwik.php
+++ b/core/SettingsPiwik.php
@@ -216,20 +216,9 @@ class SettingsPiwik
     }
 
     /**
-     * @see SettingsPiwik::isPiwikInstalled
      * @return bool
      */
     public static function isMatomoInstalled()
-    {
-        return self::isPiwikInstalled();
-    }
-
-    /**
-     * Return true if Piwik is installed (installation is done).
-     * @deprecated since Matomo 3.8.0, please use {@link isMatomoInstalled()} instead.
-     * @return bool
-     */
-    public static function isPiwikInstalled()
     {
         $config = Config::getInstance()->getLocalPath();
         $exists = file_exists($config);
@@ -474,7 +463,7 @@ class SettingsPiwik
     public static function getPiwikInstanceId()
     {
         // until Piwik is installed, we use hostname as instance_id
-        if (!self::isPiwikInstalled()
+        if (!self::isMatomoInstalled()
             && Common::isPhpCliMode()) {
             // enterprise:install use case
             return Config::getHostname();
@@ -507,7 +496,7 @@ class SettingsPiwik
      */
     public static function isHttpsForced()
     {
-        if (!SettingsPiwik::isPiwikInstalled()) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             // Only enable this feature after Piwik is already installed
             return false;
         }

--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -97,7 +97,7 @@ class Tracker
     public function isInstalled()
     {
         if (is_null($this->isInstalled)) {
-            $this->isInstalled = SettingsPiwik::isPiwikInstalled();
+            $this->isInstalled = SettingsPiwik::isMatomoInstalled();
         }
 
         return $this->isInstalled;

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\CorePluginsAdmin;
 
 use Exception;
+use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
@@ -483,7 +484,7 @@ class Controller extends Plugin\ControllerAdmin
     public function deactivate($redirectAfter = true)
     {
         if($this->isAllowedToTroubleshootAsSuperUser()) {
-            Piwik::doAsSuperUser(function() use ($redirectAfter) {
+            Access::doAsSuperUser(function() use ($redirectAfter) {
                 $this->doDeactivatePlugin($redirectAfter);
             });
         } else {

--- a/plugins/CustomPiwikJs/CustomPiwikJs.php
+++ b/plugins/CustomPiwikJs/CustomPiwikJs.php
@@ -14,7 +14,7 @@ use Piwik\Plugin;
 
 class CustomPiwikJs extends Plugin
 {
-    public function getListHooksRegistered()
+    public function registerEvents()
     {
         return array(
             'CoreUpdater.update.end' => 'updateTracker',

--- a/plugins/Diagnostics/Diagnostic/DbMaxPacket.php
+++ b/plugins/Diagnostics/Diagnostic/DbMaxPacket.php
@@ -27,7 +27,7 @@ class DbMaxPacket implements Diagnostic
 
     public function execute()
     {
-        if (!SettingsPiwik::isPiwikInstalled()) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             return array(); // only possible to perform check once we have DB connection
         }
 

--- a/plugins/ExampleTheme/ExampleTheme.php
+++ b/plugins/ExampleTheme/ExampleTheme.php
@@ -13,7 +13,7 @@ use Piwik\Plugin;
 
 class ExampleTheme extends Plugin
 {
-    public function getListHooksRegistered()
+    public function registerEvents()
     {
         return [
             'Theme.configureThemeVariables' => 'configureThemeVariables',

--- a/plugins/Installation/Controller.php
+++ b/plugins/Installation/Controller.php
@@ -619,7 +619,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
     private function checkPiwikIsNotInstalled($possibleErrorMessage = null)
     {
-        if (!SettingsPiwik::isPiwikInstalled()) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             return;
         }
 

--- a/plugins/Installation/Installation.php
+++ b/plugins/Installation/Installation.php
@@ -64,7 +64,7 @@ class Installation extends \Piwik\Plugin
     {
         $general = Config::getInstance()->General;
 
-        if (!SettingsPiwik::isPiwikInstalled() && !$general['enable_installer']) {
+        if (!SettingsPiwik::isMatomoInstalled() && !$general['enable_installer']) {
             throw new NotYetInstalledException('Matomo is not set up yet');
         }
 

--- a/plugins/Intl/Intl.php
+++ b/plugins/Intl/Intl.php
@@ -10,7 +10,7 @@ namespace Piwik\Plugins\Intl;
 
 class Intl extends \Piwik\Plugin
 {
-    public function getListHooksRegistered()
+    public function registerEvents()
     {
         return [
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',

--- a/plugins/LanguagesManager/Menu.php
+++ b/plugins/LanguagesManager/Menu.php
@@ -18,7 +18,7 @@ class Menu extends \Piwik\Plugin\Menu
 {
     public function configureTopMenu(MenuTop $menu)
     {
-        if (Piwik::isUserIsAnonymous() || !SettingsPiwik::isPiwikInstalled()) {
+        if (Piwik::isUserIsAnonymous() || !SettingsPiwik::isMatomoInstalled()) {
             $langManager = new LanguagesManager();
             $menu->addHtml('LanguageSelector', $langManager->getLanguagesSelector(), true, $order = 30, false);
         }

--- a/plugins/Login/config/test.php
+++ b/plugins/Login/config/test.php
@@ -6,7 +6,7 @@ return array(
         \Piwik\Access::doAsSuperUser(function () use ($settings, $c) {
             if ($c->get('test.vars.bruteForceBlockIps')) {
                 $settings->blacklistedBruteForceIps->setValue(array('10.2.3.4'));
-            } elseif (\Piwik\SettingsPiwik::isPiwikInstalled()) {
+            } elseif (\Piwik\SettingsPiwik::isMatomoInstalled()) {
                 $settings->blacklistedBruteForceIps->setValue(array());
             }
         });
@@ -26,7 +26,7 @@ return array(
                 // we block this IP
                 $detection->addFailedAttempt(\Piwik\IP::getIpFromHeader());
             }
-        } elseif (\Piwik\SettingsPiwik::isPiwikInstalled()) {
+        } elseif (\Piwik\SettingsPiwik::isMatomoInstalled()) {
             // prevent tests from blocking other tests
             $detection->deleteAll();
         }

--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -109,7 +109,7 @@ class TwoFactorAuth extends \Piwik\Plugin
 
     public function onApiGetTokenAuth($returnedValue, $params)
     {
-        if (!SettingsPiwik::isPiwikInstalled()) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             return;
         }
 

--- a/plugins/TwoFactorAuth/Validator.php
+++ b/plugins/TwoFactorAuth/Validator.php
@@ -34,7 +34,7 @@ class Validator
             return false;
         }
 
-        if (!SettingsPiwik::isPiwikInstalled()) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             return false;
         }
 
@@ -45,7 +45,7 @@ class Validator
     {
         Piwik::checkUserIsNotAnonymous();
 
-        if (!SettingsPiwik::isPiwikInstalled()) {
+        if (!SettingsPiwik::isMatomoInstalled()) {
             throw new NotYetInstalledException('Matomo is not set up yet');
         }
     }

--- a/plugins/TwoFactorAuth/config/test.php
+++ b/plugins/TwoFactorAuth/config/test.php
@@ -6,7 +6,7 @@ return array(
     'Piwik\Plugins\TwoFactorAuth\TwoFactorAuthentication' => DI\decorate(function ($previous) {
         /** @var Piwik\Plugins\TwoFactorAuth\TwoFactorAuthentication $previous */
 
-        if (!\Piwik\SettingsPiwik::isPiwikInstalled()) {
+        if (!\Piwik\SettingsPiwik::isMatomoInstalled()) {
             return $previous;
         }
 
@@ -30,7 +30,7 @@ return array(
     'Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao' => DI\decorate(function ($previous) {
         /** @var Piwik\Plugins\TwoFactorAuth\Dao\RecoveryCodeDao $previous */
 
-        if (!\Piwik\SettingsPiwik::isPiwikInstalled()) {
+        if (!\Piwik\SettingsPiwik::isMatomoInstalled()) {
             return $previous;
         }
 
@@ -47,7 +47,7 @@ return array(
     }),
     'Piwik\Plugins\TwoFactorAuth\SystemSettings' => DI\decorate(function ($previous) {
         /** @var Piwik\Plugins\TwoFactorAuth\SystemSettings $previous */
-        if (!\Piwik\SettingsPiwik::isPiwikInstalled()) {
+        if (!\Piwik\SettingsPiwik::isMatomoInstalled()) {
             return $previous;
         }
 

--- a/tests/PHPUnit/Integration/Plugin/ManagerTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ManagerTest.php
@@ -91,7 +91,7 @@ class ManagerTest extends IntegrationTestCase
     public function test_ListenNotToControllerMethodEventsThatDoesNotExists()
     {
         foreach ($this->manager->getLoadedPlugins() as $plugin) {
-            $hooks = $plugin->getListHooksRegistered();
+            $hooks = $plugin->registerEvents();
             foreach ($hooks as $hook => $callback) {
                 if (0 === strpos($hook, 'Controller.')) {
                     list($controller, $module, $action) = explode('.', $hook);

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -127,7 +127,7 @@ function prepareTestDatabaseConfig(Config $config)
     $config->forceSave();
 }
 
-if (!SettingsPiwik::isPiwikInstalled()) {
+if (!SettingsPiwik::isMatomoInstalled()) {
     throw new Exception('Piwik needs to be installed in order to run the tests');
 }
 


### PR DESCRIPTION
* Removes deprecated Plugin.getListHooksRegistered and uses Plugin.registerEvents instead
* Removes deprecated method Piwik\Piwik::doAsSuperUser
* Removes deprecated SettingsPiwik::isPiwikInstalled and use SettingsPiwik::isMatomoInstalled instead