### PR TITLE
Ensure a valid timestamp is set when recording a conversion

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -877,10 +877,14 @@ class GoalManager
 
     private function getGoalFromVisitor(VisitProperties $visitProperties, Request $request, $action)
     {
+        $lastVisitTime = $visitProperties->getProperty('visit_last_action_time');
+        if (!$lastVisitTime) {
+            $lastVisitTime = $request->getCurrentTimestamp();
+        }
         $goal = array(
             'idvisit'     => $visitProperties->getProperty('idvisit'),
             'idvisitor'   => $visitProperties->getProperty('idvisitor'),
-            'server_time' => Date::getDatetimeFromTimestamp($visitProperties->getProperty('visit_last_action_time')),
+            'server_time' => Date::getDatetimeFromTimestamp($lastVisitTime),
         );
 
         $visitDimensions = VisitDimension::getAllDimensions();

--- a/core/Tracker/Model.php
+++ b/core/Tracker/Model.php
@@ -416,6 +416,16 @@ class Model
         return $visitRow;
     }
 
+    public function hasVisit($idSite, $idVisit)
+    {
+        // will use INDEX index_idsite_idvisitor (idsite, idvisitor)
+        $sql = 'SELECT idsite FROM ' . Common::prefixTable('log_visit') . ' WHERE idvisit = ? LIMIT 1';
+        $bindSql = array($idVisit);
+
+        $val = $this->getDb()->fetchOne($sql, $bindSql);
+        return $val == $idSite;
+    }
+
     private function findVisitorByVisitorId($idVisitor, $select, $from, $where, $bindSql)
     {
         // will use INDEX index_idsite_idvisitor (idsite, idvisitor)

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -409,7 +409,10 @@ class Visit implements VisitInterface
 
         if ($wasInserted) {
             Common::printDebug('Updated existing visit: ' . var_export($valuesToUpdate, true));
-        } else {
+        } elseif (!$this->getModel()->hasVisit($idSite, $idVisit)) {
+            // mostly for WordPress. see https://github.com/matomo-org/matomo/pull/15587
+            // as WP doesn't set `MYSQLI_CLIENT_FOUND_ROWS` and therefore when the update succeeded but no value changed
+            // it would still return 0 vs OnPremise would return 1 or 2.
             throw new VisitorNotFoundInDb(
                 "The visitor with idvisitor=" . bin2hex($this->visitProperties->getProperty('idvisitor'))
                 . " and idvisit=" . @$this->visitProperties->getProperty('idvisit')

--- a/tests/PHPUnit/Integration/Tracker/ModelTest.php
+++ b/tests/PHPUnit/Integration/Tracker/ModelTest.php
@@ -7,7 +7,9 @@
  */
 namespace Piwik\Tests\Integration\Tracker;
 
+use Matomo\Network\IPUtils;
 use Piwik\Common;
+use Piwik\Date;
 use Piwik\Db;
 use Piwik\Tests\Fixtures\OneVisitorTwoVisits;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -33,6 +35,29 @@ class ModelTest extends IntegrationTestCase
         parent::setUp();
 
         $this->model = new Model();
+    }
+
+    public function test_hasVisit() {
+        $this->model->createVisit(array(
+            'idvisitor' => hex2bin('1234567812345678'),
+            'config_id' => '1234567',
+            'location_ip' => IPUtils::binaryToStringIP('10.10.10.10'),
+            'idvisit' => '4',
+            'idsite' => '3',
+            'visitor_count_visits' => 0,
+            'visit_total_time' => 0,
+            'visit_first_action_time' => Date::now()->getDatetime(),
+            'visit_last_action_time' => Date::now()->getDatetime(),
+        ));
+
+        $this->assertTrue($this->model->hasVisit(3, 4));
+        $this->assertTrue($this->model->hasVisit('3', '4'));
+
+        // idsite not match
+        $this->assertFalse($this->model->hasVisit(9, 4));
+
+        // idvisit not match
+        $this->assertFalse($this->model->hasVisit(3, 8));
     }
 
     public function test_createNewIdAction_CreatesNewAction_WhenNoActionWithSameNameAndType()


### PR DESCRIPTION
refs https://github.com/matomo-org/wp-matomo/issues/215

see https://github.com/matomo-org/wp-matomo/issues/215#issuecomment-587160358

There should be no harm in this logic. Basically the last visit time is the current timestamp anyway. It be actually probably even more accurate to use the current timestamp there in general.

Eg this could happen if an exception was triggered in https://github.com/matomo-org/matomo/blob/3.13.2/core/Tracker/Visit.php#L192-L194 where the visitor was not found for some reason when updating, or when no value changed I suppose because it was updated within a few ms. 

Another possibility that may be better be to set the `visit_last_action_time ` https://github.com/matomo-org/matomo/blob/3.13.2/core/Tracker/Visit.php#L249 at the beginning of that function or so. Not sure if there is maybe a reason it's set at the end. Or maybe it could be at least moved up one line before `updateExistingVisit` https://github.com/matomo-org/matomo/blob/3.13.2/core/Tracker/Visit.php#L247 so if it triggers an exception then we still have surely a value set. Not sure if it would fix that particular error though. Can't really think of a different way though how this would happen so far.

I was able to trigger the VisitorNotFoundInDb exception when no value changed 
![image](https://user-images.githubusercontent.com/273120/74700501-ac5bdf80-5268-11ea-91ca-d2f21299810b.png)

in 
![image](https://user-images.githubusercontent.com/273120/74700526-bc73bf00-5268-11ea-97dc-869bde88ca3b.png)

To be safe could apply both patches. The one already done in GoalManager and moving up one line setting the last visit time.
