### PR TITLE
Improve lock ID check for max length

### DIFF
--- a/core/Concurrency/Lock.php
+++ b/core/Concurrency/Lock.php
@@ -50,17 +50,6 @@ class Lock
 
     public function execute($id, $callback)
     {
-        $maxLen = self::MAX_KEY_LEN;
-        if (!empty($this->lockKeyStart)) {
-            $maxLen = $maxLen - strlen($this->lockKeyStart);
-        }
-        if (Common::mb_strlen($id) > $maxLen) {
-            // Lock key might be too long for DB column, so we hash it but leave the start of the original as well
-            // to make it more readable
-            $md5Len = 32;
-            $id = Common::mb_substr($id, 0, $maxLen - $md5Len - 1) . md5($id);
-        }
-
         $i = 0;
         while (!$this->acquireLock($id)) {
             $i++;
@@ -79,6 +68,13 @@ class Lock
     public function acquireLock($id, $ttlInSeconds = 60)
     {
         $this->lockKey = $this->lockKeyStart . $id;
+
+        if (Common::mb_strlen($this->lockKey) > self::MAX_KEY_LEN) {
+            // Lock key might be too long for DB column, so we hash it but leave the start of the original as well
+            // to make it more readable
+            $md5Len = 32;
+            $this->lockKey = Common::mb_substr($id, 0, self::MAX_KEY_LEN - $md5Len - 1) . md5($id);
+        }
 
         $lockValue = substr(Common::generateUniqId(), 0, 12);
         $locked    = $this->backend->setIfNotExists($this->lockKey, $lockValue, $ttlInSeconds);


### PR DESCRIPTION
Better patch for https://github.com/matomo-org/matomo/pull/15401 which was merged last minute...

This way it always works even when someone calls `acquireLock` directly instead of `execute`

Pushing this for now into 3.x-dev but can also put it into 4.x-dev directly but then there might be merge conflicts when merging 3.x-dev into 4.x-dev