### PR TITLE
Fix failing Live system test

### DIFF
--- a/plugins/Live/tests/System/expected/test_actionSegment__Live.getLastVisitsDetails_day.xml
+++ b/plugins/Live/tests/System/expected/test_actionSegment__Live.getLastVisitsDetails_day.xml
@@ -2,213 +2,23 @@
 <result>
 	<row>
 		<idSite>1</idSite>
-		<idVisit>2</idVisit>
+		<idVisit>4</idVisit>
 		<visitIp>156.5.3.2</visitIp>
 		
-		<fingerprint>e16cf2bbaeea2c88</fingerprint>
+		<fingerprint>5041e282fc23fef1</fingerprint>
 		<actionDetails>
 			<row>
 				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title -2</pageTitle>
-				<pageIdAction>4</pageIdAction>
+				<url>http://example.org/my/dir/page0</url>
+				<pageTitle>incredible title 0</pageTitle>
+				<pageIdAction>9</pageIdAction>
 				
 				
-				<pageId>2</pageId>
+				<pageId>14</pageId>
 				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
 				<interactionPosition>1</interactionPosition>
-				<title>incredible title -2</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>3</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition>2</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>4</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition>3</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>5</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition>4</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>6</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition>5</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>7</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition>6</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>8</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition>7</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>9</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition>8</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>10</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition>9</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>11</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<interactionPosition>10</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://example.org/my/dir/page-2</url>
-				<pageTitle>incredible title 1</pageTitle>
-				<pageIdAction>4</pageIdAction>
-				
-				
-				<pageId>12</pageId>
-				<bandwidth />
-				<interactionPosition>11</interactionPosition>
-				<title>incredible title 1</title>
-				<subtitle>http://example.org/my/dir/page-2</subtitle>
+				<title>incredible title 0</title>
+				<subtitle>http://example.org/my/dir/page0</subtitle>
 				<icon />
 				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
 				
@@ -230,8 +40,8 @@
 		
 		
 		<userId />
-		<visitorType>new</visitorType>
-		<visitorTypeIcon />
+		<visitorType>returning</visitorType>
+		<visitorTypeIcon>plugins/Live/images/returningVisitor.png</visitorTypeIcon>
 		<visitConverted>0</visitConverted>
 		<visitConvertedIcon />
 		<visitCount>1</visitCount>
@@ -239,11 +49,11 @@
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
 		<daysSinceLastEcommerceOrder>0</daysSinceLastEcommerceOrder>
-		<visitDuration>1</visitDuration>
-		<visitDurationPretty>1s</visitDurationPretty>
+		<visitDuration>0</visitDuration>
+		<visitDurationPretty>0s</visitDurationPretty>
 		<searches>0</searches>
-		<actions>11</actions>
-		<interactions>11</interactions>
+		<actions>1</actions>
+		<interactions>1</interactions>
 		<referrerType>direct</referrerType>
 		<referrerTypeName>Direct Entry</referrerTypeName>
 		<referrerName />
@@ -254,24 +64,24 @@
 		<referrerSearchEngineIcon />
 		<referrerSocialNetworkUrl />
 		<referrerSocialNetworkIcon />
-		<languageCode>fr</languageCode>
-		<language>French</language>
-		<deviceType>Desktop</deviceType>
-		<deviceTypeIcon>plugins/Morpheus/icons/dist/devices/desktop.png</deviceTypeIcon>
+		<languageCode />
+		<language>Unknown</language>
+		<deviceType>Unknown</deviceType>
+		<deviceTypeIcon>plugins/Morpheus/icons/dist/devices/unknown.png</deviceTypeIcon>
 		<deviceBrand>Unknown</deviceBrand>
-		<deviceModel>Generic Desktop</deviceModel>
-		<operatingSystem>Windows XP</operatingSystem>
-		<operatingSystemName>Windows</operatingSystemName>
-		<operatingSystemIcon>plugins/Morpheus/icons/dist/os/WIN.png</operatingSystemIcon>
-		<operatingSystemCode>WIN</operatingSystemCode>
-		<operatingSystemVersion>XP</operatingSystemVersion>
-		<browserFamily>Gecko</browserFamily>
-		<browserFamilyDescription>Gecko (Firefox)</browserFamilyDescription>
-		<browser>Firefox 3.6</browser>
-		<browserName>Firefox</browserName>
-		<browserIcon>plugins/Morpheus/icons/dist/browsers/FF.png</browserIcon>
-		<browserCode>FF</browserCode>
-		<browserVersion>3.6</browserVersion>
+		<deviceModel>Unknown</deviceModel>
+		<operatingSystem>Unknown</operatingSystem>
+		<operatingSystemName>Unknown</operatingSystemName>
+		<operatingSystemIcon>plugins/Morpheus/icons/dist/os/UNK.png</operatingSystemIcon>
+		<operatingSystemCode>UNK</operatingSystemCode>
+		<operatingSystemVersion>UNK</operatingSystemVersion>
+		<browserFamily />
+		<browserFamilyDescription>Unknown</browserFamilyDescription>
+		<browser>Unknown</browser>
+		<browserName>Unknown</browserName>
+		<browserIcon>plugins/Morpheus/icons/dist/browsers/UNK.png</browserIcon>
+		<browserCode>UNK</browserCode>
+		<browserVersion />
 		<totalEcommerceRevenue>0</totalEcommerceRevenue>
 		<totalEcommerceConversions>0</totalEcommerceConversions>
 		<totalEcommerceItems>0</totalEcommerceItems>
@@ -279,15 +89,15 @@
 		<totalAbandonedCarts>0</totalAbandonedCarts>
 		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
 		<events>0</events>
-		<continent>Europe</continent>
-		<continentCode>eur</continentCode>
-		<country>France</country>
-		<countryCode>fr</countryCode>
-		<countryFlag>plugins/Morpheus/icons/dist/flags/fr.png</countryFlag>
+		<continent>Unknown</continent>
+		<continentCode>unk</continentCode>
+		<country>Unknown</country>
+		<countryCode>xx</countryCode>
+		<countryFlag>plugins/Morpheus/icons/dist/flags/xx.png</countryFlag>
 		<region />
 		<regionCode />
 		<city />
-		<location>France</location>
+		<location>Unknown</location>
 		<latitude />
 		<longitude />
 		<visitLocalTime>12:34:06</visitLocalTime>


### PR DESCRIPTION
Investigated why one System test of Live plugin is failing on `4.x-dev` but not on `3.x-dev`. Looking back through the builds it turned out the reason actually is #14847, which changed the `referrer_url` column from `TEXT` to `VARCHAR(4000)`. I'm able to reproduce that locally. Changing back to `TEXT` fixes the test again.
I guess that is a sorting issue in MySQL. Most attributes of the visits are identical, and the referrer urls are even empty. Not sure if there is anything we need to adjust. Might be fine to simply update the expected file.

ping @diosmosis @tsteur 
