### PR TITLE
Use \PHPUnit\Framework\TestCase instead of \PHPUnit_Framework_TestCase

### DIFF
--- a/plugins/API/tests/Unit/ConsoleRendererTest.php
+++ b/plugins/API/tests/Unit/ConsoleRendererTest.php
@@ -17,7 +17,7 @@ use Piwik\Plugins\CoreHome\Columns\Metrics\AverageTimeOnSite;
  * @group Plugin
  * @group API
  */
-class ConsoleRendererTest extends \PHPUnit_Framework_TestCase
+class ConsoleRendererTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Console

--- a/plugins/API/tests/Unit/CsvRendererTest.php
+++ b/plugins/API/tests/Unit/CsvRendererTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugins\API\Renderer\Csv;
  * @group Plugin
  * @group API
  */
-class CsvRendererTest extends \PHPUnit_Framework_TestCase
+class CsvRendererTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Csv

--- a/plugins/API/tests/Unit/DataTable/MergeDataTablesTest.php
+++ b/plugins/API/tests/Unit/DataTable/MergeDataTablesTest.php
@@ -13,7 +13,7 @@ namespace Piwik\Plugins\API\tests\Unit\DataTable;
 use Piwik\DataTable;
 use Piwik\Plugins\API\DataTable\MergeDataTables;
 
-class MergeDataTablesTest extends \PHPUnit_Framework_TestCase
+class MergeDataTablesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var MergeDataTables

--- a/plugins/API/tests/Unit/HtmlRendererTest.php
+++ b/plugins/API/tests/Unit/HtmlRendererTest.php
@@ -17,7 +17,7 @@ use Piwik\Plugins\CoreHome\Columns\Metrics\AverageTimeOnSite;
  * @group Plugin
  * @group API
  */
-class HtmlRendererTest extends \PHPUnit_Framework_TestCase
+class HtmlRendererTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Html

--- a/plugins/API/tests/Unit/JsonRendererTest.php
+++ b/plugins/API/tests/Unit/JsonRendererTest.php
@@ -18,7 +18,7 @@ use Piwik\Plugins\API\Renderer\Json2;
  * @group API_JsonRendererTest
  * @group JsonRenderer
  */
-class JsonRendererTest extends \PHPUnit_Framework_TestCase
+class JsonRendererTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Json

--- a/plugins/API/tests/Unit/OriginalRendererTest.php
+++ b/plugins/API/tests/Unit/OriginalRendererTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugins\API\Renderer\Original;
  * @group Plugin
  * @group API
  */
-class OriginalRendererTest extends \PHPUnit_Framework_TestCase
+class OriginalRendererTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Original

--- a/plugins/API/tests/Unit/PhpRendererTest.php
+++ b/plugins/API/tests/Unit/PhpRendererTest.php
@@ -16,7 +16,7 @@ use Piwik\Plugins\API\Renderer\Php;
  * @group API
  * @group PhpRendererTest
  */
-class PhpRendererTest extends \PHPUnit_Framework_TestCase
+class PhpRendererTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Php

--- a/plugins/API/tests/Unit/WidgetMetadataTest.php
+++ b/plugins/API/tests/Unit/WidgetMetadataTest.php
@@ -25,7 +25,7 @@ use Piwik\Widget\WidgetContainerConfig;
  * @group WidgetMetadata
  * @group WidgetMetadataTest
  */
-class WidgetMetadataTest extends \PHPUnit_Framework_TestCase
+class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var WidgetMetadata

--- a/plugins/API/tests/Unit/XmlRendererTest.php
+++ b/plugins/API/tests/Unit/XmlRendererTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugins\API\Renderer\Xml;
  * @group Plugin
  * @group API
  */
-class XmlRendererTest extends \PHPUnit_Framework_TestCase
+class XmlRendererTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Xml

--- a/plugins/Actions/tests/Unit/ArchiverTest.php
+++ b/plugins/Actions/tests/Unit/ArchiverTest.php
@@ -19,7 +19,7 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/Actions/Actions.php';
  * @group ArchiverTest
  * @group Plugins
  */
-class ArchiverTests extends \PHPUnit_Framework_TestCase
+class ArchiverTests extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/plugins/BulkTracking/tests/Unit/RequestsTest.php
+++ b/plugins/BulkTracking/tests/Unit/RequestsTest.php
@@ -16,7 +16,7 @@ use Piwik\Tracker\Request;
  * @group RequestsTest
  * @group Plugins
  */
-class RequestsTest extends \PHPUnit_Framework_TestCase
+class RequestsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Requests

--- a/plugins/CoreAdminHome/tests/Unit/SetConfig/ConfigSettingManipulationTest.php
+++ b/plugins/CoreAdminHome/tests/Unit/SetConfig/ConfigSettingManipulationTest.php
@@ -44,7 +44,7 @@ class DumbMockConfig extends \Piwik\Config
  * @group CoreAdminHome
  * @group CoreAdminHome_Unit
  */
-class ConfigSettingManipulationTest extends \PHPUnit_Framework_TestCase
+class ConfigSettingManipulationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Config

--- a/plugins/CoreHome/tests/Unit/CoreHomeTest.php
+++ b/plugins/CoreHome/tests/Unit/CoreHomeTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugins\CoreHome\CoreHome;
  * @group CoreHomeTest
  * @group Plugins
  */
-class CoreHomeTest extends \PHPUnit_Framework_TestCase
+class CoreHomeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var CoreHome

--- a/plugins/CoreUpdater/tests/Unit/ModelTest.php
+++ b/plugins/CoreUpdater/tests/Unit/ModelTest.php
@@ -16,7 +16,7 @@ use Piwik\Plugins\CoreUpdater\Model;
  * @group Unit
  * @group Plugins
  */
-class ModelTest extends \PHPUnit_Framework_TestCase
+class ModelTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Model

--- a/plugins/CoreVisualizations/tests/Unit/GraphTest.php
+++ b/plugins/CoreVisualizations/tests/Unit/GraphTest.php
@@ -16,7 +16,7 @@ use Piwik\DataTable;
  * @group Sparklines
  * @group Plugins
  */
-class GraphTest extends \PHPUnit_Framework_TestCase
+class GraphTest extends \PHPUnit\Framework\TestCase
 {
     public function testSelectableColumnsAlreadySet()
     {

--- a/plugins/CoreVisualizations/tests/Unit/SparklinesConfigTest.php
+++ b/plugins/CoreVisualizations/tests/Unit/SparklinesConfigTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines\Config;
  * @group Sparklines
  * @group Plugins
  */
-class SparklinesConfigTest extends \PHPUnit_Framework_TestCase
+class SparklinesConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Config

--- a/plugins/Diagnostics/tests/Unit/Diagnostic/DiagnosticResultTest.php
+++ b/plugins/Diagnostics/tests/Unit/Diagnostic/DiagnosticResultTest.php
@@ -11,7 +11,7 @@ namespace Piwik\Plugins\Diagnostics\tests\Unit\Diagnostic;
 use Piwik\Plugins\Diagnostics\Diagnostic\DiagnosticResult;
 use Piwik\Plugins\Diagnostics\Diagnostic\DiagnosticResultItem;
 
-class DiagnosticResultTest extends \PHPUnit_Framework_TestCase
+class DiagnosticResultTest extends \PHPUnit\Framework\TestCase
 {
     public function test_getStatus_shouldReturnTheWorstStatus()
     {

--- a/plugins/Diagnostics/tests/Unit/DiagnosticReportTest.php
+++ b/plugins/Diagnostics/tests/Unit/DiagnosticReportTest.php
@@ -11,7 +11,7 @@ namespace Piwik\Plugins\Diagnostics\tests\Unit;
 use Piwik\Plugins\Diagnostics\Diagnostic\DiagnosticResult;
 use Piwik\Plugins\Diagnostics\DiagnosticReport;
 
-class DiagnosticReportTest extends \PHPUnit_Framework_TestCase
+class DiagnosticReportTest extends \PHPUnit\Framework\TestCase
 {
     public function test_shouldComputeErrorAndWarningCount()
     {

--- a/plugins/Diagnostics/tests/Unit/DiagnosticServiceTest.php
+++ b/plugins/Diagnostics/tests/Unit/DiagnosticServiceTest.php
@@ -14,7 +14,7 @@ use Piwik\Plugins\Diagnostics\tests\Mock\DiagnosticWithError;
 use Piwik\Plugins\Diagnostics\tests\Mock\DiagnosticWithSuccess;
 use Piwik\Plugins\Diagnostics\tests\Mock\DiagnosticWithWarning;
 
-class DiagnosticServiceTest extends \PHPUnit_Framework_TestCase
+class DiagnosticServiceTest extends \PHPUnit\Framework\TestCase
 {
     public function test_runDiagnostics()
     {

--- a/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
+++ b/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
@@ -13,7 +13,7 @@ namespace Piwik\Plugins\ExamplePlugin\tests\Unit;
  * @group SimpleTest
  * @group Plugins
  */
-class SimpleTest extends \PHPUnit_Framework_TestCase
+class SimpleTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/plugins/GeoIp2/tests/Integration/LocationProviderTest.php
+++ b/plugins/GeoIp2/tests/Integration/LocationProviderTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\GeoIp2\LocationProvider\GeoIp2;
 /**
  * @group GeoIp2
  */
-class LocationProviderTest extends \PHPUnit_Framework_TestCase
+class LocationProviderTest extends \PHPUnit\Framework\TestCase
 {
     public function testGeoIP2City()
     {

--- a/plugins/GeoIp2/tests/Integration/UpdateTest.php
+++ b/plugins/GeoIp2/tests/Integration/UpdateTest.php
@@ -11,7 +11,7 @@ namespace Piwik\Plugins\GeoIp2\tests\Integration;
 /**
  * @group GeoIp2
  */
-class UpdateTest extends \PHPUnit_Framework_TestCase
+class UpdateTest extends \PHPUnit\Framework\TestCase
 {
     public function testEnsureFileForUpdateIsPresent()
     {

--- a/plugins/Goals/tests/Unit/AppendNameToColumnNamesTest.php
+++ b/plugins/Goals/tests/Unit/AppendNameToColumnNamesTest.php
@@ -17,7 +17,7 @@ use Piwik\DataTable\Row;
  * @group Filter
  * @group Goals
  */
-class AppendNameToColumnNamesTest extends \PHPUnit_Framework_TestCase
+class AppendNameToColumnNamesTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'Piwik\Plugins\Goals\DataTable\Filter\AppendNameToColumnNames';
 

--- a/plugins/Insights/tests/Unit/BaseUnitTest.php
+++ b/plugins/Insights/tests/Unit/BaseUnitTest.php
@@ -19,7 +19,7 @@ use Piwik\DataTable\Row;
  * @group Unit
  * @group Core
  */
-abstract class BaseUnitTest extends \PHPUnit_Framework_TestCase
+abstract class BaseUnitTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var DataTable

--- a/plugins/Insights/tests/Unit/InsightReportTest.php
+++ b/plugins/Insights/tests/Unit/InsightReportTest.php
@@ -19,7 +19,7 @@ use Piwik\Plugins\Insights\Visualizations\Insight;
  * @group Unit
  * @group Core
  */
-class InsightReportTest extends \PHPUnit_Framework_TestCase
+class InsightReportTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var InsightReport

--- a/plugins/LanguagesManager/tests/Integration/LanguagesManagerTest.php
+++ b/plugins/LanguagesManager/tests/Integration/LanguagesManagerTest.php
@@ -25,7 +25,7 @@ use Piwik\Translate;
 /**
  * @group LanguagesManager
  */
-class LanguagesManagerTest extends \PHPUnit_Framework_TestCase
+class LanguagesManagerTest extends \PHPUnit\Framework\TestCase
 {
     function getTestDataForLanguageFiles()
     {

--- a/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/ByBaseTranslationsTest.php
+++ b/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/ByBaseTranslationsTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\ByBaseTranslations;
 /**
  * @group LanguagesManager
  */
-class ByBaseTranslationsTest extends \PHPUnit_Framework_TestCase
+class ByBaseTranslationsTest extends \PHPUnit\Framework\TestCase
 {
     public function getFilterTestData()
     {

--- a/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/ByParameterCountTest.php
+++ b/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/ByParameterCountTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\ByParameterCount;
 /**
  * @group LanguagesManager
  */
-class ByParameterCountTest extends \PHPUnit_Framework_TestCase
+class ByParameterCountTest extends \PHPUnit\Framework\TestCase
 {
     public function getFilterTestData()
     {

--- a/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/EmptyTranslationsTest.php
+++ b/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/EmptyTranslationsTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\EmptyTranslations;
 /**
  * @group LanguagesManager
  */
-class EmptyTranslationsTest extends \PHPUnit_Framework_TestCase
+class EmptyTranslationsTest extends \PHPUnit\Framework\TestCase
 {
     public function getFilterTestData()
     {

--- a/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/EncodedEntitiesTest.php
+++ b/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/EncodedEntitiesTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\EncodedEntities;
 /**
  * @group LanguagesManager
  */
-class EncodedEntitiesTest extends \PHPUnit_Framework_TestCase
+class EncodedEntitiesTest extends \PHPUnit\Framework\TestCase
 {
     public function getFilterTestData()
     {

--- a/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/UnnecassaryWhitespacesTest.php
+++ b/plugins/LanguagesManager/tests/Unit/TranslationWriter/Filter/UnnecassaryWhitespacesTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\LanguagesManager\TranslationWriter\Filter\UnnecassaryWhitespac
 /**
  * @group LanguagesManager
  */
-class UnnecassaryWhitepsacesTest extends \PHPUnit_Framework_TestCase
+class UnnecassaryWhitepsacesTest extends \PHPUnit\Framework\TestCase
 {
     public function getFilterTestData()
     {

--- a/plugins/LanguagesManager/tests/Unit/TranslationWriter/Validate/CoreTranslationsTest.php
+++ b/plugins/LanguagesManager/tests/Unit/TranslationWriter/Validate/CoreTranslationsTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\CoreTranslations;
 /**
  * @group LanguagesManager
  */
-class CoreTranslationsTest extends \PHPUnit_Framework_TestCase
+class CoreTranslationsTest extends \PHPUnit\Framework\TestCase
 {
     public function getFilterTestDataValid()
     {

--- a/plugins/LanguagesManager/tests/Unit/TranslationWriter/Validate/NoScriptsTest.php
+++ b/plugins/LanguagesManager/tests/Unit/TranslationWriter/Validate/NoScriptsTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\LanguagesManager\TranslationWriter\Validate\NoScripts;
 /**
  * @group LanguagesManager
  */
-class NoScriptsTest extends \PHPUnit_Framework_TestCase
+class NoScriptsTest extends \PHPUnit\Framework\TestCase
 {
     public function getFilterTestDataValid()
     {

--- a/plugins/LanguagesManager/tests/Unit/TranslationWriter/WriterTest.php
+++ b/plugins/LanguagesManager/tests/Unit/TranslationWriter/WriterTest.php
@@ -19,7 +19,7 @@ use Piwik\Plugins\LanguagesManager\TranslationWriter\Writer;
 /**
  * @group LanguagesManager
  */
-class WriterTest extends \PHPUnit_Framework_TestCase
+class WriterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @group Core

--- a/plugins/Marketplace/tests/Unit/ConsumerTest.php
+++ b/plugins/Marketplace/tests/Unit/ConsumerTest.php
@@ -17,7 +17,7 @@ use Piwik\Plugins\Marketplace\tests\Framework\Mock\Consumer as ConsumerBuilder;
  * @group Consumer
  * @group Plugins
  */
-class ConsumerTest extends \PHPUnit_Framework_TestCase
+class ConsumerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Service

--- a/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
+++ b/plugins/Monolog/tests/Unit/Formatter/LineMessageFormatterTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugins\Monolog\Formatter\LineMessageFormatter;
  * @group Log
  * @covers \Piwik\Plugins\Monolog\Formatter\LineMessageFormatter
  */
-class LineMessageFormatterTest extends \PHPUnit_Framework_TestCase
+class LineMessageFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/plugins/Monolog/tests/Unit/Processor/ClassNameProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/ClassNameProcessorTest.php
@@ -14,7 +14,7 @@ use Piwik\Plugins\Monolog\Processor\ClassNameProcessor;
  * @group Log
  * @covers \Piwik\Plugins\Monolog\Processor\ClassNameProcessor
  */
-class ClassNameProcessorTest extends \PHPUnit_Framework_TestCase
+class ClassNameProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugins\Monolog\Processor\ExceptionToTextProcessor;
  * @group Log
  * @covers \Piwik\Plugins\Monolog\Processor\ExceptionToTextProcessor
  */
-class ExceptionToTextProcessorTest extends \PHPUnit_Framework_TestCase
+class ExceptionToTextProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/plugins/Monolog/tests/Unit/Processor/RequestIdProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/RequestIdProcessorTest.php
@@ -8,7 +8,7 @@
 
 namespace Piwik\Plugins\Monolog\tests\Unit\Processor;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\Common;
 use Piwik\Plugins\Monolog\Processor\RequestIdProcessor;
 
@@ -16,7 +16,7 @@ use Piwik\Plugins\Monolog\Processor\RequestIdProcessor;
  * @group Log
  * @covers \Piwik\Plugins\Monolog\Processor\RequestIdProcessor
  */
-class RequestIdProcessorTest extends \PHPUnit_Framework_TestCase
+class RequestIdProcessorTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/plugins/Monolog/tests/Unit/Processor/SprintfProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/SprintfProcessorTest.php
@@ -14,7 +14,7 @@ use Piwik\Plugins\Monolog\Processor\SprintfProcessor;
  * @group Log
  * @covers \Piwik\Plugins\Monolog\Processor\SprintfProcessor
  */
-class SprintfProcessorTest extends \PHPUnit_Framework_TestCase
+class SprintfProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/plugins/Monolog/tests/Unit/Processor/TokenProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/TokenProcessorTest.php
@@ -14,7 +14,7 @@ use Piwik\Plugins\Monolog\Processor\TokenProcessor;
  * @group Log
  * @covers \Piwik\Plugins\Monolog\Processor\TokenProcessor
  */
-class TokenProcessorTest extends \PHPUnit_Framework_TestCase
+class TokenProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/plugins/PrivacyManager/tests/Unit/AnonymizeIPTest.php
+++ b/plugins/PrivacyManager/tests/Unit/AnonymizeIPTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\PrivacyManager\IPAnonymizer;
 
 require_once PIWIK_INCLUDE_PATH . '/plugins/PrivacyManager/IPAnonymizer.php';
 
-class AnonymizeIPTest extends \PHPUnit_Framework_TestCase
+class AnonymizeIPTest extends \PHPUnit\Framework\TestCase
 {
     // IPv4 addresses and expected results
     public function getipv4Addresses()

--- a/plugins/PrivacyManager/tests/Unit/DoNotTrackHeaderCheckerTest.php
+++ b/plugins/PrivacyManager/tests/Unit/DoNotTrackHeaderCheckerTest.php
@@ -16,7 +16,7 @@ use Piwik\Plugins\PrivacyManager\DoNotTrackHeaderChecker;
  * Class DoNotTrackHeaderCheckerTest
  * @group DoNotTrackHeaderCheckerTest
  */
-class DoNotTrackHeaderCheckerTest extends \PHPUnit_Framework_TestCase
+class DoNotTrackHeaderCheckerTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/plugins/Proxy/tests/Unit/ProxyTest.php
+++ b/plugins/Proxy/tests/Unit/ProxyTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugins\Proxy\Controller;
  * @group ProxyTest
  * @group Plugins
  */
-class ProxyTest extends \PHPUnit_Framework_TestCase
+class ProxyTest extends \PHPUnit\Framework\TestCase
 {
     public function getAcceptableRemoteUrls()
     {

--- a/plugins/Referrers/tests/Unit/DataTable/Filter/UrlsFromWebsiteIdTest.php
+++ b/plugins/Referrers/tests/Unit/DataTable/Filter/UrlsFromWebsiteIdTest.php
@@ -13,7 +13,7 @@ use Piwik\Plugins\Referrers\DataTable\Filter\UrlsFromWebsiteId;
 
 require_once PIWIK_INCLUDE_PATH . '/plugins/Referrers/functions.php';
 
-class UrlsFromWebsiteIdTest extends \PHPUnit_Framework_TestCase
+class UrlsFromWebsiteIdTest extends \PHPUnit\Framework\TestCase
 {
     public function test_filter_ignoresDomainsPortssAndPortsInRecord()
     {

--- a/plugins/Referrers/tests/Unit/GroupDifferentSocialWritingsTest.php
+++ b/plugins/Referrers/tests/Unit/GroupDifferentSocialWritingsTest.php
@@ -18,7 +18,7 @@ use Piwik\Plugins\Referrers\DataTable\Filter\GroupDifferentSocialWritings;
  * @group Core
  * @group sort
  */
-class GroupDifferentSocialWritingsTest extends \PHPUnit_Framework_TestCase
+class GroupDifferentSocialWritingsTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testRowsAreGrouped()

--- a/plugins/Referrers/tests/Unit/ReferrersTest.php
+++ b/plugins/Referrers/tests/Unit/ReferrersTest.php
@@ -17,7 +17,7 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/Referrers/Referrers.php';
 /**
  * @group Plugin
  */
-class ReferrersTest extends \PHPUnit_Framework_TestCase
+class ReferrersTest extends \PHPUnit\Framework\TestCase
 {
     public function removeUrlProtocolTestData()
     {

--- a/plugins/Referrers/tests/Unit/SearchEngineTest.php
+++ b/plugins/Referrers/tests/Unit/SearchEngineTest.php
@@ -14,7 +14,7 @@ use Spyc;
 /**
  * @group SearchEngine
  */
-class SearchEngineTest extends \PHPUnit_Framework_TestCase
+class SearchEngineTest extends \PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/plugins/Referrers/tests/Unit/SocialTest.php
+++ b/plugins/Referrers/tests/Unit/SocialTest.php
@@ -15,7 +15,7 @@ use Spyc;
  * @group Social
  * @group Plugins
  */
-class SocialTest extends \PHPUnit_Framework_TestCase
+class SocialTest extends \PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
+++ b/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
@@ -17,7 +17,7 @@ use Piwik\Tests\Framework\Mock\Plugin\LogTablesProvider;
  * @group SegmentEditor
  * @group SegmentEditor_Unit
  */
-class SegmentQueryDecoratorTest extends \PHPUnit_Framework_TestCase
+class SegmentQueryDecoratorTest extends \PHPUnit\Framework\TestCase
 {
     public static $storedSegments = array(
         array('definition' => 'countryCode==abc', 'idsegment' => 1),

--- a/plugins/SitesManager/tests/Unit/APITest.php
+++ b/plugins/SitesManager/tests/Unit/APITest.php
@@ -18,7 +18,7 @@ use Piwik\Translate;
  * @group APITest
  * @group Plugins
  */
-class APITest extends \PHPUnit_Framework_TestCase
+class APITest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Api

--- a/plugins/UserCountry/tests/Unit/UserCountryTest.php
+++ b/plugins/UserCountry/tests/Unit/UserCountryTest.php
@@ -19,7 +19,7 @@ use Exception;
 require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/UserCountry.php';
 require_once PIWIK_INCLUDE_PATH . '/plugins/UserCountry/functions.php';
 
-class UserCountryTest extends \PHPUnit_Framework_TestCase
+class UserCountryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @group Plugins

--- a/plugins/VisitTime/tests/Unit/AddSegmentByLabelInUTCTest.php
+++ b/plugins/VisitTime/tests/Unit/AddSegmentByLabelInUTCTest.php
@@ -16,7 +16,7 @@ use Piwik\DataTable;
  * @group AddSegmentByLabelInUTCTest
  * @group Plugins
  */
-class AddSegmentByLabelInUTCTest extends \PHPUnit_Framework_TestCase
+class AddSegmentByLabelInUTCTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'Piwik\Plugins\VisitTime\DataTable\Filter\AddSegmentByLabelInUTC';
 

--- a/plugins/VisitsSummary/tests/Unit/Reports/GetTest.php
+++ b/plugins/VisitsSummary/tests/Unit/Reports/GetTest.php
@@ -17,7 +17,7 @@ use Piwik\Plugins\VisitsSummary\Reports\Get;
  * @group GetTest
  * @group Plugins
  */
-class GetTest extends \PHPUnit_Framework_TestCase
+class GetTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Get

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -29,7 +29,7 @@ use Piwik\Tests\Framework\TestRequest\ApiTestConfig;
 use Piwik\Tests\Framework\TestRequest\Collection;
 use Piwik\Tests\Framework\TestRequest\Response;
 use Piwik\Log;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Translation\Translator;
 use Piwik\Url;
@@ -41,7 +41,7 @@ use Piwik\Url;
  *
  * @since 2.8.0
  */
-abstract class SystemTestCase extends PHPUnit_Framework_TestCase
+abstract class SystemTestCase extends TestCase
 {
     /**
      * Identifies the last language used in an API/Controller call.

--- a/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
@@ -19,7 +19,7 @@ use Piwik\Tests\Framework\Mock\File;
  *
  * @since 2.10.0
  */
-abstract class UnitTestCase extends \PHPUnit_Framework_TestCase
+abstract class UnitTestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Environment

--- a/tests/PHPUnit/Integration/Application/Kernel/PluginListTest.php
+++ b/tests/PHPUnit/Integration/Application/Kernel/PluginListTest.php
@@ -14,7 +14,7 @@ use Piwik\Container\StaticContainer;
  * @group PluginListTest
  * @group Core
  */
-class PluginListTest extends \PHPUnit_Framework_TestCase
+class PluginListTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/PHPUnit/Integration/AssetManager/UIAssetMinifierTest.php
+++ b/tests/PHPUnit/Integration/AssetManager/UIAssetMinifierTest.php
@@ -11,7 +11,7 @@ namespace Piwik\Tests\Integration\AssetManager;
 use Piwik\AssetManager\UIAsset\OnDiskUIAsset;
 use Piwik\AssetManager\UIAssetMinifier;
 
-class UIAssetMinifierTest extends \PHPUnit_Framework_TestCase
+class UIAssetMinifierTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var UIAssetMinifier

--- a/tests/PHPUnit/Integration/CliMulti/OutputTest.php
+++ b/tests/PHPUnit/Integration/CliMulti/OutputTest.php
@@ -15,7 +15,7 @@ use Piwik\Url;
 /**
  * @group CliMulti
  */
-class OutputTest extends \PHPUnit_Framework_TestCase
+class OutputTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Output

--- a/tests/PHPUnit/Integration/CliMulti/ProcessTest.php
+++ b/tests/PHPUnit/Integration/CliMulti/ProcessTest.php
@@ -15,7 +15,7 @@ use ReflectionProperty;
 /**
  * @group CliMulti
  */
-class ProcessTest extends \PHPUnit_Framework_TestCase
+class ProcessTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Process

--- a/tests/PHPUnit/Integration/Config/CacheTest.php
+++ b/tests/PHPUnit/Integration/Config/CacheTest.php
@@ -7,7 +7,6 @@
  */
 namespace Piwik\Tests\Integration\Config\Cache;
 
-use PHPUnit_Framework_TestCase;
 use Piwik\Config;
 use Piwik\Config\Cache;
 use Piwik\Config\IniFileChain;

--- a/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
+++ b/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
@@ -8,7 +8,7 @@
 
 namespace Piwik\Tests\Integration;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\API\DocumentationGenerator;
 use Piwik\API\Proxy;
 use Piwik\EventDispatcher;
@@ -16,7 +16,7 @@ use Piwik\EventDispatcher;
 /**
  * @group Core
  */
-class DocumentationGeneratorTest extends PHPUnit_Framework_TestCase
+class DocumentationGeneratorTest extends TestCase
 {
     public function test_CheckIfModule_ContainsHideAnnotation()
     {

--- a/tests/PHPUnit/Integration/EmailValidatorTest.php
+++ b/tests/PHPUnit/Integration/EmailValidatorTest.php
@@ -14,7 +14,7 @@ use Piwik\Piwik;
 /**
  * @group Core
  */
-class EmailValidatorTest extends \PHPUnit_Framework_TestCase
+class EmailValidatorTest extends \PHPUnit\Framework\TestCase
 {
     protected function isValid($email)
     {

--- a/tests/PHPUnit/Integration/FilesystemTest.php
+++ b/tests/PHPUnit/Integration/FilesystemTest.php
@@ -14,7 +14,7 @@ use Piwik\Filesystem;
 /**
  * @group Core
  */
-class FilesystemTest extends \PHPUnit_Framework_TestCase
+class FilesystemTest extends \PHPUnit\Framework\TestCase
 {
     public function test_getFileSize_ShouldRecognizeLowerUnits()
     {

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -17,7 +17,7 @@ use Piwik\Version;
  * @group Core
  * @group HttpTest
  */
-class HttpTest extends \PHPUnit_Framework_TestCase
+class HttpTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Dataprovider for testFetchRemoteFile

--- a/tests/PHPUnit/Integration/MailTest.php
+++ b/tests/PHPUnit/Integration/MailTest.php
@@ -10,7 +10,7 @@ namespace Piwik\Tests\Integration;
 
 use Piwik\Mail;
 
-class MailTest extends \PHPUnit_Framework_TestCase
+class MailTest extends \PHPUnit\Framework\TestCase
 {
 
     public function getEmailFilenames()

--- a/tests/PHPUnit/Integration/NumberFormatterTest.php
+++ b/tests/PHPUnit/Integration/NumberFormatterTest.php
@@ -16,7 +16,7 @@ use Piwik\Translation\Translator;
  * @group Core
  * @group NumberFormatter
  */
-class NumberFormatterTest extends \PHPUnit_Framework_TestCase
+class NumberFormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Translator

--- a/tests/PHPUnit/Integration/ProfessionalSupport/AdvertisingTest.php
+++ b/tests/PHPUnit/Integration/ProfessionalSupport/AdvertisingTest.php
@@ -18,7 +18,7 @@ use Piwik\Tests\Framework\Mock\Plugin\Manager;
  * @group Advertising
  * @group Integration
  */
-class AdvertisingTest extends \PHPUnit_Framework_TestCase
+class AdvertisingTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Advertising

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -24,7 +24,7 @@ use RecursiveIteratorIterator;
  * @group Core
  * @group ReleaseCheckListTest
  */
-class ReleaseCheckListTest extends \PHPUnit_Framework_TestCase
+class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
 {
     private $globalConfig;
 

--- a/tests/PHPUnit/Integration/Report/ReportsTest.php
+++ b/tests/PHPUnit/Integration/Report/ReportsTest.php
@@ -14,7 +14,7 @@ use Piwik\Plugin\Manager as PluginManager;
 /**
  * @group Core
  */
-class ReportTest extends \PHPUnit_Framework_TestCase
+class ReportTest extends \PHPUnit\Framework\TestCase
 {
     public function test_getAllReports_shouldNotFindAReport_IfNoPluginLoaded()
     {

--- a/tests/PHPUnit/Integration/ServeStaticFileTest.php
+++ b/tests/PHPUnit/Integration/ServeStaticFileTest.php
@@ -47,7 +47,7 @@ define("PARTIAL_BYTE_START", 1204);
 define("PARTIAL_BYTE_END", 14724);
 
 // If the static file server has not been requested, the standard unit test case class is defined
-class ServeStaticFileTest extends \PHPUnit_Framework_TestCase
+class ServeStaticFileTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/PHPUnit/Integration/SessionTest.php
+++ b/tests/PHPUnit/Integration/SessionTest.php
@@ -18,7 +18,7 @@ use Piwik\Tests\Framework\Fixture;
  * @group Session
  * @group SessionTest
  */
-class SessionTest extends \PHPUnit_Framework_TestCase
+class SessionTest extends \PHPUnit\Framework\TestCase
 {
 	public function test_session_should_not_be_started_if_it_was_already_started()
 	{

--- a/tests/PHPUnit/Integration/Settings/SettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/SettingTest.php
@@ -23,7 +23,7 @@ use Piwik\Validators\NumberRange;
  * @group Settings
  * @group Setting
  */
-class SettingTest extends \PHPUnit_Framework_TestCase
+class SettingTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/PHPUnit/Integration/Settings/Storage/Backend/NullTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/Backend/NullTest.php
@@ -15,7 +15,7 @@ use Piwik\Settings\Storage\Backend\NullBackend;
  * @group Backend
  * @group Storage
  */
-class NullTest extends \PHPUnit_Framework_TestCase
+class NullTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/PHPUnit/Unit/API/ApiRendererTest.php
+++ b/tests/PHPUnit/Unit/API/ApiRendererTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugin\Manager;
  * @group Core
  * @group Only2
  */
-class ApiRendererTest extends \PHPUnit_Framework_TestCase
+class ApiRendererTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/API/DataTableGenericFilterTest.php
+++ b/tests/PHPUnit/Unit/API/DataTableGenericFilterTest.php
@@ -12,7 +12,7 @@ namespace Piwik\Tests\Unit\API;
 use Piwik\API\DataTableGenericFilter;
 use Piwik\DataTable;
 
-class DataTableGenericFilterTest extends \PHPUnit_Framework_TestCase
+class DataTableGenericFilterTest extends \PHPUnit\Framework\TestCase
 {
     public function test_genericFiltersToDisableMetadata_shouldBeRespected()
     {

--- a/tests/PHPUnit/Unit/API/ResponseBuilderTest.php
+++ b/tests/PHPUnit/Unit/API/ResponseBuilderTest.php
@@ -17,7 +17,7 @@ use Piwik\Plugin\Manager;
 /**
  * @group Core
  */
-class ResponseBuilderTest extends \PHPUnit_Framework_TestCase
+class ResponseBuilderTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/Archive/ChunkTest.php
+++ b/tests/PHPUnit/Unit/Archive/ChunkTest.php
@@ -14,7 +14,7 @@ use Piwik\Archive\Chunk;
  * @group ChunkTest
  * @group Archive
  */
-class ChunkTest extends \PHPUnit_Framework_TestCase
+class ChunkTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Chunk

--- a/tests/PHPUnit/Unit/Archive/DataCollectionTest.php
+++ b/tests/PHPUnit/Unit/Archive/DataCollectionTest.php
@@ -17,7 +17,7 @@ use Piwik\Segment;
  * @group DataCollectionTest
  * @group Archive
  */
-class DataCollectionTest extends \PHPUnit_Framework_TestCase
+class DataCollectionTest extends \PHPUnit\Framework\TestCase
 {
     private $site1 = 1;
     private $site2 = 2;

--- a/tests/PHPUnit/Unit/Archiver/RequestTest.php
+++ b/tests/PHPUnit/Unit/Archiver/RequestTest.php
@@ -13,7 +13,7 @@ namespace Piwik\Tests\Unit\Archiver;
 use Piwik\Archiver\Request;
 use Piwik\Date;
 
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends \PHPUnit\Framework\TestCase
 {
     protected function tearDown()
     {

--- a/tests/PHPUnit/Unit/AssetManager/UIAssetCacheBusterTest.php
+++ b/tests/PHPUnit/Unit/AssetManager/UIAssetCacheBusterTest.php
@@ -8,10 +8,10 @@
 
 namespace Piwik\Tests\Unit\AssetManager;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\AssetManager\UIAssetCacheBuster;
 
-class UIAssetCacheBusterTest extends PHPUnit_Framework_TestCase
+class UIAssetCacheBusterTest extends TestCase
 {
     /**
      * @var UIAssetCacheBuster

--- a/tests/PHPUnit/Unit/AssetManager/UIAssetCatalogSorterTest.php
+++ b/tests/PHPUnit/Unit/AssetManager/UIAssetCatalogSorterTest.php
@@ -8,12 +8,12 @@
 
 namespace Piwik\Tests\Unit\AssetManager;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\AssetManager\UIAsset\OnDiskUIAsset;
 use Piwik\AssetManager\UIAssetCatalog;
 use Piwik\AssetManager\UIAssetCatalogSorter;
 
-class UIAssetCatalogSorterTest extends PHPUnit_Framework_TestCase
+class UIAssetCatalogSorterTest extends TestCase
 {
     /**
      * @group Core

--- a/tests/PHPUnit/Unit/AssetManagerTest.php
+++ b/tests/PHPUnit/Unit/AssetManagerTest.php
@@ -14,7 +14,7 @@ use Piwik\Config;
 /**
  * @group AssetManager
  */
-class AssetManagerTest extends \PHPUnit_Framework_TestCase
+class AssetManagerTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testIsMergedAssetsDisabled()

--- a/tests/PHPUnit/Unit/CacheTest.php
+++ b/tests/PHPUnit/Unit/CacheTest.php
@@ -13,7 +13,7 @@ use Piwik\Cache;
 /**
  * @group Cache
  */
-class CacheTest extends \PHPUnit_Framework_TestCase
+class CacheTest extends \PHPUnit\Framework\TestCase
 {
     public function test_getLazyCache_shouldCreateAnInstanceOfLazy()
     {

--- a/tests/PHPUnit/Unit/Category/CategoryListTest.php
+++ b/tests/PHPUnit/Unit/Category/CategoryListTest.php
@@ -16,7 +16,7 @@ use Piwik\Category\Category;
  * @group CategoryList
  * @group CategoryListTest
  */
-class CategoryListTest extends \PHPUnit_Framework_TestCase
+class CategoryListTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var CategoryList

--- a/tests/PHPUnit/Unit/Category/CategoryTest.php
+++ b/tests/PHPUnit/Unit/Category/CategoryTest.php
@@ -16,7 +16,7 @@ use Piwik\Category\Subcategory;
  * @group Category
  * @group CategoryTest
  */
-class CategoryTest extends \PHPUnit_Framework_TestCase
+class CategoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Category

--- a/tests/PHPUnit/Unit/Category/SubcategoryTest.php
+++ b/tests/PHPUnit/Unit/Category/SubcategoryTest.php
@@ -16,7 +16,7 @@ use Piwik\Category\Subcategory;
  * @group Subcategory
  * @group SubcategoryTest
  */
-class SubcategoryTest extends \PHPUnit_Framework_TestCase
+class SubcategoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Subcategory

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -9,7 +9,7 @@
 namespace Piwik\Tests\Unit;
 
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\Application\Environment;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
@@ -22,7 +22,7 @@ use Piwik\Tests\Framework\Mock\FakeLogger;
  * @backupGlobals enabled
  * @group Common
  */
-class CommonTest extends PHPUnit_Framework_TestCase
+class CommonTest extends TestCase
 {
     public function test_getProcessId()
     {

--- a/tests/PHPUnit/Unit/Config/IniFileChainTest.php
+++ b/tests/PHPUnit/Unit/Config/IniFileChainTest.php
@@ -7,13 +7,13 @@
  */
 namespace Piwik\Tests\Unit\Config;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\Config\IniFileChain;
 
 /**
  * @group Core
  */
-class IniFileChainTest extends PHPUnit_Framework_TestCase
+class IniFileChainTest extends TestCase
 {
     /**
      * Data provider for testCompareElements

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -8,7 +8,6 @@
 
 namespace Piwik\Tests\Unit;
 
-use PHPUnit_Framework_TestCase;
 use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Config;
 use Piwik\Tests\Framework\Mock\TestConfig;
@@ -52,7 +51,7 @@ class DumpConfigTestMockConfig extends Config
 /**
  * @group Core
  */
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     public function testUserConfigOverwritesSectionGlobalConfigValue()
     {

--- a/tests/PHPUnit/Unit/ConsoleTest.php
+++ b/tests/PHPUnit/Unit/ConsoleTest.php
@@ -13,7 +13,7 @@ use Piwik\Version;
 /**
  * @group Console
  */
-class ConsoleTest extends \PHPUnit_Framework_TestCase
+class ConsoleTest extends \PHPUnit\Framework\TestCase
 {
     public function testIsApplicationNameAndVersionCorrect()
     {

--- a/tests/PHPUnit/Unit/Container/IniConfigDefinitionSourceTest.php
+++ b/tests/PHPUnit/Unit/Container/IniConfigDefinitionSourceTest.php
@@ -12,7 +12,7 @@ use DI\Definition\ValueDefinition;
 use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Container\IniConfigDefinitionSource;
 
-class IniConfigDefinitionSourceTest extends \PHPUnit_Framework_TestCase
+class IniConfigDefinitionSourceTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test

--- a/tests/PHPUnit/Unit/ContextTest.php
+++ b/tests/PHPUnit/Unit/ContextTest.php
@@ -12,7 +12,7 @@ namespace Piwik\Tests\Unit;
 use Piwik\Context;
 use Piwik\Tracker;
 
-class ContextTest extends \PHPUnit_Framework_TestCase
+class ContextTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/PHPUnit/Unit/CookieTest.php
+++ b/tests/PHPUnit/Unit/CookieTest.php
@@ -10,7 +10,7 @@ namespace Piwik\Tests\Unit;
 
 use Piwik\Cookie;
 
-class CookieTest extends \PHPUnit_Framework_TestCase
+class CookieTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Dataprovider for testJsonSerialize

--- a/tests/PHPUnit/Unit/CronArchive/FixedSiteIdsTest.php
+++ b/tests/PHPUnit/Unit/CronArchive/FixedSiteIdsTest.php
@@ -13,7 +13,7 @@ use Piwik\CronArchive\FixedSiteIds;
 /**
  * @group Core
  */
-class FixedSiteIdsTest extends \PHPUnit_Framework_TestCase
+class FixedSiteIdsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var FixedSiteIds

--- a/tests/PHPUnit/Unit/CronArchive/SegmentArchivingRequestUrlProviderTest.php
+++ b/tests/PHPUnit/Unit/CronArchive/SegmentArchivingRequestUrlProviderTest.php
@@ -14,7 +14,7 @@ use Piwik\CronArchive\SegmentArchivingRequestUrlProvider;
 /**
  * @group Core
  */
-class SegmentArchivingRequestUrlProviderTest extends \PHPUnit_Framework_TestCase
+class SegmentArchivingRequestUrlProviderTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_NOW = '2015-03-01';
 

--- a/tests/PHPUnit/Unit/DataAccess/ArchiveTableCreatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/ArchiveTableCreatorTest.php
@@ -13,7 +13,7 @@ use Piwik\DataAccess\ArchiveTableCreator;
 /**
  * @group Core
  */
-class ArchiveTableCreatorTest extends \PHPUnit_Framework_TestCase
+class ArchiveTableCreatorTest extends \PHPUnit\Framework\TestCase
 {
     private $tables;
 

--- a/tests/PHPUnit/Unit/DataAccess/ArchiveWriterTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/ArchiveWriterTest.php
@@ -18,7 +18,7 @@ use Piwik\Segment;
  * @group Archive
  * @group Core
  */
-class ArchiveWriterTest extends \PHPUnit_Framework_TestCase
+class ArchiveWriterTest extends \PHPUnit\Framework\TestCase
 {
     private $recordName = 'Actions_Action_url';
 

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
@@ -16,7 +16,7 @@ use Piwik\Tracker\Visit;
 /**
  * @group Core
  */
-class JoinGeneratorTest extends \PHPUnit_Framework_TestCase
+class JoinGeneratorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var JoinGenerator

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
@@ -15,7 +15,7 @@ use Piwik\Tracker\Visit;
 /**
  * @group Core
  */
-class JoinTablesTest extends \PHPUnit_Framework_TestCase
+class JoinTablesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var JoinTables

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterByLabelMappingTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterByLabelMappingTest.php
@@ -16,7 +16,7 @@ use Piwik\DataTable\Row;
  * @group DataTable
  * @group Filter
  */
-class AddSegmentByLabelMappingTest extends \PHPUnit_Framework_TestCase
+class AddSegmentByLabelMappingTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'AddSegmentByLabelMapping';
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterBySegmentValueTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterBySegmentValueTest.php
@@ -22,7 +22,7 @@ use Piwik\Plugins\VisitsSummary\Reports\Get;
  * @group Filter
  * @group Core
  */
-class AddSegmentBySegmentValueTest extends \PHPUnit_Framework_TestCase
+class AddSegmentBySegmentValueTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'AddSegmentBySegmentValue';
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterTest.php
@@ -16,7 +16,7 @@ use Piwik\DataTable\Row;
  * @group DataTable
  * @group Filter
  */
-class AddSegmentByLabelTest extends \PHPUnit_Framework_TestCase
+class AddSegmentByLabelTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'AddSegmentByLabel';
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentValueTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentValueTest.php
@@ -16,7 +16,7 @@ use Piwik\DataTable\Row;
  * @group DataTable
  * @group Filter
  */
-class AddSegmentValueTest extends \PHPUnit_Framework_TestCase
+class AddSegmentValueTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'AddSegmentValue';
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSummaryRowTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSummaryRowTest.php
@@ -14,7 +14,7 @@ use Piwik\DataTable\Row;
 /**
  * @group DataTableTest
  */
-class DataTable_Filter_AddSummaryRowTest extends \PHPUnit_Framework_TestCase
+class DataTable_Filter_AddSummaryRowTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @group AddSummaryRow

--- a/tests/PHPUnit/Unit/DataTable/Filter/ColumnCallbackDeleteMetadataTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/ColumnCallbackDeleteMetadataTest.php
@@ -16,7 +16,7 @@ use Piwik\DataTable\Row;
  * @group DataTable
  * @group Filter
  */
-class ColumnCallbackDeleteMetadataTest extends \PHPUnit_Framework_TestCase
+class ColumnCallbackDeleteMetadataTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'ColumnCallbackDeleteMetadata';
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/ColumnDeleteTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/ColumnDeleteTest.php
@@ -11,7 +11,7 @@ namespace Piwik\Tests\Unit\DataTable\Filter;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 
-class ColumnDeleteTest extends \PHPUnit_Framework_TestCase
+class ColumnDeleteTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'ColumnDelete';
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/ExcludeLowPopulationTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/ExcludeLowPopulationTest.php
@@ -15,7 +15,7 @@ use Piwik\DataTable\Row;
 /**
  * @group DataTableTest
  */
-class DataTable_Filter_ExcludeLowPopulationTest extends \PHPUnit_Framework_TestCase
+class DataTable_Filter_ExcludeLowPopulationTest extends \PHPUnit\Framework\TestCase
 {
     protected function getTestDataTable()
     {

--- a/tests/PHPUnit/Unit/DataTable/Filter/LimitTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/LimitTest.php
@@ -15,7 +15,7 @@ use Piwik\DataTable\Row;
 /**
  * @group DataTableTest
  */
-class DataTable_Filter_LimitTest extends \PHPUnit_Framework_TestCase
+class DataTable_Filter_LimitTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Returns table used for the tests

--- a/tests/PHPUnit/Unit/DataTable/Filter/PatternRecursiveTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PatternRecursiveTest.php
@@ -14,7 +14,7 @@ use Piwik\DataTable\Row;
 /**
  * @group DataTableTest
  */
-class DataTable_Filter_PatternRecursiveTest extends \PHPUnit_Framework_TestCase
+class DataTable_Filter_PatternRecursiveTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Returns a data table for testing

--- a/tests/PHPUnit/Unit/DataTable/Filter/PatternTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PatternTest.php
@@ -15,7 +15,7 @@ use Piwik\DataTable\Row;
  * @group DataTableTest
  * @group Core
  */
-class PatternTest extends \PHPUnit_Framework_TestCase
+class PatternTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Dataprovider for testFilterPattern

--- a/tests/PHPUnit/Unit/DataTable/Filter/PrependSegmentFilterTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PrependSegmentFilterTest.php
@@ -16,7 +16,7 @@ use Piwik\DataTable\Row;
  * @group DataTable
  * @group Filter
  */
-class PrependSegmentTest extends \PHPUnit_Framework_TestCase
+class PrependSegmentTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'PrependSegment';
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/PrependValueToMetadataTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PrependValueToMetadataTest.php
@@ -16,7 +16,7 @@ use Piwik\DataTable\Row;
  * @group DataTable
  * @group Filter
  */
-class PrependValueToMetadataTest extends \PHPUnit_Framework_TestCase
+class PrependValueToMetadataTest extends \PHPUnit\Framework\TestCase
 {
     private $filter = 'PrependValueToMetadata';
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/RangeCheckTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/RangeCheckTest.php
@@ -16,7 +16,7 @@ use Piwik\Plugins\CoreHome\Columns\Metrics\VisitsPercent;
 /**
  * @group DataTableTest
  */
-class DataTable_Filter_RangeCheckTest extends \PHPUnit_Framework_TestCase
+class DataTable_Filter_RangeCheckTest extends \PHPUnit\Framework\TestCase
 {
     public function testRangeCheckNormalDataTable()
     {

--- a/tests/PHPUnit/Unit/DataTable/Filter/SortTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/SortTest.php
@@ -17,7 +17,7 @@ use Piwik\DataTable\Row;
  * @group Core
  * @group sort
  */
-class SortTest extends \PHPUnit_Framework_TestCase
+class SortTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testNormalSortDescending()

--- a/tests/PHPUnit/Unit/DataTable/Filter/TruncateTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/TruncateTest.php
@@ -15,7 +15,7 @@ use Piwik\DataTable\Row;
 /**
  * @group DataTableTest
  */
-class DataTable_Filter_TruncateTest extends \PHPUnit_Framework_TestCase
+class DataTable_Filter_TruncateTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testUnrelatedDataTableNotFiltered()

--- a/tests/PHPUnit/Unit/DataTable/ManagerTest.php
+++ b/tests/PHPUnit/Unit/DataTable/ManagerTest.php
@@ -12,7 +12,7 @@ use Piwik\DataTable\Row;
  * @group ManagerTest
  * @group Core
  */
-class ManagerTest extends \PHPUnit_Framework_TestCase
+class ManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Manager

--- a/tests/PHPUnit/Unit/DataTable/MapTest.php
+++ b/tests/PHPUnit/Unit/DataTable/MapTest.php
@@ -11,7 +11,7 @@ use Piwik\Tests\Framework\Mock\TestConfig;
 /**
  * @group DataTableTest
  */
-class Test_DataTable_Map extends \PHPUnit_Framework_TestCase
+class Test_DataTable_Map extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
@@ -17,7 +17,7 @@ use Piwik\DataTable\Simple;
 /**
  * @group DataTableTest
  */
-class DataTable_Renderer_CSVTest extends \PHPUnit_Framework_TestCase
+class DataTable_Renderer_CSVTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/DataTable/Renderer/ConsoleTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/ConsoleTest.php
@@ -16,7 +16,7 @@ use Piwik\DataTable\Row;
 /**
  * @group DataTableTest
  */
-class DataTable_Renderer_ConsoleTest extends \PHPUnit_Framework_TestCase
+class DataTable_Renderer_ConsoleTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/DataTable/Renderer/JSONTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/JSONTest.php
@@ -17,7 +17,7 @@ use Piwik\DataTable\Simple;
 /**
  * @group DataTableTest
  */
-class DataTable_Renderer_JSONTest extends \PHPUnit_Framework_TestCase
+class DataTable_Renderer_JSONTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/DataTable/Renderer/PHPTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/PHPTest.php
@@ -17,7 +17,7 @@ use Piwik\DataTable\Simple;
 /**
  * @group DataTableTest
  */
-class DataTable_Renderer_PHPTest extends \PHPUnit_Framework_TestCase
+class DataTable_Renderer_PHPTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/DataTable/Renderer/XMLTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/XMLTest.php
@@ -17,7 +17,7 @@ use Piwik\DataTable\Simple;
 /**
  * @group DataTableTest
  */
-class DataTable_Renderer_XMLTest extends \PHPUnit_Framework_TestCase
+class DataTable_Renderer_XMLTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/DataTable/RowTest.php
+++ b/tests/PHPUnit/Unit/DataTable/RowTest.php
@@ -14,7 +14,7 @@ use Piwik\DataTable\Row;
 /**
  * @group DataTableTest
  */
-class RowTest extends \PHPUnit_Framework_TestCase
+class RowTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Row

--- a/tests/PHPUnit/Unit/DataTable/SimpleTest.php
+++ b/tests/PHPUnit/Unit/DataTable/SimpleTest.php
@@ -13,7 +13,7 @@ use Piwik\DataTable;
 use Piwik\DataTable\Row;
 use Piwik\DataTable\Simple;
 
-class SimpleTest extends \PHPUnit_Framework_TestCase
+class SimpleTest extends \PHPUnit\Framework\TestCase
 {
     public function test_serialize_includesAllRequiredData()
     {

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
  * @group DataTable
  * @group Core
  */
-class DataTableTest extends \PHPUnit_Framework_TestCase
+class DataTableTest extends \PHPUnit\Framework\TestCase
 {
     public function testApplyFilter()
     {

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -16,7 +16,7 @@ use Piwik\Translate;
 
 /**
  */
-class DateTest extends \PHPUnit_Framework_TestCase
+class DateTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/DbHelperTest.php
+++ b/tests/PHPUnit/Unit/DbHelperTest.php
@@ -16,7 +16,7 @@ use Piwik\DbHelper;
  * @group Core
  * @group Core_Unit
  */
-class DbHelperTest extends \PHPUnit_Framework_TestCase
+class DbHelperTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
+++ b/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
@@ -16,7 +16,7 @@ use ReflectionClass;
  * @group DeprecatedMethodsTest
  * @group Core
  */
-class DeprecatedMethodsTest extends \PHPUnit_Framework_TestCase
+class DeprecatedMethodsTest extends \PHPUnit\Framework\TestCase
 {
     public function test_deprecations()
     {

--- a/tests/PHPUnit/Unit/FactoryTest.php
+++ b/tests/PHPUnit/Unit/FactoryTest.php
@@ -13,7 +13,7 @@ use Piwik\BaseFactory;
 /**
  * @group Core
  */
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreatingExistingClassSucceeds()
     {

--- a/tests/PHPUnit/Unit/FilesystemTest.php
+++ b/tests/PHPUnit/Unit/FilesystemTest.php
@@ -15,7 +15,7 @@ use Piwik\Tests\Framework\TestCase\SystemTestCase;
 /**
  * @group Core
  */
-class FilesystemTest extends \PHPUnit_Framework_TestCase
+class FilesystemTest extends \PHPUnit\Framework\TestCase
 {
     private $testPath;
 

--- a/tests/PHPUnit/Unit/Http/RouterTest.php
+++ b/tests/PHPUnit/Unit/Http/RouterTest.php
@@ -13,7 +13,7 @@ use Piwik\Http\Router;
 /**
  * @group Core
  */
-class RouterTest extends \PHPUnit_Framework_TestCase
+class RouterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider urlProvider

--- a/tests/PHPUnit/Unit/IPTest.php
+++ b/tests/PHPUnit/Unit/IPTest.php
@@ -16,7 +16,7 @@ use Piwik\IP;
 /**
  * @group Core
  */
-class IPTest extends \PHPUnit_Framework_TestCase
+class IPTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Dataprovider for long2ip test

--- a/tests/PHPUnit/Unit/LegacyAutoLoaderTest.php
+++ b/tests/PHPUnit/Unit/LegacyAutoLoaderTest.php
@@ -12,7 +12,7 @@ namespace Piwik\Tests\Unit;
  * @group Core
  * @group LegacyAutoLoader
  */
-class LegacyAutoLoaderTest extends \PHPUnit_Framework_TestCase
+class LegacyAutoLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testPackageClassWorks()
     {

--- a/tests/PHPUnit/Unit/Mail/EmailStylesTest.php
+++ b/tests/PHPUnit/Unit/Mail/EmailStylesTest.php
@@ -12,7 +12,7 @@ namespace Piwik\Tests\Unit\Mail;
 
 use Piwik\Mail\EmailStyles;
 
-class EmailStylesTest extends \PHPUnit_Framework_TestCase
+class EmailStylesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getTestDataForRgbToHex

--- a/tests/PHPUnit/Unit/Metrics/Formatter/HtmlTest.php
+++ b/tests/PHPUnit/Unit/Metrics/Formatter/HtmlTest.php
@@ -16,7 +16,7 @@ use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
 /**
  * @group Core
  */
-class HtmlTest extends \PHPUnit_Framework_TestCase
+class HtmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Html

--- a/tests/PHPUnit/Unit/Metrics/FormatterTest.php
+++ b/tests/PHPUnit/Unit/Metrics/FormatterTest.php
@@ -16,7 +16,7 @@ use Piwik\Plugins\SitesManager\API as SitesManagerAPI;
 /**
  * @group Core
  */
-class FormatterTest extends \PHPUnit_Framework_TestCase
+class FormatterTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Formatter

--- a/tests/PHPUnit/Unit/NonceTest.php
+++ b/tests/PHPUnit/Unit/NonceTest.php
@@ -14,7 +14,7 @@ use Piwik\Nonce;
 /**
  * @backupGlobals enabled
  */
-class NonceTest extends \PHPUnit_Framework_TestCase
+class NonceTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Dataprovider for acceptable origins test

--- a/tests/PHPUnit/Unit/Period/BasePeriodTest.php
+++ b/tests/PHPUnit/Unit/Period/BasePeriodTest.php
@@ -10,7 +10,7 @@ namespace Piwik\Tests\Unit\Period;
 
 use Piwik\Translate;
 
-abstract class BasePeriodTest extends \PHPUnit_Framework_TestCase
+abstract class BasePeriodTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/PHPUnit/Unit/PeriodTest.php
+++ b/tests/PHPUnit/Unit/PeriodTest.php
@@ -19,7 +19,7 @@ use Piwik\Translation\Translator;
 /**
  * @group Core
  */
-class PeriodTest extends \PHPUnit_Framework_TestCase
+class PeriodTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetId()
     {

--- a/tests/PHPUnit/Unit/Plugin/ComponentFactoryTest.php
+++ b/tests/PHPUnit/Unit/Plugin/ComponentFactoryTest.php
@@ -7,7 +7,7 @@
  */
 namespace Piwik\Tests\Core\Plugin;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Piwik\Config;
 use Piwik\Plugin\ComponentFactory;
 use Piwik\Plugin\Manager as PluginManager;
@@ -17,7 +17,7 @@ use Piwik\Tests\Framework\Mock\TestConfig;
 /**
  * @group Core
  */
-class ComponentFactoryTest extends PHPUnit_Framework_TestCase
+class ComponentFactoryTest extends TestCase
 {
     const REPORT_CLASS_NAME = 'Piwik\\Plugin\\Report';
 

--- a/tests/PHPUnit/Unit/RankingQueryTest.php
+++ b/tests/PHPUnit/Unit/RankingQueryTest.php
@@ -10,7 +10,7 @@ namespace Piwik\Tests\Unit;
 
 use Piwik\RankingQuery;
 
-class RankingQueryTest extends \PHPUnit_Framework_TestCase
+class RankingQueryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @group Core

--- a/tests/PHPUnit/Unit/Report/ReportWidgetConfigTest.php
+++ b/tests/PHPUnit/Unit/Report/ReportWidgetConfigTest.php
@@ -16,7 +16,7 @@ use Piwik\Report\ReportWidgetConfig;
  * @group ReportWidgetConfig
  * @group ReportWidgetConfigTest
  */
-class ReportWidgetConfigTest extends \PHPUnit_Framework_TestCase
+class ReportWidgetConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ReportWidgetConfig

--- a/tests/PHPUnit/Unit/Report/ReportWidgetFactoryTest.php
+++ b/tests/PHPUnit/Unit/Report/ReportWidgetFactoryTest.php
@@ -42,7 +42,7 @@ class GetBasicReport extends Report
  * @group ReportWidgetFactory
  * @group ReportWidgetFactoryTest
  */
-class ReportWidgetFactoryTest extends \PHPUnit_Framework_TestCase
+class ReportWidgetFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var ReportWidgetFactory

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/DailyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/DailyTest.php
@@ -15,7 +15,7 @@ use Piwik\Scheduler\Schedule\Schedule;
 /**
  * @group Scheduler
  */
-class DailyTest extends \PHPUnit_Framework_TestCase
+class DailyTest extends \PHPUnit\Framework\TestCase
 {
     private static $_JANUARY_01_1971_09_00_00;
     private static $_JANUARY_01_1971_09_10_00;

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/HourlyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/HourlyTest.php
@@ -14,7 +14,7 @@ use Piwik\Scheduler\Schedule\Hourly;
 /**
  * @group Scheduler
  */
-class HourlyTest extends \PHPUnit_Framework_TestCase
+class HourlyTest extends \PHPUnit\Framework\TestCase
 {
     private static $_JANUARY_01_1971_09_00_00;
     private static $_JANUARY_01_1971_09_10_00;

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
@@ -13,7 +13,7 @@ use Piwik\Scheduler\Schedule\Monthly;
 /**
  * @group Scheduler
  */
-class MonthlyTest extends \PHPUnit_Framework_TestCase
+class MonthlyTest extends \PHPUnit\Framework\TestCase
 {
     public static $_JANUARY_01_1971_09_00_00; // initialized below class definition
     public static $_JANUARY_02_1971_09_00_00;

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
@@ -14,7 +14,7 @@ use Piwik\Scheduler\Schedule\Weekly;
 /**
  * @group Scheduler
  */
-class WeeklyTest extends \PHPUnit_Framework_TestCase
+class WeeklyTest extends \PHPUnit\Framework\TestCase
 {
     public static $_JANUARY_01_1971_09_10_00; // initialized below class declaration
     public static $_JANUARY_04_1971_00_00_00;

--- a/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
@@ -20,7 +20,7 @@ use ReflectionProperty;
 /**
  * @group Scheduler
  */
-class SchedulerTest extends \PHPUnit_Framework_TestCase
+class SchedulerTest extends \PHPUnit\Framework\TestCase
 {
     private static function getTestTimetable()
     {

--- a/tests/PHPUnit/Unit/Scheduler/TaskTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/TaskTest.php
@@ -14,7 +14,7 @@ use Piwik\Scheduler\Task;
 /**
  * @group Scheduler
  */
-class TaskTest extends \PHPUnit_Framework_TestCase
+class TaskTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetClassName()
     {

--- a/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
@@ -18,7 +18,7 @@ use ReflectionProperty;
 /**
  * @group Scheduler
  */
-class TimetableTest extends \PHPUnit_Framework_TestCase
+class TimetableTest extends \PHPUnit\Framework\TestCase
 {
     private $timetable = array(
         'CoreAdminHome.purgeOutdatedArchives' => 1355529607,

--- a/tests/PHPUnit/Unit/Segment/SegmentExpressionTest.php
+++ b/tests/PHPUnit/Unit/Segment/SegmentExpressionTest.php
@@ -14,7 +14,7 @@ use Piwik\Segment\SegmentExpression;
  * @group SegmentExpressionTest
  * @group Segment
  */
-class SegmentExpressionTest extends \PHPUnit_Framework_TestCase
+class SegmentExpressionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Dataprovider for testSegmentSqlSimpleNoOperation

--- a/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
+++ b/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
@@ -13,7 +13,7 @@ namespace Piwik\Tests\Unit\Session;
 use Piwik\Date;
 use Piwik\Session\SessionFingerprint;
 
-class SessionFingerprintTest extends \PHPUnit_Framework_TestCase
+class SessionFingerprintTest extends \PHPUnit\Framework\TestCase
 {
     const TEST_TIME_VALUE = 4567;
 

--- a/tests/PHPUnit/Unit/Session/SessionInitializerTest.php
+++ b/tests/PHPUnit/Unit/Session/SessionInitializerTest.php
@@ -14,7 +14,7 @@ use Piwik\AuthResult;
 use Piwik\Session\SessionFingerprint;
 use Piwik\Session\SessionInitializer;
 
-class SessionInitializerTest extends \PHPUnit_Framework_TestCase
+class SessionInitializerTest extends \PHPUnit\Framework\TestCase
 {
     private $oldUnitTestValue;
 

--- a/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
@@ -15,7 +15,7 @@ use Piwik\Tracker\RequestSet;
  * @group RequestSetTest
  * @group Tracker
  */
-class RequestSetTest extends \PHPUnit_Framework_TestCase
+class RequestSetTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestRequestSet

--- a/tests/PHPUnit/Unit/Tracker/ResponseTest.php
+++ b/tests/PHPUnit/Unit/Tracker/ResponseTest.php
@@ -33,7 +33,7 @@ class TestResponse extends Response {
  * @group Plugins
  * @group Tracker
  */
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestResponse

--- a/tests/PHPUnit/Unit/TrackerTest.php
+++ b/tests/PHPUnit/Unit/TrackerTest.php
@@ -17,7 +17,7 @@ use Piwik\Tracker;
  * @group TrackerTest
  * @group Tracker
  */
-class TrackerTest extends \PHPUnit_Framework_TestCase
+class TrackerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestTracker

--- a/tests/PHPUnit/Unit/TranslateTest.php
+++ b/tests/PHPUnit/Unit/TranslateTest.php
@@ -13,7 +13,7 @@ use Piwik\Translate;
 /**
  * @group Translation
  */
-class TranslateTest extends \PHPUnit_Framework_TestCase
+class TranslateTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Dataprovider for testClean

--- a/tests/PHPUnit/Unit/Translation/FilesTest.php
+++ b/tests/PHPUnit/Unit/Translation/FilesTest.php
@@ -15,7 +15,7 @@ use Piwik\Translation\Translator;
  * @group Translation
  * @group langfiles
  */
-class FilesTest extends \PHPUnit_Framework_TestCase
+class FilesTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getTranslationFiles

--- a/tests/PHPUnit/Unit/Translation/Loader/DevelopmentLoaderTest.php
+++ b/tests/PHPUnit/Unit/Translation/Loader/DevelopmentLoaderTest.php
@@ -13,7 +13,7 @@ use Piwik\Translation\Loader\DevelopmentLoader;
 /**
  * @group Translation
  */
-class DevelopmentLoaderTest extends \PHPUnit_Framework_TestCase
+class DevelopmentLoaderTest extends \PHPUnit\Framework\TestCase
 {
     private $translations = array(
         'General' => array(

--- a/tests/PHPUnit/Unit/Translation/Loader/JsonFileLoaderTest.php
+++ b/tests/PHPUnit/Unit/Translation/Loader/JsonFileLoaderTest.php
@@ -13,7 +13,7 @@ use Piwik\Translation\Loader\JsonFileLoader;
 /**
  * @group Translation
  */
-class JsonFileLoaderTest extends \PHPUnit_Framework_TestCase
+class JsonFileLoaderTest extends \PHPUnit\Framework\TestCase
 {
     public function test_shouldLoadJsonFile()
     {

--- a/tests/PHPUnit/Unit/Translation/Loader/LoaderCacheTest.php
+++ b/tests/PHPUnit/Unit/Translation/Loader/LoaderCacheTest.php
@@ -15,7 +15,7 @@ use Piwik\Translation\Loader\LoaderCache;
 /**
  * @group Translation
  */
-class LoaderCacheTest extends \PHPUnit_Framework_TestCase
+class LoaderCacheTest extends \PHPUnit\Framework\TestCase
 {
     public function test_shouldNotLoad_ifInCache()
     {

--- a/tests/PHPUnit/Unit/Translation/TranslatorTest.php
+++ b/tests/PHPUnit/Unit/Translation/TranslatorTest.php
@@ -14,7 +14,7 @@ use Piwik\Translation\Translator;
 /**
  * @group Translation
  */
-class TranslatorTest extends \PHPUnit_Framework_TestCase
+class TranslatorTest extends \PHPUnit\Framework\TestCase
 {
     public function test_translate_shouldReturnTranslationId_ifNoTranslationFound()
     {

--- a/tests/PHPUnit/Unit/TwigTest.php
+++ b/tests/PHPUnit/Unit/TwigTest.php
@@ -13,7 +13,7 @@ require_once(PIWIK_INCLUDE_PATH . '/core/Twig.php');
 /**
  * @group Twig
  */
-class TwigTest extends \PHPUnit_Framework_TestCase
+class TwigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getTruncateTests

--- a/tests/PHPUnit/Unit/UrlHelperTest.php
+++ b/tests/PHPUnit/Unit/UrlHelperTest.php
@@ -12,7 +12,7 @@ use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\UrlHelper;
 use Spyc;
 
-class UrlHelperTest extends \PHPUnit_Framework_TestCase
+class UrlHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Dataprovider for testIsUrl

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -15,7 +15,7 @@ use Piwik\Url;
  * @backupGlobals enabled
  * @group Core
  */
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends \PHPUnit\Framework\TestCase
 {
     public function testAllMethods()
     {

--- a/tests/PHPUnit/Unit/Validator/CharacterLengthTest.php
+++ b/tests/PHPUnit/Unit/Validator/CharacterLengthTest.php
@@ -15,7 +15,7 @@ use Piwik\Validators\CharacterLength;
  * @group CharacterLength
  * @group CharacterLengthTest
  */
-class CharacterLengthTest extends \PHPUnit_Framework_TestCase
+class CharacterLengthTest extends \PHPUnit\Framework\TestCase
 {
     public function test_validate_successValueNotEmpty()
     {

--- a/tests/PHPUnit/Unit/Validator/DateTimeTest.php
+++ b/tests/PHPUnit/Unit/Validator/DateTimeTest.php
@@ -15,7 +15,7 @@ use Piwik\Validators\DateTime;
  * @group DateTime
  * @group DateTimeTest
  */
-class DateTimeTest extends \PHPUnit_Framework_TestCase
+class DateTimeTest extends \PHPUnit\Framework\TestCase
 {
     public function test_validate_successValueNotEmpty()
     {

--- a/tests/PHPUnit/Unit/Validator/EmailTest.php
+++ b/tests/PHPUnit/Unit/Validator/EmailTest.php
@@ -15,7 +15,7 @@ use Piwik\Validators\Email;
  * @group Email
  * @group EmailTest
  */
-class EmailTest extends \PHPUnit_Framework_TestCase
+class EmailTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getValidEmails

--- a/tests/PHPUnit/Unit/Validator/IpRangesTest.php
+++ b/tests/PHPUnit/Unit/Validator/IpRangesTest.php
@@ -15,7 +15,7 @@ use Piwik\Validators\IpRanges;
  * @group IpRanges
  * @group IpRangesTest
  */
-class IpRangesTest extends \PHPUnit_Framework_TestCase
+class IpRangesTest extends \PHPUnit\Framework\TestCase
 {
     public function test_validate_success()
     {

--- a/tests/PHPUnit/Unit/Validator/NotEmptyTest.php
+++ b/tests/PHPUnit/Unit/Validator/NotEmptyTest.php
@@ -15,7 +15,7 @@ use Piwik\Validators\NotEmpty;
  * @group NotEmpty
  * @group NotEmptyTest
  */
-class NotEmptyTest extends \PHPUnit_Framework_TestCase
+class NotEmptyTest extends \PHPUnit\Framework\TestCase
 {
     public function test_validate_successValueNotEmpty()
     {

--- a/tests/PHPUnit/Unit/Validator/NumberRangeTest.php
+++ b/tests/PHPUnit/Unit/Validator/NumberRangeTest.php
@@ -15,7 +15,7 @@ use Piwik\Validators\NumberRange;
  * @group NumberRange
  * @group NumberRangeTest
  */
-class NumberRangeTest extends \PHPUnit_Framework_TestCase
+class NumberRangeTest extends \PHPUnit\Framework\TestCase
 {
     public function test_validate_successValueNotEmpty()
     {

--- a/tests/PHPUnit/Unit/Validator/UrlLikeTest.php
+++ b/tests/PHPUnit/Unit/Validator/UrlLikeTest.php
@@ -15,7 +15,7 @@ use Piwik\Validators\UrlLike;
  * @group UrlLike
  * @group UrlLikeTest
  */
-class UrlLikeTest extends \PHPUnit_Framework_TestCase
+class UrlLikeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider getValidUrls

--- a/tests/PHPUnit/Unit/Validator/WhiteListedValueTest.php
+++ b/tests/PHPUnit/Unit/Validator/WhiteListedValueTest.php
@@ -15,7 +15,7 @@ use Piwik\Validators\WhitelistedValue;
  * @group WhiteListedValue
  * @group WhiteListedValueTest
  */
-class WhiteListedValueTest extends \PHPUnit_Framework_TestCase
+class WhiteListedValueTest extends \PHPUnit\Framework\TestCase
 {
     public function test_validate_successValueNotEmpty()
     {

--- a/tests/PHPUnit/Unit/VersionTest.php
+++ b/tests/PHPUnit/Unit/VersionTest.php
@@ -10,7 +10,7 @@ namespace Piwik\Tests\Unit;
 
 use Piwik\Version;
 
-class VersionTest extends \PHPUnit_Framework_TestCase
+class VersionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Version

--- a/tests/PHPUnit/Unit/Widget/WidgetConfigTest.php
+++ b/tests/PHPUnit/Unit/Widget/WidgetConfigTest.php
@@ -15,7 +15,7 @@ use Piwik\Widget\WidgetConfig;
  * @group WidgetConfig
  * @group WidgetConfigTest
  */
-class WidgetConfigTest extends \PHPUnit_Framework_TestCase
+class WidgetConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var WidgetConfig

--- a/tests/PHPUnit/Unit/Widget/WidgetContainerConfigTest.php
+++ b/tests/PHPUnit/Unit/Widget/WidgetContainerConfigTest.php
@@ -16,7 +16,7 @@ use Piwik\Widget\WidgetContainerConfig;
  * @group WidgetContainerConfig
  * @group WidgetContainerConfigTest
  */
-class WidgetContainerConfigTest extends \PHPUnit_Framework_TestCase
+class WidgetContainerConfigTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var WidgetContainerConfig

--- a/tests/PHPUnit/Unit/Widget/WidgetsListTest.php
+++ b/tests/PHPUnit/Unit/Widget/WidgetsListTest.php
@@ -17,7 +17,7 @@ use Piwik\Widget\WidgetsList;
  * @group WidgetsList
  * @group WidgetsListTest
  */
-class WidgetsListTest extends \PHPUnit_Framework_TestCase
+class WidgetsListTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var WidgetsList

--- a/tests/resources/custompluginsdir/CustomDirPlugin/tests/Unit/CustomClassTest.php
+++ b/tests/resources/custompluginsdir/CustomDirPlugin/tests/Unit/CustomClassTest.php
@@ -14,7 +14,7 @@ use Piwik\Plugins\CustomDirPlugin\CustomClass;
  * @group CustomClassTest
  * @group Plugins
  */
-class CustomClassTest extends \PHPUnit_Framework_TestCase
+class CustomClassTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
Newer versions of PHPUnit will only support new namespace structure. our used (very old) version already implements a simple forward compatibility for that class, so already replacing it is simple and will make an update of PHPUnit easier later

(will do that for the other repos as well)