### PR TITLE
Better handling of processing uniques for multiple sites

### DIFF
--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -421,6 +421,13 @@ class ArchiveProcessor
 
         $sites = $this->getIdSitesToComputeNbUniques();
 
+        if (empty($sites)) {
+            // a plugin disabled it by removing all sites
+            $row->deleteColumn('nb_uniq_visitors');
+            $row->deleteColumn('nb_users');
+            return;
+        }
+
         if (count($sites) === 1) {
             $uniqueVisitorsMetric = Metrics::INDEX_NB_UNIQ_VISITORS;
         } else {
@@ -434,13 +441,6 @@ class ArchiveProcessor
         $metrics[] = $uniqueVisitorsMetric;
 
         $uniques = $this->computeNbUniques($metrics, $sites);
-
-        if ($uniques === null) {
-            // query was not executed because a plugin disabled it by removing all sites
-            $row->deleteColumn('nb_uniq_visitors');
-            $row->deleteColumn('nb_users');
-            return;
-        }
 
         // see edge case as described in https://github.com/piwik/piwik/issues/9357 where uniq_visitors might be higher
         // than visits because we archive / process it after nb_visits. Between archiving nb_visits and nb_uniq_visitors

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -103,15 +103,6 @@ class ArchiveProcessor
 
     private $numberOfVisitsConverted = false;
 
-    /**
-     * If true, unique visitors are not calculated when we are aggregating data for multiple sites.
-     * The `[General] enable_processing_unique_visitors_multiple_sites` INI config option controls
-     * the value of this variable.
-     *
-     * @var bool
-     */
-    private $skipUniqueVisitorsCalculationForMultipleSites = true;
-
     public function __construct(Parameters $params, ArchiveWriter $archiveWriter, LogAggregator $logAggregator)
     {
         $this->params = $params;

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -415,11 +415,13 @@ class ArchiveProcessor
             return;
         }
 
-        $metrics = array(
-            Metrics::INDEX_NB_USERS
-        );
-
         $sites = $this->getIdSitesToComputeNbUniques();
+
+        /*
+        if (count($sites) > 1 && Rules::shouldSkipUniqueVisitorsCalculationForMultipleSites()) {
+            return;
+        }
+        */
 
         if (empty($sites)) {
             // a plugin disabled it by removing all sites
@@ -438,7 +440,10 @@ class ArchiveProcessor
             }
             $uniqueVisitorsMetric = Metrics::INDEX_NB_UNIQ_FINGERPRINTS;
         }
-        $metrics[] = $uniqueVisitorsMetric;
+        $metrics = array(
+            Metrics::INDEX_NB_USERS,
+            $uniqueVisitorsMetric
+        );
 
         $uniques = $this->computeNbUniques($metrics, $sites);
 

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -184,6 +184,16 @@ class LogAggregator
         $this->logger = $logger ?: StaticContainer::get('Psr\Log\LoggerInterface');
     }
 
+    public function setSites($sites)
+    {
+        $this->sites = array_map('intval', $sites);
+    }
+
+    public function getSites()
+    {
+        return $this->sites;
+    }
+
     public function getSegment()
     {
         return $this->segment;

--- a/tests/PHPUnit/System/MultipleSitesArchivingTest.php
+++ b/tests/PHPUnit/System/MultipleSitesArchivingTest.php
@@ -33,6 +33,12 @@ class MultipleSitesArchivingTest extends SystemTestCase
             }
         });
 
+        Piwik::addAction("ArchiveProcessor.ComputeNbUniques.getIdSites", function (&$sites) use ($extraSite) {
+            if (reset($sites) == $extraSite) {
+                $sites = array(1, 2, 3);
+            }
+        });
+
         Config::getInstance()->General['enable_processing_unique_visitors_multiple_sites'] = 1;
         Config::getInstance()->Tracker['enable_fingerprinting_across_websites'] = 1;
     }


### PR DESCRIPTION
Fixes a problem with roll up reporting when `enable_processing_unique_visitors_multiple_sites = 1`.

The problem is assuming `idSite` is a roll up (say `idSite = 12` which has as children sites the idsites `2 and 4`), and period is say `week` (same applies for month, year, range):

* `new LogAggregator(new Parameters($idSite, $period))`.
* `LogAggregator::__construct`
   * `$this->idSites = Piwik::postEvent('ArchiveProcessor.Parameters.getIdSites', $idSite, $period)`. // meaning $this->idSites = array(2,4)
* Compute Nb Metrics by calling
    * `$logAggregator->queryVisitsByDimension(array(2,4));` // this is correct and wanted
* Then we do the regular plugins archiving which also calls many times
    * `$archiver->aggregateMultipleReports()`
        * `$logAggregator->getIdSites();` // so it basically aggregates the custom reports by aggregating the custom report from idSite 2 and 4 but there wouldn't be an archive for the custom report in the roll up and therefore week, month, year,range be always no data. 

The problem is basically that when we archive multiple reports for a roll up idSite 12, then we want to aggregate all archives of idSite = 12 for each day within the week that is being processed. In the current buggy implementation it would have aggregated the archives of all children sites 2 and 4. This is problematic when thinking of custom reports. Where the roll up might have a custom report configured, but the children idSites 2 and 4 don't have a custom report configured. This means it can't find an archive for idSite 2 and 4 and would therefore create an empty archive even though each day in idSite 12 has an archive. This means, `aggregateMultipleReports` always needs to only have the `rollUpReportingIdSite`.

On the contrary, when processing unique metrics, then we actually want to operate on all children sites (2 and 4) and include them in the query for the unique visitors and users metric. This is totally opposite behaviour of what we need when aggregating archives. 

However, both use the same LogAggregator class and the same list of `$parameters->getIdSites()` which is determined by `Piwik::postEvent('ArchiveProcessor.Parameters.getIdSites', $idSite, $period).`. When that event is triggered and roll up reporting decides whether to look at the roll up site, or the children sites, it cannot know behave differently for `computeNbMetrics` and for `aggregateMultipleReports` but it is needed to make things work. 

Therefore I had to change logic a bit. Also in Roll Up Reporting itself (see PR there). 

Basically, we need two different events to ensure correct behaviour.