### PR TITLE
Make sure to set secure flag when setting samesite none

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -20,6 +20,7 @@ use Piwik\Network\IPUtils;
 use Piwik\Piwik;
 use Piwik\Plugins\CustomVariables\CustomVariables;
 use Piwik\Plugins\UsersManager\UsersManager;
+use Piwik\ProxyHttp;
 use Piwik\Tracker;
 use Piwik\Cache as PiwikCache;
 
@@ -686,7 +687,12 @@ class Request
         $cookie = $this->makeThirdPartyCookieUID();
         $idVisitor = bin2hex($idVisitor);
         $cookie->set(0, $idVisitor);
-        $cookie->save('None');
+        if (ProxyHttp::isHttps()) {
+            $cookie->setSecure(true);
+            $cookie->save('None');
+        } else {
+            $cookie->save('Lax');
+        }
 
         Common::printDebug(sprintf("We set the visitor ID to %s in the 3rd party cookie...", $idVisitor));
     }


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/15672 
this PR will also need to be merged to fix #15672 https://github.com/matomo-org/tag-manager/pull/229

@MichaelHeerklotz can you maybe also have a look at this PR

Not sure how to fallback when HTTPS is not used. Should we still set to None and assume it works for a while in some browsers that are not Chrome but eventually it'll fail? I suppose it's not quite a solution. I assume `Lax` maybe won't work so well for 3rd party tracking?

