### PR TITLE
Avoid warning from passing 2 args to ucwords() on older PHP versions

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -934,9 +934,12 @@ class Http
          * With HTTP/2 Cloudflare is passing headers in lowercase (e.g. 'content-type' instead of 'Content-Type')
          * which breaks any code which uses the header data.
          */
-        $camelName = ucwords($name, '-');
-        if ($camelName !== $name) {
-            $headers[$camelName] = trim($value);
+        if (version_compare(PHP_VERSION, '5.5.16', '>=')) {
+            // Passing a second arg to ucwords is not supported by older versions of PHP
+            $camelName = ucwords($name, '-');
+            if ($camelName !== $name) {
+                $headers[$camelName] = trim($value);
+            }
         }
     }
 


### PR DESCRIPTION
fixes #14694