### PR TITLE
Do not always extend visit for content impressions

### DIFF
--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -545,9 +545,9 @@ class Visit implements VisitInterface
     private function setIdVisitorForExistingVisit($valuesToUpdate)
     {
         // Might update the idvisitor when it was forced or overwritten for this visit
-        if (strlen($this->visitProperties->getProperty('idvisitor')) == Tracker::LENGTH_BINARY_ID) {
-            $binIdVisitor = $this->visitProperties->getProperty('idvisitor');
-            $valuesToUpdate['idvisitor'] = $binIdVisitor;
+        if (strlen($this->visitProperties->getProperty('idvisitor')) == Tracker::LENGTH_BINARY_ID &&
+            $this->visitProperties->getProperty('idvisitor') != $this->visitProperties->getProperty('originalIdvisitor')) {
+            $valuesToUpdate['idvisitor'] = $this->visitProperties->getProperty('idvisitor');
         }
 
         return $valuesToUpdate;

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -546,7 +546,8 @@ class Visit implements VisitInterface
     {
         // Might update the idvisitor when it was forced or overwritten for this visit
         if (strlen($this->visitProperties->getProperty('idvisitor')) == Tracker::LENGTH_BINARY_ID &&
-            $this->visitProperties->getProperty('idvisitor') != $this->visitProperties->getProperty('originalIdvisitor')) {
+            (empty($this->visitProperties->getProperty('originalIdvisitor')) ||
+            bin2hex($this->visitProperties->getProperty('idvisitor')) != bin2hex($this->visitProperties->getProperty('originalIdvisitor')))) {
             $valuesToUpdate['idvisitor'] = $this->visitProperties->getProperty('idvisitor');
         }
 

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -106,6 +106,7 @@ class VisitorRecognizer
             && count($visitRow) > 0
         ) {
             $visitProperties->setProperty('idvisitor', $visitRow['idvisitor']);
+            $visitProperties->setProperty('originalIdvisitor', $visitRow['idvisitor']);
             $visitProperties->setProperty('user_id', $visitRow['user_id']);
 
             Common::printDebug("The visitor is known (idvisitor = " . bin2hex($visitProperties->getProperty('idvisitor')) . ",

--- a/plugins/Actions/Tracker/ActionsRequestProcessor.php
+++ b/plugins/Actions/Tracker/ActionsRequestProcessor.php
@@ -70,27 +70,7 @@ class ActionsRequestProcessor extends RequestProcessor
 
         if (!empty($action)) { // other plugins can unset the action if they want
             $action->loadIdsFromLogActionTable();
-            if ($action instanceof ActionContent && !$request->getParam('c_i') && !$this->shouldUpdateLastVisit($visitProperties)) {
-                // impressions dont extend visit
-                $request->setMetadata('Actions', 'doNotExtendVisit', true);
-            }
         }
-    }
-    private function shouldUpdateLastVisit(VisitProperties $visitProperties)
-    {
-        $lastActionTime = $visitProperties->getProperty('visit_last_action_time');
-        if (!empty($lastActionTime)) {
-            // it is only numeric when directly being called afterRequestProcessed() and not eg handleExistingVisit
-            // because the VisitLastActionTime dimension will overwrite the original value of the visitor.
-            // we want to make sure to work on the value from the DB
-            $lastActionTimeDate = Date::factory($lastActionTime)->addPeriod(1, 'minutes');
-            if ($lastActionTimeDate->isEarlier(Date::now())) {
-                // we update visit_last_action_time only if visit_last_action_time was updated more than 5 min ago
-                // we do not update all the time or every minute as not needed and to save resources
-                return true;
-            }
-        }
-        return false;
     }
 
     /**
@@ -105,7 +85,11 @@ class ActionsRequestProcessor extends RequestProcessor
      */
     public function onExistingVisit(&$valuesToUpdate, VisitProperties $visitProperties, Request $request)
     {
-        if ($request->getMetadata('Actions', 'doNotExtendVisit')) {
+        /** @var Action $action */
+        $action = $request->getMetadata('Actions', 'action');
+
+        if (!empty($action) && $action instanceof ActionContent && !$request->getParam('c_i')) {
+            // content impressions should not extend the visit, only content interactions
             unset($valuesToUpdate['visit_last_action_time']);
             unset($valuesToUpdate['visit_total_time']);
         }


### PR DESCRIPTION
@mattab the idea here is that content impressions is not quite an interactive action and as such it should not extend the visit or maybe only less often (if user scrolls after a while on the page we could consider it maybe interactive). The reason is mostly performance related to have less concurrent log_visit updates and therefore less potential locks. Often people have say 10-30 content blocks and either all of them are sent at the same time (eg if trackAllContentBlocks) or many of them are sent in parallel (when trackVisibleBlocksOnly and many become visible while scrolling). In Matomo 4 we can start queueing this requests so they are not sent all at the same time and instead as bulk (maybe they are already not sure) but in general we want to avoid too many concurrent requests here. 

The idea is so far we only extend visit if the last action was more than a minute ago. Could also completely remove it and never extend the visit (only content interactions would extend it). This can avoid many log_visit locks.

Haven't fully tested it yet, but wanted to get feedback on it as I reckon it can help.

For content impressions it will basically no longer update anything on log_visit which be good.