### PR TITLE
fix: enable user-defined value for insertIntoTempIterationStep

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -910,8 +910,10 @@ enable_sql_profiler = 0
 [Deletelogs]
 ; delete_logs_enable - enable (1) or disable (0) delete log feature. Make sure that all archives for the given period have been processed (setup a cronjob!),
 ; otherwise you may lose tracking data.
-; delete_logs_schedule_lowest_interval - lowest possible interval between two table deletes (in days, 1|7|30). Default: 7.
+; delete_logs_schedule_lowest_interval - lowest possible interval between two table deletes, for table log_visit (in days, 1|7|30). Default: 7.
 ; delete_logs_older_than - delete data older than XX (days). Default: 180
+; delete_logs_unused_actions_schedule_lowest_interval - lowest possible interval between two table deletes, for table log_action (in days, 1|7|30). Default: 30.
+; *_max_rows_per_query - can be increased for large sites to speed up delete processes
 delete_logs_enable = 0
 delete_logs_schedule_lowest_interval = 7
 delete_logs_older_than = 180

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -916,6 +916,7 @@ delete_logs_enable = 0
 delete_logs_schedule_lowest_interval = 7
 delete_logs_older_than = 180
 delete_logs_max_rows_per_query = 100000
+delete_logs_unused_actions_max_rows_per_query = 100000
 enable_auto_database_size_estimate = 1
 enable_database_size_estimate = 1
 delete_logs_unused_actions_schedule_lowest_interval = 30

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -218,14 +218,15 @@ class API extends \Piwik\Plugin\API
 
         $settings['delete_reports_older_than'] = $deleteReportsOlderThan;
 
-        $settings['delete_reports_keep_basic_metrics']   = (int) $keepBasic;
-        $settings['delete_reports_keep_day_reports']     = (int) $keepDay;
-        $settings['delete_reports_keep_week_reports']    = (int) $keepWeek;
-        $settings['delete_reports_keep_month_reports']   = (int) $keepMonth;
-        $settings['delete_reports_keep_year_reports']    = (int) $keepYear;
-        $settings['delete_reports_keep_range_reports']   = (int) $keepRange;
-        $settings['delete_reports_keep_segment_reports'] = (int) $keepSegments;
-        $settings['delete_logs_max_rows_per_query']      = PiwikConfig::getInstance()->Deletelogs['delete_logs_max_rows_per_query'];
+        $settings['delete_reports_keep_basic_metrics']             = (int) $keepBasic;
+        $settings['delete_reports_keep_day_reports']               = (int) $keepDay;
+        $settings['delete_reports_keep_week_reports']              = (int) $keepWeek;
+        $settings['delete_reports_keep_month_reports']             = (int) $keepMonth;
+        $settings['delete_reports_keep_year_reports']              = (int) $keepYear;
+        $settings['delete_reports_keep_range_reports']             = (int) $keepRange;
+        $settings['delete_reports_keep_segment_reports']           = (int) $keepSegments;
+        $settings['delete_logs_max_rows_per_query']                = PiwikConfig::getInstance()->Deletelogs['delete_logs_max_rows_per_query'];
+        $settings['delete_logs_unused_actions_max_rows_per_query'] = PiwikConfig::getInstance()->Deletelogs['delete_logs_unused_actions_max_rows_per_query'];
 
         return $this->savePurgeDataSettings($settings);
     }

--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -59,14 +59,15 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $settings['delete_reports_enable'] = Common::getRequestVar("enableDeleteReports", 0);
         $deleteReportsOlderThan = Common::getRequestVar("deleteReportsOlderThan", 3);
         $settings['delete_reports_older_than'] = $deleteReportsOlderThan < 2 ? 2 : $deleteReportsOlderThan;
-        $settings['delete_reports_keep_basic_metrics']   = Common::getRequestVar("keepBasic", 0);
-        $settings['delete_reports_keep_day_reports']     = Common::getRequestVar("keepDay", 0);
-        $settings['delete_reports_keep_week_reports']    = Common::getRequestVar("keepWeek", 0);
-        $settings['delete_reports_keep_month_reports']   = Common::getRequestVar("keepMonth", 0);
-        $settings['delete_reports_keep_year_reports']    = Common::getRequestVar("keepYear", 0);
-        $settings['delete_reports_keep_range_reports']   = Common::getRequestVar("keepRange", 0);
-        $settings['delete_reports_keep_segment_reports'] = Common::getRequestVar("keepSegments", 0);
-        $settings['delete_logs_max_rows_per_query']      = PiwikConfig::getInstance()->Deletelogs['delete_logs_max_rows_per_query'];
+        $settings['delete_reports_keep_basic_metrics']             = Common::getRequestVar("keepBasic", 0);
+        $settings['delete_reports_keep_day_reports']               = Common::getRequestVar("keepDay", 0);
+        $settings['delete_reports_keep_week_reports']              = Common::getRequestVar("keepWeek", 0);
+        $settings['delete_reports_keep_month_reports']             = Common::getRequestVar("keepMonth", 0);
+        $settings['delete_reports_keep_year_reports']              = Common::getRequestVar("keepYear", 0);
+        $settings['delete_reports_keep_range_reports']             = Common::getRequestVar("keepRange", 0);
+        $settings['delete_reports_keep_segment_reports']           = Common::getRequestVar("keepSegments", 0);
+        $settings['delete_logs_max_rows_per_query']                = PiwikConfig::getInstance()->Deletelogs['delete_logs_max_rows_per_query'];
+        $settings['delete_logs_unused_actions_max_rows_per_query'] = PiwikConfig::getInstance()->Deletelogs['delete_logs_unused_actions_max_rows_per_query'];
 
         return $settings;
     }

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -53,6 +53,7 @@ class PrivacyManager extends Plugin
         'delete_logs_older_than'               => 'Deletelogs',
         'delete_logs_max_rows_per_query'       => 'Deletelogs',
         'delete_logs_unused_actions_schedule_lowest_interval' => 'Deletelogs',
+        'delete_logs_unused_actions_max_rows_per_query'       => 'Deletelogs',
         'enable_auto_database_size_estimate'   => 'Deletelogs',
         'enable_database_size_estimate'        => 'Deletelogs',
         'delete_reports_enable'                => 'Deletereports',

--- a/plugins/PrivacyManager/tests/Integration/DataPurgingTest.php
+++ b/plugins/PrivacyManager/tests/Integration/DataPurgingTest.php
@@ -123,6 +123,7 @@ class DataPurgingTest extends IntegrationTestCase
         $settings['delete_logs_older_than'] = 35 + $daysSinceToday;
         $settings['delete_logs_schedule_lowest_interval'] = 7;
         $settings['delete_logs_max_rows_per_query'] = 100000;
+        $settings['delete_logs_unused_actions_max_rows_per_query'] = 100000;
         $settings['delete_reports_enable'] = 1;
         $settings['delete_reports_older_than'] = $monthsSinceToday;
         $settings['delete_reports_keep_basic_metrics'] = 0;

--- a/plugins/PrivacyManager/tests/Integration/PrivacyManagerTest.php
+++ b/plugins/PrivacyManager/tests/Integration/PrivacyManagerTest.php
@@ -149,6 +149,7 @@ class PrivacyManagerTest extends IntegrationTestCase
             'delete_logs_schedule_lowest_interval' => 7,
             'delete_logs_older_than' => 180,
             'delete_logs_max_rows_per_query' => 100000,
+            'delete_logs_unused_actions_max_rows_per_query' => 100000,
             'delete_logs_unused_actions_schedule_lowest_interval' => 30,
             'enable_auto_database_size_estimate' => 1,
             'enable_database_size_estimate' => 1,


### PR DESCRIPTION
Intended to be used to improve performance for large sites, similar to delete_logs_max_rows_per_query and archiving_ranking_query_row_limit