### PR TITLE
Notifications with the same id might not be shown at all

### DIFF
--- a/plugins/CoreHome/angularjs/notification/notification.directive.js
+++ b/plugins/CoreHome/angularjs/notification/notification.directive.js
@@ -87,8 +87,9 @@
                 function closeExistingNotificationHavingSameIdIfNeeded(id, notificationElement) {
                     // TODO: instead of doing a global query for notification, there should be a notification-container
                     //       directive that manages notifications.
+                    var notificationStillExists = !!notificationElement.parents('body').length;
                     var existingNode = angular.element('[notification-id=' + id + ']').not(notificationElement);
-                    if (existingNode && existingNode.length) {
+                    if (notificationStillExists && existingNode && existingNode.length) {
                         existingNode.remove();
                     }
                 }


### PR DESCRIPTION
When trying to fix the tests for #15736 I wondered why the `UnprocessedSegmentTest` didn't show the notification anymore. Reproducing that locally showed that, due to the additional report on the tested page, the notification is contained two times. When loading the page directly (not by clicking the menu), the reports seems to be rendered on the same time, causing both notifications to remove each other.

Not sure if the applied fix is the best option, but wasn't sure how to prevent the removal in another way...