### PR TITLE
Keep last 100 characters of archive error message when error is too long

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -1234,8 +1234,13 @@ class CronArchive
     public function logError($m)
     {
         if (!defined('PIWIK_ARCHIVE_NO_TRUNCATE')) {
-            $m = substr($m, 0, self::TRUNCATE_ERROR_MESSAGE_SUMMARY);
             $m = str_replace(array("\n", "\t"), " ", $m);
+            if (Common::mb_strlen($m) > self::TRUNCATE_ERROR_MESSAGE_SUMMARY) {
+                $numCharactersKeepFromEnd = 100;
+                $m = Common::mb_substr($m, 0, self::TRUNCATE_ERROR_MESSAGE_SUMMARY - $numCharactersKeepFromEnd)
+                     . ' ... ' .
+                    Common::mb_substr($m, -1 * $numCharactersKeepFromEnd);
+            }
         }
         $this->errors[] = $m;
         $this->logger->error($m);


### PR DESCRIPTION
Currently investigating some archiving issue where I can only see the first 6000 characters of the serialised archive response which looks good. However, I cannot see the any of the last characters so I can't really tell if the full response looks good or what the issue could be potentially. Therefore, changing the logic to also show the last 100 characters of the response. Tested this locally and worked for me. Makes the message technically 5 characters longer because of ` ... ` but that should be fine.