### PR TITLE
Ensure to only show enabled reports in "Goals By" view

### DIFF
--- a/plugins/Goals/Goals.php
+++ b/plugins/Goals/Goals.php
@@ -280,7 +280,7 @@ class Goals extends \Piwik\Plugin
         $reports = new ReportsProvider();
 
         foreach ($reports->getAllReports() as $report) {
-            if ($report->hasGoalMetrics()) {
+            if ($report->hasGoalMetrics() && $report->isEnabled()) {
                 $reportsWithGoals[] = array(
                     'category' => $report->getCategoryId(),
                     'name'     => $report->getName(),


### PR DESCRIPTION
When a report, that is marked as goal report, is actually not enabled it will currently still be shown in the menu of the "Goals By"-view. Clicking such a report will result in an error, as the report is not enabled.