### PR TITLE
Trigger SafeMode if a plugin update is broken

### DIFF
--- a/core/Updater.php
+++ b/core/Updater.php
@@ -241,6 +241,8 @@ class Updater
 
                 $className = $this->getUpdateClassName($componentName, $fileVersion);
                 if (!class_exists($className, false)) {
+                    // throwing an error here causes Matomo to show the safe mode instead of showing an exception fatal only
+                    // that makes it possible to deactivate / uninstall a broken plugin to recover Matomo directly
                     throw new \Error("The class $className was not found in $file");
                 }
 

--- a/core/Updater.php
+++ b/core/Updater.php
@@ -241,7 +241,7 @@ class Updater
 
                 $className = $this->getUpdateClassName($componentName, $fileVersion);
                 if (!class_exists($className, false)) {
-                    throw new \Exception("The class $className was not found in $file");
+                    throw new \Error("The class $className was not found in $file");
                 }
 
                 if (in_array($className, $classNames)) {

--- a/plugins/CoreUpdater/CoreUpdater.php
+++ b/plugins/CoreUpdater/CoreUpdater.php
@@ -65,6 +65,8 @@ class CoreUpdater extends \Piwik\Plugin
             || $module == 'Proxy'
             // Do not show update page during installation.
             || $module == 'Installation'
+            || ($module == 'CorePluginsAdmin' && $action == 'deactivate')
+            || ($module == 'CorePluginsAdmin' && $action == 'uninstall')
             || ($module == 'LanguagesManager' && $action == 'saveLanguage')) {
             return;
         }


### PR DESCRIPTION
Assuming a plugin contains an invalid update script (e.g. classname, filename or namespace doesn't match), Matomo will currently get stuck in the update process with a message like `The class \Piwik\Plugins\TestPlugin\Updates_0_2_3 was not found in /path/to/matomo/plugins/TestPlugin/Updates/0.2.3.php`. There is currently no solution to fix that, besides deactivating the plugin on command line or directly in config.

By throwing an `Error` instead of an `Exception`, Matomo will show the safemode sceen, that allows deactivating/uninstalling a plugin directly.