### PR TITLE
Fixed lang sk typo in translation.

### DIFF
--- a/lang/sk.json
+++ b/lang/sk.json
@@ -283,7 +283,7 @@
         "OrCancel": "alebo %1$s Zatvoriť %2$s",
         "Others": "Ostatné",
         "Outlink": "Odchádzajúci preklik",
-        "Outlinks": "Konkajšie odkazy",
+        "Outlinks": "Vonkajšie odkazy",
         "OverlayRowActionTooltip": "Pozrite si analytické dáta priamo na vašom webe (otvorí novú kartu)",
         "OverlayRowActionTooltipTitle": "Otvoriť prekrytie stránky",
         "Overview": "Prehľad",


### PR DESCRIPTION
Sk typo in translations file for key Outlinks. In SK there is no "Konkajšie" but Vonkajšie. Word mens outer or external.