### PR TITLE
Use SameSite none for session token when embedded into iframe

### DIFF
--- a/core/Session.php
+++ b/core/Session.php
@@ -186,6 +186,17 @@ class Session extends Zend_Session
         return self::$sessionStarted;
     }
 
+    public static function getSameSiteCookieValue()
+    {
+        $config = Config::getInstance();
+        $general = $config->General;
+        if (!empty($general['enable_framed_pages']) && ProxyHttp::isHttps()) {
+            return 'None';
+        }
+
+        return 'Lax';
+    }
+
     /**
      * Write cookie header.  Similar to the native setcookie() function but also supports
      * the SameSite cookie property.

--- a/core/Session/SessionAuth.php
+++ b/core/Session/SessionAuth.php
@@ -195,7 +195,7 @@ class SessionAuth implements Auth
             $sessionParams['domain'],
             $sessionParams['secure'],
             $sessionParams['httponly'],
-            'lax'
+            Session::getSameSiteCookieValue()
         );
 
         // ...and we also update the expiration time stored server side so we can prevent expired sessions from being reused

--- a/libs/Zend/Session.php
+++ b/libs/Zend/Session.php
@@ -341,7 +341,7 @@ class Zend_Session extends Zend_Session_Abstract
         }
 
         if (stripos($cookieHeader, 'SameSite') === false) {
-            $cookieHeader .= '; SameSite=Lax';
+            $cookieHeader .= '; SameSite=' . \Piwik\Session::getSameSiteCookieValue();
             header($cookieHeader);
         }
     }
@@ -798,7 +798,7 @@ class Zend_Session extends Zend_Session_Abstract
                 $cookie_params['domain'],
                 $cookie_params['secure'],
                 false,
-                'lax'
+                \Piwik\Session::getSameSiteCookieValue()
             );
         }
     }


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/15414

Worked for me after enabling embed framed pages. It was setting the `None` as SameSite though instead of `Lax` and I was able to view reports within the frame etc.

Used this:
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>Title</title>
</head>
<body>
<iframe width="100%" height="600" src="https://example.com/index.php?module=Login&action=logme&login=root&password=TOKEN"></iframe>

</body>
</html>
```
