### PR TITLE
When segment browser archiving is disabled, assume all segments are supposed to be preprocessed

### DIFF
--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -61,6 +61,10 @@ class Rules
             return true;
         }
 
+        if (SettingsServer::isArchivePhpTriggered() && !Rules::isBrowserTriggerEnabled() && !Rules::isBrowserArchivingAvailableForSegments()) {
+            return true;
+        }
+
         return self::isSegmentPreProcessed($idSites, $segment);
     }
 


### PR DESCRIPTION
This ensures that if someone disables browser segment archiving, and had previously set some segments to be archived in browser, that these segments will then be correctly preprocessed during archiving without needing to change the `auto_archive` flag in the segment DB table (or through the UI).

It also prevents random archive done flags to be created like `done90a5a511e1974bcb37613b6daec137ba.MultiChannelConversionAttribution`