### PR TITLE
Retry compiling less file if it fails

### DIFF
--- a/plugins/Proxy/Controller.php
+++ b/plugins/Proxy/Controller.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\Proxy;
 use Piwik\AssetManager;
 use Piwik\AssetManager\UIAsset;
 use Piwik\Common;
+use Piwik\Exception\StylesheetLessCompileException;
 use Piwik\Piwik;
 use Piwik\ProxyHttp;
 use Piwik\Url;
@@ -33,7 +34,11 @@ class Controller extends \Piwik\Plugin\Controller
      */
     public function getCss()
     {
-        $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet();
+        try {
+            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet();
+        } catch (StylesheetLessCompileException $exception) {
+            $cssMergedFile = AssetManager::getInstance()->getMergedStylesheet();
+        }
         ProxyHttp::serverStaticFile($cssMergedFile->getAbsoluteLocation(), "text/css");
     }
 


### PR DESCRIPTION
For some reason that we can't explain it seems like something is playing up like once out of say 100K requests where it fails to compile the less file and it seems this workaround fixes it. 

It hides the actual error kind of but only thing I can think of so far is some odd filesystem or opcache glitch.