### PR TITLE
Do not record the stack trace for user input errors

### DIFF
--- a/core/Exception/InvalidRequestParameterException.php
+++ b/core/Exception/InvalidRequestParameterException.php
@@ -10,4 +10,9 @@ namespace Piwik\Exception;
 
 class InvalidRequestParameterException extends Exception
 {
+  
+    public function __toString()
+    {
+        return $this->getMessage() . ' ' . $this->getFile() . ':' . $this->getLine();
+    }
 }


### PR DESCRIPTION
Follow up from https://github.com/matomo-org/matomo/pull/14771

Have been debugging and the above PR alone did not help since the `PsrLogMessageProcessor` would call the toString method of the exception and add the message again. This makes sure the logs are more readble.