### PR TITLE
Order of implode() args, avoid E_NOTICE in PHP7.4

### DIFF
--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -346,7 +346,7 @@ class Model
 
         list($updateParts, $sqlBind) = $this->fieldsToQuery($valuesToUpdate);
 
-        $parts = implode($updateParts, ', ');
+        $parts = implode(', ', $updateParts);
         $table = Common::prefixTable('log_link_visit_action');
 
         $sqlQuery = "UPDATE $table SET $parts WHERE idlink_va = ?";


### PR DESCRIPTION
https://www.php.net/implode
 > implode() can, for historical reasons, accept its parameters in either order. For consistency with explode(), however, it is deprecated not to use the documented order of arguments.

This commit switches the order of the arguments to `implode()` to avoid a deprecated `E_NOTICE` in PHP 7.4.