### PR TITLE
Remove LoginHttpAuth submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,10 +18,6 @@
     path = plugins/TasksTimetable
     url = https://github.com/matomo-org/plugin-TasksTimetable.git
     branch = master
-[submodule "plugins/LoginHttpAuth"]
-    path = plugins/LoginHttpAuth
-    url = https://github.com/matomo-org/plugin-LoginHttpAuth.git
-    branch = master
 [submodule "plugins/QueuedTracking"]
     path = plugins/QueuedTracking
     url = https://github.com/matomo-org/plugin-QueuedTracking.git

--- a/tests/PHPUnit/Framework/TestingEnvironmentVariables.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentVariables.php
@@ -104,7 +104,6 @@ class TestingEnvironmentVariables
         $pluginManager = new PluginManager($pluginList);
 
         $disabledPlugins = $pluginList->getCorePluginsDisabledByDefault();
-        $disabledPlugins[] = 'LoginHttpAuth';
         $disabledPlugins[] = 'LoginLdap';
         $disabledPlugins[] = 'MarketingCampaignsReporting';
         $disabledPlugins[] = 'ExampleVisualization';


### PR DESCRIPTION
We decided we no longer support it in Matomo 4 for various reasons such as security and wanting to focus more on the essential things and being able to focus. I suppose we could create an issue on LoginHttpAuth if someone wanted to take over the project and continue supporting it? A few changes would need to be made to make it compatible with Matomo 4 because of #6559 