### PR TITLE
Update to PHPUnit 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "aws/aws-sdk-php": "2.7.1",
         "lox/xhprof": "dev-master",
         "phpseclib/phpseclib": "~0.3.8",
-        "phpunit/phpunit": "~4.8",
+        "phpunit/phpunit": "~8.5",
         "symfony/var-dumper": "~2.6.0",
         "symfony/yaml": "~2.6.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef319f0bec0c7988dd83727e05ac2b39",
+    "content-hash": "e0cf7a238ff49c3657c22fbd22937f08",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1563,16 +1563,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+                "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
                 "shasum": ""
             },
             "require": {
@@ -1584,7 +1584,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.13-dev"
                 }
             },
             "autoload": {
@@ -1617,7 +1617,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "szymach/c-pchart",
@@ -1882,32 +1882,34 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -1927,12 +1929,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2019-10-21T16:45:58+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -2070,24 +2072,72 @@
             "time": "2015-08-31T22:07:48+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "name": "myclabs/deep-copy",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2020-01-17T21:11:47+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
             },
             "type": "library",
             "extra": {
@@ -2096,10 +2146,110 @@
                 }
             },
             "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2121,86 +2271,93 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.2",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/a48807183a4b819072f26e347bbd0b5199a9d15f",
+                "reference": "a48807183a4b819072f26e347bbd0b5199a9d15f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.3.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "^7.1",
+                "php": "^7.2",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpdocumentor/type-resolver": "^1.0",
+                "webmozart/assert": "^1"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08T06:39:58+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "doctrine/instantiator": "^1",
+                "mockery/mockery": "^1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2020-02-09T09:16:15+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2213,7 +2370,8 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-06-03T08:32:36+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T18:11:29+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -2315,33 +2473,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.9.0",
+            "version": "v1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203"
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f6811d96d97bdf400077a0cc100ae56aa32b9203",
-                "reference": "f6811d96d97bdf400077a0cc100ae56aa32b9203",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
@@ -2374,43 +2532,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2019-10-03T11:07:50+00:00"
+            "time": "2020-01-20T15:57:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "7.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.1.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2425,7 +2584,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2436,29 +2595,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2019-11-20T13:55:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2473,7 +2635,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2483,7 +2645,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -2528,28 +2690,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -2564,7 +2726,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -2573,33 +2735,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
+                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -2622,45 +2784,56 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-12-04T08:55:13+00:00"
+            "time": "2019-09-17T06:23:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.36",
+            "version": "8.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
+                "reference": "018b6ac3c8ab20916db85fa91bf6465acb64d1e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/018b6ac3c8ab20916db85fa91bf6465acb64d1e0",
+                "reference": "018b6ac3c8ab20916db85fa91bf6465acb64d1e0",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.2.0",
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.9.1",
+                "phar-io/manifest": "^1.0.3",
+                "phar-io/version": "^2.0.1",
+                "php": "^7.2",
+                "phpspec/prophecy": "^1.8.1",
+                "phpunit/php-code-coverage": "^7.0.7",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.2",
+                "sebastian/comparator": "^3.0.2",
+                "sebastian/diff": "^3.0.2",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/exporter": "^3.1.1",
+                "sebastian/global-state": "^3.0.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0.1",
+                "sebastian/type": "^1.1.3",
+                "sebastian/version": "^2.0.1"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-soap": "*",
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0.0"
             },
             "bin": [
                 "phpunit"
@@ -2668,7 +2841,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
@@ -2694,38 +2867,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21T08:07:12+00:00"
+            "time": "2020-01-08T08:49:49+00:00"
         },
         {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
+                "phpunit/phpunit": "^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -2740,45 +2907,39 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "email": "sebastian@phpunit.de"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2015-10-02T06:51:40+00:00"
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2809,38 +2970,39 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2865,34 +3027,40 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -2917,34 +3085,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2019-11-20T08:46:58+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -2958,6 +3126,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -2966,16 +3138,12 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
@@ -2984,27 +3152,30 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -3012,7 +3183,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3035,32 +3206,124 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2019-02-01T05:30:01+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.5",
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -3088,23 +3351,119 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
+            "require": {
+                "php": "^7.1"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2018-10-04T04:07:39+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "time": "2019-07-02T08:10:15+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -3123,7 +3482,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -3236,32 +3595,70 @@
             "time": "2015-07-26T08:59:42+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.5.0",
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/88e6d84706d09a236046d686bbea96f07b3a34f4",
-                "reference": "88e6d84706d09a236046d686bbea96f07b3a34f4",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+                "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.3 || ^7.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "vimeo/psalm": "<3.6.0"
+            },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -3283,7 +3680,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2019-08-24T08:43:50+00:00"
+            "time": "2019-11-24T13:36:37+00:00"
         }
     ],
     "aliases": [],

--- a/plugins/API/tests/Integration/APITest.php
+++ b/plugins/API/tests/Integration/APITest.php
@@ -30,7 +30,7 @@ class APITest extends IntegrationTestCase
 
     private $hasSuperUserAccess = false;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -45,7 +45,7 @@ class APITest extends IntegrationTestCase
         $this->makeSureTestRunsInContextOfAnonymousUser();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Access::getInstance()->hasSuperUserAccess($this->hasSuperUserAccess);
         parent::tearDown();

--- a/plugins/API/tests/Integration/RowEvolutionTest.php
+++ b/plugins/API/tests/Integration/RowEvolutionTest.php
@@ -20,18 +20,16 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 class RowEvolutionTest extends IntegrationTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Fixture::createWebsite('2014-01-01 00:00:00');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Reports like VisitsSummary.get which do not have a dimension are not supported by row evolution
-     */
     public function test_getRowEvolution_shouldTriggerAnException_IfReportHasNoDimension()
     {
+        $this->expectException(\Exception::class);
+        $this->expectDeprecationMessage("Reports like VisitsSummary.get which do not have a dimension are not supported by row evolution");
         $rowEvolution = new RowEvolution();
         $rowEvolution->getRowEvolution(1, 'day', 'last7', 'VisitsSummary', 'get');
     }

--- a/plugins/API/tests/Integration/RssRendererTest.php
+++ b/plugins/API/tests/Integration/RssRendererTest.php
@@ -25,7 +25,7 @@ class RssRendererTest extends IntegrationTestCase
      */
     private $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -64,51 +64,42 @@ class RssRendererTest extends IntegrationTestCase
         $this->assertEquals('Error: The API cannot handle this data structure.', $response);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage RSS feeds can be generated for one specific website
-     */
     public function test_renderScalar_shouldFailForBooleanScalar()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
         $this->builder->renderScalar(true);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage RSS feeds can be generated for one specific website
-     */
     public function test_renderScalar_shouldFailForIntegerScalar()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
         $this->builder->renderScalar(5);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage RSS feeds can be generated for one specific website
-     */
     public function test_renderScalar_shouldFailForStringScalar()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
         $this->builder->renderScalar('string');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage RSS feeds can be generated for one specific website
-     */
     public function test_renderDataTable_shouldFailForDataTable()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
         $dataTable = new DataTable();
         $dataTable->addRowFromSimpleArray(array('nb_visits' => 5, 'nb_random' => 10));
 
         $this->builder->renderDataTable($dataTable);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage RSS feeds can be generated for one specific website
-     */
     public function test_renderDataTable_shouldFailForSubtables()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
+
         $subtable = new DataTable();
         $subtable->addRowFromSimpleArray(array('nb_visits' => 2, 'nb_random' => 6));
 
@@ -119,12 +110,11 @@ class RssRendererTest extends IntegrationTestCase
         $this->builder->renderDataTable($dataTable);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage RSS feeds can be generated for one specific website
-     */
     public function test_renderDataTable_shouldFail_IfKeynameIsNotDate()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
+
         $map = new DataTable\Map();
 
         $dataTable = new DataTable();
@@ -161,24 +151,22 @@ class RssRendererTest extends IntegrationTestCase
 </rss>', $response);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage RSS feeds can be generated for one specific website
-     */
     public function test_renderDataTable_shouldFailForSimpleDataTable()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
+
         $dataTable = new DataTable\Simple();
         $dataTable->addRowsFromArray(array('nb_visits' => 3, 'nb_random' => 6));
 
         $this->builder->renderDataTable($dataTable);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage RSS feeds can be generated for one specific website
-     */
     public function test_renderArray_ShouldFailForArrays()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('RSS feeds can be generated for one specific website');
+
         $input = array(1, 2, 5, 'string', 10);
 
         $this->builder->renderArray($input);

--- a/plugins/API/tests/System/AutoSuggestAPITest.php
+++ b/plugins/API/tests/System/AutoSuggestAPITest.php
@@ -51,14 +51,14 @@ class AutoSuggestAPITest extends SystemTestCase
     protected static $processed = 0;
     protected static $skipped = array();
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
         API::setSingletonInstance(CachedAPI::getInstance());
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
 

--- a/plugins/API/tests/Unit/ConsoleRendererTest.php
+++ b/plugins/API/tests/Unit/ConsoleRendererTest.php
@@ -24,7 +24,7 @@ class ConsoleRendererTest extends \PHPUnit\Framework\TestCase
      */
     private $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = $this->makeBuilder(array());
         DataTable\Manager::getInstance()->deleteAll();
@@ -114,12 +114,11 @@ class ConsoleRendererTest extends \PHPUnit\Framework\TestCase
 ", $response);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Data structure returned is not convertible in the requested format
-     */
     public function test_renderArray_ShouldConvertMultiDimensionalAssociativeArrayToJson()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Data structure returned is not convertible in the requested format');
+
         $input = array(
             "firstElement"  => "isFirst",
             "secondElement" => array(

--- a/plugins/API/tests/Unit/CsvRendererTest.php
+++ b/plugins/API/tests/Unit/CsvRendererTest.php
@@ -22,7 +22,7 @@ class CsvRendererTest extends \PHPUnit\Framework\TestCase
      */
     private $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = $this->makeBuilder(array('method' => 'MultiSites_getAll', 'convertToUnicode' => 0));
     }
@@ -285,12 +285,11 @@ firstElement,secondElement,
 ,,thirdElement', $actual);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Data structure returned is not convertible in the requested format
-     */
     public function test_renderArray_ShouldConvertMultiDimensionalAssociativeArrayToJson()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Data structure returned is not convertible in the requested format');
+
         $input = array(
             "firstElement"  => "isFirst",
             "secondElement" => array(
@@ -302,12 +301,11 @@ firstElement,secondElement,
         $this->builder->renderArray($input);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Data structure returned is not convertible in the requested format
-     */
     public function test_renderArray_ShouldConvertMultiDimensionalIndexArrayToJson()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Data structure returned is not convertible in the requested format');
+
         $input = array(array("firstElement",
             array(
                 "firstElement",
@@ -318,12 +316,11 @@ firstElement,secondElement,
         $this->builder->renderArray($input);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Data structure returned is not convertible in the requested format
-     */
     public function test_renderArray_ShouldConvertMultiDimensionalMixedArrayToJson()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Data structure returned is not convertible in the requested format');
+
         $input = array(
             "firstElement" => "isFirst",
             array(

--- a/plugins/API/tests/Unit/DataTable/MergeDataTablesTest.php
+++ b/plugins/API/tests/Unit/DataTable/MergeDataTablesTest.php
@@ -20,7 +20,7 @@ class MergeDataTablesTest extends \PHPUnit\Framework\TestCase
      */
     private $instance;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->instance = new MergeDataTables();

--- a/plugins/API/tests/Unit/HtmlRendererTest.php
+++ b/plugins/API/tests/Unit/HtmlRendererTest.php
@@ -24,7 +24,7 @@ class HtmlRendererTest extends \PHPUnit\Framework\TestCase
      */
     private $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = $this->makeBuilder(array('method' => 'MultiSites_getAll'));
         DataTable\Manager::getInstance()->deleteAll();
@@ -449,12 +449,11 @@ message', $response);
 ', $actual);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Data structure returned is not convertible in the requested format
-     */
     public function test_renderArray_ShouldConvertMultiDimensionalAssociativeArrayToJson()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Data structure returned is not convertible in the requested format');
+
         $input = array(
             "firstElement"  => "isFirst",
             "secondElement" => array(
@@ -466,12 +465,11 @@ message', $response);
         $this->builder->renderArray($input);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Data structure returned is not convertible in the requested format
-     */
     public function test_renderArray_ShouldConvertMultiDimensionalIndexArrayToJson()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Data structure returned is not convertible in the requested format');
+
         $input = array(array("firstElement",
             array(
                 "firstElement",
@@ -482,12 +480,11 @@ message', $response);
         $this->builder->renderArray($input);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Data structure returned is not convertible in the requested format
-     */
     public function test_renderArray_ShouldConvertMultiDimensionalMixedArrayToJson()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Data structure returned is not convertible in the requested format');
+
         $input = array(
             "firstElement" => "isFirst",
             array(

--- a/plugins/API/tests/Unit/JsonRendererTest.php
+++ b/plugins/API/tests/Unit/JsonRendererTest.php
@@ -25,7 +25,7 @@ class JsonRendererTest extends \PHPUnit\Framework\TestCase
      */
     private $jsonBuilder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->jsonBuilder = $this->makeBuilder(array());
         DataTable\Manager::getInstance()->deleteAll();

--- a/plugins/API/tests/Unit/OriginalRendererTest.php
+++ b/plugins/API/tests/Unit/OriginalRendererTest.php
@@ -22,7 +22,7 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
      */
     private $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = $this->makeBuilder(array());
     }
@@ -34,12 +34,11 @@ class OriginalRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($response);
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage The other message
-     */
     public function test_renderException_shouldThrowTheException()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('The other message');
+
         $this->builder->renderException('This message should be ignored', new \BadMethodCallException('The other message'));
     }
 

--- a/plugins/API/tests/Unit/PhpRendererTest.php
+++ b/plugins/API/tests/Unit/PhpRendererTest.php
@@ -23,7 +23,7 @@ class PhpRendererTest extends \PHPUnit\Framework\TestCase
      */
     private $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = $this->makeBuilder(array('serialize' => 0));
         DataTable\Manager::getInstance()->deleteAll();

--- a/plugins/API/tests/Unit/WidgetMetadataTest.php
+++ b/plugins/API/tests/Unit/WidgetMetadataTest.php
@@ -32,7 +32,7 @@ class WidgetMetadataTest extends \PHPUnit\Framework\TestCase
      */
     private $metadata;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->metadata = new WidgetMetadata();
     }

--- a/plugins/API/tests/Unit/XmlRendererTest.php
+++ b/plugins/API/tests/Unit/XmlRendererTest.php
@@ -22,13 +22,13 @@ class XmlRendererTest extends \PHPUnit\Framework\TestCase
      */
     private $builder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->builder = $this->makeBuilder(array());
         DataTable\Manager::getInstance()->deleteAll();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         DataTable\Manager::getInstance()->deleteAll();
     }

--- a/plugins/Actions/tests/Integration/ActionSiteSearchTest.php
+++ b/plugins/Actions/tests/Integration/ActionSiteSearchTest.php
@@ -20,7 +20,7 @@ use Piwik\Tracker\Request;
  */
 class ActionSiteSearchTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Actions/tests/Unit/ArchiverTest.php
+++ b/plugins/Actions/tests/Unit/ArchiverTest.php
@@ -21,12 +21,12 @@ require_once PIWIK_INCLUDE_PATH . '/plugins/Actions/Actions.php';
  */
 class ArchiverTests extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Fixture::loadAllTranslations();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
     }

--- a/plugins/BulkTracking/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/plugins/BulkTracking/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -20,14 +20,14 @@ class SimpleFixtureTrackFewVisits extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         $this->trackFirstVisit();
         $this->trackSecondVisit();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/BulkTracking/tests/Framework/TestCase/BulkTrackingTestCase.php
+++ b/plugins/BulkTracking/tests/Framework/TestCase/BulkTrackingTestCase.php
@@ -31,7 +31,7 @@ class BulkTrackingTestCase extends IntegrationTestCase
 
     private $pluginBackup;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -41,7 +41,7 @@ class BulkTrackingTestCase extends IntegrationTestCase
         Plugin\Manager::getInstance()->addLoadedPlugin('BulkTracking', $this->bulk);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Plugin\Manager::getInstance()->addLoadedPlugin('BulkTracking', $this->pluginBackup);
         parent::tearDown();

--- a/plugins/BulkTracking/tests/Integration/BulkTrackingTest.php
+++ b/plugins/BulkTracking/tests/Integration/BulkTrackingTest.php
@@ -74,12 +74,11 @@ class BulkTrackingTest extends BulkTrackingTestCase
         $this->assertCount(2, $requests);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage token_auth must be specified when using Bulk Tracking Import
-     */
     public function test_initRequestSet_shouldTriggerException_InCaseNoValidTokenProvidedAndAuthenticationIsRequired()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('token_auth must be specified when using Bulk Tracking Import');
+
         $request = $this->getDummyRequest(false);
 
         $this->initRequestSet($request, true);

--- a/plugins/BulkTracking/tests/Integration/HandlerTest.php
+++ b/plugins/BulkTracking/tests/Integration/HandlerTest.php
@@ -46,7 +46,7 @@ class HandlerTest extends IntegrationTestCase
      */
     private $requestSet;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BulkTracking/tests/Integration/RequestsTest.php
+++ b/plugins/BulkTracking/tests/Integration/RequestsTest.php
@@ -29,7 +29,7 @@ class RequestsTest extends IntegrationTestCase
      */
     private $requests;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -38,7 +38,7 @@ class RequestsTest extends IntegrationTestCase
         $this->requests = new Requests();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // clean up your test here if needed
 
@@ -65,32 +65,29 @@ class RequestsTest extends IntegrationTestCase
         TrackerConfig::setConfigValue('bulk_requests_require_authentication', $oldConfig);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage token_auth must be specified when using Bulk Tracking Import
-     */
     public function test_authenticateRequests_shouldThrowAnException_IfTokenAuthIsEmpty()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('token_auth must be specified when using Bulk Tracking Import');
+
         $requests = array($this->buildDummyRequest());
         $this->requests->authenticateRequests($requests);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage token_auth must be specified when using Bulk Tracking Import
-     */
     public function test_authenticateRequests_shouldThrowAnException_IfAnyTokenAuthIsEmpty()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('token_auth must be specified when using Bulk Tracking Import');
+
         $requests = array($this->buildDummyRequest($this->getSuperUserToken()), $this->buildDummyRequest());
         $this->requests->authenticateRequests($requests);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage token_auth specified does not have Admin permission for idsite=1
-     */
     public function test_authenticateRequests_shouldThrowAnException_IfTokenIsNotValid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('token_auth specified does not have Admin permission for idsite=1');
+
         $dummyToken = API::getInstance()->createTokenAuth('test');
         $superUserToken = $this->getSuperUserToken();
 

--- a/plugins/BulkTracking/tests/Integration/TrackerTest.php
+++ b/plugins/BulkTracking/tests/Integration/TrackerTest.php
@@ -36,7 +36,7 @@ class TrackerTest extends BulkTrackingTestCase
      */
     private $tracker;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BulkTracking/tests/System/TrackerTest.php
+++ b/plugins/BulkTracking/tests/System/TrackerTest.php
@@ -26,7 +26,7 @@ class TrackerTest extends SystemTestCase
      */
     private $tracker;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/BulkTracking/tests/Unit/RequestsTest.php
+++ b/plugins/BulkTracking/tests/Unit/RequestsTest.php
@@ -23,7 +23,7 @@ class RequestsTest extends \PHPUnit\Framework\TestCase
      */
     private $requests;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->requests = new Requests();

--- a/plugins/BulkTracking/tests/Unit/ResponseTest.php
+++ b/plugins/BulkTracking/tests/Unit/ResponseTest.php
@@ -33,7 +33,7 @@ class ResponseTest extends UnitTestCase
      */
     private $response;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Contents/tests/Fixtures/TwoVisitsWithContents.php
+++ b/plugins/Contents/tests/Fixtures/TwoVisitsWithContents.php
@@ -21,7 +21,7 @@ class TwoVisitsWithContents extends Fixture
     public $idSite = 1;
     public $idGoal1 = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
@@ -91,7 +91,7 @@ class TwoVisitsWithContents extends Fixture
         self::checkResponse($vis->doTrackContentImpression('Video Ad', 'movie.mov'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 }

--- a/plugins/Contents/tests/System/ContentsTest.php
+++ b/plugins/Contents/tests/System/ContentsTest.php
@@ -45,13 +45,13 @@ class ContentsTest extends SystemTestCase
         );
     }
 
-    protected function setup()
+    public function setUp(): void
     {
-        parent::setup();
+        parent::setUp();
         Fixture::loadAllTranslations();
     }
 
-    protected function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Fixture::resetTranslations();

--- a/plugins/CoreAdminHome/tests/Fixture/DuplicateActions.php
+++ b/plugins/CoreAdminHome/tests/Fixture/DuplicateActions.php
@@ -142,7 +142,7 @@ class DuplicateActions extends Fixture
         )
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/CoreAdminHome/tests/Fixture/TrackingFailures.php
+++ b/plugins/CoreAdminHome/tests/Fixture/TrackingFailures.php
@@ -15,7 +15,7 @@ class TrackingFailures extends Fixture
     public $idSite = 1;
     public $dateTime = '2013-01-02 03:04:05';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/CoreAdminHome/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/plugins/CoreAdminHome/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -20,14 +20,14 @@ class SimpleFixtureTrackFewVisits extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         $this->trackFirstVisit();
         $this->trackSecondVisit();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/CoreAdminHome/tests/Integration/APITest.php
+++ b/plugins/CoreAdminHome/tests/Integration/APITest.php
@@ -30,7 +30,7 @@ class APITest extends \Piwik\Tests\Framework\TestCase\IntegrationTestCase
      */
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->api = API::getInstance();
@@ -39,12 +39,11 @@ class APITest extends \Piwik\Tests\Framework\TestCase\IntegrationTestCase
         }
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     * @expectedExceptionMessage checkUserHasSomeAdminAccess
-     */
     public function test_getTrackingFailures_failsForViewUser()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasSomeAdminAccess');
+
         $this->setUser();
         $this->api->getTrackingFailures();
     }
@@ -58,12 +57,11 @@ class APITest extends \Piwik\Tests\Framework\TestCase\IntegrationTestCase
         $this->assertSame(array(), $this->api->getTrackingFailures());
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     * @expectedExceptionMessage checkUserHasSomeAdminAccess
-     */
     public function test_deleteAllTrackingFailures_failsForViewUser()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasSomeAdminAccess');
+
         $this->setUser();
         $this->api->deleteAllTrackingFailures();
     }
@@ -76,22 +74,20 @@ class APITest extends \Piwik\Tests\Framework\TestCase\IntegrationTestCase
         $this->api->deleteAllTrackingFailures();
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     * @expectedExceptionMessage checkUserHasAdminAccess
-     */
     public function test_deleteTrackingFailure_failsForViewUser()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasAdminAccess');
+
         $this->setUser();
         $this->api->deleteTrackingFailure(1, 2);
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     * @expectedExceptionMessage checkUserHasAdminAccess
-     */
     public function test_deleteTrackingFailure_failsForAdminUserIfNotAdminAccessToThatSite()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasAdminAccess');
+
         $this->setAdminUser();
         $this->api->deleteTrackingFailure(2, 2);
     }

--- a/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
@@ -38,7 +38,7 @@ class DeleteLogsDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $result, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains('Invalid date range supplied', $this->applicationTester->getDisplay());
+        self::assertStringContainsString('Invalid date range supplied', $this->applicationTester->getDisplay());
     }
 
     public function getTestDataForInvalidDateRangeTest()
@@ -64,7 +64,7 @@ class DeleteLogsDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $result, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains('Invalid site ID', $this->applicationTester->getDisplay());
+        self::assertStringContainsString('Invalid site ID', $this->applicationTester->getDisplay());
     }
 
     /**
@@ -83,7 +83,7 @@ class DeleteLogsDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $result, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains('Invalid row limit supplied', $this->applicationTester->getDisplay());
+        self::assertStringContainsString('Invalid row limit supplied', $this->applicationTester->getDisplay());
     }
 
     public function getTestDataForInvalidIterationStepTest()
@@ -128,7 +128,7 @@ class DeleteLogsDataTest extends ConsoleCommandTestCase
         ), $options);
 
         $this->assertEquals(0, $result, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("Successfully deleted 19 visits", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Successfully deleted 19 visits", $this->applicationTester->getDisplay());
     }
 
     private function setCommandInput($value)

--- a/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
@@ -17,7 +17,7 @@ use Piwik\Tests\Framework\TestCase\ConsoleCommandTestCase;
  */
 class InvalidateReportDataTest extends ConsoleCommandTestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -41,7 +41,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("Invalid date or date range specifier", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalid date or date range specifier", $this->applicationTester->getDisplay());
     }
 
     public function getInvalidDateRanges()
@@ -67,7 +67,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("Invalid period type", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalid period type", $this->applicationTester->getDisplay());
     }
 
     public function getInvalidPeriodTypes()
@@ -92,7 +92,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("Invalid --sites value", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalid --sites value", $this->applicationTester->getDisplay());
     }
 
     public function getInvalidSiteLists()
@@ -117,7 +117,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("The segment condition 'ablksdjfdslkjf' is not valid", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("The segment condition 'ablksdjfdslkjf' is not valid", $this->applicationTester->getDisplay());
     }
 
     /**
@@ -139,7 +139,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
 
         foreach ($expectedOutputs as $output) {
-            $this->assertContains($output, $this->applicationTester->getDisplay());
+            self::assertStringContainsString($output, $this->applicationTester->getDisplay());
         }
     }
 
@@ -155,7 +155,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
     }
 
     public function test_Command_InvalidateDateRange_invalidDate()
@@ -170,7 +170,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("The date '2019-01-01,2019-01--09' is not a correct date range", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("The date '2019-01-01,2019-01--09' is not a correct date range", $this->applicationTester->getDisplay());
     }
 
     public function test_Command_InvalidateDateRange_onlyOneDate()
@@ -185,7 +185,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("The date '2019-01-01' is not a correct date range", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("The date '2019-01-01' is not a correct date range", $this->applicationTester->getDisplay());
     }
 
     public function test_Command_InvalidateDateRange_tooManyDatesInRange()
@@ -200,7 +200,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("The date '2019-01-01,2019-01-09,2019-01-12,2019-01-15' is not a correct date range", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("The date '2019-01-01,2019-01-09,2019-01-12,2019-01-15' is not a correct date range", $this->applicationTester->getDisplay());
     }
 
     public function test_Command_InvalidateDateRange_multipleDateRanges()
@@ -215,7 +215,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-15", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-15", $this->applicationTester->getDisplay());
     }
 
     public function test_Command_InvalidateDateRange_invalidateAllPeriodTypesSkipsRangeWhenNotRangeDAte()
@@ -230,8 +230,8 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertNotContains("range", $this->applicationTester->getDisplay());
-        $this->assertNotContains("Range", $this->applicationTester->getDisplay());
+        self::assertStringNotContainsString("range", $this->applicationTester->getDisplay());
+        self::assertStringNotContainsString("Range", $this->applicationTester->getDisplay());
     }
 
     public function test_Command_InvalidateDateRange_invalidateAllPeriodTypes()
@@ -246,11 +246,11 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("Invalidating day periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
-        $this->assertContains("Invalidating week periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
-        $this->assertContains("Invalidating month periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
-        $this->assertContains("Invalidating year periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
-        $this->assertContains("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating day periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating week periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating month periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating year periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
     }
 
     public function test_Command_InvalidateAll_multipleDateRanges()
@@ -265,7 +265,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-13 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-13 [segment = ]", $this->applicationTester->getDisplay());
     }
 
     public function getTestDataForSuccessTests()

--- a/plugins/CoreAdminHome/tests/Integration/Commands/OptimizeArchiveTablesTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/OptimizeArchiveTablesTest.php
@@ -18,7 +18,7 @@ use Piwik\Tests\Framework\TestCase\ConsoleCommandTestCase;
  */
 class OptimizeArchiveTablesTest extends ConsoleCommandTestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/plugins/CoreAdminHome/tests/Integration/Commands/PurgeOldArchiveDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/PurgeOldArchiveDataTest.php
@@ -35,7 +35,7 @@ class PurgeOldArchiveDataTest extends IntegrationTestCase
      */
     protected $application;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -57,7 +57,7 @@ class PurgeOldArchiveDataTest extends IntegrationTestCase
         self::$fixture->assertInvalidatedArchivesNotPurged(self::$fixture->february);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         PurgeOldArchiveData::$todayOverride = null;
 
@@ -138,9 +138,9 @@ class PurgeOldArchiveDataTest extends IntegrationTestCase
         self::$fixture->assertTemporaryArchivesNotPurged(self::$fixture->january);
         self::$fixture->assertCustomRangesNotPurged(self::$fixture->january);
 
-        $this->assertContains("Skipping purge outdated archive data.", $this->applicationTester->getDisplay());
-        $this->assertContains("Skipping purge invalidated archive data.", $this->applicationTester->getDisplay());
-        $this->assertContains("Skipping OPTIMIZE TABLES.", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Skipping purge outdated archive data.", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Skipping purge invalidated archive data.", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Skipping OPTIMIZE TABLES.", $this->applicationTester->getDisplay());
     }
 
     protected function getCommandDisplayOutputErrorMessage()

--- a/plugins/CoreAdminHome/tests/Integration/FixDuplicateActionsTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/FixDuplicateActionsTest.php
@@ -29,7 +29,7 @@ class FixDuplicateActionsTest extends IntegrationTestCase
      */
     protected $applicationTester = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -54,7 +54,7 @@ class FixDuplicateActionsTest extends IntegrationTestCase
         $this->assertDuplicatesFixedInLogConversionTable();
         $this->assertDuplicatesFixedInLogConversionItemTable();
 
-        $this->assertContains("Found and deleted 7 duplicate action entries", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Found and deleted 7 duplicate action entries", $this->applicationTester->getDisplay());
 
         $expectedAffectedArchives = array(
             array('idsite' => '1', 'server_time' => '2012-01-01'),
@@ -64,7 +64,7 @@ class FixDuplicateActionsTest extends IntegrationTestCase
             array('idsite' => '2', 'server_time' => '2012-03-01'),
         );
         foreach ($expectedAffectedArchives as $archive) {
-            $this->assertContains("[ idSite = {$archive['idsite']}, date = {$archive['server_time']} ]", $this->applicationTester->getDisplay());
+            self::assertStringContainsString("[ idSite = {$archive['idsite']}, date = {$archive['server_time']} ]", $this->applicationTester->getDisplay());
         }
     }
 

--- a/plugins/CoreAdminHome/tests/Integration/Model/DuplicateActionRemoverTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Model/DuplicateActionRemoverTest.php
@@ -28,7 +28,7 @@ class DuplicateActionRemoverTest extends IntegrationTestCase
      */
     private $duplicateActionRemover;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/CoreAdminHome/tests/Integration/SetConfigTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/SetConfigTest.php
@@ -22,21 +22,21 @@ class SetConfigTest extends ConsoleCommandTestCase
 {
     const TEST_CONFIG_PATH = '/tmp/test.config.ini.php';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::removeTestConfigFile();
 
         parent::setUpBeforeClass();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         self::removeTestConfigFile();
 
         parent::setUp();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $this->makeLocalConfigWritable();
@@ -57,7 +57,7 @@ class SetConfigTest extends ConsoleCommandTestCase
         $config = $this->makeNewConfig();
         $this->assertEquals(array('setting' => 'myvalue'), $config->MySection);
 
-        $this->assertContains('Setting [MySection] setting = "myvalue"', $this->applicationTester->getDisplay());
+        self::assertStringContainsString('Setting [MySection] setting = "myvalue"', $this->applicationTester->getDisplay());
     }
 
     /**
@@ -72,7 +72,7 @@ class SetConfigTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains('Invalid assignment string', $this->applicationTester->getDisplay());
+        self::assertStringContainsString('Invalid assignment string', $this->applicationTester->getDisplay());
     }
 
     public function getInvalidArgumentsForTest()
@@ -99,7 +99,7 @@ class SetConfigTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains('[Piwik\Exception\MissingFilePermissionException]', $this->applicationTester->getDisplay());
+        self::assertStringContainsString('[Piwik\Exception\MissingFilePermissionException]', $this->applicationTester->getDisplay());
     }
 
     public function test_Command_SucceedsWhenArgumentsUsed()
@@ -131,7 +131,7 @@ class SetConfigTest extends ConsoleCommandTestCase
         $this->assertEquals(array('def'), $config->MySection['object_value']);
         $this->assertArrayNotHasKey('other_array_value', $config->MySection);
 
-        $this->assertContains("done.", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("done.", $this->applicationTester->getDisplay());
     }
 
     /**
@@ -150,7 +150,7 @@ class SetConfigTest extends ConsoleCommandTestCase
         $config = self::makeNewConfig();
 
         $this->assertEquals(0, $config->Tracker['debug']);
-        $this->assertContains("done.", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("done.", $this->applicationTester->getDisplay());
     }
 
     public function getOptionsForSettingValueToZeroTests()

--- a/plugins/CoreAdminHome/tests/Integration/TasksTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/TasksTest.php
@@ -58,7 +58,7 @@ class TasksTest extends IntegrationTestCase
      */
     private $mail;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -77,7 +77,7 @@ class TasksTest extends IntegrationTestCase
         $this->mail = null;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_GET['trigger']);
 

--- a/plugins/CoreAdminHome/tests/Unit/SetConfig/ConfigSettingManipulationTest.php
+++ b/plugins/CoreAdminHome/tests/Unit/SetConfig/ConfigSettingManipulationTest.php
@@ -51,7 +51,7 @@ class ConfigSettingManipulationTest extends \PHPUnit\Framework\TestCase
      */
     private $mockConfig;
 
-    protected function setUp()
+    public function setUp(): void
     {
         $this->mockConfig = new DumbMockConfig();
         $this->mockConfigData = array();
@@ -94,11 +94,12 @@ class ConfigSettingManipulationTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider getFailureTestDataForMake
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid assignment string
      */
     public function test_make_ThrowsWhenInvalidAssignmentStringSupplied($assignmentString)
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid assignment string');
+
         ConfigSettingManipulation::make($assignmentString);
     }
 
@@ -113,24 +114,22 @@ class ConfigSettingManipulationTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Trying to append to non-array setting value
-     */
     public function test_manipulate_ThrowsIfAppendingNonArraySetting()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Trying to append to non-array setting value');
+
         $this->mockConfig->mockConfigData['General']['config'] = "5";
 
         $manipulation = new ConfigSettingManipulation("General", "config", "10", true);
         $manipulation->manipulate($this->mockConfig);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Trying to set non-array value to array setting
-     */
     public function test_manipulate_ThrowsIfAssigningNonArrayValue_ToArraySetting()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Trying to set non-array value to array setting');
+
         $this->mockConfig->mockConfigData['General']['config'] = array("5");
 
         $manipulation = new ConfigSettingManipulation("General", "config", "10", false);

--- a/plugins/CoreConsole/tests/System/ArchiveCronTest.php
+++ b/plugins/CoreConsole/tests/System/ArchiveCronTest.php
@@ -142,7 +142,7 @@ class ArchiveCronTest extends SystemTestCase
         $output = implode("\n", $output);
 
         $this->assertRegExp('/Usage:\s*core:archive/', $output);
-        $this->assertNotContains("Starting Piwik reports archiving...", $output);
+        self::assertStringNotContainsString("Starting Piwik reports archiving...", $output);
     }
 
     private function setLastRunArchiveOptions()

--- a/plugins/CoreHome/tests/Integration/Column/UserIdTest.php
+++ b/plugins/CoreHome/tests/Integration/Column/UserIdTest.php
@@ -33,7 +33,7 @@ class UserIdTest extends IntegrationTestCase
 
     protected $date = '2014-04-04';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->userId = new UserId();
@@ -45,7 +45,7 @@ class UserIdTest extends IntegrationTestCase
         Fixture::createWebsite('2014-01-01 00:00:00');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // clean up your test here if needed
         $tables = ArchiveTableCreator::getTablesArchivesInstalled();

--- a/plugins/CoreHome/tests/Integration/LoginWhitelistTest.php
+++ b/plugins/CoreHome/tests/Integration/LoginWhitelistTest.php
@@ -42,7 +42,7 @@ class LoginWhitelistTest extends IntegrationTestCase
 
     private $cliMode;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -52,7 +52,7 @@ class LoginWhitelistTest extends IntegrationTestCase
         $this->whitelist = new CustomLoginWhitelist();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Common::$isCliMode = $this->cliMode;
         parent::tearDown();

--- a/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
+++ b/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
@@ -141,7 +141,7 @@ class VisitRequestProcessorTest extends IntegrationTestCase
         $dimensions = array();
         foreach ($dimensionOnNewVisitResults as $onNewVisitResult) {
             $dim = $this->getMockBuilder('Piwik\\Plugin\\Dimension')
-                        ->setMethods(array('shouldForceNewVisit', 'getColumnName'))
+                        ->onlyMethods(array('shouldForceNewVisit', 'getColumnName'))
                         ->getMock();
             $dim->expects($this->any())->method('shouldForceNewVisit')->will($this->returnValue($onNewVisitResult));
             $dimensions[] = $dim;

--- a/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
+++ b/plugins/CoreHome/tests/Integration/Tracker/VisitRequestProcessorTest.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\CoreHome\tests\Integration\Tracker;
 use Piwik\Cache;
 use Piwik\CacheId;
 use Piwik\Date;
+use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\CoreHome\Tracker\VisitRequestProcessor;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\Plugins\SitesManager\API;
@@ -140,7 +141,7 @@ class VisitRequestProcessorTest extends IntegrationTestCase
     {
         $dimensions = array();
         foreach ($dimensionOnNewVisitResults as $onNewVisitResult) {
-            $dim = $this->getMockBuilder('Piwik\\Plugin\\Dimension')
+            $dim = $this->getMockBuilder(VisitDimension::class)
                         ->onlyMethods(array('shouldForceNewVisit', 'getColumnName'))
                         ->getMock();
             $dim->expects($this->any())->method('shouldForceNewVisit')->will($this->returnValue($onNewVisitResult));

--- a/plugins/CoreHome/tests/Unit/CoreHomeTest.php
+++ b/plugins/CoreHome/tests/Unit/CoreHomeTest.php
@@ -22,7 +22,7 @@ class CoreHomeTest extends \PHPUnit\Framework\TestCase
      */
     private $coreHome;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/CorePluginsAdmin/tests/Integration/TagManagerTeaserTest.php
+++ b/plugins/CorePluginsAdmin/tests/Integration/TagManagerTeaserTest.php
@@ -25,7 +25,7 @@ class TagManagerTeaserTest extends IntegrationTestCase
      */
     private $teaser;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/CoreUpdater/tests/Integration/Commands/UpdateTest.php
+++ b/plugins/CoreUpdater/tests/Integration/Commands/UpdateTest.php
@@ -30,7 +30,7 @@ class UpdateTest extends ConsoleCommandTestCase
 
     private $oldScriptName = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class UpdateTest extends ConsoleCommandTestCase
         Updates_2_10_0_b5::$archiveBlobTables = null;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $_SERVER['SCRIPT_NAME'] = $this->oldScriptName;
 
@@ -96,7 +96,7 @@ class UpdateTest extends ConsoleCommandTestCase
         $this->assertEquals(0, $result, $this->getCommandDisplayOutputErrorMessage());
 
         // check no update occurred
-        $this->assertContains("Everything is already up to date.", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Everything is already up to date.", $this->applicationTester->getDisplay());
         $this->assertEquals(Version::VERSION, Option::get('version_core'));
     }
 
@@ -112,12 +112,12 @@ class UpdateTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(1, $result, $this->getCommandDisplayOutputErrorMessage());
-        $this->assertContains("Matomo could not be updated! See above for more information.", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Matomo could not be updated! See above for more information.", $this->applicationTester->getDisplay());
     }
 
     private function assertDryRunExecuted($output)
     {
-        $this->assertContains("Note: this is a Dry Run", $output);
-        $this->assertContains(self::EXPECTED_SQL_FROM_2_10, $output);
+        self::assertStringContainsString("Note: this is a Dry Run", $output);
+        self::assertStringContainsString(self::EXPECTED_SQL_FROM_2_10, $output);
     }
 }

--- a/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
+++ b/plugins/CoreUpdater/tests/Integration/ReleaseChannelTest.php
@@ -41,7 +41,7 @@ class ReleaseChannelTest extends IntegrationTestCase
      */
     private $channel;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/CoreUpdater/tests/Integration/UpdateCommunicationTest.php
+++ b/plugins/CoreUpdater/tests/Integration/UpdateCommunicationTest.php
@@ -22,7 +22,7 @@ use Piwik\View;
  */
 class UpdateCommunicationTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/plugins/CoreUpdater/tests/Unit/ModelTest.php
+++ b/plugins/CoreUpdater/tests/Unit/ModelTest.php
@@ -23,7 +23,7 @@ class ModelTest extends \PHPUnit\Framework\TestCase
      */
     private $model;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -42,14 +42,14 @@ class ModelTest extends \PHPUnit\Framework\TestCase
         $plugins = $this->model->getPluginsFromDirectoy(PIWIK_INCLUDE_PATH);
 
         $this->assertGreaterThan(40, count($plugins));
-        $this->assertContains('/plugins/API', $plugins);
-        $this->assertContains('/plugins/Actions', $plugins);
-        $this->assertContains('/plugins/Annotations', $plugins);
+        self::assertTrue(in_array('/plugins/API', $plugins));
+        self::assertTrue(in_array('/plugins/Actions', $plugins));
+        self::assertTrue(in_array('/plugins/Annotations', $plugins));
 
-        $this->assertNotContains('/plugins/.', $plugins);
-        $this->assertNotContains('/plugins/..', $plugins);
-        $this->assertNotContains('/plugins', $plugins);
-        $this->assertNotContains('/plugins/', $plugins);
+        self::assertTrue(!in_array('/plugins/.', $plugins));
+        self::assertTrue(!in_array('/plugins/..', $plugins));
+        self::assertTrue(!in_array('/plugins', $plugins));
+        self::assertTrue(!in_array('/plugins/', $plugins));
 
         foreach ($plugins as $plugin) {
             $this->assertTrue(is_dir(PIWIK_INCLUDE_PATH . $plugin));

--- a/plugins/CoreVisualizations/tests/Integration/SparklinesConfigTest.php
+++ b/plugins/CoreVisualizations/tests/Integration/SparklinesConfigTest.php
@@ -25,7 +25,7 @@ class SparklinesConfigTest extends IntegrationTestCase
      */
     private $config;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         FakeAccess::$superUser = true;
@@ -39,7 +39,7 @@ class SparklinesConfigTest extends IntegrationTestCase
         Fixture::loadAllTranslations();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
 
@@ -118,12 +118,11 @@ class SparklinesConfigTest extends IntegrationTestCase
         $this->assertSame($expectedSparkline, $sparklines[''][0]['metrics']['']);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Values: 10, 20, 30 Descriptions: Visits, Actions
-     */
     public function test_addSparkline_shouldThrowAnException_IfValuesDoesNotMatchAmountOfDescriptions()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Values: 10, 20, 30 Descriptions: Visits, Actions');
+
         $this->config->addSparkline($this->sparklineParams(), $values = array(10, 20, 30), $description = array('Visits', 'Actions'));
     }
 

--- a/plugins/CoreVisualizations/tests/Unit/GraphTest.php
+++ b/plugins/CoreVisualizations/tests/Unit/GraphTest.php
@@ -139,10 +139,10 @@ class GraphTest extends \PHPUnit\Framework\TestCase
         $dataTable = new DataTable();
         $dataTable->setRows(array($row));
 
-        $bar = $this->getMock('Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Bar',
-            array('getDataTable'),
-            array('', '')
-        );
+        $bar = $this->getMockBuilder('Piwik\Plugins\CoreVisualizations\Visualizations\JqplotGraph\Bar')
+            ->setMethods(['getDataTable'])
+            ->setConstructorArgs(['', ''])
+            ->getMock();
         $bar->expects($this->any())
             ->method('getDataTable')
             ->will($this->returnValue($dataTable));

--- a/plugins/CoreVisualizations/tests/Unit/SparklinesConfigTest.php
+++ b/plugins/CoreVisualizations/tests/Unit/SparklinesConfigTest.php
@@ -22,7 +22,7 @@ class SparklinesConfigTest extends \PHPUnit\Framework\TestCase
      */
     private $config;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->config = new Config();
     }

--- a/plugins/CustomJsTracker/tests/Integration/ApiTest.php
+++ b/plugins/CustomJsTracker/tests/Integration/ApiTest.php
@@ -26,7 +26,7 @@ class ApiTest extends IntegrationTestCase
      */
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -35,22 +35,20 @@ class ApiTest extends IntegrationTestCase
         $this->api = API::getInstance();
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     * @expectedExceptionMessage checkUserHasSomeAdminAccess
-     */
     public function test_doesIncludePluginTrackersAutomatically_failsIfNotEnoughPermission()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasSomeAdminAccess');
+
         $this->setUser();
         $this->api->doesIncludePluginTrackersAutomatically();
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     * @expectedExceptionMessage checkUserHasSomeAdminAccess
-     */
     public function test_doesIncludePluginTrackersAutomatically_failsIfNotEnoughPermissionAnonymous()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
+        $this->expectExceptionMessage('checkUserHasSomeAdminAccess');
+
         $this->setAnonymousUser();
         $this->api->doesIncludePluginTrackersAutomatically();
     }

--- a/plugins/CustomJsTracker/tests/Integration/FileTest.php
+++ b/plugins/CustomJsTracker/tests/Integration/FileTest.php
@@ -31,7 +31,7 @@ class FileTest extends IntegrationTestCase
      */
     private $dir = '';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->dir = PIWIK_DOCUMENT_ROOT . '/plugins/CustomJsTracker/tests/resources/';
@@ -44,7 +44,7 @@ class FileTest extends IntegrationTestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // restore permissions changed by makeNotWritableFile()
         chmod($this->dir, 0777);
@@ -152,21 +152,19 @@ class FileTest extends IntegrationTestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Piwik\Plugins\CustomJsTracker\Exception\AccessDeniedException
-     * @expectedExceptionMessage not readable
-     */
     public function test_checkReadable_shouldThrowException_IfNotIsReadable()
     {
+        $this->expectException(\Piwik\Plugins\CustomJsTracker\Exception\AccessDeniedException::class);
+        $this->expectExceptionMessage('not readable');
+
         $this->makeNotReadableFile()->checkReadable();
     }
 
-    /**
-     * @expectedException \Piwik\Plugins\CustomJsTracker\Exception\AccessDeniedException
-     * @expectedExceptionMessage not writable
-     */
     public function test_checkWritable_shouldThrowException_IfNotIsWritable()
     {
+        $this->expectException(\Piwik\Plugins\CustomJsTracker\Exception\AccessDeniedException::class);
+        $this->expectExceptionMessage('not writable');
+
         $this->makeNotReadableFile_inNonWritableDirectory()->checkWritable();
     }
 

--- a/plugins/CustomJsTracker/tests/Integration/TrackerUpdaterTest.php
+++ b/plugins/CustomJsTracker/tests/Integration/TrackerUpdaterTest.php
@@ -24,7 +24,7 @@ class TrackerUpdaterTest extends IntegrationTestCase
     private $dir;
     private $trackerJsChangedEventPath = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->dir = PIWIK_DOCUMENT_ROOT . '/plugins/CustomJsTracker/tests/resources/';
@@ -33,7 +33,7 @@ class TrackerUpdaterTest extends IntegrationTestCase
         $this->cleanUp();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -112,12 +112,11 @@ class TrackerUpdaterTest extends IntegrationTestCase
         $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Piwik\Plugins\CustomJsTracker\Exception\AccessDeniedException
-     * @expectedExceptionMessage not writable
-     */
     public function test_checkWillSucceed_shouldNotThrowExceptionIfTargetIsNotWritable()
     {
+        $this->expectException(\Piwik\Plugins\CustomJsTracker\Exception\AccessDeniedException::class);
+        $this->expectExceptionMessage('not writable');
+
         $updater = $this->makeUpdater(null, $this->dir . 'not-writable/MyNotExisIngFilessss.js');
         $updater->checkWillSucceed();
     }

--- a/plugins/CustomJsTracker/tests/System/PiwikJsContentTest.php
+++ b/plugins/CustomJsTracker/tests/System/PiwikJsContentTest.php
@@ -33,7 +33,7 @@ class PiwikJsContentTest extends SystemTestCase
         $piwikMin = PIWIK_DOCUMENT_ROOT . '/js/piwik.min.js';
         $content  = file_get_contents($piwikMin);
 
-        $this->assertContains(PiwikJsManipulator::HOOK, $content);
+        self::assertStringContainsString(PiwikJsManipulator::HOOK, $content);
     }
 
 }

--- a/plugins/CustomVariables/tests/Commands/InfoTest.php
+++ b/plugins/CustomVariables/tests/Commands/InfoTest.php
@@ -25,7 +25,7 @@ class InfoTest extends IntegrationTestCase
 {
     public function testExecute_ShouldOutputInfoSuccess_IfEverythingIsOk()
     {
-        $this->assertContains('Your Piwik is configured for 5 custom variables.', $this->executeCommand());
+        self::assertStringContainsString('Your Piwik is configured for 5 custom variables.', $this->executeCommand());
     }
 
     public function testExecute_ShouldOutputErrorMessage_IfColumnsDoNotMatch()
@@ -33,7 +33,7 @@ class InfoTest extends IntegrationTestCase
         $model = new Model(Model::SCOPE_PAGE);
         $model->removeCustomVariable();
 
-        $this->assertContains('There is a problem with your custom variables configuration', $this->executeCommand());
+        self::assertStringContainsString('There is a problem with your custom variables configuration', $this->executeCommand());
     }
 
     private function executeCommand()

--- a/plugins/CustomVariables/tests/Commands/SetNumberOfCustomVariablesTest.php
+++ b/plugins/CustomVariables/tests/Commands/SetNumberOfCustomVariablesTest.php
@@ -23,30 +23,27 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class SetNumberOfCustomVariablesTest extends IntegrationTestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage  Not enough arguments
-     */
     public function testExecute_ShouldThrowException_IfArgumentIsMissing()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
+
         $this->executeCommand(null);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage  The number of available custom variables has to be a number
-     */
     public function testExecute_ShouldThrowException_HasToBeANumber()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The number of available custom variables has to be a number');
+
         $this->executeCommand('a');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage  There has to be at least five custom variables
-     */
     public function testExecute_ShouldThrowException_Minimum2CustomVarsRequired()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('There has to be at least five custom variables');
+
         $this->executeCommand(4);
     }
 
@@ -60,7 +57,7 @@ class SetNumberOfCustomVariablesTest extends IntegrationTestCase
     {
         $result = $this->executeCommand(5);
 
-        $this->assertContains('Your Piwik is already configured for 5 custom variables', $result);
+        self::assertStringContainsString('Your Piwik is already configured for 5 custom variables', $result);
     }
 
     public function testExecute_ShouldAddMaxCustomVars_IfNumberIsHigherThanActual()
@@ -69,13 +66,13 @@ class SetNumberOfCustomVariablesTest extends IntegrationTestCase
 
         $result = $this->executeCommand(6);
 
-        $this->assertContains('Configuring Piwik for 6 custom variables', $result);
-        $this->assertContains('1 new custom variables having the index(es) 6 will be ADDED', $result);
-        $this->assertContains('Starting to apply changes', $result);
-        $this->assertContains('Added a variable in scope "Page" having the index 6', $result);
-        $this->assertContains('Added a variable in scope "Visit" having the index 6', $result);
-        $this->assertContains('Added a variable in scope "Conversion" having the index 6', $result);
-        $this->assertContains('Your Piwik is now configured for 6 custom variables.', $result);
+        self::assertStringContainsString('Configuring Piwik for 6 custom variables', $result);
+        self::assertStringContainsString('1 new custom variables having the index(es) 6 will be ADDED', $result);
+        self::assertStringContainsString('Starting to apply changes', $result);
+        self::assertStringContainsString('Added a variable in scope "Page" having the index 6', $result);
+        self::assertStringContainsString('Added a variable in scope "Visit" having the index 6', $result);
+        self::assertStringContainsString('Added a variable in scope "Conversion" having the index 6', $result);
+        self::assertStringContainsString('Your Piwik is now configured for 6 custom variables.', $result);
 
         $this->assertEquals(6, CustomVariables::getNumUsableCustomVariables());
     }
@@ -87,13 +84,13 @@ class SetNumberOfCustomVariablesTest extends IntegrationTestCase
 
         $result = $this->executeCommand(5);
 
-        $this->assertContains('Configuring Piwik for 5 custom variables', $result);
-        $this->assertContains('1 existing custom variables having the index(es) 6 will be REMOVED.', $result);
-        $this->assertContains('Starting to apply changes', $result);
-        $this->assertContains('Removed a variable in scope "Page" having the index 6', $result);
-        $this->assertContains('Removed a variable in scope "Visit" having the index 6', $result);
-        $this->assertContains('Removed a variable in scope "Conversion" having the index 6', $result);
-        $this->assertContains('Your Piwik is now configured for 5 custom variables.', $result);
+        self::assertStringContainsString('Configuring Piwik for 5 custom variables', $result);
+        self::assertStringContainsString('1 existing custom variables having the index(es) 6 will be REMOVED.', $result);
+        self::assertStringContainsString('Starting to apply changes', $result);
+        self::assertStringContainsString('Removed a variable in scope "Page" having the index 6', $result);
+        self::assertStringContainsString('Removed a variable in scope "Visit" having the index 6', $result);
+        self::assertStringContainsString('Removed a variable in scope "Conversion" having the index 6', $result);
+        self::assertStringContainsString('Your Piwik is now configured for 5 custom variables.', $result);
 
         $this->assertEquals(5, CustomVariables::getNumUsableCustomVariables());
     }

--- a/plugins/CustomVariables/tests/Fixtures/VisitWithManyCustomVariables.php
+++ b/plugins/CustomVariables/tests/Fixtures/VisitWithManyCustomVariables.php
@@ -22,14 +22,14 @@ class VisitWithManyCustomVariables extends Fixture
     public $visitorId = '61e8cc2d51fea26d';
     private $numCustomVars = 8;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpCustomVars();
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/CustomVariables/tests/Integration/ModelTest.php
+++ b/plugins/CustomVariables/tests/Integration/ModelTest.php
@@ -21,7 +21,7 @@ class ModelTest extends IntegrationTestCase
 {
     private static $cvarScopes = array('page', 'visit', 'conversion');
 
-    public function setUp()
+    public function setUp(): void
     {
         // do not call parent::setUp() since it expects database to be created,
         // but DB for this test is removed in tearDown
@@ -29,26 +29,24 @@ class ModelTest extends IntegrationTestCase
         self::$fixture->performSetUp();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
         self::$fixture->performTearDown();
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_construct_shouldFailInCaseOfEmptyScope()
     {
+        $this->expectException(\Exception::class);
+
         new Model(null);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_construct_shouldFailInCaseOfInvalidScope()
     {
+        $this->expectException(\Exception::class);
+
         new Model('inValId');
     }
 

--- a/plugins/Dashboard/tests/Integration/APITest.php
+++ b/plugins/Dashboard/tests/Integration/APITest.php
@@ -33,7 +33,7 @@ class APITest extends IntegrationTestCase
      */
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -103,24 +103,22 @@ class APITest extends IntegrationTestCase
         $this->assertCount(1, $result);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ExceptionCheckUserHasSuperUserAccessOrIsTheUser
-     */
     public function testGetDashboardsShouldNotReturnForeignDashboardsForNonSuperUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionCheckUserHasSuperUserAccessOrIsTheUser');
+
         FakeAccess::$superUser = false;
         FakeAccess::$identity = 'eva';
 
         $this->api->getDashboards('peter', false);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ExceptionCheckUserHasSuperUserAccessOrIsTheUser
-     */
     public function testCreateNewDashboardForOtherUserDoesNotWorkForNonSuperUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionCheckUserHasSuperUserAccessOrIsTheUser');
+
         FakeAccess::$superUser = false;
 
         $layout ='[[{"uniqueId":"widgetLivewidget","parameters":{"module":"Live","action":"widget"}}]]';
@@ -168,12 +166,11 @@ class APITest extends IntegrationTestCase
         $this->assertEquals($dashboard['layout'], $layout);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Dashboard not found
-     */
     public function testCopyDashboardToUserFails()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Dashboard not found');
+
         $this->api->copyDashboardToUser(5, 'eva', 'new name');
     }
 

--- a/plugins/DevicesDetection/tests/Fixtures/MultiDeviceGoalConversions.php
+++ b/plugins/DevicesDetection/tests/Fixtures/MultiDeviceGoalConversions.php
@@ -20,7 +20,7 @@ class MultiDeviceGoalConversions extends Fixture
     public $idSite   = 1;
     public $idGoal   = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackSmartphoneVisits();
@@ -28,7 +28,7 @@ class MultiDeviceGoalConversions extends Fixture
         $this->trackOtherVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/Diagnostics/tests/Integration/Commands/AnalyzeArchiveTableTest.php
+++ b/plugins/Diagnostics/tests/Integration/Commands/AnalyzeArchiveTableTest.php
@@ -23,7 +23,7 @@ class AnalyzeArchiveTableTest extends ConsoleCommandTestCase
      */
     public static $fixture = null;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/plugins/Diagnostics/tests/Integration/ConfigReaderTest.php
+++ b/plugins/Diagnostics/tests/Integration/ConfigReaderTest.php
@@ -29,7 +29,7 @@ class ConfigReaderTest extends IntegrationTestCase
      */
     private $configReader;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/ExampleLogTables/tests/Fixtures/VisitsWithUserIdAndCustomData.php
+++ b/plugins/ExampleLogTables/tests/Fixtures/VisitsWithUserIdAndCustomData.php
@@ -19,7 +19,7 @@ class VisitsWithUserIdAndCustomData extends Fixture
 
     private static $countryCodes = ['CA', 'CN', 'DE', 'ES', 'FR', 'IE', 'IN', 'IT', 'MX', 'PT', 'RU', 'GB', 'US'];
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!self::siteCreated($idSite = 1)) {
             self::createWebsite($this->dateTime);

--- a/plugins/ExamplePlugin/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/plugins/ExamplePlugin/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -20,14 +20,14 @@ class SimpleFixtureTrackFewVisits extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         $this->trackFirstVisit();
         $this->trackSecondVisit();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/ExamplePlugin/tests/Integration/SimpleTest.php
+++ b/plugins/ExamplePlugin/tests/Integration/SimpleTest.php
@@ -18,14 +18,14 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 class SimpleTest extends IntegrationTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         // set up your test here if needed
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // clean up your test here if needed
 

--- a/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
+++ b/plugins/ExamplePlugin/tests/Unit/SimpleTest.php
@@ -15,12 +15,12 @@ namespace Piwik\Plugins\ExamplePlugin\tests\Unit;
  */
 class SimpleTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // set up here if needed
     }
     
-    public function tearDown()
+    public function tearDown(): void
     {
         // tear down here if needed
     }

--- a/plugins/Feedback/tests/Fixtures/FeedbackPopupFixture.php
+++ b/plugins/Feedback/tests/Fixtures/FeedbackPopupFixture.php
@@ -9,14 +9,14 @@ use Piwik\Tests\Fixtures\UITestFixture;
 
 class FeedbackPopupFixture extends UITestFixture
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $yesterday = Date::yesterday();
         Option::set('Feedback.nextFeedbackReminder.superUserLogin', $yesterday->toString('Y-m-d'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Option::delete('Feedback.nextFeedbackReminder.superUserLogin');

--- a/plugins/Feedback/tests/Integration/ControllerTest.php
+++ b/plugins/Feedback/tests/Integration/ControllerTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Plugins\Feedback\tests\Unit;
+namespace Piwik\Plugins\Feedback\tests\Integration;
 
 use Piwik\Date;
 use Piwik\NoAccessException;
@@ -26,7 +26,7 @@ class ControllerTest extends IntegrationTestCase
 
     private $now;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->controller = new Controller();
@@ -47,7 +47,7 @@ class ControllerTest extends IntegrationTestCase
         Date::$now = Date::factory('2019-05-31')->getTimestamp();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Option::deleteLike('Feedback.nextFeedbackReminder.%');
         $this->userModel->deleteUserOnly('user1');
@@ -84,9 +84,9 @@ class ControllerTest extends IntegrationTestCase
 
     public function test_updateFeedbackReminder_notLoggedIn()
     {
+        $this->expectException(NoAccessException::class);
         FakeAccess::$identity = null;
         FakeAccess::$superUser = false;
-        $this->setExpectedException(NoAccessException::class);
         $this->controller->updateFeedbackReminderDate();
     }
 }

--- a/plugins/Feedback/tests/Integration/FeedbackTest.php
+++ b/plugins/Feedback/tests/Integration/FeedbackTest.php
@@ -26,11 +26,11 @@ class FeedbackTest extends IntegrationTestCase
 
     private $now;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
-        $this->feedback = $this->getMock(Feedback::class, ['isDisabledInTestMode']);
+        $this->feedback = $this->createPartialMock(Feedback::class, ['isDisabledInTestMode']);
         $this->feedback->method('isDisabledInTestMode')->willReturn(false);
 
         $this->userModel = new Model();
@@ -48,7 +48,7 @@ class FeedbackTest extends IntegrationTestCase
         $this->now = Date::$now;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Option::deleteLike('Feedback.nextFeedbackReminder.%');
         $this->userModel->deleteUserOnly('user1');

--- a/plugins/GeoIp2/tests/System/ConvertRegionCodesToIsoTest.php
+++ b/plugins/GeoIp2/tests/System/ConvertRegionCodesToIsoTest.php
@@ -30,7 +30,7 @@ class ConvertRegionCodesToIsoTest extends IntegrationTestCase
 
     protected static $idSite;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -81,7 +81,7 @@ class ConvertRegionCodesToIsoTest extends IntegrationTestCase
         Fixture::checkResponse($t->doTrackPageView('It\'s pitch black...'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Option::delete(ConvertRegionCodesToIso::OPTION_NAME);
@@ -115,7 +115,7 @@ class ConvertRegionCodesToIsoTest extends IntegrationTestCase
 
         $result = $this->executeCommand();
 
-        $this->assertContains('All region codes converted', $result);
+        self::assertStringContainsString('All region codes converted', $result);
 
         $queryParams = array(
             'idSite'  => self::$idSite,

--- a/plugins/GeoIp2/tests/Unit/GeoIp2Test.php
+++ b/plugins/GeoIp2/tests/Unit/GeoIp2Test.php
@@ -14,7 +14,7 @@ use Piwik\Plugins\GeoIp2\LocationProvider\GeoIp2;
 use Piwik\Plugins\UserCountry\LocationProvider;
 use Exception;
 
-class GeoIp2Test extends \PHPUnit_Framework_TestCase
+class GeoIp2Test extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test that redundant checks work.
@@ -71,7 +71,7 @@ class GeoIp2Test extends \PHPUnit_Framework_TestCase
 
     protected $backUpNames;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->backUpNames = GeoIp2::$dbNames;
 
@@ -81,7 +81,7 @@ class GeoIp2Test extends \PHPUnit_Framework_TestCase
         ];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         GeoIp2::$dbNames = $this->backUpNames;
 

--- a/plugins/Goals/tests/Integration/APITest.php
+++ b/plugins/Goals/tests/Integration/APITest.php
@@ -29,7 +29,7 @@ class APITest extends IntegrationTestCase
 
     private $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->api = API::getInstance();
@@ -100,39 +100,35 @@ class APITest extends IntegrationTestCase
         $this->assertGoal($idGoal, 'MyName', '', 'title', 'rere(.*)', 'regex', 1, 50, 1);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ValidatorErrorXNotWhitelisted
-     */
     public function test_addGoal_shouldThrowException_IfPatternTypeIsInvalid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorXNotWhitelisted');
+
         $this->api->addGoal($this->idSite, 'MyName', 'external_website', 'www.test.de', 'invalid');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ValidatorErrorNoValidRegex
-     */
     public function test_addGoal_shouldThrowException_IfPatternRegexIsInvalid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorNoValidRegex');
+
         $this->api->addGoal($this->idSite, 'MyName', 'url', '/(%$f', 'regex');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Goals_ExceptionInvalidMatchingString
-     */
     public function test_addGoal_shouldThrowException_IfPatternTypeIsExactAndMatchAttributeNotEvent()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Goals_ExceptionInvalidMatchingString');
+
         $this->api->addGoal($this->idSite, 'MyName', 'url', 'www.test.de', 'exact');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Goals_ExceptionInvalidMatchingString
-     */
     public function test_addGoal_shouldThrowException_IfPatternTypeIsExactAndMatchAttributeNotEvent2()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Goals_ExceptionInvalidMatchingString');
+
         $this->api->addGoal($this->idSite, 'MyName', 'external_website', 'www.test.de', 'exact');
     }
 
@@ -145,34 +141,31 @@ class APITest extends IntegrationTestCase
         $this->assertSame('3', (string)$idGoal);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasWriteAccess Fake exception
-     */
     public function test_addGoal_shouldThrowException_IfNotEnoughPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasWriteAccess Fake exception');
+
         $this->setNonAdminUser();
         $this->createAnyGoal();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasWriteAccess Fake exception
-     */
     public function test_updateGoal_shouldThrowException_IfNotEnoughPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasWriteAccess Fake exception');
+
         $idGoal = $this->createAnyGoal();
         $this->assertSame(1, $idGoal); // make sure goal is created and does not already fail here
         $this->setNonAdminUser();
         $this->api->updateGoal($this->idSite, $idGoal, 'MyName', 'url', 'www.test.de', 'exact');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Goals_ExceptionInvalidMatchingString
-     */
     public function test_updateGoal_shouldThrowException_IfPatternTypeIsExactAndMatchAttributeNotEvent()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Goals_ExceptionInvalidMatchingString');
+
         $idGoal = $this->createAnyGoal();
         $this->api->updateGoal($this->idSite, $idGoal, 'MyName', 'url', 'www.test.de', 'exact');
     }
@@ -236,12 +229,11 @@ class APITest extends IntegrationTestCase
         $this->assertHasNoGoals();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasViewAccess Fake exception
-     */
     public function test_getGoal_shouldThrowException_IfNotEnoughPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('heckUserHasViewAccess Fake exception');
+
         $idGoal = $this->createAnyGoal();
         $this->assertSame(1, $idGoal);
         $this->setNonAdminUser();

--- a/plugins/Goals/tests/Unit/AppendNameToColumnNamesTest.php
+++ b/plugins/Goals/tests/Unit/AppendNameToColumnNamesTest.php
@@ -26,7 +26,7 @@ class AppendNameToColumnNamesTest extends \PHPUnit\Framework\TestCase
      */
     private $table;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable\Simple();
         $this->addRow(array('nb_visits' => 1, 'nb_conversions' => 5, 'revenue' => 10, 'conversion_rate' => 20));

--- a/plugins/Insights/tests/Fixtures/SomeVisitsDifferentPathsOnTwoDays.php
+++ b/plugins/Insights/tests/Fixtures/SomeVisitsDifferentPathsOnTwoDays.php
@@ -21,13 +21,13 @@ class SomeVisitsDifferentPathsOnTwoDays extends Fixture
     public $date1  = '2010-12-14';
     public $date2  = '2010-12-13';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/Insights/tests/Integration/ApiTest.php
+++ b/plugins/Insights/tests/Integration/ApiTest.php
@@ -35,7 +35,7 @@ class ApiTest extends SystemTestCase
     private $api;
     private $idSite;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -45,7 +45,7 @@ class ApiTest extends SystemTestCase
         $this->api = API::getInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -88,7 +88,7 @@ class ApiTest extends SystemTestCase
             'evolutionDifference' => -9
         );
 
-        $this->assertInternalType('array', $metadata['report']);
+        self::assertIsArray($metadata['report']);
         $this->assertEquals('Actions', $metadata['report']['module']);
         $this->assertEquals('getPageUrls', $metadata['report']['action']);
         unset($metadata['report']);

--- a/plugins/Insights/tests/Integration/ModelTest.php
+++ b/plugins/Insights/tests/Integration/ModelTest.php
@@ -18,7 +18,6 @@ use Piwik\Tests\Framework\TestCase\SystemTestCase;
  * @group Insights
  * @group ModelTest
  * @group Plugins
- * @group Plugins
  */
 class ModelTest extends SystemTestCase
 {
@@ -32,7 +31,7 @@ class ModelTest extends SystemTestCase
      */
     private $model;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -101,7 +100,7 @@ class ModelTest extends SystemTestCase
         $total = $this->model->getMetricTotalValue($table, 'nb_visits');
 
         $this->assertEquals(17, $total);
-        $this->assertInternalType('integer', $total);
+        self::assertIsInt($total);
     }
 
     public function test_getMetricTotalValue_shouldReturnZeroIfMetricHasNoTotal()
@@ -114,11 +113,10 @@ class ModelTest extends SystemTestCase
         $this->assertEquals(0, $total);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_getLastDate_shouldThrowExceptionIfNotPossibleToGetLastDate()
     {
+        $this->expectException(\Exception::class);
+
         $this->model->getLastDate('last10', 'day', 1);
     }
 

--- a/plugins/Insights/tests/Unit/FilterExcludeLowValueTest.php
+++ b/plugins/Insights/tests/Unit/FilterExcludeLowValueTest.php
@@ -20,7 +20,7 @@ use Piwik\Plugins\Insights\DataTable\Filter\ExcludeLowValue;
  */
 class FilterExcludeLowValueTest extends BaseUnitTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
         $this->table->addRowsFromArray(array(

--- a/plugins/Insights/tests/Unit/FilterInsightTest.php
+++ b/plugins/Insights/tests/Unit/FilterInsightTest.php
@@ -30,7 +30,7 @@ class FilterInsightTest extends BaseUnitTest
      */
     private $pastTable;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->currentTable = new DataTable();
         $this->currentTable->addRowsFromArray(array(

--- a/plugins/Insights/tests/Unit/FilterLimitTest.php
+++ b/plugins/Insights/tests/Unit/FilterLimitTest.php
@@ -20,7 +20,7 @@ use Piwik\Plugins\Insights\DataTable\Filter\Limit;
  */
 class FilterLimitTest extends BaseUnitTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
         $this->table->addRowsFromArray(array(

--- a/plugins/Insights/tests/Unit/FilterMinGrowthTest.php
+++ b/plugins/Insights/tests/Unit/FilterMinGrowthTest.php
@@ -21,7 +21,7 @@ use Piwik\Plugins\Insights\DataTable\Filter\MinGrowth;
 class FilterMinGrowthTest extends BaseUnitTest
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
         $this->table->addRowsFromArray(array(

--- a/plugins/Insights/tests/Unit/FilterOrderByTest.php
+++ b/plugins/Insights/tests/Unit/FilterOrderByTest.php
@@ -21,7 +21,7 @@ use Piwik\Tests\Framework\TestCase\SystemTestCase;
  */
 class FilterOrderByTest extends BaseUnitTest
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
     }

--- a/plugins/Insights/tests/Unit/InsightReportTest.php
+++ b/plugins/Insights/tests/Unit/InsightReportTest.php
@@ -55,7 +55,7 @@ class InsightReportTest extends \PHPUnit\Framework\TestCase
      */
 
     // TODO use data providers
-    public function setUp()
+    public function setUp(): void
     {
         $this->currentTable = new DataTable();
         $this->currentTable->addRowsFromArray(array(
@@ -110,12 +110,11 @@ class InsightReportTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Unsupported orderBy
-     */
     public function test_generateInsight_Order_ShouldThrowException_IfInvalid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unsupported orderBy');
+
         $this->generateInsight(2, 2, 2, 17, -17, 'InvalidOrDeRbY');
     }
 
@@ -270,7 +269,7 @@ class InsightReportTest extends \PHPUnit\Framework\TestCase
             'minDisappearedPercent' => 8,
         );
 
-        $this->assertInternalType('array', $metadata['report']);
+        self::assertIsArray($metadata['report']);
         $this->assertEquals('TestReport', $metadata['report']['name']);
         unset($metadata['report']);
         unset($metadata['totals']);

--- a/plugins/Installation/tests/System/APITest.php
+++ b/plugins/Installation/tests/System/APITest.php
@@ -25,7 +25,7 @@ class APITest extends SystemTestCase
      */
     public static $fixture = null; // initialized below class definition
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -47,7 +47,7 @@ class APITest extends SystemTestCase
         $data = str_replace("\n", "", $response['data']);
 
         $this->assertStringStartsWith('<?xml version="1.0" encoding="utf-8" ?><result>	<error message=', $data);
-        $this->assertContains('Access denied', $data);
+        self::assertStringContainsString('Access denied', $data);
         $this->assertStringEndsWith('</result>', $data);
     }
 
@@ -58,7 +58,7 @@ class APITest extends SystemTestCase
         $data = str_replace("\n", "", $response['data']);
 
         $this->assertStringStartsWith('{"result":"error","message":"', $data);
-        $this->assertContains('Access denied', $data);
+        self::assertStringContainsString('Access denied', $data);
     }
 
     public function test_shouldReturnEmptyResultWhenNotInstalledAndDispatchIsDisabled()

--- a/plugins/IntranetMeasurable/tests/Fixtures/IntranetSitesWithVisits.php
+++ b/plugins/IntranetMeasurable/tests/Fixtures/IntranetSitesWithVisits.php
@@ -22,14 +22,14 @@ class IntranetSitesWithVisits extends Fixture
     public $idSite = 1;
     public $idSiteNotIntranet = 2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsites();
         $this->trackVisits($this->idSite);
         $this->trackVisits($this->idSiteNotIntranet);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/LanguagesManager/tests/Integration/LanguagesManagerTest.php
+++ b/plugins/LanguagesManager/tests/Integration/LanguagesManagerTest.php
@@ -87,12 +87,13 @@ class LanguagesManagerTest extends \PHPUnit\Framework\TestCase
         $translations = $translationWriter->getTranslations($language);
 
         if (empty($translations)) {
+            self::assertTrue(true);
             return; // skip language / plugin combinations that aren't present
         }
 
         $translationWriter->setTranslations($translations);
 
-        $this->assertTrue($translationWriter->isValid(), $translationWriter->getValidationMessage());
+        $this->assertTrue($translationWriter->isValid(), $translationWriter->getValidationMessage() ?: '');
 
         if ($translationWriter->wasFiltered()) {
 
@@ -116,11 +117,11 @@ class LanguagesManagerTest extends \PHPUnit\Framework\TestCase
      * test language when it's not defined
      *
      * @group Plugins
-     *
-     * @expectedException Exception
      */
     function testWriterInvalidPlugin()
     {
+        $this->expectException(\Exception::class);
+
         new Writer('de', 'iNvaLiDPluGin'); // invalid plugin throws exception
     }
 

--- a/plugins/LanguagesManager/tests/Integration/ModelTest.php
+++ b/plugins/LanguagesManager/tests/Integration/ModelTest.php
@@ -26,7 +26,7 @@ class ModelTest extends IntegrationTestCase
      */
     protected $model;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->model = new Model();
         parent::setUp();
@@ -109,7 +109,7 @@ class ModelTest extends IntegrationTestCase
         $tableNames = $this->getCurrentAvailableTableNames();
 
         foreach ($expectedTables as $expectedTable) {
-            $this->assertContains(Common::prefixTable($expectedTable), $tableNames);
+            self::assertTrue(in_array(Common::prefixTable($expectedTable), $tableNames));
         }
     }
 
@@ -118,7 +118,7 @@ class ModelTest extends IntegrationTestCase
         $tableNames = $this->getCurrentAvailableTableNames();
 
         foreach ($expectedTables as $expectedTable) {
-            $this->assertNotContains(Common::prefixTable($expectedTable), $tableNames);
+            self::assertTrue(!in_array(Common::prefixTable($expectedTable), $tableNames));
         }
     }
 

--- a/plugins/LanguagesManager/tests/Unit/TranslationWriter/WriterTest.php
+++ b/plugins/LanguagesManager/tests/Unit/TranslationWriter/WriterTest.php
@@ -44,11 +44,11 @@ class WriterTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group Core
-     *
-     * @expectedException \Exception
      */
     public function testConstructorInvalid()
     {
+        $this->expectException(\Exception::class);
+
         new Writer('en', 'InValIdPlUGin');
     }
 
@@ -115,22 +115,22 @@ class WriterTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group Core
-     *
-     * @expectedException \Exception
      */
     public function testSaveException()
     {
+        $this->expectException(\Exception::class);
+
         $writer = new Writer('it');
         $writer->save();
     }
 
     /**
      * @group Core
-     *
-     * @expectedException \Exception
      */
     public function testSaveTemporaryException()
     {
+        $this->expectException(\Exception::class);
+
         $writer = new Writer('it');
         $writer->saveTemporary();
     }
@@ -241,11 +241,12 @@ class WriterTest extends \PHPUnit\Framework\TestCase
     /**
      * @group Core
      *
-     * @expectedException \Exception
      * @dataProvider getInvalidLanguages
      */
     public function testSetLanguageInvalid($language)
     {
+        $this->expectException(\Exception::class);
+
         $writer = new Writer('en', null);
         $writer->setLanguage($language);
     }

--- a/plugins/Live/tests/Fixtures/ManyVisitsOfSameVisitor.php
+++ b/plugins/Live/tests/Fixtures/ManyVisitsOfSameVisitor.php
@@ -19,7 +19,7 @@ class ManyVisitsOfSameVisitor extends Fixture
     public $idSite = 1;
     public $idSite2 = 2;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!self::siteCreated($this->idSite)) {
             self::createWebsite($this->dateTime);
@@ -32,7 +32,7 @@ class ManyVisitsOfSameVisitor extends Fixture
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/Live/tests/Fixtures/VisitsWithAllActionsAndDevices.php
+++ b/plugins/Live/tests/Fixtures/VisitsWithAllActionsAndDevices.php
@@ -20,7 +20,7 @@ class VisitsWithAllActionsAndDevices extends Fixture
     public $dateTime = '2010-02-01 11:22:33';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!self::siteCreated($idSite = 1)) {
             self::createWebsite($this->dateTime, 1);
@@ -64,7 +64,7 @@ class VisitsWithAllActionsAndDevices extends Fixture
         $this->trackVisitTablet($t, Date::factory($this->dateTime)->addHour(156.9)->getDatetime());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/Live/tests/Integration/ModelTest.php
+++ b/plugins/Live/tests/Integration/ModelTest.php
@@ -27,7 +27,7 @@ use Piwik\Tests\Integration\SegmentTest;
  */
 class ModelTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -87,13 +87,12 @@ class ModelTest extends IntegrationTestCase
         $this->assertTrue(true);
     }
 
-	/**
-	 * @expectedException \Piwik\Plugins\Live\Exception\MaxExecutionTimeExceededException
-	 * @expectedExceptionMessage Live_QueryMaxExecutionTimeExceeded  Live_QueryMaxExecutionTimeExceededReasonUnknown
-	 */
     public function test_handleMaxExecutionTimeError_whenTimeIsExceeded_noReasonFound()
     {
-    	$db = Db::get();
+        $this->expectException(\Piwik\Plugins\Live\Exception\MaxExecutionTimeExceededException::class);
+        $this->expectExceptionMessage('Live_QueryMaxExecutionTimeExceeded  Live_QueryMaxExecutionTimeExceededReasonUnknown');
+
+        $db = Db::get();
     	$e = new \Exception('[3024] Query execution was interrupted, maximum statement execution time exceeded');
 	    $sql = 'SELECT 1';
 	    $bind = array();
@@ -106,13 +105,12 @@ class ModelTest extends IntegrationTestCase
         $model->handleMaxExecutionTimeError($db, $e, $sql, $bind, $segment, $dateStart, $dateEnd, $minTimestamp, $limit);
     }
 
-	/**
-	 * @expectedException \Piwik\Plugins\Live\Exception\MaxExecutionTimeExceededException
-	 * @expectedExceptionMessage Live_QueryMaxExecutionTimeExceeded  Live_QueryMaxExecutionTimeExceededReasonDateRange Live_QueryMaxExecutionTimeExceededReasonSegment Live_QueryMaxExecutionTimeExceededLimit
-	 */
     public function test_handleMaxExecutionTimeError_whenTimeIsExceeded_manyReasonsFound()
     {
-    	$db = Db::get();
+        $this->expectException(\Piwik\Plugins\Live\Exception\MaxExecutionTimeExceededException::class);
+        $this->expectExceptionMessage('Live_QueryMaxExecutionTimeExceeded  Live_QueryMaxExecutionTimeExceededReasonDateRange Live_QueryMaxExecutionTimeExceededReasonSegment Live_QueryMaxExecutionTimeExceededLimit');
+
+        $db = Db::get();
     	$e = new \Exception('Query execution was interrupted, maximum statement execution time exceeded');
 	    $sql = 'SELECT 1';
 	    $bind = array();

--- a/plugins/Live/tests/System/ApiCounterTest.php
+++ b/plugins/Live/tests/System/ApiCounterTest.php
@@ -35,14 +35,14 @@ class ApiCounterTest extends SystemTestCase
     private $api;
     private $idSite = 1;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$testNow = strtotime('2018-02-03 04:45:40');
 
         parent::setUpBeforeClass();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -51,12 +51,11 @@ class ApiCounterTest extends SystemTestCase
         $this->createSite();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasViewAccess Fake exception
-     */
     public function test_GetCounters_ShouldFail_IfUserHasNoPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasViewAccess Fake exception');
+
         $this->setAnonymous();
         $this->api->getCounters($this->idSite, 5);
     }

--- a/plugins/Login/tests/Integration/APITest.php
+++ b/plugins/Login/tests/Integration/APITest.php
@@ -24,19 +24,18 @@ class APITest extends IntegrationTestCase
      */
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->api = API::getInstance();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasSuperUserAccess
-     */
     public function test_unblockBruteForceIPs_requiresSuperUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasSuperUserAccess');
+
         FakeAccess::clearAccess(false, array(1,2,3));
         $this->api->unblockBruteForceIPs();
     }

--- a/plugins/Login/tests/Integration/LoginTest.php
+++ b/plugins/Login/tests/Integration/LoginTest.php
@@ -30,7 +30,7 @@ class LoginTest extends IntegrationTestCase
      */
     private $auth;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Login/tests/Integration/PasswordResetterTest.php
+++ b/plugins/Login/tests/Integration/PasswordResetterTest.php
@@ -39,7 +39,7 @@ class PasswordResetterTest extends IntegrationTestCase
      */
     private $passwordResetter;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->passwordResetter = new PasswordResetter();
@@ -83,12 +83,11 @@ class PasswordResetterTest extends IntegrationTestCase
         $this->assertNotEquals($token, $this->capturedToken);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage You have requested too many password resets recently. A new request can be made in one hour. If you have problems resetting your password, please contact your administrator for help.
-     */
     public function test_passwordReset_notAllowedMoreThanThreeTimesInAnHour()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('You have requested too many password resets recently. A new request can be made in one hour. If you have problems resetting your password, please contact your administrator for help.');
+
         $this->passwordResetter->initiatePasswordResetProcess('superUserLogin', self::NEWPASSWORD);
 
         $this->assertNotEmpty($this->capturedToken);
@@ -124,12 +123,11 @@ class PasswordResetterTest extends IntegrationTestCase
         $this->assertEquals(1, $data['requests']);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Token is invalid or has expired
-     */
     public function test_passwordReset_shouldNotAllowTokenToBeUsedMoreThanOnce()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Token is invalid or has expired');
+
         $this->passwordResetter->initiatePasswordResetProcess('superUserLogin', self::NEWPASSWORD);
         $this->assertNotEmpty($this->capturedToken);
 
@@ -157,12 +155,11 @@ class PasswordResetterTest extends IntegrationTestCase
         $this->assertNotEquals($oldCapturedToken, $this->capturedToken);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Token is invalid or has expired
-     */
     public function test_passwordReset_shouldNotAllowOldTokenToBeUsedAfterAnotherResetRequest()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Token is invalid or has expired');
+
         $this->passwordResetter->initiatePasswordResetProcess('superUserLogin', self::NEWPASSWORD);
         $this->assertNotEmpty($this->capturedToken);
 

--- a/plugins/Login/tests/Integration/PasswordVerifierTest.php
+++ b/plugins/Login/tests/Integration/PasswordVerifierTest.php
@@ -27,7 +27,7 @@ class PasswordVerifierTest extends IntegrationTestCase
      */
     private $verifier;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Login/tests/Integration/Security/BruteForceDetectionTest.php
+++ b/plugins/Login/tests/Integration/Security/BruteForceDetectionTest.php
@@ -50,7 +50,7 @@ class BruteForceDetectionTest extends IntegrationTestCase
      */
     private $settings;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Login/tests/Integration/SessionInitializerTest.php
+++ b/plugins/Login/tests/Integration/SessionInitializerTest.php
@@ -22,7 +22,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class SessionInitializerTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -69,7 +69,7 @@ class SessionInitializerTest extends IntegrationTestCase
 
     private function assertAuthCookieIsCreated(Cookie $cookie)
     {
-        $this->assertContains('login=czo5OiJ0ZXN0bG9naW4iOw==:token_auth=czozMjoiOWU5MDYxZjk2MDI0YTY3NWFmOGFkNWZmNmNiZGY2ZGMiOw==',
+        self::assertStringContainsString('login=czo5OiJ0ZXN0bG9naW4iOw==:token_auth=czozMjoiOWU5MDYxZjk2MDI0YTY3NWFmOGFkNWZmNmNiZGY2ZGMiOw==',
             $cookie->generateContentString());
     }
 

--- a/plugins/Login/tests/Integration/SystemSettingsTest.php
+++ b/plugins/Login/tests/Integration/SystemSettingsTest.php
@@ -30,7 +30,7 @@ class SystemSettingsTest extends IntegrationTestCase
         '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -63,12 +63,11 @@ class SystemSettingsTest extends IntegrationTestCase
         $this->assertSame($this->exampleIps, $this->settings->whitelisteBruteForceIps->getValue());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage SitesManager_ExceptionInvalidIPFormat
-     */
     public function test_whitelisteBruteForceIps_failsWhenContainsInvalidValue()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('SitesManager_ExceptionInvalidIPFormat');
+
         $this->settings->whitelisteBruteForceIps->setValue(array(
             '127.0.0.1', 'foobar'
         ));
@@ -100,12 +99,11 @@ class SystemSettingsTest extends IntegrationTestCase
         $this->assertSame($this->exampleIps, $this->settings->blacklistedBruteForceIps->getValue());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage SitesManager_ExceptionInvalidIPFormat
-     */
     public function test_blacklistedBruteForceIps_failsWhenContainsInvalidValue()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('SitesManager_ExceptionInvalidIPFormat');
+
         $this->settings->blacklistedBruteForceIps->setValue(array(
             '127.0.0.1', 'foobar'
         ));

--- a/plugins/Marketplace/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/plugins/Marketplace/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -15,13 +15,13 @@ class SimpleFixtureTrackFewVisits extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/Marketplace/tests/Integration/ApiTest.php
+++ b/plugins/Marketplace/tests/Integration/ApiTest.php
@@ -35,7 +35,7 @@ class ApiTest extends IntegrationTestCase
      */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -50,22 +50,20 @@ class ApiTest extends IntegrationTestCase
         $this->setSuperUser();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasSuperUserAccess
-     */
     public function test_deleteLicenseKey_requiresSuperUserAccess_IfUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasSuperUserAccess');
+
         $this->setUser();
         $this->api->deleteLicenseKey();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasSuperUserAccess
-     */
     public function test_deleteLicenseKey_requiresSuperUserAccess_IfAnonymous()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasSuperUserAccess');
+
         $this->setAnonymousUser();
         $this->api->deleteLicenseKey();
     }
@@ -80,32 +78,29 @@ class ApiTest extends IntegrationTestCase
         $this->assertNotHasLicenseKey();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasSuperUserAccess
-     */
     public function test_saveLicenseKey_requiresSuperUserAccess_IfUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasSuperUserAccess');
+
         $this->setUser();
         $this->api->saveLicenseKey('key');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasSuperUserAccess
-     */
     public function test_saveLicenseKey_requiresSuperUserAccess_IfAnonymous()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasSuperUserAccess');
+
         $this->setAnonymousUser();
         $this->api->saveLicenseKey('key');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Marketplace_ExceptionLinceseKeyIsNotValid
-     */
     public function test_saveLicenseKey_shouldThrowException_IfTokenIsNotValid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Marketplace_ExceptionLinceseKeyIsNotValid');
+
         $this->service->returnFixture('v2.0_consumer_validate-access_token-notexistingtoken.json');
         $this->api->saveLicenseKey('key');
     }
@@ -137,12 +132,11 @@ class ApiTest extends IntegrationTestCase
         $this->assertSame('123licensekey', $this->buildLicenseKey()->get());
     }
 
-    /**
-     * @expectedExceptionMessage Host not reachable
-     * @expectedException \Piwik\Plugins\Marketplace\Api\Service\Exception
-     */
     public function test_saveLicenseKey_shouldThrowException_IfConnectionToMarketplaceFailed()
     {
+        $this->expectException(\Piwik\Plugins\Marketplace\Api\Service\Exception::class);
+        $this->expectExceptionMessage('Host not reachable');
+
         $this->service->throwException(new ServiceException('Host not reachable', ServiceException::HTTP_ERROR));
         $success = $this->api->saveLicenseKey('123licensekey');
         $this->assertTrue($success);

--- a/plugins/Marketplace/tests/Integration/ClientTest.php
+++ b/plugins/Marketplace/tests/Integration/ClientTest.php
@@ -32,7 +32,7 @@ class ClientTest extends IntegrationTestCase
      */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -54,12 +54,11 @@ class ClientTest extends IntegrationTestCase
         $this->assertStringEndsWith('.zip', $file);
     }
 
-    /**
-     * @expectedException \Piwik\Plugins\Marketplace\Api\Exception
-     * @expectedExceptionMessage Requested plugin does not exist.
-     */
     public function test_getPluginInfo_shouldThrowException_IfNotAllowedToRequestPlugin()
     {
+        $this->expectException(\Piwik\Plugins\Marketplace\Api\Exception::class);
+        $this->expectExceptionMessage('Requested plugin does not exist.');
+
         $this->service->returnFixture('v2.0_plugins_CustomPlugin1_info-access_token-notexistingtoken.json');
         $this->client->getPluginInfo('CustomPlugin1');
     }

--- a/plugins/Marketplace/tests/Integration/EnvironmentTest.php
+++ b/plugins/Marketplace/tests/Integration/EnvironmentTest.php
@@ -28,7 +28,7 @@ class EnvironmentTest extends IntegrationTestCase
      */
     private $environment;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Marketplace/tests/Integration/Input/PluginNameTest.php
+++ b/plugins/Marketplace/tests/Integration/Input/PluginNameTest.php
@@ -19,7 +19,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class PluginNameTest extends IntegrationTestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_GET['pluginName']);
     }
@@ -32,12 +32,11 @@ class PluginNameTest extends IntegrationTestCase
         $this->assertSame('CoreFooBar', $pluginName->getPluginName());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Invalid plugin name given
-     */
     public function test_throws_exception_ifInvalidName()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid plugin name given');
+
         $this->setPluginName('CoreFooBar-?4');
 
         $pluginName = new PluginName();

--- a/plugins/Marketplace/tests/Integration/LicenseKeyTest.php
+++ b/plugins/Marketplace/tests/Integration/LicenseKeyTest.php
@@ -24,7 +24,7 @@ class LicenseKeyTest extends IntegrationTestCase
      */
     private $licenseKey;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Marketplace/tests/Integration/Plugins/InvalidLicensesTest.php
+++ b/plugins/Marketplace/tests/Integration/Plugins/InvalidLicensesTest.php
@@ -47,7 +47,7 @@ class InvalidLicensesTest extends IntegrationTestCase
 
     private $cacheKey = 'Marketplace_ExpiredPlugins';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -56,7 +56,7 @@ class InvalidLicensesTest extends IntegrationTestCase
         $this->cache = new Eager(new ArrayCache(), 'test');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
         parent::tearDown();

--- a/plugins/Marketplace/tests/Integration/PluginsTest.php
+++ b/plugins/Marketplace/tests/Integration/PluginsTest.php
@@ -41,7 +41,7 @@ class PluginsTest extends IntegrationTestCase
      */
     private $consumerService;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -87,7 +87,7 @@ class PluginsTest extends IntegrationTestCase
             'TreemapVisualization',
         );
         foreach ($expected as $name) {
-            $this->assertContains($name, $pluginNames);
+            self::assertTrue(in_array($name, $pluginNames));
         }
     }
 
@@ -398,9 +398,9 @@ class PluginsTest extends IntegrationTestCase
             }
 
             if ($plugin['owner'] === 'PiwikPRO') {
-                $this->assertContains($piwikProCampaign, $plugin['homepage']);
+                self::assertStringContainsString($piwikProCampaign, $plugin['homepage']);
             } else {
-                $this->assertNotContains($piwikProCampaign, $plugin['homepage']);
+                self::assertStringNotContainsString($piwikProCampaign, $plugin['homepage']);
             }
         }
     }

--- a/plugins/Marketplace/tests/Integration/ServiceTest.php
+++ b/plugins/Marketplace/tests/Integration/ServiceTest.php
@@ -25,31 +25,29 @@ class ServiceTest extends IntegrationTestCase
      */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->service = new TestService();
     }
 
-    /**
-     * @expectedException \Piwik\Plugins\Marketplace\Api\Service\Exception
-     * @expectedExceptionCode 101
-     * @expectedExceptionMessage Requested plugin does not exist.
-     */
     public function test_fetch_throwsApiError_WhenMarketplaceReturnsAnError()
     {
+        $this->expectException(\Piwik\Plugins\Marketplace\Api\Service\Exception::class);
+        $this->expectExceptionCode(101);
+        $this->expectExceptionMessage('Requested plugin does not exist.');
+
         $this->service->returnFixture('v2.0_plugins_CustomPlugin1_info-access_token-notexistingtoken.json');
         $this->service->fetch('plugins/CustomPlugin1/info', array());
     }
 
-    /**
-     * @expectedException \Piwik\Plugins\Marketplace\Api\Service\Exception
-     * @expectedExceptionCode 100
-     * @expectedExceptionMessage There was an error reading the response from the Marketplace
-     */
     public function test_fetch_throwsHttpError_WhenMarketplaceReturnsNoResultWhichMeansHttpError()
     {
+        $this->expectException(\Piwik\Plugins\Marketplace\Api\Service\Exception::class);
+        $this->expectExceptionCode(100);
+        $this->expectExceptionMessage('There was an error reading the response from the Marketplace');
+
         $this->service->setOnDownloadCallback(function () {
             return null;
         });

--- a/plugins/Marketplace/tests/Integration/UpdateCommunicationTest.php
+++ b/plugins/Marketplace/tests/Integration/UpdateCommunicationTest.php
@@ -33,7 +33,7 @@ class UpdateCommunicationTest extends IntegrationTestCase
      */
     private $settings;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Marketplace/tests/System/Api/ClientTest.php
+++ b/plugins/Marketplace/tests/System/Api/ClientTest.php
@@ -40,7 +40,7 @@ class ClientTest extends SystemTestCase
      */
     private $environment;
 
-    public function setUp()
+    public function setUp(): void
     {
         $releaseChannels = new Plugin\ReleaseChannels(Plugin\Manager::getInstance());
         $this->environment = new Environment($releaseChannels);
@@ -108,12 +108,11 @@ class ClientTest extends SystemTestCase
         $this->assertNotEmpty($lastVersion['download']);
     }
 
-    /**
-     * @expectedException \Piwik\Plugins\Marketplace\Api\Exception
-     * @expectedExceptionMessage Requested plugin does not exist.
-     */
     public function test_getPluginInfo_shouldThrowException_IfPluginDoesNotExistOnMarketplace()
     {
+        $this->expectException(\Piwik\Plugins\Marketplace\Api\Exception::class);
+        $this->expectExceptionMessage('Requested plugin does not exist.');
+
         $this->client->getPluginInfo('NotExistingPlugIn');
     }
 
@@ -176,7 +175,7 @@ class ClientTest extends SystemTestCase
         $this->assertLessThan(30, count($plugins));
 
         foreach ($plugins as $plugin) {
-            $this->assertContains($keywords, $plugin['keywords']);
+            self::assertStringContainsString($keywords, $plugin['keywords']);
         }
     }
 
@@ -236,7 +235,7 @@ class ClientTest extends SystemTestCase
         $this->assertTrue($cache->contains($id));
         $cachedPlugins = $cache->fetch($id);
 
-        $this->assertInternalType('array', $cachedPlugins);
+        self::assertIsArray($cachedPlugins);
         $this->assertNotEmpty($cachedPlugins);
         $this->assertGreaterThan(30, $cachedPlugins);
     }
@@ -283,7 +282,7 @@ class ClientTest extends SystemTestCase
         $this->assertSame(array('plugins', 'release_channel', 'prefer_stable', 'piwik', 'php', 'mysql', 'num_users', 'num_websites'), array_keys($service->params));
 
         $plugins = $service->params['plugins'];
-        $this->assertInternalType('string', $plugins);
+        self::assertIsString($plugins);
         $this->assertJson($plugins);
         $plugins = json_decode($plugins, true);
 

--- a/plugins/Marketplace/tests/System/Api/ServiceTest.php
+++ b/plugins/Marketplace/tests/System/Api/ServiceTest.php
@@ -85,28 +85,26 @@ class ServiceTest extends SystemTestCase
 
         $this->assertLessThan(20, count($response['plugins']));
         foreach ($response['plugins'] as $plugin) {
-            $this->assertContains($keyword, $plugin['keywords']);
+            self::assertTrue(in_array($keyword, $plugin['keywords']));
         }
     }
 
-    /**
-     * @expectedException \Piwik\Plugins\Marketplace\Api\Service\Exception
-     * @expectedExceptionMessage Not authenticated
-     * @expectedExceptionCode 101
-     */
     public function test_fetch_shouldThrowException_WhenNotBeingAuthenticated()
     {
+        $this->expectException(\Piwik\Plugins\Marketplace\Api\Service\Exception::class);
+        $this->expectExceptionCode(101);
+        $this->expectExceptionMessage('Not authenticated');
+
         $service = $this->buildService();
         $service->fetch('consumer', array());
     }
 
-    /**
-     * @expectedException \Piwik\Plugins\Marketplace\Api\Service\Exception
-     * @expectedExceptionMessage Not authenticated
-     * @expectedExceptionCode 101
-     */
     public function test_fetch_shouldThrowException_WhenBeingAuthenticatedWithInvalidTokens()
     {
+        $this->expectException(\Piwik\Plugins\Marketplace\Api\Service\Exception::class);
+        $this->expectExceptionCode(101);
+        $this->expectExceptionMessage('Not authenticated');
+
         $service = $this->buildService();
         $service->authenticate('1234567890');
         $service->fetch('consumer', array());
@@ -117,7 +115,7 @@ class ServiceTest extends SystemTestCase
         $service = $this->buildService();
         $response = $service->download($this->domain . '/api/2.0/plugins');
 
-        $this->assertInternalType('string', $response);
+        self::assertIsString($response);
         $this->assertNotEmpty($response);
         $this->assertStringStartsWith('{"plugins"', $response);
     }

--- a/plugins/Marketplace/tests/Unit/ConsumerTest.php
+++ b/plugins/Marketplace/tests/Unit/ConsumerTest.php
@@ -24,7 +24,7 @@ class ConsumerTest extends \PHPUnit\Framework\TestCase
      */
     private $service;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->service = new Service();
     }

--- a/plugins/MobileMessaging/tests/Integration/MobileMessagingTest.php
+++ b/plugins/MobileMessaging/tests/Integration/MobileMessagingTest.php
@@ -25,7 +25,7 @@ class MobileMessagingTest extends IntegrationTestCase
 {
     protected $idSiteAccess;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Monolog/tests/Integration/LogTest.php
+++ b/plugins/Monolog/tests/Integration/LogTest.php
@@ -34,7 +34,7 @@ class LogTest extends IntegrationTestCase
     public static $expectedErrorOutput = '[Monolog] [%s] dummyerrorfile.php(145): Unknown error (102) - dummy error string
   dummy backtrace';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +44,7 @@ class LogTest extends IntegrationTestCase
         Log::$debugBacktraceForTests = "dummy backtrace";
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Log::unsetInstance();
 

--- a/plugins/Monolog/tests/System/TrackerLoggingTest.php
+++ b/plugins/Monolog/tests/System/TrackerLoggingTest.php
@@ -24,7 +24,7 @@ class TrackerLoggingTest extends SystemTestCase
 {
     private $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Monolog/tests/Unit/Processor/RequestIdProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/RequestIdProcessorTest.php
@@ -16,15 +16,15 @@ use Piwik\Plugins\Monolog\Processor\RequestIdProcessor;
  * @group Log
  * @covers \Piwik\Plugins\Monolog\Processor\RequestIdProcessor
  */
-class RequestIdProcessorTest extends \PHPUnit\Framework\TestCase
+class RequestIdProcessorTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Common::$isCliMode = false;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         Common::$isCliMode = true;
@@ -40,7 +40,7 @@ class RequestIdProcessorTest extends \PHPUnit\Framework\TestCase
         $result = $processor(array());
 
         $this->assertArrayHasKey('request_id', $result['extra']);
-        $this->assertInternalType('string', $result['extra']['request_id']);
+        self::assertIsString($result['extra']['request_id']);
         $this->assertNotEmpty($result['extra']['request_id']);
     }
 

--- a/plugins/MultiSites/tests/Fixtures/ManySitesWithVisits.php
+++ b/plugins/MultiSites/tests/Fixtures/ManySitesWithVisits.php
@@ -20,7 +20,7 @@ class ManySitesWithVisits extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         $this->trackFirstVisit($this->idSite);
@@ -31,7 +31,7 @@ class ManySitesWithVisits extends Fixture
         $this->trackSecondVisit($siteId = 4);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/MultiSites/tests/Integration/DashboardTest.php
+++ b/plugins/MultiSites/tests/Integration/DashboardTest.php
@@ -29,7 +29,7 @@ class DashboardTest extends IntegrationTestCase
 
     private $numSitesToCreate = 3;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/MultiSites/tests/Integration/MultiSitesTest.php
+++ b/plugins/MultiSites/tests/Integration/MultiSitesTest.php
@@ -23,7 +23,7 @@ class MultiSitesTest extends IntegrationTestCase
 {
     protected $idSiteAccess;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -68,9 +68,9 @@ class MultiSitesTest extends IntegrationTestCase
 
         $output = FrontController::getInstance()->fetchDispatch('API');
 
-        $this->assertContains('<item>', $output);
-        $this->assertContains('</rss>', $output);
-        $this->assertNotContains('error', $output);
+        self::assertStringContainsString('<item>', $output);
+        self::assertStringContainsString('</rss>', $output);
+        self::assertStringNotContainsString('error', $output);
 
         $_GET = array();
     }

--- a/plugins/PrivacyManager/tests/Fixtures/FewVisitsAnonymizedFixture.php
+++ b/plugins/PrivacyManager/tests/Fixtures/FewVisitsAnonymizedFixture.php
@@ -20,7 +20,7 @@ class FewVisitsAnonymizedFixture extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         Option::set(PrivacyManager::OPTION_USERID_SALT, 'simpleuseridsalt1');
         Cache::clearCacheGeneral();
@@ -30,7 +30,7 @@ class FewVisitsAnonymizedFixture extends Fixture
         $this->trackAnonymizedOrderId();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/PrivacyManager/tests/Fixtures/MultipleSitesMultipleVisitsFixture.php
+++ b/plugins/PrivacyManager/tests/Fixtures/MultipleSitesMultipleVisitsFixture.php
@@ -167,7 +167,7 @@ class MultipleSitesMultipleVisitsFixture extends Fixture
     private $numSites = 5;
     private $currentUserId;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->installLogTables();
@@ -176,7 +176,7 @@ class MultipleSitesMultipleVisitsFixture extends Fixture
         $this->trackVisitsForMultipleSites();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->tearDownLocation();
     }

--- a/plugins/PrivacyManager/tests/Integration/Dao/LogDataAnonymizerTest.php
+++ b/plugins/PrivacyManager/tests/Integration/Dao/LogDataAnonymizerTest.php
@@ -36,7 +36,7 @@ class LogDataAnonymizerTest extends IntegrationTestCase
      */
     private $theFixture;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -49,7 +49,7 @@ class LogDataAnonymizerTest extends IntegrationTestCase
         $this->theFixture->setUpLocation();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->theFixture->tearDownLocation();
     }
@@ -64,30 +64,27 @@ class LogDataAnonymizerTest extends IntegrationTestCase
         $this->assertNull($this->anonymizer->checkAllVisitColumns(array('visitor_localtime', 'location_region')));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage  The column "foobarbaz" seems to not exist in log_visit or cannot be unset
-     */
     public function test_checkAllVisitColumns_notExistingColumnGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The column "foobarbaz" seems to not exist in log_visit or cannot be unset');
+
         $this->anonymizer->checkAllVisitColumns(array('visitor_localtime', 'foobarbaz'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage  The column "idsite" seems to not exist in log_visit or cannot be unset
-     */
     public function test_checkAllVisitColumns_blacklistedColumnGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The column "idsite" seems to not exist in log_visit or cannot be unset');
+
         $this->anonymizer->checkAllVisitColumns(array('visitor_localtime', 'idsite'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage  The column "visit_total_time" seems to not exist in log_visit or cannot be unset
-     */
     public function test_checkAllVisitColumns_columnWithoutDefaultValueGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The column "visit_total_time" seems to not exist in log_visit or cannot be unset');
+
         $this->anonymizer->checkAllVisitColumns(array('visitor_localtime', 'visit_total_time'));
     }
 
@@ -101,21 +98,19 @@ class LogDataAnonymizerTest extends IntegrationTestCase
         $this->assertNull($this->anonymizer->checkAllLinkVisitActionColumns(array('time_spent_ref_action', 'idaction_content_piece')));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage  The column "foobarbaz" seems to not exist in log_link_visit_action or cannot be unset
-     */
     public function test_checkAllLinkVisitActionColumns_notExistingColumnGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The column "foobarbaz" seems to not exist in log_link_visit_action or cannot be unset');
+
         $this->anonymizer->checkAllLinkVisitActionColumns(array('time_spent_ref_action', 'foobarbaz'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage  The column "idsite" seems to not exist in log_link_visit_action or cannot be unset
-     */
     public function test_checkAllLinkVisitActionColumns_blacklistedColumnGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The column "idsite" seems to not exist in log_link_visit_action or cannot be unset');
+
         $this->anonymizer->checkAllLinkVisitActionColumns(array('time_spent_ref_action', 'idsite'));
     }
 

--- a/plugins/PrivacyManager/tests/Integration/DataPurgingTest.php
+++ b/plugins/PrivacyManager/tests/Integration/DataPurgingTest.php
@@ -95,7 +95,7 @@ class DataPurgingTest extends IntegrationTestCase
         $fixture->createSuperUser = true;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -138,7 +138,7 @@ class DataPurgingTest extends IntegrationTestCase
         $this->instance = new PrivacyManager();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/PrivacyManager/tests/Integration/Model/DataSubjectsTest.php
+++ b/plugins/PrivacyManager/tests/Integration/Model/DataSubjectsTest.php
@@ -43,7 +43,7 @@ class DataSubjectsTest extends IntegrationTestCase
 
     private $originalTimezone;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -57,7 +57,7 @@ class DataSubjectsTest extends IntegrationTestCase
         $this->originalTrackingTime = $this->theFixture->trackingTime;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->theFixture->uninstallLogTables();
         $this->theFixture->tearDownLocation();

--- a/plugins/PrivacyManager/tests/Integration/Model/LogDataAnonymizationsTest.php
+++ b/plugins/PrivacyManager/tests/Integration/Model/LogDataAnonymizationsTest.php
@@ -27,7 +27,7 @@ class LogDataAnonymizationsTest extends IntegrationTestCase
 
     private $tableName;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -42,12 +42,11 @@ class LogDataAnonymizationsTest extends IntegrationTestCase
         $this->assertEquals(array('idlogdata_anonymization', 'idsites', 'date_start', 'date_end', 'anonymize_ip', 'anonymize_location', 'anonymize_userid', 'unset_visit_columns', 'unset_link_visit_action_columns', 'output', 'scheduled_date', 'job_start_date', 'job_finish_date', 'requester'), $columns);
     }
 
-    /**
-     * @expectedException \Zend_Db_Statement_Exception
-     * @expectedExceptionMessage privacy_logdata_anonymizations
-     */
     public function test_shouldBeAbleToUninstallTable()
     {
+        $this->expectException(\Zend_Db_Statement_Exception::class);
+        $this->expectExceptionMessage('privacy_logdata_anonymizations');
+
         $this->dao->uninstall();
 
         try {
@@ -61,48 +60,43 @@ class LogDataAnonymizationsTest extends IntegrationTestCase
         $this->dao->install();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ValidatorErrorEmptyValue
-     */
     public function test_scheduleEntry_fails_whenNoDateGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorEmptyValue');
+
         $this->scheduleEntry(null, null);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ExceptionInvalidDateFormat
-     */
     public function test_scheduleEntry_fails_whenInvalidDateGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionInvalidDateFormat');
+
         $this->scheduleEntry(null, 'foobar');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The column "visitor_foobar_Baz" seems to not exist in log_visit
-     */
     public function test_scheduleEntry_fails_whenInvalidVisitColumnsGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The column "visitor_foobar_Baz" seems to not exist in log_visit');
+
         $this->scheduleEntry(null, '2018-01-02', false, false, false, ['visitor_localtime', 'visitor_foobar_Baz', 'config_device_type']);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The column "idaction_foobar_baz" seems to not exist in log_link_visit_action
-     */
     public function test_scheduleEntry_fails_whenInvalidLinkVisitActionColumnsGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The column "idaction_foobar_baz" seems to not exist in log_link_visit_action');
+
         $this->scheduleEntry(null, '2018-01-02', false, false, false, [], ['idaction_event_category', 'idaction_foobar_baz']);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Nothing is selected to be anonymized
-     */
     public function test_scheduleEntry_fails_whenNoWorkScheduled()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Nothing is selected to be anonymized');
+
         $this->scheduleEntry(null, '2018-01-02', false, false, false, [], []);
     }
 
@@ -159,12 +153,11 @@ class LogDataAnonymizationsTest extends IntegrationTestCase
         ), $entry);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Specified date range is invalid.
-     */
     public function test_scheduleEntry_failsInvalidDateRange()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Specified date range is invalid.');
+
         $this->scheduleStartedEntry(null, '2018-04-06,2017-03-01', false, true, [], false, 'mylogin2');
     }
 

--- a/plugins/PrivacyManager/tests/Integration/PrivacyManagerConfigTest.php
+++ b/plugins/PrivacyManager/tests/Integration/PrivacyManagerConfigTest.php
@@ -22,7 +22,7 @@ class PrivacyManagerConfigTest extends IntegrationTestCase
      */
     private $config;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/PrivacyManager/tests/Integration/PrivacyManagerTest.php
+++ b/plugins/PrivacyManager/tests/Integration/PrivacyManagerTest.php
@@ -28,7 +28,7 @@ class PrivacyManagerTest extends IntegrationTestCase
      */
     private $manager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -38,7 +38,7 @@ class PrivacyManagerTest extends IntegrationTestCase
         \Piwik\Option::set('delete_reports_keep_week_reports', 1);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_GET['date']);
         unset($_GET['period']);

--- a/plugins/PrivacyManager/tests/Integration/Tracker/RequestProcessorTest.php
+++ b/plugins/PrivacyManager/tests/Integration/Tracker/RequestProcessorTest.php
@@ -36,7 +36,7 @@ class RequestProcessorTest extends IntegrationTestCase
      */
     private $requestProcessor;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/PrivacyManager/tests/System/APITest.php
+++ b/plugins/PrivacyManager/tests/System/APITest.php
@@ -31,18 +31,17 @@ class APITest extends SystemTestCase
      */
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->api = API::getInstance();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No list of visits given
-     */
     public function test_exportDataSubjects_failsWhenNoVisitsGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No list of visits given');
+
         $this->assertNull($this->api->exportDataSubjects(false));
     }
 
@@ -65,12 +64,11 @@ class APITest extends SystemTestCase
         $this->assertJsonResponse('exportDataSubject_allVisits', $result);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No idsite key set for visit at index 1
-     */
     public function test_exportDataSubjects_failsWhenMissingIdSite()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No idsite key set for visit at index 1');
+
         $this->assertNull($this->api->exportDataSubjects([['idsite' => '9999', 'idvisit' => '9999'], []]));
     }
 

--- a/plugins/PrivacyManager/tests/System/AnonymizationTest.php
+++ b/plugins/PrivacyManager/tests/System/AnonymizationTest.php
@@ -31,7 +31,7 @@ class AnonymizationTest extends SystemTestCase
      */
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->api = API::getInstance();

--- a/plugins/PrivacyManager/tests/System/PurgeDataTest.php
+++ b/plugins/PrivacyManager/tests/System/PurgeDataTest.php
@@ -22,7 +22,7 @@ class PurgeDataTest extends SystemTestCase
 {
     public static $fixture = null; // initialized below class definition
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
 
     }
@@ -31,12 +31,12 @@ class PurgeDataTest extends SystemTestCase
 
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUpBeforeClass();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDownAfterClass();
     }

--- a/plugins/PrivacyManager/tests/Unit/DoNotTrackHeaderCheckerTest.php
+++ b/plugins/PrivacyManager/tests/Unit/DoNotTrackHeaderCheckerTest.php
@@ -18,14 +18,14 @@ use Piwik\Plugins\PrivacyManager\DoNotTrackHeaderChecker;
  */
 class DoNotTrackHeaderCheckerTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->cleanupServerGlobals();
 
         $this->setUserAgentToChrome();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->cleanupServerGlobals();
     }

--- a/plugins/Referrers/tests/Integration/Columns/ReferrerKeywordTest.php
+++ b/plugins/Referrers/tests/Integration/Columns/ReferrerKeywordTest.php
@@ -32,7 +32,7 @@ class ReferrerKeywordTest extends IntegrationTestCase
     private $idSite2 = 2;
     private $idSite3 = 3;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/Referrers/tests/Integration/Columns/ReferrerNameTest.php
+++ b/plugins/Referrers/tests/Integration/Columns/ReferrerNameTest.php
@@ -35,7 +35,7 @@ class ReferrerNameTest extends IntegrationTestCase
     private $idSite3 = 3;
     private $idSite4 = 4;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -52,7 +52,7 @@ class ReferrerNameTest extends IntegrationTestCase
         $this->referrerName = new ReferrerName();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // clean up your test here if needed
         Cache::clearCacheGeneral();

--- a/plugins/Referrers/tests/Integration/Columns/ReferrerTypeTest.php
+++ b/plugins/Referrers/tests/Integration/Columns/ReferrerTypeTest.php
@@ -35,7 +35,7 @@ class ReferrerTypeTest extends IntegrationTestCase
     private $idSite4 = 4;
     private $idSite5 = 5;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class ReferrerTypeTest extends IntegrationTestCase
         $this->referrerType = new ReferrerType();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // clean up your test here if needed
         Cache::clearCacheGeneral();

--- a/plugins/Referrers/tests/Unit/SearchEngineTest.php
+++ b/plugins/Referrers/tests/Unit/SearchEngineTest.php
@@ -16,7 +16,7 @@ use Spyc;
  */
 class SearchEngineTest extends \PHPUnit\Framework\TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         // inject definitions to avoid database usage
         $yml = file_get_contents(PIWIK_PATH_TEST_TO_ROOT . SearchEngine::DEFINITION_FILE);
@@ -143,6 +143,8 @@ class SearchEngineTest extends \PHPUnit\Framework\TestCase
 
             $this->assertTrue(in_array($name['host'] . '.png', $favicons), $name['host']);
         }
+
+        $this->assertTrue(true); // ensure there is an assertion, to prevent warning
     }
 
     /**

--- a/plugins/Referrers/tests/Unit/SocialTest.php
+++ b/plugins/Referrers/tests/Unit/SocialTest.php
@@ -17,7 +17,7 @@ use Spyc;
  */
 class SocialTest extends \PHPUnit\Framework\TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         // inject definitions to avoid database usage
         $yml = file_get_contents(PIWIK_PATH_TEST_TO_ROOT . Social::DEFINITION_FILE);
@@ -92,6 +92,6 @@ class SocialTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetLogoFromUrl($url, $expected)
     {
-        $this->assertContains($expected, Social::getInstance()->getLogoFromUrl($url));
+        self::assertStringContainsString($expected, Social::getInstance()->getLogoFromUrl($url));
     }
 }

--- a/plugins/SEO/tests/Integration/SEOTest.php
+++ b/plugins/SEO/tests/Integration/SEOTest.php
@@ -21,7 +21,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class SEOTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/ScheduledReports/tests/Fixtures/ReportSubscription.php
+++ b/plugins/ScheduledReports/tests/Fixtures/ReportSubscription.php
@@ -18,7 +18,7 @@ class ReportSubscription extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!Fixture::siteCreated(1)) {
             Fixture::createWebsite('2012-01-01 00:00:00');

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -42,7 +42,7 @@ class ApiTest extends IntegrationTestCase
 {
     private $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -485,17 +485,16 @@ class ApiTest extends IntegrationTestCase
             $language = false, $outputType = APIScheduledReports::OUTPUT_RETURN);
         ob_end_clean();
 
-        $this->assertContains('id="VisitsSummary_get"', $result);
-        $this->assertContains('id="Referrers_getWebsites"', $result);
-        $this->assertNotContains('id="UserCountry_getCountry"', $result);
+        self::assertStringContainsString('id="VisitsSummary_get"', $result);
+        self::assertStringContainsString('id="Referrers_getWebsites"', $result);
+        self::assertStringNotContainsString('id="UserCountry_getCountry"', $result);
     }
 
-    /**
-     * @expectedException \Piwik\Http\BadRequestException
-     * @expectedExceptionMessage This API method does not support multiple periods.
-     */
     public function test_generateReport_throwsIfMultiplePeriodsRequested()
     {
+        $this->expectException(\Piwik\Http\BadRequestException::class);
+        $this->expectExceptionMessage('This API method does not support multiple periods.');
+
         $idReport = APIScheduledReports::getInstance()->addReport(
             1,
             '',
@@ -515,12 +514,11 @@ class ApiTest extends IntegrationTestCase
             $language = false, $outputType = APIScheduledReports::OUTPUT_RETURN);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Invalid evolutionPeriodFor value
-     */
     public function test_addReport_validatesEvolutionPeriodForParam()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid evolutionPeriodFor value');
+
         self::setSuperUser();
 
         APIScheduledReports::getInstance()->addReport(
@@ -541,12 +539,11 @@ class ApiTest extends IntegrationTestCase
         );
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Evolution period amount must be a positive number
-     */
     public function test_addReport_validatesEvolutionPeriodNParam()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Evolution period amount must be a positive number');
+
         self::setSuperUser();
 
         APIScheduledReports::getInstance()->addReport(
@@ -568,12 +565,11 @@ class ApiTest extends IntegrationTestCase
         );
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The evolutionPeriodN param has no effect when evolutionPeriodFor is "each".
-     */
     public function test_addReport_throwsIfEvolutionPeriodNParamIsEach_AndLastNSupplied()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The evolutionPeriodN param has no effect when evolutionPeriodFor is "each".');
+
         self::setSuperUser();
 
         APIScheduledReports::getInstance()->addReport(
@@ -595,12 +591,11 @@ class ApiTest extends IntegrationTestCase
         );
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Invalid evolutionPeriodFor value
-     */
     public function test_updateReport_validatesEvolutionPeriodForParam()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid evolutionPeriodFor value');
+
         self::setSuperUser();
 
         $idReport = APIScheduledReports::getInstance()->addReport(
@@ -635,12 +630,11 @@ class ApiTest extends IntegrationTestCase
         );
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Evolution period amount must be a positive number
-     */
     public function test_updateReport_validatesEvolutionPeriodNParam()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Evolution period amount must be a positive number');
+
         self::setSuperUser();
 
         $idReport = APIScheduledReports::getInstance()->addReport(
@@ -676,12 +670,11 @@ class ApiTest extends IntegrationTestCase
         );
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The evolutionPeriodN param has no effect when evolutionPeriodFor is "each".
-     */
     public function test_updateReport_throwsIfEvolutionPeriodNParamIsEach_AndLastNSupplied()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The evolutionPeriodN param has no effect when evolutionPeriodFor is "each".');
+
         self::setSuperUser();
 
         $idReport = APIScheduledReports::getInstance()->addReport(

--- a/plugins/ScheduledReports/tests/Integration/ReportEmailGenerator/AttachedFileReportEmailGeneratorTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ReportEmailGenerator/AttachedFileReportEmailGeneratorTest.php
@@ -24,7 +24,7 @@ class AttachedFileReportEmailGeneratorTest extends IntegrationTestCase
      */
     private $testInstance;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -54,8 +54,8 @@ class AttachedFileReportEmailGeneratorTest extends IntegrationTestCase
 
         $this->assertStringStartsWith('<html', $mail->getBodyHtml()->getContent());
         $this->assertEquals('General_Report report - pretty date', $mail->getSubject());
-        $this->assertContains('ScheduledReports_PleaseFindAttachedFile', $mailContent);
-        $this->assertContains('ScheduledReports_SentFromX', $mailContent);
+        self::assertStringContainsString('ScheduledReports_PleaseFindAttachedFile', $mailContent);
+        self::assertStringContainsString('ScheduledReports_SentFromX', $mailContent);
         $this->assertEquals('Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 Content-Disposition: inline
@@ -100,7 +100,7 @@ Content-Disposition: inline; filename="General_Report report - pretty date.thing
         $mailContent = $this->getMailContent($mail);
 
         $this->assertStringStartsWith('<html', $mailContent);
-        $this->assertContains('ScheduledReports_PleaseFindAttachedFile', $mailContent);
+        self::assertStringContainsString('ScheduledReports_PleaseFindAttachedFile', $mailContent);
         $this->assertEquals('Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 Content-Disposition: inline
@@ -130,9 +130,9 @@ Content-Disposition: inline
         $mailContent = $this->getMailContent($mail);
 
         $this->assertStringStartsWith('<html', $mailContent);
-        $this->assertContains("ScheduledReports_PleaseFindAttachedFile", $mailContent);
-        $this->assertContains('ScheduledReports_SentFromX=', $mailContent);
-        $this->assertContains('ScheduledReports_CustomVisitorSegment', $mailContent);
+        self::assertStringContainsString("ScheduledReports_PleaseFindAttachedFile", $mailContent);
+        self::assertStringContainsString('ScheduledReports_SentFromX=', $mailContent);
+        self::assertStringContainsString('ScheduledReports_CustomVisitorSegment', $mailContent);
         $this->assertEquals('Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 Content-Disposition: inline

--- a/plugins/ScheduledReports/tests/Integration/ReportEmailGenerator/HtmlReportEmailGeneratorTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ReportEmailGenerator/HtmlReportEmailGeneratorTest.php
@@ -21,7 +21,7 @@ class HtmlReportEmailGeneratorTest extends IntegrationTestCase
      */
     private $testInstance;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->testInstance = new HtmlReportEmailGenerator();

--- a/plugins/ScheduledReports/tests/Integration/ReportEmailGeneratorTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ReportEmailGeneratorTest.php
@@ -36,7 +36,7 @@ class ReportEmailGeneratorTest extends IntegrationTestCase
      */
     private $testInstance;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/ScheduledReports/tests/Integration/ScheduledReportsTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ScheduledReportsTest.php
@@ -29,7 +29,7 @@ class ScheduledReportsTest extends IntegrationTestCase
     private $reports;
     private $reportIds = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -130,7 +130,7 @@ class ScheduledReportsTest extends IntegrationTestCase
             $this->getReport($login, $idSite);
             $this->fail("Report for $login, $idSite should not exist but does");
         } catch (\Exception $e) {
-            $this->assertContains("Requested report couldn't be found", $e->getMessage());
+            self::assertStringContainsString("Requested report couldn't be found", $e->getMessage());
         }
     }
 

--- a/plugins/SegmentEditor/tests/Integration/ApiTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ApiTest.php
@@ -25,7 +25,7 @@ class ApiTest extends IntegrationTestCase
      */
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/SegmentEditor/tests/Integration/ModelTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ModelTest.php
@@ -27,7 +27,7 @@ class ModelTest extends IntegrationTestCase
 
     private $idSegment4;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->model = new Model();
@@ -53,7 +53,7 @@ class ModelTest extends IntegrationTestCase
         ));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         // Force a hard delete of segment

--- a/plugins/SegmentEditor/tests/Integration/SegmentEditorTest.php
+++ b/plugins/SegmentEditor/tests/Integration/SegmentEditorTest.php
@@ -24,7 +24,7 @@ use Exception;
  */
 class SegmentEditorTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/SegmentEditor/tests/Integration/SegmentFormatterTest.php
+++ b/plugins/SegmentEditor/tests/Integration/SegmentFormatterTest.php
@@ -28,7 +28,7 @@ class SegmentFormatterTest extends IntegrationTestCase
 
     private $idSite;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -38,7 +38,7 @@ class SegmentFormatterTest extends IntegrationTestCase
         Fixture::loadAllTranslations();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
     }
@@ -91,21 +91,19 @@ class SegmentFormatterTest extends IntegrationTestCase
         $this->assertSame('Page URL contains "piwik" or Visit ID is not "1"', $readable);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The segment 'noTexisTinG' does not exist
-     */
     public function test_getHumanReadable_ShouldThrowAnException_IfTheGivenSegmentNameDoesNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The segment \'noTexisTinG\' does not exist');
+
         $this->formatter->getHumanReadable($segment = 'noTexisTinG==1.0', $this->idSite);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The segment condition 'pageUrl=!1.0' is not valid.
-     */
     public function test_getHumanReadable_ShouldThrowAnException_IfSegmentCannotBeParsedBecauseOfInvalidFormat()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The segment condition \'pageUrl=!1.0\' is not valid.');
+
         $invalidOperator = '=!';
         $this->formatter->getHumanReadable($segment = 'pageUrl' . $invalidOperator . '1.0', $this->idSite);
     }

--- a/plugins/SegmentEditor/tests/Integration/SegmentListTest.php
+++ b/plugins/SegmentEditor/tests/Integration/SegmentListTest.php
@@ -29,7 +29,7 @@ class SegmentListTest extends IntegrationTestCase
 
     private $idSite;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -42,7 +42,7 @@ class SegmentListTest extends IntegrationTestCase
         $segmentName = 'pageUrl';
 
         $segment = $this->list->findSegment($segmentName, $this->idSite);
-        $this->assertInternalType('array', $segment);
+        self::assertIsArray($segment);
         $this->assertSame($segmentName, $segment['segment']);
     }
 
@@ -52,12 +52,11 @@ class SegmentListTest extends IntegrationTestCase
         $this->assertNull($segment);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasViewAccess
-     */
     public function test_findSegment_ShouldThrowException_IfNotEnoughPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasViewAccess');
+
         FakeAccess::clearAccess($superUser = false, array(1));
 
         $segment = $this->list->findSegment('pageUrl', 999);

--- a/plugins/SegmentEditor/tests/Integration/SegmentQueryDecoratorTest.php
+++ b/plugins/SegmentEditor/tests/Integration/SegmentQueryDecoratorTest.php
@@ -25,7 +25,7 @@ class SegmentQueryDecoratorTest extends IntegrationTestCase
      */
     private $segmentQueryDecorator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/SegmentEditor/tests/System/UnprocessedSegmentsTest.php
+++ b/plugins/SegmentEditor/tests/System/UnprocessedSegmentsTest.php
@@ -37,7 +37,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        self::assertTrue(in_array(self::TEST_SEGMENT, $segments));
+        self::assertTrue(!in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'customSegmentUnprocessed', [
             'idSite' => self::$fixture->idSite,

--- a/plugins/SegmentEditor/tests/System/UnprocessedSegmentsTest.php
+++ b/plugins/SegmentEditor/tests/System/UnprocessedSegmentsTest.php
@@ -37,7 +37,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        $this->assertNotContains(self::TEST_SEGMENT, $segments);
+        self::assertTrue(in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'customSegmentUnprocessed', [
             'idSite' => self::$fixture->idSite,
@@ -57,7 +57,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        $this->assertNotContains(self::TEST_SEGMENT, $segments);
+        self::assertTrue(!in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'realTimeSegmentUnprocessed', [
             'idSite' => self::$fixture->idSite,
@@ -77,7 +77,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        $this->assertContains(self::TEST_SEGMENT, $segments);
+        self::assertTrue(in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'autoArchiveSegmentUnprocessed', [
             'idSite' => self::$fixture->idSite,
@@ -97,7 +97,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        $this->assertContains(self::TEST_SEGMENT, $segments);
+        self::assertTrue(in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'autoArchiveSegmentUnprocessedEncoded', [
             'idSite' => self::$fixture->idSite,
@@ -120,7 +120,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        $this->assertContains(self::TEST_SEGMENT, $segments);
+        self::assertTrue(in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'autoArchiveSegmentPreprocessed', [
             'idSite' => self::$fixture->idSite,
@@ -138,7 +138,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        $this->assertNotContains(self::TEST_SEGMENT, $segments);
+        self::assertTrue(!in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'customSegmentPreprocessed', [
             'idSite' => self::$fixture->idSite,
@@ -163,7 +163,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        $this->assertContains(self::TEST_SEGMENT, $segments);
+        self::assertTrue(in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'autoArchiveSegmentNoDataPreprocessed', [
             'idSite' => self::$fixture->idSite,
@@ -185,7 +185,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        $this->assertContains(self::TEST_SEGMENT, $segments);
+        self::assertTrue(in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'noLogDataSegmentUnprocessed', [
             'idSite' => self::$fixture->idSite,
@@ -205,7 +205,7 @@ class UnprocessedSegmentsTest extends IntegrationTestCase
         Rules::setBrowserTriggerArchiving(false);
 
         $segments = Rules::getSegmentsToProcess([self::$fixture->idSite]);
-        $this->assertContains(self::TEST_SEGMENT, $segments);
+        self::assertTrue(in_array(self::TEST_SEGMENT, $segments));
 
         $this->runAnyApiTest('VisitsSummary.get', 'noLogDataSegmentUnprocessedMultiSite', [
             'idSite' => 'all',

--- a/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
+++ b/plugins/SegmentEditor/tests/Unit/SegmentQueryDecoratorTest.php
@@ -31,7 +31,7 @@ class SegmentQueryDecoratorTest extends \PHPUnit\Framework\TestCase
      */
     private $decorator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -83,8 +83,11 @@ class SegmentQueryDecoratorTest extends \PHPUnit\Framework\TestCase
 
     private function getMockSegmentEditorService()
     {
-        $mock = $this->getMock('Piwik\Plugins\SegmentEditor\Services\StoredSegmentService',
-            array('getAllSegmentsAndIgnoreVisibility'), array(), '', $callOriginalConstructor = false);
+        $mock = $this->getMockBuilder('Piwik\Plugins\SegmentEditor\Services\StoredSegmentService')
+            ->setMethods(['getAllSegmentsAndIgnoreVisibility'])
+            ->setConstructorArgs([])
+            ->disableOriginalConstructor()
+            ->getMock();
         $mock->expects($this->any())->method('getAllSegmentsAndIgnoreVisibility')->willReturn(self::$storedSegments);
         return $mock;
     }

--- a/plugins/SitesManager/tests/Fixtures/ManySites.php
+++ b/plugins/SitesManager/tests/Fixtures/ManySites.php
@@ -19,7 +19,7 @@ class ManySites extends Fixture
 {
     public $dateTime = '2010-01-03 11:22:33';
 
-    public function setUp()
+    public function setUp(): void
     {
         for ($idSite = 1; $idSite < 64; $idSite++) {
             if (!self::siteCreated($idSite)) {

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -22,7 +22,6 @@ use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Exception;
-use PHPUnit_Framework_Constraint_IsType;
 
 /**
  * Class Plugins_SitesManagerTest
@@ -33,7 +32,7 @@ use PHPUnit_Framework_Constraint_IsType;
  */
 class ApiTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -43,7 +42,7 @@ class ApiTest extends IntegrationTestCase
         FakeAccess::$superUser = true;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 
@@ -52,10 +51,11 @@ class ApiTest extends IntegrationTestCase
 
     /**
      * empty name -> exception
-     * @expectedException \Exception
      */
     public function test_addSite_WithEmptyName_ThrowsException()
     {
+        $this->expectException(\Exception::class);
+
         API::getInstance()->addSite("", array("http://piwik.net"));
     }
 
@@ -77,10 +77,10 @@ class ApiTest extends IntegrationTestCase
      * wrong urls -> exception
      *
      * @dataProvider getInvalidUrlData
-     * @expectedException \Exception
      */
     public function test_addSite_WithWrongUrls_ThrowsException($url)
     {
+        $this->expectException(\Exception::class);
         API::getInstance()->addSite("name", $url);
     }
 
@@ -155,10 +155,10 @@ class ApiTest extends IntegrationTestCase
      * Test with invalid IPs
      *
      * @dataProvider getInvalidIPsData
-     * @expectedException \Exception
      */
     public function test_addSite_WithInvalidExcludedIps_ThrowsException($ip)
     {
+        $this->expectException(\Exception::class);
         API::getInstance()->addSite("name", "http://piwik.net/", $ecommerce = 0,
             $siteSearch = 1, $searchKeywordParameters = null, $searchCategoryParameters = null, $ip);
     }
@@ -171,7 +171,7 @@ class ApiTest extends IntegrationTestCase
         $url = "http://piwik.net/";
         $urlOK = "http://piwik.net";
         $idsite = API::getInstance()->addSite("name", $url);
-        $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_INT, $idsite);
+        self::assertIsInt($idsite);
 
         $siteInfo = API::getInstance()->getSiteFromId($idsite);
         $this->assertEquals($urlOK, $siteInfo['main_url']);
@@ -189,7 +189,7 @@ class ApiTest extends IntegrationTestCase
         $urls = array("http://piwik.net/", "http://piwik.com", "https://piwik.net/test/", "piwik.net/another/test");
         $urlsOK = array("http://piwik.net", "http://piwik.com", "http://piwik.net/another/test", "https://piwik.net/test");
         $idsite = API::getInstance()->addSite("super website", $urls);
-        $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_INT, $idsite);
+        self::assertIsInt($idsite);
 
         $siteInfo = API::getInstance()->getSiteFromId($idsite);
         $this->assertEquals($urlsOK[0], $siteInfo['main_url']);
@@ -205,7 +205,7 @@ class ApiTest extends IntegrationTestCase
     {
         $name = "supertest(); ~@@()''!£\$'%%^'!£ போ";
         $idsite = API::getInstance()->addSite($name, "http://piwik.net");
-        $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_INT, $idsite);
+        self::assertIsInt($idsite);
 
         $siteInfo = API::getInstance()->getSiteFromId($idsite);
         $this->assertEquals($name, $siteInfo['name']);
@@ -213,12 +213,13 @@ class ApiTest extends IntegrationTestCase
     }
 
     /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage SitesManager_OnlyMatchedUrlsAllowed
      * @dataProvider getDifferentTypesDataProvider
      */
     public function test_addSite_ShouldFailAndNotCreatedASite_IfASettingIsInvalid($type)
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('SitesManager_OnlyMatchedUrlsAllowed');
+
         try {
             $settings = array('WebsiteMeasurable' => array(array('name' => 'exclude_unknown_urls', 'value' => 'fooBar')));
             $this->addSiteWithType($type, $settings);
@@ -263,7 +264,7 @@ class ApiTest extends IntegrationTestCase
     {
         $name = "website ";
         $idsite = API::getInstance()->addSite($name, array("http://piwik.net", "http://piwik.com/test/"));
-        $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_INT, $idsite);
+        self::assertIsInt($idsite);
 
         $siteInfo = API::getInstance()->getSiteFromId($idsite);
         $this->assertEquals($name, $siteInfo['name']);
@@ -423,10 +424,11 @@ class ApiTest extends IntegrationTestCase
 
     /**
      * wrong format urls => exception
-     * @expectedException \Exception
      */
     public function test_addSiteAliasUrls_WithIncorrectFormat_ThrowsException_3()
     {
+        $this->expectException(\Exception::class);
+
         $idsite = $this->_addSite();
         $toAdd = array("http:mpigeq");
         API::getInstance()->addSiteAliasUrls($idsite, $toAdd);
@@ -434,20 +436,20 @@ class ApiTest extends IntegrationTestCase
 
     /**
      * wrong idsite => no exception because simply no access to this resource
-     * @expectedException \Exception
      */
     public function test_addSiteAliasUrls_WithWrongIdSite_ThrowsException()
     {
+        $this->expectException(\Exception::class);
         $toAdd = array("http://pigeq.com/test");
         API::getInstance()->addSiteAliasUrls(-1, $toAdd);
     }
 
     /**
      * wrong idsite => exception
-     * @expectedException \Exception
      */
     public function test_addSiteAliasUrls_WithWrongIdSite_ThrowsException2()
     {
+        $this->expectException(\Exception::class);
         $toAdd = array("http://pigeq.com/test");
         API::getInstance()->addSiteAliasUrls(155, $toAdd);
     }
@@ -492,28 +494,28 @@ class ApiTest extends IntegrationTestCase
 
     /**
      * wrong id => exception
-     * @expectedException \Exception
      */
     public function test_getSiteFromId_WithWrongId_ThrowsException1()
     {
+        $this->expectException(\Exception::class);
         API::getInstance()->getSiteFromId(0);
     }
 
     /**
      * wrong id => exception
-     * @expectedException \Exception
      */
     public function test_getSiteFromId_WithWrongId_ThrowsException2()
     {
+        $this->expectException(\Exception::class);
         API::getInstance()->getSiteFromId("x1");
     }
 
     /**
      * wrong id : no access => exception
-     * @expectedException \Exception
      */
     public function test_getSiteFromId_ThrowsException_WhenTheUserDoesNotHavaAcessToTheSite()
     {
+        $this->expectException(\Exception::class);
         $idsite = API::getInstance()->addSite("site", array("http://piwik.net", "http://piwik.com/test/"));
         $this->assertEquals(1, $idsite);
 
@@ -531,7 +533,7 @@ class ApiTest extends IntegrationTestCase
     {
         $name = "website ''";
         $idsite = API::getInstance()->addSite($name, array("http://piwik.net", "http://piwik.com/test/"));
-        $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_INT, $idsite);
+        self::assertIsInt($idsite);
 
         $siteInfo = API::getInstance()->getSiteFromId($idsite);
         $this->assertEquals($name, $siteInfo['name']);
@@ -757,10 +759,10 @@ class ApiTest extends IntegrationTestCase
 
     /**
      * wrongId => exception
-     * @expectedException \Exception
      */
     public function test_getSiteUrlsFromId_ThrowsException_WhenSiteIdIsIncorrect()
     {
+        $this->expectException(\Exception::class);
         FakeAccess::setIdSitesView(array(3));
         FakeAccess::setIdSitesAdmin(array());
         API::getInstance()->getSiteUrlsFromId(1);
@@ -881,12 +883,11 @@ class ApiTest extends IntegrationTestCase
         $this->assertEquals($newurls, $allUrls);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage SitesManager_OnlyMatchedUrlsAllowed
-     */
     public function test_updateSite_ShouldFailAndNotUpdateSite_IfASettingIsInvalid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('SitesManager_OnlyMatchedUrlsAllowed');
+
         $type  = MobileAppMeasurable\Type::ID;
         $idSite = $this->addSiteWithType($type, array());
 
@@ -970,12 +971,11 @@ class ApiTest extends IntegrationTestCase
         );
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage SitesManager_ExceptionDeleteSite
-     */
     public function test_delete_ShouldNotDeleteASiteInCaseThereIsOnlyOneSite()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('SitesManager_ExceptionDeleteSite');
+
         $siteId1 = $this->_addSite();
 
         $this->assertHasSite($siteId1);
@@ -989,12 +989,11 @@ class ApiTest extends IntegrationTestCase
         }
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage website id = 99999498 not found
-     */
     public function test_delete_ShouldTriggerException_IfGivenSiteDoesNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('website id = 99999498 not found');
+
         API::getInstance()->deleteSite(99999498);
     }
 
@@ -1068,19 +1067,19 @@ class ApiTest extends IntegrationTestCase
     /**
      *
      * @dataProvider getInvalidTimezoneData
-     * @expectedException \Exception
      */
     public function test_addSite_WithInvalidTimezone_ThrowsException($timezone)
     {
+        $this->expectException(\Exception::class);
+
         API::getInstance()->addSite("site1", array('http://example.org'), $ecommerce = 0,
             $siteSearch = 1, $searchKeywordParameters = null, $searchCategoryParameters = null, $ip = '', $params = '', $timezone);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_addSite_WithInvalidCurrency_ThrowsException()
     {
+        $this->expectException(\Exception::class);
+
         $invalidCurrency = '€';
         API::getInstance()->addSite("site1", array('http://example.org'), $ecommerce = 0,
             $siteSearch = 1, $searchKeywordParameters = null, $searchCategoryParameters = null, '', 'UTC', $invalidCurrency);

--- a/plugins/SitesManager/tests/Integration/ModelTest.php
+++ b/plugins/SitesManager/tests/Integration/ModelTest.php
@@ -24,7 +24,7 @@ class ModelTest extends IntegrationTestCase
      */
     private $model;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/SitesManager/tests/Integration/SiteUrlsTest.php
+++ b/plugins/SitesManager/tests/Integration/SiteUrlsTest.php
@@ -29,7 +29,7 @@ class SiteUrlsTest extends IntegrationTestCase
      */
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/SitesManager/tests/Integration/SitesManagerTest.php
+++ b/plugins/SitesManager/tests/Integration/SitesManagerTest.php
@@ -35,7 +35,7 @@ class SitesManagerTest extends IntegrationTestCase
 
     private $siteId;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/SitesManager/tests/Unit/APITest.php
+++ b/plugins/SitesManager/tests/Unit/APITest.php
@@ -25,7 +25,7 @@ class APITest extends \PHPUnit\Framework\TestCase
      */
     private $api;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -38,7 +38,7 @@ class APITest extends \PHPUnit\Framework\TestCase
         $this->api = API::getInstance();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/plugins/Tour/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/plugins/Tour/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -21,13 +21,13 @@ class SimpleFixtureTrackFewVisits extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         $this->trackFirstVisit();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/Tour/tests/Integration/ChallengeTest.php
+++ b/plugins/Tour/tests/Integration/ChallengeTest.php
@@ -50,7 +50,7 @@ class ChallengeTest extends IntegrationTestCase
      */
     private $challenge2;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -58,7 +58,7 @@ class ChallengeTest extends IntegrationTestCase
         $this->challenge2 = new CustomTest2Challenge();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Challenge::clearCache();
         parent::tearDown();

--- a/plugins/Tour/tests/System/APITest.php
+++ b/plugins/Tour/tests/System/APITest.php
@@ -61,21 +61,19 @@ class APITest extends SystemTestCase
         $this->assertTrue($steps[1]['isSkipped']);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Challenge already completed
-     */
     public function test_skipStep_alreadyCompleted()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Challenge already completed');
+
         Request::processRequest('Tour.skipChallenge', array('id' => 'track_data'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Challenge not found
-     */
     public function test_skipStep_invalid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Challenge not found');
+
         Request::processRequest('Tour.skipChallenge', array('id' => 'foobarbaz'));
     }
 

--- a/plugins/Tour/tests/System/DataFinderTest.php
+++ b/plugins/Tour/tests/System/DataFinderTest.php
@@ -32,7 +32,7 @@ class DataFinderTest extends SystemTestCase
      */
     private $dataFinder;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->dataFinder = new DataFinder();

--- a/plugins/Tour/tests/System/TourTest.php
+++ b/plugins/Tour/tests/System/TourTest.php
@@ -29,7 +29,7 @@ class TourTest extends SystemTestCase
      */
     public static $fixture = null; // initialized below class definition
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/plugins/TwoFactorAuth/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/plugins/TwoFactorAuth/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -20,14 +20,14 @@ class SimpleFixtureTrackFewVisits extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         Fixture::createSuperUser(true);
         $this->createSuperUser = true;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/TwoFactorAuth/tests/Fixtures/TwoFactorFixture.php
+++ b/plugins/TwoFactorAuth/tests/Fixtures/TwoFactorFixture.php
@@ -42,7 +42,7 @@ class TwoFactorFixture extends Fixture
      */
     private $twoFa;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->dao = StaticContainer::get(RecoveryCodeDao::class);
         $this->twoFa = StaticContainer::get(TwoFactorAuthentication::class);
@@ -52,7 +52,7 @@ class TwoFactorFixture extends Fixture
         $this->trackFirstVisit();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/TwoFactorAuth/tests/Integration/APITest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/APITest.php
@@ -39,7 +39,7 @@ class APITest extends IntegrationTestCase
      */
     private $twoFa;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -56,12 +56,11 @@ class APITest extends IntegrationTestCase
         $this->twoFa = StaticContainer::get(TwoFactorAuthentication::class);
     }
 
-    /**
-     * @expectedExceptionMessage checkUserHasSuperUserAccess Fake exception
-     * @expectedException \Exception
-     */
     public function test_resetTwoFactorAuth_failsWhenNotPermissions()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasSuperUserAccess Fake exception');
+
         $this->setAdminUser();
         $this->api->resetTwoFactorAuth('login');
     }

--- a/plugins/TwoFactorAuth/tests/Integration/Dao/RecoveryCodeDaoTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/Dao/RecoveryCodeDaoTest.php
@@ -25,7 +25,7 @@ class RecoveryCodeDaoTest extends IntegrationTestCase
      */
     private $dao;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/TwoFactorAuth/tests/Integration/Dao/RecoveryCodeRandomGeneratorTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/Dao/RecoveryCodeRandomGeneratorTest.php
@@ -24,7 +24,7 @@ class RecoveryCodeRandomGeneratorTest extends IntegrationTestCase
      */
     private $generator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/TwoFactorAuth/tests/Integration/Dao/RecoveryCodeStaticGeneratorTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/Dao/RecoveryCodeStaticGeneratorTest.php
@@ -24,7 +24,7 @@ class RecoveryCodeStaticGeneratorTest extends IntegrationTestCase
      */
     private $generator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/TwoFactorAuth/tests/Integration/Dao/TwoFaSecretRandomGeneratorTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/Dao/TwoFaSecretRandomGeneratorTest.php
@@ -24,7 +24,7 @@ class TwoFaSecretRandomGeneratorTest extends IntegrationTestCase
      */
     private $generator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/TwoFactorAuth/tests/Integration/Dao/TwoFaSecretStaticGeneratorTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/Dao/TwoFaSecretStaticGeneratorTest.php
@@ -23,7 +23,7 @@ class TwoFaSecretStaticGeneratorTest extends IntegrationTestCase
      */
     private $generator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/TwoFactorAuth/tests/Integration/SystemSettingsTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/SystemSettingsTest.php
@@ -24,7 +24,7 @@ class SystemSettingsTest extends IntegrationTestCase
      */
     private $settings;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthTest.php
@@ -44,7 +44,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
     private $userPassword = '123abcDk3_l3';
     private $user2faSecret = '123456';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -64,7 +64,7 @@ class TwoFactorAuthTest extends IntegrationTestCase
         unset($_GET['authCode']);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_GET['authCode']);
     }
@@ -87,24 +87,22 @@ class TwoFactorAuthTest extends IntegrationTestCase
         $this->assertEquals(32, strlen($token));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage TwoFactorAuth_MissingAuthCodeAPI
-     */
     public function test_onApiGetTokenAuth_throwsErrorWhenMissingTokenWhenUsing2FaAndAuthenticatedCorrectly()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('TwoFactorAuth_MissingAuthCodeAPI');
+
         Request::processRequest('UsersManager.getTokenAuth', array(
             'userLogin' => $this->userWith2Fa,
             'md5Password' => md5($this->userPassword)
         ));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage TwoFactorAuth_InvalidAuthCode
-     */
     public function test_onApiGetTokenAuth_throwsErrorWhenInvalidTokenWhenUsing2FaAndAuthenticatedCorrectly()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('TwoFactorAuth_InvalidAuthCode');
+
         $_GET['authCode'] = '111222';
         Request::processRequest('UsersManager.getTokenAuth', array(
             'userLogin' => $this->userWith2Fa,

--- a/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthenticationTest.php
+++ b/plugins/TwoFactorAuth/tests/Integration/TwoFactorAuthenticationTest.php
@@ -39,7 +39,7 @@ class TwoFactorAuthenticationTest extends IntegrationTestCase
      */
     private $twoFa;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -92,21 +92,19 @@ class TwoFactorAuthenticationTest extends IntegrationTestCase
         $this->assertEquals([], $this->dao->getAllRecoveryCodesForLogin('mylogin'));
     }
 
-    /**
-     * @expectedExceptionMessage Anonymous cannot use
-     * @expectedException \Exception
-     */
     public function test_saveSecret_neverWorksForAnonymous()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Anonymous cannot use');
+
         $this->twoFa->saveSecret('anonymous', '123456');
     }
 
-    /**
-     * @expectedExceptionMessage no recovery codes have been created
-     * @expectedException \Exception
-     */
     public function test_saveSecret_notWorksWhenNoRecoveryCodesCreated()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('no recovery codes have been created');
+
         $this->twoFa->saveSecret('not', '123456');
     }
 

--- a/plugins/TwoFactorAuth/tests/System/TwoFactorAuthTest.php
+++ b/plugins/TwoFactorAuth/tests/System/TwoFactorAuthTest.php
@@ -47,7 +47,7 @@ class TwoFactorAuthTest extends SystemTestCase
      */
     private $twoFa;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/UserCountry/tests/Integration/APITest.php
+++ b/plugins/UserCountry/tests/Integration/APITest.php
@@ -29,7 +29,7 @@ class APITest extends IntegrationTestCase
      */
     private $api;
     
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -51,31 +51,28 @@ class APITest extends IntegrationTestCase
         $this->assertEquals($locationProvider, Common::getCurrentLocationProviderId());
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_setLocationProviderInvalid()
     {
+        $this->expectException(\Exception::class);
+
         $locationProvider = 'invalidProvider';
         $this->api->setLocationProvider($locationProvider);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_setLocationProviderNoSuperUser()
     {
+        $this->expectException(\Exception::class);
+
         Access::getInstance()->setSuperUserAccess(false);
 
         $locationProvider = GeoIp2\Php::ID;
         $this->api->setLocationProvider($locationProvider);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_setLocationProviderDisabledInConfig()
     {
+        $this->expectException(\Exception::class);
+
         Config::getInstance()->General['enable_geolocation_admin'] = 0;
 
         $locationProvider = GeoIp2\Php::ID;

--- a/plugins/UserCountry/tests/Integration/VisitorGeolocatorTest.php
+++ b/plugins/UserCountry/tests/Integration/VisitorGeolocatorTest.php
@@ -8,7 +8,6 @@
  */
 namespace Piwik\Plugins\UserCountry\tests\Integration;
 
-use PHPUnit_Framework_MockObject_MockObject;
 use Piwik\Common;
 use Piwik\Db;
 use Matomo\Network\IPUtils;
@@ -34,7 +33,7 @@ class VisitorGeolocatorTest extends IntegrationTestCase
      */
     private $logInserter;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -359,7 +358,7 @@ class VisitorGeolocatorTest extends IntegrationTestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|LocationProvider
+     * @return \PHPUnit\Framework\MockObject\MockObject|LocationProvider
      */
     protected function getProviderMock()
     {

--- a/plugins/UserCountry/tests/Integration/VisitorGeolocatorTest.php
+++ b/plugins/UserCountry/tests/Integration/VisitorGeolocatorTest.php
@@ -235,13 +235,13 @@ class VisitorGeolocatorTest extends IntegrationTestCase
         $geolocator = new VisitorGeolocator($mockLocationProvider);
         $valuesUpdated = $geolocator->attributeExistingVisit($visit, $useCache = false);
 
-        $this->assertEquals($expectedVisitProperties, $this->logInserter->getVisit($visit['idvisit']), $message = '', $delta = 0.001);
+        $this->assertEqualsWithDelta($expectedVisitProperties, $this->logInserter->getVisit($visit['idvisit']), $delta = 0.001);
 
         $expectedUpdateValues = $expectedUpdateValues === null ? $expectedVisitProperties : $expectedUpdateValues;
-        $this->assertEquals($expectedUpdateValues, $valuesUpdated, $message = '', $delta = 0.001);
+        $this->assertEqualsWithDelta($expectedUpdateValues, $valuesUpdated, $delta = 0.001);
 
         $conversions = $this->getConversions($visit);
-        $this->assertEquals(array($expectedVisitProperties, $expectedVisitProperties), $conversions, $message = '', $delta = 0.001);
+        $this->assertEqualsWithDelta(array($expectedVisitProperties, $expectedVisitProperties), $conversions, $delta = 0.001);
     }
 
     public function test_attributeExistingVisit_ReturnsNull_AndSkipsAttribution_IfIdVisitMissingFromInput()

--- a/plugins/UserCountry/tests/System/AttributeHistoricalDataWithLocationsTest.php
+++ b/plugins/UserCountry/tests/System/AttributeHistoricalDataWithLocationsTest.php
@@ -31,7 +31,7 @@ class AttributeHistoricalDataWithLocationsTest extends IntegrationTestCase
      */
     public static $fixture = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -60,21 +60,19 @@ class AttributeHistoricalDataWithLocationsTest extends IntegrationTestCase
         self::$fixture->setLocationProvider('GeoIP2-City.mmdb');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage  Not enough arguments
-     */
     public function testExecute_ShouldThrowException_IfArgumentIsMissing()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments');
+
         $this->executeCommand(null);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ExceptionInvalidDateFormat
-     */
     public function testExecute_ShouldReturnMessage_IfDatesAreInvalid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionInvalidDateFormat');
+
         $this->executeCommand('test');
     }
 
@@ -90,7 +88,7 @@ class AttributeHistoricalDataWithLocationsTest extends IntegrationTestCase
     {
         $result = $this->executeCommand('2010-01-03,2010-06-03');
 
-        $this->assertContains(
+        self::assertStringContainsString(
             'Re-attribution for date range: 2010-01-03 to 2010-06-03. 35 visits to process with provider "geoip2php".',
             $result
         );

--- a/plugins/UserCountry/tests/Unit/UserCountryTest.php
+++ b/plugins/UserCountry/tests/Unit/UserCountryTest.php
@@ -51,10 +51,10 @@ class UserCountryTest extends \PHPUnit\Framework\TestCase
         // Get list of countries
         foreach ($countries as $country => $continent) {
             // test continent
-            $this->assertContains($continent, $continents);
+            self::assertTrue(in_array($continent, $continents));
 
             // test flag
-            $this->assertContains($country . '.png', $flags);
+            self::assertTrue(in_array($country . '.png', $flags));
         }
 
         foreach ($flags as $filename) {

--- a/plugins/UserId/tests/Fixtures/TrackFewVisitsAndCreateUsers.php
+++ b/plugins/UserId/tests/Fixtures/TrackFewVisitsAndCreateUsers.php
@@ -19,7 +19,7 @@ class TrackFewVisitsAndCreateUsers extends Fixture
     public $dateTime = '2010-02-01 11:22:33';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!self::siteCreated($idSite = 1)) {
             self::createWebsite($this->dateTime);

--- a/plugins/UserLanguage/tests/Fixtures/LanguageFixture.php
+++ b/plugins/UserLanguage/tests/Fixtures/LanguageFixture.php
@@ -18,13 +18,13 @@ class LanguageFixture extends Fixture
     public $dateTime = '2014-09-04 00:00:00';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
 
     }

--- a/plugins/UsersManager/tests/Fixtures/ManyUsers.php
+++ b/plugins/UsersManager/tests/Fixtures/ManyUsers.php
@@ -68,13 +68,13 @@ class ManyUsers extends Fixture
         $this->addTextSuffixes = $addTextSuffixes;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         $this->setUpUsers();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -145,7 +145,7 @@ class APITest extends IntegrationTestCase
 
     private $email = 'userlogin@password.de';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -161,7 +161,7 @@ class APITest extends IntegrationTestCase
         $this->api->addUser($this->login, $this->password, $this->email);
     }
     
-    public function tearDown()
+    public function tearDown(): void
     {
         Config::getInstance()->General['enable_update_users_email'] = 1;
 
@@ -293,11 +293,10 @@ class APITest extends IntegrationTestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_setUserPreference_throws_whenPreferenceNameContainsUnderscore()
     {
+        $this->expectException(\Exception::class);
+
         $user2 = 'userLogin2';
         $this->api->addUser($user2, 'password', 'userlogin2@password.de');
         $this->api->setUserPreference($user2, 'ohOH_myPreferenceName', 'valueForUser2');
@@ -382,12 +381,11 @@ class APITest extends IntegrationTestCase
         $this->assertSame($userBefore['ts_password_modified'], $user['ts_password_modified']);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionInvalidPasswordTooLong
-     */
     public function test_updateUser_failsIfPasswordTooLong()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionInvalidPasswordTooLong');
+
         $this->api->updateUser($this->login, str_pad('foo', UsersManager::PASSWORD_MAX_LENGTH + 1), 'email@example.com', 'newAlias', false, $this->password);
     }
 
@@ -759,75 +757,67 @@ class APITest extends IntegrationTestCase
         $this->assertEquals($expected, $access);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionMultipleRoleSet
-     */
     public function test_setUserAccess_MultipleRolesCannotBeSet()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionMultipleRoleSet');
+
         $this->api->setUserAccess($this->login, array('view', 'admin'), array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionNoRoleSet
-     */
     public function test_setUserAccess_NeedsAtLeastOneRole()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionNoRoleSet');
+
         $this->api->setUserAccess($this->login, array(TestCap2::ID), array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionAccessValues
-     */
     public function test_setUserAccess_NeedsAtLeastOneRoleAsString()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAccessValues');
+
         $this->api->setUserAccess($this->login, TestCap2::ID, array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionAccessValues
-     */
     public function test_setUserAccess_InvalidCapability()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAccessValues');
+
         $this->api->setUserAccess($this->login, array('admin', 'foobar'), array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionNoRoleSet
-     */
     public function test_setUserAccess_NeedsAtLeastOneRoleNoneGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionNoRoleSet');
+
         $this->api->setUserAccess($this->login, array(), array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage  UsersManager_ExceptionAnonymousAccessNotPossible
-     */
     public function test_setUserAccess_CannotSetAdminToAnonymous()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAnonymousAccessNotPossible');
+
         $this->api->setUserAccess('anonymous', 'admin', array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage  UsersManager_ExceptionAnonymousAccessNotPossible
-     */
     public function test_setUserAccess_CannotSetWriteToAnonymous()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAnonymousAccessNotPossible');
+
         $this->api->setUserAccess('anonymous', 'write', array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function test_setUserAccess_UserDoesNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $this->api->setUserAccess('foobar', Admin::ID, array(1));
     }
 
@@ -862,30 +852,27 @@ class APITest extends IntegrationTestCase
         $this->assertEquals(array(array('site' => '1', 'access' => 'view')), $access);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionAccessValues
-     */
     public function test_addCapabilities_failsWhenNotCapabilityIsGivenAsString()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAccessValues');
+
         $this->api->addCapabilities($this->login, View::ID, array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionAccessValues
-     */
     public function test_addCapabilities_failsWhenNotCapabilityIsGivenAsArray()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAccessValues');
+
         $this->api->addCapabilities($this->login, array(TestCap2::ID, View::ID), array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function test_addCapabilities_failsWhenUserDoesNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $this->api->addCapabilities('foobar', array(TestCap2::ID), array(1));
     }
 
@@ -963,30 +950,27 @@ class APITest extends IntegrationTestCase
         $this->assertEquals($expected, $access);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionAccessValues
-     */
     public function test_removeCapabilities_failsWhenNotCapabilityIsGivenAsString()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAccessValues');
+
         $this->api->removeCapabilities($this->login, View::ID, array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionAccessValues
-     */
     public function test_removeCapabilities_failsWhenNotCapabilityIsGivenAsArray()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAccessValues');
+
         $this->api->removeCapabilities($this->login, array(TestCap2::ID, View::ID), array(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function test_removeCapabilities_failsWhenUserDoesNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $this->api->removeCapabilities('foobar', array(TestCap2::ID), array(1));
     }
 
@@ -1004,12 +988,11 @@ class APITest extends IntegrationTestCase
         $this->assertEquals(array(View::ID, TestCap1::ID), $access);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_CurrentPasswordNotCorrect
-     */
     public function test_setSuperUserAccess_failsIfCurrentPasswordIsIncorrect()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_CurrentPasswordNotCorrect');
+
         $this->api->setSuperUserAccess($this->login, true, 'asldfkjds');
     }
 

--- a/plugins/UsersManager/tests/Integration/ModelTest.php
+++ b/plugins/UsersManager/tests/Integration/ModelTest.php
@@ -44,7 +44,7 @@ class ModelTest extends IntegrationTestCase
 
     private $login = 'userLogin';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/UsersManager/tests/Integration/UserAccessFilterTest.php
+++ b/plugins/UsersManager/tests/Integration/UserAccessFilterTest.php
@@ -56,7 +56,7 @@ class UserAccessFilterTest extends IntegrationTestCase
         'login8' => array('view' => array(4,7),     'admin' => array(2,5)), // access to a couple of sites with admin and view
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/UsersManager/tests/Integration/UserPreferencesTest.php
+++ b/plugins/UsersManager/tests/Integration/UserPreferencesTest.php
@@ -29,7 +29,7 @@ class UserPreferencesTest extends IntegrationTestCase
      */
     private $userPreferences;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/plugins/UsersManager/tests/Integration/UsersManagerTest.php
+++ b/plugins/UsersManager/tests/Integration/UsersManagerTest.php
@@ -45,7 +45,7 @@ class UsersManagerTest extends IntegrationTestCase
 
     private $backupIdentity;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -67,7 +67,7 @@ class UsersManagerTest extends IntegrationTestCase
         $this->model = new Model();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         FakeAccess::$identity = $this->backupIdentity;
         parent::tearDown();
@@ -125,12 +125,13 @@ class UsersManagerTest extends IntegrationTestCase
     }
 
     /**
-     * bad password => exception#
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionInvalidPassword
+     * bad password => exception
      */
     public function testUpdateUserBadpasswd()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionInvalidPassword');
+
         $login = "login";
         $user  = array('login'    => $login,
                        'password' => "geqgeagae",
@@ -162,31 +163,32 @@ class UsersManagerTest extends IntegrationTestCase
 
     /**
      * @dataProvider getAddUserInvalidLoginData
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionInvalidLogin
      */
     public function testAddUserWrongLogin($userLogin, $password, $email, $alias)
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionInvalidLogin');
+
         $this->api->addUser($userLogin, $password, $email, $alias);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionLoginExists
-     */
     public function testAddUserExistingLogin()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionLoginExists');
+
         $this->api->addUser("test", "password", "email@email.com", "alias");
         $this->api->addUser("test", "password2", "em2ail@email.com", "al2ias");
     }
 
     /**
      * @see https://github.com/piwik/piwik/issues/8548
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionLoginExists
      */
     public function testAddUserExistingLoginCaseInsensitive()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionLoginExists');
+
         $this->api->addUser("test", "password", "email@email.com", "alias");
         $this->api->addUser("TeSt", "password2", "em2ail@email.com", "al2ias");
     }
@@ -204,20 +206,20 @@ class UsersManagerTest extends IntegrationTestCase
 
     /**
      * @dataProvider getWrongPasswordTestData
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionInvalidPassword
      */
     public function testAddUserWrongPassword($userLogin, $password, $email, $alias)
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionInvalidPassword');
+
         $this->api->addUser($userLogin, $password, $email, $alias);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage mail
-     */
     public function testAddUserWrongEmail()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('mail');
+
         $this->api->addUser('geggeqgeqag', 'geqgeagae', "ema il@email.com", 'alias');
     }
 
@@ -323,64 +325,58 @@ class UsersManagerTest extends IntegrationTestCase
         ], $access);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_AddUserNoInitialAccessError
-     */
     public function test_addUser_shouldNotAllowAdminUsersToCreateUsers_WithNoInitialSiteWithAccess()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_AddUserNoInitialAccessError');
+
         FakeAccess::$superUser = false;
         FakeAccess::$idSitesAdmin = [1];
 
         $this->api->addUser('userLogin2', 'password', 'userlogin2@email.com', 'userLogin2');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasAdminAccess Fake exception
-     */
     public function test_addUser_shouldNotAllowAdminUsersToCreateUsersWithAccessToSite_ThatAdminUserDoesNotHaveAccessTo()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasAdminAccess Fake exception');
+
         FakeAccess::$superUser = false;
         FakeAccess::$idSitesAdmin = [2];
 
         $this->api->addUser('userLogin2', 'password', 'userlogin2@email.com', 'userLogin2', false, 1);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testDeleteUserDoesntExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $this->api->addUser("geggeqgeqag", "geqgeagae", "test@test.com", "alias");
         $this->api->deleteUser("geggeqggnew");
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testDeleteUserEmptyUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $this->api->deleteUser("");
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testDeleteUserNullUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $this->api->deleteUser(null);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionDeleteOnlyUserWithSuperUserAccess
-     */
     public function testDeleteUser_ShouldFail_InCaseTheUserIsTheOnlyRemainingSuperUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionDeleteOnlyUserWithSuperUserAccess');
+
         //add user and set some rights
         $this->api->addUser("regularuser", "geqgeagae1", "test1@test.com", "alias1");
         $this->api->addUser("superuser", "geqgeagae2", "test2@test.com", "alias2");
@@ -439,12 +435,11 @@ class UsersManagerTest extends IntegrationTestCase
         $this->assertFalse($option);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testGetUserNoUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         // try to get it, it should raise an exception
         $this->api->getUser("geggeqgeqag");
     }
@@ -464,8 +459,8 @@ class UsersManagerTest extends IntegrationTestCase
 
         // check that all fields are the same
         $this->assertEquals($login, $user['login']);
-        $this->assertInternalType('string', $user['password']);
-        $this->assertInternalType('string', $user['date_registered']);
+        self::assertIsString($user['password']);
+        self::assertIsString($user['date_registered']);
         $this->assertEquals($email, $user['email']);
 
         //alias shouldn't be empty even if no alias specified
@@ -501,12 +496,11 @@ class UsersManagerTest extends IntegrationTestCase
         $this->assertEquals(array($user1, $user2), $this->_removeNonTestableFieldsFromUsers($this->api->getUsers('gegg4564eqgeqag,geggeqge632ge56a4qag')));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasSomeAdminAccess Fake exception
-     */
     public function testGetUsers_withViewAccess_shouldThrowAnException()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasSomeAdminAccess Fake exception');
+
         $this->api->addUser("gegg4564eqgeqag", "geqgegagae", "tegst@tesgt.com", "alias");
         $this->api->addUser("geggeqge632ge56a4qag", "geqgegeagae", "tesggt@tesgt.com", "alias");
         $this->api->addUser("geggeqgeqagqegg", "geqgeaggggae", "tesgggt@tesgt.com");
@@ -553,73 +547,66 @@ class UsersManagerTest extends IntegrationTestCase
         $this->assertSame('geggeqge632ge56a4qag', $this->api->getUserLoginFromUserEmail('teSGgT@tesgt.com'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testGetUserLoginFromUserEmail_shouldThrowException_IfUserDoesNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $this->api->getUserLoginFromUserEmail('unknownUser@teSsgt.com');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasSomeAdminAccess Fake exception
-     */
     public function testGetUserLoginFromUserEmail_shouldThrowException_IfUserDoesNotHaveAtLeastAdminPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasSomeAdminAccess Fake exception');
+
         FakeAccess::clearAccess($superUser = false, $admin =array(), $view = array(1));
         $this->api->getUserLoginFromUserEmail('tegst@tesgt.com');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testSetUserAccessNoLogin()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         FakeAccess::clearAccess($superUser = false, $admin =array(1), $view = array());
         $this->api->setUserAccess("nologin", "view", 1);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionAccessValues
-     */
     public function testSetUserAccessWrongAccessSpecified()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAccessValues');
+
         $this->api->addUser("gegg4564eqgeqag", "geqgegagae", "tegst@tesgt.com", "alias");
         FakeAccess::clearAccess($superUser = false, $admin =array(1), $view = array());
         $this->api->setUserAccess("gegg4564eqgeqag", "viewnotknown", 1);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionAccessValues
-     */
     public function testSetUserAccess_ShouldFail_SuperUserAccessIsNotAllowed()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAccessValues');
+
         $this->api->addUser("gegg4564eqgeqag", "geqgegagae", "tegst@tesgt.com", "alias");
         FakeAccess::clearAccess($superUser = false, $admin =array(1), $view = array());
         $this->api->setUserAccess("gegg4564eqgeqag", "superuser", 1);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testSetUserAccess_ShouldFail_IfLoginIsConfigSuperUserLogin()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         FakeAccess::clearAccess($superUser = false, $admin =array(1), $view = array());
         $this->api->setUserAccess('superusertest', 'view', 1);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserHasSuperUserAccess
-     */
     public function testSetUserAccess_ShouldFail_IfLoginIsUserWithSuperUserAccess()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserHasSuperUserAccess');
+
         $this->api->addUser("gegg4564eqgeqag", "geqgegagae", "tegst@tesgt.com", "alias");
         $userUpdater = new UserUpdater();
         $userUpdater->setSuperUserAccessWithoutCurrentPassword('gegg4564eqgeqag', true);
@@ -672,11 +659,10 @@ class UsersManagerTest extends IntegrationTestCase
         $this->assertEquals($idSites, array_keys($access));
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testSetUserAccess_ShouldNotBeAbleToSetAnyAccess_IfIdSitesIsEmpty()
     {
+        $this->expectException(\Exception::class);
+
         $this->api->addUser("gegg4564eqgeqag", "geqgegagae", "tegst@tesgt.com", "alias");
 
         $this->api->setUserAccess("gegg4564eqgeqag", "view", array());
@@ -818,44 +804,40 @@ class UsersManagerTest extends IntegrationTestCase
         $this->assertEquals($wanted1, $access1);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage checkUserHasSuperUserAccess Fake exception
-     */
     public function testSetSuperUserAccess_ShouldFail_IfUserHasNotSuperUserPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('checkUserHasSuperUserAccess Fake exception');
+
         $pwd = $this->createCurrentUser();
 
         FakeAccess::$superUser= false;
         $this->api->setSuperUserAccess('nologin', false, $pwd);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testSetSuperUserAccess_ShouldFail_IfUserWithGivenLoginDoesNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $pwd = $this->createCurrentUser();
         $this->api->setSuperUserAccess('nologin', false, $pwd);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionEditAnonymous
-     */
     public function testSetSuperUserAccess_ShouldFail_IfUserIsAnonymous()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionEditAnonymous');
+
         $pwd = $this->createCurrentUser();
         $this->api->setSuperUserAccess('anonymous', true, $pwd);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionRemoveSuperUserAccessOnlySuperUser
-     */
     public function testSetSuperUserAccess_ShouldFail_IfUserIsOnlyRemainingUserWithSuperUserAccess()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionRemoveSuperUserAccessOnlySuperUser');
+
         $pwd = $this->createCurrentUser();
 
         $this->api->addUser('login1', 'password1', 'test@example.com', false);
@@ -923,39 +905,35 @@ class UsersManagerTest extends IntegrationTestCase
         $this->assertEquals(1, $users[2]['superuser_access']);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testGetSitesAccessFromUserWrongUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $this->api->getSitesAccessFromUser("user1");
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testGetUsersAccessFromSiteWrongIdSite()
     {
+        $this->expectException(\Exception::class);
+
         FakeAccess::$superUser = false;
         $this->api->getUsersAccessFromSite(1);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionAccessValues
-     */
     public function testGetUsersSitesFromAccessWrongSite()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionAccessValues');
+
         $this->api->getUsersSitesFromAccess('unknown');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionUserDoesNotExist
-     */
     public function testUpdateUserNonExistingLogin()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionUserDoesNotExist');
+
         $this->api->updateUser("lolgin", "password");
     }
 
@@ -979,12 +957,11 @@ class UsersManagerTest extends IntegrationTestCase
         $this->_checkUserHasNotChanged($user, "passowordOK");
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ConfirmWithPassword
-     */
     public function testUpdateUserFailsNoCurrentPassword()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ConfirmWithPassword');
+
         $login = "login";
         $user  = array('login'    => $login,
                        'password' => "geqgeagae",
@@ -997,12 +974,11 @@ class UsersManagerTest extends IntegrationTestCase
         $this->api->updateUser($login, "passowordOK", false, false, false, "");
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_CurrentPasswordNotCorrect
-     */
     public function testUpdateUserFailsWrongCurrentPassword()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_CurrentPasswordNotCorrect');
+
         $login = "login";
         $user  = array('login'    => $login,
                        'password' => "geqgeagae",
@@ -1015,12 +991,11 @@ class UsersManagerTest extends IntegrationTestCase
         $this->api->updateUser($login, "passowordOK", false, false, false, "geqgeag");
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_CurrentPasswordNotCorrect
-     */
     public function testUpdateUserFailsWrongCurrentPassword_requiresThePasswordOfCurrentLoggedInUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_CurrentPasswordNotCorrect');
+
         $login = "login";
         $user  = array('login'    => $login,
                        'password' => "geqgeagae",
@@ -1072,22 +1047,23 @@ class UsersManagerTest extends IntegrationTestCase
 
     /**
      * check to modify as the user
-     * @expectedException \Exception
-     * @expectedExceptionMessage UsersManager_ExceptionLoginExists
      */
     public function testAddUserIAmTheUser()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('UsersManager_ExceptionLoginExists');
+
         FakeAccess::$identity = 'login';
         $this->testUpdateUserNoEmailNoAlias();
     }
 
     /**
      * check to modify as being another user => exception
-     *
-     * @expectedException \Exception
      */
     public function testUpdateUserIAmNotTheUser()
     {
+        $this->expectException(\Exception::class);
+
         FakeAccess::$identity = 'login2';
         FakeAccess::$superUser = false;
         $this->testUpdateUserNoEmailNoAlias();
@@ -1112,11 +1088,10 @@ class UsersManagerTest extends IntegrationTestCase
         $this->_checkUserHasNotChanged($user, "passowordOK", "email@geaga.com", "NEW ALIAS");
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testGetUserByEmailInvalidMail()
     {
+        $this->expectException(\Exception::class);
+
         $this->api->getUserByEmail('email@test.com');
     }
 

--- a/plugins/VisitFrequency/tests/Integration/APITest.php
+++ b/plugins/VisitFrequency/tests/Integration/APITest.php
@@ -19,7 +19,7 @@ class APITest extends IntegrationTestCase
 
     private $idSite;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->api = API::getInstance();

--- a/plugins/VisitTime/tests/Unit/AddSegmentByLabelInUTCTest.php
+++ b/plugins/VisitTime/tests/Unit/AddSegmentByLabelInUTCTest.php
@@ -25,7 +25,7 @@ class AddSegmentByLabelInUTCTest extends \PHPUnit\Framework\TestCase
      */
     private $table;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
         $this->addRow(array('label' => '0'));

--- a/plugins/VisitsSummary/tests/Integration/VisitsSummaryTest.php
+++ b/plugins/VisitsSummary/tests/Integration/VisitsSummaryTest.php
@@ -31,7 +31,7 @@ class VisitsSummaryTest extends IntegrationTestCase
     protected $date = '2014-04-04';
     private $column = 'nb_users';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->plugin = new VisitsSummary();
@@ -42,7 +42,7 @@ class VisitsSummaryTest extends IntegrationTestCase
         Fixture::createWebsite('2014-01-01 00:00:00');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // clean up your test here if needed
         $tables = ArchiveTableCreator::getTablesArchivesInstalled();

--- a/plugins/VisitsSummary/tests/Unit/Reports/GetTest.php
+++ b/plugins/VisitsSummary/tests/Unit/Reports/GetTest.php
@@ -26,7 +26,7 @@ class GetTest extends \PHPUnit\Framework\TestCase
 
     private $column = 'nb_users';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->get = new Get();

--- a/plugins/Widgetize/tests/Fixtures/WidgetizeFixture.php
+++ b/plugins/Widgetize/tests/Fixtures/WidgetizeFixture.php
@@ -26,13 +26,13 @@ class WidgetizeFixture extends Fixture
         array('name' => 'Visit Docs',         'match' => 'url', 'pattern' => 'docs',       'patternType' => 'contains', 'revenue' => false),
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
         $this->setUpGoals();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/plugins/Widgetize/tests/System/WidgetTest.php
+++ b/plugins/Widgetize/tests/System/WidgetTest.php
@@ -28,7 +28,7 @@ class WidgetTest extends SystemTestCase
      */
     public static $fixture = null; // initialized below class definition
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -38,7 +38,7 @@ class WidgetTest extends SystemTestCase
         $_GET['date']   = '2013-01-23';
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $_GET = array();
         parent::tearDown();

--- a/tests/PHPUnit/Benchmarks/ArchiveQueryBenchmark.php
+++ b/tests/PHPUnit/Benchmarks/ArchiveQueryBenchmark.php
@@ -19,7 +19,7 @@ class ArchiveQueryBenchmark extends BenchmarkTestCase
 {
     private $archivingLaunched = false;
 
-    public function setUp()
+    public function setUp(): void
     {
         $archivingTables = ArchiveTableCreator::getTablesArchivesInstalled();
         if (empty($archivingTables)) {

--- a/tests/PHPUnit/Benchmarks/ArchivingProcessBenchmark.php
+++ b/tests/PHPUnit/Benchmarks/ArchivingProcessBenchmark.php
@@ -13,7 +13,7 @@ use Piwik\Tests\Framework\TestCase\BenchmarkTestCase;
  */
 class ArchivingProcessBenchmark extends BenchmarkTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         BenchmarkTestCase::deleteArchiveTables();
     }

--- a/tests/PHPUnit/Benchmarks/Fixtures/ManyThousandSitesOneVisitEach.php
+++ b/tests/PHPUnit/Benchmarks/Fixtures/ManyThousandSitesOneVisitEach.php
@@ -20,7 +20,7 @@ class Piwik_Test_Fixture_ManyThousandSitesOneVisitEach
     public $siteCount = 20000;
     public $idSite = 'all';
 
-    public function setUp()
+    public function setUp(): void
     {
         for ($i = 0; $i != $this->siteCount; ++$i) {
             $idSite = Fixture::createWebsite(

--- a/tests/PHPUnit/Benchmarks/Fixtures/OneSiteThousandsOfDistinctUrlsOverMonth.php
+++ b/tests/PHPUnit/Benchmarks/Fixtures/OneSiteThousandsOfDistinctUrlsOverMonth.php
@@ -21,7 +21,7 @@ class Piwik_Test_Fixture_OneSiteThousandsOfDistinctUrlsOverMonth
     public $period = 'month';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         // add one site
         Fixture::createWebsite(

--- a/tests/PHPUnit/Benchmarks/Fixtures/OneSiteTwelveThousandVisitsOneYear.php
+++ b/tests/PHPUnit/Benchmarks/Fixtures/OneSiteTwelveThousandVisitsOneYear.php
@@ -21,7 +21,7 @@ class Piwik_Test_Fixture_OneSiteTwelveThousandVisitsOneYear
     public $idGoal1 = 1;
     public $idGoal2 = 2;
 
-    public function setUp()
+    public function setUp(): void
     {
         // add one site
         Fixture::createWebsite(

--- a/tests/PHPUnit/Benchmarks/Fixtures/ThousandSitesTwelveVisitsEachOneDay.php
+++ b/tests/PHPUnit/Benchmarks/Fixtures/ThousandSitesTwelveVisitsEachOneDay.php
@@ -18,7 +18,7 @@ class Piwik_Test_Fixture_ThousandSitesTwelveVisitsEachOneDay
     public $period = 'day';
     public $idSite = 'all';
 
-    public function setUp()
+    public function setUp(): void
     {
         // add one thousand sites
         $allIdSites = array();

--- a/tests/PHPUnit/Benchmarks/MultiSitesBenchmark.php
+++ b/tests/PHPUnit/Benchmarks/MultiSitesBenchmark.php
@@ -18,7 +18,7 @@ class MultiSitesBenchmark extends BenchmarkTestCase
 {
     private $archivingLaunched = false;
 
-    public function setUp()
+    public function setUp(): void
     {
         $archivingTables = ArchiveTableCreator::getTablesArchivesInstalled();
         if (empty($archivingTables)) {

--- a/tests/PHPUnit/Benchmarks/TrackerBenchmark.php
+++ b/tests/PHPUnit/Benchmarks/TrackerBenchmark.php
@@ -20,7 +20,7 @@ class TrackerBenchmark extends BenchmarkTestCase
     private $visitTimes = array();
     private $t = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         // set up action URLs
         for ($i = 0; $i != 100; ++$i) {

--- a/tests/PHPUnit/Fixtures/FewVisitsWithSetVisitorId.php
+++ b/tests/PHPUnit/Fixtures/FewVisitsWithSetVisitorId.php
@@ -24,7 +24,7 @@ class FewVisitsWithSetVisitorId extends Fixture
 
     const USER_ID_EXAMPLE_COM = 'email@example.com';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits_setVisitorId();
@@ -34,7 +34,7 @@ class FewVisitsWithSetVisitorId extends Fixture
         $this->trackVisits_oneWeekLater_setUserId();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/InvalidVisits.php
+++ b/tests/PHPUnit/Fixtures/InvalidVisits.php
@@ -24,13 +24,13 @@ class InvalidVisits extends Fixture
 
     public $trackInvalidRequests = true;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/JSTrackingUIFixture.php
+++ b/tests/PHPUnit/Fixtures/JSTrackingUIFixture.php
@@ -16,7 +16,7 @@ use Piwik\Tests\Framework\Fixture;
 
 class JSTrackingUIFixture extends Fixture
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Fixtures/LatestStableInstall.php
+++ b/tests/PHPUnit/Fixtures/LatestStableInstall.php
@@ -30,7 +30,7 @@ class LatestStableInstall extends Fixture
         $this->subdirToInstall = $subdirToInstall;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->removeLatestStableInstall();
 

--- a/tests/PHPUnit/Fixtures/ManySitesImportedLogs.php
+++ b/tests/PHPUnit/Fixtures/ManySitesImportedLogs.php
@@ -32,7 +32,7 @@ class ManySitesImportedLogs extends Fixture
     public $includeNginxJson = false;
     public $includeApiCustomVarMapping = false;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
 
@@ -45,7 +45,7 @@ class ManySitesImportedLogs extends Fixture
         $this->setupSegments();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         LocationProvider::$providers = null;
         ManyVisitsWithGeoIP::unsetLocationProvider();
@@ -158,7 +158,7 @@ class ManySitesImportedLogs extends Fixture
         $output = self::executeLogImporter($logFile, $opts);
         $output = implode("\n", $output);
 
-        $this->assertContains('4 filtered log lines', $output);
+        self::assertStringContainsString('4 filtered log lines', $output);
     }
 
     private function logWithIncludeFilters()
@@ -174,7 +174,7 @@ class ManySitesImportedLogs extends Fixture
         $output = self::executeLogImporter($logFile, $opts);
         $output = implode("\n", $output);
 
-        $this->assertContains('2 filtered log lines', $output);
+        self::assertStringContainsString('2 filtered log lines', $output);
     }
 
     private function setupSegments()
@@ -288,13 +288,13 @@ class ManySitesImportedLogs extends Fixture
         $output = self::executeLogImporter($logFile, $opts);
         $output = implode("\n", $output);
 
-        $this->assertContains('1 filtered log lines', $output);
+        self::assertStringContainsString('1 filtered log lines', $output);
 
         // test that correct logs are excluded when the host is in the log file
         $output = self::executeLogImporter($logFileWithHost, $opts);
         $output = implode("\n", $output);
 
-        $this->assertContains('2 filtered log lines', $output);
+        self::assertStringContainsString('2 filtered log lines', $output);
     }
 
     /**

--- a/tests/PHPUnit/Fixtures/ManySitesImportedLogsWithXssAttempts.php
+++ b/tests/PHPUnit/Fixtures/ManySitesImportedLogsWithXssAttempts.php
@@ -28,7 +28,7 @@ class ManySitesImportedLogsWithXssAttempts extends ManySitesImportedLogs
         $this->now = Date::factory('now');
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
+++ b/tests/PHPUnit/Fixtures/ManyVisitsWithGeoIP.php
@@ -56,7 +56,7 @@ class ManyVisitsWithGeoIP extends Fixture
     protected $idGoal;
     protected $idGoal2;
 
-    public function setUp()
+    public function setUp(): void
     {
         // set option, so tracked data for the past won't get converted
         Option::set(GeoIp2::SWITCH_TO_ISO_REGIONS_OPTION_NAME, 1);
@@ -78,7 +78,7 @@ class ManyVisitsWithGeoIP extends Fixture
         $this->setLocationProvider('GeoIP2-City.mmdb');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->unsetLocationProvider();
     }

--- a/tests/PHPUnit/Fixtures/ManyVisitsWithMockLocationProvider.php
+++ b/tests/PHPUnit/Fixtures/ManyVisitsWithMockLocationProvider.php
@@ -30,7 +30,7 @@ class ManyVisitsWithMockLocationProvider extends Fixture
         $this->nextDay = Date::factory($this->dateTime)->addDay(1)->getDatetime();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->customDimensionId = CustomDimensions\API::getInstance()->configureNewCustomDimension($this->idSite, 'testdim', 'visit', '1');
@@ -41,7 +41,7 @@ class ManyVisitsWithMockLocationProvider extends Fixture
         ManyVisitsWithGeoIP::unsetLocationProvider();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         ManyVisitsWithGeoIP::unsetLocationProvider();
     }

--- a/tests/PHPUnit/Fixtures/ManyVisitsWithSubDirReferrersAndCustomVars.php
+++ b/tests/PHPUnit/Fixtures/ManyVisitsWithSubDirReferrersAndCustomVars.php
@@ -19,13 +19,13 @@ class ManyVisitsWithSubDirReferrersAndCustomVars extends Fixture
     public $dateTime = '2010-03-05 11:22:33';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/OmniFixture.php
+++ b/tests/PHPUnit/Fixtures/OmniFixture.php
@@ -122,7 +122,7 @@ class OmniFixture extends Fixture
         return $result;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $firstFixture = array_shift($this->fixtures);
         $this->setUpFixture($firstFixture);
@@ -140,7 +140,7 @@ class OmniFixture extends Fixture
         Option::set("Tests.forcedNowTimestamp", $this->now->getTimestamp());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach ($this->fixtures as $fixture) {
             echo "Tearing down " . get_class($fixture) . "...\n";

--- a/tests/PHPUnit/Fixtures/OneVisitSeveralPageViews.php
+++ b/tests/PHPUnit/Fixtures/OneVisitSeveralPageViews.php
@@ -18,13 +18,13 @@ class OneVisitSeveralPageViews extends Fixture
     public $dateTime = '2010-03-06 11:22:33';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/OneVisitWithAbnormalPageviewUrls.php
+++ b/tests/PHPUnit/Fixtures/OneVisitWithAbnormalPageviewUrls.php
@@ -19,13 +19,13 @@ class OneVisitWithAbnormalPageviewUrls extends Fixture
     public $dateTime = '2010-03-06 11:22:33';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/OneVisitWithSiteSearch.php
+++ b/tests/PHPUnit/Fixtures/OneVisitWithSiteSearch.php
@@ -9,13 +9,13 @@ class OneVisitWithSiteSearch extends Fixture
     public $dateTime = '2012-01-11 07:22:33';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/OneVisitorTwoVisits.php
+++ b/tests/PHPUnit/Fixtures/OneVisitorTwoVisits.php
@@ -30,14 +30,14 @@ class OneVisitorTwoVisits extends Fixture
     public $simulateIntegerOverflow = false;
     public $maxUnsignedIntegerValue = '4294967295';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->simulateIntegerOverflow();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/RawArchiveDataWithTempAndInvalidated.php
+++ b/tests/PHPUnit/Fixtures/RawArchiveDataWithTempAndInvalidated.php
@@ -355,7 +355,7 @@ class RawArchiveDataWithTempAndInvalidated extends Fixture
      */
     public $february;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Fixtures/SomeVisitsAllConversions.php
+++ b/tests/PHPUnit/Fixtures/SomeVisitsAllConversions.php
@@ -21,13 +21,13 @@ class SomeVisitsAllConversions extends Fixture
     public $idGoal_OneConversionPerVisit = 1;
     public $idGoal_MultipleConversionPerVisit = 2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/SomeVisitsCustomVariablesCampaignsNotHeuristics.php
+++ b/tests/PHPUnit/Fixtures/SomeVisitsCustomVariablesCampaignsNotHeuristics.php
@@ -24,14 +24,14 @@ class SomeVisitsCustomVariablesCampaignsNotHeuristics extends Fixture
     public $idGoal = 1;
     private $tmpHost = '';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setPiwikEnvironmentOverrides();
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
@@ -233,7 +233,7 @@ class SomeVisitsCustomVariablesCampaignsNotHeuristics extends Fixture
         $_COOKIE[$customVarCookieName] = '{"1":["VAR 1 set, var 2 not set","yes"],"3":["var 3 set","yes!!!!"]}';
 
         // test loading 'id' cookie
-        self::assertContains("_viewts=" . $viewts, $t->getUrlTrackPageView());
+        self::assertStringContainsString("_viewts=" . $viewts, $t->getUrlTrackPageView());
         self::assertEquals($uuid, $t->getVisitorId());
         self::assertEquals($t->getAttributionInfo(), $_COOKIE[$refCookieName]);
         self::assertEquals(array("VAR 1 set, var 2 not set", "yes"), $t->getCustomVariable(1));

--- a/tests/PHPUnit/Fixtures/SomeVisitsManyPageviewsWithTransitions.php
+++ b/tests/PHPUnit/Fixtures/SomeVisitsManyPageviewsWithTransitions.php
@@ -22,13 +22,13 @@ class SomeVisitsManyPageviewsWithTransitions extends Fixture
 
     private $prefixCounter = 0;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/SomeVisitsWithLongUrls.php
+++ b/tests/PHPUnit/Fixtures/SomeVisitsWithLongUrls.php
@@ -19,13 +19,13 @@ class SomeVisitsWithLongUrls extends Fixture
     public $dateTime = '2010-03-06 01:22:33';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/SomeVisitsWithNonUnicodePageTitles.php
+++ b/tests/PHPUnit/Fixtures/SomeVisitsWithNonUnicodePageTitles.php
@@ -19,13 +19,13 @@ class SomeVisitsWithNonUnicodePageTitles extends Fixture
     public $idSite1 = 1;
     public $dateTime = '2010-01-03 11:22:33';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsites();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/SqlDump.php
+++ b/tests/PHPUnit/Fixtures/SqlDump.php
@@ -27,7 +27,7 @@ class SqlDump extends Fixture
     public $tablesPrefix = 'piwik_';
     public $dumpUrl = "http://piwik-team.s3.amazonaws.com/generated-logs-one-day.sql.gz";
 
-    public function setUp()
+    public function setUp(): void
     {
         // drop all tables
         Db::dropAllTables();

--- a/tests/PHPUnit/Fixtures/ThreeGoalsOnePageview.php
+++ b/tests/PHPUnit/Fixtures/ThreeGoalsOnePageview.php
@@ -23,14 +23,14 @@ class ThreeGoalsOnePageview extends Fixture
     public $idGoal2 = 2;
     public $idGoal3 = 3;
 
-    public function setUp()
+    public function setUp(): void
     {
         Fixture::createSuperUser();
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/ThreeSitesWithManyVisitsWithSiteSearch.php
+++ b/tests/PHPUnit/Fixtures/ThreeSitesWithManyVisitsWithSiteSearch.php
@@ -22,13 +22,13 @@ class ThreeSitesWithManyVisitsWithSiteSearch extends Fixture
     public $idSite3 = 3;
     public $dateTime = '2010-01-03 11:22:33';
 
-    public function setUp()
+    public function setUp(): void
     {
         self::setUpWebsites();
         self::trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/ThreeSitesWithSharedVisitors.php
+++ b/tests/PHPUnit/Fixtures/ThreeSitesWithSharedVisitors.php
@@ -20,13 +20,13 @@ class ThreeSitesWithSharedVisitors extends Fixture
     public $idSite2 = 3;
     public $dateTime = '2010-03-06 11:22:33';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/ThreeVisitsWithCustomEvents.php
+++ b/tests/PHPUnit/Fixtures/ThreeVisitsWithCustomEvents.php
@@ -21,7 +21,7 @@ class ThreeVisitsWithCustomEvents extends Fixture
     public $idSite = 1;
     public static $idGoalTriggeredOnEventCategory = 3;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
@@ -226,7 +226,7 @@ class ThreeVisitsWithCustomEvents extends Fixture
         $vis->setCustomVariable($id = 1, $name = 'Visit Scope Custom var', $value = 'should not appear in events report Bis', $scope = 'visit');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 }

--- a/tests/PHPUnit/Fixtures/TwoSitesEcommerceOrderWithItems.php
+++ b/tests/PHPUnit/Fixtures/TwoSitesEcommerceOrderWithItems.php
@@ -21,7 +21,7 @@ class TwoSitesEcommerceOrderWithItems extends Fixture
     public $idSite2 = 2;
     public $idGoalStandard = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         self::setUpScheduledReports($this->idSite);
@@ -30,7 +30,7 @@ class TwoSitesEcommerceOrderWithItems extends Fixture
         $this->trackVisitsSite2($url = 'http://example-site2.com/index.htm');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/TwoSitesManyVisitsOverSeveralDaysWithSearchEngineReferrers.php
+++ b/tests/PHPUnit/Fixtures/TwoSitesManyVisitsOverSeveralDaysWithSearchEngineReferrers.php
@@ -26,13 +26,13 @@ class TwoSitesManyVisitsOverSeveralDaysWithSearchEngineReferrers extends Fixture
         'justice )(&^#%$ NOT \'" corruption!',
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/TwoSitesTwoVisitorsDifferentDays.php
+++ b/tests/PHPUnit/Fixtures/TwoSitesTwoVisitorsDifferentDays.php
@@ -27,14 +27,14 @@ class TwoSitesTwoVisitorsDifferentDays extends Fixture
     const URL_IS_GOAL_WITH_CAMPAIGN_PARAMETERS = 'http://example.org/index.htm?pk_campaign=goal-matching-url-parameter';
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         self::setUpScheduledReports($this->idSite1);
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/TwoSitesVisitsInPast.php
+++ b/tests/PHPUnit/Fixtures/TwoSitesVisitsInPast.php
@@ -22,13 +22,13 @@ class TwoSitesVisitsInPast extends Fixture
     public $idSite = 1;
     public $idSite2 = 2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/TwoSitesWithAnnotations.php
+++ b/tests/PHPUnit/Fixtures/TwoSitesWithAnnotations.php
@@ -22,13 +22,13 @@ class TwoSitesWithAnnotations extends Fixture
     public $idSite1 = 1;
     public $idSite2 = 2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->addAnnotations();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/TwoVisitsNoKeywordWithBot.php
+++ b/tests/PHPUnit/Fixtures/TwoVisitsNoKeywordWithBot.php
@@ -20,13 +20,13 @@ class TwoVisitsNoKeywordWithBot extends Fixture
     public $dateTime = '2010-03-06 11:22:33';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/TwoVisitsWithCustomVariables.php
+++ b/tests/PHPUnit/Fixtures/TwoVisitsWithCustomVariables.php
@@ -28,13 +28,13 @@ class TwoVisitsWithCustomVariables extends Fixture
     public $resolutionWidthToUse = 1111;
     public $resolutionHeightToUse = 222;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/UITestFixture.php
+++ b/tests/PHPUnit/Fixtures/UITestFixture.php
@@ -66,7 +66,7 @@ class UITestFixture extends SqlDump
         $this->xssTesting = new XssTesting();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Fixtures/Utf8mb4.php
+++ b/tests/PHPUnit/Fixtures/Utf8mb4.php
@@ -20,13 +20,13 @@ class Utf8mb4 extends Fixture
 
     public $trackInvalidRequests = true;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/VisitOverSeveralDaysImportedLogs.php
+++ b/tests/PHPUnit/Fixtures/VisitOverSeveralDaysImportedLogs.php
@@ -19,13 +19,13 @@ class VisitOverSeveralDaysImportedLogs extends Fixture
     public $dateTime = '2013-04-07 19:00:00';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/VisitsInDifferentTimezones.php
+++ b/tests/PHPUnit/Fixtures/VisitsInDifferentTimezones.php
@@ -25,13 +25,13 @@ class VisitsInDifferentTimezones extends Fixture
         $this->date = Date::factory($this->dateTime)->toString();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/VisitsOverSeveralDays.php
+++ b/tests/PHPUnit/Fixtures/VisitsOverSeveralDays.php
@@ -42,13 +42,13 @@ class VisitsOverSeveralDays extends Fixture
         'http://mixi.jp',
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Fixtures/VisitsTwoWebsitesWithAdditionalVisits.php
+++ b/tests/PHPUnit/Fixtures/VisitsTwoWebsitesWithAdditionalVisits.php
@@ -21,13 +21,13 @@ class VisitsTwoWebsitesWithAdditionalVisits extends Fixture
     public $idSite1 = 1;
     public $idSite2 = 2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsitesAndGoals();
         $this->trackVisits();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/PHPUnit/Framework/Constraint/HttpResponseText.php
+++ b/tests/PHPUnit/Framework/Constraint/HttpResponseText.php
@@ -10,9 +10,10 @@ namespace Piwik\Tests\Framework\Constraint;
 /**
  * @deprecated
  */
-class HttpResponseText extends \PHPUnit_Framework_Constraint
+class HttpResponseText extends \PHPUnit\Framework\Constraint\Constraint
 {
     private $actualCode;
+    private $value;
 
     /**
      * @param string $value Expected response text.
@@ -47,7 +48,7 @@ class HttpResponseText extends \PHPUnit_Framework_Constraint
      * @param mixed $other Value or object to evaluate.
      * @return bool
      */
-    public function matches($other)
+    public function matches($other): bool
     {
         $this->actualCode = $this->getResponse($other);
 
@@ -59,8 +60,8 @@ class HttpResponseText extends \PHPUnit_Framework_Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
-        return 'does not return response text ' . $this->exporter->export($this->value) . ' it is ' . $this->actualCode;
+        return 'does not return response text ' . $this->exporter()->export($this->value) . ' it is ' . $this->actualCode;
     }
-}?>
+}

--- a/tests/PHPUnit/Framework/Constraint/ResponseCode.php
+++ b/tests/PHPUnit/Framework/Constraint/ResponseCode.php
@@ -10,9 +10,10 @@ namespace Piwik\Tests\Framework\Constraint;
 /**
  * @deprecated
  */
-class ResponseCode extends \PHPUnit_Framework_Constraint
+class ResponseCode extends \PHPUnit\Framework\Constraint\Constraint
 {
     private $actualCode;
+    private $value;
 
     /**
      * @param integer $value Expected response code
@@ -30,7 +31,7 @@ class ResponseCode extends \PHPUnit_Framework_Constraint
      * @param mixed $other Value or object to evaluate.
      * @return bool
      */
-    public function matches($other)
+    public function matches($other): bool
     {
         $options = array(
             CURLOPT_URL            => $other,
@@ -55,8 +56,8 @@ class ResponseCode extends \PHPUnit_Framework_Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
-        return 'does not return response code ' . $this->exporter->export($this->value) . ' it is ' . $this->actualCode;
+        return 'does not return response code ' . $this->exporter()->export($this->value) . ' it is ' . $this->actualCode;
     }
-}?>
+}

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -72,7 +72,7 @@ use ReflectionClass;
  *                merging some together.
  * @since 2.8.0
  */
-class Fixture extends \PHPUnit_Framework_Assert
+class Fixture extends \PHPUnit\Framework\Assert
 {
     const IMAGES_GENERATED_ONLY_FOR_OS = 'linux';
     const IMAGES_GENERATED_FOR_PHP = '7.2';
@@ -174,13 +174,13 @@ class Fixture extends \PHPUnit_Framework_Assert
     }
 
     /** Adds data to Piwik. Creates sites, tracks visits, imports log files, etc. */
-    public function setUp()
+    public function setUp(): void
     {
         // empty
     }
 
     /** Does any clean up. Most of the time there will be no need to clean up. */
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }
@@ -670,10 +670,10 @@ class Fixture extends \PHPUnit_Framework_Assert
         $trans_gif_64 = "R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
         $expectedResponse = base64_decode($trans_gif_64);
 
-        self::assertContains($expectedResponse, $response);
-        self::assertContains('This resource is part of Matomo.', $response);
-        self::assertNotContains('Error', $response);
-        self::assertNotContains('Fatal', $response);
+        self::assertStringContainsString($expectedResponse, $response);
+        self::assertStringContainsString('This resource is part of Matomo.', $response);
+        self::assertStringNotContainsString('Error', $response);
+        self::assertStringNotContainsString('Fatal', $response);
     }
 
     /**

--- a/tests/PHPUnit/Framework/TestCase/BenchmarkTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/BenchmarkTestCase.php
@@ -27,7 +27,7 @@ abstract class BenchmarkTestCase extends SystemTestCase
 {
     public static $fixture;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $dbName = false;
         if (!empty($GLOBALS['PIWIK_BENCHMARK_DATABASE'])) {
@@ -69,7 +69,7 @@ abstract class BenchmarkTestCase extends SystemTestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         // only drop the database if PIWIK_BENCHMARK_DATABASE isn't set
         $dropDatabase = empty($GLOBALS['PIWIK_BENCHMARK_DATABASE']);
@@ -104,7 +104,7 @@ class Piwik_Test_Fixture_EmptyOneSite
     public $period = 'day';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         // add one site
         Fixture::createWebsite(

--- a/tests/PHPUnit/Framework/TestCase/ConsoleCommandTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/ConsoleCommandTestCase.php
@@ -71,7 +71,7 @@ class ConsoleCommandTestCase extends SystemTestCase
      */
     protected $application;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -46,18 +46,18 @@ abstract class IntegrationTestCase extends SystemTestCase
      * If your test modifies table columns, you will need to recreate the database
      * completely. This can be accomplished by:
      *
-     *     public function setUp()
+     *     public function setUp(): void
      *     {
      *         self::$fixture->performSetUp();
      *     }
      *
-     *     public function tearDown()
+     *     public function tearDown(): void
      *     {
      *         parent::tearDown();
      *         self::$fixture->performTearDown();
      *     }
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         static::configureFixture(static::$fixture);
         parent::setUpBeforeClass();
@@ -66,7 +66,7 @@ abstract class IntegrationTestCase extends SystemTestCase
         self::$tableData = self::getDbTablesWithData();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$tableData = array();
     }
@@ -74,7 +74,7 @@ abstract class IntegrationTestCase extends SystemTestCase
     /**
      * Setup the database and create the base tables for all tests
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -98,7 +98,7 @@ abstract class IntegrationTestCase extends SystemTestCase
     /**
      * Resets all caches and drops the database
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         static::$fixture->clearInMemoryCaches();
         static::$fixture->destroyEnvironment();

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -58,7 +58,7 @@ abstract class SystemTestCase extends TestCase
      */
     public static $fixture;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Log::debug("Setting up " . get_called_class());
 
@@ -83,7 +83,7 @@ abstract class SystemTestCase extends TestCase
         }
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         Log::debug("Tearing down " . get_called_class());
 

--- a/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/UnitTestCase.php
@@ -26,7 +26,7 @@ abstract class UnitTestCase extends \PHPUnit\Framework\TestCase
      */
     protected $environment;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -35,7 +35,7 @@ abstract class UnitTestCase extends \PHPUnit\Framework\TestCase
         File::reset();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         File::reset();
 

--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -9,7 +9,7 @@
 namespace Piwik\Tests\Framework\TestRequest;
 
 use Piwik\API\Request;
-use PHPUnit_Framework_Assert as Asserts;
+use PHPUnit\Framework\Assert as Asserts;
 use Exception;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;

--- a/tests/PHPUnit/Framework/XssTesting.php
+++ b/tests/PHPUnit/Framework/XssTesting.php
@@ -170,7 +170,7 @@ JS;
         $actualEntries = array_values($actualEntries);
 
         try {
-            \PHPUnit_Framework_Assert::assertEquals($expectedEntries, $actualEntries);
+            \PHPUnit\Framework\Assert::assertEquals($expectedEntries, $actualEntries);
         } catch (\Exception $ex) {
             print "XssTesting::sanityCheck() failed, got: " . var_export($actualEntries, true)
                 . "\nexpected: " . var_export($expectedEntries, true);

--- a/tests/PHPUnit/Integration/API/RequestTest.php
+++ b/tests/PHPUnit/Integration/API/RequestTest.php
@@ -18,9 +18,9 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class RequestTest extends IntegrationTestCase
 {
-    /** @var \Piwik\Auth|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \Piwik\Auth|\PHPUnit\Framework\MockObject\MockObject */
     private $auth;
-    /** @var \Piwik\Access|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \Piwik\Access|\PHPUnit\Framework\MockObject\MockObject */
     private $access;
 
     private $userAuthToken = 'token';

--- a/tests/PHPUnit/Integration/AccessTest.php
+++ b/tests/PHPUnit/Integration/AccessTest.php
@@ -167,11 +167,9 @@ class AccessTest extends IntegrationTestCase
         $this->assertEmpty($access->getSitesIdWithViewAccess());
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasSuperUserAccessWithEmptyAccess()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $access = $this->getAccess();
         $access->checkUserHasSuperUserAccess();
     }
@@ -183,11 +181,9 @@ class AccessTest extends IntegrationTestCase
         $access->checkUserHasSuperUserAccess();
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasSomeAdminAccessWithEmptyAccess()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $access = $this->getAccess();
         $access->checkUserHasSomeAdminAccess();
     }
@@ -212,38 +208,30 @@ class AccessTest extends IntegrationTestCase
         $this->assertFalse($access->isUserHasSomeAdminAccess());
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function test_CheckUserHasSomeAdminAccessWithSomeAccessFails_IfUserHasPermissionsToSitesButIsNotAuthenticated()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $mock = $this->createAccessMockWithAccessToSitesButUnauthenticated(array(2, 9));
         $mock->checkUserHasSomeAdminAccess();
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function test_checkUserHasAdminAccessFails_IfUserHasPermissionsToSitesButIsNotAuthenticated()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $mock = $this->createAccessMockWithAccessToSitesButUnauthenticated(array(2, 9));
         $mock->checkUserHasAdminAccess('2');
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function test_checkUserHasSomeViewAccessFails_IfUserHasPermissionsToSitesButIsNotAuthenticated()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $mock = $this->createAccessMockWithAccessToSitesButUnauthenticated(array(2, 9));
         $mock->checkUserHasSomeViewAccess();
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function test_checkUserHasViewAccessFails_IfUserHasPermissionsToSitesButIsNotAuthenticated()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $mock = $this->createAccessMockWithAccessToSitesButUnauthenticated(array(2, 9));
         $mock->checkUserHasViewAccess('2');
     }
@@ -259,11 +247,9 @@ class AccessTest extends IntegrationTestCase
         $mock->checkUserHasSomeAdminAccess();
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasSomeViewAccessWithEmptyAccess()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $access = $this->getAccess();
         $access->checkUserHasSomeViewAccess();
     }
@@ -297,11 +283,9 @@ class AccessTest extends IntegrationTestCase
         $mock->checkUserHasSomeWriteAccess();
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasSomeWriteAccessWithSomeAccessDoesNotHaveAccess()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $mock = $this->createAccessMockWithAuthenticatedUser(array('getRawSitesWithSomeViewAccess'));
 
         $mock->expects($this->once())
@@ -311,11 +295,9 @@ class AccessTest extends IntegrationTestCase
         $mock->checkUserHasSomeWriteAccess();
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasViewAccessWithEmptyAccessNoSiteIdsGiven()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $access = $this->getAccess();
         $access->checkUserHasViewAccess(array());
     }
@@ -351,12 +333,10 @@ class AccessTest extends IntegrationTestCase
         $mock->checkUserHasViewAccess('all');
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasViewAccessWithSomeAccessFailure()
     {
-        $mock = $this->getMockBuilder('Piwik\Access')->setMethods(array('getSitesIdWithAtLeastViewAccess'))->getMock();
+        $this->expectException(\Piwik\NoAccessException::class);
+        $mock = $this->getMockBuilder('Piwik\Access')->onlyMethods(array('getSitesIdWithAtLeastViewAccess'))->getMock();
 
         $mock->expects($this->once())
             ->method('getSitesIdWithAtLeastViewAccess')
@@ -365,11 +345,9 @@ class AccessTest extends IntegrationTestCase
         $mock->checkUserHasViewAccess(array(1, 5));
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasWriteAccessWithEmptyAccessNoSiteIdsGiven()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $access = $this->getAccess();
         $access->checkUserHasWriteAccess(array());
     }
@@ -381,12 +359,10 @@ class AccessTest extends IntegrationTestCase
         $access->checkUserHasWriteAccess(array());
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasWriteAccessWithSomeAccessFailure()
     {
-        $mock = $this->getMockBuilder('Piwik\Access')->setMethods(array('getSitesIdWithAtLeastWriteAccess'))->getMock();
+        $this->expectException(\Piwik\NoAccessException::class);
+        $mock = $this->getMockBuilder('Piwik\Access')->onlyMethods(array('getSitesIdWithAtLeastWriteAccess'))->getMock();
 
         $mock->expects($this->once())
             ->method('getSitesIdWithAtLeastWriteAccess')
@@ -402,18 +378,16 @@ class AccessTest extends IntegrationTestCase
         $access->checkUserHasAdminAccess(array());
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasAdminAccessWithEmptyAccessNoSiteIdsGiven()
     {
+        $this->expectException(\Piwik\NoAccessException::class);
         $access = $this->getAccess();
         $access->checkUserHasViewAccess(array());
     }
 
     public function testCheckUserHasAdminAccessWithSomeAccessSuccessIdSitesAsString()
     {
-        $mock = $this->getMock(
+        $mock = $this->createPartialMock(
             'Piwik\Access',
             array('getSitesIdWithAdminAccess')
         );
@@ -427,7 +401,7 @@ class AccessTest extends IntegrationTestCase
 
     public function testCheckUserHasAdminAccessWithSomeAccessSuccessAllSites()
     {
-        $mock = $this->getMock(
+        $mock = $this->createPartialMock(
             'Piwik\Access',
             array('getSitesIdWithAdminAccess', 'getSitesIdWithAtLeastViewAccess')
         );
@@ -443,12 +417,10 @@ class AccessTest extends IntegrationTestCase
         $mock->checkUserHasAdminAccess('all');
     }
 
-    /**
-     * @expectedException \Piwik\NoAccessException
-     */
     public function testCheckUserHasAdminAccessWithSomeAccessFailure()
     {
-        $mock = $this->getMock(
+        $this->expectException(\Piwik\NoAccessException::class);
+        $mock = $this->createPartialMock(
             'Piwik\Access',
             array('getSitesIdWithAdminAccess')
         );
@@ -697,7 +669,7 @@ class AccessTest extends IntegrationTestCase
     private function createPiwikAuthMockInstance()
     {
         return $this->getMockBuilder('Piwik\\Auth')
-                    ->setMethods(array('authenticate', 'getName', 'getTokenAuthSecret', 'getLogin', 'setTokenAuth', 'setLogin',
+                    ->onlyMethods(array('authenticate', 'getName', 'getTokenAuthSecret', 'getLogin', 'setTokenAuth', 'setLogin',
             'setPassword', 'setPasswordHash'))
                     ->getMock();
     }
@@ -705,7 +677,7 @@ class AccessTest extends IntegrationTestCase
     private function createAccessMockWithAccessToSitesButUnauthenticated($idSites)
     {
         $mock = $this->getMockBuilder('Piwik\Access')
-                     ->setMethods(array('getRawSitesWithSomeViewAccess', 'loadSitesIfNeeded'))
+                     ->onlyMethods(array('getRawSitesWithSomeViewAccess', 'loadSitesIfNeeded'))
                      ->getMock();
 
         // this method will be actually never called as it is unauthenticated. The tests are supposed to fail if it
@@ -719,7 +691,7 @@ class AccessTest extends IntegrationTestCase
 
     private function createAccessMockWithAuthenticatedUser($methodsToMock = array())
     {
-        $methods = array('authenticate');
+        $methods = [];
 
         foreach ($methodsToMock as $methodToMock) {
             $methods[] = $methodToMock;
@@ -730,7 +702,7 @@ class AccessTest extends IntegrationTestCase
             ->method('authenticate')
             ->will($this->returnValue(new AuthResult(AuthResult::SUCCESS, 'login', 'token')));
 
-        $mock = $this->getMockBuilder('Piwik\Access')->setMethods($methods)->getMock();
+        $mock = $this->getMockBuilder('Piwik\Access')->onlyMethods($methods)->getMock();
         $mock->reloadAccess($authMock);
 
         return $mock;

--- a/tests/PHPUnit/Integration/Application/Kernel/PluginListTest.php
+++ b/tests/PHPUnit/Integration/Application/Kernel/PluginListTest.php
@@ -22,7 +22,7 @@ class PluginListTest extends \PHPUnit\Framework\TestCase
      */
     private $pluginList = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->pluginList = $this->makePluginList();

--- a/tests/PHPUnit/Integration/Archive/ArchivePurgerTest.php
+++ b/tests/PHPUnit/Integration/Archive/ArchivePurgerTest.php
@@ -41,7 +41,7 @@ class ArchivePurgerTest extends IntegrationTestCase
      */
     private $february;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Archive/ChunksTest.php
+++ b/tests/PHPUnit/Integration/Archive/ChunksTest.php
@@ -33,7 +33,7 @@ class ChunksTest extends IntegrationTestCase
 {
     private $date = '2015-01-01';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Archive/DataTableFactoryTest.php
+++ b/tests/PHPUnit/Integration/Archive/DataTableFactoryTest.php
@@ -42,7 +42,7 @@ class DataTableFactoryTest extends IntegrationTestCase
         'nb_visits' => 97
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -267,12 +267,11 @@ class DataTableFactoryTest extends IntegrationTestCase
         $this->assertRowEquals($row3, $this->site2, $map->getTable($this->date2)->getRowFromId(1));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage supposed to work with non-numeric data types but it is not tested
-     */
     public function test_makeMerged_shouldThrowAnException_IfANonNumericDataTypeIsGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('supposed to work with non-numeric data types but it is not tested');
+
         $dataType  = 'blob';
         $dataNames = array('nb_visits');
 

--- a/tests/PHPUnit/Integration/ArchiveProcessingTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessingTest.php
@@ -40,7 +40,7 @@ class ArchiveProcessorTest extends ArchiveProcessor\Loader
  */
 class ArchiveProcessingTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -50,7 +50,7 @@ class ArchiveProcessingTest extends IntegrationTestCase
         ArchiveTableCreator::$tablesAlreadyInstalled = null;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         ArchiveTableCreator::$tablesAlreadyInstalled = null;
     }

--- a/tests/PHPUnit/Integration/ArchiveProcessor/ArchivingStatusTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/ArchivingStatusTest.php
@@ -22,7 +22,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
 class ArchivingStatusTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/ArchiveProcessor/ParametersTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/ParametersTest.php
@@ -19,7 +19,7 @@ use Piwik\Period;
 
 class ParametersTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
+++ b/tests/PHPUnit/Integration/ArchiveProcessor/PluginsArchiverTest.php
@@ -60,7 +60,7 @@ class PluginsArchiverTest extends IntegrationTestCase
      */
     private $pluginsArchiver;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -81,13 +81,12 @@ class PluginsArchiverTest extends IntegrationTestCase
         return $params;
     }
 
-    /**
-     * @expectedException \Piwik\ArchiveProcessor\PluginsArchiverException
-     * @expectedExceptionMessage Failed query foo bar - in plugin MyPluginName
-     * @expectedExceptionCode 42
-     */
     public function test_purgeOutdatedArchives_PurgesCorrectTemporaryArchives_WhileKeepingNewerTemporaryArchives_WithBrowserTriggeringEnabled()
     {
+        $this->expectException(\Piwik\ArchiveProcessor\PluginsArchiverException::class);
+        $this->expectExceptionCode(42);
+        $this->expectExceptionMessage('Failed query foo bar - in plugin MyPluginName');
+
         $this->pluginsArchiver->callAggregateAllPlugins(1, 1);
     }
 

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -57,7 +57,7 @@ class ArchiveTest extends IntegrationTestCase
      */
     public static $fixture;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/PHPUnit/Integration/ArchiveWithNoVisitsTest.php
+++ b/tests/PHPUnit/Integration/ArchiveWithNoVisitsTest.php
@@ -40,7 +40,7 @@ class ArchiveWithNoVisitsTest_MockArchiver extends Archiver
 
 class ArchiveWithNoVisitsTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/AssetManager/UIAssetMinifierTest.php
+++ b/tests/PHPUnit/Integration/AssetManager/UIAssetMinifierTest.php
@@ -18,7 +18,7 @@ class UIAssetMinifierTest extends \PHPUnit\Framework\TestCase
      */
     private $assetMinifier;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->assetMinifier = UIAssetMinifier::getInstance();
     }

--- a/tests/PHPUnit/Integration/AssetManagerTest.php
+++ b/tests/PHPUnit/Integration/AssetManagerTest.php
@@ -61,7 +61,7 @@ class AssetManagerTest extends IntegrationTestCase
      */
     private $pluginManager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -80,7 +80,7 @@ class AssetManagerTest extends IntegrationTestCase
         $this->setUpPlugins();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->assetManager !== null) {
             $this->assetManager->removeMergedAssets();

--- a/tests/PHPUnit/Integration/CacheIdTest.php
+++ b/tests/PHPUnit/Integration/CacheIdTest.php
@@ -18,12 +18,12 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class CacheIdTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Fixture::loadAllTranslations();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
     }

--- a/tests/PHPUnit/Integration/CliMulti/OutputTest.php
+++ b/tests/PHPUnit/Integration/CliMulti/OutputTest.php
@@ -22,7 +22,7 @@ class OutputTest extends \PHPUnit\Framework\TestCase
      */
     private $output;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +31,7 @@ class OutputTest extends \PHPUnit\Framework\TestCase
         $this->output = new Output('myid');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if(is_object($this->output)){
             $this->output->destroy();
@@ -42,12 +42,11 @@ class OutputTest extends \PHPUnit\Framework\TestCase
         parent::tearDown();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The given output id has an invalid format
-     */
     public function test_construct_shouldFail_IfInvalidOutputIdGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The given output id has an invalid format');
+
         new Output('../../');
     }
 

--- a/tests/PHPUnit/Integration/CliMulti/ProcessTest.php
+++ b/tests/PHPUnit/Integration/CliMulti/ProcessTest.php
@@ -22,7 +22,7 @@ class ProcessTest extends \PHPUnit\Framework\TestCase
      */
     private $process;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -30,7 +30,7 @@ class ProcessTest extends \PHPUnit\Framework\TestCase
         $this->process = new Process('testPid');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if(is_object($this->process)){
             $this->process->finishProcess();
@@ -38,12 +38,11 @@ class ProcessTest extends \PHPUnit\Framework\TestCase
         File::reset();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The given pid has an invalid format
-     */
     public function test_construct_shouldFailInCasePidIsInvalid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The given pid has an invalid format');
+
         new Process('../../htaccess');
     }
 

--- a/tests/PHPUnit/Integration/Columns/ComputedMetricFactoryTest.php
+++ b/tests/PHPUnit/Integration/Columns/ComputedMetricFactoryTest.php
@@ -24,7 +24,7 @@ class ComputedMetricFactoryTest extends IntegrationTestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -33,7 +33,7 @@ class ComputedMetricFactoryTest extends IntegrationTestCase
         $this->factory = new ComputedMetricFactory(MetricsList::get());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
         parent::tearDown();

--- a/tests/PHPUnit/Integration/Columns/DimensionMetricFactoryTest.php
+++ b/tests/PHPUnit/Integration/Columns/DimensionMetricFactoryTest.php
@@ -24,7 +24,7 @@ class DimensionMetricFactoryTest extends IntegrationTestCase
     /** @var  Dimension */
     private $country;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -33,7 +33,7 @@ class DimensionMetricFactoryTest extends IntegrationTestCase
         $this->country = new Country();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
         parent::tearDown();

--- a/tests/PHPUnit/Integration/Columns/DimensionTest.php
+++ b/tests/PHPUnit/Integration/Columns/DimensionTest.php
@@ -79,7 +79,7 @@ class ColumnDimensionTest extends IntegrationTestCase
      */
     private $dimension;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -93,7 +93,7 @@ class ColumnDimensionTest extends IntegrationTestCase
         $this->dimension = new CustomDimensionTest();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
         parent::tearDown();

--- a/tests/PHPUnit/Integration/Columns/UpdaterTest.php
+++ b/tests/PHPUnit/Integration/Columns/UpdaterTest.php
@@ -59,7 +59,7 @@ class UpdaterTest extends IntegrationTestCase
      */
     private $columnsUpdater;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -189,7 +189,7 @@ class UpdaterTest extends IntegrationTestCase
 
     private function getMockUpdater($hasNewVersion = true)
     {
-        $result = $this->getMockBuilder("Piwik\\Updater")->setMethods(array('hasNewVersion'))->getMock();
+        $result = $this->getMockBuilder("Piwik\\Updater")->onlyMethods(array('hasNewVersion'))->getMock();
 
         $result->expects($this->any())->method('hasNewVersion')->will($this->returnCallback(function () use ($hasNewVersion) {
             return $hasNewVersion;

--- a/tests/PHPUnit/Integration/Concurrency/DistributedListTest.php
+++ b/tests/PHPUnit/Integration/Concurrency/DistributedListTest.php
@@ -33,7 +33,7 @@ class DistributedListTest extends IntegrationTestCase
      */
     private $distributedList;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Concurrency/LockBackend/MysqlLockBackendTest.php
+++ b/tests/PHPUnit/Integration/Concurrency/LockBackend/MysqlLockBackendTest.php
@@ -21,7 +21,7 @@ class MysqlLockBackendTest extends IntegrationTestCase
     private $backend;
     private $key = 'testKeyValueKey';
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!$this->hasDependencies()) {
             parent::setUp();
@@ -34,7 +34,7 @@ class MysqlLockBackendTest extends IntegrationTestCase
         $this->backend = $this->createMysqlBackend();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $GLOBALS['PIWIK_TRACKER_MODE'] = false;
         Db::destroyDatabaseObject();

--- a/tests/PHPUnit/Integration/Concurrency/LockTest.php
+++ b/tests/PHPUnit/Integration/Concurrency/LockTest.php
@@ -23,7 +23,7 @@ class LockTest extends IntegrationTestCase
      */
     public $lock;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +31,7 @@ class LockTest extends IntegrationTestCase
         $this->lock = $this->createLock($mysql);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/PHPUnit/Integration/Config/CacheTest.php
+++ b/tests/PHPUnit/Integration/Config/CacheTest.php
@@ -24,7 +24,7 @@ class CacheTest extends IntegrationTestCase
 
     private $testHost = 'analytics.test.matomo.org';
 
-    public function setUp()
+    public function setUp(): void
     {
         unset($GLOBALS['ENABLE_CONFIG_PHP_CACHE']);
         $this->setTrustedHosts();
@@ -39,7 +39,7 @@ class CacheTest extends IntegrationTestCase
         Config::setSetting('General', 'trusted_hosts', array($this->testHost, 'foonot.exists'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->setTrustedHosts();
         $this->cache->doDelete(IniFileChain::CONFIG_CACHE_KEY);
@@ -55,11 +55,12 @@ class CacheTest extends IntegrationTestCase
 
     /**
      * @dataProvider getRandmHosts
-     * @expectedException \Exception
-     * @expectedExceptionMessage  Unsupported host
      */
     public function test_construct_failsWhenUsingRandomHost($host)
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unsupported host');
+
         $_SERVER['HTTP_HOST'] = $host;
         new Cache();
     }

--- a/tests/PHPUnit/Integration/CronArchive/SharedSiteIdsTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/SharedSiteIdsTest.php
@@ -22,7 +22,7 @@ class SharedSiteIdsTest extends IntegrationTestCase
      */
     private $sharedSiteIds;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -34,7 +34,7 @@ class SharedSiteIdsTest extends IntegrationTestCase
         $this->sharedSiteIds = $this->makeSharedSiteIds(array(1,2,5,9));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (!SharedSiteIds::isSupported()) {
             return;

--- a/tests/PHPUnit/Integration/CronArchiveTest.php
+++ b/tests/PHPUnit/Integration/CronArchiveTest.php
@@ -106,9 +106,9 @@ class CronArchiveTest extends IntegrationTestCase
         $archiver->init();
         $archiver->run();
 
-        $this->assertContains('Will skip segments archiving for today unless they were created recently', $logger->output);
-        $this->assertContains('Segment "actions>=1" was created or changed recently and will therefore archive today', $logger->output);
-        $this->assertNotContains('Segment "actions>=2" was created recently', $logger->output);
+        self::assertStringContainsString('Will skip segments archiving for today unless they were created recently', $logger->output);
+        self::assertStringContainsString('Segment "actions>=1" was created or changed recently and will therefore archive today', $logger->output);
+        self::assertStringNotContainsString('Segment "actions>=2" was created recently', $logger->output);
     }
 
     public function test_output()
@@ -212,7 +212,7 @@ Will pre-process for website id = 1, period = day, date = last52
 - pre-processing all visits
 LOG;
 
-        $this->assertContains($expected, $logger->output);
+        self::assertStringContainsString($expected, $logger->output);
     }
 
     public function provideContainerConfig()

--- a/tests/PHPUnit/Integration/DataAccess/ActionsTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ActionsTest.php
@@ -22,7 +22,7 @@ class ActionsTest extends IntegrationTestCase
      */
     private $actionsAccess;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -54,7 +54,7 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
      */
     private static $segment2;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -72,7 +72,7 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveTableDaoTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveTableDaoTest.php
@@ -28,7 +28,7 @@ class ArchiveTableDaoTest extends IntegrationTestCase
      */
     private $archiveTableDao;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveWriterTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveWriterTest.php
@@ -38,7 +38,7 @@ class ArchiveWriterTest extends IntegrationTestCase
 {
     private $idSite;
 
-    public function setUp()
+    public function setUp(): void
     {
         Access::getInstance()->setSuperUserAccess(true);
         $this->idSite = Fixture::createWebsite('2019-08-29');

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -41,7 +41,7 @@ class LogAggregatorTest extends IntegrationTestCase
      */
     private $logAggregator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/DataAccess/ModelTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ModelTest.php
@@ -23,7 +23,7 @@ class ModelTest extends IntegrationTestCase
     private $model;
     private $tableName = 'archive_numeric_test';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/DataAccess/TableMetadataTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/TableMetadataTest.php
@@ -21,7 +21,7 @@ class TableMetadataTest extends IntegrationTestCase
      */
     private $tableMetadataAccess;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/DataTable/Filter/PivotByDimensionTest.php
+++ b/tests/PHPUnit/Integration/DataTable/Filter/PivotByDimensionTest.php
@@ -39,7 +39,7 @@ class PivotByDimensionTest extends IntegrationTestCase
      */
     public $segmentUsedToGetIntersected = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -50,67 +50,61 @@ class PivotByDimensionTest extends IntegrationTestCase
         $this->segmentTableCount = 0;
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Unsupported pivot: report 'ExampleReport.getExampleReport' has no subtable dimension.
-     */
     public function test_construction_ShouldFail_WhenReportHasNoSubtableAndSegmentFetchingIsDisabled()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unsupported pivot: report \'ExampleReport.getExampleReport\' has no subtable dimension.');
+
         $this->loadPlugins('ExampleReport', 'UserCountry');
 
         new PivotByDimension(new DataTable(), "ExampleReport.GetExampleReport", "UserCountry.City", 'nb_visits', $columnLimit = -1, $enableFetchBySegment = false);
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Unsupported pivot: the subtable dimension for 'Referrers.getKeywords' does not match the requested pivotBy dimension.
-     */
     public function test_construction_ShouldFail_WhenDimensionIsNotSubtableAndSegmentFetchingIsDisabled()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unsupported pivot: the subtable dimension for \'Referrers.getKeywords\' does not match the requested pivotBy dimension.');
+
         $this->loadPlugins('Referrers', 'UserCountry');
 
         new PivotByDimension(new DataTable(), "Referrers.getKeywords", "UserCountry.City", "nb_visits", $columnLimit = -1, $enableFetchBySegment = false);
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Unsupported pivot: No segment for dimension of report 'Resolution.getConfiguration'
-     */
     public function test_construction_ShouldFail_WhenDimensionIsNotSubtableAndSegmentFetchingIsEnabledButThereIsNoSegment()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unsupported pivot: No segment for dimension of report \'Resolution.getConfiguration\'');
+
         $this->loadPlugins('Referrers', 'Resolution');
 
         new PivotByDimension(new DataTable(), "Resolution.GetConfiguration", "Referrers.Keyword", "nb_visits");
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Invalid dimension 'ExampleTracker.InvalidDimension'
-     */
     public function test_construction_ShouldFail_WhenDimensionDoesNotExist()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid dimension \'ExampleTracker.InvalidDimension\'');
+
         $this->loadPlugins('ExampleReport', 'ExampleTracker');
 
         new PivotByDimension(new DataTable(), "ExampleReport.GetExampleReport", "ExampleTracker.InvalidDimension", 'nb_visits');
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Unsupported pivot: No report for pivot dimension 'ExampleTracker.ExampleDimension'
-     */
     public function test_construction_ShouldFail_WhenThereIsNoReportForADimension()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unsupported pivot: No report for pivot dimension \'ExampleTracker.ExampleDimension\'');
+
         $this->loadPlugins('ExampleReport', 'ExampleTracker');
 
         new PivotByDimension(new DataTable(), "ExampleReport.GetExampleReport", "ExampleTracker.ExampleDimension", "nb_visits");
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Unable to find report 'ExampleReport.InvalidReport'
-     */
     public function test_construction_ShouldFail_WhenSpecifiedReportIsNotValid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to find report \'ExampleReport.InvalidReport\'');
+
         $this->loadPlugins('ExampleReport', 'Referrers');
 
         new PivotByDimension(new DataTable(), "ExampleReport.InvalidReport", "Referrers.Keyword", "nb_visits");
@@ -380,7 +374,7 @@ class PivotByDimensionTest extends IntegrationTestCase
 
     public function provideContainerConfig()
     {
-        $proxyMock = $this->getMockBuilder('stdClass')->setMethods(array('call'))->getMock();
+        $proxyMock = $this->getMockBuilder('stdClass')->addMethods(array('call'))->getMock();
         $proxyMock->expects($this->any())->method('call')->willReturnCallback(function ($className, $methodName, $parameters) {
             if ($className == "\\Piwik\\Plugins\\UserCountry\\API"
                 && $methodName == 'getCity'

--- a/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
+++ b/tests/PHPUnit/Integration/Db/TransactionLevelTest.php
@@ -30,7 +30,7 @@ class TransactionLevelTest extends IntegrationTestCase
 	 */
 	private $db;
 
-	public function setUp()
+	public function setUp(): void
 	{
 		parent::setUp();
 		$this->db = Db::get();

--- a/tests/PHPUnit/Integration/DbHelperTest.php
+++ b/tests/PHPUnit/Integration/DbHelperTest.php
@@ -16,7 +16,7 @@ use Piwik\Version;
 
 class DbHelperTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -93,14 +93,14 @@ class DbHelperTest extends IntegrationTestCase
     {
         $dbs = Db::fetchAll("SHOW DATABASES");
         $dbs = array_column($dbs, 'Database');
-        $this->assertContains($this->cleanName($dbName), $dbs);
+        self::assertTrue(in_array($this->cleanName($dbName), $dbs));
     }
 
     private function assertDbNotExists($dbName)
     {
         $dbs = Db::fetchAll("SHOW DATABASES");
         $dbs = array_column($dbs, 'Database');
-        $this->assertNotContains($this->cleanName($dbName), $dbs);
+        self::assertTrue(!in_array($this->cleanName($dbName), $dbs));
     }
 
     private function cleanName($dbName)

--- a/tests/PHPUnit/Integration/DbTest.php
+++ b/tests/PHPUnit/Integration/DbTest.php
@@ -20,14 +20,14 @@ class DbTest extends IntegrationTestCase
 {
     private $dbReaderConfigBackup;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->dbReaderConfigBackup = Config::getInstance()->database_reader;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Db::destroyDatabaseObject();
         Config::getInstance()->database_reader = $this->dbReaderConfigBackup;
@@ -130,12 +130,11 @@ class DbTest extends IntegrationTestCase
         $this->assertSame($expected, $result);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessagelock name has to be 64 characters or less
-     */
     public function test_getDbLock_shouldThrowAnException_IfDbLockNameIsTooLong()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('name has to be 64 characters or less');
+
         Db::getDbLock(str_pad('test', 65, '1'));
     }
 

--- a/tests/PHPUnit/Integration/DependencyTest.php
+++ b/tests/PHPUnit/Integration/DependencyTest.php
@@ -23,7 +23,7 @@ class DependencyTest extends IntegrationTestCase
      */
     private $dependency;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->dependency = new Dependency();

--- a/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
+++ b/tests/PHPUnit/Integration/DocumentationGeneratorTest.php
@@ -23,7 +23,7 @@ class DocumentationGeneratorTest extends TestCase
         $annotation = '@hideExceptForSuperUser test test';
         $mock = $this->getMockBuilder('ReflectionClass')
             ->disableOriginalConstructor()
-            ->setMethods(array('getDocComment'))
+            ->onlyMethods(array('getDocComment'))
             ->getMock();
         $mock->expects($this->once())->method('getDocComment')->willReturn($annotation);
         $documentationGenerator = new DocumentationGenerator();

--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -270,21 +270,21 @@ class HttpTest extends \PHPUnit\Framework\TestCase
      *      curl_exec: server certificate verification failed. CAfile: /home/travis/build/piwik/piwik/core/DataFiles/cacert.pem CRLfile: none. Hostname requested was: self-signed.badssl.com
      * or
      *      curl_exec: SSL certificate problem: self signed certificate. Hostname requested was: self-signed.badssl.com
-     * @expectedException \Exception
-     * @expectedExceptionMessageRegExp /curl_exec: .*certificate.* /
      */
     public function testCurlHttpsFailsWithInvalidCertificate()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageRegExp('/curl_exec: .*certificate.* /');
+
         // use a domain from https://badssl.com/
         Http::sendHttpRequestBy('curl', 'https://self-signed.badssl.com/', 10);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage failed to open stream
-     */
     public function testFopenHttpsFailsWithInvalidCertificate()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('failed to open stream');
+
         // use a domain from https://badssl.com/
         Http::sendHttpRequestBy('fopen', 'https://self-signed.badssl.com/', 10);
     }

--- a/tests/PHPUnit/Integration/JsProxyTest.php
+++ b/tests/PHPUnit/Integration/JsProxyTest.php
@@ -16,7 +16,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class JsProxyTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Fixture::createWebsite('2014-01-01 02:03:04');

--- a/tests/PHPUnit/Integration/LogDeleterTest.php
+++ b/tests/PHPUnit/Integration/LogDeleterTest.php
@@ -31,7 +31,7 @@ class LogDeleterTest extends IntegrationTestCase
      */
     private $logDeleter;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Measurable/MeasurableSettingTest.php
+++ b/tests/PHPUnit/Integration/Measurable/MeasurableSettingTest.php
@@ -20,7 +20,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class MeasurableSettingTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Fixture::createWebsite('2014-01-01 00:00:01');
@@ -42,23 +42,21 @@ class MeasurableSettingTest extends IntegrationTestCase
         $this->assertSame('test', $value);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed
-     */
     public function testSetValue_shouldThrowException_IfOnlyViewPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
         FakeAccess::clearAccess();
         FakeAccess::setIdSitesView(array(1, 2, 3));
         $this->createSetting()->setValue('test');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed
-     */
     public function testSetValue_shouldThrowException_IfNoPermissionAtAll()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
         FakeAccess::clearAccess();
         $this->createSetting()->setValue('test');
     }

--- a/tests/PHPUnit/Integration/Measurable/MeasurableSettingsTest.php
+++ b/tests/PHPUnit/Integration/Measurable/MeasurableSettingsTest.php
@@ -29,7 +29,7 @@ class MeasurableSettingsTest extends IntegrationTestCase
      */
     private $settings;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -56,12 +56,11 @@ class MeasurableSettingsTest extends IntegrationTestCase
         $this->assertStoredSettingsValue(array('value3'), 'sitesearch_category_parameters');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed
-     */
     public function test_save_shouldCheckAdminPermissionsForThatSite()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
         FakeAccess::clearAccess();
 
         $this->settings = $this->createSettings();

--- a/tests/PHPUnit/Integration/NumberFormatterTest.php
+++ b/tests/PHPUnit/Integration/NumberFormatterTest.php
@@ -23,14 +23,14 @@ class NumberFormatterTest extends \PHPUnit\Framework\TestCase
      */
     private $translator;
 
-    public function setUp()
+    public function setUp(): void
     {
         \Piwik\Plugin\Manager::getInstance()->loadPluginTranslations();
 
         $this->translator = StaticContainer::get('Piwik\Translation\Translator');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->translator->reset();
     }

--- a/tests/PHPUnit/Integration/Period/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Period/FactoryTest.php
@@ -100,21 +100,19 @@ class FactoryTest extends IntegrationTestCase
         $this->assertInstanceOf(TestPeriod::class, $period);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ExceptionInvalidPeriod
-     */
     public function test_build_ThrowsIfPeriodIsUnrecognized()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionInvalidPeriod');
+
         Period\Factory::build('garbageperiod', '2015-01-01');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ExceptionInvalidPeriod
-     */
     public function test_build_ThrowsIfPeriodIsNotEnabledForApi()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionInvalidPeriod');
+
         Config::getInstance()->General['enabled_periods_API'] = 'day';
         Period\Factory::build('week', '2015-01-01');
     }

--- a/tests/PHPUnit/Integration/PiwikTest.php
+++ b/tests/PHPUnit/Integration/PiwikTest.php
@@ -103,10 +103,10 @@ class PiwikTest extends IntegrationTestCase
 
     /**
      * @dataProvider getInvalidLoginStringData
-     * @expectedException \Exception
      */
     public function testCheckInvalidLoginString($toTest)
     {
+        $this->expectException(\Exception::class);
         Piwik::checkValidLoginString($toTest);
     }
 
@@ -242,7 +242,7 @@ class PiwikTest extends IntegrationTestCase
     private function createPiwikAuthMockInstance()
     {
         return $this->getMockBuilder('Piwik\\Auth')
-            ->setMethods(array('authenticate', 'getName', 'getTokenAuthSecret', 'getLogin', 'setTokenAuth', 'setLogin',
+            ->onlyMethods(array('authenticate', 'getName', 'getTokenAuthSecret', 'getLogin', 'setTokenAuth', 'setLogin',
                 'setPassword', 'setPasswordHash'))
             ->getMock();
     }

--- a/tests/PHPUnit/Integration/Plugin/ArchivedMetricTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ArchivedMetricTest.php
@@ -33,7 +33,7 @@ class ArchivedMetricTest extends IntegrationTestCase
      */
     private $metric;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -45,7 +45,7 @@ class ArchivedMetricTest extends IntegrationTestCase
         $this->metric = $this->makeMetric('%s');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
         parent::tearDown();

--- a/tests/PHPUnit/Integration/Plugin/CategoriesTest.php
+++ b/tests/PHPUnit/Integration/Plugin/CategoriesTest.php
@@ -27,7 +27,7 @@ class CategoriesTest extends IntegrationTestCase
      */
     private $categories;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -39,7 +39,7 @@ class CategoriesTest extends IntegrationTestCase
         $this->categories = new Categories(StaticContainer::get('Piwik\Plugin\Manager'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         unset($_GET['idSite']);

--- a/tests/PHPUnit/Integration/Plugin/ComputedMetricTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ComputedMetricTest.php
@@ -22,7 +22,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class ComputedMetricTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +31,7 @@ class ComputedMetricTest extends IntegrationTestCase
         Fixture::createWebsite('2015-01-01 00:00:00');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
         parent::tearDown();

--- a/tests/PHPUnit/Integration/Plugin/Dimension/ActionDimensionTest.php
+++ b/tests/PHPUnit/Integration/Plugin/Dimension/ActionDimensionTest.php
@@ -53,7 +53,7 @@ class ActionDimensionTest extends IntegrationTestCase
      */
     private $dimension;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Plugin/Dimension/ConversionDimensionTest.php
+++ b/tests/PHPUnit/Integration/Plugin/Dimension/ConversionDimensionTest.php
@@ -53,7 +53,7 @@ class ConversionDimensionTest extends IntegrationTestCase
      */
     private $dimension;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Plugin/Dimension/DimensionMetadataProviderTest.php
+++ b/tests/PHPUnit/Integration/Plugin/Dimension/DimensionMetadataProviderTest.php
@@ -15,7 +15,7 @@ use Piwik\Plugin\Manager as PluginManager;
 
 class DimensionMetadataProviderTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Plugin/Dimension/VisitDimensionTest.php
+++ b/tests/PHPUnit/Integration/Plugin/Dimension/VisitDimensionTest.php
@@ -74,7 +74,7 @@ class VisitDimensionTest extends IntegrationTestCase
      */
     private $conversionDimension;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -212,12 +212,11 @@ class VisitDimensionTest extends IntegrationTestCase
         $this->assertSame(array($dimension3, $dimension4, $dimension2, $dimension1), $instances);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage  Circular reference detected for required field column4 in dimension column2
-     */
     public function test_sortDimensions_ShouldThrowAnException_IfCircularReferenceDetected()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Circular reference detected for required field column4 in dimension column2');
+
         $dimension1 = new FakeVisitDimension();
         $dimension1->set('columnName', 'column1');
         $dimension1->requiredFields = array('column3');

--- a/tests/PHPUnit/Integration/Plugin/ManagerTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ManagerTest.php
@@ -30,7 +30,7 @@ class ManagerTest extends IntegrationTestCase
      */
     private $manager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->manager = Plugin\Manager::getInstance();

--- a/tests/PHPUnit/Integration/Plugin/ReleaseChannelsTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ReleaseChannelsTest.php
@@ -30,7 +30,7 @@ class ReleaseChannelsTest extends IntegrationTestCase
      */
     private $channels;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Plugin/SettingsProviderTest.php
+++ b/tests/PHPUnit/Integration/Plugin/SettingsProviderTest.php
@@ -37,7 +37,7 @@ class SettingsProviderTest extends IntegrationTestCase
 
     private $examplePlugin = 'ExampleSettingsPlugin';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -50,7 +50,7 @@ class SettingsProviderTest extends IntegrationTestCase
         $this->settings = new SettingsProvider($this->pluginManager);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         unset($_GET['idSite']);

--- a/tests/PHPUnit/Integration/Plugin/WidgetsProviderTest.php
+++ b/tests/PHPUnit/Integration/Plugin/WidgetsProviderTest.php
@@ -28,7 +28,7 @@ class WidgetsProviderTest extends IntegrationTestCase
      */
     private $widgets;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -40,7 +40,7 @@ class WidgetsProviderTest extends IntegrationTestCase
         $this->widgets = new WidgetsProvider(StaticContainer::get('Piwik\Plugin\Manager'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         unset($_GET['idSite']);

--- a/tests/PHPUnit/Integration/ProfessionalSupport/AdvertisingTest.php
+++ b/tests/PHPUnit/Integration/ProfessionalSupport/AdvertisingTest.php
@@ -37,7 +37,7 @@ class AdvertisingTest extends \PHPUnit\Framework\TestCase
 
     private $exampleUrl = 'https://piwik.xyz/test';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->config = new FakeConfig(array('General' => array('piwik_professional_support_ads_enabled' => '1')));
         $this->pluginManager = new Manager();

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -30,7 +30,7 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
 
     const MINIMUM_PHP_VERSION = '7.2.0';
 
-    public function setUp()
+    public function setUp(): void
     {
         $iniReader = new IniReader();
         $this->globalConfig = $iniReader->readFile(PIWIK_PATH_TEST_TO_ROOT . '/config/global.ini.php');
@@ -222,6 +222,7 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
             PIWIK_INCLUDE_PATH . '/tests/resources/overlay-test-site-real/',
             PIWIK_INCLUDE_PATH . '/tests/resources/overlay-test-site/',
             PIWIK_INCLUDE_PATH . '/vendor/lox/xhprof/xhprof_html/docs/',
+            PIWIK_INCLUDE_PATH . '/vendor/phpunit/php-code-coverage/tests',
             PIWIK_INCLUDE_PATH . '/plugins/Morpheus/icons/',
         );
 

--- a/tests/PHPUnit/Integration/ReportRenderingTest.php
+++ b/tests/PHPUnit/Integration/ReportRenderingTest.php
@@ -31,6 +31,6 @@ class ReportRenderingTest extends IntegrationTestCase
         $frontController = FrontController::getInstance();
         $response = $frontController->dispatch('DevicesDetection', 'getBrand');
 
-        $this->assertContains('Diagnostics_NoDataForReportArchivingNotRun', $response);
+        self::assertStringContainsString('Diagnostics_NoDataForReportArchivingNotRun', $response);
     }
 }

--- a/tests/PHPUnit/Integration/ReportTest.php
+++ b/tests/PHPUnit/Integration/ReportTest.php
@@ -102,7 +102,7 @@ class ReportTest extends IntegrationTestCase
      */
     private $advancedReport;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -116,7 +116,7 @@ class ReportTest extends IntegrationTestCase
         $this->advancedReport = new GetAdvancedReport();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($_GET['idSite']);
         parent::tearDown();
@@ -142,12 +142,11 @@ class ReportTest extends IntegrationTestCase
         $this->assertTrue($this->basicReport->isEnabled());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ExceptionReportNotEnabled
-     */
     public function test_checkIsEnabled_shouldThrowAnExceptionIfReportIsNotEnabled()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionReportNotEnabled');
+
         $this->disabledReport->checkIsEnabled();
     }
 
@@ -365,7 +364,7 @@ class ReportTest extends IntegrationTestCase
     {
         PluginManager::getInstance()->loadPlugins(array('API', 'ExampleReport'));
 
-        $proxyMock = $this->getMockBuilder('stdClass')->setMethods(array('call', '__construct'))->getMock();
+        $proxyMock = $this->getMockBuilder('stdClass')->addMethods(array('call', '__construct'))->getMock();
         $proxyMock->expects($this->once())->method('call')->with(
             '\\Piwik\\Plugins\\ExampleReport\\API', 'getExampleReport', array(
                 'idSite' => 1,
@@ -389,7 +388,7 @@ class ReportTest extends IntegrationTestCase
     {
         PluginManager::getInstance()->loadPlugins(array('API', 'Referrers'));
 
-        $proxyMock = $this->getMockBuilder('stdClass')->setMethods(array('call', '__construct'))->getMock();
+        $proxyMock = $this->getMockBuilder('stdClass')->addMethods(array('call', '__construct'))->getMock();
         $proxyMock->expects($this->once())->method('call')->with(
             '\\Piwik\\Plugins\\Referrers\\API', 'getSearchEnginesFromKeywordId', array(
                 'idSubtable' => 23,

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -33,7 +33,7 @@ class SegmentTest extends IntegrationTestCase
 
     private $exampleSegment = 'visitCount>=1';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/SequenceTest.php
+++ b/tests/PHPUnit/Integration/SequenceTest.php
@@ -42,12 +42,11 @@ class SequenceTest extends IntegrationTestCase
         $this->assertSame(11, $id);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Duplicate entry
-     */
     public function test_create_shouldFailIfSequenceAlreadyExists()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Duplicate entry');
+
         $sequence = $this->getExistingSequence();
 
         $sequence->create();
@@ -62,12 +61,11 @@ class SequenceTest extends IntegrationTestCase
         $this->assertNextIdGenerated($sequence, 3);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Sequence 'notCreatedSequence' not found
-     */
     public function test_getNextId_shouldFailIfThereIsNoSequenceHavingThisName()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Sequence \'notCreatedSequence\' not found');
+
         $sequence = $this->getEmptySequence();
         $sequence->getNextId();
     }

--- a/tests/PHPUnit/Integration/ServeStaticFileTest.php
+++ b/tests/PHPUnit/Integration/ServeStaticFileTest.php
@@ -49,7 +49,7 @@ define("PARTIAL_BYTE_END", 14724);
 // If the static file server has not been requested, the standard unit test case class is defined
 class ServeStaticFileTest extends \PHPUnit\Framework\TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         if(!chmod(TEST_FILE_LOCATION, 0644)) {
@@ -159,7 +159,7 @@ class ServeStaticFileTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(200, $responseInfo["http_code"]);
 
         // Tests content type
-        $this->assertContains(TEST_FILE_CONTENT_TYPE, $responseInfo["content_type"]);
+        self::assertStringContainsString(TEST_FILE_CONTENT_TYPE, $responseInfo["content_type"]);
 
         // Tests no compression has been applied
         $this->assertNull($this->getContentEncodingValue($fullResponse));

--- a/tests/PHPUnit/Integration/Session/SessionAuthTest.php
+++ b/tests/PHPUnit/Integration/Session/SessionAuthTest.php
@@ -29,7 +29,7 @@ class SessionAuthTest extends IntegrationTestCase
      */
     private $testInstance;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Settings/BaseSettingsTestCase.php
+++ b/tests/PHPUnit/Integration/Settings/BaseSettingsTestCase.php
@@ -41,12 +41,11 @@ class BaseSettingsTestCase extends IntegrationTestCase
         $this->assertNotNull($this->settings->getSetting('myName'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage A setting with name "myName" does already exist for plugin "ExampleSettingsPlugin"
-     */
     public function test_makeSetting_ShouldFailWhenAdingSameSettingTwice()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('A setting with name "myName" does already exist for plugin "ExampleSettingsPlugin"');
+
         $this->makeSetting('myName');
         $this->makeSetting('myName');
     }
@@ -136,12 +135,11 @@ class BaseSettingsTestCase extends IntegrationTestCase
         $this->assertSame($setting, $settings->getSetting($settingName));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage "testSetting" does already exist
-     */
     public function test_addSetting_throwsException_IfSameSettingAddedTwice()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('"testSetting" does already exist');
+
         $settingName = 'testSetting';
         $setting  = $this->buildSetting($settingName);
         $settings = $this->createSettingsInstance();

--- a/tests/PHPUnit/Integration/Settings/IntegrationTestCase.php
+++ b/tests/PHPUnit/Integration/Settings/IntegrationTestCase.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Integration\Settings;
 
+use PHPUnit\Framework\Constraint\IsType;
 use Piwik\Db;
 use Piwik\Settings\Setting;
 use Piwik\Settings\Storage;
@@ -26,7 +27,7 @@ class IntegrationTestCase extends \Piwik\Tests\Framework\TestCase\IntegrationTes
      */
     protected $settings;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Db::destroyDatabaseObject();
@@ -39,7 +40,10 @@ class IntegrationTestCase extends \Piwik\Tests\Framework\TestCase\IntegrationTes
         $this->assertEquals($expectedValue, $value);
 
         if (!is_null($expectedType)) {
-            $this->assertInternalType($expectedType, $value);
+            static::assertThat(
+                $value,
+                new IsType($expectedType)
+            );
         }
     }
 

--- a/tests/PHPUnit/Integration/Settings/Measurable/MeasurablePropertyTest.php
+++ b/tests/PHPUnit/Integration/Settings/Measurable/MeasurablePropertyTest.php
@@ -25,7 +25,7 @@ use Piwik\Tests\Integration\Settings\IntegrationTestCase;
 class MeasurablePropertyTest extends IntegrationTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Db::destroyDatabaseObject();
@@ -49,12 +49,11 @@ class MeasurablePropertyTest extends IntegrationTestCase
         $this->assertNotDbConnectionCreated();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Name "name" is not allowed to be used
-     */
     public function test_constructor_shouldThrowAnExceptionWhenNotWhitelistedNameIsUsed()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Name "name" is not allowed to be used');
+
         new MeasurableProperty('name', $default = 5, FieldConfig::TYPE_INT, 'MyPlugin', $idSite = 1);
     }
 

--- a/tests/PHPUnit/Integration/Settings/Measurable/MeasurableSettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/Measurable/MeasurableSettingTest.php
@@ -24,7 +24,7 @@ use Piwik\Tests\Integration\Settings\IntegrationTestCase;
 class MeasurableSettingTest extends IntegrationTestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         foreach (array(2,3) as $idSite) {

--- a/tests/PHPUnit/Integration/Settings/Plugin/SystemConfigSettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/Plugin/SystemConfigSettingTest.php
@@ -24,7 +24,7 @@ class SystemConfigSettingTest extends IntegrationTestCase
 {
     private $section = 'MySection';
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->setConfigValues(array());
         parent::tearDown();
@@ -39,24 +39,22 @@ class SystemConfigSettingTest extends IntegrationTestCase
         $this->assertNotDbConnectionCreated();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed
-     */
     public function test_setSettingValue_shouldThrowException_IfAUserIsTryingToSetASettingWhichNeedsSuperUserPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
         $this->setUser();
         $setting = $this->buildSetting('mysystem');
 
         $setting->setValue(2);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed
-     */
     public function test_setSettingValue_shouldThrowException_IfAnonymousIsTryingToSetASettingWhichNeedsSuperUserPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
         $this->setAnonymousUser();
         $setting = $this->buildSetting('mysystem');
 

--- a/tests/PHPUnit/Integration/Settings/Plugin/SystemSettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/Plugin/SystemSettingTest.php
@@ -22,7 +22,7 @@ use Piwik\Tests\Integration\Settings\IntegrationTestCase;
 class SystemSettingTest extends IntegrationTestCase
 {
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Config::getInstance()->MyPluginName = array();
         parent::tearDown();
@@ -37,24 +37,22 @@ class SystemSettingTest extends IntegrationTestCase
         $this->assertNotDbConnectionCreated();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed
-     */
     public function test_setSettingValue_shouldThrowException_IfAUserIsTryingToSetASettingWhichNeedsSuperUserPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
         $this->setUser();
         $setting = $this->buildSetting('mysystem');
 
         $setting->setValue(2);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed
-     */
     public function test_setSettingValue_shouldThrowException_IfAnonymousIsTryingToSetASettingWhichNeedsSuperUserPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
         $this->setAnonymousUser();
         $setting = $this->buildSetting('mysystem');
 
@@ -147,12 +145,11 @@ class SystemSettingTest extends IntegrationTestCase
         $this->assertTrue($setting->isWritableByCurrentUser());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed
-     */
     public function test_setSettingsValue_shouldNotBePossible_AsSoonAsAConfigValueIsConfigured()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
         $this->setSuperUser();
         $setting = $this->buildSetting('myusersetting');
 

--- a/tests/PHPUnit/Integration/Settings/Plugin/UserSettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/Plugin/UserSettingTest.php
@@ -68,12 +68,11 @@ class UserSettingTest extends IntegrationTestCase
         $this->assertDbConnectionCreated();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingChangeNotAllowed
-     */
     public function test_setSettingValue_shouldThrowException_IfAnonymousIsTryingToSetASettingWhichNeedsUserPermission()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingChangeNotAllowed');
+
         $this->setAnonymousUser();
         $setting = $this->buildSetting('mysystem');
 
@@ -141,12 +140,11 @@ class UserSettingTest extends IntegrationTestCase
         $this->assertSettingHasValue($setting, 43939, 'integer');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Validation Fail
-     */
     public function test_setSettingValue_shouldValidateAValue_IfAFilterIsSet()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Validation Fail');
+
         $this->setUser();
         $self = $this;
 

--- a/tests/PHPUnit/Integration/Settings/SettingTest.php
+++ b/tests/PHPUnit/Integration/Settings/SettingTest.php
@@ -25,25 +25,24 @@ use Piwik\Validators\NumberRange;
  */
 class SettingTest extends \PHPUnit\Framework\TestCase
 {
-    protected function setUp()
+    public function setUp(): void
     {
         $fixutre = new Fixture();
         $fixutre->createEnvironmentInstance();
     }
 
-    protected function tearDown()
+    public function tearDown(): void
     {
         $fixutre = new Fixture();
         $fixutre->clearInMemoryCaches();
         $fixutre->destroyEnvironment();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage setting name "myname-" in plugin "MyPluginName" is invalid
-     */
     public function test_constructor_shouldThrowException_IfTheSettingNameIsNotValid()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('setting name "myname-" in plugin "MyPluginName" is invalid');
+
         $this->makeSetting('myname-');
     }
 
@@ -58,24 +57,22 @@ class SettingTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(FieldConfig::UI_CONTROL_CHECKBOX, $field->uiControl);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Type must be an array when using a multi select
-     */
     public function test_configureField_ShouldCheckThatTypeMakesActuallySenseForConfiguredUiControl()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Type must be an array when using a multi select');
+
         $setting = $this->makeSetting('myname', FieldConfig::TYPE_STRING, $default = '', function (FieldConfig $field) {
             $field->uiControl = FieldConfig::UI_CONTROL_MULTI_SELECT;
         });
         $setting->configureField();
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Type does not exist
-     */
     public function test_configureField_ChecksTheGivenTypeIsKnown()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Type does not exist');
+
         $setting = $this->makeSetting('myname', 'unknOwnTyPe');
         $setting->configureField();
     }
@@ -93,19 +90,18 @@ class SettingTest extends \PHPUnit\Framework\TestCase
         try {
             $setting->setValue('invAliDValue');
         } catch (Exception $e) {
-            $this->assertContains('CoreAdminHome_PluginSettingsValueNotAllowed', $e->getMessage());
+            self::assertStringContainsString('CoreAdminHome_PluginSettingsValueNotAllowed', $e->getMessage());
             return;
         }
 
         $this->fail('An expected exception has not been thrown');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage CoreAdminHome_PluginSettingsValueNotAllowed
-     */
     public function test_setValue_shouldApplyValidationAndFail_IfOptionsAreSetAndValueIsAnArray()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('CoreAdminHome_PluginSettingsValueNotAllowed');
+
         $setting = $this->makeSetting('myname', FieldConfig::TYPE_ARRAY, $default = '', function (FieldConfig $field) {
             $field->availableValues = array('allowedval' => 'DisplayName', 'allowedval2' => 'Name 2');
             $field->uiControl = FieldConfig::UI_CONTROL_MULTI_SELECT;
@@ -146,7 +142,7 @@ class SettingTest extends \PHPUnit\Framework\TestCase
         try {
             $setting->setValue('invAliDValue');
         } catch (Exception $e) {
-            $this->assertContains('CoreAdminHome_PluginSettingsValueNotAllowed', $e->getMessage());
+            self::assertStringContainsString('CoreAdminHome_PluginSettingsValueNotAllowed', $e->getMessage());
             return;
         }
 
@@ -170,7 +166,7 @@ class SettingTest extends \PHPUnit\Framework\TestCase
         try {
             $setting->setValue('1invalid');
         } catch (Exception $e) {
-            $this->assertContains('CoreAdminHome_PluginSettingsValueNotAllowed', $e->getMessage());
+            self::assertStringContainsString('CoreAdminHome_PluginSettingsValueNotAllowed', $e->getMessage());
             return;
         }
 
@@ -192,21 +188,21 @@ class SettingTest extends \PHPUnit\Framework\TestCase
             $setting->setValue('1invalid');
             $this->fail('An expected exception has not been thrown');
         } catch (Exception $e) {
-            $this->assertContains('General_ValidatorErrorNotANumber', $e->getMessage());
+            self::assertStringContainsString('General_ValidatorErrorNotANumber', $e->getMessage());
         }
 
         try {
             $setting->setValue('3');
             $this->fail('An expected exception has not been thrown');
         } catch (Exception $e) {
-            $this->assertContains('General_ValidatorErrorNumberTooLow', $e->getMessage());
+            self::assertStringContainsString('General_ValidatorErrorNumberTooLow', $e->getMessage());
         }
 
         try {
             $setting->setValue('');
             $this->fail('An expected exception has not been thrown');
         } catch (Exception $e) {
-            $this->assertContains('General_ValidatorErrorEmptyValue', $e->getMessage());
+            self::assertStringContainsString('General_ValidatorErrorEmptyValue', $e->getMessage());
         }
     }
 

--- a/tests/PHPUnit/Integration/Settings/Storage/Backend/CacheTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/Backend/CacheTest.php
@@ -30,7 +30,7 @@ class CacheTest extends IntegrationTestCase
      */
     private $cacheBackend;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Settings/Storage/Backend/ConfigTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/Backend/ConfigTest.php
@@ -41,7 +41,7 @@ class ConfigTest extends IntegrationTestCase
      */
     private $allBackends = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -56,12 +56,11 @@ class ConfigTest extends IntegrationTestCase
         return new Config($plugin);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No section given
-     */
     public function test_construct_shouldThrowAnException_IfSectionIsEmpty()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No section given');
+
         $this->createSettings('');
     }
 

--- a/tests/PHPUnit/Integration/Settings/Storage/Backend/MeasurableSettingsTableTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/Backend/MeasurableSettingsTableTest.php
@@ -41,7 +41,7 @@ class MeasurableSettingsTableTest extends IntegrationTestCase
      */
     private $allBackends = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -56,21 +56,19 @@ class MeasurableSettingsTableTest extends IntegrationTestCase
         return new MeasurableSettingsTable($idSite, $plugin);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No plugin name given
-     */
     public function test_construct_shouldThrowAnException_IfPluginNameIsEmpty()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No plugin name given');
+
         $this->createSettings(1, '');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No idSite given
-     */
     public function test_construct_shouldThrowAnException_IfIdSiteIsEmpty()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No idSite given');
+
         $this->createSettings(0, 'MyPlugin');
     }
 

--- a/tests/PHPUnit/Integration/Settings/Storage/Backend/NullTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/Backend/NullTest.php
@@ -23,7 +23,7 @@ class NullTest extends \PHPUnit\Framework\TestCase
      */
     private $backend;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Settings/Storage/Backend/PluginSettingsTableTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/Backend/PluginSettingsTableTest.php
@@ -46,7 +46,7 @@ class PluginSettingsTableTest extends IntegrationTestCase
      */
     private $allBackends = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -62,30 +62,27 @@ class PluginSettingsTableTest extends IntegrationTestCase
         return new PluginSettingsTable($plugin, $login);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No plugin name given
-     */
     public function test_construct_shouldThrowAnException_IfPluginNameIsEmpty()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No plugin name given');
+
         $this->createSettings('', '');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Invalid user login name
-     */
     public function test_construct_shouldThrowAnException_IfUserLoginFalse()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid user login name');
+
         $this->createSettings('MyPlugin', false);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Invalid user login name
-     */
     public function test_construct_shouldThrowAnException_IfUserLoginNull()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid user login name');
+
         $this->createSettings('MyPlugin', null);
     }
 
@@ -263,12 +260,11 @@ class PluginSettingsTableTest extends IntegrationTestCase
         }
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No userLogin specified
-     */
     public function test_removeAllUserSettingsForUser_shouldThrowAnExceptionIfLoginIsEmpty()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No userLogin specified');
+
         PluginSettingsTable::removeAllUserSettingsForUser('');
     }
 

--- a/tests/PHPUnit/Integration/Settings/Storage/Backend/SitesTableTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/Backend/SitesTableTest.php
@@ -32,7 +32,7 @@ class SitesTableTest extends IntegrationTestCase
      */
     private $backendSite2;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -48,12 +48,11 @@ class SitesTableTest extends IntegrationTestCase
         return new SitesTable($idSite);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No idSite given
-     */
     public function test_construct_shouldThrowAnException_IfPluginNameIsEmpty()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('No idSite given');
+
         $this->createSettings(0);
     }
 
@@ -63,11 +62,10 @@ class SitesTableTest extends IntegrationTestCase
         $this->assertFieldsLoaded(array('idsite' => '2'), $this->backendSite2);
     }
 
-    /**
-     * @expectedException \Piwik\Exception\UnexpectedWebsiteFoundException
-     */
     public function test_load_shouldThrowException_IfSiteDoesNotExist()
     {
+        $this->expectException(\Piwik\Exception\UnexpectedWebsiteFoundException::class);
+
         $this->createSettings($idSite = 999)->load();
     }
 

--- a/tests/PHPUnit/Integration/Settings/Storage/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/FactoryTest.php
@@ -33,7 +33,7 @@ class FactoryTest extends IntegrationTestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->factory = new Factory();

--- a/tests/PHPUnit/Integration/Settings/Storage/StorageTest.php
+++ b/tests/PHPUnit/Integration/Settings/Storage/StorageTest.php
@@ -36,7 +36,7 @@ class StorageTest extends IntegrationTestCase
      */
     protected $settingName = 'myname';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/SiteTest.php
+++ b/tests/PHPUnit/Integration/SiteTest.php
@@ -22,7 +22,7 @@ class SiteTest extends IntegrationTestCase
 
     public $siteAppendix = ' foo';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -39,12 +39,11 @@ class SiteTest extends IntegrationTestCase
         });
     }
 
-    /**
-     * @expectedException \Piwik\Exception\UnexpectedWebsiteFoundException
-     * @expectedExceptionMessage An unexpected website was found in the request
-     */
     public function test_constructor_throwsException_ifSiteDoesNotExist()
     {
+        $this->expectException(\Piwik\Exception\UnexpectedWebsiteFoundException::class);
+        $this->expectExceptionMessage('An unexpected website was found in the request');
+
         $this->makeSite(9999);
     }
 

--- a/tests/PHPUnit/Integration/SqlTest.php
+++ b/tests/PHPUnit/Integration/SqlTest.php
@@ -16,7 +16,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class SqlTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -29,7 +29,7 @@ class SqlTest extends IntegrationTestCase
         Db::exec("CREATE TABLE table4 (d INT) ENGINE=InnoDB");
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/PHPUnit/Integration/Tracker/ActionTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ActionTest.php
@@ -24,7 +24,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class ActionTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -40,7 +40,7 @@ class ActionTest extends IntegrationTestCase
         Fixture::loadAllTranslations();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/PHPUnit/Integration/Tracker/DbTest.php
+++ b/tests/PHPUnit/Integration/Tracker/DbTest.php
@@ -22,7 +22,7 @@ use Piwik\Tracker;
 class DbTest extends IntegrationTestCase
 {
     private $tableName;
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->tableName = Common::prefixTable('option');
@@ -60,24 +60,22 @@ class DbTest extends IntegrationTestCase
         $this->assertSame(1, $db->rowCount($result));
     }
 
-    /**
-     * @expectedExceptionMessage doesn't exist
-     * @expectedException  \Piwik\Tracker\Db\DbException
-     */
     public function test_fetchOne_notExistingTable()
     {
+        $this->expectException(\Piwik\Tracker\Db\DbException::class);
+        $this->expectExceptionMessage('doesn\'t exist');
+
         $db = Tracker::getDatabase();
         $this->insertRowId(3);
         $val = $db->fetchOne('SELECT option_value FROM foobarbaz where option_value = "rowid"');
         $this->assertEquals('3', $val);
     }
 
-    /**
-     * @expectedExceptionMessage Duplicate entry
-     * @expectedException  \Piwik\Tracker\Db\DbException
-     */
     public function test_query_error_whenInsertingDuplicateRow()
     {
+        $this->expectException(\Piwik\Tracker\Db\DbException::class);
+        $this->expectExceptionMessage('Duplicate entry');
+
         $this->insertRowId();
         $this->insertRowId();
     }

--- a/tests/PHPUnit/Integration/Tracker/FailuresTest.php
+++ b/tests/PHPUnit/Integration/Tracker/FailuresTest.php
@@ -30,7 +30,7 @@ class FailuresTest extends IntegrationTestCase
      */
     private $now;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Tracker/Handler/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Tracker/Handler/FactoryTest.php
@@ -53,12 +53,11 @@ class FactoryTest extends IntegrationTestCase
         $this->assertSame($handlerToUse, $handler);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The Handler object set in the plugin
-     */
     public function test_make_shouldTriggerExceptionInCaseWrongInstanceCreatedInHandler()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The Handler object set in the plugin');
+
         Piwik::addAction('Tracker.newHandler', function (&$handler) {
             $handler = new Tracker();
         });

--- a/tests/PHPUnit/Integration/Tracker/HandlerTest.php
+++ b/tests/PHPUnit/Integration/Tracker/HandlerTest.php
@@ -46,7 +46,7 @@ class HandlerTest extends IntegrationTestCase
      */
     private $requestSet;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Tracker/ModelTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ModelTest.php
@@ -30,7 +30,7 @@ class ModelTest extends IntegrationTestCase
      */
     private $model;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Tracker/PingRequestTest.php
+++ b/tests/PHPUnit/Integration/Tracker/PingRequestTest.php
@@ -26,7 +26,7 @@ class PingRequestTest extends IntegrationTestCase
     const CHANGED_COUNTRY = 'jp';
     const CHANGED_REGION = '22';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Tracker/RequestSetTest.php
+++ b/tests/PHPUnit/Integration/Tracker/RequestSetTest.php
@@ -40,7 +40,7 @@ class RequestSetTest extends IntegrationTestCase
     private $post;
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -63,7 +63,7 @@ class RequestSetTest extends IntegrationTestCase
         $_POST = array();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $_GET  = $this->get;
         $_POST = $this->post;

--- a/tests/PHPUnit/Integration/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Integration/Tracker/RequestTest.php
@@ -34,7 +34,7 @@ class RequestTest extends IntegrationTestCase
 
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -50,12 +50,11 @@ class RequestTest extends IntegrationTestCase
         $this->time = 1416795617;
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Custom timestamp is 86500 seconds old
-     */
     public function test_cdt_ShouldNotTrackTheRequest_IfNotAuthenticatedAndTimestampIsNotRecent()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Custom timestamp is 86500 seconds old');
+
         $request = $this->buildRequest(array('cdt' => '' . $this->time - 86500));
         $request->setCurrentTimestamp($this->time);
         $this->assertSame($this->time, $request->getCurrentTimestamp());
@@ -99,22 +98,20 @@ class RequestTest extends IntegrationTestCase
         $this->assertSame(14, $request->getIdSite());
     }
 
-    /**
-     * @expectedException \Piwik\Exception\UnexpectedWebsiteFoundException
-     * @expectedExceptionMessage Invalid idSite: '0'
-     */
     public function test_getIdSite_shouldNotThrowException_IfValueIsZero()
     {
+        $this->expectException(\Piwik\Exception\UnexpectedWebsiteFoundException::class);
+        $this->expectExceptionMessage('Invalid idSite: \'0\'');
+
         $request = $this->buildRequest(array('idsite' => '0'));
         $request->getIdSite();
     }
 
-    /**
-     * @expectedException \Piwik\Exception\UnexpectedWebsiteFoundException
-     * @expectedExceptionMessage Invalid idSite: '-1'
-     */
     public function test_getIdSite_shouldThrowException_IfValueIsLowerThanZero()
     {
+        $this->expectException(\Piwik\Exception\UnexpectedWebsiteFoundException::class);
+        $this->expectExceptionMessage('Invalid idSite: \'-1\'');
+
         $request = $this->buildRequest(array('idsite' => '-1'));
         $request->getIdSite();
     }
@@ -472,12 +469,11 @@ class RequestTest extends IntegrationTestCase
         );
     }
 
-    /**
-     * @expectedException \Piwik\Exception\UnexpectedWebsiteFoundException
-     * @expectedExceptionMessage An unexpected website was found in the request: website id was set to '155'
-     */
     public function test_getIdSite_shouldTriggerExceptionWhenSiteNotExists()
     {
+        $this->expectException(\Piwik\Exception\UnexpectedWebsiteFoundException::class);
+        $this->expectExceptionMessage('An unexpected website was found in the request: website id was set to \'155\'');
+
         $self = $this;
         Piwik::addAction('Tracker.Request.getIdSite', function (&$idSite, $params) use ($self) {
             $self->assertSame(14, $idSite);

--- a/tests/PHPUnit/Integration/Tracker/SettingsTest.php
+++ b/tests/PHPUnit/Integration/Tracker/SettingsTest.php
@@ -26,7 +26,7 @@ class SettingsTest extends IntegrationTestCase
      */
     protected $ip = '123.30.30.30';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Tracker/Visit/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit/FactoryTest.php
@@ -54,12 +54,11 @@ class FactoryTest extends IntegrationTestCase
         $this->assertSame($visitToUse, $visit);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage The Visit object set in the plugin
-     */
     public function test_make_shouldTriggerExceptionInCaseWrongInstanceCreatedInHandler()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The Visit object set in the plugin');
+
         Piwik::addAction('Tracker.makeNewVisitObject', function (&$visit) {
             $visit = new Tracker();
         });

--- a/tests/PHPUnit/Integration/Tracker/Visit/ReferrerSpamFilterTest.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit/ReferrerSpamFilterTest.php
@@ -25,7 +25,7 @@ class ReferrerSpamFilterTest extends IntegrationTestCase
      */
     private $filter;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -33,7 +33,7 @@ class ReferrerSpamFilterTest extends IntegrationTestCase
         $this->filter = new ReferrerSpamFilter;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/PHPUnit/Integration/Tracker/Visit2Test.php
+++ b/tests/PHPUnit/Integration/Tracker/Visit2Test.php
@@ -141,7 +141,7 @@ class FakeTrackerVisit extends Visit
  */
 class Visit2Test extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Fixture::createWebsite('2014-01-01 00:00:00');

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -27,7 +27,7 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
  */
 class VisitTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/TrackerTest.php
+++ b/tests/PHPUnit/Integration/TrackerTest.php
@@ -40,7 +40,7 @@ class TrackerTest extends IntegrationTestCase
 
     private $iniTimeZone;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -52,7 +52,7 @@ class TrackerTest extends IntegrationTestCase
         $this->iniTimeZone = ini_get('date.timezone');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->restoreConfigFile();
         

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/FactoryTest.php
@@ -43,7 +43,7 @@ class FactoryTest extends IntegrationTestCase
     private $testTable = 'tablename';
     private $testTablePrefixed = '';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
@@ -32,14 +32,14 @@ class MigrationsTest extends IntegrationTestCase
     private $testTable = 'tablename';
     private $testTablePrefixed = '';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
         self::dropTestTableIfNeeded();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::dropTestTableIfNeeded();
 
@@ -52,7 +52,7 @@ class MigrationsTest extends IntegrationTestCase
         Db::exec("DROP TABLE IF EXISTS `$table`");
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -156,6 +156,7 @@ class MigrationsTest extends IntegrationTestCase
     public function test_changeColumnType()
     {
         $this->factory->changeColumnType($this->testTable, 'column2', 'SMALLINT(4) NOT NULL')->exec();
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/PHPUnit/Integration/Updater/Migration/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/FactoryTest.php
@@ -25,7 +25,7 @@ class FactoryTest extends IntegrationTestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Updater/Migration/Plugin/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Plugin/FactoryTest.php
@@ -26,7 +26,7 @@ class FactoryTest extends IntegrationTestCase
 
     private $pluginName = 'MyTestPluginName';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Integration/Validator/IdSiteTest.php
+++ b/tests/PHPUnit/Integration/Validator/IdSiteTest.php
@@ -18,7 +18,7 @@ use Piwik\Validators\IdSite;
  */
 class IdSiteTest extends IntegrationTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Fixture::createWebsite('2012-03-04 05:06:07');
@@ -34,27 +34,24 @@ class IdSiteTest extends IntegrationTestCase
         $this->validate(2);
     }
 
-    /**
-     * @expectedException \Piwik\Exception\UnexpectedWebsiteFoundException
-     */
     public function test_validate_failValueDoesNotExist()
     {
+        $this->expectException(\Piwik\Exception\UnexpectedWebsiteFoundException::class);
+
         $this->validate(99);
     }
 
-    /**
-     * @expectedException \Piwik\Exception\UnexpectedWebsiteFoundException
-     */
     public function test_validate_failValueIsEmpty()
     {
+        $this->expectException(\Piwik\Exception\UnexpectedWebsiteFoundException::class);
+
         $this->validate(0);
     }
 
-    /**
-     * @expectedException \Piwik\Exception\UnexpectedWebsiteFoundException
-     */
     public function test_validate_failValueIsFalse()
     {
+        $this->expectException(\Piwik\Exception\UnexpectedWebsiteFoundException::class);
+
         $this->validate(false);
     }
 

--- a/tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php
+++ b/tests/PHPUnit/Integration/ViewDataTable/ManagerTest.php
@@ -41,12 +41,11 @@ class ManagerTest extends IntegrationTestCase
         $this->assertEquals($params['params'], $storedParams);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Setting parameters translations is not allowed. Please report this bug to the Matomo team.
-     */
     public function test_setViewDataTableParameters_inConfigProperty_shouldOnlyAllowOverridableParams()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Setting parameters translations is not allowed. Please report this bug to the Matomo team.');
+
         $login  = 'mylogin';
         $method = 'API.get';
         $params = array(
@@ -58,12 +57,11 @@ class ManagerTest extends IntegrationTestCase
         ViewDataTableManager::saveViewDataTableParameters($login, $method, $params);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Setting parameters filters is not allowed. Please report this bug to the Matomo team.
-     */
     public function test_setViewDataTableParameters_inConfigProperty_shouldOnlyAllowOverridableParams_bis()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Setting parameters filters is not allowed. Please report this bug to the Matomo team.');
+
         $login  = 'mylogin';
         $method = 'API.get';
         $params = array(
@@ -75,12 +73,11 @@ class ManagerTest extends IntegrationTestCase
         ViewDataTableManager::saveViewDataTableParameters($login, $method, $params);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Setting parameters apiMethodToRequestDataTable is not allowed. Please report this bug to the Matomo team.
-     */
     public function test_setViewDataTableParameters_inRequestConfigProperty_shouldOnlyAllowOverridableParams()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Setting parameters apiMethodToRequestDataTable is not allowed. Please report this bug to the Matomo team.');
+
         $login  = 'mylogin';
         $method = 'API.get';
         $params = array(

--- a/tests/PHPUnit/System/AllWebsitesTest.php
+++ b/tests/PHPUnit/System/AllWebsitesTest.php
@@ -21,7 +21,7 @@ class AllWebsitesTest extends SystemTestCase
     public static $fixture = null; // initialized below class definition
     protected static $userTokenAuth = '34bcc4d2c330259d6f37bc3d98d425f4';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/PHPUnit/System/ApiGetReportMetadataTest.php
+++ b/tests/PHPUnit/System/ApiGetReportMetadataTest.php
@@ -24,7 +24,7 @@ class ApiGetReportMetadataTest extends SystemTestCase
 {
     public static $fixture = null; // initialized below class definition
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -34,7 +34,7 @@ class ApiGetReportMetadataTest extends SystemTestCase
         Proxy::getInstance()->setHideIgnoredFunctions(false);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/PHPUnit/System/BackwardsCompatibility1XTest.php
+++ b/tests/PHPUnit/System/BackwardsCompatibility1XTest.php
@@ -26,7 +26,7 @@ class BackwardsCompatibility1XTest extends SystemTestCase
 
     public static $fixture = null; // initialized below class
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -29,7 +29,7 @@ class BlobReportLimitingTest extends SystemTestCase
      */
     public static $fixture = null; // initialized below class definition
 
-    public function setUp()
+    public function setUp(): void
     {
         Cache::getTransientCache()->flushAll();
         parent::setUp();

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -39,7 +39,7 @@ class CliMultiTest extends SystemTestCase
      */
     private $responses = array();
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -66,12 +66,9 @@ class CliMultiTest extends SystemTestCase
         $this->assertEquals(array(), $response);
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error
-     */
     public function test_request_shouldFail_IfUrlsIsNotAnArray()
     {
-        $this->setExpectedException('TypeError');
+        $this->expectException('TypeError');
         $this->cliMulti->request('');
     }
 
@@ -145,7 +142,7 @@ class CliMultiTest extends SystemTestCase
     {
         $this->cliMulti->runAsSuperUser();
         $response = $this->cliMulti->request(array($this->completeUrl('')));
-        $this->assertContains('Error: no website was found', $response[0]);
+        self::assertStringContainsString('Error: no website was found', $response[0]);
     }
 
     public function test_request_shouldBeAbleToRenderARegularPageInPiwik()

--- a/tests/PHPUnit/System/ConsoleTest.php
+++ b/tests/PHPUnit/System/ConsoleTest.php
@@ -107,7 +107,7 @@ class TestCommandWithException extends ConsoleCommand
 
 class ConsoleTest extends ConsoleCommandTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->application->addCommands([

--- a/tests/PHPUnit/System/CookieTest.php
+++ b/tests/PHPUnit/System/CookieTest.php
@@ -23,14 +23,14 @@ class CookieTest extends SystemTestCase
 
     private $originalAssumeSecureValue;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->testVars = static::$fixture->getTestEnvironment();
         $this->originalAssumeSecureValue = Config::getInstance()->General['assume_secure_protocol'];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $this->testVars->overrideConfig('General', 'assume_secure_protocol', $this->originalAssumeSecureValue);
@@ -68,7 +68,7 @@ class CookieTest extends SystemTestCase
     {
         $headers = $this->setIgnoreCookie(self::USERAGENT_SAFARI);
         $cookie = $this->findIgnoreCookie($headers);
-        $this->assertNotContains($cookie, 'SameSite');
+        self::assertStringNotContainsString($cookie, 'SameSite');
     }
 
     private function setIgnoreCookie($userAgent)
@@ -103,6 +103,6 @@ class CookieTest extends SystemTestCase
 
     private function assertCookieSameSiteMatches($expectedSameSite, $cookieHeader)
     {
-        $this->assertContains('SameSite=' . $expectedSameSite, $cookieHeader);
+        self::assertStringContainsString('SameSite=' . $expectedSameSite, $cookieHeader);
     }
 }

--- a/tests/PHPUnit/System/CustomEventsTest.php
+++ b/tests/PHPUnit/System/CustomEventsTest.php
@@ -44,7 +44,7 @@ class CustomEventsTest extends SystemTestCase
         );
     }
 
-    protected function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/PHPUnit/System/DuplicateActionsTest.php
+++ b/tests/PHPUnit/System/DuplicateActionsTest.php
@@ -30,7 +30,7 @@ class DuplicateActionsTest extends SystemTestCase
      */
     public static $fixture = null; // initialized below class
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/PHPUnit/System/EnvironmentValidationTest.php
+++ b/tests/PHPUnit/System/EnvironmentValidationTest.php
@@ -27,7 +27,7 @@ class EnvironmentValidationTest extends SystemTestCase
         );
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -57,7 +57,7 @@ class EnvironmentValidationTest extends SystemTestCase
         $this->simulateAbsentConfigFile('config.ini.php');
 
         $output = $this->triggerPiwikFrom('tracker');
-        $this->assertContains('As Matomo is not installed yet, the Tracking API cannot proceed and will exit without error.', $output);
+        self::assertStringContainsString('As Matomo is not installed yet, the Tracking API cannot proceed and will exit without error.', $output);
     }
 
     public function test_NoLocalConfigFile_TriggersError_inConsole()
@@ -135,7 +135,7 @@ class EnvironmentValidationTest extends SystemTestCase
 
     private function assertInstallationProcessStarted($output)
     {
-        $this->assertContains('<title>Matomo '. Version::VERSION .' &rsaquo; Installation</title>', $output);
+        self::assertStringContainsString('<title>Matomo '. Version::VERSION .' &rsaquo; Installation</title>', $output);
     }
 
     private function simulateAbsentConfigFile($fileName)

--- a/tests/PHPUnit/System/FrontControllerTest.php
+++ b/tests/PHPUnit/System/FrontControllerTest.php
@@ -24,9 +24,9 @@ class FrontControllerTest extends SystemTestCase
         $header = $this->getResponseHeader($url);
 
         if ($redirection) {
-            $this->assertContains('Location: ' . Fixture::getRootUrl() . 'tests/PHPUnit/proxy/' . $redirection . "\r\n", $header);
+            self::assertStringContainsString('Location: ' . Fixture::getRootUrl() . 'tests/PHPUnit/proxy/' . $redirection . "\r\n", $header);
         } else {
-            $this->assertNotContains('Location: ', $header);
+            self::assertStringNotContainsString('Location: ', $header);
         }
     }
 

--- a/tests/PHPUnit/System/ImportLogsTest.php
+++ b/tests/PHPUnit/System/ImportLogsTest.php
@@ -27,7 +27,7 @@ class ImportLogsTest extends SystemTestCase
     /** @var ManySitesImportedLogs */
     public static $fixture = null; // initialized below class definition
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -132,8 +132,8 @@ class ImportLogsTest extends SystemTestCase
         $this->assertEquals(1, count($whateverDotCom));
 
         // make sure invalid requests are reported correctly
-        $this->assertContains('The Matomo tracker identified 2 invalid requests on lines: 10, 11', $output);
-        $this->assertContains("The following lines were not tracked by Matomo, either due to a malformed tracker request or error in the tracker:\n\n10, 11", $output);
+        self::assertStringContainsString('The Matomo tracker identified 2 invalid requests on lines: 10, 11', $output);
+        self::assertStringContainsString("The following lines were not tracked by Matomo, either due to a malformed tracker request or error in the tracker:\n\n10, 11", $output);
     }
 
     public function test_LogImporter_RetriesWhenServerFails()
@@ -153,12 +153,12 @@ class ImportLogsTest extends SystemTestCase
         $output = implode("\n", $output);
 
         for ($i = 2; $i != 6; ++$i) {
-            $this->assertContains("Retrying request, attempt number $i", $output);
+            self::assertStringContainsString("Retrying request, attempt number $i", $output);
         }
 
-        $this->assertNotContains("Retrying request, attempt number 6", $output);
+        self::assertStringNotContainsString("Retrying request, attempt number 6", $output);
 
-        $this->assertContains("Max number of attempts reached, server is unreachable!", $output);
+        self::assertStringContainsString("Max number of attempts reached, server is unreachable!", $output);
     }
 
     private function simulateTrackerFailure()

--- a/tests/PHPUnit/System/MultipleSitesArchivingTest.php
+++ b/tests/PHPUnit/System/MultipleSitesArchivingTest.php
@@ -21,7 +21,7 @@ class MultipleSitesArchivingTest extends SystemTestCase
 {
     public static $fixture = null; // initialized below class definition
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/PHPUnit/System/OneVisitorTwoVisitsTest.php
+++ b/tests/PHPUnit/System/OneVisitorTwoVisitsTest.php
@@ -33,12 +33,12 @@ class OneVisitorTwoVisitsTest extends SystemTestCase
      */
     public static $fixture = null; // initialized below class
 
-    public function setUp()
+    public function setUp(): void
     {
         Proxy::getInstance()->setHideIgnoredFunctions(false);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Proxy::getInstance()->setHideIgnoredFunctions(true);
     }

--- a/tests/PHPUnit/System/PeriodIsRangeDateIsLastNMetadataAndNormalAPITest.php
+++ b/tests/PHPUnit/System/PeriodIsRangeDateIsLastNMetadataAndNormalAPITest.php
@@ -21,7 +21,7 @@ class PeriodIsRangeDateIsLastNMetadataAndNormalAPITest extends SystemTestCase
 {
     public static $fixture = null;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$fixture->dateTime = Date::factory('yesterday')->getDateTime();
         parent::setUpBeforeClass();

--- a/tests/PHPUnit/System/PivotByQueryParamTest.php
+++ b/tests/PHPUnit/System/PivotByQueryParamTest.php
@@ -23,7 +23,7 @@ class PivotByQueryParamTest extends SystemTestCase
      */
     public static $fixture = null;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 

--- a/tests/PHPUnit/System/RawLogDaoTest.php
+++ b/tests/PHPUnit/System/RawLogDaoTest.php
@@ -44,7 +44,7 @@ class RawLogDaoTest extends SystemTestCase
 
     private $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -85,12 +85,11 @@ class RawLogDaoTest extends SystemTestCase
         $this->assertSame('idvisit', $this->dao->getIdFieldForLogTable('log_visit'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Unknown log table 'log_foobarbaz'
-     */
     public function test_getIdFieldForLogTable_whenUnknownTable()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unknown log table \'log_foobarbaz\'');
+
         $this->dao->getIdFieldForLogTable('log_foobarbaz');
     }
 

--- a/tests/PHPUnit/System/TimezonesTest.php
+++ b/tests/PHPUnit/System/TimezonesTest.php
@@ -24,7 +24,7 @@ class TimezonesTest extends SystemTestCase
      */
     public static $fixture = null; // initialized below class definition
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/System/TrackerResponseTest.php
+++ b/tests/PHPUnit/System/TrackerResponseTest.php
@@ -24,7 +24,7 @@ class TrackerResponseTest extends SystemTestCase
      */
     private $tracker;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/System/TrackerTest.php
+++ b/tests/PHPUnit/System/TrackerTest.php
@@ -30,7 +30,7 @@ class TrackerTest extends IntegrationTestCase
     const TASKS_FINISHED_OPTION_NAME = "Tests.scheduledTasksFinished";
     const TASKS_STARTED_OPTION_NAME = "Tests.scheduledTasksStarted";
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -161,7 +161,7 @@ class TrackerTest extends IntegrationTestCase
         $this->assertEquals(1, count($this->getConversionItems()));
 
         $response = $this->sendTrackingRequestByCurl($urlToTest);
-        $this->assertContains('This resource is part of Matomo.', $response);
+        self::assertStringContainsString('This resource is part of Matomo.', $response);
 
         $this->assertEquals(1, $this->getCountOfConversions());
         $this->assertEquals(1, count($this->getConversionItems()));
@@ -210,7 +210,7 @@ class TrackerTest extends IntegrationTestCase
 
         $this->assertScheduledTasksWereRun();
 
-        $this->assertContains('Scheduled Tasks: Starting...', $response);
+        self::assertStringContainsString('Scheduled Tasks: Starting...', $response);
     }
 
     public function getTypesOfErrorsForScheduledTasksTrackerFailureTest()
@@ -255,11 +255,11 @@ class TrackerTest extends IntegrationTestCase
         $this->assertStringStartsWith('{"status":', $output);
 
         if($expectTrackingToSucceed) {
-            $this->assertNotContains('error', $output);
-            $this->assertContains('success', $output);
+            self::assertStringNotContainsString('error', $output);
+            self::assertStringContainsString('success', $output);
         } else {
-            $this->assertContains('error', $output);
-            $this->assertNotContains('success', $output);
+            self::assertStringContainsString('error', $output);
+            self::assertStringNotContainsString('success', $output);
         }
     }
 
@@ -359,7 +359,7 @@ class TrackerTest extends IntegrationTestCase
             $initialTask = new Task($this, 'markCustomTaskExecuted', null, Schedule::factory('hourly'));
             $tasksToAdd = array_merge(array($initialTask), $tasksToAdd);
 
-            $mockTaskLoader = $this->getMock('Piwik\Scheduler\TaskLoader', array('loadTasks'));
+            $mockTaskLoader = $this->createPartialMock('Piwik\Scheduler\TaskLoader', array('loadTasks'));
             $mockTaskLoader->expects($this->any())->method('loadTasks')->will($this->returnValue($tasksToAdd));
             $result['Piwik\Scheduler\TaskLoader'] = $mockTaskLoader;
         }

--- a/tests/PHPUnit/System/UserIdAndVisitorIdTest.php
+++ b/tests/PHPUnit/System/UserIdAndVisitorIdTest.php
@@ -21,12 +21,12 @@ class UserIdAndVisitorIdTest extends SystemTestCase
 {
     public static $fixture = null; // initialized below class definition
 
-    public function setUp()
+    public function setUp(): void
     {
         Proxy::getInstance()->setHideIgnoredFunctions(false);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Proxy::getInstance()->setHideIgnoredFunctions(true);
     }

--- a/tests/PHPUnit/Unit/API/ApiRendererTest.php
+++ b/tests/PHPUnit/Unit/API/ApiRendererTest.php
@@ -17,7 +17,7 @@ use Piwik\Plugin\Manager;
  */
 class ApiRendererTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Manager::getInstance()->loadPlugins(array('API'));
     }
@@ -40,12 +40,11 @@ class ApiRendererTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Piwik\Plugins\API\Renderer\Original', $renderer);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage General_ExceptionInvalidRendererFormat
-     */
     public function test_factory_shouldThrowAnException_IfInvalidFormatGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionInvalidRendererFormat');
+
         ApiRenderer::factory('phpi', array());
     }
 }

--- a/tests/PHPUnit/Unit/API/ResponseBuilderTest.php
+++ b/tests/PHPUnit/Unit/API/ResponseBuilderTest.php
@@ -19,7 +19,7 @@ use Piwik\Plugin\Manager;
  */
 class ResponseBuilderTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Manager::getInstance()->loadPlugins(array('API'));
     }

--- a/tests/PHPUnit/Unit/Archive/ChunkTest.php
+++ b/tests/PHPUnit/Unit/Archive/ChunkTest.php
@@ -23,7 +23,7 @@ class ChunkTest extends \PHPUnit\Framework\TestCase
 
     private $recordName = 'Actions_ActionsUrl';
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->chunk = new Chunk();
     }

--- a/tests/PHPUnit/Unit/Archiver/RequestTest.php
+++ b/tests/PHPUnit/Unit/Archiver/RequestTest.php
@@ -15,7 +15,7 @@ use Piwik\Date;
 
 class RequestTest extends \PHPUnit\Framework\TestCase
 {
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         Date::$now = null;

--- a/tests/PHPUnit/Unit/AssetManager/UIAssetCacheBusterTest.php
+++ b/tests/PHPUnit/Unit/AssetManager/UIAssetCacheBusterTest.php
@@ -18,7 +18,7 @@ class UIAssetCacheBusterTest extends TestCase
      */
     private $cacheBuster;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cacheBuster = UIAssetCacheBuster::getInstance();
     }

--- a/tests/PHPUnit/Unit/Category/CategoryListTest.php
+++ b/tests/PHPUnit/Unit/Category/CategoryListTest.php
@@ -23,7 +23,7 @@ class CategoryListTest extends \PHPUnit\Framework\TestCase
      */
     private $categoryList;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->categoryList = new CategoryList();
     }
@@ -40,12 +40,11 @@ class CategoryListTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array('myTest' => $category), $this->categoryList->getCategories());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Category myTest already exists
-     */
     public function test_addCategory_shouldThrowException_IfAddingSameCategoryIdTwice()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Category myTest already exists');
+
         $this->addCategory('myTest');
         $this->addCategory('myTest');
     }

--- a/tests/PHPUnit/Unit/Category/CategoryTest.php
+++ b/tests/PHPUnit/Unit/Category/CategoryTest.php
@@ -23,7 +23,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
      */
     private $category;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->category = new Category();
@@ -76,12 +76,11 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array($subcategory1, $subcategory2), $this->category->getSubcategories());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Subcategory id1 already exists
-     */
     public function test_addSubcategory_ShouldThrowException_WhenAddingSubcategoryWithSameIdTwice()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Subcategory id1 already exists');
+
         $subcategory1 = $this->createSubcategory('id1', 'name1');
         $subcategory2 = $this->createSubcategory('id1', 'name2');
 

--- a/tests/PHPUnit/Unit/Category/SubcategoryTest.php
+++ b/tests/PHPUnit/Unit/Category/SubcategoryTest.php
@@ -23,7 +23,7 @@ class SubcategoryTest extends \PHPUnit\Framework\TestCase
      */
     private $subcategory;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->subcategory = new Subcategory();

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -120,13 +120,9 @@ class CommonTest extends TestCase
      */
     public function testGetRequestVarEmptyVarName()
     {
-        try {
-            $_GET[''] = 1;
-            Common::getRequestVar('');
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+        $_GET[''] = 1;
+        Common::getRequestVar('');
     }
 
     /**
@@ -134,12 +130,8 @@ class CommonTest extends TestCase
      */
     public function testGetRequestVarNoDefaultNoTypeNoValue()
     {
-        try {
-            Common::getRequestVar('test');
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+        Common::getRequestVar('test');
     }
 
     /**
@@ -168,11 +160,11 @@ class CommonTest extends TestCase
 
     /**
      * nodefault Withtype WithValue => exception cos type not matching
-     * @expectedException \Exception
-     * @expectedExceptionMessage The parameter 'test' isn't set in the Request
      */
     public function testGetRequestVarNoDefaultWithTypeWithValue()
     {
+        $this->expectException(Exception::class);
+        $this->expectDeprecationMessage("The parameter 'test' isn't set in the Request");
         $_GET['test'] = false;
         Common::getRequestVar('test', null, 'string');
     }
@@ -182,13 +174,8 @@ class CommonTest extends TestCase
      */
     public function testGetRequestVarNoDefaultWithTypeWithValue2()
     {
-        try {
-            Common::getRequestVar('test', null, 'string');
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
-
+        $this->expectException(Exception::class);
+        Common::getRequestVar('test', null, 'string');
     }
 
     /**
@@ -285,7 +272,7 @@ class CommonTest extends TestCase
             "WHITE SPACE",
         );
         foreach ($notvalid as $toTest) {
-            $this->assertFalse(Filesystem::isValidFilename($toTest), $toTest . " valid but shouldn't!");
+            self::assertFalse(Filesystem::isValidFilename($toTest), $toTest . " valid but shouldn't!");
         }
     }
 
@@ -299,8 +286,8 @@ class CommonTest extends TestCase
 
         // strings not unserializable should return false and trigger a debug log
         $logger = $this->createFakeLogger();
-        $this->assertFalse(Common::safe_unserialize('{1:somebroken}'));
-        $this->assertContains('Unable to unserialize a string: unserialize(): Error at offset 0 of 14 bytes', $logger->output);
+        self::assertFalse(Common::safe_unserialize('{1:somebroken}'));
+        self::assertStringContainsString('Unable to unserialize a string: unserialize(): Error at offset 0 of 14 bytes', $logger->output);
     }
 
     private function createFakeLogger()

--- a/tests/PHPUnit/Unit/Config/IniFileChainCacheTest.php
+++ b/tests/PHPUnit/Unit/Config/IniFileChainCacheTest.php
@@ -45,7 +45,7 @@ class IniFileChainCacheTest extends IniFileChainTest
 
     private $testHost = 'mytest.matomo.org';
 
-    public function setUp()
+    public function setUp(): void
     {
         $GLOBALS['ENABLE_CONFIG_PHP_CACHE'] = true;
         $_SERVER['HTTP_HOST'] = $this->testHost;
@@ -59,7 +59,7 @@ class IniFileChainCacheTest extends IniFileChainTest
         Config::setSetting('General', 'trusted_hosts', array($this->testHost, 'foonot.exists'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->cache->doDelete(IniFileChain::CONFIG_CACHE_KEY);
         unset($GLOBALS['ENABLE_CONFIG_PHP_CACHE']);

--- a/tests/PHPUnit/Unit/ConfigTest.php
+++ b/tests/PHPUnit/Unit/ConfigTest.php
@@ -8,9 +8,9 @@
 
 namespace Piwik\Tests\Unit;
 
+use PHPUnit\Framework\TestCase;
 use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Config;
-use Piwik\Tests\Framework\Mock\TestConfig;
 
 class DumpConfigTestMockIniFileChain extends Config\IniFileChain
 {
@@ -51,7 +51,7 @@ class DumpConfigTestMockConfig extends Config
 /**
  * @group Core
  */
-class ConfigTest extends \PHPUnit\Framework\TestCase
+class ConfigTest extends TestCase
 {
     public function testUserConfigOverwritesSectionGlobalConfigValue()
     {

--- a/tests/PHPUnit/Unit/Container/IniConfigDefinitionSourceTest.php
+++ b/tests/PHPUnit/Unit/Container/IniConfigDefinitionSourceTest.php
@@ -77,7 +77,7 @@ class IniConfigDefinitionSourceTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($definition instanceof ValueDefinition);
         $this->assertEquals('ini.General', $definition->getName());
-        $this->assertInternalType('array', $definition->getValue());
+        self::assertIsArray($definition->getValue());
         $this->assertEquals(array('foo' => 'bar'), $definition->getValue());
     }
 
@@ -103,10 +103,11 @@ class IniConfigDefinitionSourceTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|GlobalSettingsProvider
+     * @return \PHPUnit\Framework\MockObject\MockObject|GlobalSettingsProvider
      */
     private function createConfig()
     {
-        return $this->getMock('Piwik\Application\Kernel\GlobalSettingsProvider', array(), array(), '', false);
+        return $this->getMockBuilder('Piwik\Application\Kernel\GlobalSettingsProvider')
+                ->disableOriginalConstructor()->getMock();
     }
 }

--- a/tests/PHPUnit/Unit/CookieTest.php
+++ b/tests/PHPUnit/Unit/CookieTest.php
@@ -44,7 +44,7 @@ class CookieTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider getJsonSerializeData
      */
-    public function testJsonSerialize($testData, $id)
+    public function testJsonSerialize($id, $testData)
     {
         $this->assertEquals($testData, json_decode(json_encode($testData), $assoc = true), $id);
     }

--- a/tests/PHPUnit/Unit/CronArchive/FixedSiteIdsTest.php
+++ b/tests/PHPUnit/Unit/CronArchive/FixedSiteIdsTest.php
@@ -20,7 +20,7 @@ class FixedSiteIdsTest extends \PHPUnit\Framework\TestCase
      */
     private $fixedSiteIds;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fixedSiteIds = new FixedSiteIds(array(1,2,5,9));
     }

--- a/tests/PHPUnit/Unit/CronArchive/SegmentArchivingRequestUrlProviderTest.php
+++ b/tests/PHPUnit/Unit/CronArchive/SegmentArchivingRequestUrlProviderTest.php
@@ -20,7 +20,7 @@ class SegmentArchivingRequestUrlProviderTest extends \PHPUnit\Framework\TestCase
 
     private $mockSegmentEntries;
 
-    public function setUp()
+    public function setUp(): void
     {
         Config::getInstance()->General['enabled_periods_API'] = 'day,week,month,year,range';
 
@@ -247,7 +247,7 @@ class SegmentArchivingRequestUrlProviderTest extends \PHPUnit\Framework\TestCase
 
     private function createUrlProviderToTest($processNewSegmentsFrom)
     {
-        $mockSegmentEditorModel = $this->getMock('Piwik\Plugins\SegmentEditor\Model', array('getAllSegmentsAndIgnoreVisibility'));
+        $mockSegmentEditorModel = $this->createPartialMock('Piwik\Plugins\SegmentEditor\Model', array('getAllSegmentsAndIgnoreVisibility'));
         $mockSegmentEditorModel->expects($this->any())->method('getAllSegmentsAndIgnoreVisibility')->will($this->returnValue($this->mockSegmentEntries));
 
         return new SegmentArchivingRequestUrlProvider($processNewSegmentsFrom, $mockSegmentEditorModel, null, Date::factory(self::TEST_NOW));

--- a/tests/PHPUnit/Unit/DataAccess/ArchiveTableCreatorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/ArchiveTableCreatorTest.php
@@ -17,7 +17,7 @@ class ArchiveTableCreatorTest extends \PHPUnit\Framework\TestCase
 {
     private $tables;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -33,7 +33,7 @@ class ArchiveTableCreatorTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         ArchiveTableCreator::clear();
 

--- a/tests/PHPUnit/Unit/DataAccess/ArchiveWriterTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/ArchiveWriterTest.php
@@ -97,7 +97,10 @@ class ArchiveWriterTest extends \PHPUnit\Framework\TestCase
 
     private function assertInsertBlobRecordInsertedRecordsInBulk($expectedBlobs, $blobs)
     {
-        $writer = $this->getMock('Piwik\DataAccess\ArchiveWriter', array('insertRecord', 'compress'), array(), '', false);
+        $writer = $this->getMockBuilder('Piwik\DataAccess\ArchiveWriter')
+            ->disableOriginalConstructor()
+            ->onlyMethods(array('insertRecord', 'compress'))
+            ->getMock();
         $writer->expects($this->exactly(count($expectedBlobs)))
                ->method('compress')
                ->will($this->returnArgument(0));
@@ -114,7 +117,10 @@ class ArchiveWriterTest extends \PHPUnit\Framework\TestCase
 
     private function assertInsertBlobRecordInsertedASingleRecord($expectedBlob, $blob)
     {
-        $writer = $this->getMock('Piwik\DataAccess\ArchiveWriter', array('insertRecord', 'compress'), array(), '', false);
+        $writer = $this->getMockBuilder('Piwik\DataAccess\ArchiveWriter')
+            ->disableOriginalConstructor()
+            ->onlyMethods(array('insertRecord', 'compress'))
+            ->getMock();
         $writer->expects($this->once())
                ->method('compress')
                ->will($this->returnArgument(0));

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinGeneratorTest.php
@@ -23,7 +23,7 @@ class JoinGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     private $generator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->generator = $this->makeTables(array(
             'log_visit',
@@ -100,14 +100,14 @@ class JoinGeneratorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Table 'log_visit' can't be joined for segmentation
-     *
      * Note: the exception reports `log_visit` and not `log_custom` as it resolves the dependencies as so resolves
      * from `log_custom` to `log_visit` but is then not able to find a way to join `log_visit` with `log_action`
      */
     public function test_generate_getJoinString_CustomVisitTableCantBeJoinedWithAction()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Table \'log_visit\' can\'t be joined for segmentation');
+
         $generator = $this->generate(array('log_action', 'log_custom'));
         $generator->getJoinString();
     }
@@ -161,12 +161,11 @@ class JoinGeneratorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $generator->getJoinString());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Please reorganize the joined tables as the table log_conversion in {"0":"log_visit","1":"log_conversion","2":"log_link_visit_action","3":{"table":"log_conversion","joinOn":"log_link_visit_action.idvisit2 = log_conversion.idvisit2"}} cannot be joined correctly.
-     */
     public function test_generate_getJoinString_manuallyJoinedAlreadyWithCustomConditionInArrayInverted()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Please reorganize the joined tables as the table log_conversion in {"0":"log_visit","1":"log_conversion","2":"log_link_visit_action","3":{"table":"log_conversion","joinOn":"log_link_visit_action.idvisit2 = log_conversion.idvisit2"}} cannot be joined correctly.');
+
         $generator = $this->generate(array(
             'log_visit',
             'log_conversion',

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
@@ -22,7 +22,7 @@ class JoinTablesTest extends \PHPUnit\Framework\TestCase
      */
     private $tables;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->tables = $this->makeTables(array(
             'log_visit',
@@ -30,12 +30,11 @@ class JoinTablesTest extends \PHPUnit\Framework\TestCase
             'log_action'));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Table 'log_foo_bar_baz' can't be used for segmentation
-     */
     public function test_construct_shouldThrowException_IfTableIsNotPossibleToJoin()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Table \'log_foo_bar_baz\' can\'t be used for segmentation');
+
         $this->makeTables(array('log_visit', 'log_foo_bar_baz'));
     }
 
@@ -72,12 +71,11 @@ class JoinTablesTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->tables->hasJoinedTable($table));
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Table 'log_foo_bar_baz' can't be used for segmentation
-     */
     public function test_addTableToJoin_shouldCheckIfTableCanBeUsedForSegmentation()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Table \'log_foo_bar_baz\' can\'t be used for segmentation');
+
         $table = 'log_foo_bar_baz';
         $this->assertFalse($this->tables->hasJoinedTable($table));
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterByLabelMappingTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterByLabelMappingTest.php
@@ -25,7 +25,7 @@ class AddSegmentByLabelMappingTest extends \PHPUnit\Framework\TestCase
      */
     private $table;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterBySegmentValueTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterBySegmentValueTest.php
@@ -33,7 +33,7 @@ class AddSegmentBySegmentValueTest extends \PHPUnit\Framework\TestCase
 
     private $report;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentFilterTest.php
@@ -25,7 +25,7 @@ class AddSegmentByLabelTest extends \PHPUnit\Framework\TestCase
      */
     private $table;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
         $this->addRow(array('label' => 'http://piwik.org/test'));

--- a/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentValueTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/AddSegmentValueTest.php
@@ -25,7 +25,7 @@ class AddSegmentValueTest extends \PHPUnit\Framework\TestCase
      */
     private $table;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
         $this->addRow(array('label' => 'http://piwik.org/test'));

--- a/tests/PHPUnit/Unit/DataTable/Filter/ColumnCallbackDeleteMetadataTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/ColumnCallbackDeleteMetadataTest.php
@@ -25,7 +25,7 @@ class ColumnCallbackDeleteMetadataTest extends \PHPUnit\Framework\TestCase
      */
     private $table;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
         $this->addRowWithMetadata(array('test' => '1'));

--- a/tests/PHPUnit/Unit/DataTable/Filter/PrependSegmentFilterTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PrependSegmentFilterTest.php
@@ -25,7 +25,7 @@ class PrependSegmentTest extends \PHPUnit\Framework\TestCase
      */
     private $table;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
         $this->addRowWithMetadata(array('test' => '1'));

--- a/tests/PHPUnit/Unit/DataTable/Filter/PrependValueToMetadataTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/PrependValueToMetadataTest.php
@@ -25,7 +25,7 @@ class PrependValueToMetadataTest extends \PHPUnit\Framework\TestCase
      */
     private $table;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->table = new DataTable();
         $this->addRowWithMetadata(array('test' => '1'));

--- a/tests/PHPUnit/Unit/DataTable/Filter/TruncateTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Filter/TruncateTest.php
@@ -22,7 +22,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit\Framework\TestCase
     {
         // remark: this unit test would become invalid and would need to be rewritten if
         // Truncate filter stops calling getRowsCount() on the DataTable being filtered.
-        $mockedDataTable = $this->getMock('\Piwik\DataTable', array('getRowsCount'));
+        $mockedDataTable = $this->createPartialMock('\Piwik\DataTable', array('getRowsCount'));
         $mockedDataTable->expects($this->never())->method('getRowsCount');
 
         $dataTableBeingFiltered = new DataTable();
@@ -46,7 +46,7 @@ class DataTable_Filter_TruncateTest extends \PHPUnit\Framework\TestCase
 
         // remark: this unit test would become invalid and would need to be rewritten if
         // Truncate filter stops calling getIdSubDataTable() on rows associated with a SubDataTable
-        $rowBeingFiltered = $this->getMock('\Piwik\DataTable\Row', array('getIdSubDataTable'));
+        $rowBeingFiltered = $this->createPartialMock('\Piwik\DataTable\Row', array('getIdSubDataTable'));
         $rowBeingFiltered->expects($this->never())->method('getIdSubDataTable');
 
         $dataTableBeingFiltered->addRow($rowBeingFiltered);

--- a/tests/PHPUnit/Unit/DataTable/ManagerTest.php
+++ b/tests/PHPUnit/Unit/DataTable/ManagerTest.php
@@ -19,7 +19,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
      */
     private $manager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->manager = new Manager();
@@ -30,12 +30,11 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         return new DataTable();
     }
 
-    /**
-     * @expectedException \Piwik\DataTable\TableNotFoundException
-     * @expectedExceptionMessage table id 1 not found in memory
-     */
     public function test_getTable_shouldThrowException_IfTableIdDoesNotExist()
     {
+        $this->expectException(\Piwik\DataTable\TableNotFoundException::class);
+        $this->expectExceptionMessage('table id 1 not found in memory');
+
         $this->manager->getTable(1);
     }
 

--- a/tests/PHPUnit/Unit/DataTable/MapTest.php
+++ b/tests/PHPUnit/Unit/DataTable/MapTest.php
@@ -13,7 +13,7 @@ use Piwik\Tests\Framework\Mock\TestConfig;
  */
 class Test_DataTable_Map extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Manager::getInstance()->deleteAll();

--- a/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
@@ -19,7 +19,7 @@ use Piwik\DataTable\Simple;
  */
 class DataTable_Renderer_CSVTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Manager::getInstance()->deleteAll();

--- a/tests/PHPUnit/Unit/DataTable/Renderer/ConsoleTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/ConsoleTest.php
@@ -18,7 +18,7 @@ use Piwik\DataTable\Row;
  */
 class DataTable_Renderer_ConsoleTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Manager::getInstance()->deleteAll();

--- a/tests/PHPUnit/Unit/DataTable/Renderer/JSONTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/JSONTest.php
@@ -19,7 +19,7 @@ use Piwik\DataTable\Simple;
  */
 class DataTable_Renderer_JSONTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Manager::getInstance()->deleteAll();

--- a/tests/PHPUnit/Unit/DataTable/Renderer/PHPTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/PHPTest.php
@@ -19,7 +19,7 @@ use Piwik\DataTable\Simple;
  */
 class DataTable_Renderer_PHPTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Manager::getInstance()->deleteAll();

--- a/tests/PHPUnit/Unit/DataTable/Renderer/XMLTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/XMLTest.php
@@ -19,7 +19,7 @@ use Piwik\DataTable\Simple;
  */
 class DataTable_Renderer_XMLTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Manager::getInstance()->deleteAll();

--- a/tests/PHPUnit/Unit/DataTable/RowTest.php
+++ b/tests/PHPUnit/Unit/DataTable/RowTest.php
@@ -21,7 +21,7 @@ class RowTest extends \PHPUnit\Framework\TestCase
      */
     private $row;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->row = new Row();
     }
@@ -421,12 +421,11 @@ class RowTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(array('my_array' => $arrayValue), $this->row->getMetadata());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Trying to sum unsupported operands for column mycol in row with label = row1: array + integer
-     */
     public function test_sumRow_throwsIfAddingUnsupportedTypes()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Trying to sum unsupported operands for column mycol in row with label = row1: array + integer');
+
         $row1 = new Row();
         $row1->addColumn('label', 'row1');
         $row1->addColumn('mycol', ['a']);

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -396,12 +396,11 @@ class DataTableTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(array(5, 145), $finalRow->getColumn('test_int'));
     }
 
-    /**
-     * @expectedException  \Exception
-     * @expectedExceptionMessage Unknown operation 'foobarinvalid'
-     */
     public function testSumRow_ShouldThrowExceptionIfInvalidOperationIsGiven()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unknown operation \'foobarinvalid\'');
+
         $row1 = new Row(array(Row::COLUMNS => array('test_int' => 145)));
         $finalRow = new Row(array(Row::COLUMNS => array('test_int' => 5)));
         $finalRow->sumRow($row1, $copyMetadata = true, $operation = array('test_int' => 'fooBarInvalid'));
@@ -442,11 +441,11 @@ class DataTableTest extends \PHPUnit\Framework\TestCase
     /**
      * Test serialize with an infinite recursion (a row linked to a table in the parent hierarchy)
      * After 100 recursion must throw an exception
-     *
-     * @expectedException \Exception
      */
     public function testSerializeWithInfiniteRecursion()
     {
+        $this->expectException(\Exception::class);
+
         $table = new DataTable;
         $table->addRowFromArray(array(Row::COLUMNS => array('visits' => 245, 'visitors' => 245),
                                       Row::DATATABLE_ASSOCIATED => $table));
@@ -938,7 +937,7 @@ class DataTableTest extends \PHPUnit\Framework\TestCase
 
     public function testUnrelatedDataTableNotDestructed()
     {
-        $mockedDataTable = $this->getMock('\Piwik\DataTable', array('__destruct'));
+        $mockedDataTable = $this->createPartialMock('\Piwik\DataTable', array('__destruct'));
         $mockedDataTable->expects($this->never())->method('__destruct');
 
         $rowBeingDestructed = new Row();
@@ -982,7 +981,9 @@ class DataTableTest extends \PHPUnit\Framework\TestCase
      */
     public function testSubDataTableIsDestructed()
     {
-        $mockedDataTable = $this->getMock('\Piwik\DataTable', array('__destruct'));
+        $mockedDataTable = $this->getMockBuilder('\Piwik\DataTable')
+            ->onlyMethods(['__destruct'])
+            ->getMock();
         $mockedDataTable->expects($this->once())->method('__destruct');
 
         $rowBeingDestructed = new Row();

--- a/tests/PHPUnit/Unit/DateTest.php
+++ b/tests/PHPUnit/Unit/DateTest.php
@@ -18,7 +18,7 @@ use Piwik\Tests\Framework\Fixture;
  */
 class DateTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -26,7 +26,7 @@ class DateTest extends \PHPUnit\Framework\TestCase
         date_default_timezone_set('UTC');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Date::$now = null;
         date_default_timezone_set('UTC');
@@ -77,12 +77,8 @@ class DateTest extends \PHPUnit\Framework\TestCase
      */
     public function testInvalidDateThrowsException()
     {
-        try {
-            Date::factory('0001-01-01');
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+        Date::factory('0001-01-01');
     }
 
     public function getTimezoneOffsets()
@@ -466,21 +462,19 @@ class DateTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Date::factoryInTimezone() should not be used with
-     */
     public function test_factoryInTimezone_doesNotWorkWithNormalDates()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Date::factoryInTimezone() should not be used with');
+
         Date::factoryInTimezone('2012-02-03', 'America/Toronto');
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Date::factoryInTimezone() should not be used with
-     */
     public function test_factoryInTimezone_doesNotWorkWithTimestamps()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Date::factoryInTimezone() should not be used with');
+
         Date::factoryInTimezone(time(), 'America/Toronto');
     }
 }

--- a/tests/PHPUnit/Unit/FactoryTest.php
+++ b/tests/PHPUnit/Unit/FactoryTest.php
@@ -23,12 +23,11 @@ class FactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Piwik\Timer', $instance);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Invalid class ID
-     */
     public function testCreatingInvalidClassThrows()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid class ID');
+
         BaseFactory::factory("This\\Class\\Does\\Not\\Exist");
     }
 }

--- a/tests/PHPUnit/Unit/FilesystemTest.php
+++ b/tests/PHPUnit/Unit/FilesystemTest.php
@@ -19,14 +19,14 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
 {
     private $testPath;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->testPath = PIWIK_INCLUDE_PATH . '/tmp/filesystemtest';
         Filesystem::mkdir($this->testPath);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Filesystem::unlinkRecursive($this->testPath, true);
 
@@ -173,6 +173,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
         $target = $this->createEmptyTarget();
 
         Filesystem::unlinkTargetFilesNotPresentInSource($source, $target);
+        $this->assertTrue(true);
     }
 
     public function test_unlinkTargetFilesNotPresentInSource_shouldUnlinkAllTargetFiles_IfSourceIsEmpty()
@@ -188,7 +189,7 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
 
         // make sure there is no longer a difference
         $result = Filesystem::directoryDiff($source, $target);
-        $this->assertEquals(array(), $result);
+        $this->assertEquals([], $result);
 
         $result = Filesystem::directoryDiff($target, $source);
         $this->assertEquals(array(), $result);
@@ -348,12 +349,11 @@ class FilesystemTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $size);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Invalid unit given
-     */
     public function test_getFileSize_ShouldThrowException_IfInvalidUnit()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid unit given');
+
         Filesystem::getFileSize(__FILE__, 'iV');
     }
 

--- a/tests/PHPUnit/Unit/LegacyAutoLoaderTest.php
+++ b/tests/PHPUnit/Unit/LegacyAutoLoaderTest.php
@@ -39,19 +39,17 @@ class LegacyAutoLoaderTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(\Matomo\DummyClass::class, $class);
     }
 
-    /**
-     * @expectedException \Error
-     */
     public function testNotExistingMatomoClassStillFails()
     {
+        $this->expectException(\Error::class);
+
         $class = new \Matomo\ClassNotFound();
     }
 
-    /**
-     * @expectedException \Error
-     */
     public function testNotExistingPiwikClassStillFails()
     {
+        $this->expectException(\Error::class);
+
         $class = new \Piwik\ClassNotFound();
     }
 }

--- a/tests/PHPUnit/Unit/Metrics/Formatter/HtmlTest.php
+++ b/tests/PHPUnit/Unit/Metrics/Formatter/HtmlTest.php
@@ -24,7 +24,7 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
 
     private $sitesInfo;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->sitesInfo = array(
             1 => array(
@@ -39,7 +39,7 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
         $this->setSiteManagerApiMock();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
         $this->unsetSiteManagerApiMock();
@@ -96,7 +96,7 @@ class HtmlTest extends \PHPUnit\Framework\TestCase
     {
         $sitesInfo = $this->sitesInfo;
 
-        $mock = $this->getMock('stdClass', array('getSiteFromId'));
+        $mock = $this->getMockBuilder('stdClass')->addMethods(['getSiteFromId'])->getMock();
         $mock->expects($this->any())->method('getSiteFromId')->willReturnCallback(function ($idSite) use ($sitesInfo) {
             return $sitesInfo[$idSite];
         });

--- a/tests/PHPUnit/Unit/Metrics/FormatterTest.php
+++ b/tests/PHPUnit/Unit/Metrics/FormatterTest.php
@@ -25,7 +25,7 @@ class FormatterTest extends \PHPUnit\Framework\TestCase
 
     private $sitesInfo;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->sitesInfo = array(
             1 => array(
@@ -56,7 +56,7 @@ class FormatterTest extends \PHPUnit\Framework\TestCase
         $this->setSiteManagerApiMock();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Fixture::resetTranslations();
         NumberFormatter::getInstance()->clearCache();
@@ -225,7 +225,7 @@ class FormatterTest extends \PHPUnit\Framework\TestCase
     {
         $sitesInfo = $this->sitesInfo;
 
-        $mock = $this->getMock('stdClass', array('getSiteFromId'));
+        $mock = $this->getMockBuilder('stdClass')->addMethods(['getSiteFromId'])->getMock();
         $mock->expects($this->any())->method('getSiteFromId')->willReturnCallback(function ($idSite) use ($sitesInfo) {
             return $sitesInfo[$idSite];
         });

--- a/tests/PHPUnit/Unit/Metrics/SorterTest.php
+++ b/tests/PHPUnit/Unit/Metrics/SorterTest.php
@@ -30,7 +30,7 @@ class SorterTest extends UnitTestCase
      */
     private $config;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Unit/Period/BasePeriodTest.php
+++ b/tests/PHPUnit/Unit/Period/BasePeriodTest.php
@@ -12,14 +12,14 @@ use Piwik\Tests\Framework\Fixture;
 
 abstract class BasePeriodTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         Fixture::loadAllTranslations();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/PHPUnit/Unit/Period/DayTest.php
+++ b/tests/PHPUnit/Unit/Period/DayTest.php
@@ -19,14 +19,9 @@ class DayTest extends BasePeriodTest
      */
     public function testInvalidDate()
     {
-        try {
-            new Day('Invalid Date');
-        } catch (\Exception $e) {
-            return;
-        } catch (\Throwable $e) {
-            return;
-        }
-        $this->fail('Expected Exception not raised');
+        $this->expectException(\TypeError::class);
+
+        new Day('Invalid Date');
     }
 
     /**
@@ -200,16 +195,12 @@ class DayTest extends BasePeriodTest
      */
     public function testAddSubperiodFails()
     {
+        $this->expectException(\Exception::class);
+
         // create the period
         $period = new Day(Date::factory("2007-12-31"));
 
-        try {
-            $period->addSubperiod('');
-        } catch (\Exception $e) {
-            return;
-        }
-        // expected string
-        $this->fail('Exception not raised');
+        $period->addSubperiod('');
     }
 
     public function getLocalizedShortStrings()

--- a/tests/PHPUnit/Unit/Period/RangeTest.php
+++ b/tests/PHPUnit/Unit/Period/RangeTest.php
@@ -1165,16 +1165,13 @@ class RangeTest extends BasePeriodTest
 
     public function testCustomRangeBeforeIsAfterYearRight()
     {
-        try {
-            $range = new Range('range', '2007-02-09,2007-02-01');
-            $this->assertEquals(0, $range->getNumberOfSubperiods());
-            $this->assertEquals(array(), $range->toString());
+        $this->expectException(Exception::class);
 
-            $range->getPrettyString();
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $range = new Range('range', '2007-02-09,2007-02-01');
+        $this->assertEquals(0, $range->getNumberOfSubperiods());
+        $this->assertEquals(array(), $range->toString());
+
+        $range->getPrettyString();
     }
 
     public function testCustomRangeLastN()
@@ -1218,13 +1215,10 @@ class RangeTest extends BasePeriodTest
 
     public function testInvalidRangeThrows()
     {
-        try {
-            $range = new Range('range', '0001-01-01,today');
-            $range->getLocalizedLongString();
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+
+        $range = new Range('range', '0001-01-01,today');
+        $range->getLocalizedLongString();
     }
 
     public function testGetLocalizedShortString()

--- a/tests/PHPUnit/Unit/PeriodTest.php
+++ b/tests/PHPUnit/Unit/PeriodTest.php
@@ -37,19 +37,19 @@ class PeriodTest extends \PHPUnit\Framework\TestCase
     {
         $period = new Day(Date::today());
         $label = $period->getLabel();
-        $this->assertInternalType('string', $label);
+        self::assertIsString($label);
         $this->assertNotEmpty($label);
         $period = new Week(Date::today());
         $label = $period->getLabel();
-        $this->assertInternalType('string', $label);
+        self::assertIsString($label);
         $this->assertNotEmpty($label);
         $period = new Month(Date::today());
         $label = $period->getLabel();
-        $this->assertInternalType('string', $label);
+        self::assertIsString($label);
         $this->assertNotEmpty($label);
         $period = new Year(Date::today());
         $label = $period->getLabel();
-        $this->assertInternalType('string', $label);
+        self::assertIsString($label);
         $this->assertNotEmpty($label);
     }
 
@@ -65,15 +65,18 @@ class PeriodTest extends \PHPUnit\Framework\TestCase
         Period::checkDateFormat('previous30');
         Period::checkDateFormat('+1 day');
         Period::checkDateFormat('next Thursday');
+
+        $this->assertTrue(true);
     }
 
     /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Date format must be: YYYY-MM-DD, or 'today' or 'yesterday' or any keyword supported by the strtotime function (see http://php.net/strtotime for more information):
      * @dataProvider getInvalidDateFormats
      */
     public function testValidate_InvalidDates($invalidDateFormat)
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Date format must be: YYYY-MM-DD, or \'today\' or \'yesterday\' or any keyword supported by the strtotime function (see http://php.net/strtotime for more information):');
+
         Period::checkDateFormat($invalidDateFormat);
     }
 
@@ -148,12 +151,13 @@ class PeriodTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage is a date before first website was online. Try date that's after
      * @dataProvider getInvalidDatesBeforeFirstWebsite
      */
     public function testValidate_InvalidDatesBeforeFirstWebsite($invalidDatesBeforeFirstWebsite)
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('is a date before first website was online. Try date that\'s after');
+
         Period::checkDateFormat($invalidDatesBeforeFirstWebsite);
     }
     

--- a/tests/PHPUnit/Unit/Plugin/ComponentFactoryTest.php
+++ b/tests/PHPUnit/Unit/Plugin/ComponentFactoryTest.php
@@ -12,7 +12,6 @@ use Piwik\Config;
 use Piwik\Plugin\ComponentFactory;
 use Piwik\Plugin\Manager as PluginManager;
 use Piwik\Plugin\Report;
-use Piwik\Tests\Framework\Mock\TestConfig;
 
 /**
  * @group Core
@@ -21,7 +20,7 @@ class ComponentFactoryTest extends TestCase
 {
     const REPORT_CLASS_NAME = 'Piwik\\Plugin\\Report';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Unit/Report/ReportWidgetConfigTest.php
+++ b/tests/PHPUnit/Unit/Report/ReportWidgetConfigTest.php
@@ -23,7 +23,7 @@ class ReportWidgetConfigTest extends \PHPUnit\Framework\TestCase
      */
     private $config;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->config = new ReportWidgetConfig();
@@ -216,13 +216,14 @@ class ReportWidgetConfigTest extends \PHPUnit\Framework\TestCase
     {
         $this->config->enable();
         $this->config->checkIsEnabled();
+
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_checkIsEnabled_shouldThrowException_IfDisabled()
     {
+        $this->expectException(\Exception::class);
+
         $this->config->disable();
         $this->config->checkIsEnabled();
     }

--- a/tests/PHPUnit/Unit/Report/ReportWidgetFactoryTest.php
+++ b/tests/PHPUnit/Unit/Report/ReportWidgetFactoryTest.php
@@ -49,7 +49,7 @@ class ReportWidgetFactoryTest extends \PHPUnit\Framework\TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/DailyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/DailyTest.php
@@ -23,7 +23,7 @@ class DailyTest extends \PHPUnit\Framework\TestCase
     private static $_JANUARY_02_1971_00_00_00;
     private static $_JANUARY_02_1971_09_00_00;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::$_JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
@@ -38,14 +38,10 @@ class DailyTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetHourScheduledTimeDailyNegative()
     {
-        try {
-            $dailySchedule = Schedule::factory('daily');
-            $dailySchedule->setHour(-1);
+        $this->expectException(Exception::class);
 
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $dailySchedule = Schedule::factory('daily');
+        $dailySchedule->setHour(-1);
     }
 
     /**
@@ -53,13 +49,10 @@ class DailyTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetHourScheduledTimeDailyOver24()
     {
-        try {
-            $dailySchedule = Schedule::factory('daily');
-            $dailySchedule->setHour(25);
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+
+        $dailySchedule = Schedule::factory('daily');
+        $dailySchedule->setHour(25);
     }
 
     /**
@@ -67,13 +60,10 @@ class DailyTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetDayScheduledTimeDaily()
     {
-        try {
-            $dailySchedule = Schedule::factory('daily');
-            $dailySchedule->setDay(1);
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+
+        $dailySchedule = Schedule::factory('daily');
+        $dailySchedule->setDay(1);
     }
 
     /**
@@ -167,7 +157,7 @@ class DailyTest extends \PHPUnit\Framework\TestCase
      */
     private function getDailyMock($currentTime)
     {
-        $mock = $this->getMock('Piwik\Scheduler\Schedule\Daily', array('getTime'));
+        $mock = $this->createPartialMock('Piwik\Scheduler\Schedule\Daily', array('getTime'));
         $mock->expects($this->any())
             ->method('getTime')
             ->will($this->returnValue($currentTime));

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/HourlyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/HourlyTest.php
@@ -20,7 +20,7 @@ class HourlyTest extends \PHPUnit\Framework\TestCase
     private static $_JANUARY_01_1971_09_10_00;
     private static $_JANUARY_01_1971_10_00_00;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::$_JANUARY_01_1971_09_00_00 = mktime(9, 00, 00, 1, 1, 1971);
@@ -34,13 +34,10 @@ class HourlyTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetHourScheduledTimeHourly()
     {
-        try {
-            $hourlySchedule = new Hourly();
-            $hourlySchedule->setHour(0);
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+
+        $hourlySchedule = new Hourly();
+        $hourlySchedule->setHour(0);
     }
 
     /**
@@ -49,13 +46,10 @@ class HourlyTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetDayScheduledTimeHourly()
     {
-        try {
-            $hourlySchedule = new Hourly();
-            $hourlySchedule->setDay(1);
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+
+        $hourlySchedule = new Hourly();
+        $hourlySchedule->setDay(1);
     }
 
     /**
@@ -73,7 +67,7 @@ class HourlyTest extends \PHPUnit\Framework\TestCase
          * Expected :
          *  getRescheduledTime returns Friday January 1 1971 10:00:00 GMT
          */
-        $mock = $this->getMock('Piwik\Scheduler\Schedule\Hourly', array('getTime'));
+        $mock = $this->createPartialMock('Piwik\Scheduler\Schedule\Hourly', array('getTime'));
         $mock->expects($this->any())
             ->method('getTime')
             ->will($this->returnValue(self::$_JANUARY_01_1971_09_00_00));
@@ -88,7 +82,7 @@ class HourlyTest extends \PHPUnit\Framework\TestCase
          * Expected :
          *  getRescheduledTime returns Friday January 1 1971 10:00:00 GMT
          */
-        $mock = $this->getMock('Piwik\Scheduler\Schedule\Hourly', array('getTime'));
+        $mock = $this->createPartialMock('Piwik\Scheduler\Schedule\Hourly', array('getTime'));
         $mock->expects($this->any())
             ->method('getTime')
             ->will($this->returnValue(self::$_JANUARY_01_1971_09_10_00));

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/MonthlyTest.php
@@ -25,47 +25,51 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
     public static $_FEBRUARY_21_1971_09_00_00;
     public static $_FEBRUARY_28_1971_00_00_00;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
     }
 
     /**
      * Tests invalid call to setHour on Monthly
-     * @expectedException \Exception
      */
     public function testSetHourScheduledTimeMonthlyNegative()
     {
+        $this->expectException(\Exception::class);
+
         $monthlySchedule = new Monthly();
         $monthlySchedule->setHour(-1);
     }
 
     /**
      * Tests invalid call to setHour on Monthly
-     * @expectedException \Exception
      */
     public function testSetHourScheduledTimMonthlyOver24()
     {
+        $this->expectException(\Exception::class);
+
         $monthlySchedule = new Monthly();
         $monthlySchedule->setHour(25);
     }
 
     /**
      * Tests invalid call to setDay on Monthly
-     * @expectedException \Exception
      */
     public function testSetDayScheduledTimeMonthlyDay0()
     {
+        $this->expectException(\Exception::class);
+
         $monthlySchedule = new Monthly();
         $monthlySchedule->setDay(0);
     }
 
     /**
      * Tests invalid call to setDay on Monthly
-     * @expectedException \Exception
      */
     public function testSetDayScheduledTimeMonthlyOver31()
     {
+        $this->expectException(\Exception::class);
+
         $monthlySchedule = new Monthly();
         $monthlySchedule->setDay(32);
     }
@@ -239,10 +243,11 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
      * _Monthly
      *
      * @dataProvider getInvalidDayOfWeekData
-     * @expectedException \Exception
      */
     public function testMonthlyDayOfWeekInvalid($day, $week)
     {
+        $this->expectException(\Exception::class);
+
         $mock = $this->getMonthlyMock(self::$_JANUARY_15_1971_09_00_00);
         $mock->setDayOfWeek($day, $week);
     }
@@ -271,7 +276,7 @@ class MonthlyTest extends \PHPUnit\Framework\TestCase
      */
     private function getMonthlyMock($currentTime)
     {
-        $mock = $this->getMock('Piwik\Scheduler\Schedule\Monthly', array('getTime'));
+        $mock = $this->createPartialMock('Piwik\Scheduler\Schedule\Monthly', array('getTime'));
         $mock->expects($this->any())
              ->method('getTime')
              ->will($this->returnValue($currentTime));

--- a/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/Schedule/WeeklyTest.php
@@ -24,7 +24,7 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
     public static $_JANUARY_15_1971_00_00_00;
     public static $_JANUARY_08_1971_00_00_00;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
     }
@@ -34,13 +34,10 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetHourScheduledTimeWeeklyNegative()
     {
-        try {
-            $weeklySchedule = new Weekly();
-            $weeklySchedule->setHour(-1);
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+
+        $weeklySchedule = new Weekly();
+        $weeklySchedule->setHour(-1);
     }
 
     /**
@@ -48,13 +45,10 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetHourScheduledTimeWeeklyOver24()
     {
-        try {
-            $weeklySchedule = new Weekly();
-            $weeklySchedule->setHour(25);
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+
+        $weeklySchedule = new Weekly();
+        $weeklySchedule->setHour(25);
     }
 
     /**
@@ -62,13 +56,10 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetDayScheduledTimeWeeklyDay0()
     {
-        try {
-            $weeklySchedule = new Weekly();
-            $weeklySchedule->setDay(0);
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+
+        $weeklySchedule = new Weekly();
+        $weeklySchedule->setDay(0);
     }
 
     /**
@@ -76,13 +67,10 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetDayScheduledTimeWeeklyOver7()
     {
-        try {
-            $weeklySchedule = new Weekly();
-            $weeklySchedule->setDay(8);
-        } catch (Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised');
+        $this->expectException(Exception::class);
+
+        $weeklySchedule = new Weekly();
+        $weeklySchedule->setDay(8);
     }
 
     /**
@@ -182,7 +170,7 @@ class WeeklyTest extends \PHPUnit\Framework\TestCase
      */
     private function getWeeklyMock($currentTime)
     {
-        $mock = $this->getMock('Piwik\Scheduler\Schedule\Weekly', array('getTime'));
+        $mock = $this->createPartialMock('Piwik\Scheduler\Schedule\Weekly', array('getTime'));
         $mock->expects($this->any())
             ->method('getTime')
             ->will($this->returnValue($currentTime));

--- a/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/SchedulerTest.php
@@ -51,7 +51,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     {
         self::stubPiwikOption($timetable);
 
-        $taskLoader = $this->getMock('Piwik\Scheduler\TaskLoader');
+        $taskLoader = $this->createMock('Piwik\Scheduler\TaskLoader');
         $scheduler = new Scheduler($taskLoader, new NullLogger());
 
         $this->assertEquals($expectedTime, $scheduler->getScheduledTimeForMethod($className, $methodName, $methodParameter));
@@ -84,7 +84,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
     {
         $now = time();
 
-        $dailySchedule = $this->getMock('Piwik\Scheduler\Schedule\Daily', array('getTime'));
+        $dailySchedule = $this->createPartialMock('Piwik\Scheduler\Schedule\Daily', array('getTime'));
         $dailySchedule->expects($this->any())
             ->method('getTime')
             ->will($this->returnValue($now));
@@ -171,7 +171,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
      */
     public function testRun($expectedTimetable, $expectedExecutedTasks, $timetableBeforeTaskExecution, $configuredTasks)
     {
-        $taskLoader = $this->getMock('Piwik\Scheduler\TaskLoader');
+        $taskLoader = $this->createMock('Piwik\Scheduler\TaskLoader');
         $taskLoader->expects($this->atLeastOnce())
             ->method('loadTasks')
             ->willReturn($configuredTasks);
@@ -204,7 +204,7 @@ class SchedulerTest extends \PHPUnit\Framework\TestCase
      */
     public function testRunTaskNow($expectedTimetable, $expectedExecutedTasks, $timetableBeforeTaskExecution, $configuredTasks)
     {
-        $taskLoader = $this->getMock('Piwik\Scheduler\TaskLoader');
+        $taskLoader = $this->createMock('Piwik\Scheduler\TaskLoader');
         $taskLoader->expects($this->atLeastOnce())
             ->method('loadTasks')
             ->willReturn($configuredTasks);

--- a/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
+++ b/tests/PHPUnit/Unit/Scheduler/TimetableTest.php
@@ -25,7 +25,7 @@ class TimetableTest extends \PHPUnit\Framework\TestCase
         'PrivacyManager.deleteReportData_1'   => 1322229607,
     );
 
-    public function tearDown()
+    public function tearDown(): void
     {
         self::resetPiwikOption();
     }

--- a/tests/PHPUnit/Unit/Segment/SegmentExpressionTest.php
+++ b/tests/PHPUnit/Unit/Segment/SegmentExpressionTest.php
@@ -136,14 +136,11 @@ class SegmentExpressionTest extends \PHPUnit\Framework\TestCase
      */
     public function testBogusFiltersExpectExceptionThrown($bogus)
     {
-        try {
-            $segment = new SegmentExpression($bogus);
-            $segment->parseSubExpressions();
-            $segment->getSql();
-        } catch (\Exception $e) {
-            return;
-        }
-        $this->fail('Expected exception not raised for:' . var_export($segment->getSql(), true));
+        $this->expectException(\Exception::class);
+
+        $segment = new SegmentExpression($bogus);
+        $segment->parseSubExpressions();
+        $segment->getSql();
     }
 
     /**

--- a/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
+++ b/tests/PHPUnit/Unit/Session/SessionFingerprintTest.php
@@ -22,14 +22,14 @@ class SessionFingerprintTest extends \PHPUnit\Framework\TestCase
      */
     private $testInstance;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->testInstance = new SessionFingerprint();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Date::$now = null;
 

--- a/tests/PHPUnit/Unit/Session/SessionInitializerTest.php
+++ b/tests/PHPUnit/Unit/Session/SessionInitializerTest.php
@@ -18,7 +18,7 @@ class SessionInitializerTest extends \PHPUnit\Framework\TestCase
 {
     private $oldUnitTestValue;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -26,40 +26,27 @@ class SessionInitializerTest extends \PHPUnit\Framework\TestCase
         \Zend_Session::$_unitTestEnabled = true;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         \Zend_Session::$_unitTestEnabled = $this->oldUnitTestValue;
 
         parent::tearDown();
     }
 
-    /**
-     * @dataProvider getTestDataForInitSession
-     * @expectedExceptionMessage Login_LoginPasswordNotCorrect
-     */
-    public function test_initSession_Throws_IfAuthenticationFailed($rememberMe)
+    public function test_initSession_Throws_IfAuthenticationFailed()
     {
+        $this->expectExceptionMessage('Login_LoginPasswordNotCorrect');
+
         $sessionInitializer = new TestSessionInitializer();
-        $sessionInitializer->initSession($this->makeMockAuth(AuthResult::SUCCESS));
+        $sessionInitializer->initSession($this->makeMockAuth(AuthResult::FAILURE));
     }
 
-    /**
-     * @dataProvider getTestDataForInitSession
-     */
-    public function test_initSession_InitializesTheSessionCorrectly_IfAuthenticationSucceeds($rememberMe)
+    public function test_initSession_InitializesTheSessionCorrectly_IfAuthenticationSucceeds()
     {
         $sessionInitializer = new TestSessionInitializer();
         $sessionInitializer->initSession($this->makeMockAuth(AuthResult::SUCCESS));
 
         $this->assertSessionCreatedCorrectly();
-    }
-
-    public function getTestDataForInitSession()
-    {
-        return [
-            [true],
-            [false],
-        ];
     }
 
     private function makeMockAuth($resultCode)

--- a/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
@@ -23,7 +23,7 @@ class RequestSetTest extends \PHPUnit\Framework\TestCase
     private $requestSet;
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -209,7 +209,7 @@ class RequestSetTest extends \PHPUnit\Framework\TestCase
     public function test_intertnalFakeEnvironment_shouldActuallyReturnAValue()
     {
         $myEnv = $this->getFakeEnvironment();
-        $this->assertInternalType('array', $myEnv);
+        self::assertIsArray($myEnv);
         $this->assertNotEmpty($myEnv);
     }
 

--- a/tests/PHPUnit/Unit/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestTest.php
@@ -29,7 +29,7 @@ class RequestTest extends UnitTestCase
     private $request;
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -284,12 +284,11 @@ class RequestTest extends UnitTestCase
         $this->assertEquals('05:20:17', $request->getLocalTime());
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Requested parameter myCustomFaKeParaM is not a known Tracking API Parameter
-     */
     public function test_getParam_shouldThrowException_IfTryingToAccessInvalidParam()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Requested parameter myCustomFaKeParaM is not a known Tracking API Parameter');
+
         $this->request->getParam('myCustomFaKeParaM');
     }
 
@@ -433,7 +432,7 @@ class RequestTest extends UnitTestCase
 
     private function assertCookieContains($needle, Cookie $cookie)
     {
-        $this->assertContains($needle, $cookie . '');
+        self::assertStringContainsString($needle, $cookie . '');
     }
 
     public function test_getLocalTime()

--- a/tests/PHPUnit/Unit/Tracker/ResponseTest.php
+++ b/tests/PHPUnit/Unit/Tracker/ResponseTest.php
@@ -40,7 +40,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
      */
     private $response;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->response = new TestResponse();
@@ -65,8 +65,8 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
 
         $content = $this->response->getOutput();
 
-        $this->assertContains('<title>Matomo &rsaquo; Error</title>', $content);
-        $this->assertContains('<p>My Custom Message', $content);
+        self::assertStringContainsString('<title>Matomo &rsaquo; Error</title>', $content);
+        self::assertStringContainsString('<p>My Custom Message', $content);
     }
 
     public function test_outputResponse_shouldOutputStandardApiResponse()
@@ -143,7 +143,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     public function test_getMessageFromException_ShouldReturnMessageAndTrace_InCaseIsCli()
     {
         $message = $this->response->getMessageFromException(new Exception('Test Message', 8150));
-        $this->assertStringStartsWith("Test Message\n#0 [internal function]", $message);
+        $this->assertStringStartsWith("Test Message\n#0 ", $message);
     }
 
     public function test_getMessageFromException_ShouldOnlyReturnMessage_InCaseIsNotCli()

--- a/tests/PHPUnit/Unit/TrackerTest.php
+++ b/tests/PHPUnit/Unit/TrackerTest.php
@@ -36,7 +36,7 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
 
     private $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -157,12 +157,11 @@ class TrackerTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($this->handler->isOnException);
     }
 
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage My Exception During Process
-     */
     public function test_track_shouldNotCatchAnyException_IfExceptionWasThrown()
     {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('My Exception During Process');
+
         $this->handler->enableTriggerExceptionInProcess();
         $this->tracker->track($this->handler, $this->requestSet);
     }

--- a/tests/PHPUnit/Unit/Translation/Loader/LoaderCacheTest.php
+++ b/tests/PHPUnit/Unit/Translation/Loader/LoaderCacheTest.php
@@ -19,7 +19,7 @@ class LoaderCacheTest extends \PHPUnit\Framework\TestCase
 {
     public function test_shouldNotLoad_ifInCache()
     {
-        $cache = $this->getMock('Matomo\Cache\Lazy', array(), array(), '', false);
+        $cache = $this->getMockBuilder('Matomo\Cache\Lazy')->disableOriginalConstructor()->getMock();
         $cache->expects($this->any())
             ->method('fetch')
             ->willReturn(array('translations!'));
@@ -35,7 +35,7 @@ class LoaderCacheTest extends \PHPUnit\Framework\TestCase
 
     public function test_shouldLoad_ifNotInCache()
     {
-        $cache = $this->getMock('Matomo\Cache\Lazy', array(), array(), '', false);
+        $cache = $this->getMockBuilder('Matomo\Cache\Lazy')->disableOriginalConstructor()->getMock();
         $cache->expects($this->any())
             ->method('fetch')
             ->willReturn(null);

--- a/tests/PHPUnit/Unit/UrlHelperTest.php
+++ b/tests/PHPUnit/Unit/UrlHelperTest.php
@@ -8,9 +8,7 @@
 
 namespace Piwik\Tests\Unit;
 
-use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\UrlHelper;
-use Spyc;
 
 class UrlHelperTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/PHPUnit/Unit/Validator/CharacterLengthTest.php
+++ b/tests/PHPUnit/Unit/Validator/CharacterLengthTest.php
@@ -24,32 +24,28 @@ class CharacterLengthTest extends \PHPUnit\Framework\TestCase
         $this->validate('mytest', 6, 6);
         $this->validate('', 0, 6);
         $this->validate('testwewe', 0, 10);
+
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorCharacterTooShort
-     */
     public function test_validate_failValueIsTooShort()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorCharacterTooShort');
         $this->validate('myte', 5);
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorCharacterTooLong
-     */
     public function test_validate_failValueIsTooLong()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorCharacterTooLong');
         $this->validate('mytestfoo', null, 4);
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorCharacterTooLong
-     */
     public function test_validate_failValueIsTooNotInRange()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorCharacterTooLong');
         $this->validate('mytestfoobar', 5, 8);
     }
 

--- a/tests/PHPUnit/Unit/Validator/DateTimeTest.php
+++ b/tests/PHPUnit/Unit/Validator/DateTimeTest.php
@@ -23,21 +23,25 @@ class DateTimeTest extends \PHPUnit\Framework\TestCase
         $this->validate('2014-05-06T10:13:14');
         $this->validate('2014-05-06 10:13:14Z');
         $this->validate('2014-05-06T10:13:14Z');
+
+        $this->assertTrue(true);
     }
 
     public function test_validate_successValueMayBeEmpty()
     {
         $this->validate(false);
         $this->validate('');
+
+        $this->assertTrue(true);
     }
 
     /**
      * @dataProvider getWrongFormat
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorInvalidDateTimeFormat
      */
     public function test_validate_failInvalidFormat($date)
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorInvalidDateTimeFormat');
         $this->validate($date);
     }
 
@@ -56,12 +60,10 @@ class DateTimeTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ExceptionInvalidDateFormat
-     */
     public function test_validate_invalidDate()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ExceptionInvalidDateFormat');
         $this->validate('2014-15-26 90:43:32');
     }
 

--- a/tests/PHPUnit/Unit/Validator/EmailTest.php
+++ b/tests/PHPUnit/Unit/Validator/EmailTest.php
@@ -37,11 +37,12 @@ class EmailTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider getFailedEmails
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage ValidatorErrorNotEmailLike
      */
     public function test_validate_failValueIsNotValidEmail($email)
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('ValidatorErrorNotEmailLike');
+
         $this->validate($email);
     }
 

--- a/tests/PHPUnit/Unit/Validator/IpRangesTest.php
+++ b/tests/PHPUnit/Unit/Validator/IpRangesTest.php
@@ -28,14 +28,14 @@ class IpRangesTest extends \PHPUnit\Framework\TestCase
         $this->validate(false);
         $this->validate('');
         $this->validate(null);
+
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage SitesManager_ExceptionInvalidIPFormat
-     */
     public function test_validate_failNotValidIpRange()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('SitesManager_ExceptionInvalidIPFormat');
         $this->validate(array('127.0.0.1', 'foo'));
     }
 

--- a/tests/PHPUnit/Unit/Validator/NotEmptyTest.php
+++ b/tests/PHPUnit/Unit/Validator/NotEmptyTest.php
@@ -27,11 +27,12 @@ class NotEmptyTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider getFailValues
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorEmptyValue
      */
     public function test_validate_failValueIsEmpty($value)
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorEmptyValue');
+
         $this->validate($value);
     }
 

--- a/tests/PHPUnit/Unit/Validator/NumberRangeTest.php
+++ b/tests/PHPUnit/Unit/Validator/NumberRangeTest.php
@@ -29,50 +29,42 @@ class NumberRangeTest extends \PHPUnit\Framework\TestCase
         $this->validate('5', 4);
         $this->validate('5', null, '6');
         $this->validate('-5', -10, '-4');
+
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorNumberTooLow
-     */
     public function test_validate_failValueIsTooLow()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorNumberTooLow');
         $this->validate(3, 5);
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorNumberTooHigh
-     */
     public function test_validate_failValueIsTooHigh()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorNumberTooHigh');
         $this->validate(10, null, 8);
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorNumberTooHigh
-     */
     public function test_validate_failValueIsTooNotInRange()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorNumberTooHigh');
         $this->validate(10, 5, 8);
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorNumberTooLow
-     */
     public function test_validate_failValueIsTooNotInRangeFloat()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorNumberTooLow');
         $this->validate(5.43, 5.44, 8);
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorNotANumber
-     */
     public function test_validate_failValueIsNotNumber()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorNotANumber');
         $this->validate('foo');
     }
 

--- a/tests/PHPUnit/Unit/Validator/UrlLikeTest.php
+++ b/tests/PHPUnit/Unit/Validator/UrlLikeTest.php
@@ -52,11 +52,12 @@ class UrlLikeTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider getFailedUrls
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage ValidatorErrorNotUrlLike
      */
     public function test_validate_failValueIsNotUrlLike($url)
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('ValidatorErrorNotUrlLike');
+
         $this->validate($url);
     }
 

--- a/tests/PHPUnit/Unit/Validator/WhiteListedValueTest.php
+++ b/tests/PHPUnit/Unit/Validator/WhiteListedValueTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  */
 
-namespace Piwik\Tests\Unit\Translation\Loader;
+namespace Piwik\Tests\Unit\Validator;
 
 use Piwik\Validators\WhitelistedValue;
 
@@ -23,15 +23,17 @@ class WhiteListedValueTest extends \PHPUnit\Framework\TestCase
         $this->validate('bar');
         $this->validate('baz');
         $this->validate('lorem');
+
+        $this->assertTrue(true);
     }
 
     /**
      * @dataProvider getInvalidValues
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage General_ValidatorErrorXNotWhitelisted
      */
     public function test_validate_failInvalidFormat($date)
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorXNotWhitelisted');
         $this->validate($date);
     }
 
@@ -46,12 +48,10 @@ class WhiteListedValueTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException \Piwik\Validators\Exception
-     * @expectedExceptionMessage The whitelisted values need to be an array
-     */
     public function test_construct_throwsExceptionIfParamIsNotAnArray()
     {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('The whitelisted values need to be an array');
         new WhitelistedValue('foobar');
     }
 

--- a/tests/PHPUnit/Unit/VersionTest.php
+++ b/tests/PHPUnit/Unit/VersionTest.php
@@ -17,7 +17,7 @@ class VersionTest extends \PHPUnit\Framework\TestCase
      */
     private $version;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->version = new Version();
     }

--- a/tests/PHPUnit/Unit/Widget/WidgetConfigTest.php
+++ b/tests/PHPUnit/Unit/Widget/WidgetConfigTest.php
@@ -22,7 +22,7 @@ class WidgetConfigTest extends \PHPUnit\Framework\TestCase
      */
     private $config;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->config = new WidgetConfig();
@@ -189,13 +189,14 @@ class WidgetConfigTest extends \PHPUnit\Framework\TestCase
     {
         $this->config->enable();
         $this->config->checkIsEnabled();
+
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_checkIsEnabled_shouldThrowException_IfDisabled()
     {
+        $this->expectException(\Exception::class);
+
         $this->config->disable();
         $this->config->checkIsEnabled();
     }

--- a/tests/PHPUnit/Unit/Widget/WidgetContainerConfigTest.php
+++ b/tests/PHPUnit/Unit/Widget/WidgetContainerConfigTest.php
@@ -25,7 +25,7 @@ class WidgetContainerConfigTest extends \PHPUnit\Framework\TestCase
 
     private $id = 'MyTestContainer';
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->config = new WidgetContainerConfig();
@@ -216,13 +216,14 @@ class WidgetContainerConfigTest extends \PHPUnit\Framework\TestCase
     {
         $this->config->enable();
         $this->config->checkIsEnabled();
+
+        $this->assertTrue(true);
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function test_checkIsEnabled_shouldThrowException_IfDisabled()
     {
+        $this->expectException(\Exception::class);
+
         $this->config->disable();
         $this->config->checkIsEnabled();
     }

--- a/tests/PHPUnit/Unit/Widget/WidgetsListTest.php
+++ b/tests/PHPUnit/Unit/Widget/WidgetsListTest.php
@@ -24,7 +24,7 @@ class WidgetsListTest extends \PHPUnit\Framework\TestCase
      */
     private $list;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->list = new WidgetsList();

--- a/tests/PHPUnit/phpunit.xml.dist
+++ b/tests/PHPUnit/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
          backupGlobals="true"
          backupStaticAttributes="false"
          bootstrap="bootstrap.php"
@@ -10,7 +10,6 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          forceCoversAnnotation="false"
-         mapTestClassNameToCoveredClassName="false"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"

--- a/tests/resources/custompluginsdir/CustomDirPlugin/tests/Fixtures/SimpleFixtureTrackFewVisits.php
+++ b/tests/resources/custompluginsdir/CustomDirPlugin/tests/Fixtures/SimpleFixtureTrackFewVisits.php
@@ -14,12 +14,12 @@ class SimpleFixtureTrackFewVisits extends Fixture
     public $dateTime = '2013-01-23 01:23:45';
     public $idSite = 1;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->setUpWebsite();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // empty
     }

--- a/tests/resources/custompluginsdir/CustomDirPlugin/tests/Integration/SystemSettingsTest.php
+++ b/tests/resources/custompluginsdir/CustomDirPlugin/tests/Integration/SystemSettingsTest.php
@@ -23,7 +23,7 @@ class SystemSettingsTest extends IntegrationTestCase
      */
     private $settings;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/resources/custompluginsdir/CustomDirPlugin/tests/Unit/CustomClassTest.php
+++ b/tests/resources/custompluginsdir/CustomDirPlugin/tests/Unit/CustomClassTest.php
@@ -16,12 +16,12 @@ use Piwik\Plugins\CustomDirPlugin\CustomClass;
  */
 class CustomClassTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         // set up here if needed
     }
     
-    public function tearDown()
+    public function tearDown(): void
     {
         // tear down here if needed
     }


### PR DESCRIPTION
We are still using PHPUnit 4.8. Support for that version already ended in 2017

PHPUnit 8.5 requires at least PHP 7.2. PHPUnit 9 was already released but it requires PHP 7.3. So we can only update after removing PHP 7.2 support.

This PR is including various adjustments for all tests cause of namespace and method changes within PHPUnit:

* `@expectedException \Exception` annotation is no longer supported. Instead `$this->expectException(\Exception::class);` needs to be used. Similar for `@expectedExceptionMessage`, ...
* Some assertion methods have been deprecated, removed or replaced. Like `assertContains`, `getMock` with multiple parameters or `assertInternalType`
* `setUp()`, `tearDown()`, `setUpBeforeClass()`, `tearDownAfterClass` needs to be defined with ` : void` return type hint

submodule plugins are already done. will create PRs for those and all other plugins the coming days
