### PR TITLE
Fix session cookies for Matomo installed in subdirectory

### DIFF
--- a/core/Session.php
+++ b/core/Session.php
@@ -222,10 +222,10 @@ class Session extends Zend_Session
     {
         $headerStr = 'Set-Cookie: ' . rawurlencode($name) . '=' . rawurlencode($value);
         if ($expires) {
-            $headerStr .= '; expires=' . rawurlencode($expires);
+            $headerStr .= '; expires=' . $expires;
         }
         if ($path) {
-            $headerStr .= '; path=' . rawurlencode($path);
+            $headerStr .= '; path=' . $path;
         }
         if ($domain) {
             $headerStr .= '; domain=' . rawurlencode($domain);
@@ -237,8 +237,9 @@ class Session extends Zend_Session
             $headerStr .= '; httponly';
         }
         if ($sameSite) {
-            $headerStr .= '; SameSite=' . rawurlencode($sameSite);
+            $headerStr .= '; SameSite=' . $sameSite;
         }
+
         Common::sendHeader($headerStr);
         return $headerStr;
     }


### PR DESCRIPTION
Sending the cookie path encoded seems to let the browser discard the path value as invalid and use the current path instead. This causes two session cookies, one with current path, one with `/`. When logging out only of the cookies gets a new session id, the other one remains. That makes it impossible to login again until the cookies are cleared (or expire).