### PR TITLE
Ensure the number of fraction digits is correct

### DIFF
--- a/core/NumberFormatter.php
+++ b/core/NumberFormatter.php
@@ -239,7 +239,7 @@ class NumberFormatter
         if ($minimumFractionDigits <= $maximumFractionDigits) {
             // Strip any trailing zeroes.
             $minorDigits = rtrim($minorDigits, '0');
-            if (strlen($minorDigits) && strlen($minorDigits) < $minimumFractionDigits) {
+            if (strlen($minorDigits) < $minimumFractionDigits) {
                 // Now there are too few digits, re-add trailing zeroes
                 // until the desired length is reached.
                 $neededZeroes = $minimumFractionDigits - strlen($minorDigits);

--- a/plugins/CoreHome/DataTableRowAction/RowEvolution.php
+++ b/plugins/CoreHome/DataTableRowAction/RowEvolution.php
@@ -284,8 +284,8 @@ class RowEvolution
             $fractionDigits = max($this->getFractionDigits($first), $this->getFractionDigits($last));
 
             $details = Piwik::translate('RowEvolution_MetricBetweenText', array(
-                NumberFormatter::getInstance()->format($first, $fractionDigits, $fractionDigits) . $unit,
-                NumberFormatter::getInstance()->format($last, $fractionDigits, $fractionDigits) . $unit,
+                NumberFormatter::getInstance()->format($first, $fractionDigits) . $unit,
+                NumberFormatter::getInstance()->format($last, $fractionDigits) . $unit,
             ));
 
             if ($change !== false) {

--- a/tests/PHPUnit/Integration/NumberFormatterTest.php
+++ b/tests/PHPUnit/Integration/NumberFormatterTest.php
@@ -70,7 +70,7 @@ class NumberFormatterTest extends \PHPUnit\Framework\TestCase
         $this->translator->setCurrentLanguage($language);
         $numberFormatter = new NumberFormatter($this->translator);
 
-        $this->assertEquals($expected, $numberFormatter->formatNumber($value, $maximumFractionDigits, $minimumFractionDigits));
+        $this->assertSame($expected, $numberFormatter->formatNumber($value, $maximumFractionDigits, $minimumFractionDigits));
     }
 
     public function getNumberFormattingTestData()
@@ -114,7 +114,7 @@ class NumberFormatterTest extends \PHPUnit\Framework\TestCase
             array('en', -5, 0, 3, '-5%'),
             array('en', 5.299, 0, 0, '5%'),
             array('en', 5.299, 3, 0, '5.299%'),
-            array('en', -50, 3, 3, '-50%'),
+            array('en', -50, 3, 3, '-50.000%'),
             array('en', -50.1, 3, 3, '-50.100%'),
             array('en', 5000, 0, 0, '5,000%'),
             array('en', +5000, 0, 0, '5,000%'),


### PR DESCRIPTION
The current behavior when formatting number is a bit inconsistent when the minimum number of fraction digits is set.

Let's assume we have minimum number of fraction digits set to 3. The current fomating would do that:

| number | formatted number |
| - | - |
| 50.001 | 50.001 |
| 50 | 50 |
| 50.1 | 50.100 |

With the suggested changes the `50` should result in `50.000`. There is actually a test covering exact that case, unfortunately it doesn't fail at the moment, as the `assertEquals` in the PHPUnit version we are using returns true when comparing `50` and `50.000` 🤷‍♂ 
(The `assertSame` would actually fail. In newer PHPUnit versions the `assertEquals` fails, too)