### PR TITLE
Trigger exception when idgoal does not exist

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -18,6 +18,7 @@ use Piwik\Plugin\Dimension\ConversionDimension;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\CustomVariables\CustomVariables;
 use Piwik\Plugins\Events\Actions\ActionEvent;
+use Piwik\Tracker;
 use Piwik\Tracker\Visit\VisitProperties;
 
 /**
@@ -253,7 +254,7 @@ class GoalManager
         $goals = $this->getGoalDefinitions($idSite);
 
         if (!isset($goals[$idGoal])) {
-            return null;
+            throw new InvalidRequestParameterException('idGoal ' . $idGoal . ' does not exist');
         }
 
         $goal = $goals[$idGoal];

--- a/tests/PHPUnit/System/TrackerResponseTest.php
+++ b/tests/PHPUnit/System/TrackerResponseTest.php
@@ -85,6 +85,15 @@ class TrackerResponseTest extends SystemTestCase
         $this->assertEquals(400, $response['status']);
     }
 
+    public function test_response_ShouldSend400ResponseCode_IfIdGoalIsInvalid()
+    {
+        $url = $this->tracker->getUrlTrackPageView('Test');
+        $url .= '&idgoal=9999';
+
+        $response = $this->sendHttpRequest($url);
+        $this->assertEquals(400, $response['status']);
+    }
+
     public function test_response_ShouldSend400ResponseCode_IfSiteIdIsNegative()
     {
         $url = $this->tracker->getUrlTrackPageView('Test');


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/12739
When idGoal is invalid, we return an HTTP 400 error just like we do for other things. The JSON response suggested in 12739 as an alternative we generally don't do.