### PR TITLE
Prevent server gone away error in CronArchive

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1248,11 +1248,6 @@ class CronArchive
 
     private function disconnectDb()
     {
-        if (empty($this->lastDbReset)) {
-            $this->lastDbReset = time();
-            return;
-        }
-
         $twoHoursInSeconds = 60 * 60 * 2;
 
         if (time() > ($this->lastDbReset + $twoHoursInSeconds)) {


### PR DESCRIPTION
What happens is basically eg some archive requests run for 6 hours, then it returns back into the `CronArchive` scripts, it tries to execute a query, and results in a server gone away error because the DB connection wasn't used for hours.

Fixes only when a CronArchive happens directly in CronArchive.php script. We've tested this in production for one month and worked nicely.