### PR TITLE
Fix non-numeric value encountered in session recording

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/HtmlTable.php
+++ b/plugins/CoreVisualizations/Visualizations/HtmlTable.php
@@ -235,9 +235,11 @@ class HtmlTable extends Visualization
 
                 $reportTotal = isset($totals[$column]) ? $totals[$column] : 0;
 
-                $percentageColumnName = $column . '_row_percentage';
-                $rowPercentage = $formatter->formatPercent(Piwik::getPercentageSafe($value, $reportTotal, $precision = 1), $precision);
-                $row->setMetadata($percentageColumnName, $rowPercentage);
+                if (is_numeric($value)) {
+                    $percentageColumnName = $column . '_row_percentage';
+                    $rowPercentage = $formatter->formatPercent(Piwik::getPercentageSafe($value, $reportTotal, $precision = 1), $precision);
+                    $row->setMetadata($percentageColumnName, $rowPercentage);
+                }
 
                 if ($siteTotalRow) {
                     $siteTotal = $siteTotalRow->getColumn($column) ?: 0;


### PR DESCRIPTION
fix DEV-1879
In session recording some columns aren't numeric like the time:

![image](https://user-images.githubusercontent.com/273120/74488203-544e7180-4f26-11ea-909b-b6044ba6767f.png)

This caused these notices to be shown in the admin

![image](https://user-images.githubusercontent.com/273120/74488215-5d3f4300-4f26-11ea-95b0-a2dc90d9236a.png)

It's the easiest fix I can think of for now. This regressed in https://github.com/matomo-org/matomo/pull/15304 by the looks.
