### PR TITLE
Empty auto complete results in segment editor when changing the segment

### DIFF
--- a/plugins/SegmentEditor/angularjs/segment-generator/segmentgenerator.controller.js
+++ b/plugins/SegmentEditor/angularjs/segment-generator/segmentgenerator.controller.js
@@ -149,7 +149,13 @@
             orCondition.isLoading = true;
 
             this.updateSegmentDefinition();
-
+            
+            var inputElement = $('.orCondId' + orCondition.id + " .metricValueBlock input");
+            inputElement.autocomplete({
+                source: [],
+                minLength: 0
+            });
+            
             var resolved = false;
 
             var promise = piwikApi.fetch({


### PR DESCRIPTION
Avoids seeing results from previous segment while the new list of suggestion is not loaded yet