### PR TITLE
Make sure to increase time limit when archiving

### DIFF
--- a/core/SettingsServer.php
+++ b/core/SettingsServer.php
@@ -142,6 +142,11 @@ class SettingsServer
      */
     public static function raiseMemoryLimitIfNecessary()
     {
+        if (self::isArchivePhpTriggered()) {
+            // core:archive command: no time limit
+            self::setMaxExecutionTime( 0 );
+        }
+
         $memoryLimit = self::getMemoryLimitValue();
         if ($memoryLimit === false) {
             return false;
@@ -149,8 +154,7 @@ class SettingsServer
         $minimumMemoryLimit = Config::getInstance()->General['minimum_memory_limit'];
 
         if (self::isArchivePhpTriggered()) {
-            // core:archive command: no time limit, high memory limit
-            self::setMaxExecutionTime(0);
+            // core:archive command:  high memory limit
             $minimumMemoryLimitWhenArchiving = Config::getInstance()->General['minimum_memory_limit_when_archiving'];
             if ($memoryLimit < $minimumMemoryLimitWhenArchiving) {
                 return self::setMemoryLimit($minimumMemoryLimitWhenArchiving);


### PR DESCRIPTION
Even if memory limit is already not set. May prevent some archiving issue around empty or invalid response.