### PR TITLE
Fix inconsistent usage of segment idSites

### DIFF
--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -172,7 +172,7 @@ class Loader
     protected function doesRequestedPluginIncludeVisitsSummary()
     {
         $processAllReportsIncludingVisitsSummary =
-                Rules::shouldProcessReportsAllPlugins($this->params->getIdSites(), $this->params->getSegment(), $this->params->getPeriod()->getLabel());
+                Rules::shouldProcessReportsAllPlugins(array($this->params->getSite()->getId()), $this->params->getSegment(), $this->params->getPeriod()->getLabel());
         $doesRequestedPluginIncludeVisitsSummary = $processAllReportsIncludingVisitsSummary
                                                         || $this->params->getRequestedPlugin() == 'VisitsSummary';
         return $doesRequestedPluginIncludeVisitsSummary;

--- a/core/ArchiveProcessor/PluginsArchiver.php
+++ b/core/ArchiveProcessor/PluginsArchiver.php
@@ -269,7 +269,7 @@ class PluginsArchiver
         }
 
         if (Rules::shouldProcessReportsAllPlugins(
-            $this->params->getIdSites(),
+            array($this->params->getSite()->getId()),
             $this->params->getSegment(),
             $this->params->getPeriod()->getLabel())) {
             return true;


### PR DESCRIPTION
In all other cases that method `Rules::shouldProcessReportsAllPlugins` is called with the idSite we are currently archiving vs in these cases it was potentially called with children idSites (when roll up reporting is used with a specific setting). 

Problem?
* Roll up reporting idSite 3 has a segment defined. The roll up has 2 children sites 1 and 2.
* There is a segment configured to be auto archived for idSite 3 (the roll up). The same segment is not configured in idSite 1 and 2.
* When then the segment for idSite was about to be archived, it checked whether the segment is configured to be prearchived in `Rules::isSegmentPreProcessed() -> Rules::getSegmentsToProcess()`
* Before it was calling `Rules::isSegmentPreProcessed(1,2)` but then it thinks the segment for idSite 3 is not prearchived. 
* If neither idSite 1 or 2 had the very same segment defined, it would only archive visits summary details but no other report for the roll up.

I've done some extensive testing and it seems this change alone fixes the issue and no change in roll up reporting is needed. I can only assume the reason this was never noticed is:

* View people have segment browser archiving disabled enforced
* Often the segment might still be configured for all websites in which case this issue is not happening
* The same segment exists for another site as well
