### PR TITLE
Add more parameters to the computeNbUnique event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Matomo 3.13.5
+
+### New API
+* A new event `ArchiveProcessor.ComputeNbUniques.getIdSites` was added so plugins can change which site IDs should be included when processing the number unique visitors and users for a specific site.
+
 ## Matomo 3.13.1
 
 ### Deprecations

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -480,7 +480,8 @@ class ArchiveProcessor
 
     private function getIdSitesToComputeNbUniques()
     {
-        $sites = array($this->getParams()->getSite()->getId());
+        $params = $this->getParams();
+        $sites = array($params->getSite()->getId());
 
         /**
          * Triggered to change which site ids should be looked at when processing unique visitors and users.
@@ -488,8 +489,10 @@ class ArchiveProcessor
          * @param array &$idSites An array with one idSite. This site is being archived currently. To cancel the query
          *                        you can change this value to an empty array. To include other sites in the query you
          *                        can add more idSites to this list of idSites.
+         * @param Period $period  The period that is being requested to be archived.
+         * @param Segment $segment The segment that is request to be archived.
          */
-        Piwik::postEvent('ArchiveProcessor.ComputeNbUniques.getIdSites', array(&$sites));
+        Piwik::postEvent('ArchiveProcessor.ComputeNbUniques.getIdSites', array(&$sites, $params->getPeriod(), $params->getSegment()));
 
         return $sites;
     }


### PR DESCRIPTION
Needed for Roll Up Reporting to optionally disable unique visitors when a segment is applied.

Could add it to developer changelog but maybe not even needed as we only just added this event and wouldn't be used by anyone. Looks like we didn't add the event name last time to the changelog. Happy to add it though.