### PR TITLE
Fix displaying of actions when loading additional visits in visitor profile

### DIFF
--- a/plugins/Live/Controller.php
+++ b/plugins/Live/Controller.php
@@ -195,6 +195,8 @@ class Controller extends \Piwik\Plugin\Controller
             return '';
         }
 
+        VisitorLog::groupActionsByPageviewId($nextVisits);
+
         $view = new View('@Live/getVisitList.twig');
         $view->idSite = $this->idSite;
         $view->startCounter = $startCounter < $nextVisits->getRowsCount() ? $nextVisits->getRowsCount() : $startCounter;

--- a/plugins/Live/tests/UI/Live_spec.js
+++ b/plugins/Live/tests/UI/Live_spec.js
@@ -75,6 +75,16 @@ describe("Live", function () {
         expect(await dialog.screenshot()).to.matchImage('visitor_profile');
     });
 
+    it('should load additional visits in visitor log', async function() {
+
+        await page.click('.visitor-profile-more-info a');
+
+        await page.waitForNetworkIdle();
+
+        var dialog = await page.$('.ui-dialog');
+        expect(await dialog.screenshot()).to.matchImage('visitor_profile_more_visits');
+    });
+
     it('should hide all action details', async function() {
         await page.evaluate(function(){
             $('.visitor-profile-toggle-actions').click();

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_action_details.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_action_details.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:922ac457ffa3b2a0117b8056e66530e01b5165d38b5b3b386c3d47bfa1ef9b38
-size 286501
+oid sha256:9c2167bbdb95c2415908e5e6721d6cc9e23f2a4b71d9cbf000ec4dec59316c5e
+size 294763

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_actions_hidden.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_actions_hidden.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eaeba2afebc1c74fd8d13d74ea8ccfc7f9cb3dd9418d288ac8e4420ed85f47d4
-size 253276
+oid sha256:3e29bbe67d6d3361acaeb421154428694c0e70502b570b908f1d386af1c99c55
+size 260800

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_more_visits.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_more_visits.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a87acf1f5a1e86b8ae95df58fd32e6dd50e2082ed47d896b09bcd58ea2b12c63
+size 444121

--- a/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_visit_details.png
+++ b/plugins/Live/tests/UI/expected-screenshots/Live_visitor_profile_visit_details.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d935ef09c39f74682a18f6cd285b8efddb93777e249876d2ad245e2aff08eab
-size 263232
+oid sha256:b5b0c3881ec1bff05049533a34203505dbad74e1ffb8011b5c9f03041b882ba8
+size 270434


### PR DESCRIPTION
When clicking the `load more visits` link in a visitor profile, the post loaded visits currently do not display any details for the actions.

See bug report in forum: https://forum.matomo.org/t/besucherprofil-nicht-alle-besuche-werden-detailliert-angezeigt/36614