### PR TITLE
Make sparklines work when mbstring extension is not installed

### DIFF
--- a/libs/upgradephp/upgrade.php
+++ b/libs/upgradephp/upgrade.php
@@ -681,9 +681,22 @@ if (!function_exists('utf8_decode')) {
  * @param string $charset
  */
 if(!function_exists('mb_strtolower')) {
-	function mb_strtolower($input, $charset) {
-		return strtolower($input);
-	}
+    function mb_strtolower($input, $charset = '') {
+        return strtolower($input);
+    }
+}
+
+/**
+ * Use strlen if mb_strlen doesn't exist (i.e., php not compiled with --enable-mbstring)
+ * This is not a functional replacement for mb_strlen.
+ *
+ * @param string $input
+ * @param string $charset
+ */
+if(!function_exists('mb_strlen')) {
+    function mb_strlen($input, $charset = '') {
+        return strlen($input);
+    }
 }
 
 /**


### PR DESCRIPTION
1) Too few arguments to function mb_strtolower(), 1 passed in matomo/vendor/davaxi/sparkline/src/Sparkline/StyleTrait.php on line 129 and exactly 2 expected

2) mb_strlen is not defined