### PR TITLE
Fix tests for tracker plugins no longer worked

### DIFF
--- a/plugins/CustomPiwikJs/TrackingCode/JsTestPluginTrackerFiles.php
+++ b/plugins/CustomPiwikJs/TrackingCode/JsTestPluginTrackerFiles.php
@@ -19,6 +19,23 @@ class JsTestPluginTrackerFiles extends PluginTrackerFiles
         $this->ignoreMinified = true;
     }
 
+    protected function getDirectoriesToLook()
+    {
+        $dirs = array();
+        $trackerFiles = \_glob(PIWIK_DOCUMENT_ROOT . '/plugins/*/' . self::TRACKER_FILE);
+        foreach ($trackerFiles as $trackerFile) {
+            $pluginName = $this->getPluginNameFromFile($trackerFile);
+            $dirs[$pluginName] = dirname($trackerFile) . '/';
+        }
+        return $dirs;
+    }
+
+    protected function getPluginNameFromFile($file)
+    {
+        $file = str_replace(array(PIWIK_DOCUMENT_ROOT . '/plugins/', self::TRACKER_FILE), '', $file);
+        return trim($file, '/');
+    }
+
     protected function isPluginActivated($pluginName)
     {
         return true;


### PR DESCRIPTION
Regression from https://github.com/matomo-org/matomo/pull/15568

When running JS tests like https://foo.bar/tests/javascript/ then the tracker.js of tracking plugins was no longer included in the matomo.js