### PR TITLE
Fix piwik js minified tests

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -247,7 +247,7 @@ if (typeof window.JSON === 'object' && typeof window.JSON.stringify === 'functio
                     // Detect incomplete support for accessing string characters by index.
                     var charIndexBuggy = has("bug-string-char-index");
 
-                    // Define additional utility methods if the `Date` methods are buggy.
+                    // Define additional utility methods if the `Date` methods are buggy. 
                     if (!isExtended) {
                         var floor = Math.floor;
                         // A mapping between the months of the year and the number of days between


### PR DESCRIPTION
I think after merging https://github.com/matomo-org/matomo/pull/15784#event-3214586635 the JS tests are broken. In the PR the tests were green but that's because we merged another piwikjs PR that was created afterwards that it is broken now