### PR TITLE
Anonymise fingerprint

### DIFF
--- a/core/Tracker/Settings.php
+++ b/core/Tracker/Settings.php
@@ -8,8 +8,10 @@
  */
 namespace Piwik\Tracker;
 
-use Piwik\Config;
 use Piwik\Container\StaticContainer;
+use Piwik\Date;
+use Piwik\Plugins\PrivacyManager\PrivacyManager;
+use Piwik\Site;
 use Piwik\Tracker;
 use Piwik\DeviceDetector\DeviceDetectorFactory;
 use Piwik\SettingsPiwik;
@@ -118,6 +120,10 @@ class Settings // TODO: merge w/ visitor recognizer or make it it's own service.
 
         if (!$this->isSameFingerprintsAcrossWebsites) {
             $configString .= $request->getIdSite();
+        }
+
+        if (PrivacyManager::shouldAnonymiseFingerprint()) {
+            $configString .= Date::now()->setTimezone(Site::getTimezoneFor($request->getIdSite()))->toString();
         }
 
         $hash = md5($configString, $raw_output = true);

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -12,6 +12,7 @@ use Piwik\Common;
 use Piwik\EventDispatcher;
 use Piwik\Plugin\Dimension\VisitDimension;
 use Piwik\Plugins\CustomVariables\CustomVariables;
+use Piwik\Plugins\PrivacyManager\PrivacyManager;
 use Piwik\Tracker\Visit\VisitProperties;
 
 /**
@@ -87,7 +88,11 @@ class VisitorRecognizer
 
         $isVisitorIdToLookup = !empty($idVisitor);
 
-        if ($isVisitorIdToLookup) {
+        if (PrivacyManager::shouldAnonymiseFingerprint()) {
+            $isVisitorIdToLookup = false;
+            $idVisitor = false;
+            Common::printDebug("Visitor ID ignored as we anonymise the fingerprint...");
+        } elseif ($isVisitorIdToLookup) {
             $visitProperties->setProperty('idvisitor', $idVisitor);
             Common::printDebug("Matching visitors with: visitorId=" . bin2hex($idVisitor) . " OR configId=" . bin2hex($configId));
         } else {

--- a/plugins/Live/Visualizations/VisitorLog.php
+++ b/plugins/Live/Visualizations/VisitorLog.php
@@ -117,8 +117,13 @@ class VisitorLog extends Visualization
             $this->config->custom_parameters['totalRows'] = 10000000;
         }
 
+        $hideProfileLink = (int)(1 == Common::getRequestVar('hideProfileLink', 0, 'int'));
+        if (PrivacyManager::shouldAnonymiseFingerprint()) {
+            $hideProfileLink = 1;
+        }
+
+        $this->config->custom_parameters['hideProfileLink'] = $hideProfileLink;
         $this->config->custom_parameters['smallWidth'] = (int)(1 == Common::getRequestVar('small', 0, 'int'));
-        $this->config->custom_parameters['hideProfileLink'] = (int)(1 == Common::getRequestVar('hideProfileLink', 0, 'int'));
         $this->config->custom_parameters['pageUrlNotDefined'] = Piwik::translate('General_NotDefined', Piwik::translate('Actions_ColumnPageURL'));
 
         if (!$this->isInPopover()) {

--- a/plugins/Live/Widgets/GetVisitorProfilePopup.php
+++ b/plugins/Live/Widgets/GetVisitorProfilePopup.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\Live\Widgets;
 
 use Piwik\Piwik;
+use Piwik\Plugins\PrivacyManager\PrivacyManager;
 use Piwik\Widget\WidgetConfig;
 
 class GetVisitorProfilePopup extends \Piwik\Widget\Widget
@@ -21,6 +22,8 @@ class GetVisitorProfilePopup extends \Piwik\Widget\Widget
         $config->setOrder(25);
 
         if (Piwik::isUserIsAnonymous()) {
+            $config->disable();
+        } elseif (PrivacyManager::shouldAnonymiseFingerprint()) {
             $config->disable();
         }
     }

--- a/plugins/PrivacyManager/API.php
+++ b/plugins/PrivacyManager/API.php
@@ -120,7 +120,7 @@ class API extends \Piwik\Plugin\API
     /**
      * @internal
      */
-    public function setAnonymizeIpSettings($anonymizeIPEnable, $maskLength, $useAnonymizedIpForVisitEnrichment, $anonymizeUserId = false, $anonymizeOrderId = false)
+    public function setAnonymizeIpSettings($anonymizeIPEnable, $maskLength, $useAnonymizedIpForVisitEnrichment, $anonymizeUserId = false, $anonymizeOrderId = false, $anonymizeFingerprint = false)
     {
         Piwik::checkUserHasSuperUserAccess();
 
@@ -142,6 +142,10 @@ class API extends \Piwik\Plugin\API
 
         if (false !== $anonymizeOrderId) {
             $privacyConfig->anonymizeOrderId = (bool) $anonymizeOrderId;
+        }
+
+        if (false !== $anonymizeFingerprint) {
+            $privacyConfig->anonymizeFingerprint = (bool) $anonymizeFingerprint;
         }
 
         return true;

--- a/plugins/PrivacyManager/Config.php
+++ b/plugins/PrivacyManager/Config.php
@@ -25,6 +25,7 @@ use Piwik\Tracker\Cache;
  *                                      For IPv6 addresses 0..4 means that 0, 64, 80, 104 or all bits are masked.
  * @property int  $anonymizeUserId      If enabled, it will pseudo anonymize the User ID
  * @property int  $anonymizeOrderId     If enabled, it will anonymize the Order ID
+ * @property int  $anonymizeFingerprint   If enabled, it will disable the fingerprint
  */
 class Config
 {
@@ -35,6 +36,7 @@ class Config
         'ipAnonymizerEnabled'               => array('type' => 'boolean', 'default' => true),
         'anonymizeUserId'                   => array('type' => 'boolean', 'default' => false),
         'anonymizeOrderId'                  => array('type' => 'boolean', 'default' => false),
+        'anonymizeFingerprint'              => array('type' => 'boolean', 'default' => false),
     );
 
     public function __set($name, $value)

--- a/plugins/PrivacyManager/Controller.php
+++ b/plugins/PrivacyManager/Controller.php
@@ -309,6 +309,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         $anonymizeIP["maskLength"] = $privacyConfig->ipAddressMaskLength;
         $anonymizeIP["anonymizeOrderId"] = $privacyConfig->anonymizeOrderId;
         $anonymizeIP["anonymizeUserId"] = $privacyConfig->anonymizeUserId;
+        $anonymizeIP["anonymizeFingerprint"] = $privacyConfig->anonymizeFingerprint;
         $anonymizeIP["useAnonymizedIpForVisitEnrichment"] = $privacyConfig->useAnonymizedIpForVisitEnrichment;
         if (!$anonymizeIP["useAnonymizedIpForVisitEnrichment"]) {
             $anonymizeIP["useAnonymizedIpForVisitEnrichment"] = '0';

--- a/plugins/PrivacyManager/PrivacyManager.php
+++ b/plugins/PrivacyManager/PrivacyManager.php
@@ -186,6 +186,15 @@ class PrivacyManager extends Plugin
         );
     }
 
+    public static function shouldAnonymiseFingerprint()
+    {
+        if (Plugin\Manager::getInstance()->isPluginActivated('PrivacyManager')) {
+            $config = new Config();
+            return $config->anonymizeFingerprint;
+        }
+        return false;
+    }
+
     public function isTrackerPlugin()
     {
         return true;

--- a/plugins/PrivacyManager/angularjs/anonymize-ip/anonymize-ip.controller.js
+++ b/plugins/PrivacyManager/angularjs/anonymize-ip/anonymize-ip.controller.js
@@ -22,6 +22,7 @@
                 anonymizeIPEnable: this.enabled ? '1' : '0',
                 anonymizeUserId: this.anonymizeUserId ? '1' : '0',
                 anonymizeOrderId: this.anonymizeOrderId ? '1' : '0',
+                anonymizeFingerprint: this.anonymizeFingerprint ? '1' : '0',
                 maskLength: this.maskLength,
                 useAnonymizedIpForVisitEnrichment: parseInt(this.useAnonymizedIpForVisitEnrichment, 10) ? '1' : '0'
             }).then(function (success) {

--- a/plugins/PrivacyManager/templates/privacySettings.twig
+++ b/plugins/PrivacyManager/templates/privacySettings.twig
@@ -56,6 +56,13 @@
              inline-help="{{ 'PrivacyManager_AnonymizeOrderIdNote'|translate|e('html_attr') }}">
         </div>
 
+        <div piwik-field uicontrol="checkbox" name="anonymizeFingerprint"
+             ng-model="anonymizeIp.anonymizeFingerprint"
+             data-title="Anonymize fingerprint"
+             value="{{ anonymizeIP.anonymizeFingerprint }}"
+             inline-help="By anonymising the fingerprint, Matomo will still generate a fingerprint. However, this fingerprint will change for each visitor every 24 hours. This means a visitor can no longer be followed over multiple days, no profile can be generated, and an individual cannot be identfied. This setting currently applies to all websites. When enabled, it will ignore any visitorId and as a result, the unique visitor metric will become inaccurate and sometimes different visitors may be falsely identified as the same visitor if the used device is similar. It will partially also disable the visitor profile in the UI. Please note that this feature does not deactivate the UserId feature.">
+        </div>
+
         <div piwik-save-button onconfirm="anonymizeIp.save()" saving="anonymizeIp.isLoading"></div>
     </div>
 </div>


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/13655

@mattab was quickly working on this 30 min for 3.X. 

The full feature https://github.com/matomo-org/matomo/issues/13655#issuecomment-616892565 could be developed in 4.X. While it's not fully implemented, it would be something though that could already help. The idea is basically to add the current date to the fingerprint, to ignore any visitorId unless it is a userId, and to disable the visitor profile in the visitor log (not in userId feature or API etc which can all be done in Matomo 4)

Not sure if "Disable fingerprint" is the right word since a fingerprint is still needed. Of course there could be also a feature "Disable fingerprint" which generates a new visit on every tracking request. It would basically add the dateTime to the fingerprint as well as some random generated string. That can be useful if people only want to know how often eg a page was viewed etc.

Any thoughts?