### PR TITLE
Forward instance_id from local config when reseting config during tests.

### DIFF
--- a/tests/PHPUnit/Framework/Mock/TestConfig.php
+++ b/tests/PHPUnit/Framework/Mock/TestConfig.php
@@ -58,9 +58,18 @@ class TestConfig extends Config
 
         // Ensure local mods do not affect tests
         if (empty($pathGlobal)) {
+            $general = $chain->getFrom($this->getLocalPath(), 'General');
+            $instanceId = isset($general['instance_id']) ? $general['instance_id'] : null;
+
             $chain->set('Debug', $chain->getFrom($this->getGlobalPath(), 'Debug'));
             $chain->set('mail', $chain->getFrom($this->getGlobalPath(), 'mail'));
-            $chain->set('General', $chain->getFrom($this->getGlobalPath(), 'General'));
+
+            $globalGeneral = $chain->getFrom($this->getGlobalPath(), 'General');
+            if ($instanceId) {
+                $globalGeneral['instance_id'] = $instanceId;
+            }
+            $chain->set('General', $globalGeneral);
+
             $chain->set('Segments', $chain->getFrom($this->getGlobalPath(), 'Segments'));
             $chain->set('Tracker', $chain->getFrom($this->getGlobalPath(), 'Tracker'));
             $chain->set('Deletelogs', $chain->getFrom($this->getGlobalPath(), 'Deletelogs'));


### PR DESCRIPTION
If this isn't done and you use a domain when running tests, the instance_id won't be used during tests. So the main PHPUnit execution context will use one tmp dir path (w/o the instance id), but other execution contexts (like climulti) will use a directory with a tmp dir path. Which can result in very hard to debug errors.