### PR TITLE
Fix tests

### DIFF
--- a/plugins/Marketplace/tests/System/Api/ClientTest.php
+++ b/plugins/Marketplace/tests/System/Api/ClientTest.php
@@ -129,7 +129,7 @@ class ClientTest extends SystemTestCase
     {
         $plugins = $this->client->searchForPlugins($keywords = '', $query = '', $sort = '', $purchaseType = PurchaseType::TYPE_ALL);
 
-        $this->assertGreaterThan(15, count($plugins));
+        $this->assertGreaterThan(0, count($plugins));
 
         foreach ($plugins as $plugin) {
             $this->assertNotEmpty($plugin['name']);
@@ -141,7 +141,7 @@ class ClientTest extends SystemTestCase
     {
         $plugins = $this->client->searchForPlugins($keywords = '', $query = '', $sort = '', $purchaseType = PurchaseType::TYPE_FREE);
 
-        $this->assertGreaterThan(15, count($plugins));
+        $this->assertGreaterThan(0, count($plugins));
 
         foreach ($plugins as $plugin) {
             $this->assertTrue($plugin['isFree']);


### PR DESCRIPTION
This fixes some tests in Matomo v4.x, specific count values were used however v4.x only returns 6 plugins matches. I've changed the check to >0 as it shouldn't really matter how many are returned as long as there is plugin data returned from the marketplace.