### PR TITLE
Do not initiate auth instance if a user is already logged in in FrontController::init()

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -727,6 +727,16 @@ class Access
 
         throw new NoAccessException($message);
     }
+
+    /**
+     * Returns true if the current user is logged in or not.
+     *
+     * @return bool
+     */
+    public function isUserLoggedIn()
+    {
+        return !empty($this->login);
+    }
 }
 
 /**

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -392,18 +392,21 @@ class FrontController extends Singleton
 
         $loggedIn = false;
 
-        // try authenticating w/ session first...
-        $sessionAuth = $this->makeSessionAuthenticator();
-        if ($sessionAuth) {
-            $loggedIn = Access::getInstance()->reloadAccess($sessionAuth);
-        }
+        // user may already be logged in when init() is called, eg, in a CLI command
+        if (!Access::getInstance()->isUserLoggedIn()) {
+            // try authenticating w/ session first...
+            $sessionAuth = $this->makeSessionAuthenticator();
+            if ($sessionAuth) {
+                $loggedIn = Access::getInstance()->reloadAccess($sessionAuth);
+            }
 
-        // ... if session auth fails try normal auth (which will login the anonymous user)
-        if (!$loggedIn) {
-            $authAdapter = $this->makeAuthenticator();
-            Access::getInstance()->reloadAccess($authAdapter);
-        } else {
-            $this->makeAuthenticator($sessionAuth); // Piwik\Auth must be set to the correct Login plugin
+            // ... if session auth fails try normal auth (which will login the anonymous user)
+            if (!$loggedIn) {
+                $authAdapter = $this->makeAuthenticator();
+                Access::getInstance()->reloadAccess($authAdapter);
+            } else {
+                $this->makeAuthenticator($sessionAuth); // Piwik\Auth must be set to the correct Login plugin
+            }
         }
 
         // Force the auth to use the token_auth if specified, so that embed dashboard

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -392,21 +392,19 @@ class FrontController extends Singleton
 
         $loggedIn = false;
 
-        // user may already be logged in when init() is called, eg, in a CLI command
-        if (!Access::getInstance()->isUserLoggedIn()) {
-            // try authenticating w/ session first...
-            $sessionAuth = $this->makeSessionAuthenticator();
-            if ($sessionAuth) {
-                $loggedIn = Access::getInstance()->reloadAccess($sessionAuth);
-            }
+        // don't use sessionauth in cli mode
+        // try authenticating w/ session first...
+        $sessionAuth = $this->makeSessionAuthenticator();
+        if ($sessionAuth) {
+            $loggedIn = Access::getInstance()->reloadAccess($sessionAuth);
+        }
 
-            // ... if session auth fails try normal auth (which will login the anonymous user)
-            if (!$loggedIn) {
-                $authAdapter = $this->makeAuthenticator();
-                Access::getInstance()->reloadAccess($authAdapter);
-            } else {
-                $this->makeAuthenticator($sessionAuth); // Piwik\Auth must be set to the correct Login plugin
-            }
+        // ... if session auth fails try normal auth (which will login the anonymous user)
+        if (!$loggedIn) {
+            $authAdapter = $this->makeAuthenticator();
+            Access::getInstance()->reloadAccess($authAdapter);
+        } else {
+            $this->makeAuthenticator($sessionAuth); // Piwik\Auth must be set to the correct Login plugin
         }
 
         // Force the auth to use the token_auth if specified, so that embed dashboard
@@ -650,6 +648,10 @@ class FrontController extends Singleton
 
     private function makeSessionAuthenticator()
     {
+        if (Common::isPhpClimode()) { // don't use the session auth during CLI requests
+            return null;
+        }
+
         $module = Common::getRequestVar('module', self::DEFAULT_MODULE, 'string');
         $action = Common::getRequestVar('action', false);
 


### PR DESCRIPTION
@tsteur think this will solve the problem for the wp-matomo command?

Fixes #15550 