### PR TITLE
Fix comparing segments doesn't work with condition startsWith

### DIFF
--- a/plugins/CoreHome/javascripts/broadcast.js
+++ b/plugins/CoreHome/javascripts/broadcast.js
@@ -804,8 +804,8 @@ var broadcast = {
             var value = url.substring(startPos + lookFor.length, endStr);
 
             // we sanitize values to add a protection layer against XSS
-            // &segment= (and &popover=) value is not sanitized, since segments are designed to accept any user input
-            if(param != 'segment' && param != 'popover') {
+            // parameters 'segment', 'popover' and 'compareSegments' are not sanitized, since segments are designed to accept any user input
+            if(param != 'segment' && param != 'popover' && param != 'compareSegments') {
                 value = value.replace(/[^_%~\*\+\-\<\>!@\$\.()=,;0-9a-zA-Z]/gi, '');
             }
             return value;


### PR DESCRIPTION
In case of comparing of two or more segments with condition "startsWith" an error will occur because parameter 'compareSegments' is sanitized resulting to removal of '^' chararcter from start of the parameter value.
