### PR TITLE
Fallback to JSON renderer if no valid format is given

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -276,6 +276,10 @@ class Request
                 'ignoreInScreenWriter' => true,
             ]);
 
+            if (empty($response)) {
+               $response = new ResponseBuilder('console', $this->request);
+            }
+            
             $toReturn = $response->getResponseException($e);
         } finally {
             --self::$nestedApiInvocationCount;

--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -215,6 +215,8 @@ class Request
      */
     public function process()
     {
+        $shouldReloadAuth = false;
+
         try {
             ++self::$nestedApiInvocationCount;
 
@@ -233,7 +235,6 @@ class Request
             $corsHandler->handle();
 
             $tokenAuth = Common::getRequestVar('token_auth', '', 'string', $this->request);
-            $shouldReloadAuth = false;
 
             // IP check is needed here as we cannot listen to API.Request.authenticate as it would then not return proper API format response.
             // We can also not do it by listening to API.Request.dispatch as by then the user is already authenticated and we want to make sure

--- a/tests/PHPUnit/System/ApiGetReportMetadataTest.php
+++ b/tests/PHPUnit/System/ApiGetReportMetadataTest.php
@@ -75,6 +75,14 @@ class ApiGetReportMetadataTest extends SystemTestCase
             array('Actions.getPageTitles', array('idSite'     => $idSite, 'date' => $dateTime,
                                                  'testSuffix' => '_pageTitleZeroString')),
 
+            // Test w/ no format, should default to format=json
+            ['Actions.getPageTitles', [
+                'idSite'     => $idSite,
+                'date' => $dateTime,
+                'testSuffix' => '_defaultFormatValue',
+                'format' => '',
+            ]],
+
             // test php renderer w/ array data
             array('API.getDefaultMetricTranslations', array('idSite' => $idSite, 'date' => $dateTime,
                                                             'format' => 'php', 'testSuffix' => '_phpRenderer')),

--- a/tests/PHPUnit/System/ApiGetReportMetadataTest.php
+++ b/tests/PHPUnit/System/ApiGetReportMetadataTest.php
@@ -80,7 +80,7 @@ class ApiGetReportMetadataTest extends SystemTestCase
                 'idSite'     => $idSite,
                 'date' => $dateTime,
                 'testSuffix' => '_defaultFormatValue',
-                'format' => '',
+                'format' => 'asldjkf',
             ]],
 
             // test php renderer w/ array data

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_defaultFormatValue__Actions.getPageTitles_day.asldjkf
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_defaultFormatValue__Actions.getPageTitles_day.asldjkf
@@ -1,0 +1,3 @@
+Error: Renderer format 'asldjkf' not valid. Try any of the following instead: console, csv, html, json, json2, original, php, rss, tsv, xml.
+ 
+ --&gt; To temporarily debug this error further, set const PIWIK_PRINT_ERROR_BACKTRACE=true; in index.php


### PR DESCRIPTION
Prevents exceptions like these which we are getting quite often due to security researchers trying different inputs

> Call to a member function getResponseException() on null","file":"\/core\/API\/Request.php","line":279,"request_id":"3e2b6","backtrace":" on \/var\/www\/html\/core\/API\/Request.php(279)\n#0 \/plugins\/API\/Controller.php(41)

Ideally will add a test but probably won't find the time soon.