### PR TITLE
Support tracker js files from custom plugin directories

### DIFF
--- a/plugins/CustomPiwikJs/tests/Integration/PluginTrackerFilesTest.php
+++ b/plugins/CustomPiwikJs/tests/Integration/PluginTrackerFilesTest.php
@@ -14,32 +14,11 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 class CustomPluginTrackerFiles extends PluginTrackerFiles {
 
-    private $pluginNamesForFile = array();
 
-    public function __construct($pluginNameForRegularTrackerFile = 'CustomPiwikJs', $pluginNameForMinifiedTracker = 'CustomPiwikJs')
-    {
-        parent::__construct();
-
-        $this->dir = PIWIK_DOCUMENT_ROOT . '/plugins/CustomPiwikJs/tests/';
-
-        $this->pluginNamesForFile = array(
-            'tracker.js' => $pluginNameForRegularTrackerFile,
-            'tracker.min.js' => $pluginNameForMinifiedTracker
+    protected function getDirectoriesToLook() {
+        return array(
+            'CustomPiwikJs' => PIWIK_DOCUMENT_ROOT . '/plugins/CustomPiwikJs/tests/resources/'
         );
-    }
-
-    protected function getPluginNameFromFile($file)
-    {
-        $fileName = basename($file);
-        return $this->pluginNamesForFile[$fileName];
-    }
-}
-
-class CustomPluginTrackerFiles2 extends PluginTrackerFiles {
-
-    public function getPluginNameFromFile($file)
-    {
-        return parent::getPluginNameFromFile($file);
     }
 }
 
@@ -72,72 +51,20 @@ class PluginTrackerFilesTest extends IntegrationTestCase
         $this->assertEquals('tracker.js', $foundFiles['CustomPiwikJs']->getName());
     }
 
-    public function test_find_ifMultiplePluginsImplementATracker_ShouldReturnEachOfThem()
-    {
-        $trackerFiles = new CustomPluginTrackerFiles('CustomPiwikJs', 'Goals');
-        $foundFiles = $trackerFiles->find();
-
-        $this->assertCount(2, $foundFiles);
-        $this->assertTrue(isset($foundFiles['CustomPiwikJs']));
-        $this->assertTrue(isset($foundFiles['Goals']));
-        $this->assertEquals('tracker.js', $foundFiles['CustomPiwikJs']->getName());
-        $this->assertEquals('tracker.min.js', $foundFiles['Goals']->getName());
-    }
-
     public function test_find_EventsCanIgnoreFiles()
     {
-        $trackerFiles = new CustomPluginTrackerFiles('CustomPiwikJs', 'Goals');
+        $trackerFiles = new CustomPluginTrackerFiles();
         $foundFiles = $trackerFiles->find();
-        $this->assertCount(2, $foundFiles);
+        $this->assertCount(1, $foundFiles);
 
         Piwik::addAction('CustomPiwikJs.shouldAddTrackerFile', function (&$shouldAdd, $pluginName) {
-            if ($pluginName === 'Goals') {
+            if ($pluginName === 'CustomPiwikJs') {
                 $shouldAdd = false;
             }
         });
 
         $foundFiles = $trackerFiles->find();
-        $this->assertCount(1, $foundFiles);
-        $this->assertTrue(isset($foundFiles['CustomPiwikJs']));
-        $this->assertFalse(isset($foundFiles['Goals']));
-    }
-
-    public function test_find_shouldNotReturnATrackerFile_IfPluginIsNotActivatedOrLoaded()
-    {
-        $trackerFiles = new CustomPluginTrackerFiles('MyNotExistingPlugin', 'Goals');
-        $foundFiles = $trackerFiles->find();
-
-        $this->assertCount(1, $foundFiles);
-        $this->assertTrue(isset($foundFiles['Goals']));
-        $this->assertEquals('tracker.min.js', $foundFiles['Goals']->getName());
-
-        $trackerFiles = new CustomPluginTrackerFiles('Goals', 'MyNotExistingPlugin');
-        $foundFiles = $trackerFiles->find();
-
-        $this->assertCount(1, $foundFiles);
-        $this->assertTrue(isset($foundFiles['Goals']));
-        $this->assertEquals('tracker.js', $foundFiles['Goals']->getName());
-    }
-
-    public function test_find_shouldNotReturnFileIfNoPluginActivated()
-    {
-        $trackerFiles = new CustomPluginTrackerFiles('MyNotExistingPlugin', 'MyNotExistingPlugin2');
-        $foundFiles = $trackerFiles->find();
-
-        $this->assertSame(array(), $foundFiles);
-    }
-
-    public function test_getPluginNameFromFile_shouldDetectPluginName()
-    {
-        $trackerFiles = new CustomPluginTrackerFiles2();
-        $pluginName = $trackerFiles->getPluginNameFromFile(PIWIK_DOCUMENT_ROOT . '/plugins/MyFooBarPlugin/tracker.js');
-        $this->assertSame('MyFooBarPlugin', $pluginName);
-
-        $pluginName = $trackerFiles->getPluginNameFromFile(PIWIK_DOCUMENT_ROOT . '/plugins//MyFooBarPlugin//tracker.js');
-        $this->assertSame('MyFooBarPlugin', $pluginName);
-
-        $pluginName = $trackerFiles->getPluginNameFromFile(PIWIK_DOCUMENT_ROOT . '/plugins//MyFooBarPlugin//tracker.min.js');
-        $this->assertSame('MyFooBarPlugin', $pluginName);
+        $this->assertCount(0, $foundFiles);
     }
 
 }


### PR DESCRIPTION
When a plugin was not placed in the regular `$matomoInstall/plugins` directory but in some alternative directory, then the `tracker.js` or `tracker.min.js` was not found. Therefore had to change the logic so that all tracker files can be found correctly. This is needed for WordPress as otherwise some plugins don't work there.