### PR TITLE
Use safemode when running CLI commands

### DIFF
--- a/console
+++ b/console
@@ -1,5 +1,8 @@
 #!/usr/bin/env php
 <?php
+
+use Piwik\FrontController;
+
 if (!defined('PIWIK_DOCUMENT_ROOT')) {
     define('PIWIK_DOCUMENT_ROOT', dirname(__FILE__) == '/' ? '' : dirname(__FILE__));
 }
@@ -22,6 +25,8 @@ if (!defined('PIWIK_ENABLE_ERROR_HANDLER') || PIWIK_ENABLE_ERROR_HANDLER) {
     Piwik\ErrorHandler::registerErrorHandler();
     Piwik\ExceptionHandler::setUp();
 }
+
+FrontController::setUpSafeMode();
 
 $console = new Piwik\Console();
 $console->run();

--- a/core/Console.php
+++ b/core/Console.php
@@ -89,50 +89,56 @@ class Console extends Application
 
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        if ($input->hasParameterOption('--xhprof')) {
-            Profiler::setupProfilerXHProf(true, true);
-        }
-
-        $this->initMatomoHost($input);
-        $this->initEnvironment($output);
-        $this->initLoggerOutput($output);
-
         try {
-            self::initPlugins();
-        } catch (ConfigNotFoundException $e) {
-            // Piwik not installed yet, no config file?
-            Log::warning($e->getMessage());
+            if ($input->hasParameterOption('--xhprof')) {
+                Profiler::setupProfilerXHProf(true, true);
+            }
+
+            $this->initMatomoHost($input);
+            $this->initEnvironment($output);
+            $this->initLoggerOutput($output);
+
+            try {
+                self::initPlugins();
+            } catch (ConfigNotFoundException $e) {
+                // Piwik not installed yet, no config file?
+                Log::warning($e->getMessage());
+            }
+
+            $this->initAuth();
+
+            $commands = $this->getAvailableCommands();
+
+            foreach ($commands as $command) {
+                $this->addCommandIfExists($command);
+            }
+
+            $exitCode = null;
+
+            /**
+             * @ignore
+             */
+            Piwik::postEvent('Console.doRun', [&$exitCode, $input, $output]);
+
+            if ($exitCode === null) {
+                $self = $this;
+                $exitCode = Access::doAsSuperUser(function () use ($input, $output, $self) {
+                    return call_user_func(array($self, 'Symfony\Component\Console\Application::doRun'), $input, $output);
+                });
+            }
+
+            $importantLogDetector = StaticContainer::get(FailureLogMessageDetector::class);
+            if ($exitCode === 0 && $importantLogDetector->hasEncounteredImportantLog()) {
+                $output->writeln("Error: error or warning logs detected, exit 1");
+                $exitCode = 1;
+            }
+
+            return $exitCode;
+        } catch (\Exception $ex) {
+            print $ex->getMessage() ."\n" . $ex->getTraceAsString();
+            FrontController::generateSafeModeOutputFromException($ex);
+            throw $ex;
         }
-
-        $this->initAuth();
-
-        $commands = $this->getAvailableCommands();
-
-        foreach ($commands as $command) {
-            $this->addCommandIfExists($command);
-        }
-
-        $exitCode = null;
-
-        /**
-         * @ignore
-         */
-        Piwik::postEvent('Console.doRun', [&$exitCode, $input, $output]);
-
-        if ($exitCode === null) {
-            $self = $this;
-            $exitCode = Access::doAsSuperUser(function () use ($input, $output, $self) {
-                return call_user_func(array($self, 'Symfony\Component\Console\Application::doRun'), $input, $output);
-            });
-        }
-
-        $importantLogDetector = StaticContainer::get(FailureLogMessageDetector::class);
-        if ($exitCode === 0 && $importantLogDetector->hasEncounteredImportantLog()) {
-            $output->writeln("Error: error or warning logs detected, exit 1");
-            $exitCode = 1;
-        }
-
-        return $exitCode;
     }
 
     private function addCommandIfExists($command)

--- a/core/Console.php
+++ b/core/Console.php
@@ -135,8 +135,12 @@ class Console extends Application
 
             return $exitCode;
         } catch (\Exception $ex) {
-            print $ex->getMessage() ."\n" . $ex->getTraceAsString();
-            FrontController::generateSafeModeOutputFromException($ex);
+            try {
+                FrontController::generateSafeModeOutputFromException($ex);
+            } catch (\Exception $ex) {
+                // ignore, we re-throw the original exception, not a wrapped one
+            }
+
             throw $ex;
         }
     }

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -106,7 +106,7 @@ class FrontController extends Singleton
      * @param Exception $e
      * @return string
      */
-    private static function generateSafeModeOutputFromException($e)
+    public static function generateSafeModeOutputFromException($e)
     {
         StaticContainer::get(LoggerInterface::class)->error('Uncaught exception: {exception}', [
             'exception' => $e,

--- a/plugins/VisitsSummary/API.php
+++ b/plugins/VisitsSummary/API.php
@@ -25,7 +25,6 @@ class API extends \Piwik\Plugin\API
 {
     public function get($idSite, $period, $date, $segment = false, $columns = false)
     {
-       // throw new \Exception("forced test");
         Piwik::checkUserHasViewAccess($idSite);
         $archive = Archive::build($idSite, $period, $date, $segment);
 

--- a/plugins/VisitsSummary/API.php
+++ b/plugins/VisitsSummary/API.php
@@ -25,6 +25,7 @@ class API extends \Piwik\Plugin\API
 {
     public function get($idSite, $period, $date, $segment = false, $columns = false)
     {
+       // throw new \Exception("forced test");
         Piwik::checkUserHasViewAccess($idSite);
         $archive = Archive::build($idSite, $period, $date, $segment);
 

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -15,6 +15,7 @@ use Piwik\Auth;
 use Piwik\Auth\Password;
 use Piwik\Cache\Backend\File;
 use Piwik\Cache as PiwikCache;
+use Piwik\CliMulti\CliPhp;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
@@ -146,6 +147,20 @@ class Fixture extends \PHPUnit_Framework_Assert
         }
 
         return 'python';
+    }
+
+    public static function getCliCommandBase()
+    {
+        $cliPhp = new CliPhp();
+        $php = $cliPhp->findPhpBinary();
+
+        $command = $php . ' ' . PIWIK_INCLUDE_PATH .'/tests/PHPUnit/proxy/console ';
+
+        if (!empty($_SERVER['HTTP_HOST'])) {
+            $command .= '--matomo-domain=' . $_SERVER['HTTP_HOST'];
+        }
+
+        return $command;
     }
 
     public static function getTestRootUrl()

--- a/tests/PHPUnit/System/ConsoleTest.php
+++ b/tests/PHPUnit/System/ConsoleTest.php
@@ -8,9 +8,13 @@
 
 namespace Piwik\Tests\System;
 
+use Piwik\CliMulti\CliPhp;
+use Piwik\Config;
 use Piwik\Container\StaticContainer;
+use Piwik\Development;
 use Piwik\Plugin\ConsoleCommand;
 use Piwik\Plugins\Monolog\Handler\FailureLogMessageDetector;
+use Piwik\Tests\Framework\Fixture;
 use Psr\Log\LoggerInterface;
 use Monolog\Logger;
 use Symfony\Component\Console\Input\InputInterface;
@@ -48,6 +52,56 @@ class TestCommandWithError extends ConsoleCommand
         if (!$input->getOption('no-error')) {
             StaticContainer::get(LoggerInterface::class)->error('error');
         }
+    }
+}
+
+class TestCommandWithFatalError extends ConsoleCommand
+{
+    public function configure()
+    {
+        parent::configure();
+
+        $this->setName('test-command-with-fatal-error');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            \Piwik\ErrorHandler::pushFatalErrorBreadcrumb(static::class);
+
+            $this->executeImpl($input, $output);
+        } finally {
+            \Piwik\ErrorHandler::popFatalErrorBreadcrumb();
+        }
+    }
+
+    public function executeImpl(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            \Piwik\ErrorHandler::pushFatalErrorBreadcrumb(static::class, []);
+
+            $val = "";
+            while (true) {
+                $val .= str_repeat("*", 1024 * 1024 * 1024);
+            }
+        } finally {
+            \Piwik\ErrorHandler::popFatalErrorBreadcrumb();
+        }
+    }
+}
+
+class TestCommandWithException extends ConsoleCommand
+{
+    public function configure()
+    {
+        parent::configure();
+
+        $this->setName('test-command-with-exception');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        throw new \Exception('test error');
     }
 }
 
@@ -89,12 +143,87 @@ class ConsoleTest extends ConsoleCommandTestCase
         $this->assertEquals(0, $exitCode);
     }
 
+    public function test_Console_handlesFatalErrorsCorrectly()
+    {
+        $command = Fixture::getCliCommandBase();
+        $command .= ' test-command-with-fatal-error';
+        $command .= ' 2>&1';
+
+        $output = shell_exec($command);
+        $output = $this->normalizeOutput($output);
+
+        $expected = <<<END
+#!/usr/bin/env php
+
+Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 1073741856 bytes) in /tests/PHPUnit/System/ConsoleTest.php on line 85
+*** IN SAFEMODE ***
+Matomo encountered an error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 1073741856 bytes) (which lead to: Error: array (
+  'type' => 1,
+  'message' => 'Allowed memory size of 2147483648 bytes exhausted (tried to allocate 1073741856 bytes)',
+  'file' => '/tests/PHPUnit/System/ConsoleTest.php',
+  'line' => 85,
+  'backtrace' => ' on /tests/PHPUnit/System/ConsoleTest.php(85)
+#0 /tests/PHPUnit/System/ConsoleTest.php(72): Piwik\\\\Tests\\\\System\\\\TestCommandWithFatalError->executeImpl()
+#1 /vendor/symfony/console/Symfony/Component/Console/Command/Command.php(257): Piwik\\\\Tests\\\\System\\\\TestCommandWithFatalError->execute()
+',
+))
+END;
+        $this->assertEquals($expected, $output);
+    }
+
+    public function test_Console_handlesExceptionsCorrectly()
+    {
+        $command = Fixture::getCliCommandBase();
+        $command .= ' test-command-with-exception';
+        $command .= ' 2>&1';
+
+        $output = shell_exec($command);
+        $output = $this->normalizeOutput($output);
+
+        $expected = <<<END
+#!/usr/bin/env php
+*** IN SAFEMODE ***
+
+
+               
+  [Exception]  
+  test error   
+               
+
+
+test-command-with-exception
+
+
+
+END;
+        $this->assertEquals($expected, $output);
+    }
+
     public static function provideContainerConfigBeforeClass()
     {
         return [
             'log.handlers' => [\DI\get(FailureLogMessageDetector::class)],
             LoggerInterface::class => \DI\object(Logger::class)
                 ->constructor('piwik', \DI\get('log.handlers'), \DI\get('log.processors')),
+
+            'observers.global' => \DI\add([
+                ['Console.filterCommands', function (&$commands) {
+                    $commands[] = TestCommandWithFatalError::class;
+                    $commands[] = TestCommandWithException::class;
+                }],
+
+                ['Request.dispatch', function ($module, $action) {
+                    if ($module === 'CorePluginsAdmin' && $action === 'safemode') {
+                        print "*** IN SAFEMODE ***\n"; // will appear in output
+                    }
+                }],
+            ]),
         ];
+    }
+
+    private function normalizeOutput($output)
+    {
+        $output = str_replace(PIWIK_INCLUDE_PATH, '', $output);
+        return $output;
     }
 }

--- a/tests/PHPUnit/System/ConsoleTest.php
+++ b/tests/PHPUnit/System/ConsoleTest.php
@@ -155,11 +155,11 @@ class ConsoleTest extends ConsoleCommandTestCase
         $expected = <<<END
 #!/usr/bin/env php
 
-Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 1073741856 bytes) in /tests/PHPUnit/System/ConsoleTest.php on line 85
+Fatal error: Allowed memory size of 1073741824 bytes exhausted (tried to allocate 1073741825 bytes) in /tests/PHPUnit/System/ConsoleTest.php on line 85
 *** IN SAFEMODE ***
-Matomo encountered an error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 1073741856 bytes) (which lead to: Error: array (
+Matomo encountered an error: Allowed memory size of 1073741824 bytes exhausted (tried to allocate 1073741856 bytes) (which lead to: Error: array (
   'type' => 1,
-  'message' => 'Allowed memory size of 2147483648 bytes exhausted (tried to allocate 1073741856 bytes)',
+  'message' => 'Allowed memory size of 1073741824 bytes exhausted (tried to allocate 1073741825 bytes)',
   'file' => '/tests/PHPUnit/System/ConsoleTest.php',
   'line' => 85,
   'backtrace' => ' on /tests/PHPUnit/System/ConsoleTest.php(85)


### PR DESCRIPTION
This would allow the controller method in plugins to be used when an error or exception occurs during a CLI command (which should result in an email on cloud, but I haven't tested).