### PR TITLE
Enable MobileAppMeasurable plugin to allow users to track mobile apps

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -955,6 +955,7 @@ Plugins[] = CoreAdminHome
 Plugins[] = CoreHome
 Plugins[] = WebsiteMeasurable
 Plugins[] = IntranetMeasurable
+Plugins[] = MobileAppMeasurable
 Plugins[] = Diagnostics
 Plugins[] = CoreVisualizations
 Plugins[] = Proxy


### PR DESCRIPTION
This would not provide much value but would make it clear that Matomo can be used to track mobile apps. Also the plugin already exists and be great to leverage it. For example it would be valuable to hide some specific menus for mobile app measurables, where we know the menu will never have data (eg. Referrers, Forms, Media, Sessions, Heatmaps...)

refs https://github.com/matomo-org/matomo/issues/7893