### PR TITLE
Fix fatal error when trying to install Matomo when PHP version is too low

### DIFF
--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -84,7 +84,9 @@ if (!function_exists('Piwik_GetErrorMessagePage')) {
      */
     function Piwik_ShouldPrintBackTraceWithMessage()
     {
-        if (\Piwik\SettingsServer::isArchivePhpTriggered()
+        if (class_exists('\Piwik\SettingsServer')
+            && class_exists('\Piwik\Common')
+            && \Piwik\SettingsServer::isArchivePhpTriggered()
             && \Piwik\Common::isPhpCliMode()
         ) {
             return true;

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -28,8 +28,7 @@ if ($minimumPhpInvalid) {
     $piwik_errorMessage .= "<p><strong>To run Matomo you need at least PHP version $piwik_minimumPHPVersion</strong></p>
 				<p>Unfortunately it seems your webserver is using PHP version $piwik_currentPHPVersion. </p>
 				<p>Please try to update your PHP version, Matomo is really worth it! Nowadays most web hosts
-				support PHP $piwik_minimumPHPVersion.</p>
-				<p>Also see the FAQ: <a href='https://matomo.org/faq/how-to-install/#faq_77'>My Web host supports PHP4 by default. How can I enable PHP5?</a></p>";
+				support PHP $piwik_minimumPHPVersion.</p>";
 } else {
     if (!extension_loaded('session')) {
         $piwik_errorMessage .= "<p><strong>Matomo and Zend_Session require the session extension</strong></p>


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/15771

To reproduce issue you can change `$piwik_minimumPHPVersion = '7.2.0';` to eg `$piwik_minimumPHPVersion = '7.5.0';` and temporarily remove your `config/config.ini.php`. You will then see it shows a fatal error because the auto loader has not been loaded yet.

With this patch it shows correct error message 
![image](https://user-images.githubusercontent.com/273120/79290243-b2e09d80-7f1f-11ea-992f-caf0acac2501.png)

Not needed for 3.X since most users would have PHP 5.5+ anyway.

Also removed the sentence mentioning PHP4 and PHP 5.3 linking to https://matomo.org/faq/how-to-install/faq_77/ as it's outdated and the solution in https://matomo.org/faq/how-to-install/faq_77/ likely doesn't even work that often and is quite complicated so not too helpful.