### PR TITLE
Use archive for userId segment suggested values

### DIFF
--- a/plugins/CoreHome/Columns/UserId.php
+++ b/plugins/CoreHome/Columns/UserId.php
@@ -12,6 +12,7 @@ use Piwik\Cache;
 use Piwik\DataTable;
 use Piwik\DataTable\Map;
 use Piwik\Metrics;
+use Piwik\Plugin;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\VisitsSummary\API as VisitsSummaryApi;
 use Piwik\Tracker\Request;
@@ -38,6 +39,13 @@ class UserId extends VisitDimension
      * @var string
      */
     protected $columnType = 'VARCHAR(200) NULL';
+
+    public function __construct()
+    {
+        if (Plugin\Manager::getInstance()->isPluginActivated('UserId')) {
+            $this->suggestedValuesApi = 'UserId.getUsers';
+        }
+    }
 
     /**
      * @param Request $request

--- a/plugins/ExampleLogTables/tests/System/expected/test_ExampleLogTables_admin__UserId.getUsers_month.xml
+++ b/plugins/ExampleLogTables/tests/System/expected/test_ExampleLogTables_admin__UserId.getUsers_month.xml
@@ -11,6 +11,7 @@
 		<sum_daily_nb_uniq_visitors>30</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		
+		<segment>userId==user3</segment>
 	</row>
 	<row>
 		<label>user1</label>
@@ -23,5 +24,6 @@
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		
+		<segment>userId==user1</segment>
 	</row>
 </result>

--- a/plugins/ExampleLogTables/tests/System/expected/test_ExampleLogTables_all__UserId.getUsers_month.xml
+++ b/plugins/ExampleLogTables/tests/System/expected/test_ExampleLogTables_all__UserId.getUsers_month.xml
@@ -11,6 +11,7 @@
 		<sum_daily_nb_uniq_visitors>40</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		
+		<segment>userId==user4</segment>
 	</row>
 	<row>
 		<label>user3</label>
@@ -23,6 +24,7 @@
 		<sum_daily_nb_uniq_visitors>30</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		
+		<segment>userId==user3</segment>
 	</row>
 	<row>
 		<label>user2</label>
@@ -35,6 +37,7 @@
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		
+		<segment>userId==user2</segment>
 	</row>
 	<row>
 		<label>user1</label>
@@ -47,5 +50,6 @@
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		
+		<segment>userId==user1</segment>
 	</row>
 </result>

--- a/plugins/ExampleLogTables/tests/System/expected/test_ExampleLogTables_men__UserId.getUsers_month.xml
+++ b/plugins/ExampleLogTables/tests/System/expected/test_ExampleLogTables_men__UserId.getUsers_month.xml
@@ -11,6 +11,7 @@
 		<sum_daily_nb_uniq_visitors>40</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		
+		<segment>userId==user4</segment>
 	</row>
 	<row>
 		<label>user1</label>
@@ -23,5 +24,6 @@
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		
+		<segment>userId==user1</segment>
 	</row>
 </result>

--- a/plugins/ExampleLogTables/tests/System/expected/test_ExampleLogTables_women__UserId.getUsers_month.xml
+++ b/plugins/ExampleLogTables/tests/System/expected/test_ExampleLogTables_women__UserId.getUsers_month.xml
@@ -11,6 +11,7 @@
 		<sum_daily_nb_uniq_visitors>30</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		
+		<segment>userId==user3</segment>
 	</row>
 	<row>
 		<label>user2</label>
@@ -23,5 +24,6 @@
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		
+		<segment>userId==user2</segment>
 	</row>
 </result>

--- a/plugins/UserId/API.php
+++ b/plugins/UserId/API.php
@@ -40,6 +40,7 @@ class API extends \Piwik\Plugin\API
 
         $dataTable->queueFilter('ReplaceColumnNames');
         $dataTable->queueFilter('ReplaceSummaryRowLabel');
+        $dataTable->queueFilter('AddSegmentByLabel', array('userId'));
 
         return $dataTable;
     }

--- a/plugins/UserId/tests/System/expected/test___UserId.getUsers_day.xml
+++ b/plugins/UserId/tests/System/expected/test___UserId.getUsers_day.xml
@@ -11,6 +11,7 @@
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user1</segment>
 	</row>
 	<row>
 		<label>user2</label>
@@ -23,6 +24,7 @@
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user2</segment>
 	</row>
 	<row>
 		<label>user3</label>
@@ -35,5 +37,6 @@
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user3</segment>
 	</row>
 </result>

--- a/plugins/UserId/tests/System/expected/test___UserId.getUsers_range.xml
+++ b/plugins/UserId/tests/System/expected/test___UserId.getUsers_range.xml
@@ -11,6 +11,7 @@
 		<sum_daily_nb_uniq_visitors>30</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>30</sum_daily_nb_users>
 		
+		<segment>userId==user3</segment>
 	</row>
 	<row>
 		<label>user2</label>
@@ -23,6 +24,7 @@
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>20</sum_daily_nb_users>
 		
+		<segment>userId==user2</segment>
 	</row>
 	<row>
 		<label>user1</label>
@@ -35,5 +37,6 @@
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>10</sum_daily_nb_users>
 		
+		<segment>userId==user1</segment>
 	</row>
 </result>

--- a/plugins/UserId/tests/System/expected/test_ascSortOrder__UserId.getUsers_day.xml
+++ b/plugins/UserId/tests/System/expected/test_ascSortOrder__UserId.getUsers_day.xml
@@ -11,6 +11,7 @@
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user3</segment>
 	</row>
 	<row>
 		<label>user2</label>
@@ -23,6 +24,7 @@
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user2</segment>
 	</row>
 	<row>
 		<label>user1</label>
@@ -35,5 +37,6 @@
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user1</segment>
 	</row>
 </result>

--- a/plugins/UserId/tests/System/expected/test_ascSortOrder__UserId.getUsers_range.xml
+++ b/plugins/UserId/tests/System/expected/test_ascSortOrder__UserId.getUsers_range.xml
@@ -11,6 +11,7 @@
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>10</sum_daily_nb_users>
 		
+		<segment>userId==user1</segment>
 	</row>
 	<row>
 		<label>user2</label>
@@ -23,6 +24,7 @@
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>20</sum_daily_nb_users>
 		
+		<segment>userId==user2</segment>
 	</row>
 	<row>
 		<label>user3</label>
@@ -35,5 +37,6 @@
 		<sum_daily_nb_uniq_visitors>30</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>30</sum_daily_nb_users>
 		
+		<segment>userId==user3</segment>
 	</row>
 </result>

--- a/plugins/UserId/tests/System/expected/test_limit__UserId.getUsers_day.xml
+++ b/plugins/UserId/tests/System/expected/test_limit__UserId.getUsers_day.xml
@@ -11,6 +11,7 @@
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user2</segment>
 	</row>
 	<row>
 		<label>user3</label>
@@ -23,5 +24,6 @@
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user3</segment>
 	</row>
 </result>

--- a/plugins/UserId/tests/System/expected/test_limit__UserId.getUsers_range.xml
+++ b/plugins/UserId/tests/System/expected/test_limit__UserId.getUsers_range.xml
@@ -11,6 +11,7 @@
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>20</sum_daily_nb_users>
 		
+		<segment>userId==user2</segment>
 	</row>
 	<row>
 		<label>user1</label>
@@ -23,5 +24,6 @@
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>10</sum_daily_nb_users>
 		
+		<segment>userId==user1</segment>
 	</row>
 </result>

--- a/plugins/UserId/tests/System/expected/test_searchByUserId__UserId.getUsers_day.xml
+++ b/plugins/UserId/tests/System/expected/test_searchByUserId__UserId.getUsers_day.xml
@@ -11,5 +11,6 @@
 		<bounce_count>1</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user2</segment>
 	</row>
 </result>

--- a/plugins/UserId/tests/System/expected/test_searchByUserId__UserId.getUsers_range.xml
+++ b/plugins/UserId/tests/System/expected/test_searchByUserId__UserId.getUsers_range.xml
@@ -11,5 +11,6 @@
 		<sum_daily_nb_uniq_visitors>20</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>20</sum_daily_nb_users>
 		
+		<segment>userId==user2</segment>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserId.getUsers_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserId.getUsers_month.xml
@@ -11,6 +11,7 @@
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>1</sum_daily_nb_users>
 		
+		<segment>userId==user1</segment>
 	</row>
 	<row>
 		<label>commonuser</label>
@@ -23,6 +24,7 @@
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>1</sum_daily_nb_users>
 		
+		<segment>userId==commonuser</segment>
 	</row>
 	<row>
 		<label>user2</label>
@@ -35,5 +37,6 @@
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>1</sum_daily_nb_users>
 		
+		<segment>userId==user2</segment>
 	</row>
 </result>

--- a/tests/PHPUnit/System/expected/test_reportLimiting__UserId.getUsers_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting__UserId.getUsers_day.xml
@@ -11,6 +11,7 @@
 		<bounce_count>5</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user0</segment>
 	</row>
 	<row>
 		<label>user1</label>
@@ -23,6 +24,7 @@
 		<bounce_count>5</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user1</segment>
 	</row>
 	<row>
 		<label>Others</label>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_flattened__UserId.getUsers_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_flattened__UserId.getUsers_day.xml
@@ -11,6 +11,7 @@
 		<bounce_count>5</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user0</segment>
 	</row>
 	<row>
 		<label>user1</label>
@@ -23,6 +24,7 @@
 		<bounce_count>5</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user1</segment>
 	</row>
 	<row>
 		<label>Others</label>

--- a/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__UserId.getUsers_day.xml
+++ b/tests/PHPUnit/System/expected/test_reportLimiting_rankingQuery__UserId.getUsers_day.xml
@@ -11,6 +11,7 @@
 		<bounce_count>5</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user0</segment>
 	</row>
 	<row>
 		<label>user1</label>
@@ -23,6 +24,7 @@
 		<bounce_count>5</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		
+		<segment>userId==user1</segment>
 	</row>
 	<row>
 		<label>Others</label>


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/15823

refs https://github.com/matomo-org/matomo/issues/15440 as it will add segmented visitor log to the userId report
![image](https://user-images.githubusercontent.com/273120/79521072-61194e00-80ac-11ea-9ff0-844506217b23.png)
