### PR TITLE
Improve / Fix UserID tests

### DIFF
--- a/tests/PHPUnit/Fixtures/FewVisitsWithSetVisitorId.php
+++ b/tests/PHPUnit/Fixtures/FewVisitsWithSetVisitorId.php
@@ -147,7 +147,7 @@ class FewVisitsWithSetVisitorId extends Fixture
         // Request from a different computer not yet logged in, this should not be added to our User ID session
         $t->setUserId(false);
         // make sure the Id is not so random as to not fail the test
-        $t->randomVisitorId = '5e15b4d842cc294d';
+        $t->setVisitorId('5e15b4d842cc294d');
 
         $t->setIp('1.2.4.7');
         $t->setUserAgent("New unique device");

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__Live.getLastVisitsDetails_month.xml
@@ -193,8 +193,6 @@
 				<serverTimePretty>Mar 6, 2010 16:28:33</serverTimePretty>
 				<pageId>9</pageId>
 				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
 				<interactionPosition>2</interactionPosition>
 				<title>second pageview - by this user id</title>
 				<subtitle>http://example.org/home</subtitle>
@@ -203,6 +201,15 @@
 				<timestamp>1267892913</timestamp>
 				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
+		</actionDetails>
+		<lastActionDateTime>2010-03-06 16:28:33</lastActionDateTime>
+		<userId>new-email@example.com</userId>
+		<actions>2</actions>
+	</row>
+	<row>
+		<idVisit>6</idVisit>
+		<visitorId>5e15b4d842cc294d</visitorId>
+		<actionDetails>
 			<row>
 				<type>action</type>
 				<url>http://example.org/home</url>
@@ -214,7 +221,7 @@
 				<bandwidth />
 				<timeSpent>721</timeSpent>
 				<timeSpentPretty>12 min 1s</timeSpentPretty>
-				<interactionPosition>3</interactionPosition>
+				<interactionPosition>1</interactionPosition>
 				<title>pageview - should not be tracked by our user id but in a new visit</title>
 				<subtitle>http://example.org/home</subtitle>
 				<icon />
@@ -264,10 +271,10 @@
 		</actionDetails>
 		<lastActionDateTime>2010-03-06 16:40:33</lastActionDateTime>
 		<userId>new-email@example.com</userId>
-		<actions>3</actions>
+		<actions>1</actions>
 	</row>
 	<row>
-		<idVisit>6</idVisit>
+		<idVisit>7</idVisit>
 		<visitorId>7dcebef4faef4325</visitorId>
 		<actionDetails>
 			<row>
@@ -293,7 +300,7 @@
 		<actions>1</actions>
 	</row>
 	<row>
-		<idVisit>7</idVisit>
+		<idVisit>8</idVisit>
 		<visitorId>6ccebef4faef4969</visitorId>
 		<actionDetails>
 			<row>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_day.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_uniq_visitors>5</nb_uniq_visitors>
+	<nb_uniq_visitors>6</nb_uniq_visitors>
 	<nb_users>2</nb_users>
-	<nb_visits>5</nb_visits>
+	<nb_visits>6</nb_visits>
 	<nb_actions>10</nb_actions>
 	<nb_visits_converted>1</nb_visits_converted>
-	<bounce_count>2</bounce_count>
-	<sum_visit_length>1983</sum_visit_length>
+	<bounce_count>3</bounce_count>
+	<sum_visit_length>1984</sum_visit_length>
 	<max_actions>3</max_actions>
-	<bounce_rate>40%</bounce_rate>
-	<nb_actions_per_visit>2</nb_actions_per_visit>
-	<avg_time_on_site>397</avg_time_on_site>
+	<bounce_rate>50%</bounce_rate>
+	<nb_actions_per_visit>1.7</nb_actions_per_visit>
+	<avg_time_on_site>331</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_month.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_uniq_visitors>7</nb_uniq_visitors>
+	<nb_uniq_visitors>8</nb_uniq_visitors>
 	<nb_users>3</nb_users>
-	<nb_visits>7</nb_visits>
+	<nb_visits>8</nb_visits>
 	<nb_actions>12</nb_actions>
 	<nb_visits_converted>1</nb_visits_converted>
-	<bounce_count>4</bounce_count>
-	<sum_visit_length>1983</sum_visit_length>
+	<bounce_count>5</bounce_count>
+	<sum_visit_length>1984</sum_visit_length>
 	<max_actions>3</max_actions>
-	<bounce_rate>57%</bounce_rate>
-	<nb_actions_per_visit>1.7</nb_actions_per_visit>
-	<avg_time_on_site>283</avg_time_on_site>
+	<bounce_rate>63%</bounce_rate>
+	<nb_actions_per_visit>1.5</nb_actions_per_visit>
+	<avg_time_on_site>248</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_week.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_week.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_uniq_visitors>5</nb_uniq_visitors>
+	<nb_uniq_visitors>6</nb_uniq_visitors>
 	<nb_users>2</nb_users>
-	<nb_visits>5</nb_visits>
+	<nb_visits>6</nb_visits>
 	<nb_actions>10</nb_actions>
 	<nb_visits_converted>1</nb_visits_converted>
-	<bounce_count>2</bounce_count>
-	<sum_visit_length>1983</sum_visit_length>
+	<bounce_count>3</bounce_count>
+	<sum_visit_length>1984</sum_visit_length>
 	<max_actions>3</max_actions>
-	<bounce_rate>40%</bounce_rate>
-	<nb_actions_per_visit>2</nb_actions_per_visit>
-	<avg_time_on_site>397</avg_time_on_site>
+	<bounce_rate>50%</bounce_rate>
+	<nb_actions_per_visit>1.7</nb_actions_per_visit>
+	<avg_time_on_site>331</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_year.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId__VisitsSummary.get_year.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>7</nb_visits>
+	<nb_visits>8</nb_visits>
 	<nb_actions>12</nb_actions>
 	<nb_visits_converted>1</nb_visits_converted>
-	<bounce_count>4</bounce_count>
-	<sum_visit_length>1983</sum_visit_length>
+	<bounce_count>5</bounce_count>
+	<sum_visit_length>1984</sum_visit_length>
 	<max_actions>3</max_actions>
-	<bounce_rate>57%</bounce_rate>
-	<nb_actions_per_visit>1.7</nb_actions_per_visit>
-	<avg_time_on_site>283</avg_time_on_site>
+	<bounce_rate>63%</bounce_rate>
+	<nb_actions_per_visit>1.5</nb_actions_per_visit>
+	<avg_time_on_site>248</avg_time_on_site>
 </result>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId_segmentUserId__Goals.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId_segmentUserId__Goals.get_day.xml
@@ -3,11 +3,11 @@
 	<nb_conversions>1</nb_conversions>
 	<nb_visits_converted>1</nb_visits_converted>
 	<revenue>0</revenue>
-	<conversion_rate>50%</conversion_rate>
+	<conversion_rate>33.33%</conversion_rate>
 	<nb_conversions_new_visit>1</nb_conversions_new_visit>
 	<nb_visits_converted_new_visit>1</nb_visits_converted_new_visit>
 	<revenue_new_visit>0</revenue_new_visit>
-	<conversion_rate_new_visit>50%</conversion_rate_new_visit>
+	<conversion_rate_new_visit>33.33%</conversion_rate_new_visit>
 	<nb_conversions_returning_visit>0</nb_conversions_returning_visit>
 	<nb_visits_converted_returning_visit>0</nb_visits_converted_returning_visit>
 	<revenue_returning_visit>0</revenue_returning_visit>

--- a/tests/PHPUnit/System/expected/test_UserId_VisitorId_segmentUserId__VisitsSummary.get_day.xml
+++ b/tests/PHPUnit/System/expected/test_UserId_VisitorId_segmentUserId__VisitsSummary.get_day.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_uniq_visitors>2</nb_uniq_visitors>
+	<nb_uniq_visitors>3</nb_uniq_visitors>
 	<nb_users>1</nb_users>
-	<nb_visits>2</nb_visits>
+	<nb_visits>3</nb_visits>
 	<nb_actions>4</nb_actions>
 	<nb_visits_converted>1</nb_visits_converted>
-	<bounce_count>1</bounce_count>
-	<sum_visit_length>1081</sum_visit_length>
-	<max_actions>3</max_actions>
-	<bounce_rate>50%</bounce_rate>
-	<nb_actions_per_visit>2</nb_actions_per_visit>
-	<avg_time_on_site>541</avg_time_on_site>
+	<bounce_count>2</bounce_count>
+	<sum_visit_length>1082</sum_visit_length>
+	<max_actions>2</max_actions>
+	<bounce_rate>67%</bounce_rate>
+	<nb_actions_per_visit>1.3</nb_actions_per_visit>
+	<avg_time_on_site>361</avg_time_on_site>
 </result>


### PR DESCRIPTION
For #15520 I investigated why the one action that should be tracked as a new visit, wasn't tracked as that. Turned out the problem is, that all visits before are tracked with `->setVisitorId()`, but that one tries to set a `->randomVisitorId`. That doesn't work as `setVisitorId()` sets a forced visitor id, which overrules the random one...