### PR TITLE
Convert range date to date archive if needed

### DIFF
--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -74,6 +74,7 @@ abstract class Factory
         self::checkPeriodIsEnabled($period);
 
         if (is_string($date)) {
+            list($period, $date) = self::convertRangeToDateIfNeeded($period, $date);
             if (Period::isMultiplePeriod($date, $period)
                 || $period == 'range'
             ) {
@@ -130,6 +131,19 @@ abstract class Factory
         throw new Exception($message);
     }
 
+    private static function convertRangeToDateIfNeeded($period, $date)
+    {
+        if (is_string($period) && is_string($date) && $period === 'range') {
+            $dates = explode(',', $date);
+            if (count($dates) === 2 && $dates[0] === $dates[1]) {
+                $period = 'day';
+                $date = $dates[0];
+            }
+        }
+
+        return array($period, $date);
+    }
+
     /**
      * Creates a Period instance using a period, date and timezone.
      *
@@ -145,6 +159,8 @@ abstract class Factory
         if (empty($timezone)) {
             $timezone = 'UTC';
         }
+
+        list($period, $date) = self::convertRangeToDateIfNeeded($period, $date);
 
         if ($period == 'range') {
             self::checkPeriodIsEnabled('range');

--- a/tests/PHPUnit/Integration/Period/FactoryTest.php
+++ b/tests/PHPUnit/Integration/Period/FactoryTest.php
@@ -83,6 +83,7 @@ class FactoryTest extends IntegrationTestCase
 
             ['range', '2015-01-01,2015-01-10', 'UTC', Range::class, '2015-01-01,2015-01-10'],
             ['range', '2015-01-01,2015-01-10', 'Antarctica/Casey', Range::class, '2015-01-01,2015-01-10'],
+            ['range', '2015-01-01,2015-01-01', 'Antarctica/Casey', Day::class, '2015-01-01,2015-01-01'],
 
             // multiple periods
             ['day', '2015-01-01,2015-01-10', 'UTC', Range::class, '2015-01-01,2015-01-10'],
@@ -90,6 +91,13 @@ class FactoryTest extends IntegrationTestCase
             ['month', '2015-01-01,2015-02-10', 'UTC', Range::class, '2015-01-01,2015-02-28'],
             ['year', '2015-01-01,2016-01-10', 'UTC', Range::class, '2015-01-01,2016-12-31'],
         ];
+    }
+
+    public function test_makePeriodFromQueryParams()
+    {
+        $factory = Period\Factory::makePeriodFromQueryParams('UTC', 'range', '2019-01-01,2019-01-01');
+        $this->assertTrue($factory instanceof Day);
+        $this->assertEquals('2019-01-01', $factory->toString());
     }
 
     public function test_build_CreatesCustomPeriodInstances()


### PR DESCRIPTION
refs DEV-1884

If a range date is selected with same start and end date, convert it to a day period instead so we wouldn't launch archiving if browser archiving is disabled but range archiving enabled.

It doesn't work if `today` or `yesterday` is used like `2020-01-03,today` and today is 2020-01-03 but that should be fine for now.