### PR TITLE
Add test to ensure there are no plugin updates for core plugins

### DIFF
--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -624,8 +624,12 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
         $pluginsWithUnexpectedUpdates = array();
         $pluginsWithUpdates = array();
         $numTestedCorePlugins = 0;
+
+        // eg these plugins are managed in a submodule and they are installing all tables/columns as part of their plugin install method etc.
+        $corePluginsThatAreIndependent = array('TagManager');
+
         foreach ($plugins as $pluginName => $info) {
-            if ($manager->isPluginBundledWithCore($pluginName)) {
+            if ($manager->isPluginBundledWithCore($pluginName) && !in_array($pluginName, $corePluginsThatAreIndependent)) {
                 $numTestedCorePlugins++;
                 $pathToUpdates = Manager::getPluginDirectory($pluginName) . '/Updates/*.php';
                 $files = _glob($pathToUpdates);
@@ -641,8 +645,6 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
                         // since matomo 3.13.0 we basically don't want to see any plugin specific updates for core plugins
                         // they should be instead in core/Updates/*
                         $pluginsWithUnexpectedUpdates[$pluginName] = $file;
-
-                        var_export($pluginName . $file);
                     } else {
                         $pluginsWithUpdates[] = $pluginName;
                     }


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/11221

see https://github.com/matomo-org/matomo/issues/11221#issuecomment-613792193 and below.

Basically things are working except if someone was to manually remove a plugin from `PluginInstalled`. We basically don't want to define plugin updates for core plugins anyway and rather want to ensure to have them in `core/Updates`.

This test worked for me. I was basically copying a test into Goals plugin and then the test failed

![image](https://user-images.githubusercontent.com/273120/79298381-19bc8180-7f35-11ea-9e1f-0fa99ddbf6e7.png)
