### PR TITLE
Prevent possible notice and hiding actual error in debug trace

### DIFF
--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -81,12 +81,15 @@ class LineMessageFormatter implements FormatterInterface
             }
 
             $level = $trace[$i];
+            $levelTrace = '';
             if (isset($level['file'], $level['line'])) {
                 $levelTrace = '#' . $i . (str_replace(PIWIK_DOCUMENT_ROOT, '', $level['file'])) . '(' . $level['line'] . ')';
-            } else {
+            } elseif (isset($level['class']) && isset($level['type']) && isset($level['function'])) {
                 $levelTrace = '[internal function]: ' . $level['class'] . $level['type'] . $level['function'] . '()';
             }
-            $strTrace .= $levelTrace . ",";
+            if ($levelTrace) {
+                $strTrace .= $levelTrace . ",";
+            }
         }
         return trim($strTrace, ",");
     }

--- a/plugins/Monolog/Formatter/LineMessageFormatter.php
+++ b/plugins/Monolog/Formatter/LineMessageFormatter.php
@@ -84,7 +84,7 @@ class LineMessageFormatter implements FormatterInterface
             $levelTrace = '';
             if (isset($level['file'], $level['line'])) {
                 $levelTrace = '#' . $i . (str_replace(PIWIK_DOCUMENT_ROOT, '', $level['file'])) . '(' . $level['line'] . ')';
-            } elseif (isset($level['class']) && isset($level['type']) && isset($level['function'])) {
+            } elseif (isset($level['class'], $level['type'], $level['function'])) {
                 $levelTrace = '[internal function]: ' . $level['class'] . $level['type'] . $level['function'] . '()';
             }
             if ($levelTrace) {


### PR DESCRIPTION
refs https://forum.matomo.org/t/empty-or-invalid-response-php-notice-undefined-index-class-when-archiving/36908/2

Not really needed for 3.x