### PR TITLE
Process unique visitor metric for Roll-ups (set enable_processing_unique_visitors_multiple_sites = 1)

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -200,7 +200,7 @@ enable_processing_unique_visitors_range = 0
 ; controls whether Unique Visitors will be processed for groups of websites. these metrics describe the number
 ; of unique visitors across the entire set of websites, so if a visitor visited two websites in the group, she
 ; would still only be counted as one. only relevant when using plugins that group sites together
-enable_processing_unique_visitors_multiple_sites = 0
+enable_processing_unique_visitors_multiple_sites = 1
 
 ; The list of periods that are available in the Matomo calendar
 ; Example use case: custom date range requests are processed in real time,

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87360f5222f27304819732abfe576f4a67fd9b51828199bc2256488496e6813c
-size 4224996
+oid sha256:0d5ab1fb97f68102fca57d3bc55235b6a5e63733c4b5bedde9b2cdb1da7f77dc
+size 4224819


### PR DESCRIPTION
Alternatively, we could remove this setting completely and always assume we want to process unique visitors across websites. I'm not sure there is any reason not to want this enabled?