### PR TITLE
Prevent possible notice curly braces on array - PHP 7.4 compatibility

### DIFF
--- a/libs/HTML/QuickForm2/Element/Date.php
+++ b/libs/HTML/QuickForm2/Element/Date.php
@@ -128,7 +128,7 @@ class HTML_QuickForm2_Element_Date extends HTML_QuickForm2_Container_Group
         $separator =  '';
 
         for ($i = 0, $length = strlen($this->data['format']); $i < $length; $i++) {
-            $sign = $this->data['format']{$i};
+            $sign = $this->data['format'][$i];
             if ($backslash) {
                 $backslash  = false;
                 $separator .= $sign;

--- a/libs/Zend/Validate/Isbn.php
+++ b/libs/Zend/Validate/Isbn.php
@@ -168,7 +168,7 @@ class Zend_Validate_Isbn extends Zend_Validate_Abstract
                 $isbn10 = str_replace($this->_separator, '', $value);
                 $sum    = 0;
                 for ($i = 0; $i < 9; $i++) {
-                    $sum += (10 - $i) * $isbn10{$i};
+                    $sum += (10 - $i) * $isbn10[$i];
                 }
 
                 // checksum
@@ -186,9 +186,9 @@ class Zend_Validate_Isbn extends Zend_Validate_Abstract
                 $sum    = 0;
                 for ($i = 0; $i < 12; $i++) {
                     if ($i % 2 == 0) {
-                        $sum += $isbn13{$i};
+                        $sum += $isbn13[$i];
                     } else {
-                        $sum += 3 * $isbn13{$i};
+                        $sum += 3 * $isbn13[$i];
                     }
                 }
                 // checksum


### PR DESCRIPTION
Was running a `php -l` check on all files while investigating some WordPress issue and noticed these files were still using curly braces... The ISBN isn't in use and don't think the quickform is in use either. So no need to merge as part of Matomo 3. 

Noticed also warnings for many other files but these we can't change ourselves and suppose by the time we release Matomo 4 they might be fixed in the packages directly
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 126
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 126
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 141
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 141
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 144
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 189
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 193
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 202
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 203
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 299
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/console_getopt/> Console/Getopt.php on line 303
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/pear-core-minimal/> src/System.php on line 268
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/pear/pear-core-minimal/> src/OS/Guess.php on line 243
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/tecnickcom/tcpdf/> include/barcodes/pdf417.php on line 881
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/tecnickcom/tcpdf/> include/barcodes/pdf417.php on line 891
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/tecnickcom/tcpdf/> include/barcodes/pdf417.php on line 955
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/tecnickcom/tcpdf/> include/barcodes/datamatrix.php on line 632
> Deprecated: Array and string offset access syntax with curly braces is deprecated in app/vendor/leafo/lessphp/lessify.inc.php on line 57
