### PR TITLE
Add event that allows plugins to disable archiving for certain periods/sites if they want.

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -649,10 +649,11 @@ class Archive implements ArchiveQuery
             foreach ($this->params->getIdSites() as $idSite) {
                 $site = new Site($idSite);
 
-                 if ($period->getLabel() === 'day'
+                if ($period->getLabel() === 'day'
                     && !$this->params->getSegment()->isEmpty()
                     && Common::getRequestVar('skipArchiveSegmentToday', 0, 'int')
-                    && $period->getDateStart()->toString() == Date::factory('now', $site->getTimezone())->toString()) {
+                    && $period->getDateStart()->toString() == Date::factory('now', $site->getTimezone())->toString()
+                ) {
 
                     Log::debug("Skipping archive %s for %s as segment today is disabled", $period->getLabel(), $period->getPrettyString());
                     continue;

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -226,9 +226,24 @@ class Rules
         return !$isArchivingEnabled;
     }
 
-    public static function isRequestAuthorizedToArchive()
+    public static function isRequestAuthorizedToArchive(Parameters $params = null)
     {
-        return Rules::isBrowserTriggerEnabled() || SettingsServer::isArchivePhpTriggered();
+        $isRequestAuthorizedToArchive = null;
+        if (!empty($params)) {
+            /**
+             * @ignore
+             *
+             * @params bool &$isRequestAuthorizedToArchive
+             * @params Parameters $params
+             */
+            Piwik::postEvent('Rules.isRequestAuthorizedToArchive', [&$isRequestAuthorizedToArchive, $params]);
+        }
+
+        if ($isRequestAuthorizedToArchive === null) {
+            $isRequestAuthorizedToArchive = Rules::isBrowserTriggerEnabled() || SettingsServer::isArchivePhpTriggered();
+        }
+
+        return $isRequestAuthorizedToArchive;
     }
 
     public static function isBrowserTriggerEnabled()
@@ -293,11 +308,11 @@ class Rules
      *
      * @return string[]
      */
-    public static function getSelectableDoneFlagValues($includeInvalidated = true)
+    public static function getSelectableDoneFlagValues($includeInvalidated = true, Parameters $params = null)
     {
         $possibleValues = array(ArchiveWriter::DONE_OK, ArchiveWriter::DONE_OK_TEMPORARY);
 
-        if (!Rules::isRequestAuthorizedToArchive()
+        if (!Rules::isRequestAuthorizedToArchive($params)
             && $includeInvalidated
         ) {
             //If request is not authorized to archive then fetch also invalidated archives

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -228,7 +228,8 @@ class Rules
 
     public static function isRequestAuthorizedToArchive(Parameters $params = null)
     {
-        $isRequestAuthorizedToArchive = null;
+        $isRequestAuthorizedToArchive = Rules::isBrowserTriggerEnabled() || SettingsServer::isArchivePhpTriggered();
+
         if (!empty($params)) {
             /**
              * @ignore
@@ -236,11 +237,7 @@ class Rules
              * @params bool &$isRequestAuthorizedToArchive
              * @params Parameters $params
              */
-            Piwik::postEvent('Rules.isRequestAuthorizedToArchive', [&$isRequestAuthorizedToArchive, $params]);
-        }
-
-        if ($isRequestAuthorizedToArchive === null) {
-            $isRequestAuthorizedToArchive = Rules::isBrowserTriggerEnabled() || SettingsServer::isArchivePhpTriggered();
+            Piwik::postEvent('Archiving.isRequestAuthorizedToArchive', [&$isRequestAuthorizedToArchive, $params]);
         }
 
         return $isRequestAuthorizedToArchive;

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -71,7 +71,7 @@ class ArchiveSelector
         $plugins = array("VisitsSummary", $requestedPlugin);
 
         $doneFlags      = Rules::getDoneFlags($plugins, $segment);
-        $doneFlagValues = Rules::getSelectableDoneFlagValues($includeInvalidated);
+        $doneFlagValues = Rules::getSelectableDoneFlagValues($includeInvalidated, $params);
 
         $results = self::getModel()->getArchiveIdAndVisits($numericTable, $idSite, $period, $dateStartIso, $dateEndIso, $minDatetimeIsoArchiveProcessedUTC, $doneFlags, $doneFlagValues);
 


### PR DESCRIPTION
New event is not public. Would be useful for the GA importer to make sure day archives are not re-archived, erasing imported data.

Added to 3.13.2 since it would be good for this functionality to work for users of 3.x installs, but I don't require it.