### PR TITLE
Removes deprecated console param --piwik-domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The deprecated Platform API class `\Piwik\TaskScheduler` has been removed. Use `\Piwik\Scheduler\Scheduler` instead
 * The deprecated Platform API class `\Piwik\DeviceDetectorFactory` has been removed. Use `\Piwik\DeviceDetector\DeviceDetectorFactory` instead
 * The JavaScript tracker now uses `sendBeacon` by default if supported by the browser. You can disable this by calling the tracker method `disableAlwaysUseSendBeacon`. As a result, callback parameters won't work anymore and a tracking request might not appear in the developer tools.
+* The console option `--piwik-domain` has been removed. Use `--matomo-domain` instead
 
 ## Matomo 3.13.1
 

--- a/core/CliMulti/RequestCommand.php
+++ b/core/CliMulti/RequestCommand.php
@@ -95,8 +95,7 @@ class RequestCommand extends ConsoleCommand
     {
         $_GET = array();
 
-        // @todo remove piwik-domain fallback in Matomo 4
-        $hostname = $input->getOption('matomo-domain') ?: $input->getOption('piwik-domain');
+        $hostname = $input->getOption('matomo-domain');
         Url::setHost($hostname);
 
         $query = $input->getArgument('url-query');

--- a/core/Console.php
+++ b/core/Console.php
@@ -46,15 +46,6 @@ class Console extends Application
 
         $this->getDefinition()->addOption($option);
 
-        // @todo  Remove this alias in Matomo 4.0
-        $option = new InputOption('piwik-domain',
-            null,
-            InputOption::VALUE_OPTIONAL,
-            '[DEPRECATED] Matomo URL (protocol and domain) eg. "http://matomo.example.org"'
-        );
-
-        $this->getDefinition()->addOption($option);
-
         $option = new InputOption('xhprof',
             null,
             InputOption::VALUE_NONE,
@@ -212,10 +203,6 @@ class Console extends Application
     protected function initMatomoHost(InputInterface $input)
     {
         $matomoHostname = $input->getParameterOption('--matomo-domain');
-
-        if (empty($matomoHostname)) {
-            $matomoHostname = $input->getParameterOption('--piwik-domain');
-        }
 
         if (empty($matomoHostname)) {
             $matomoHostname = $input->getParameterOption('--url');

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -410,10 +410,7 @@ class CronArchive
                     (!$instanceId
                       || strpos($process, '--matomo-domain=' . $instanceId) !== false
                       || strpos($process, '--matomo-domain="' . $instanceId . '"') !== false
-                      || strpos($process, '--matomo-domain=\'' . $instanceId . "'") !== false
-                      || strpos($process, '--piwik-domain=' . $instanceId) !== false
-                      || strpos($process, '--piwik-domain="' . $instanceId . '"') !== false
-                      || strpos($process, '--piwik-domain=\'' . $instanceId . "'") !== false)) {
+                      || strpos($process, '--matomo-domain=\'' . $instanceId . "'") !== false)) {
                     $numRunning++;
                 }
             }

--- a/plugins/TestRunner/Commands/TestsRun.php
+++ b/plugins/TestRunner/Commands/TestsRun.php
@@ -43,8 +43,7 @@ class TestsRun extends ConsoleCommand
         $options = $input->getOption('options');
         $groups  = $input->getOption('group');
         $magics  = $input->getArgument('variables');
-        // @todo remove piwik-domain fallback in Matomo 4
-        $matomoDomain = $input->getOption('matomo-domain') ?: $input->getOption('piwik-domain');
+        $matomoDomain = $input->getOption('matomo-domain');
         $enableLogging = $input->getOption('enable-logging');
 
         $groups = $this->getGroupsFromString($groups);

--- a/plugins/TestRunner/Commands/TestsRunUI.php
+++ b/plugins/TestRunner/Commands/TestsRunUI.php
@@ -58,8 +58,7 @@ class TestsRunUI extends ConsoleCommand
         $storeInUiTestsRepo = $input->getOption('store-in-ui-tests-repo');
         $screenshotRepo = $input->getOption('screenshot-repo');
         $debug = $input->getOption('debug');
-        // @todo remove piwik-domain fallback in Matomo 4
-        $matomoDomain = $input->getOption('matomo-domain') ?: $input->getOption('piwik-domain');
+        $matomoDomain = $input->getOption('matomo-domain');
         $enableLogging = $input->getOption('enable-logging');
         $timeout = $input->getOption('timeout');
 

--- a/tests/lib/screenshot-testing/support/test-environment.js
+++ b/tests/lib/screenshot-testing/support/test-environment.js
@@ -190,8 +190,8 @@ TestingEnvironment.prototype.setupFixture = function (fixtureClass, done) {
         args.push('--plugins=' + options['plugin']);
     }
 
-    if (options['piwik-domain'] || options['matomo-domain']) {
-        args.push('--piwik-domain=' + (options['piwik-domain'] || options['matomo-domain']));
+    if (options['matomo-domain']) {
+        args.push('--matomo-domain=' + options['matomo-domain']);
     }
 
     if (options['enable-logging']) {
@@ -258,8 +258,8 @@ TestingEnvironment.prototype.teardownFixture = function (fixtureClass, done) {
 
     var args = [fixtureClass || DEFAULT_UI_TEST_FIXTURE_NAME, "--teardown", '--server-global=' + JSON.stringify(config.phpServer)];
 
-    if (options['piwik-domain']) {
-        args.push('--piwik-domain=' + options['piwik-domain']);
+    if (options['matomo-domain']) {
+        args.push('--matomo-domain=' + options['matomo-domain']);
     }
 
     this.executeConsoleCommand('tests:setup-fixture', args, function (code) {


### PR DESCRIPTION
Has been marked as removal for Matomo 4 in changelog.

refs #12420