### PR TITLE
During archive invalidation clear general cache less often

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -125,7 +125,6 @@ class ArchiveInvalidator
 
         $generalCache = Cache::getCacheGeneral();
         if (empty($generalCache[$cacheKey][$idSite][$dateStr])) {
-            Cache::clearCacheGeneral();
             return [];
         }
 

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -184,6 +184,8 @@ class ArchiveInvalidator
 
     /**
      * @internal
+     * After calling this method, make sure to call Cache::clearCacheGeneral(); For performance reasons we don't call
+     * this here immediately in case there are multiple invalidations.
      */
     public function forgetRememberedArchivedReportsToInvalidate($idSite, Date $date)
     {

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -192,7 +192,6 @@ class ArchiveInvalidator
         // The process pid is added to the end of the entry in order to support multiple concurrent transactions.
         //  So this must be a deleteLike call to get all the entries, where there used to only be one.
         Option::deleteLike($id . '%');
-        Cache::clearCacheGeneral();
     }
 
     /**
@@ -268,6 +267,7 @@ class ArchiveInvalidator
                 $this->forgetRememberedArchivedReportsToInvalidate($idSite, $date);
             }
         }
+        Cache::clearCacheGeneral();
 
         return $invalidationInfo;
     }
@@ -309,6 +309,8 @@ class ArchiveInvalidator
                 $invalidationInfo->processedDates[] = $dateRange[0];
             }
         }
+
+        Cache::clearCacheGeneral();
 
         $archivesToPurge = new ArchivesToPurgeDistributedList();
         $archivesToPurge->add($invalidatedMonths);


### PR DESCRIPTION
I know the code is not ideal since everyone who calls `forgetRememberedArchivedReportsToInvalidate` would need to know to ideally also invalidate the general tracker cache. On the other side we're seeing quite a lot of invalidations like sometimes 50 invalidations within a few ms causing heaps of cache invalidations and cache re-generations across many servers within few ms potentially resulting in locks and temporary performance issues. 

Maybe this helps to prevent also things like #15545

@diosmosis maybe you can have a look? Maybe since the code is only used internally it may be fine like that?