### PR TITLE
Avoid possible error subtable already exists but not loaded

### DIFF
--- a/core/Archive/DataTableFactory.php
+++ b/core/Archive/DataTableFactory.php
@@ -404,13 +404,17 @@ class DataTableFactory
             foreach ($dataTable->getRowsWithoutSummaryRow() as $row) {
                 $row->removeSubtable();
             }
+            $summaryRow = $dataTable->getRowFromId(DataTable::ID_SUMMARY_ROW);
+            if ($summaryRow) {
+                $summaryRow->removeSubtable();
+            }
 
             return;
         }
 
         $dataName = reset($this->dataNames);
 
-        foreach ($dataTable->getRowsWithoutSummaryRow() as $row) {
+        foreach ($dataTable->getRows() as $row) {
             $sid = $row->getIdSubDataTable();
             if ($sid === null) {
                 continue;


### PR DESCRIPTION
Below is part of the stack trace. The change seems to fix the issue from what I can see. I would honestly not know though how this really happens or what the issue is or how to create a test for it. I basically guessed the issue was there after setting a breakpoint when a summary row was created with a subtable, went up the backtrace and noticed this code. Saw the code didn't handle summary rows (which was the case in below warning) so added it. With this change the archive warning is gone.

```
WARNING: Row with label '-1' (columns = -1, 40, 40, 316, 4.243, 36, 0.01, 1.177) has already a subtable id=129 but it was not loaded - overwriting the existing sub-table. Trace: [{"file":"core\/DataTable\/Row.php","line":291,"function":"warnIfSubtableAlreadyExists","class":"Piwik\\DataTable\\Row","object":{"label":-1,"2":40,"12":40,"13":316,"30":4.2429999999999986,"31":36,"32":"0.01","33":"1.177"},"type":"->","args":[]},{"file":"core\/DataTable.php","line":1916,"function":"sumSubtable","class":"Piwik\\DataTable\\Row","object":{"label":-1,"2":40,"12":40,"13":316,"30":4.2429999999999986,"31":36,"32":"0.01","33":"1.177"},"type":"->","args":[{}]},{"file":"core\/DataTable.php","line":644,"function":"aggregateRowWithLabel","class":"Piwik\\DataTable","object":{},"type":"->","args":[{"label":"-1","2":1,"12":1,"13":0,"30":0.344,"31":1,"32":"0.344","33":"0.344"},{"33":"max","32":"min"}]},{"file":"\/var\/www\/html
\/core\/DataTable\/Row.php","line":298,"function":"addDataTable","class":"Piwik\\DataTable","object":{},"type":"->","args":[{}]},{"file":"core\/DataTable.php","line":1916,"function":"sumSubtable","class":"Piwik\\DataTable\\Row","object":{"label":"example","2":260,"12":595,"13":14985,"30":48.316,"31":548,"32":"0.002","33":"2.852","15":7,"19":2,"20":16,"21":64,"22":1},"type":"->","args":[{}]},{"file":"core\/DataTable.php","line":644,"function":"aggregateRowWithLabel","class":"Piwik\\DataTable","object":{},"type":"->","args":[{"label":"example","2":112,"12":229,"13":3467,"30":15.905,"31":203,"32":"0.006","33":"0.645","15":2,"19":1,"20":1,"21":0,"22":1},{"33":"max","32":"min"}]},{"file":"core\/ArchiveProcessor.php","line":560,"function":"addDataTable","class":"Piwik\\DataTable","object":{},"type":"->","args":[{}]},{"file":"core\/ArchiveProcessor.php","line":541,"function":"aggregatedDataTableMapsAsOne","class"
:"Piwik\\ArchiveProcessor","object":{"archive":{}},"type":"->","args":[{},{}]},{"file":"core\/ArchiveProcessor.php","line":366,"function":"getAggregatedDataTableMap","class":"Piwik\\ArchiveProcessor","object":{"archive":{}},"type":"->","args":[{},{"33":"max","32":"min"}]},{"file":"core\/ArchiveProcessor.php","line":208,"function":"aggregateDataTableRecord","class":"Piwik\\ArchiveProcessor","object":{"archive":{}},"type":"->","args":["Actions_actions_url",{"33":"max","32":"min"},{"1":11,"17":18,"14":16}]},{"file":"plugins\/Actions\/Archiver.php","line":525,"function":"aggregateDataTableRecords","class":"Piwik\\ArchiveProcessor","object":{"archive":{}},"type":"->","args":[["Actions_actions","Actions_actions_url"],500,100,2,{"33":"max","32":"min"},{"1":11,"17":18,"14":16},[]]},{"file":"core\/Plugin\/Archiver.php","line":103,"function":"aggregateMultipleReports","class":"Piwik\\Plugins\\Actions\\Archiver","object":{
"maximumRows":500},"type":"->","args":[]},{"file":"core\/ArchiveProcessor\/PluginsArchiver.php","line":173,"function":"callAggregateMultipleReports","class":"Piwik\\Plugin\\Archiver","object":{"maximumRows":500},"type":"->","args":[]},{"file":"core\/ArchiveProcessor\/Loader.php","line":165,"function":"callAggregateAllPlugins","class":"Piwik\\ArchiveProcessor\\PluginsArchiver","object":{"archiveProcessor":{"archive":{}},"archiveWriter":{"idArchive":355,"idSite":1,"segment":{},"period":{},"doneFlag":"done","dateStart":{}}},"type":"->","args":[1041,0,false]},{"file":"core\/ArchiveProcessor\/Loader.php","line":111,"function":"prepareAllPluginsArchive","class":"Piwik\\ArchiveProcessor\\Loader","object":{"invalidateBeforeArchiving":false},"type":"->","args":[1041,0]},{"file":"core\/ArchiveProcessor\/Loader.php","line":84,"function":"prepareArchiveImpl","class":"Piwik\\ArchiveProcessor\\Loader","object":{"invalidateBef
oreArchiving":false},"type":"->","args":["VisitsSummary"]},{"file":"core\/Context.php","line":75,"function":"Piwik\\ArchiveProcessor\\{closure}","class":"Piwik\\ArchiveProcessor\\Loader","object":{"invalidateBeforeArchiving":false},"type":"->","args":[]},{"file":"core\/ArchiveProcessor\/Loader.php","line":85,"function":"changeIdSite","class":"Piwik\\Context","type":"::","args":[1,{}]},{"file":"core\/Archive.php","line":803,"function":"prepareArchive","class":"Piwik\\ArchiveProcessor\\Loader","object":{"invalidateBeforeArchiving":false},"type":"->","args":["VisitsSummary"]},{"file":"core\/Archive.php","line":607,"function":"prepareArchive","class":"Piwik\\Archive","object":{},"type":"->","args":[["VisitsSummary"],{},{}]},{"file":"core\/Archive.php","line":551,"function":"cacheArchiveIdsAfterLaunching","class":"Piwik\\Archive","object":{},"type":"->","args":[["VisitsSummary"],["VisitsSummary"]]},
{"file":"core\/Archive.php","line":480,"function":"getArchiveIds","class":"Piwik\\Archive","object":{},"type":"->","args":[{"0":"nb_visits","1":"nb_actions","2":"max_actions","3":"bounce_count","7":"sum_visit_length"}]},{"file":"core\/Archive.php","line":295,"function":"get","class":"Piwik\\Archive","object":{},"type":"->","args":[{"0":"nb_visits","1":"nb_actions","2":"max_actions","3":"bounce_count","7":"sum_visit_length"},"numeric"]},{"file":"plugins\/VisitsSummary\/API.php","line":36,"function":"getDataTableFromNumeric","class":"Piwik\\Archive","object":{},"type":"->","args":[{"0":"nb_visits","1":"nb_actions","2":"max_actions","3":"bounce_count","7":"sum_visit_length"}]},{"function":"get","class":"Piwik\\Plugins\\VisitsSummary\\API","object":{},"type":"->","args":["1","month","last2",false,{"0":"nb_visits","1":"nb_actions","2":"max_actions","3":"bounce_count","7":"sum_visit_length"}]},
```