### PR TITLE
Reactivates some skipped tests

### DIFF
--- a/plugins/Contents/tests/System/ContentsTest.php
+++ b/plugins/Contents/tests/System/ContentsTest.php
@@ -28,9 +28,6 @@ class ContentsTest extends SystemTestCase
     public function testApi($api, $params)
     {
         $params['xmlFieldsToRemove'] = array('idsubdatatable');
-        if(self::isMysqli()) {
-            $this->markTestSkipped('Sometimes fail on MYSQLI (at random)');
-        }
         $this->runApiTests($api, $params);
     }
 

--- a/plugins/Ecommerce/tests/System/EcommerceOrderWithItemsTest.php
+++ b/plugins/Ecommerce/tests/System/EcommerceOrderWithItemsTest.php
@@ -22,11 +22,6 @@ class EcommerceOrderWithItemsTest extends SystemTestCase
 {
     public static $fixture = null; // initialized below class definition
 
-    public function testImagesIncludedInTests()
-    {
-        $this->alertWhenImagesExcludedFromTests();
-    }
-
     /**
      * @dataProvider getApiForTesting
      */

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -111,18 +111,6 @@ abstract class SystemTestCase extends TestCase
         return getenv('MYSQL_ADAPTER') == 'MYSQLI';
     }
 
-    protected function alertWhenImagesExcludedFromTests()
-    {
-        if (!Fixture::canImagesBeIncludedInScheduledReports()) {
-            $this->markTestSkipped(
-                '(This should not occur on Travis CI server as we expect these tests to run there). Scheduled reports generated during integration tests will not contain the image graphs. ' .
-                    'For tests to generate images, use a machine with the following specifications : ' .
-                    'OS = '.Fixture::IMAGES_GENERATED_ONLY_FOR_OS.', PHP = '.Fixture::IMAGES_GENERATED_FOR_PHP .
-                    ' and GD = ' . Fixture::IMAGES_GENERATED_FOR_GD
-            );
-        }
-    }
-
     /**
      * Return 4 Api Urls for testing scheduled reports :
      * - one in HTML format with all available reports

--- a/tests/PHPUnit/Integration/ArchiveWebTest.php
+++ b/tests/PHPUnit/Integration/ArchiveWebTest.php
@@ -26,10 +26,6 @@ class ArchiveWebTest extends SystemTestCase
 {
     public function test_WebArchiving()
     {
-        if (self::isMysqli() && self::isTravisCI()) {
-            $this->markTestSkipped('Skipping on Mysqli as it randomly fails.');
-        }
-
         $host  = Fixture::getRootUrl();
         $token = Fixture::getTokenAuth();
 

--- a/tests/PHPUnit/Integration/JsProxyTest.php
+++ b/tests/PHPUnit/Integration/JsProxyTest.php
@@ -55,9 +55,6 @@ class JsProxyTest extends IntegrationTestCase
 
     public function testPiwikPhp()
     {
-        if(IntegrationTestCase::isMysqli()) {
-            $this->markTestSkipped('Sometimes fails with 500 error');
-        }
         $curlHandle = curl_init();
         $url = $this->getStaticSrvUrl() . '/js/?idsite=1';
         curl_setopt($curlHandle, CURLOPT_URL, $url);
@@ -69,9 +66,6 @@ class JsProxyTest extends IntegrationTestCase
         $this->assertEquals(200, $responseInfo["http_code"], var_export($responseInfo, true) . $fullResponse);
         $expected = "R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
         $processed = base64_encode($fullResponse);
-        if ($expected != $processed) {
-            $this->markTestSkipped("testPiwikPhp invalid response content: " . $fullResponse);
-        }
 
         $this->assertEquals(
             $expected,

--- a/tests/PHPUnit/Integration/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Integration/Tracker/RequestTest.php
@@ -55,7 +55,7 @@ class RequestTest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Custom timestamp is 86500 seconds old');
 
-        $request = $this->buildRequest(array('cdt' => '' . $this->time - 86500));
+        $request = $this->buildRequest(array('cdt' => '' . ($this->time - 86500)));
         $request->setCurrentTimestamp($this->time);
         $this->assertSame($this->time, $request->getCurrentTimestamp());
     }

--- a/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysTest.php
+++ b/tests/PHPUnit/System/TwoVisitorsTwoWebsitesDifferentDaysTest.php
@@ -27,11 +27,6 @@ class TwoVisitorsTwoWebsitesDifferentDaysTest extends SystemTestCase
 {
     public static $fixture = null; // initialized below class definition
 
-    public function testImagesIncludedInTests()
-    {
-        $this->alertWhenImagesExcludedFromTests();
-    }
-
     /**
      * @dataProvider getApiForTesting
      */

--- a/tests/PHPUnit/System/UrlNormalizationTest.php
+++ b/tests/PHPUnit/System/UrlNormalizationTest.php
@@ -28,9 +28,6 @@ class UrlNormalizationTest extends SystemTestCase
      */
     public function testApi($api, $params)
     {
-        if(self::isMysqli()) {
-            $this->markTestSkipped('Sometimes fail on MYSQLI (at random)');
-        }
         $this->runApiTests($api, $params);
     }
 


### PR DESCRIPTION
Various tests are currently skipped on mysqli because of random failures. As that occurred back on PHP 5 on trusty distribution I think it's time to give them another try.
The test ran more than 5 times now on travis and didn't fail. So guess should be fine. But let's have an eye on that and if any of those tests should fail randomly again, we maybe should investigate them instead of skipping them again.