### PR TITLE
Run UI tests of submodules with core build if possible

### DIFF
--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -38,8 +38,8 @@ var walk = function (dir, pattern, result) {
 };
 
 var isCorePlugin = function (pathToPlugin) {
-    // if the plugin is a .git checkout, it's not part of core
-    var gitDir = path.join(pathToPlugin, '.git');
+    // skip plugins that have special needs in core build
+    var gitDir = path.join(pathToPlugin, 'tests/travis');
     return !fs.existsSync(gitDir);
 };
 
@@ -160,7 +160,7 @@ Application.prototype.loadTestModules = function () {
         // we apply this option only if not a specific plugin or test suite was requested. Only there for travis to
         // split tests into multiple jobs.
         var numTestsFirstHalf = Math.round(mocha.suite.suites.length / 2);
-        numTestsFirstHalf -= 3;
+        numTestsFirstHalf -= 4;
         mocha.suite.suites = mocha.suite.suites.filter(function (suite, index) {
             if (options['run-first-half-only'] && index < numTestsFirstHalf) {
                 return true;

--- a/tests/lib/screenshot-testing/support/app.js
+++ b/tests/lib/screenshot-testing/support/app.js
@@ -38,9 +38,15 @@ var walk = function (dir, pattern, result) {
 };
 
 var isCorePlugin = function (pathToPlugin) {
-    // skip plugins that have special needs in core build
-    var gitDir = path.join(pathToPlugin, 'tests/travis');
+    // if the plugin is a .git checkout, it's not part of core
+    var gitDir = path.join(pathToPlugin, '.git');
     return !fs.existsSync(gitDir);
+};
+
+var hasSpecialNeeds = function (pathToPlugin) {
+    // skip plugins that have special needs in core build
+    var travisDir = path.join(pathToPlugin, 'tests/travis');
+    return !!fs.existsSync(travisDir);
 };
 
 var Application = function () {
@@ -123,9 +129,15 @@ Application.prototype.loadTestModules = function () {
     // load all UI tests we can find
     var modulePaths = walk(uiTestsDir, /_spec\.js$/);
 
-    if (options.core) {
+    if (options.core && !options['store-in-ui-tests-repo']) {
         plugins = plugins.filter(function (path) {
             return isCorePlugin(path);
+        });
+    }
+
+    if (!options.plugin) {
+        plugins = plugins.filter(function (path) {
+            return !hasSpecialNeeds(path);
         });
     }
 


### PR DESCRIPTION
Note: Some plugins have special needs in travis setup. Those might not be runable with core build, as they might fail. This currently affects LoginLdap & TagManager

fixes #9253