### PR TITLE
When closing a popover, leave opened any previously opened popover

### DIFF
--- a/plugins/CoreHome/javascripts/popover.js
+++ b/plugins/CoreHome/javascripts/popover.js
@@ -35,6 +35,8 @@ var Piwik_Popover = (function () {
                 }
 
                 $('.ui-widget-overlay').on('click.popover', function () {
+                    // if clicking outside of the dialog, close entire stack
+                    broadcast.resetPopoverStack();
                     container.dialog('close');
                 });
 
@@ -47,11 +49,6 @@ var Piwik_Popover = (function () {
                 }, 0);
             },
             close: function (event, ui) {
-                // if clicking outside of the dialog, close entire stack
-                if (!event.currentTarget && !$(event.currentTarget).is('button')) {
-                    broadcast.resetPopoverStack();
-                }
-
                 container.find('div.jqplot-target').trigger('piwikDestroyPlot');
                 container[0].innerHTML = '';
                 container.dialog('destroy').remove();
@@ -70,7 +67,7 @@ var Piwik_Popover = (function () {
 
                 // if we were not called by Piwik_Popover.close(), then the user clicked the close button or clicked
                 // the overlay, in which case we want to handle the popover URL as well as the actual modal.
-                if (!isProgrammaticClose) {
+                if (!isProgrammaticClose || isEscapeKey(event)) {
                     broadcast.propagateNewPopoverParameter(false);
                 }
             }


### PR DESCRIPTION
While investigating #15404 I discovered that the popover stack "feature" is kind of broken:

When opening popovers (segmented visitor log, visitor profile, ...) it is possible to open a popover from within another one. Those popovers are stored in a popover stack in javascript, to make it possible to open the previous popover if the current one is closed.
That is currently broken. When closing a popover it seems the stack is completely destroyed in any case.

With those changes the behaviour will be:

*Clicking outside of the popover*: complete stack will be closed
*Clicking the close button (x)*: current popover will be closed, previous will be opened (if any)
*Pressing Excape key*: complete stack will be closed

Is that expected, or should that be changed some more?