### PR TITLE
Add possibility to silently stop the archiver without an error

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -19,6 +19,7 @@ use Piwik\CronArchive\FixedSiteIds;
 use Piwik\CronArchive\Performance\Logger;
 use Piwik\CronArchive\SharedSiteIds;
 use Piwik\Archive\ArchiveInvalidator;
+use Piwik\CronArchive\StopArchiverException;
 use Piwik\DataAccess\ArchiveSelector;
 use Piwik\DataAccess\RawLogDao;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
@@ -324,10 +325,14 @@ class CronArchive
 
         $self = $this;
         Access::doAsSuperUser(function () use ($self) {
-            $self->init();
-            $self->run();
-            $self->runScheduledTasks();
-            $self->end();
+            try {
+                $self->init();
+                $self->run();
+                $self->runScheduledTasks();
+                $self->end();
+            } catch (StopArchiverException $e) {
+                $this->logger->info("Archiving stopped by stop archiver exception");
+            }
         });
     }
 

--- a/core/CronArchive/StopArchiverException.php
+++ b/core/CronArchive/StopArchiverException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\CronArchive;
+
+use Piwik\Exception\Exception;
+
+class StopArchiverException extends Exception
+{
+}


### PR DESCRIPTION
Needing this for cloud. We're listening there to `CronArchive.init.start` event and under circumstances we may trigger an exception there to not archive any data.

The problem is, that this exception is passed on to the `console` command and then it returns exit code  != 0 meaning we receive an email from crontab every time this happens.

Could have appended another parameter to the postEvent to specifically abort archiving in this event but wasn't sure if that could cause any issue breaking things in 3.X and using the exception you can technically abort the archiving at any time which may be helpful. Won't be an official feature though.

Tested this and worked nicely. We will be using this on Cloud already with 3.13.4 in a patch.