### PR TITLE
Make sure to clean up tracking failures before sending email notification

### DIFF
--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -195,6 +195,7 @@ class Tasks extends \Piwik\Plugin\Tasks
      */
     public function notifyTrackingFailures()
     {
+        $this->cleanupTrackingFailures();
         $failures = $this->trackingFailures->getAllFailures();
         $general = Config::getInstance()->General;
         if (!empty($failures) && $general['enable_tracking_failures_notification']) {


### PR DESCRIPTION

Feedback from a customer... Eg the daily `cleanupTrackingFailures()` action might be only executed after the weekly `notifyTrackingFailures` therefore we should try to clean up failures first and then check if any are left. Avoids the case where a user opens hours later the email they receive and then there are no tracking failures reported. This could still happen but it's a bit less likely.