### PR TITLE
Improve sorting of action details

### DIFF
--- a/plugins/Live/Visualizations/VisitorLog.php
+++ b/plugins/Live/Visualizations/VisitorLog.php
@@ -241,6 +241,10 @@ class VisitorLog extends Visualization
             $a[$field] = strtotime($a[$field]);
             $b[$field] = strtotime($b[$field]);
         }
+        if ($field === 'type') {
+            $a[$field] = (string) $a[$field];
+            $b[$field] = (string) $b[$field];
+        }
         if ($a[$field] === $b[$field]) {
             return 0;
         }


### PR DESCRIPTION
The result of sorting the actions differed between PDO and MYSQLI database adapters.
That's the reason why various tests were failing in the AllTests build.
The reason is quite simple, but was hard to find...
PDO returns integer values as integers while MYSQLI returns them as strings. The sorting by action `type` then results in different results as the value might be a string or an integer. Comparing those can have different results...