### PR TITLE
Update visit only when needed

### DIFF
--- a/core/Tracker/GoalManager.php
+++ b/core/Tracker/GoalManager.php
@@ -877,10 +877,22 @@ class GoalManager
 
     private function getGoalFromVisitor(VisitProperties $visitProperties, Request $request, $action)
     {
+        $lastVisitTime = $visitProperties->getProperty('visit_last_action_time');
+        if (!$lastVisitTime) {
+            $lastVisitTime = $request->getCurrentTimestamp(); // fallback in case visit_last_action_time is not set
+        }
+
+        if (!empty($lastVisitTime) && is_numeric($lastVisitTime)) {
+            // visit last action time might be 2020-05-05 00:00:00
+            // we want it to prevent this being converted to a timestamp of 2020
+            // resulting in some day in 1970
+            $lastVisitTime = Date::getDatetimeFromTimestamp($lastVisitTime);
+        }
+
         $goal = array(
             'idvisit'     => $visitProperties->getProperty('idvisit'),
             'idvisitor'   => $visitProperties->getProperty('idvisitor'),
-            'server_time' => Date::getDatetimeFromTimestamp($visitProperties->getProperty('visit_last_action_time')),
+            'server_time' => $lastVisitTime,
         );
 
         $visitDimensions = VisitDimension::getAllDimensions();

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -545,9 +545,10 @@ class Visit implements VisitInterface
     private function setIdVisitorForExistingVisit($valuesToUpdate)
     {
         // Might update the idvisitor when it was forced or overwritten for this visit
-        if (strlen($this->visitProperties->getProperty('idvisitor')) == Tracker::LENGTH_BINARY_ID) {
-            $binIdVisitor = $this->visitProperties->getProperty('idvisitor');
-            $valuesToUpdate['idvisitor'] = $binIdVisitor;
+        if (strlen($this->visitProperties->getProperty('idvisitor')) == Tracker::LENGTH_BINARY_ID &&
+            (empty($this->visitProperties->getProperty('originalIdvisitor')) ||
+                bin2hex($this->visitProperties->getProperty('idvisitor')) != bin2hex($this->visitProperties->getProperty('originalIdvisitor')))) {
+            $valuesToUpdate['idvisitor'] = $this->visitProperties->getProperty('idvisitor');
         }
 
         return $valuesToUpdate;

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -106,6 +106,7 @@ class VisitorRecognizer
             && count($visitRow) > 0
         ) {
             $visitProperties->setProperty('idvisitor', $visitRow['idvisitor']);
+            $visitProperties->setProperty('originalIdvisitor', $visitRow['idvisitor']);
             $visitProperties->setProperty('user_id', $visitRow['user_id']);
 
             Common::printDebug("The visitor is known (idvisitor = " . bin2hex($visitProperties->getProperty('idvisitor')) . ",

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -20,6 +20,12 @@ use Piwik\Tracker\Visit\VisitProperties;
 class VisitorRecognizer
 {
     /**
+     * Set when a visit was found. Stores the original values of the row that is currently stored in the DB when
+     * the visit was selected.
+     */
+    const KEY_ORIGINAL_VISIT_ROW = 'originalVisit';
+
+    /**
      * Local variable cache for the getVisitFieldsPersist() method.
      *
      * @var array
@@ -105,8 +111,8 @@ class VisitorRecognizer
         if ($visitRow
             && count($visitRow) > 0
         ) {
+            $visitProperties->setProperty(self::KEY_ORIGINAL_VISIT_ROW, $visitRow);
             $visitProperties->setProperty('idvisitor', $visitRow['idvisitor']);
-            $visitProperties->setProperty('originalIdvisitor', $visitRow['idvisitor']);
             $visitProperties->setProperty('user_id', $visitRow['user_id']);
 
             Common::printDebug("The visitor is known (idvisitor = " . bin2hex($visitProperties->getProperty('idvisitor')) . ",
@@ -120,6 +126,35 @@ class VisitorRecognizer
 
             return false;
         }
+    }
+
+    public function removeUnchangedValues(VisitProperties $visitProperties, $visit)
+    {
+        $originalRow = $visitProperties->getProperty(self::KEY_ORIGINAL_VISIT_ROW);
+
+        if (empty($originalRow)) {
+            return $visit;
+        }
+
+        if (!empty($originalRow['idvisitor'])
+            && !empty($visit['idvisitor'])
+            && bin2hex($originalRow['idvisitor']) === bin2hex($visit['idvisitor'])) {
+            unset($visit['idvisitor']);
+        }
+
+        $fieldsToCompareValue = array('user_id', 'visit_last_action_time', 'visit_total_time');
+        foreach ($fieldsToCompareValue as $field) {
+            if (!empty($originalRow[$field])
+                && !empty($visit[$field])
+                && $visit[$field] == $originalRow[$field]) {
+                // we can't use === eg for visit_total_time which may be partially an integer and sometimes a string
+                // because we check for !empty things should still work as expected though
+                // (eg we wouldn't compare false with 0)
+                unset($visit[$field]);
+            }
+        }
+
+        return $visit;
     }
 
     public function updateVisitPropertiesFromLastVisitRow(VisitProperties $visitProperties)

--- a/plugins/CoreHome/Columns/VisitLastActionTime.php
+++ b/plugins/CoreHome/Columns/VisitLastActionTime.php
@@ -14,6 +14,7 @@ use Piwik\Tracker\Action;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\Visitor;
 use Piwik\Metrics\Formatter;
+use Piwik\Tracker\VisitorRecognizer;
 
 require_once PIWIK_INCLUDE_PATH . '/plugins/VisitTime/functions.php';
 
@@ -67,7 +68,15 @@ class VisitLastActionTime extends VisitDimension
         if ($request->getParam('ping') == 1) {
             return false;
         }
-        
+
+        $originalVisit = $visitor->getVisitorColumn(VisitorRecognizer::KEY_ORIGINAL_VISIT_ROW);
+
+        if (!empty($originalVisit['visit_last_action_time'])
+            && Date::factory($originalVisit['visit_last_action_time'])->getTimestamp() > $request->getCurrentTimestamp()) {
+            // make sure to not set visit_last_action_time to an earlier time eg if tracking requests aren't sent in order
+            return $originalVisit['visit_last_action_time'];
+        }
+
         return $this->onNewVisit($request, $visitor, $action);
     }
 }

--- a/plugins/CoreHome/tests/Integration/Column/VisitLastActionTimeTest.php
+++ b/plugins/CoreHome/tests/Integration/Column/VisitLastActionTimeTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreHome\tests\Integration\Column;
+
+use Piwik\Cache;
+use Piwik\Common;
+use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\Date;
+use Piwik\Db;
+use Piwik\Metrics;
+use Piwik\Plugins\CoreHome\Columns\UserId;
+use Piwik\Plugins\CoreHome\Columns\VisitLastActionTime;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\Mock\FakeAccess;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\DataTable;
+use Piwik\Tracker\Request;
+use Piwik\Tracker\Visit\VisitProperties;
+use Piwik\Tracker\Visitor;
+use Piwik\Tracker\VisitorRecognizer;
+
+/**
+ * @group CoreHome
+ * @group VisitLastActionTimeTest
+ * @group Plugins
+ * @group Column
+ */
+class VisitLastActionTimeTest extends IntegrationTestCase
+{
+    /**
+     * @var VisitLastActionTime
+     */
+    private $lastAction;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->lastAction = new VisitLastActionTime();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+    }
+
+
+    private function makeRequest($request)
+    {
+        $request['idsite'] = 1;
+
+        return new Request($request);
+    }
+
+    private function getVisitor()
+    {
+        $visit = new VisitProperties();
+        $visit->setProperty('idvisit', '321');
+        $visit->setProperty('idvisitor', Common::hex2bin('1234567890234567'));
+        $visitor = new Visitor($visit, $isKnown = false);
+
+        return $visitor;
+    }
+
+    public function test_onExistingVisit_whenPing()
+    {
+        $request = $this->makeRequest(array('ping' => 1));
+        $visitor = $this->getVisitor();
+        $this->assertFalse($this->lastAction->onExistingVisit($request, $visitor, $action = null));
+    }
+
+    public function test_onExistingVisit_whenNewVisitReturnsTimeFromRequest()
+    {
+        $now = time() - 5; // -5 so we make sure this time is used and not actually now
+        $request = $this->makeRequest(array('cdt' => $now));
+        $this->assertEquals($now, $request->getCurrentTimestamp());
+
+        $visitor = $this->getVisitor();
+
+        $expected = Date::factory($now)->getDatetime();
+        $this->assertSame($expected, $this->lastAction->onExistingVisit($request, $visitor, $action = null));
+    }
+
+    public function test_onExistingVisit_whenKnownVisitRequestTimeIsNewer()
+    {
+        $now = time() - 5; // -5 so we make sure this time is used and not actually now
+        $previousTime = $now - 10; // is older
+        $request = $this->makeRequest(array('cdt' => $now));
+        $this->assertEquals($now, $request->getCurrentTimestamp());
+
+        $visitor = $this->getVisitor();
+        $visitor->setVisitorColumn(VisitorRecognizer::KEY_ORIGINAL_VISIT_ROW,
+            array('visit_last_action_time' => Date::factory($previousTime)->getDatetime())
+        );
+
+        $expected = Date::factory($now)->getDatetime();
+        $this->assertSame($expected, $this->lastAction->onExistingVisit($request, $visitor, $action = null));
+    }
+
+    public function test_onExistingVisit_whenKnownVisitAndPreviousVisitTimeIsNewer()
+    {
+        $now = time() - 5; // -5 so we make sure this time is used and not actually now
+        $previousTime = $now + 10; // is newer
+        $request = $this->makeRequest(array('cdt' => $now));
+        $this->assertEquals($now, $request->getCurrentTimestamp());
+
+        $visitor = $this->getVisitor();
+        $visitor->setVisitorColumn(VisitorRecognizer::KEY_ORIGINAL_VISIT_ROW,
+            array('visit_last_action_time' => Date::factory($previousTime)->getDatetime())
+        );
+
+        $expected = Date::factory($previousTime)->getDatetime();
+        // should keep existing visit last action time
+        $this->assertSame($expected, $this->lastAction->onExistingVisit($request, $visitor, $action = null));
+    }
+}

--- a/plugins/Goals/tests/System/expected/test_trackGoals_allowMultipleConversionsPerVisit__Goals.get_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_allowMultipleConversionsPerVisit__Goals.get_day.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_conversions>8</nb_conversions>
+	<nb_conversions>7</nb_conversions>
 	<nb_visits_converted>2</nb_visits_converted>
 	<revenue>1332</revenue>
 	<conversion_rate>100%</conversion_rate>
-	<nb_conversions_new_visit>6</nb_conversions_new_visit>
+	<nb_conversions_new_visit>4</nb_conversions_new_visit>
 	<nb_visits_converted_new_visit>1</nb_visits_converted_new_visit>
 	<revenue_new_visit>1332</revenue_new_visit>
 	<conversion_rate_new_visit>100%</conversion_rate_new_visit>
-	<nb_conversions_returning_visit>2</nb_conversions_returning_visit>
+	<nb_conversions_returning_visit>3</nb_conversions_returning_visit>
 	<nb_visits_converted_returning_visit>1</nb_visits_converted_returning_visit>
 	<revenue_returning_visit>0</revenue_returning_visit>
 	<conversion_rate_returning_visit>100%</conversion_rate_returning_visit>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_allowMultipleConversionsPerVisit__VisitTime.getVisitInformationPerServerTime_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_allowMultipleConversionsPerVisit__VisitTime.getVisitInformationPerServerTime_day.xml
@@ -6,9 +6,9 @@
 		<nb_visits>2</nb_visits>
 		<nb_actions>5</nb_actions>
 		<nb_users>0</nb_users>
-		<max_actions>3</max_actions>
-		<sum_visit_length>363</sum_visit_length>
-		<bounce_count>0</bounce_count>
+		<max_actions>4</max_actions>
+		<sum_visit_length>1121</sum_visit_length>
+		<bounce_count>1</bounce_count>
 		<nb_visits_converted>2</nb_visits_converted>
 		<goals>
 			<row idgoal='1'>
@@ -22,8 +22,8 @@
 				<revenue>666</revenue>
 			</row>
 			<row idgoal='3'>
-				<nb_conversions>2</nb_conversions>
-				<nb_visits_converted>2</nb_visits_converted>
+				<nb_conversions>1</nb_conversions>
+				<nb_visits_converted>1</nb_visits_converted>
 				<revenue>0</revenue>
 			</row>
 			<row idgoal='4'>
@@ -37,7 +37,7 @@
 				<revenue>0</revenue>
 			</row>
 		</goals>
-		<nb_conversions>8</nb_conversions>
+		<nb_conversions>7</nb_conversions>
 		<revenue>1332</revenue>
 		<segment>visitStartServerHour==0</segment>
 	</row>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_allowMultipleConversionsPerVisit__VisitsSummary.get_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_allowMultipleConversionsPerVisit__VisitsSummary.get_day.xml
@@ -5,10 +5,10 @@
 	<nb_visits>2</nb_visits>
 	<nb_actions>5</nb_actions>
 	<nb_visits_converted>2</nb_visits_converted>
-	<bounce_count>0</bounce_count>
-	<sum_visit_length>363</sum_visit_length>
-	<max_actions>3</max_actions>
-	<bounce_rate>0%</bounce_rate>
+	<bounce_count>1</bounce_count>
+	<sum_visit_length>1121</sum_visit_length>
+	<max_actions>4</max_actions>
+	<bounce_rate>50%</bounce_rate>
 	<nb_actions_per_visit>2.5</nb_actions_per_visit>
-	<avg_time_on_site>182</avg_time_on_site>
+	<avg_time_on_site>561</avg_time_on_site>
 </result>

--- a/plugins/Goals/tests/System/expected/test_trackGoals_allowMultipleConversionsPerVisit_withLogLinkVisitActionSegment__Goals.get_day.xml
+++ b/plugins/Goals/tests/System/expected/test_trackGoals_allowMultipleConversionsPerVisit_withLogLinkVisitActionSegment__Goals.get_day.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_conversions>8</nb_conversions>
+	<nb_conversions>7</nb_conversions>
 	<nb_visits_converted>2</nb_visits_converted>
 	<revenue>1332</revenue>
 	<conversion_rate>100%</conversion_rate>
-	<nb_conversions_new_visit>6</nb_conversions_new_visit>
+	<nb_conversions_new_visit>4</nb_conversions_new_visit>
 	<nb_visits_converted_new_visit>1</nb_visits_converted_new_visit>
 	<revenue_new_visit>1332</revenue_new_visit>
 	<conversion_rate_new_visit>100%</conversion_rate_new_visit>
-	<nb_conversions_returning_visit>2</nb_conversions_returning_visit>
+	<nb_conversions_returning_visit>3</nb_conversions_returning_visit>
 	<nb_visits_converted_returning_visit>1</nb_visits_converted_returning_visit>
 	<revenue_returning_visit>0</revenue_returning_visit>
 	<conversion_rate_returning_visit>100%</conversion_rate_returning_visit>

--- a/tests/PHPUnit/Integration/Tracker/VisitorRecognizerTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitorRecognizerTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Tracker;
+
+use Piwik\Common;
+use Piwik\EventDispatcher;
+use Piwik\Tracker\Model;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Tracker\Visit\VisitProperties;
+use Piwik\Tracker\VisitorRecognizer;
+
+/**
+ * @group Core
+ */
+class VisitorRecognizerTest extends IntegrationTestCase
+{
+    /**
+     * @var VisitorRecognizer
+     */
+    private $recognizer;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->recognizer = new VisitorRecognizer(true, 1800, 24000,
+            new Model(), EventDispatcher::getInstance());
+    }
+
+    private function getVisitProperties($originalVisit = false)
+    {
+        $visit = new VisitProperties();
+        $visit->setProperty('idvisit', '321');
+        $visit->setProperty('idvisitor', Common::hex2bin('1234567890234567'));
+        if ($originalVisit) {
+            $visit->setProperty(VisitorRecognizer::KEY_ORIGINAL_VISIT_ROW, $originalVisit);
+        }
+
+        return $visit;
+    }
+
+    public function test_removeUnchangedValues_newVisit_shouldNotChangeAnything()
+    {
+        $visit = array(
+            'visit_last_action_time' => '2020-05-05 05:05:05',
+            'visit_total_time' => '50',
+            'foo' => 'bar',
+        );
+        $result = $this->recognizer->removeUnchangedValues($this->getVisitProperties(), $visit);
+
+        $this->assertEquals($visit, $result);
+    }
+
+    public function test_removeUnchangedValues_existingVisitWithDifferentValues_shouldNotChangeAnything()
+    {
+        $visit = array(
+            'idvisitor' => Common::hex2bin('1234567890234567'),
+            'visit_last_action_time' => '2020-05-05 05:05:05',
+            'visit_total_time' => '50',
+            'foo' => 'bar',
+        );
+        $properties = $this->getVisitProperties(array(
+            'visit_last_action_time' => '2020-05-05 04:05:05',
+            'visit_total_time' => '40',
+        ));
+        $result = $this->recognizer->removeUnchangedValues($properties, $visit);
+
+        $this->assertEquals($visit, $result);
+    }
+
+    public function test_removeUnchangedValues_existingVisitWithSomeSameValues_shouldRemoveUnchangedValues()
+    {
+        $visit = array(
+            'idvisitor' => Common::hex2bin('1234567890234569'),
+            'user_id' => 'hello',
+            'visit_last_action_time' => '2020-05-05 05:05:05',
+            'visit_total_time' => '50',
+            'foo' => 'bar',
+        );
+        $properties = $this->getVisitProperties(array(
+            'idvisitor' => Common::hex2bin('1234567890234567'),
+            'user_id' => 'hello',
+            'visit_last_action_time' => '2020-05-05 04:05:05',
+            'visit_total_time' => '50',
+        ));
+        $result = $this->recognizer->removeUnchangedValues($properties, $visit);
+
+        $this->assertEquals(array(
+            'visit_last_action_time' => '2020-05-05 05:05:05',
+            'foo' => 'bar',
+            'idvisitor' => Common::hex2bin('1234567890234569'),
+        ), $result);
+    }
+
+    public function test_removeUnchangedValues_existingVisitWithAllSameValues_shouldRemoveEmptyArray()
+    {
+        $visit = array(
+            'idvisitor' => Common::hex2bin('1234567890234569'),
+            'user_id' => 'hello',
+            'visit_last_action_time' => '2020-05-05 05:05:05',
+            'visit_total_time' => '50',
+        );
+        $properties = $this->getVisitProperties($visit);
+        $result = $this->recognizer->removeUnchangedValues($properties, $visit);
+
+        $this->assertEquals(array(), $result);
+    }
+
+}

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Actions.getPageUrls_day.xml
@@ -33,7 +33,7 @@
 		<nb_visits>1</nb_visits>
 		<nb_uniq_visitors>1</nb_uniq_visitors>
 		<nb_hits>1</nb_hits>
-		<sum_time_spent>1620</sum_time_spent>
+		<sum_time_spent>1499</sum_time_spent>
 		<nb_hits_with_time_generation>1</nb_hits_with_time_generation>
 		<min_time_generation>0.333</min_time_generation>
 		<max_time_generation>0.333</max_time_generation>
@@ -47,7 +47,7 @@
 		<entry_sum_visit_length>3601</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
 		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>1620</avg_time_on_page>
+		<avg_time_on_page>1499</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<avg_time_generation>0.333</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Actions.getPageUrls_month.xml
@@ -32,7 +32,7 @@
 		<label>/webradio</label>
 		<nb_visits>1</nb_visits>
 		<nb_hits>1</nb_hits>
-		<sum_time_spent>1620</sum_time_spent>
+		<sum_time_spent>1499</sum_time_spent>
 		<nb_hits_with_time_generation>1</nb_hits_with_time_generation>
 		<min_time_generation>0.333</min_time_generation>
 		<max_time_generation>0.333</max_time_generation>
@@ -47,7 +47,7 @@
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>1620</avg_time_on_page>
+		<avg_time_on_page>1499</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<avg_time_generation>0.333</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_day.xml
@@ -731,8 +731,8 @@
 				<eventCategory>Music</eventCategory>
 				<eventAction>play25%</eventAction>
 				<bandwidth />
-				<timeSpent>60</timeSpent>
-				<timeSpentPretty>1 min 0s</timeSpentPretty>
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
 				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
@@ -794,8 +794,8 @@
 				<eventCategory>Music</eventCategory>
 				<eventAction>play50%</eventAction>
 				<bandwidth />
-				<timeSpent>60</timeSpent>
-				<timeSpentPretty>1 min 0s</timeSpentPretty>
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
 				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
@@ -939,8 +939,8 @@
 				<eventCategory>Music</eventCategory>
 				<eventAction>rating</eventAction>
 				<bandwidth />
-				<timeSpent>1620</timeSpent>
-				<timeSpentPretty>27 min 0s</timeSpentPretty>
+				<timeSpent>1499</timeSpent>
+				<timeSpentPretty>24 min 59s</timeSpentPretty>
 				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Live.getLastVisitsDetails_month.xml
@@ -1772,8 +1772,8 @@
 				<eventCategory>Music</eventCategory>
 				<eventAction>play25%</eventAction>
 				<bandwidth />
-				<timeSpent>60</timeSpent>
-				<timeSpentPretty>1 min 0s</timeSpentPretty>
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
 				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
@@ -1835,8 +1835,8 @@
 				<eventCategory>Music</eventCategory>
 				<eventAction>play50%</eventAction>
 				<bandwidth />
-				<timeSpent>60</timeSpent>
-				<timeSpentPretty>1 min 0s</timeSpentPretty>
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
 				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>
@@ -1980,8 +1980,8 @@
 				<eventCategory>Music</eventCategory>
 				<eventAction>rating</eventAction>
 				<bandwidth />
-				<timeSpent>1620</timeSpent>
-				<timeSpentPretty>27 min 0s</timeSpentPretty>
+				<timeSpent>1499</timeSpent>
+				<timeSpentPretty>24 min 59s</timeSpentPretty>
 				<interactionPosition>1</interactionPosition>
 				
 				<icon>plugins/Morpheus/images/event.png</icon>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Actions.getPageUrls_day.xml
@@ -33,7 +33,7 @@
 		<nb_visits>1</nb_visits>
 		<nb_uniq_visitors>1</nb_uniq_visitors>
 		<nb_hits>1</nb_hits>
-		<sum_time_spent>1620</sum_time_spent>
+		<sum_time_spent>1499</sum_time_spent>
 		<nb_hits_with_time_generation>1</nb_hits_with_time_generation>
 		<min_time_generation>0.333</min_time_generation>
 		<max_time_generation>0.333</max_time_generation>
@@ -47,7 +47,7 @@
 		<entry_sum_visit_length>3601</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
 		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>1620</avg_time_on_page>
+		<avg_time_on_page>1499</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<avg_time_generation>0.333</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Actions.getPageUrls_day.xml
@@ -33,7 +33,7 @@
 		<nb_visits>1</nb_visits>
 		<nb_uniq_visitors>1</nb_uniq_visitors>
 		<nb_hits>1</nb_hits>
-		<sum_time_spent>1620</sum_time_spent>
+		<sum_time_spent>1499</sum_time_spent>
 		<nb_hits_with_time_generation>1</nb_hits_with_time_generation>
 		<min_time_generation>0.333</min_time_generation>
 		<max_time_generation>0.333</max_time_generation>
@@ -47,7 +47,7 @@
 		<entry_sum_visit_length>3601</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
 		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>1620</avg_time_on_page>
+		<avg_time_on_page>1499</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<avg_time_generation>0.333</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Actions.getPageUrls_day.xml
@@ -33,7 +33,7 @@
 		<nb_visits>1</nb_visits>
 		<nb_uniq_visitors>1</nb_uniq_visitors>
 		<nb_hits>1</nb_hits>
-		<sum_time_spent>1620</sum_time_spent>
+		<sum_time_spent>1499</sum_time_spent>
 		<nb_hits_with_time_generation>1</nb_hits_with_time_generation>
 		<min_time_generation>0.333</min_time_generation>
 		<max_time_generation>0.333</max_time_generation>
@@ -47,7 +47,7 @@
 		<entry_sum_visit_length>3601</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
 		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>1620</avg_time_on_page>
+		<avg_time_on_page>1499</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<avg_time_generation>0.333</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_month.xml
@@ -496,186 +496,6 @@
 		</subtable>
 	</row>
 	<row>
-		<label>hello</label>
-		<nb_visits>4</nb_visits>
-		<nb_hits>4</nb_hits>
-		<sum_time_spent>0</sum_time_spent>
-		<nb_hits_with_time_generation>4</nb_hits_with_time_generation>
-		<min_time_generation>0.359</min_time_generation>
-		<max_time_generation>0.359</max_time_generation>
-		<sum_bandwidth>0</sum_bandwidth>
-		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
-		<entry_nb_visits>3</entry_nb_visits>
-		<entry_nb_actions>4</entry_nb_actions>
-		<entry_sum_visit_length>2</entry_sum_visit_length>
-		<entry_bounce_count>2</entry_bounce_count>
-		<exit_nb_visits>3</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>0</avg_time_on_page>
-		<bounce_rate>67%</bounce_rate>
-		<exit_rate>75%</exit_rate>
-		<avg_time_generation>0.359</avg_time_generation>
-		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello</segment>
-		<subtable>
-			<row>
-				<label>from</label>
-				<nb_visits>2</nb_visits>
-				<nb_hits>2</nb_hits>
-				<sum_time_spent>0</sum_time_spent>
-				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-				<min_time_generation>0.359</min_time_generation>
-				<max_time_generation>0.359</max_time_generation>
-				<sum_bandwidth>0</sum_bandwidth>
-				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-				<min_bandwidth />
-				<max_bandwidth />
-				<entry_nb_visits>2</entry_nb_visits>
-				<entry_nb_actions>3</entry_nb_actions>
-				<entry_sum_visit_length>2</entry_sum_visit_length>
-				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>0</avg_time_on_page>
-				<bounce_rate>50%</bounce_rate>
-				<exit_rate>50%</exit_rate>
-				<avg_time_generation>0.359</avg_time_generation>
-				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
-				<subtable>
-					<row>
-						<label>another</label>
-						<nb_visits>2</nb_visits>
-						<nb_hits>2</nb_hits>
-						<sum_time_spent>0</sum_time_spent>
-						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-						<min_time_generation>0.359</min_time_generation>
-						<max_time_generation>0.359</max_time_generation>
-						<sum_bandwidth>0</sum_bandwidth>
-						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-						<min_bandwidth />
-						<max_bandwidth />
-						<entry_nb_visits>2</entry_nb_visits>
-						<entry_nb_actions>3</entry_nb_actions>
-						<entry_sum_visit_length>2</entry_sum_visit_length>
-						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>0</avg_time_on_page>
-						<bounce_rate>50%</bounce_rate>
-						<exit_rate>50%</exit_rate>
-						<avg_time_generation>0.359</avg_time_generation>
-						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
-						<subtable>
-							<row>
-								<label>world</label>
-								<nb_visits>2</nb_visits>
-								<nb_hits>2</nb_hits>
-								<sum_time_spent>0</sum_time_spent>
-								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-								<min_time_generation>0.359</min_time_generation>
-								<max_time_generation>0.359</max_time_generation>
-								<sum_bandwidth>0</sum_bandwidth>
-								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-								<min_bandwidth />
-								<max_bandwidth />
-								<entry_nb_visits>2</entry_nb_visits>
-								<entry_nb_actions>3</entry_nb_actions>
-								<entry_sum_visit_length>2</entry_sum_visit_length>
-								<entry_bounce_count>1</entry_bounce_count>
-								<exit_nb_visits>1</exit_nb_visits>
-								<avg_time_on_page>0</avg_time_on_page>
-								<bounce_rate>50%</bounce_rate>
-								<exit_rate>50%</exit_rate>
-								<avg_time_generation>0.359</avg_time_generation>
-								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
-								<subtable>
-									<row>
-										<label>/6,681965</label>
-										<nb_visits>2</nb_visits>
-										<nb_hits>2</nb_hits>
-										<sum_time_spent>0</sum_time_spent>
-										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-										<min_time_generation>0.359</min_time_generation>
-										<max_time_generation>0.359</max_time_generation>
-										<sum_bandwidth>0</sum_bandwidth>
-										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-										<min_bandwidth />
-										<max_bandwidth />
-										<entry_nb_visits>2</entry_nb_visits>
-										<entry_nb_actions>3</entry_nb_actions>
-										<entry_sum_visit_length>2</entry_sum_visit_length>
-										<entry_bounce_count>1</entry_bounce_count>
-										<exit_nb_visits>1</exit_nb_visits>
-										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
-										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-										<avg_time_on_page>0</avg_time_on_page>
-										<bounce_rate>50%</bounce_rate>
-										<exit_rate>50%</exit_rate>
-										<avg_time_generation>0.359</avg_time_generation>
-										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
-										<segment>entryPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
-									</row>
-								</subtable>
-							</row>
-						</subtable>
-					</row>
-				</subtable>
-			</row>
-			<row>
-				<label>world</label>
-				<nb_visits>2</nb_visits>
-				<nb_hits>2</nb_hits>
-				<sum_time_spent>0</sum_time_spent>
-				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-				<min_time_generation>0.359</min_time_generation>
-				<max_time_generation>0.359</max_time_generation>
-				<sum_bandwidth>0</sum_bandwidth>
-				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-				<min_bandwidth />
-				<max_bandwidth />
-				<entry_nb_visits>1</entry_nb_visits>
-				<entry_nb_actions>1</entry_nb_actions>
-				<entry_sum_visit_length>0</entry_sum_visit_length>
-				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>2</exit_nb_visits>
-				<avg_time_on_page>0</avg_time_on_page>
-				<bounce_rate>100%</bounce_rate>
-				<exit_rate>100%</exit_rate>
-				<avg_time_generation>0.359</avg_time_generation>
-				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Fworld</segment>
-				<subtable>
-					<row>
-						<label>/6,681965</label>
-						<nb_visits>2</nb_visits>
-						<nb_hits>2</nb_hits>
-						<sum_time_spent>0</sum_time_spent>
-						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-						<min_time_generation>0.359</min_time_generation>
-						<max_time_generation>0.359</max_time_generation>
-						<sum_bandwidth>0</sum_bandwidth>
-						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-						<min_bandwidth />
-						<max_bandwidth />
-						<entry_nb_visits>1</entry_nb_visits>
-						<entry_nb_actions>1</entry_nb_actions>
-						<entry_sum_visit_length>0</entry_sum_visit_length>
-						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>2</exit_nb_visits>
-						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-						<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
-						<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-						<avg_time_on_page>0</avg_time_on_page>
-						<bounce_rate>100%</bounce_rate>
-						<exit_rate>100%</exit_rate>
-						<avg_time_generation>0.359</avg_time_generation>
-						<url>http://hello.example.com/hello/world/6,681965</url>
-						<segment>entryPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Fworld%252F6%252C681965</segment>
-					</row>
-				</subtable>
-			</row>
-		</subtable>
-	</row>
-	<row>
 		<label>/index</label>
 		<nb_visits>3</nb_visits>
 		<nb_hits>3</nb_hits>
@@ -702,6 +522,186 @@
 		<avg_time_generation>0.001</avg_time_generation>
 		<url>http://piwik.net/</url>
 		<segment>entryPageUrl==http%253A%252F%252Fpiwik.net%252F</segment>
+	</row>
+	<row>
+		<label>hello</label>
+		<nb_visits>3</nb_visits>
+		<nb_hits>4</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<nb_hits_with_time_generation>4</nb_hits_with_time_generation>
+		<min_time_generation>0.359</min_time_generation>
+		<max_time_generation>0.359</max_time_generation>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>2</entry_nb_visits>
+		<entry_nb_actions>4</entry_nb_actions>
+		<entry_sum_visit_length>2</entry_sum_visit_length>
+		<entry_bounce_count>1</entry_bounce_count>
+		<exit_nb_visits>2</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>50%</bounce_rate>
+		<exit_rate>67%</exit_rate>
+		<avg_time_generation>0.359</avg_time_generation>
+		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello</segment>
+		<subtable>
+			<row>
+				<label>world</label>
+				<nb_visits>2</nb_visits>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+				<min_time_generation>0.359</min_time_generation>
+				<max_time_generation>0.359</max_time_generation>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>1</entry_nb_actions>
+				<entry_sum_visit_length>0</entry_sum_visit_length>
+				<entry_bounce_count>1</entry_bounce_count>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>100%</bounce_rate>
+				<exit_rate>50%</exit_rate>
+				<avg_time_generation>0.359</avg_time_generation>
+				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Fworld</segment>
+				<subtable>
+					<row>
+						<label>/6,681965</label>
+						<nb_visits>2</nb_visits>
+						<nb_hits>2</nb_hits>
+						<sum_time_spent>0</sum_time_spent>
+						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+						<min_time_generation>0.359</min_time_generation>
+						<max_time_generation>0.359</max_time_generation>
+						<sum_bandwidth>0</sum_bandwidth>
+						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+						<min_bandwidth />
+						<max_bandwidth />
+						<entry_nb_visits>1</entry_nb_visits>
+						<entry_nb_actions>1</entry_nb_actions>
+						<entry_sum_visit_length>0</entry_sum_visit_length>
+						<entry_bounce_count>1</entry_bounce_count>
+						<exit_nb_visits>1</exit_nb_visits>
+						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+						<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+						<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+						<avg_time_on_page>0</avg_time_on_page>
+						<bounce_rate>100%</bounce_rate>
+						<exit_rate>50%</exit_rate>
+						<avg_time_generation>0.359</avg_time_generation>
+						<url>http://hello.example.com/hello/world/6,681965</url>
+						<segment>entryPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Fworld%252F6%252C681965</segment>
+					</row>
+				</subtable>
+			</row>
+			<row>
+				<label>from</label>
+				<nb_visits>1</nb_visits>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+				<min_time_generation>0.359</min_time_generation>
+				<max_time_generation>0.359</max_time_generation>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>3</entry_nb_actions>
+				<entry_sum_visit_length>2</entry_sum_visit_length>
+				<entry_bounce_count>0</entry_bounce_count>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>100%</exit_rate>
+				<avg_time_generation>0.359</avg_time_generation>
+				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
+				<subtable>
+					<row>
+						<label>another</label>
+						<nb_visits>1</nb_visits>
+						<nb_hits>2</nb_hits>
+						<sum_time_spent>0</sum_time_spent>
+						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+						<min_time_generation>0.359</min_time_generation>
+						<max_time_generation>0.359</max_time_generation>
+						<sum_bandwidth>0</sum_bandwidth>
+						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+						<min_bandwidth />
+						<max_bandwidth />
+						<entry_nb_visits>1</entry_nb_visits>
+						<entry_nb_actions>3</entry_nb_actions>
+						<entry_sum_visit_length>2</entry_sum_visit_length>
+						<entry_bounce_count>0</entry_bounce_count>
+						<exit_nb_visits>1</exit_nb_visits>
+						<avg_time_on_page>0</avg_time_on_page>
+						<bounce_rate>0%</bounce_rate>
+						<exit_rate>100%</exit_rate>
+						<avg_time_generation>0.359</avg_time_generation>
+						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
+						<subtable>
+							<row>
+								<label>world</label>
+								<nb_visits>1</nb_visits>
+								<nb_hits>2</nb_hits>
+								<sum_time_spent>0</sum_time_spent>
+								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+								<min_time_generation>0.359</min_time_generation>
+								<max_time_generation>0.359</max_time_generation>
+								<sum_bandwidth>0</sum_bandwidth>
+								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+								<min_bandwidth />
+								<max_bandwidth />
+								<entry_nb_visits>1</entry_nb_visits>
+								<entry_nb_actions>3</entry_nb_actions>
+								<entry_sum_visit_length>2</entry_sum_visit_length>
+								<entry_bounce_count>0</entry_bounce_count>
+								<exit_nb_visits>1</exit_nb_visits>
+								<avg_time_on_page>0</avg_time_on_page>
+								<bounce_rate>0%</bounce_rate>
+								<exit_rate>100%</exit_rate>
+								<avg_time_generation>0.359</avg_time_generation>
+								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
+								<subtable>
+									<row>
+										<label>/6,681965</label>
+										<nb_visits>1</nb_visits>
+										<nb_hits>2</nb_hits>
+										<sum_time_spent>0</sum_time_spent>
+										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+										<min_time_generation>0.359</min_time_generation>
+										<max_time_generation>0.359</max_time_generation>
+										<sum_bandwidth>0</sum_bandwidth>
+										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+										<min_bandwidth />
+										<max_bandwidth />
+										<entry_nb_visits>1</entry_nb_visits>
+										<entry_nb_actions>3</entry_nb_actions>
+										<entry_sum_visit_length>2</entry_sum_visit_length>
+										<entry_bounce_count>0</entry_bounce_count>
+										<exit_nb_visits>1</exit_nb_visits>
+										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+										<avg_time_on_page>0</avg_time_on_page>
+										<bounce_rate>0%</bounce_rate>
+										<exit_rate>100%</exit_rate>
+										<avg_time_generation>0.359</avg_time_generation>
+										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
+										<segment>entryPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
+									</row>
+								</subtable>
+							</row>
+						</subtable>
+					</row>
+				</subtable>
+			</row>
+		</subtable>
 	</row>
 	<row>
 		<label>Citrix</label>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getEntryPageUrls_range.xml
@@ -4,7 +4,7 @@
 		<label>blog</label>
 		<nb_visits>15</nb_visits>
 		<nb_hits>18</nb_hits>
-		<sum_time_spent>166</sum_time_spent>
+		<sum_time_spent>60</sum_time_spent>
 		<nb_hits_with_time_generation>7</nb_hits_with_time_generation>
 		<min_time_generation>0.023</min_time_generation>
 		<max_time_generation>1.324</max_time_generation>
@@ -18,7 +18,7 @@
 		<entry_bounce_count>13</entry_bounce_count>
 		<exit_nb_visits>13</exit_nb_visits>
 		<avg_bandwidth>3030</avg_bandwidth>
-		<avg_time_on_page>9</avg_time_on_page>
+		<avg_time_on_page>3</avg_time_on_page>
 		<bounce_rate>93%</bounce_rate>
 		<exit_rate>87%</exit_rate>
 		<avg_time_generation>0.389</avg_time_generation>
@@ -28,7 +28,7 @@
 				<label>category</label>
 				<nb_visits>12</nb_visits>
 				<nb_hits>15</nb_hits>
-				<sum_time_spent>166</sum_time_spent>
+				<sum_time_spent>60</sum_time_spent>
 				<nb_hits_with_time_generation>5</nb_hits_with_time_generation>
 				<min_time_generation>0.023</min_time_generation>
 				<max_time_generation>1.324</max_time_generation>
@@ -41,7 +41,7 @@
 				<entry_sum_visit_length>54</entry_sum_visit_length>
 				<entry_bounce_count>10</entry_bounce_count>
 				<exit_nb_visits>10</exit_nb_visits>
-				<avg_time_on_page>11</avg_time_on_page>
+				<avg_time_on_page>4</avg_time_on_page>
 				<bounce_rate>91%</bounce_rate>
 				<exit_rate>83%</exit_rate>
 				<avg_time_generation>0.443</avg_time_generation>
@@ -51,7 +51,7 @@
 						<label>meta</label>
 						<nb_visits>10</nb_visits>
 						<nb_hits>12</nb_hits>
-						<sum_time_spent>151</sum_time_spent>
+						<sum_time_spent>52</sum_time_spent>
 						<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 						<min_time_generation>0.023</min_time_generation>
 						<max_time_generation>0.123</max_time_generation>
@@ -64,7 +64,7 @@
 						<entry_sum_visit_length>54</entry_sum_visit_length>
 						<entry_bounce_count>9</entry_bounce_count>
 						<exit_nb_visits>9</exit_nb_visits>
-						<avg_time_on_page>13</avg_time_on_page>
+						<avg_time_on_page>4</avg_time_on_page>
 						<bounce_rate>90%</bounce_rate>
 						<exit_rate>90%</exit_rate>
 						<avg_time_generation>0.089</avg_time_generation>
@@ -74,7 +74,7 @@
 								<label>/index</label>
 								<nb_visits>10</nb_visits>
 								<nb_hits>12</nb_hits>
-								<sum_time_spent>151</sum_time_spent>
+								<sum_time_spent>52</sum_time_spent>
 								<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 								<min_time_generation>0.023</min_time_generation>
 								<max_time_generation>0.123</max_time_generation>
@@ -90,7 +90,7 @@
 								<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>10</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>9</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>13</avg_time_on_page>
+								<avg_time_on_page>4</avg_time_on_page>
 								<bounce_rate>90%</bounce_rate>
 								<exit_rate>90%</exit_rate>
 								<avg_time_generation>0.089</avg_time_generation>
@@ -103,7 +103,7 @@
 						<label>community</label>
 						<nb_visits>2</nb_visits>
 						<nb_hits>3</nb_hits>
-						<sum_time_spent>15</sum_time_spent>
+						<sum_time_spent>8</sum_time_spent>
 						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 						<min_time_generation>0.624</min_time_generation>
 						<max_time_generation>1.324</max_time_generation>
@@ -116,7 +116,7 @@
 						<entry_sum_visit_length>0</entry_sum_visit_length>
 						<entry_bounce_count>1</entry_bounce_count>
 						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>5</avg_time_on_page>
+						<avg_time_on_page>3</avg_time_on_page>
 						<bounce_rate>100%</bounce_rate>
 						<exit_rate>50%</exit_rate>
 						<avg_time_generation>0.974</avg_time_generation>
@@ -126,7 +126,7 @@
 								<label>/index</label>
 								<nb_visits>2</nb_visits>
 								<nb_hits>3</nb_hits>
-								<sum_time_spent>15</sum_time_spent>
+								<sum_time_spent>8</sum_time_spent>
 								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 								<min_time_generation>0.624</min_time_generation>
 								<max_time_generation>1.324</max_time_generation>
@@ -142,7 +142,7 @@
 								<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>5</avg_time_on_page>
+								<avg_time_on_page>3</avg_time_on_page>
 								<bounce_rate>100%</bounce_rate>
 								<exit_rate>50%</exit_rate>
 								<avg_time_generation>0.974</avg_time_generation>
@@ -665,7 +665,7 @@
 		<label>faq</label>
 		<nb_visits>5</nb_visits>
 		<nb_hits>7</nb_hits>
-		<sum_time_spent>52</sum_time_spent>
+		<sum_time_spent>26</sum_time_spent>
 		<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 		<min_time_generation>0.234</min_time_generation>
 		<max_time_generation>0.294</max_time_generation>
@@ -679,7 +679,7 @@
 		<entry_bounce_count>4</entry_bounce_count>
 		<exit_nb_visits>5</exit_nb_visits>
 		<avg_bandwidth>3574</avg_bandwidth>
-		<avg_time_on_page>7</avg_time_on_page>
+		<avg_time_on_page>4</avg_time_on_page>
 		<bounce_rate>100%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 		<avg_time_generation>0.255</avg_time_generation>
@@ -689,7 +689,7 @@
 				<label>/index</label>
 				<nb_visits>3</nb_visits>
 				<nb_hits>5</nb_hits>
-				<sum_time_spent>52</sum_time_spent>
+				<sum_time_spent>26</sum_time_spent>
 				<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 				<min_time_generation>0.234</min_time_generation>
 				<max_time_generation>0.294</max_time_generation>
@@ -705,7 +705,7 @@
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>3</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>10</avg_time_on_page>
+				<avg_time_on_page>5</avg_time_on_page>
 				<bounce_rate>100%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.255</avg_time_generation>
@@ -812,7 +812,7 @@
 	</row>
 	<row>
 		<label>hello</label>
-		<nb_visits>4</nb_visits>
+		<nb_visits>3</nb_visits>
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_generation>4</nb_hits_with_time_generation>
@@ -822,120 +822,18 @@
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
 		<max_bandwidth />
-		<entry_nb_visits>3</entry_nb_visits>
+		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>2</entry_sum_visit_length>
-		<entry_bounce_count>2</entry_bounce_count>
-		<exit_nb_visits>3</exit_nb_visits>
+		<entry_bounce_count>1</entry_bounce_count>
+		<exit_nb_visits>2</exit_nb_visits>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_time_on_page>0</avg_time_on_page>
-		<bounce_rate>67%</bounce_rate>
-		<exit_rate>75%</exit_rate>
+		<bounce_rate>50%</bounce_rate>
+		<exit_rate>67%</exit_rate>
 		<avg_time_generation>0.359</avg_time_generation>
 		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello</segment>
 		<subtable>
-			<row>
-				<label>from</label>
-				<nb_visits>2</nb_visits>
-				<nb_hits>2</nb_hits>
-				<sum_time_spent>0</sum_time_spent>
-				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-				<min_time_generation>0.359</min_time_generation>
-				<max_time_generation>0.359</max_time_generation>
-				<sum_bandwidth>0</sum_bandwidth>
-				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-				<min_bandwidth />
-				<max_bandwidth />
-				<entry_nb_visits>2</entry_nb_visits>
-				<entry_nb_actions>3</entry_nb_actions>
-				<entry_sum_visit_length>2</entry_sum_visit_length>
-				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>0</avg_time_on_page>
-				<bounce_rate>50%</bounce_rate>
-				<exit_rate>50%</exit_rate>
-				<avg_time_generation>0.359</avg_time_generation>
-				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
-				<subtable>
-					<row>
-						<label>another</label>
-						<nb_visits>2</nb_visits>
-						<nb_hits>2</nb_hits>
-						<sum_time_spent>0</sum_time_spent>
-						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-						<min_time_generation>0.359</min_time_generation>
-						<max_time_generation>0.359</max_time_generation>
-						<sum_bandwidth>0</sum_bandwidth>
-						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-						<min_bandwidth />
-						<max_bandwidth />
-						<entry_nb_visits>2</entry_nb_visits>
-						<entry_nb_actions>3</entry_nb_actions>
-						<entry_sum_visit_length>2</entry_sum_visit_length>
-						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>0</avg_time_on_page>
-						<bounce_rate>50%</bounce_rate>
-						<exit_rate>50%</exit_rate>
-						<avg_time_generation>0.359</avg_time_generation>
-						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
-						<subtable>
-							<row>
-								<label>world</label>
-								<nb_visits>2</nb_visits>
-								<nb_hits>2</nb_hits>
-								<sum_time_spent>0</sum_time_spent>
-								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-								<min_time_generation>0.359</min_time_generation>
-								<max_time_generation>0.359</max_time_generation>
-								<sum_bandwidth>0</sum_bandwidth>
-								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-								<min_bandwidth />
-								<max_bandwidth />
-								<entry_nb_visits>2</entry_nb_visits>
-								<entry_nb_actions>3</entry_nb_actions>
-								<entry_sum_visit_length>2</entry_sum_visit_length>
-								<entry_bounce_count>1</entry_bounce_count>
-								<exit_nb_visits>1</exit_nb_visits>
-								<avg_time_on_page>0</avg_time_on_page>
-								<bounce_rate>50%</bounce_rate>
-								<exit_rate>50%</exit_rate>
-								<avg_time_generation>0.359</avg_time_generation>
-								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
-								<subtable>
-									<row>
-										<label>/6,681965</label>
-										<nb_visits>2</nb_visits>
-										<nb_hits>2</nb_hits>
-										<sum_time_spent>0</sum_time_spent>
-										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-										<min_time_generation>0.359</min_time_generation>
-										<max_time_generation>0.359</max_time_generation>
-										<sum_bandwidth>0</sum_bandwidth>
-										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-										<min_bandwidth />
-										<max_bandwidth />
-										<entry_nb_visits>2</entry_nb_visits>
-										<entry_nb_actions>3</entry_nb_actions>
-										<entry_sum_visit_length>2</entry_sum_visit_length>
-										<entry_bounce_count>1</entry_bounce_count>
-										<exit_nb_visits>1</exit_nb_visits>
-										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
-										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-										<avg_time_on_page>0</avg_time_on_page>
-										<bounce_rate>50%</bounce_rate>
-										<exit_rate>50%</exit_rate>
-										<avg_time_generation>0.359</avg_time_generation>
-										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
-										<segment>entryPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
-									</row>
-								</subtable>
-							</row>
-						</subtable>
-					</row>
-				</subtable>
-			</row>
 			<row>
 				<label>world</label>
 				<nb_visits>2</nb_visits>
@@ -952,10 +850,10 @@
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
 				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>2</exit_nb_visits>
+				<exit_nb_visits>1</exit_nb_visits>
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>100%</bounce_rate>
-				<exit_rate>100%</exit_rate>
+				<exit_rate>50%</exit_rate>
 				<avg_time_generation>0.359</avg_time_generation>
 				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Fworld</segment>
 				<subtable>
@@ -975,16 +873,118 @@
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
 						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>2</exit_nb_visits>
+						<exit_nb_visits>1</exit_nb_visits>
 						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 						<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 						<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
 						<avg_time_on_page>0</avg_time_on_page>
 						<bounce_rate>100%</bounce_rate>
-						<exit_rate>100%</exit_rate>
+						<exit_rate>50%</exit_rate>
 						<avg_time_generation>0.359</avg_time_generation>
 						<url>http://hello.example.com/hello/world/6,681965</url>
 						<segment>entryPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Fworld%252F6%252C681965</segment>
+					</row>
+				</subtable>
+			</row>
+			<row>
+				<label>from</label>
+				<nb_visits>1</nb_visits>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+				<min_time_generation>0.359</min_time_generation>
+				<max_time_generation>0.359</max_time_generation>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>3</entry_nb_actions>
+				<entry_sum_visit_length>2</entry_sum_visit_length>
+				<entry_bounce_count>0</entry_bounce_count>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>100%</exit_rate>
+				<avg_time_generation>0.359</avg_time_generation>
+				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
+				<subtable>
+					<row>
+						<label>another</label>
+						<nb_visits>1</nb_visits>
+						<nb_hits>2</nb_hits>
+						<sum_time_spent>0</sum_time_spent>
+						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+						<min_time_generation>0.359</min_time_generation>
+						<max_time_generation>0.359</max_time_generation>
+						<sum_bandwidth>0</sum_bandwidth>
+						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+						<min_bandwidth />
+						<max_bandwidth />
+						<entry_nb_visits>1</entry_nb_visits>
+						<entry_nb_actions>3</entry_nb_actions>
+						<entry_sum_visit_length>2</entry_sum_visit_length>
+						<entry_bounce_count>0</entry_bounce_count>
+						<exit_nb_visits>1</exit_nb_visits>
+						<avg_time_on_page>0</avg_time_on_page>
+						<bounce_rate>0%</bounce_rate>
+						<exit_rate>100%</exit_rate>
+						<avg_time_generation>0.359</avg_time_generation>
+						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
+						<subtable>
+							<row>
+								<label>world</label>
+								<nb_visits>1</nb_visits>
+								<nb_hits>2</nb_hits>
+								<sum_time_spent>0</sum_time_spent>
+								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+								<min_time_generation>0.359</min_time_generation>
+								<max_time_generation>0.359</max_time_generation>
+								<sum_bandwidth>0</sum_bandwidth>
+								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+								<min_bandwidth />
+								<max_bandwidth />
+								<entry_nb_visits>1</entry_nb_visits>
+								<entry_nb_actions>3</entry_nb_actions>
+								<entry_sum_visit_length>2</entry_sum_visit_length>
+								<entry_bounce_count>0</entry_bounce_count>
+								<exit_nb_visits>1</exit_nb_visits>
+								<avg_time_on_page>0</avg_time_on_page>
+								<bounce_rate>0%</bounce_rate>
+								<exit_rate>100%</exit_rate>
+								<avg_time_generation>0.359</avg_time_generation>
+								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
+								<subtable>
+									<row>
+										<label>/6,681965</label>
+										<nb_visits>1</nb_visits>
+										<nb_hits>2</nb_hits>
+										<sum_time_spent>0</sum_time_spent>
+										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+										<min_time_generation>0.359</min_time_generation>
+										<max_time_generation>0.359</max_time_generation>
+										<sum_bandwidth>0</sum_bandwidth>
+										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+										<min_bandwidth />
+										<max_bandwidth />
+										<entry_nb_visits>1</entry_nb_visits>
+										<entry_nb_actions>3</entry_nb_actions>
+										<entry_sum_visit_length>2</entry_sum_visit_length>
+										<entry_bounce_count>0</entry_bounce_count>
+										<exit_nb_visits>1</exit_nb_visits>
+										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+										<avg_time_on_page>0</avg_time_on_page>
+										<bounce_rate>0%</bounce_rate>
+										<exit_rate>100%</exit_rate>
+										<avg_time_generation>0.359</avg_time_generation>
+										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
+										<segment>entryPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
+									</row>
+								</subtable>
+							</row>
+						</subtable>
 					</row>
 				</subtable>
 			</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_month.xml
@@ -496,186 +496,6 @@
 		</subtable>
 	</row>
 	<row>
-		<label>hello</label>
-		<nb_visits>4</nb_visits>
-		<nb_hits>4</nb_hits>
-		<sum_time_spent>0</sum_time_spent>
-		<nb_hits_with_time_generation>4</nb_hits_with_time_generation>
-		<min_time_generation>0.359</min_time_generation>
-		<max_time_generation>0.359</max_time_generation>
-		<sum_bandwidth>0</sum_bandwidth>
-		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
-		<entry_nb_visits>3</entry_nb_visits>
-		<entry_nb_actions>4</entry_nb_actions>
-		<entry_sum_visit_length>2</entry_sum_visit_length>
-		<entry_bounce_count>2</entry_bounce_count>
-		<exit_nb_visits>3</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>0</avg_time_on_page>
-		<bounce_rate>67%</bounce_rate>
-		<exit_rate>75%</exit_rate>
-		<avg_time_generation>0.359</avg_time_generation>
-		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello</segment>
-		<subtable>
-			<row>
-				<label>from</label>
-				<nb_visits>2</nb_visits>
-				<nb_hits>2</nb_hits>
-				<sum_time_spent>0</sum_time_spent>
-				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-				<min_time_generation>0.359</min_time_generation>
-				<max_time_generation>0.359</max_time_generation>
-				<sum_bandwidth>0</sum_bandwidth>
-				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-				<min_bandwidth />
-				<max_bandwidth />
-				<entry_nb_visits>2</entry_nb_visits>
-				<entry_nb_actions>3</entry_nb_actions>
-				<entry_sum_visit_length>2</entry_sum_visit_length>
-				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>0</avg_time_on_page>
-				<bounce_rate>50%</bounce_rate>
-				<exit_rate>50%</exit_rate>
-				<avg_time_generation>0.359</avg_time_generation>
-				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
-				<subtable>
-					<row>
-						<label>another</label>
-						<nb_visits>2</nb_visits>
-						<nb_hits>2</nb_hits>
-						<sum_time_spent>0</sum_time_spent>
-						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-						<min_time_generation>0.359</min_time_generation>
-						<max_time_generation>0.359</max_time_generation>
-						<sum_bandwidth>0</sum_bandwidth>
-						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-						<min_bandwidth />
-						<max_bandwidth />
-						<entry_nb_visits>2</entry_nb_visits>
-						<entry_nb_actions>3</entry_nb_actions>
-						<entry_sum_visit_length>2</entry_sum_visit_length>
-						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>0</avg_time_on_page>
-						<bounce_rate>50%</bounce_rate>
-						<exit_rate>50%</exit_rate>
-						<avg_time_generation>0.359</avg_time_generation>
-						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
-						<subtable>
-							<row>
-								<label>world</label>
-								<nb_visits>2</nb_visits>
-								<nb_hits>2</nb_hits>
-								<sum_time_spent>0</sum_time_spent>
-								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-								<min_time_generation>0.359</min_time_generation>
-								<max_time_generation>0.359</max_time_generation>
-								<sum_bandwidth>0</sum_bandwidth>
-								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-								<min_bandwidth />
-								<max_bandwidth />
-								<entry_nb_visits>2</entry_nb_visits>
-								<entry_nb_actions>3</entry_nb_actions>
-								<entry_sum_visit_length>2</entry_sum_visit_length>
-								<entry_bounce_count>1</entry_bounce_count>
-								<exit_nb_visits>1</exit_nb_visits>
-								<avg_time_on_page>0</avg_time_on_page>
-								<bounce_rate>50%</bounce_rate>
-								<exit_rate>50%</exit_rate>
-								<avg_time_generation>0.359</avg_time_generation>
-								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
-								<subtable>
-									<row>
-										<label>/6,681965</label>
-										<nb_visits>2</nb_visits>
-										<nb_hits>2</nb_hits>
-										<sum_time_spent>0</sum_time_spent>
-										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-										<min_time_generation>0.359</min_time_generation>
-										<max_time_generation>0.359</max_time_generation>
-										<sum_bandwidth>0</sum_bandwidth>
-										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-										<min_bandwidth />
-										<max_bandwidth />
-										<entry_nb_visits>2</entry_nb_visits>
-										<entry_nb_actions>3</entry_nb_actions>
-										<entry_sum_visit_length>2</entry_sum_visit_length>
-										<entry_bounce_count>1</entry_bounce_count>
-										<exit_nb_visits>1</exit_nb_visits>
-										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
-										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-										<avg_time_on_page>0</avg_time_on_page>
-										<bounce_rate>50%</bounce_rate>
-										<exit_rate>50%</exit_rate>
-										<avg_time_generation>0.359</avg_time_generation>
-										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
-										<segment>exitPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
-									</row>
-								</subtable>
-							</row>
-						</subtable>
-					</row>
-				</subtable>
-			</row>
-			<row>
-				<label>world</label>
-				<nb_visits>2</nb_visits>
-				<nb_hits>2</nb_hits>
-				<sum_time_spent>0</sum_time_spent>
-				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-				<min_time_generation>0.359</min_time_generation>
-				<max_time_generation>0.359</max_time_generation>
-				<sum_bandwidth>0</sum_bandwidth>
-				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-				<min_bandwidth />
-				<max_bandwidth />
-				<entry_nb_visits>1</entry_nb_visits>
-				<entry_nb_actions>1</entry_nb_actions>
-				<entry_sum_visit_length>0</entry_sum_visit_length>
-				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>2</exit_nb_visits>
-				<avg_time_on_page>0</avg_time_on_page>
-				<bounce_rate>100%</bounce_rate>
-				<exit_rate>100%</exit_rate>
-				<avg_time_generation>0.359</avg_time_generation>
-				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Fworld</segment>
-				<subtable>
-					<row>
-						<label>/6,681965</label>
-						<nb_visits>2</nb_visits>
-						<nb_hits>2</nb_hits>
-						<sum_time_spent>0</sum_time_spent>
-						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-						<min_time_generation>0.359</min_time_generation>
-						<max_time_generation>0.359</max_time_generation>
-						<sum_bandwidth>0</sum_bandwidth>
-						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-						<min_bandwidth />
-						<max_bandwidth />
-						<entry_nb_visits>1</entry_nb_visits>
-						<entry_nb_actions>1</entry_nb_actions>
-						<entry_sum_visit_length>0</entry_sum_visit_length>
-						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>2</exit_nb_visits>
-						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-						<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
-						<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-						<avg_time_on_page>0</avg_time_on_page>
-						<bounce_rate>100%</bounce_rate>
-						<exit_rate>100%</exit_rate>
-						<avg_time_generation>0.359</avg_time_generation>
-						<url>http://hello.example.com/hello/world/6,681965</url>
-						<segment>exitPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Fworld%252F6%252C681965</segment>
-					</row>
-				</subtable>
-			</row>
-		</subtable>
-	</row>
-	<row>
 		<label>/index</label>
 		<nb_visits>3</nb_visits>
 		<nb_hits>3</nb_hits>
@@ -702,6 +522,186 @@
 		<avg_time_generation>0.001</avg_time_generation>
 		<url>http://piwik.net/</url>
 		<segment>exitPageUrl==http%253A%252F%252Fpiwik.net%252F</segment>
+	</row>
+	<row>
+		<label>hello</label>
+		<nb_visits>3</nb_visits>
+		<nb_hits>4</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<nb_hits_with_time_generation>4</nb_hits_with_time_generation>
+		<min_time_generation>0.359</min_time_generation>
+		<max_time_generation>0.359</max_time_generation>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>2</entry_nb_visits>
+		<entry_nb_actions>4</entry_nb_actions>
+		<entry_sum_visit_length>2</entry_sum_visit_length>
+		<entry_bounce_count>1</entry_bounce_count>
+		<exit_nb_visits>2</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>50%</bounce_rate>
+		<exit_rate>67%</exit_rate>
+		<avg_time_generation>0.359</avg_time_generation>
+		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello</segment>
+		<subtable>
+			<row>
+				<label>world</label>
+				<nb_visits>2</nb_visits>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+				<min_time_generation>0.359</min_time_generation>
+				<max_time_generation>0.359</max_time_generation>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>1</entry_nb_actions>
+				<entry_sum_visit_length>0</entry_sum_visit_length>
+				<entry_bounce_count>1</entry_bounce_count>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>100%</bounce_rate>
+				<exit_rate>50%</exit_rate>
+				<avg_time_generation>0.359</avg_time_generation>
+				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Fworld</segment>
+				<subtable>
+					<row>
+						<label>/6,681965</label>
+						<nb_visits>2</nb_visits>
+						<nb_hits>2</nb_hits>
+						<sum_time_spent>0</sum_time_spent>
+						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+						<min_time_generation>0.359</min_time_generation>
+						<max_time_generation>0.359</max_time_generation>
+						<sum_bandwidth>0</sum_bandwidth>
+						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+						<min_bandwidth />
+						<max_bandwidth />
+						<entry_nb_visits>1</entry_nb_visits>
+						<entry_nb_actions>1</entry_nb_actions>
+						<entry_sum_visit_length>0</entry_sum_visit_length>
+						<entry_bounce_count>1</entry_bounce_count>
+						<exit_nb_visits>1</exit_nb_visits>
+						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+						<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+						<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+						<avg_time_on_page>0</avg_time_on_page>
+						<bounce_rate>100%</bounce_rate>
+						<exit_rate>50%</exit_rate>
+						<avg_time_generation>0.359</avg_time_generation>
+						<url>http://hello.example.com/hello/world/6,681965</url>
+						<segment>exitPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Fworld%252F6%252C681965</segment>
+					</row>
+				</subtable>
+			</row>
+			<row>
+				<label>from</label>
+				<nb_visits>1</nb_visits>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+				<min_time_generation>0.359</min_time_generation>
+				<max_time_generation>0.359</max_time_generation>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>3</entry_nb_actions>
+				<entry_sum_visit_length>2</entry_sum_visit_length>
+				<entry_bounce_count>0</entry_bounce_count>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>100%</exit_rate>
+				<avg_time_generation>0.359</avg_time_generation>
+				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
+				<subtable>
+					<row>
+						<label>another</label>
+						<nb_visits>1</nb_visits>
+						<nb_hits>2</nb_hits>
+						<sum_time_spent>0</sum_time_spent>
+						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+						<min_time_generation>0.359</min_time_generation>
+						<max_time_generation>0.359</max_time_generation>
+						<sum_bandwidth>0</sum_bandwidth>
+						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+						<min_bandwidth />
+						<max_bandwidth />
+						<entry_nb_visits>1</entry_nb_visits>
+						<entry_nb_actions>3</entry_nb_actions>
+						<entry_sum_visit_length>2</entry_sum_visit_length>
+						<entry_bounce_count>0</entry_bounce_count>
+						<exit_nb_visits>1</exit_nb_visits>
+						<avg_time_on_page>0</avg_time_on_page>
+						<bounce_rate>0%</bounce_rate>
+						<exit_rate>100%</exit_rate>
+						<avg_time_generation>0.359</avg_time_generation>
+						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
+						<subtable>
+							<row>
+								<label>world</label>
+								<nb_visits>1</nb_visits>
+								<nb_hits>2</nb_hits>
+								<sum_time_spent>0</sum_time_spent>
+								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+								<min_time_generation>0.359</min_time_generation>
+								<max_time_generation>0.359</max_time_generation>
+								<sum_bandwidth>0</sum_bandwidth>
+								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+								<min_bandwidth />
+								<max_bandwidth />
+								<entry_nb_visits>1</entry_nb_visits>
+								<entry_nb_actions>3</entry_nb_actions>
+								<entry_sum_visit_length>2</entry_sum_visit_length>
+								<entry_bounce_count>0</entry_bounce_count>
+								<exit_nb_visits>1</exit_nb_visits>
+								<avg_time_on_page>0</avg_time_on_page>
+								<bounce_rate>0%</bounce_rate>
+								<exit_rate>100%</exit_rate>
+								<avg_time_generation>0.359</avg_time_generation>
+								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
+								<subtable>
+									<row>
+										<label>/6,681965</label>
+										<nb_visits>1</nb_visits>
+										<nb_hits>2</nb_hits>
+										<sum_time_spent>0</sum_time_spent>
+										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+										<min_time_generation>0.359</min_time_generation>
+										<max_time_generation>0.359</max_time_generation>
+										<sum_bandwidth>0</sum_bandwidth>
+										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+										<min_bandwidth />
+										<max_bandwidth />
+										<entry_nb_visits>1</entry_nb_visits>
+										<entry_nb_actions>3</entry_nb_actions>
+										<entry_sum_visit_length>2</entry_sum_visit_length>
+										<entry_bounce_count>0</entry_bounce_count>
+										<exit_nb_visits>1</exit_nb_visits>
+										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+										<avg_time_on_page>0</avg_time_on_page>
+										<bounce_rate>0%</bounce_rate>
+										<exit_rate>100%</exit_rate>
+										<avg_time_generation>0.359</avg_time_generation>
+										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
+										<segment>exitPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
+									</row>
+								</subtable>
+							</row>
+						</subtable>
+					</row>
+				</subtable>
+			</row>
+		</subtable>
 	</row>
 	<row>
 		<label>Citrix</label>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getExitPageUrls_range.xml
@@ -4,7 +4,7 @@
 		<label>blog</label>
 		<nb_visits>15</nb_visits>
 		<nb_hits>18</nb_hits>
-		<sum_time_spent>166</sum_time_spent>
+		<sum_time_spent>60</sum_time_spent>
 		<nb_hits_with_time_generation>7</nb_hits_with_time_generation>
 		<min_time_generation>0.023</min_time_generation>
 		<max_time_generation>1.324</max_time_generation>
@@ -18,7 +18,7 @@
 		<entry_bounce_count>13</entry_bounce_count>
 		<exit_nb_visits>13</exit_nb_visits>
 		<avg_bandwidth>3030</avg_bandwidth>
-		<avg_time_on_page>9</avg_time_on_page>
+		<avg_time_on_page>3</avg_time_on_page>
 		<bounce_rate>93%</bounce_rate>
 		<exit_rate>87%</exit_rate>
 		<avg_time_generation>0.389</avg_time_generation>
@@ -28,7 +28,7 @@
 				<label>category</label>
 				<nb_visits>12</nb_visits>
 				<nb_hits>15</nb_hits>
-				<sum_time_spent>166</sum_time_spent>
+				<sum_time_spent>60</sum_time_spent>
 				<nb_hits_with_time_generation>5</nb_hits_with_time_generation>
 				<min_time_generation>0.023</min_time_generation>
 				<max_time_generation>1.324</max_time_generation>
@@ -41,7 +41,7 @@
 				<entry_sum_visit_length>54</entry_sum_visit_length>
 				<entry_bounce_count>10</entry_bounce_count>
 				<exit_nb_visits>10</exit_nb_visits>
-				<avg_time_on_page>11</avg_time_on_page>
+				<avg_time_on_page>4</avg_time_on_page>
 				<bounce_rate>91%</bounce_rate>
 				<exit_rate>83%</exit_rate>
 				<avg_time_generation>0.443</avg_time_generation>
@@ -51,7 +51,7 @@
 						<label>meta</label>
 						<nb_visits>10</nb_visits>
 						<nb_hits>12</nb_hits>
-						<sum_time_spent>151</sum_time_spent>
+						<sum_time_spent>52</sum_time_spent>
 						<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 						<min_time_generation>0.023</min_time_generation>
 						<max_time_generation>0.123</max_time_generation>
@@ -64,7 +64,7 @@
 						<entry_sum_visit_length>54</entry_sum_visit_length>
 						<entry_bounce_count>9</entry_bounce_count>
 						<exit_nb_visits>9</exit_nb_visits>
-						<avg_time_on_page>13</avg_time_on_page>
+						<avg_time_on_page>4</avg_time_on_page>
 						<bounce_rate>90%</bounce_rate>
 						<exit_rate>90%</exit_rate>
 						<avg_time_generation>0.089</avg_time_generation>
@@ -74,7 +74,7 @@
 								<label>/index</label>
 								<nb_visits>10</nb_visits>
 								<nb_hits>12</nb_hits>
-								<sum_time_spent>151</sum_time_spent>
+								<sum_time_spent>52</sum_time_spent>
 								<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 								<min_time_generation>0.023</min_time_generation>
 								<max_time_generation>0.123</max_time_generation>
@@ -90,7 +90,7 @@
 								<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>10</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>9</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>13</avg_time_on_page>
+								<avg_time_on_page>4</avg_time_on_page>
 								<bounce_rate>90%</bounce_rate>
 								<exit_rate>90%</exit_rate>
 								<avg_time_generation>0.089</avg_time_generation>
@@ -103,7 +103,7 @@
 						<label>community</label>
 						<nb_visits>2</nb_visits>
 						<nb_hits>3</nb_hits>
-						<sum_time_spent>15</sum_time_spent>
+						<sum_time_spent>8</sum_time_spent>
 						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 						<min_time_generation>0.624</min_time_generation>
 						<max_time_generation>1.324</max_time_generation>
@@ -116,7 +116,7 @@
 						<entry_sum_visit_length>0</entry_sum_visit_length>
 						<entry_bounce_count>1</entry_bounce_count>
 						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>5</avg_time_on_page>
+						<avg_time_on_page>3</avg_time_on_page>
 						<bounce_rate>100%</bounce_rate>
 						<exit_rate>50%</exit_rate>
 						<avg_time_generation>0.974</avg_time_generation>
@@ -126,7 +126,7 @@
 								<label>/index</label>
 								<nb_visits>2</nb_visits>
 								<nb_hits>3</nb_hits>
-								<sum_time_spent>15</sum_time_spent>
+								<sum_time_spent>8</sum_time_spent>
 								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 								<min_time_generation>0.624</min_time_generation>
 								<max_time_generation>1.324</max_time_generation>
@@ -142,7 +142,7 @@
 								<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>5</avg_time_on_page>
+								<avg_time_on_page>3</avg_time_on_page>
 								<bounce_rate>100%</bounce_rate>
 								<exit_rate>50%</exit_rate>
 								<avg_time_generation>0.974</avg_time_generation>
@@ -665,7 +665,7 @@
 		<label>faq</label>
 		<nb_visits>5</nb_visits>
 		<nb_hits>7</nb_hits>
-		<sum_time_spent>52</sum_time_spent>
+		<sum_time_spent>26</sum_time_spent>
 		<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 		<min_time_generation>0.234</min_time_generation>
 		<max_time_generation>0.294</max_time_generation>
@@ -679,7 +679,7 @@
 		<entry_bounce_count>4</entry_bounce_count>
 		<exit_nb_visits>5</exit_nb_visits>
 		<avg_bandwidth>3574</avg_bandwidth>
-		<avg_time_on_page>7</avg_time_on_page>
+		<avg_time_on_page>4</avg_time_on_page>
 		<bounce_rate>100%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 		<avg_time_generation>0.255</avg_time_generation>
@@ -689,7 +689,7 @@
 				<label>/index</label>
 				<nb_visits>3</nb_visits>
 				<nb_hits>5</nb_hits>
-				<sum_time_spent>52</sum_time_spent>
+				<sum_time_spent>26</sum_time_spent>
 				<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 				<min_time_generation>0.234</min_time_generation>
 				<max_time_generation>0.294</max_time_generation>
@@ -705,7 +705,7 @@
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>3</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>10</avg_time_on_page>
+				<avg_time_on_page>5</avg_time_on_page>
 				<bounce_rate>100%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.255</avg_time_generation>
@@ -812,7 +812,7 @@
 	</row>
 	<row>
 		<label>hello</label>
-		<nb_visits>4</nb_visits>
+		<nb_visits>3</nb_visits>
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_generation>4</nb_hits_with_time_generation>
@@ -822,120 +822,18 @@
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
 		<max_bandwidth />
-		<entry_nb_visits>3</entry_nb_visits>
+		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>2</entry_sum_visit_length>
-		<entry_bounce_count>2</entry_bounce_count>
-		<exit_nb_visits>3</exit_nb_visits>
+		<entry_bounce_count>1</entry_bounce_count>
+		<exit_nb_visits>2</exit_nb_visits>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_time_on_page>0</avg_time_on_page>
-		<bounce_rate>67%</bounce_rate>
-		<exit_rate>75%</exit_rate>
+		<bounce_rate>50%</bounce_rate>
+		<exit_rate>67%</exit_rate>
 		<avg_time_generation>0.359</avg_time_generation>
 		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello</segment>
 		<subtable>
-			<row>
-				<label>from</label>
-				<nb_visits>2</nb_visits>
-				<nb_hits>2</nb_hits>
-				<sum_time_spent>0</sum_time_spent>
-				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-				<min_time_generation>0.359</min_time_generation>
-				<max_time_generation>0.359</max_time_generation>
-				<sum_bandwidth>0</sum_bandwidth>
-				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-				<min_bandwidth />
-				<max_bandwidth />
-				<entry_nb_visits>2</entry_nb_visits>
-				<entry_nb_actions>3</entry_nb_actions>
-				<entry_sum_visit_length>2</entry_sum_visit_length>
-				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>0</avg_time_on_page>
-				<bounce_rate>50%</bounce_rate>
-				<exit_rate>50%</exit_rate>
-				<avg_time_generation>0.359</avg_time_generation>
-				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
-				<subtable>
-					<row>
-						<label>another</label>
-						<nb_visits>2</nb_visits>
-						<nb_hits>2</nb_hits>
-						<sum_time_spent>0</sum_time_spent>
-						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-						<min_time_generation>0.359</min_time_generation>
-						<max_time_generation>0.359</max_time_generation>
-						<sum_bandwidth>0</sum_bandwidth>
-						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-						<min_bandwidth />
-						<max_bandwidth />
-						<entry_nb_visits>2</entry_nb_visits>
-						<entry_nb_actions>3</entry_nb_actions>
-						<entry_sum_visit_length>2</entry_sum_visit_length>
-						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>0</avg_time_on_page>
-						<bounce_rate>50%</bounce_rate>
-						<exit_rate>50%</exit_rate>
-						<avg_time_generation>0.359</avg_time_generation>
-						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
-						<subtable>
-							<row>
-								<label>world</label>
-								<nb_visits>2</nb_visits>
-								<nb_hits>2</nb_hits>
-								<sum_time_spent>0</sum_time_spent>
-								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-								<min_time_generation>0.359</min_time_generation>
-								<max_time_generation>0.359</max_time_generation>
-								<sum_bandwidth>0</sum_bandwidth>
-								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-								<min_bandwidth />
-								<max_bandwidth />
-								<entry_nb_visits>2</entry_nb_visits>
-								<entry_nb_actions>3</entry_nb_actions>
-								<entry_sum_visit_length>2</entry_sum_visit_length>
-								<entry_bounce_count>1</entry_bounce_count>
-								<exit_nb_visits>1</exit_nb_visits>
-								<avg_time_on_page>0</avg_time_on_page>
-								<bounce_rate>50%</bounce_rate>
-								<exit_rate>50%</exit_rate>
-								<avg_time_generation>0.359</avg_time_generation>
-								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
-								<subtable>
-									<row>
-										<label>/6,681965</label>
-										<nb_visits>2</nb_visits>
-										<nb_hits>2</nb_hits>
-										<sum_time_spent>0</sum_time_spent>
-										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-										<min_time_generation>0.359</min_time_generation>
-										<max_time_generation>0.359</max_time_generation>
-										<sum_bandwidth>0</sum_bandwidth>
-										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-										<min_bandwidth />
-										<max_bandwidth />
-										<entry_nb_visits>2</entry_nb_visits>
-										<entry_nb_actions>3</entry_nb_actions>
-										<entry_sum_visit_length>2</entry_sum_visit_length>
-										<entry_bounce_count>1</entry_bounce_count>
-										<exit_nb_visits>1</exit_nb_visits>
-										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
-										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-										<avg_time_on_page>0</avg_time_on_page>
-										<bounce_rate>50%</bounce_rate>
-										<exit_rate>50%</exit_rate>
-										<avg_time_generation>0.359</avg_time_generation>
-										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
-										<segment>exitPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
-									</row>
-								</subtable>
-							</row>
-						</subtable>
-					</row>
-				</subtable>
-			</row>
 			<row>
 				<label>world</label>
 				<nb_visits>2</nb_visits>
@@ -952,10 +850,10 @@
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
 				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>2</exit_nb_visits>
+				<exit_nb_visits>1</exit_nb_visits>
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>100%</bounce_rate>
-				<exit_rate>100%</exit_rate>
+				<exit_rate>50%</exit_rate>
 				<avg_time_generation>0.359</avg_time_generation>
 				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Fworld</segment>
 				<subtable>
@@ -975,16 +873,118 @@
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
 						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>2</exit_nb_visits>
+						<exit_nb_visits>1</exit_nb_visits>
 						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 						<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 						<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
 						<avg_time_on_page>0</avg_time_on_page>
 						<bounce_rate>100%</bounce_rate>
-						<exit_rate>100%</exit_rate>
+						<exit_rate>50%</exit_rate>
 						<avg_time_generation>0.359</avg_time_generation>
 						<url>http://hello.example.com/hello/world/6,681965</url>
 						<segment>exitPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Fworld%252F6%252C681965</segment>
+					</row>
+				</subtable>
+			</row>
+			<row>
+				<label>from</label>
+				<nb_visits>1</nb_visits>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+				<min_time_generation>0.359</min_time_generation>
+				<max_time_generation>0.359</max_time_generation>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>3</entry_nb_actions>
+				<entry_sum_visit_length>2</entry_sum_visit_length>
+				<entry_bounce_count>0</entry_bounce_count>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>100%</exit_rate>
+				<avg_time_generation>0.359</avg_time_generation>
+				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
+				<subtable>
+					<row>
+						<label>another</label>
+						<nb_visits>1</nb_visits>
+						<nb_hits>2</nb_hits>
+						<sum_time_spent>0</sum_time_spent>
+						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+						<min_time_generation>0.359</min_time_generation>
+						<max_time_generation>0.359</max_time_generation>
+						<sum_bandwidth>0</sum_bandwidth>
+						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+						<min_bandwidth />
+						<max_bandwidth />
+						<entry_nb_visits>1</entry_nb_visits>
+						<entry_nb_actions>3</entry_nb_actions>
+						<entry_sum_visit_length>2</entry_sum_visit_length>
+						<entry_bounce_count>0</entry_bounce_count>
+						<exit_nb_visits>1</exit_nb_visits>
+						<avg_time_on_page>0</avg_time_on_page>
+						<bounce_rate>0%</bounce_rate>
+						<exit_rate>100%</exit_rate>
+						<avg_time_generation>0.359</avg_time_generation>
+						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
+						<subtable>
+							<row>
+								<label>world</label>
+								<nb_visits>1</nb_visits>
+								<nb_hits>2</nb_hits>
+								<sum_time_spent>0</sum_time_spent>
+								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+								<min_time_generation>0.359</min_time_generation>
+								<max_time_generation>0.359</max_time_generation>
+								<sum_bandwidth>0</sum_bandwidth>
+								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+								<min_bandwidth />
+								<max_bandwidth />
+								<entry_nb_visits>1</entry_nb_visits>
+								<entry_nb_actions>3</entry_nb_actions>
+								<entry_sum_visit_length>2</entry_sum_visit_length>
+								<entry_bounce_count>0</entry_bounce_count>
+								<exit_nb_visits>1</exit_nb_visits>
+								<avg_time_on_page>0</avg_time_on_page>
+								<bounce_rate>0%</bounce_rate>
+								<exit_rate>100%</exit_rate>
+								<avg_time_generation>0.359</avg_time_generation>
+								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
+								<subtable>
+									<row>
+										<label>/6,681965</label>
+										<nb_visits>1</nb_visits>
+										<nb_hits>2</nb_hits>
+										<sum_time_spent>0</sum_time_spent>
+										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+										<min_time_generation>0.359</min_time_generation>
+										<max_time_generation>0.359</max_time_generation>
+										<sum_bandwidth>0</sum_bandwidth>
+										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+										<min_bandwidth />
+										<max_bandwidth />
+										<entry_nb_visits>1</entry_nb_visits>
+										<entry_nb_actions>3</entry_nb_actions>
+										<entry_sum_visit_length>2</entry_sum_visit_length>
+										<entry_bounce_count>0</entry_bounce_count>
+										<exit_nb_visits>1</exit_nb_visits>
+										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+										<avg_time_on_page>0</avg_time_on_page>
+										<bounce_rate>0%</bounce_rate>
+										<exit_rate>100%</exit_rate>
+										<avg_time_generation>0.359</avg_time_generation>
+										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
+										<segment>exitPageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
+									</row>
+								</subtable>
+							</row>
+						</subtable>
 					</row>
 				</subtable>
 			</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_month.xml
@@ -2,7 +2,7 @@
 <result>
 	<row>
 		<label> Page Name not defined</label>
-		<nb_visits>33</nb_visits>
+		<nb_visits>32</nb_visits>
 		<nb_hits>34</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_generation>7</nb_hits_with_time_generation>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageTitles_range.xml
@@ -2,7 +2,7 @@
 <result>
 	<row>
 		<label> Page Name not defined</label>
-		<nb_visits>34</nb_visits>
+		<nb_visits>33</nb_visits>
 		<nb_hits>44</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_generation>17</nb_hits_with_time_generation>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_day.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_day.xml
@@ -4,7 +4,7 @@
 		<label>blog</label>
 		<nb_visits>2</nb_visits>
 		<nb_hits>5</nb_hits>
-		<sum_time_spent>166</sum_time_spent>
+		<sum_time_spent>60</sum_time_spent>
 		<nb_hits_with_time_generation>5</nb_hits_with_time_generation>
 		<min_time_generation>0.023</min_time_generation>
 		<max_time_generation>1.324</max_time_generation>
@@ -17,7 +17,7 @@
 		<entry_sum_visit_length>54</entry_sum_visit_length>
 		<entry_bounce_count>0</entry_bounce_count>
 		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>33</avg_time_on_page>
+		<avg_time_on_page>12</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>0%</exit_rate>
 		<avg_time_generation>0.443</avg_time_generation>
@@ -27,7 +27,7 @@
 				<label>category</label>
 				<nb_visits>2</nb_visits>
 				<nb_hits>5</nb_hits>
-				<sum_time_spent>166</sum_time_spent>
+				<sum_time_spent>60</sum_time_spent>
 				<nb_hits_with_time_generation>5</nb_hits_with_time_generation>
 				<min_time_generation>0.023</min_time_generation>
 				<max_time_generation>1.324</max_time_generation>
@@ -39,7 +39,7 @@
 				<entry_nb_actions>10</entry_nb_actions>
 				<entry_sum_visit_length>54</entry_sum_visit_length>
 				<entry_bounce_count>0</entry_bounce_count>
-				<avg_time_on_page>33</avg_time_on_page>
+				<avg_time_on_page>12</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>0%</exit_rate>
 				<avg_time_generation>0.443</avg_time_generation>
@@ -49,7 +49,7 @@
 						<label>community</label>
 						<nb_visits>1</nb_visits>
 						<nb_hits>2</nb_hits>
-						<sum_time_spent>15</sum_time_spent>
+						<sum_time_spent>8</sum_time_spent>
 						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 						<min_time_generation>0.624</min_time_generation>
 						<max_time_generation>1.324</max_time_generation>
@@ -57,7 +57,7 @@
 						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 						<min_bandwidth />
 						<max_bandwidth />
-						<avg_time_on_page>8</avg_time_on_page>
+						<avg_time_on_page>4</avg_time_on_page>
 						<bounce_rate>0%</bounce_rate>
 						<exit_rate>0%</exit_rate>
 						<avg_time_generation>0.974</avg_time_generation>
@@ -68,7 +68,7 @@
 								<nb_visits>1</nb_visits>
 								<nb_uniq_visitors>1</nb_uniq_visitors>
 								<nb_hits>2</nb_hits>
-								<sum_time_spent>15</sum_time_spent>
+								<sum_time_spent>8</sum_time_spent>
 								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 								<min_time_generation>0.624</min_time_generation>
 								<max_time_generation>1.324</max_time_generation>
@@ -76,7 +76,7 @@
 								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 								<min_bandwidth />
 								<max_bandwidth />
-								<avg_time_on_page>8</avg_time_on_page>
+								<avg_time_on_page>4</avg_time_on_page>
 								<bounce_rate>0%</bounce_rate>
 								<exit_rate>0%</exit_rate>
 								<avg_time_generation>0.974</avg_time_generation>
@@ -89,7 +89,7 @@
 						<label>meta</label>
 						<nb_visits>1</nb_visits>
 						<nb_hits>3</nb_hits>
-						<sum_time_spent>151</sum_time_spent>
+						<sum_time_spent>52</sum_time_spent>
 						<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 						<min_time_generation>0.023</min_time_generation>
 						<max_time_generation>0.123</max_time_generation>
@@ -101,7 +101,7 @@
 						<entry_nb_actions>10</entry_nb_actions>
 						<entry_sum_visit_length>54</entry_sum_visit_length>
 						<entry_bounce_count>0</entry_bounce_count>
-						<avg_time_on_page>50</avg_time_on_page>
+						<avg_time_on_page>17</avg_time_on_page>
 						<bounce_rate>0%</bounce_rate>
 						<exit_rate>0%</exit_rate>
 						<avg_time_generation>0.089</avg_time_generation>
@@ -112,7 +112,7 @@
 								<nb_visits>1</nb_visits>
 								<nb_uniq_visitors>1</nb_uniq_visitors>
 								<nb_hits>3</nb_hits>
-								<sum_time_spent>151</sum_time_spent>
+								<sum_time_spent>52</sum_time_spent>
 								<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 								<min_time_generation>0.023</min_time_generation>
 								<max_time_generation>0.123</max_time_generation>
@@ -125,7 +125,7 @@
 								<entry_nb_actions>10</entry_nb_actions>
 								<entry_sum_visit_length>54</entry_sum_visit_length>
 								<entry_bounce_count>0</entry_bounce_count>
-								<avg_time_on_page>50</avg_time_on_page>
+								<avg_time_on_page>17</avg_time_on_page>
 								<bounce_rate>0%</bounce_rate>
 								<exit_rate>0%</exit_rate>
 								<avg_time_generation>0.089</avg_time_generation>
@@ -203,7 +203,7 @@
 		<label>faq</label>
 		<nb_visits>1</nb_visits>
 		<nb_hits>3</nb_hits>
-		<sum_time_spent>52</sum_time_spent>
+		<sum_time_spent>26</sum_time_spent>
 		<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 		<min_time_generation>0.234</min_time_generation>
 		<max_time_generation>0.294</max_time_generation>
@@ -213,7 +213,7 @@
 		<max_bandwidth />
 		<exit_nb_visits>1</exit_nb_visits>
 		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>17</avg_time_on_page>
+		<avg_time_on_page>9</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 		<avg_time_generation>0.255</avg_time_generation>
@@ -224,7 +224,7 @@
 				<nb_visits>1</nb_visits>
 				<nb_uniq_visitors>1</nb_uniq_visitors>
 				<nb_hits>3</nb_hits>
-				<sum_time_spent>52</sum_time_spent>
+				<sum_time_spent>26</sum_time_spent>
 				<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 				<min_time_generation>0.234</min_time_generation>
 				<max_time_generation>0.294</max_time_generation>
@@ -234,7 +234,7 @@
 				<max_bandwidth />
 				<exit_nb_uniq_visitors>1</exit_nb_uniq_visitors>
 				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>17</avg_time_on_page>
+				<avg_time_on_page>9</avg_time_on_page>
 				<bounce_rate>0%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.255</avg_time_generation>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_month.xml
@@ -496,186 +496,6 @@
 		</subtable>
 	</row>
 	<row>
-		<label>hello</label>
-		<nb_visits>4</nb_visits>
-		<nb_hits>4</nb_hits>
-		<sum_time_spent>0</sum_time_spent>
-		<nb_hits_with_time_generation>4</nb_hits_with_time_generation>
-		<min_time_generation>0.359</min_time_generation>
-		<max_time_generation>0.359</max_time_generation>
-		<sum_bandwidth>0</sum_bandwidth>
-		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-		<min_bandwidth />
-		<max_bandwidth />
-		<entry_nb_visits>3</entry_nb_visits>
-		<entry_nb_actions>4</entry_nb_actions>
-		<entry_sum_visit_length>2</entry_sum_visit_length>
-		<entry_bounce_count>2</entry_bounce_count>
-		<exit_nb_visits>3</exit_nb_visits>
-		<avg_bandwidth>0</avg_bandwidth>
-		<avg_time_on_page>0</avg_time_on_page>
-		<bounce_rate>67%</bounce_rate>
-		<exit_rate>75%</exit_rate>
-		<avg_time_generation>0.359</avg_time_generation>
-		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello</segment>
-		<subtable>
-			<row>
-				<label>from</label>
-				<nb_visits>2</nb_visits>
-				<nb_hits>2</nb_hits>
-				<sum_time_spent>0</sum_time_spent>
-				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-				<min_time_generation>0.359</min_time_generation>
-				<max_time_generation>0.359</max_time_generation>
-				<sum_bandwidth>0</sum_bandwidth>
-				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-				<min_bandwidth />
-				<max_bandwidth />
-				<entry_nb_visits>2</entry_nb_visits>
-				<entry_nb_actions>3</entry_nb_actions>
-				<entry_sum_visit_length>2</entry_sum_visit_length>
-				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>0</avg_time_on_page>
-				<bounce_rate>50%</bounce_rate>
-				<exit_rate>50%</exit_rate>
-				<avg_time_generation>0.359</avg_time_generation>
-				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
-				<subtable>
-					<row>
-						<label>another</label>
-						<nb_visits>2</nb_visits>
-						<nb_hits>2</nb_hits>
-						<sum_time_spent>0</sum_time_spent>
-						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-						<min_time_generation>0.359</min_time_generation>
-						<max_time_generation>0.359</max_time_generation>
-						<sum_bandwidth>0</sum_bandwidth>
-						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-						<min_bandwidth />
-						<max_bandwidth />
-						<entry_nb_visits>2</entry_nb_visits>
-						<entry_nb_actions>3</entry_nb_actions>
-						<entry_sum_visit_length>2</entry_sum_visit_length>
-						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>0</avg_time_on_page>
-						<bounce_rate>50%</bounce_rate>
-						<exit_rate>50%</exit_rate>
-						<avg_time_generation>0.359</avg_time_generation>
-						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
-						<subtable>
-							<row>
-								<label>world</label>
-								<nb_visits>2</nb_visits>
-								<nb_hits>2</nb_hits>
-								<sum_time_spent>0</sum_time_spent>
-								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-								<min_time_generation>0.359</min_time_generation>
-								<max_time_generation>0.359</max_time_generation>
-								<sum_bandwidth>0</sum_bandwidth>
-								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-								<min_bandwidth />
-								<max_bandwidth />
-								<entry_nb_visits>2</entry_nb_visits>
-								<entry_nb_actions>3</entry_nb_actions>
-								<entry_sum_visit_length>2</entry_sum_visit_length>
-								<entry_bounce_count>1</entry_bounce_count>
-								<exit_nb_visits>1</exit_nb_visits>
-								<avg_time_on_page>0</avg_time_on_page>
-								<bounce_rate>50%</bounce_rate>
-								<exit_rate>50%</exit_rate>
-								<avg_time_generation>0.359</avg_time_generation>
-								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
-								<subtable>
-									<row>
-										<label>/6,681965</label>
-										<nb_visits>2</nb_visits>
-										<nb_hits>2</nb_hits>
-										<sum_time_spent>0</sum_time_spent>
-										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-										<min_time_generation>0.359</min_time_generation>
-										<max_time_generation>0.359</max_time_generation>
-										<sum_bandwidth>0</sum_bandwidth>
-										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-										<min_bandwidth />
-										<max_bandwidth />
-										<entry_nb_visits>2</entry_nb_visits>
-										<entry_nb_actions>3</entry_nb_actions>
-										<entry_sum_visit_length>2</entry_sum_visit_length>
-										<entry_bounce_count>1</entry_bounce_count>
-										<exit_nb_visits>1</exit_nb_visits>
-										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
-										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-										<avg_time_on_page>0</avg_time_on_page>
-										<bounce_rate>50%</bounce_rate>
-										<exit_rate>50%</exit_rate>
-										<avg_time_generation>0.359</avg_time_generation>
-										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
-										<segment>pageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
-									</row>
-								</subtable>
-							</row>
-						</subtable>
-					</row>
-				</subtable>
-			</row>
-			<row>
-				<label>world</label>
-				<nb_visits>2</nb_visits>
-				<nb_hits>2</nb_hits>
-				<sum_time_spent>0</sum_time_spent>
-				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-				<min_time_generation>0.359</min_time_generation>
-				<max_time_generation>0.359</max_time_generation>
-				<sum_bandwidth>0</sum_bandwidth>
-				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-				<min_bandwidth />
-				<max_bandwidth />
-				<entry_nb_visits>1</entry_nb_visits>
-				<entry_nb_actions>1</entry_nb_actions>
-				<entry_sum_visit_length>0</entry_sum_visit_length>
-				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>2</exit_nb_visits>
-				<avg_time_on_page>0</avg_time_on_page>
-				<bounce_rate>100%</bounce_rate>
-				<exit_rate>100%</exit_rate>
-				<avg_time_generation>0.359</avg_time_generation>
-				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Fworld</segment>
-				<subtable>
-					<row>
-						<label>/6,681965</label>
-						<nb_visits>2</nb_visits>
-						<nb_hits>2</nb_hits>
-						<sum_time_spent>0</sum_time_spent>
-						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-						<min_time_generation>0.359</min_time_generation>
-						<max_time_generation>0.359</max_time_generation>
-						<sum_bandwidth>0</sum_bandwidth>
-						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-						<min_bandwidth />
-						<max_bandwidth />
-						<entry_nb_visits>1</entry_nb_visits>
-						<entry_nb_actions>1</entry_nb_actions>
-						<entry_sum_visit_length>0</entry_sum_visit_length>
-						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>2</exit_nb_visits>
-						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-						<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
-						<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-						<avg_time_on_page>0</avg_time_on_page>
-						<bounce_rate>100%</bounce_rate>
-						<exit_rate>100%</exit_rate>
-						<avg_time_generation>0.359</avg_time_generation>
-						<url>http://hello.example.com/hello/world/6,681965</url>
-						<segment>pageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Fworld%252F6%252C681965</segment>
-					</row>
-				</subtable>
-			</row>
-		</subtable>
-	</row>
-	<row>
 		<label>/index</label>
 		<nb_visits>3</nb_visits>
 		<nb_hits>3</nb_hits>
@@ -702,6 +522,186 @@
 		<avg_time_generation>0.001</avg_time_generation>
 		<url>http://piwik.net/</url>
 		<segment>pageUrl==http%253A%252F%252Fpiwik.net%252F</segment>
+	</row>
+	<row>
+		<label>hello</label>
+		<nb_visits>3</nb_visits>
+		<nb_hits>4</nb_hits>
+		<sum_time_spent>0</sum_time_spent>
+		<nb_hits_with_time_generation>4</nb_hits_with_time_generation>
+		<min_time_generation>0.359</min_time_generation>
+		<max_time_generation>0.359</max_time_generation>
+		<sum_bandwidth>0</sum_bandwidth>
+		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+		<min_bandwidth />
+		<max_bandwidth />
+		<entry_nb_visits>2</entry_nb_visits>
+		<entry_nb_actions>4</entry_nb_actions>
+		<entry_sum_visit_length>2</entry_sum_visit_length>
+		<entry_bounce_count>1</entry_bounce_count>
+		<exit_nb_visits>2</exit_nb_visits>
+		<avg_bandwidth>0</avg_bandwidth>
+		<avg_time_on_page>0</avg_time_on_page>
+		<bounce_rate>50%</bounce_rate>
+		<exit_rate>67%</exit_rate>
+		<avg_time_generation>0.359</avg_time_generation>
+		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello</segment>
+		<subtable>
+			<row>
+				<label>world</label>
+				<nb_visits>2</nb_visits>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+				<min_time_generation>0.359</min_time_generation>
+				<max_time_generation>0.359</max_time_generation>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>1</entry_nb_actions>
+				<entry_sum_visit_length>0</entry_sum_visit_length>
+				<entry_bounce_count>1</entry_bounce_count>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>100%</bounce_rate>
+				<exit_rate>50%</exit_rate>
+				<avg_time_generation>0.359</avg_time_generation>
+				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Fworld</segment>
+				<subtable>
+					<row>
+						<label>/6,681965</label>
+						<nb_visits>2</nb_visits>
+						<nb_hits>2</nb_hits>
+						<sum_time_spent>0</sum_time_spent>
+						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+						<min_time_generation>0.359</min_time_generation>
+						<max_time_generation>0.359</max_time_generation>
+						<sum_bandwidth>0</sum_bandwidth>
+						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+						<min_bandwidth />
+						<max_bandwidth />
+						<entry_nb_visits>1</entry_nb_visits>
+						<entry_nb_actions>1</entry_nb_actions>
+						<entry_sum_visit_length>0</entry_sum_visit_length>
+						<entry_bounce_count>1</entry_bounce_count>
+						<exit_nb_visits>1</exit_nb_visits>
+						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+						<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+						<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+						<avg_time_on_page>0</avg_time_on_page>
+						<bounce_rate>100%</bounce_rate>
+						<exit_rate>50%</exit_rate>
+						<avg_time_generation>0.359</avg_time_generation>
+						<url>http://hello.example.com/hello/world/6,681965</url>
+						<segment>pageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Fworld%252F6%252C681965</segment>
+					</row>
+				</subtable>
+			</row>
+			<row>
+				<label>from</label>
+				<nb_visits>1</nb_visits>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+				<min_time_generation>0.359</min_time_generation>
+				<max_time_generation>0.359</max_time_generation>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>3</entry_nb_actions>
+				<entry_sum_visit_length>2</entry_sum_visit_length>
+				<entry_bounce_count>0</entry_bounce_count>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>100%</exit_rate>
+				<avg_time_generation>0.359</avg_time_generation>
+				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
+				<subtable>
+					<row>
+						<label>another</label>
+						<nb_visits>1</nb_visits>
+						<nb_hits>2</nb_hits>
+						<sum_time_spent>0</sum_time_spent>
+						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+						<min_time_generation>0.359</min_time_generation>
+						<max_time_generation>0.359</max_time_generation>
+						<sum_bandwidth>0</sum_bandwidth>
+						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+						<min_bandwidth />
+						<max_bandwidth />
+						<entry_nb_visits>1</entry_nb_visits>
+						<entry_nb_actions>3</entry_nb_actions>
+						<entry_sum_visit_length>2</entry_sum_visit_length>
+						<entry_bounce_count>0</entry_bounce_count>
+						<exit_nb_visits>1</exit_nb_visits>
+						<avg_time_on_page>0</avg_time_on_page>
+						<bounce_rate>0%</bounce_rate>
+						<exit_rate>100%</exit_rate>
+						<avg_time_generation>0.359</avg_time_generation>
+						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
+						<subtable>
+							<row>
+								<label>world</label>
+								<nb_visits>1</nb_visits>
+								<nb_hits>2</nb_hits>
+								<sum_time_spent>0</sum_time_spent>
+								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+								<min_time_generation>0.359</min_time_generation>
+								<max_time_generation>0.359</max_time_generation>
+								<sum_bandwidth>0</sum_bandwidth>
+								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+								<min_bandwidth />
+								<max_bandwidth />
+								<entry_nb_visits>1</entry_nb_visits>
+								<entry_nb_actions>3</entry_nb_actions>
+								<entry_sum_visit_length>2</entry_sum_visit_length>
+								<entry_bounce_count>0</entry_bounce_count>
+								<exit_nb_visits>1</exit_nb_visits>
+								<avg_time_on_page>0</avg_time_on_page>
+								<bounce_rate>0%</bounce_rate>
+								<exit_rate>100%</exit_rate>
+								<avg_time_generation>0.359</avg_time_generation>
+								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
+								<subtable>
+									<row>
+										<label>/6,681965</label>
+										<nb_visits>1</nb_visits>
+										<nb_hits>2</nb_hits>
+										<sum_time_spent>0</sum_time_spent>
+										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+										<min_time_generation>0.359</min_time_generation>
+										<max_time_generation>0.359</max_time_generation>
+										<sum_bandwidth>0</sum_bandwidth>
+										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+										<min_bandwidth />
+										<max_bandwidth />
+										<entry_nb_visits>1</entry_nb_visits>
+										<entry_nb_actions>3</entry_nb_actions>
+										<entry_sum_visit_length>2</entry_sum_visit_length>
+										<entry_bounce_count>0</entry_bounce_count>
+										<exit_nb_visits>1</exit_nb_visits>
+										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+										<avg_time_on_page>0</avg_time_on_page>
+										<bounce_rate>0%</bounce_rate>
+										<exit_rate>100%</exit_rate>
+										<avg_time_generation>0.359</avg_time_generation>
+										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
+										<segment>pageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
+									</row>
+								</subtable>
+							</row>
+						</subtable>
+					</row>
+				</subtable>
+			</row>
+		</subtable>
 	</row>
 	<row>
 		<label>Citrix</label>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.getPageUrls_range.xml
@@ -4,7 +4,7 @@
 		<label>blog</label>
 		<nb_visits>15</nb_visits>
 		<nb_hits>18</nb_hits>
-		<sum_time_spent>166</sum_time_spent>
+		<sum_time_spent>60</sum_time_spent>
 		<nb_hits_with_time_generation>7</nb_hits_with_time_generation>
 		<min_time_generation>0.023</min_time_generation>
 		<max_time_generation>1.324</max_time_generation>
@@ -18,7 +18,7 @@
 		<entry_bounce_count>13</entry_bounce_count>
 		<exit_nb_visits>13</exit_nb_visits>
 		<avg_bandwidth>3030</avg_bandwidth>
-		<avg_time_on_page>9</avg_time_on_page>
+		<avg_time_on_page>3</avg_time_on_page>
 		<bounce_rate>93%</bounce_rate>
 		<exit_rate>87%</exit_rate>
 		<avg_time_generation>0.389</avg_time_generation>
@@ -28,7 +28,7 @@
 				<label>category</label>
 				<nb_visits>12</nb_visits>
 				<nb_hits>15</nb_hits>
-				<sum_time_spent>166</sum_time_spent>
+				<sum_time_spent>60</sum_time_spent>
 				<nb_hits_with_time_generation>5</nb_hits_with_time_generation>
 				<min_time_generation>0.023</min_time_generation>
 				<max_time_generation>1.324</max_time_generation>
@@ -41,7 +41,7 @@
 				<entry_sum_visit_length>54</entry_sum_visit_length>
 				<entry_bounce_count>10</entry_bounce_count>
 				<exit_nb_visits>10</exit_nb_visits>
-				<avg_time_on_page>11</avg_time_on_page>
+				<avg_time_on_page>4</avg_time_on_page>
 				<bounce_rate>91%</bounce_rate>
 				<exit_rate>83%</exit_rate>
 				<avg_time_generation>0.443</avg_time_generation>
@@ -51,7 +51,7 @@
 						<label>meta</label>
 						<nb_visits>10</nb_visits>
 						<nb_hits>12</nb_hits>
-						<sum_time_spent>151</sum_time_spent>
+						<sum_time_spent>52</sum_time_spent>
 						<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 						<min_time_generation>0.023</min_time_generation>
 						<max_time_generation>0.123</max_time_generation>
@@ -64,7 +64,7 @@
 						<entry_sum_visit_length>54</entry_sum_visit_length>
 						<entry_bounce_count>9</entry_bounce_count>
 						<exit_nb_visits>9</exit_nb_visits>
-						<avg_time_on_page>13</avg_time_on_page>
+						<avg_time_on_page>4</avg_time_on_page>
 						<bounce_rate>90%</bounce_rate>
 						<exit_rate>90%</exit_rate>
 						<avg_time_generation>0.089</avg_time_generation>
@@ -74,7 +74,7 @@
 								<label>/index</label>
 								<nb_visits>10</nb_visits>
 								<nb_hits>12</nb_hits>
-								<sum_time_spent>151</sum_time_spent>
+								<sum_time_spent>52</sum_time_spent>
 								<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 								<min_time_generation>0.023</min_time_generation>
 								<max_time_generation>0.123</max_time_generation>
@@ -90,7 +90,7 @@
 								<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>10</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>9</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>13</avg_time_on_page>
+								<avg_time_on_page>4</avg_time_on_page>
 								<bounce_rate>90%</bounce_rate>
 								<exit_rate>90%</exit_rate>
 								<avg_time_generation>0.089</avg_time_generation>
@@ -103,7 +103,7 @@
 						<label>community</label>
 						<nb_visits>2</nb_visits>
 						<nb_hits>3</nb_hits>
-						<sum_time_spent>15</sum_time_spent>
+						<sum_time_spent>8</sum_time_spent>
 						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 						<min_time_generation>0.624</min_time_generation>
 						<max_time_generation>1.324</max_time_generation>
@@ -116,7 +116,7 @@
 						<entry_sum_visit_length>0</entry_sum_visit_length>
 						<entry_bounce_count>1</entry_bounce_count>
 						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>5</avg_time_on_page>
+						<avg_time_on_page>3</avg_time_on_page>
 						<bounce_rate>100%</bounce_rate>
 						<exit_rate>50%</exit_rate>
 						<avg_time_generation>0.974</avg_time_generation>
@@ -126,7 +126,7 @@
 								<label>/index</label>
 								<nb_visits>2</nb_visits>
 								<nb_hits>3</nb_hits>
-								<sum_time_spent>15</sum_time_spent>
+								<sum_time_spent>8</sum_time_spent>
 								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
 								<min_time_generation>0.624</min_time_generation>
 								<max_time_generation>1.324</max_time_generation>
@@ -142,7 +142,7 @@
 								<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 								<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 								<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-								<avg_time_on_page>5</avg_time_on_page>
+								<avg_time_on_page>3</avg_time_on_page>
 								<bounce_rate>100%</bounce_rate>
 								<exit_rate>50%</exit_rate>
 								<avg_time_generation>0.974</avg_time_generation>
@@ -665,7 +665,7 @@
 		<label>faq</label>
 		<nb_visits>5</nb_visits>
 		<nb_hits>7</nb_hits>
-		<sum_time_spent>52</sum_time_spent>
+		<sum_time_spent>26</sum_time_spent>
 		<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 		<min_time_generation>0.234</min_time_generation>
 		<max_time_generation>0.294</max_time_generation>
@@ -679,7 +679,7 @@
 		<entry_bounce_count>4</entry_bounce_count>
 		<exit_nb_visits>5</exit_nb_visits>
 		<avg_bandwidth>3574</avg_bandwidth>
-		<avg_time_on_page>7</avg_time_on_page>
+		<avg_time_on_page>4</avg_time_on_page>
 		<bounce_rate>100%</bounce_rate>
 		<exit_rate>100%</exit_rate>
 		<avg_time_generation>0.255</avg_time_generation>
@@ -689,7 +689,7 @@
 				<label>/index</label>
 				<nb_visits>3</nb_visits>
 				<nb_hits>5</nb_hits>
-				<sum_time_spent>52</sum_time_spent>
+				<sum_time_spent>26</sum_time_spent>
 				<nb_hits_with_time_generation>3</nb_hits_with_time_generation>
 				<min_time_generation>0.234</min_time_generation>
 				<max_time_generation>0.294</max_time_generation>
@@ -705,7 +705,7 @@
 				<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 				<sum_daily_entry_nb_uniq_visitors>2</sum_daily_entry_nb_uniq_visitors>
 				<sum_daily_exit_nb_uniq_visitors>3</sum_daily_exit_nb_uniq_visitors>
-				<avg_time_on_page>10</avg_time_on_page>
+				<avg_time_on_page>5</avg_time_on_page>
 				<bounce_rate>100%</bounce_rate>
 				<exit_rate>100%</exit_rate>
 				<avg_time_generation>0.255</avg_time_generation>
@@ -812,7 +812,7 @@
 	</row>
 	<row>
 		<label>hello</label>
-		<nb_visits>4</nb_visits>
+		<nb_visits>3</nb_visits>
 		<nb_hits>4</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<nb_hits_with_time_generation>4</nb_hits_with_time_generation>
@@ -822,120 +822,18 @@
 		<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
 		<min_bandwidth />
 		<max_bandwidth />
-		<entry_nb_visits>3</entry_nb_visits>
+		<entry_nb_visits>2</entry_nb_visits>
 		<entry_nb_actions>4</entry_nb_actions>
 		<entry_sum_visit_length>2</entry_sum_visit_length>
-		<entry_bounce_count>2</entry_bounce_count>
-		<exit_nb_visits>3</exit_nb_visits>
+		<entry_bounce_count>1</entry_bounce_count>
+		<exit_nb_visits>2</exit_nb_visits>
 		<avg_bandwidth>0</avg_bandwidth>
 		<avg_time_on_page>0</avg_time_on_page>
-		<bounce_rate>67%</bounce_rate>
-		<exit_rate>75%</exit_rate>
+		<bounce_rate>50%</bounce_rate>
+		<exit_rate>67%</exit_rate>
 		<avg_time_generation>0.359</avg_time_generation>
 		<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello</segment>
 		<subtable>
-			<row>
-				<label>from</label>
-				<nb_visits>2</nb_visits>
-				<nb_hits>2</nb_hits>
-				<sum_time_spent>0</sum_time_spent>
-				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-				<min_time_generation>0.359</min_time_generation>
-				<max_time_generation>0.359</max_time_generation>
-				<sum_bandwidth>0</sum_bandwidth>
-				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-				<min_bandwidth />
-				<max_bandwidth />
-				<entry_nb_visits>2</entry_nb_visits>
-				<entry_nb_actions>3</entry_nb_actions>
-				<entry_sum_visit_length>2</entry_sum_visit_length>
-				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>1</exit_nb_visits>
-				<avg_time_on_page>0</avg_time_on_page>
-				<bounce_rate>50%</bounce_rate>
-				<exit_rate>50%</exit_rate>
-				<avg_time_generation>0.359</avg_time_generation>
-				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
-				<subtable>
-					<row>
-						<label>another</label>
-						<nb_visits>2</nb_visits>
-						<nb_hits>2</nb_hits>
-						<sum_time_spent>0</sum_time_spent>
-						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-						<min_time_generation>0.359</min_time_generation>
-						<max_time_generation>0.359</max_time_generation>
-						<sum_bandwidth>0</sum_bandwidth>
-						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-						<min_bandwidth />
-						<max_bandwidth />
-						<entry_nb_visits>2</entry_nb_visits>
-						<entry_nb_actions>3</entry_nb_actions>
-						<entry_sum_visit_length>2</entry_sum_visit_length>
-						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>1</exit_nb_visits>
-						<avg_time_on_page>0</avg_time_on_page>
-						<bounce_rate>50%</bounce_rate>
-						<exit_rate>50%</exit_rate>
-						<avg_time_generation>0.359</avg_time_generation>
-						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
-						<subtable>
-							<row>
-								<label>world</label>
-								<nb_visits>2</nb_visits>
-								<nb_hits>2</nb_hits>
-								<sum_time_spent>0</sum_time_spent>
-								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-								<min_time_generation>0.359</min_time_generation>
-								<max_time_generation>0.359</max_time_generation>
-								<sum_bandwidth>0</sum_bandwidth>
-								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-								<min_bandwidth />
-								<max_bandwidth />
-								<entry_nb_visits>2</entry_nb_visits>
-								<entry_nb_actions>3</entry_nb_actions>
-								<entry_sum_visit_length>2</entry_sum_visit_length>
-								<entry_bounce_count>1</entry_bounce_count>
-								<exit_nb_visits>1</exit_nb_visits>
-								<avg_time_on_page>0</avg_time_on_page>
-								<bounce_rate>50%</bounce_rate>
-								<exit_rate>50%</exit_rate>
-								<avg_time_generation>0.359</avg_time_generation>
-								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
-								<subtable>
-									<row>
-										<label>/6,681965</label>
-										<nb_visits>2</nb_visits>
-										<nb_hits>2</nb_hits>
-										<sum_time_spent>0</sum_time_spent>
-										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
-										<min_time_generation>0.359</min_time_generation>
-										<max_time_generation>0.359</max_time_generation>
-										<sum_bandwidth>0</sum_bandwidth>
-										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
-										<min_bandwidth />
-										<max_bandwidth />
-										<entry_nb_visits>2</entry_nb_visits>
-										<entry_nb_actions>3</entry_nb_actions>
-										<entry_sum_visit_length>2</entry_sum_visit_length>
-										<entry_bounce_count>1</entry_bounce_count>
-										<exit_nb_visits>1</exit_nb_visits>
-										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
-										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
-										<avg_time_on_page>0</avg_time_on_page>
-										<bounce_rate>50%</bounce_rate>
-										<exit_rate>50%</exit_rate>
-										<avg_time_generation>0.359</avg_time_generation>
-										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
-										<segment>pageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
-									</row>
-								</subtable>
-							</row>
-						</subtable>
-					</row>
-				</subtable>
-			</row>
 			<row>
 				<label>world</label>
 				<nb_visits>2</nb_visits>
@@ -952,10 +850,10 @@
 				<entry_nb_actions>1</entry_nb_actions>
 				<entry_sum_visit_length>0</entry_sum_visit_length>
 				<entry_bounce_count>1</entry_bounce_count>
-				<exit_nb_visits>2</exit_nb_visits>
+				<exit_nb_visits>1</exit_nb_visits>
 				<avg_time_on_page>0</avg_time_on_page>
 				<bounce_rate>100%</bounce_rate>
-				<exit_rate>100%</exit_rate>
+				<exit_rate>50%</exit_rate>
 				<avg_time_generation>0.359</avg_time_generation>
 				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Fworld</segment>
 				<subtable>
@@ -975,16 +873,118 @@
 						<entry_nb_actions>1</entry_nb_actions>
 						<entry_sum_visit_length>0</entry_sum_visit_length>
 						<entry_bounce_count>1</entry_bounce_count>
-						<exit_nb_visits>2</exit_nb_visits>
+						<exit_nb_visits>1</exit_nb_visits>
 						<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 						<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 						<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
 						<avg_time_on_page>0</avg_time_on_page>
 						<bounce_rate>100%</bounce_rate>
-						<exit_rate>100%</exit_rate>
+						<exit_rate>50%</exit_rate>
 						<avg_time_generation>0.359</avg_time_generation>
 						<url>http://hello.example.com/hello/world/6,681965</url>
 						<segment>pageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Fworld%252F6%252C681965</segment>
+					</row>
+				</subtable>
+			</row>
+			<row>
+				<label>from</label>
+				<nb_visits>1</nb_visits>
+				<nb_hits>2</nb_hits>
+				<sum_time_spent>0</sum_time_spent>
+				<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+				<min_time_generation>0.359</min_time_generation>
+				<max_time_generation>0.359</max_time_generation>
+				<sum_bandwidth>0</sum_bandwidth>
+				<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+				<min_bandwidth />
+				<max_bandwidth />
+				<entry_nb_visits>1</entry_nb_visits>
+				<entry_nb_actions>3</entry_nb_actions>
+				<entry_sum_visit_length>2</entry_sum_visit_length>
+				<entry_bounce_count>0</entry_bounce_count>
+				<exit_nb_visits>1</exit_nb_visits>
+				<avg_time_on_page>0</avg_time_on_page>
+				<bounce_rate>0%</bounce_rate>
+				<exit_rate>100%</exit_rate>
+				<avg_time_generation>0.359</avg_time_generation>
+				<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom</segment>
+				<subtable>
+					<row>
+						<label>another</label>
+						<nb_visits>1</nb_visits>
+						<nb_hits>2</nb_hits>
+						<sum_time_spent>0</sum_time_spent>
+						<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+						<min_time_generation>0.359</min_time_generation>
+						<max_time_generation>0.359</max_time_generation>
+						<sum_bandwidth>0</sum_bandwidth>
+						<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+						<min_bandwidth />
+						<max_bandwidth />
+						<entry_nb_visits>1</entry_nb_visits>
+						<entry_nb_actions>3</entry_nb_actions>
+						<entry_sum_visit_length>2</entry_sum_visit_length>
+						<entry_bounce_count>0</entry_bounce_count>
+						<exit_nb_visits>1</exit_nb_visits>
+						<avg_time_on_page>0</avg_time_on_page>
+						<bounce_rate>0%</bounce_rate>
+						<exit_rate>100%</exit_rate>
+						<avg_time_generation>0.359</avg_time_generation>
+						<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother</segment>
+						<subtable>
+							<row>
+								<label>world</label>
+								<nb_visits>1</nb_visits>
+								<nb_hits>2</nb_hits>
+								<sum_time_spent>0</sum_time_spent>
+								<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+								<min_time_generation>0.359</min_time_generation>
+								<max_time_generation>0.359</max_time_generation>
+								<sum_bandwidth>0</sum_bandwidth>
+								<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+								<min_bandwidth />
+								<max_bandwidth />
+								<entry_nb_visits>1</entry_nb_visits>
+								<entry_nb_actions>3</entry_nb_actions>
+								<entry_sum_visit_length>2</entry_sum_visit_length>
+								<entry_bounce_count>0</entry_bounce_count>
+								<exit_nb_visits>1</exit_nb_visits>
+								<avg_time_on_page>0</avg_time_on_page>
+								<bounce_rate>0%</bounce_rate>
+								<exit_rate>100%</exit_rate>
+								<avg_time_generation>0.359</avg_time_generation>
+								<segment>pageUrl=^http%253A%252F%252Fpiwik.net%252Fhello%252Ffrom%252Fanother%252Fworld</segment>
+								<subtable>
+									<row>
+										<label>/6,681965</label>
+										<nb_visits>1</nb_visits>
+										<nb_hits>2</nb_hits>
+										<sum_time_spent>0</sum_time_spent>
+										<nb_hits_with_time_generation>2</nb_hits_with_time_generation>
+										<min_time_generation>0.359</min_time_generation>
+										<max_time_generation>0.359</max_time_generation>
+										<sum_bandwidth>0</sum_bandwidth>
+										<nb_hits_with_bandwidth>0</nb_hits_with_bandwidth>
+										<min_bandwidth />
+										<max_bandwidth />
+										<entry_nb_visits>1</entry_nb_visits>
+										<entry_nb_actions>3</entry_nb_actions>
+										<entry_sum_visit_length>2</entry_sum_visit_length>
+										<entry_bounce_count>0</entry_bounce_count>
+										<exit_nb_visits>1</exit_nb_visits>
+										<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+										<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
+										<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
+										<avg_time_on_page>0</avg_time_on_page>
+										<bounce_rate>0%</bounce_rate>
+										<exit_rate>100%</exit_rate>
+										<avg_time_generation>0.359</avg_time_generation>
+										<url>http://hello.example.com/hello/from/another/world/6,681965</url>
+										<segment>pageUrl==http%253A%252F%252Fhello.example.com%252Fhello%252Ffrom%252Fanother%252Fworld%252F6%252C681965</segment>
+									</row>
+								</subtable>
+							</row>
+						</subtable>
 					</row>
 				</subtable>
 			</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.get_month.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<nb_pageviews>45</nb_pageviews>
-	<nb_uniq_pageviews>43</nb_uniq_pageviews>
+	<nb_uniq_pageviews>42</nb_uniq_pageviews>
 	<nb_downloads>4</nb_downloads>
 	<nb_uniq_downloads>4</nb_uniq_downloads>
 	<nb_outlinks>0</nb_outlinks>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Actions.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Actions.get_range.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<nb_pageviews>69</nb_pageviews>
-	<nb_uniq_pageviews>61</nb_uniq_pageviews>
+	<nb_uniq_pageviews>60</nb_uniq_pageviews>
 	<nb_downloads>5</nb_downloads>
 	<nb_uniq_downloads>5</nb_uniq_downloads>
 	<nb_outlinks>1</nb_outlinks>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__CustomVariables.getCustomVariables_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__CustomVariables.getCustomVariables_month.xml
@@ -156,22 +156,13 @@
 	<row>
 		<label>User Name</label>
 		<nb_visits>3</nb_visits>
-		<nb_actions>5</nb_actions>
-		<max_actions>2</max_actions>
-		<sum_visit_length>5</sum_visit_length>
-		<bounce_count>1</bounce_count>
+		<nb_actions>7</nb_actions>
+		<max_actions>3</max_actions>
+		<sum_visit_length>6</sum_visit_length>
+		<bounce_count>0</bounce_count>
 		<nb_visits_converted>3</nb_visits_converted>
-		<goals>
-			<row idgoal='1'>
-				<nb_conversions>1</nb_conversions>
-				<nb_visits_converted>1</nb_visits_converted>
-				<revenue>5</revenue>
-			</row>
-		</goals>
-		<nb_conversions>1</nb_conversions>
-		<revenue>5</revenue>
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
-		<sum_daily_nb_users>1</sum_daily_nb_users>
+		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<slots>
 			<row>
 				<scope>visit</scope>
@@ -194,22 +185,13 @@
 			<row>
 				<label>user2</label>
 				<nb_visits>1</nb_visits>
-				<nb_actions>1</nb_actions>
-				<max_actions>1</max_actions>
-				<sum_visit_length>1</sum_visit_length>
-				<bounce_count>1</bounce_count>
+				<nb_actions>3</nb_actions>
+				<max_actions>3</max_actions>
+				<sum_visit_length>2</sum_visit_length>
+				<bounce_count>0</bounce_count>
 				<nb_visits_converted>1</nb_visits_converted>
-				<goals>
-					<row idgoal='1'>
-						<nb_conversions>1</nb_conversions>
-						<nb_visits_converted>1</nb_visits_converted>
-						<revenue>5</revenue>
-					</row>
-				</goals>
-				<nb_conversions>1</nb_conversions>
-				<revenue>5</revenue>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-				<sum_daily_nb_users>0</sum_daily_nb_users>
+				<sum_daily_nb_users>1</sum_daily_nb_users>
 			</row>
 		</subtable>
 	</row>
@@ -226,7 +208,7 @@
 		<subtable>
 			<row>
 				<label>359</label>
-				<nb_visits>2</nb_visits>
+				<nb_visits>1</nb_visits>
 				<nb_actions>2</nb_actions>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 			</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__CustomVariables.getUsagesOfSlots.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__CustomVariables.getUsagesOfSlots.xml
@@ -17,7 +17,7 @@
 			<row>
 				<name>User Name</name>
 				<nb_visits>3</nb_visits>
-				<nb_actions>5</nb_actions>
+				<nb_actions>7</nb_actions>
 			</row>
 			<row>
 				<name>Bot</name>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicePlugins.getPlugin_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicePlugins.getPlugin_month.xml
@@ -3,19 +3,19 @@
 	<row>
 		<label>Cookie</label>
 		<nb_visits>2</nb_visits>
-		<nb_visits_percentage>5%</nb_visits_percentage>
+		<nb_visits_percentage>6%</nb_visits_percentage>
 		<logo>plugins/Morpheus/icons/dist/plugins/cookie.png</logo>
 	</row>
 	<row>
 		<label>Flash</label>
 		<nb_visits>2</nb_visits>
-		<nb_visits_percentage>5%</nb_visits_percentage>
+		<nb_visits_percentage>6%</nb_visits_percentage>
 		<logo>plugins/Morpheus/icons/dist/plugins/flash.png</logo>
 	</row>
 	<row>
 		<label>Java</label>
 		<nb_visits>2</nb_visits>
-		<nb_visits_percentage>5%</nb_visits_percentage>
+		<nb_visits_percentage>6%</nb_visits_percentage>
 		<logo>plugins/Morpheus/icons/dist/plugins/java.png</logo>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrand_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrand_month.xml
@@ -24,21 +24,21 @@
 	</row>
 	<row>
 		<label>Apple</label>
-		<nb_visits>18</nb_visits>
+		<nb_visits>17</nb_visits>
 		<nb_actions>23</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>309</sum_visit_length>
-		<bounce_count>14</bounce_count>
-		<nb_visits_converted>17</nb_visits_converted>
+		<bounce_count>13</bounce_count>
+		<nb_visits_converted>16</nb_visits_converted>
 		<goals>
 			<row idgoal='1'>
-				<nb_conversions>17</nb_conversions>
-				<nb_visits_converted>17</nb_visits_converted>
-				<revenue>85</revenue>
+				<nb_conversions>16</nb_conversions>
+				<nb_visits_converted>16</nb_visits_converted>
+				<revenue>80</revenue>
 			</row>
 		</goals>
-		<nb_conversions>17</nb_conversions>
-		<revenue>85</revenue>
+		<nb_conversions>16</nb_conversions>
+		<revenue>80</revenue>
 		<sum_daily_nb_uniq_visitors>16</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<logo>plugins/Morpheus/icons/dist/brand/Apple.png</logo>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrowserEngines_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrowserEngines_month.xml
@@ -26,12 +26,12 @@
 	</row>
 	<row>
 		<label>Blink (Chrome, Opera)</label>
-		<nb_visits>6</nb_visits>
+		<nb_visits>5</nb_visits>
 		<nb_actions>9</nb_actions>
-		<max_actions>2</max_actions>
+		<max_actions>3</max_actions>
 		<sum_visit_length>6</sum_visit_length>
-		<bounce_count>3</bounce_count>
-		<nb_visits_converted>6</nb_visits_converted>
+		<bounce_count>2</bounce_count>
+		<nb_visits_converted>5</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>4</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<segment>browserEngine==Blink</segment>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrowserFamilies_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrowserFamilies_month.xml
@@ -14,12 +14,12 @@
 	</row>
 	<row>
 		<label>Chrome</label>
-		<nb_visits>10</nb_visits>
+		<nb_visits>9</nb_visits>
 		<nb_actions>12</nb_actions>
-		<max_actions>2</max_actions>
+		<max_actions>3</max_actions>
 		<sum_visit_length>4</sum_visit_length>
-		<bounce_count>8</bounce_count>
-		<nb_visits_converted>10</nb_visits_converted>
+		<bounce_count>7</bounce_count>
+		<nb_visits_converted>9</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		<logo>plugins/Morpheus/icons/dist/browsers/CH.png</logo>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrowserVersions_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrowserVersions_month.xml
@@ -53,19 +53,6 @@
 		<logo>plugins/Morpheus/icons/dist/browsers/UNK.png</logo>
 	</row>
 	<row>
-		<label>Chrome 37.0</label>
-		<nb_visits>3</nb_visits>
-		<nb_actions>4</nb_actions>
-		<max_actions>2</max_actions>
-		<sum_visit_length>2</sum_visit_length>
-		<bounce_count>2</bounce_count>
-		<nb_visits_converted>3</nb_visits_converted>
-		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
-		<sum_daily_nb_users>1</sum_daily_nb_users>
-		<segment>browserCode==CH;browserVersion==37.0</segment>
-		<logo>plugins/Morpheus/icons/dist/browsers/CH.png</logo>
-	</row>
-	<row>
 		<label>Android Browser</label>
 		<nb_visits>2</nb_visits>
 		<nb_actions>2</nb_actions>
@@ -102,6 +89,19 @@
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>1</sum_daily_nb_users>
 		<segment>browserCode==CH;browserVersion==20.0</segment>
+		<logo>plugins/Morpheus/icons/dist/browsers/CH.png</logo>
+	</row>
+	<row>
+		<label>Chrome 37.0</label>
+		<nb_visits>2</nb_visits>
+		<nb_actions>4</nb_actions>
+		<max_actions>3</max_actions>
+		<sum_visit_length>2</sum_visit_length>
+		<bounce_count>1</bounce_count>
+		<nb_visits_converted>2</nb_visits_converted>
+		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
+		<sum_daily_nb_users>1</sum_daily_nb_users>
+		<segment>browserCode==CH;browserVersion==37.0</segment>
 		<logo>plugins/Morpheus/icons/dist/browsers/CH.png</logo>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrowsers_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getBrowsers_month.xml
@@ -15,12 +15,12 @@
 	</row>
 	<row>
 		<label>Chrome</label>
-		<nb_visits>10</nb_visits>
+		<nb_visits>9</nb_visits>
 		<nb_actions>12</nb_actions>
-		<max_actions>2</max_actions>
+		<max_actions>3</max_actions>
 		<sum_visit_length>4</sum_visit_length>
-		<bounce_count>8</bounce_count>
-		<nb_visits_converted>10</nb_visits_converted>
+		<bounce_count>7</bounce_count>
+		<nb_visits_converted>9</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>8</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		<logo>plugins/Morpheus/icons/dist/browsers/CH.png</logo>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getModel_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getModel_month.xml
@@ -23,21 +23,21 @@
 	</row>
 	<row>
 		<label>Apple - Generic Desktop</label>
-		<nb_visits>17</nb_visits>
+		<nb_visits>16</nb_visits>
 		<nb_actions>22</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>309</sum_visit_length>
-		<bounce_count>13</bounce_count>
-		<nb_visits_converted>16</nb_visits_converted>
+		<bounce_count>12</bounce_count>
+		<nb_visits_converted>15</nb_visits_converted>
 		<goals>
 			<row idgoal='1'>
-				<nb_conversions>16</nb_conversions>
-				<nb_visits_converted>16</nb_visits_converted>
-				<revenue>80</revenue>
+				<nb_conversions>15</nb_conversions>
+				<nb_visits_converted>15</nb_visits_converted>
+				<revenue>75</revenue>
 			</row>
 		</goals>
-		<nb_conversions>16</nb_conversions>
-		<revenue>80</revenue>
+		<nb_conversions>15</nb_conversions>
+		<revenue>75</revenue>
 		<sum_daily_nb_uniq_visitors>15</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<segment>deviceBrand==Apple;deviceModel==generic+desktop</segment>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getOsFamilies_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getOsFamilies_month.xml
@@ -2,12 +2,12 @@
 <result>
 	<row>
 		<label>Mac</label>
-		<nb_visits>17</nb_visits>
+		<nb_visits>16</nb_visits>
 		<nb_actions>22</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>309</sum_visit_length>
-		<bounce_count>13</bounce_count>
-		<nb_visits_converted>16</nb_visits_converted>
+		<bounce_count>12</bounce_count>
+		<nb_visits_converted>15</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>15</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<logo>plugins/Morpheus/icons/dist/os/MAC.png</logo>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getOsVersions_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getOsVersions_month.xml
@@ -41,12 +41,12 @@
 	</row>
 	<row>
 		<label>Mac 10.10</label>
-		<nb_visits>4</nb_visits>
+		<nb_visits>3</nb_visits>
 		<nb_actions>6</nb_actions>
-		<max_actions>2</max_actions>
+		<max_actions>3</max_actions>
 		<sum_visit_length>4</sum_visit_length>
-		<bounce_count>2</bounce_count>
-		<nb_visits_converted>4</nb_visits_converted>
+		<bounce_count>1</bounce_count>
+		<nb_visits_converted>3</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<segment>operatingSystemCode==MAC;operatingSystemVersion==10.10</segment>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getType_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__DevicesDetection.getType_month.xml
@@ -2,21 +2,21 @@
 <result>
 	<row>
 		<label>Desktop</label>
-		<nb_visits>36</nb_visits>
+		<nb_visits>35</nb_visits>
 		<nb_actions>42</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>551</sum_visit_length>
-		<bounce_count>31</bounce_count>
-		<nb_visits_converted>35</nb_visits_converted>
+		<bounce_count>30</bounce_count>
+		<nb_visits_converted>34</nb_visits_converted>
 		<goals>
 			<row idgoal='1'>
-				<nb_conversions>35</nb_conversions>
-				<nb_visits_converted>35</nb_visits_converted>
-				<revenue>175</revenue>
+				<nb_conversions>34</nb_conversions>
+				<nb_visits_converted>34</nb_visits_converted>
+				<revenue>170</revenue>
 			</row>
 		</goals>
-		<nb_conversions>35</nb_conversions>
-		<revenue>175</revenue>
+		<nb_conversions>34</nb_conversions>
+		<revenue>170</revenue>
 		<sum_daily_nb_uniq_visitors>34</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		<segment>deviceType==desktop</segment>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Goals.getDaysToConversion_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Goals.getDaysToConversion_month.xml
@@ -2,7 +2,7 @@
 <result>
 	<row>
 		<label>0 days</label>
-		<nb_conversions>40</nb_conversions>
+		<nb_conversions>39</nb_conversions>
 	</row>
 	<row>
 		<label>1 day</label>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Goals.getMetrics_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Goals.getMetrics_month.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_conversions>40</nb_conversions>
-	<nb_visits_converted>40</nb_visits_converted>
-	<revenue>200</revenue>
-	<conversion_rate>90.91%</conversion_rate>
+	<nb_conversions>39</nb_conversions>
+	<nb_visits_converted>39</nb_visits_converted>
+	<revenue>195</revenue>
+	<conversion_rate>90.7%</conversion_rate>
 </result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Goals.getVisitsUntilConversion_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Goals.getVisitsUntilConversion_month.xml
@@ -2,7 +2,7 @@
 <result>
 	<row>
 		<label>1 visit</label>
-		<nb_conversions>40</nb_conversions>
+		<nb_conversions>39</nb_conversions>
 	</row>
 	<row>
 		<label>2 visits</label>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Goals.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Goals.get_month.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_conversions>40</nb_conversions>
-	<nb_visits_converted>40</nb_visits_converted>
-	<revenue>200</revenue>
-	<conversion_rate>90.91%</conversion_rate>
+	<nb_conversions>39</nb_conversions>
+	<nb_visits_converted>39</nb_visits_converted>
+	<revenue>195</revenue>
+	<conversion_rate>90.7%</conversion_rate>
 	<nb_conversions_new_visit>37</nb_conversions_new_visit>
 	<nb_visits_converted_new_visit>37</nb_visits_converted_new_visit>
 	<revenue_new_visit>185</revenue_new_visit>
 	<conversion_rate_new_visit>90.24%</conversion_rate_new_visit>
-	<nb_conversions_returning_visit>3</nb_conversions_returning_visit>
-	<nb_visits_converted_returning_visit>3</nb_visits_converted_returning_visit>
-	<revenue_returning_visit>15</revenue_returning_visit>
+	<nb_conversions_returning_visit>2</nb_conversions_returning_visit>
+	<nb_visits_converted_returning_visit>2</nb_visits_converted_returning_visit>
+	<revenue_returning_visit>10</revenue_returning_visit>
 	<conversion_rate_returning_visit>100%</conversion_rate_returning_visit>
 </result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Live.getLastVisitsDetails_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Live.getLastVisitsDetails_range.xml
@@ -2050,8 +2050,8 @@
 				
 				<pageId>71</pageId>
 				<bandwidth />
-				<timeSpent>50</timeSpent>
-				<timeSpentPretty>50s</timeSpentPretty>
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
 				<generationTimeMilliseconds>234</generationTimeMilliseconds>
 				<generationTime>0.23s</generationTime>
 				<interactionPosition>2</interactionPosition>
@@ -2077,8 +2077,8 @@
 				
 				<pageId>75</pageId>
 				<bandwidth />
-				<timeSpent>49</timeSpent>
-				<timeSpentPretty>49s</timeSpentPretty>
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
 				<generationTimeMilliseconds>294</generationTimeMilliseconds>
 				<generationTime>0.29s</generationTime>
 				<interactionPosition>6</interactionPosition>
@@ -2131,8 +2131,8 @@
 				
 				<pageId>72</pageId>
 				<bandwidth />
-				<timeSpent>26</timeSpent>
-				<timeSpentPretty>26s</timeSpentPretty>
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
 				<generationTimeMilliseconds>1324</generationTimeMilliseconds>
 				<generationTime>1.32s</generationTime>
 				<interactionPosition>3</interactionPosition>
@@ -2185,8 +2185,8 @@
 				
 				<pageId>73</pageId>
 				<bandwidth />
-				<timeSpent>8</timeSpent>
-				<timeSpentPretty>8s</timeSpentPretty>
+				<timeSpent>1</timeSpent>
+				<timeSpentPretty>1s</timeSpentPretty>
 				<generationTimeMilliseconds>543</generationTimeMilliseconds>
 				<generationTime>0.54s</generationTime>
 				<interactionPosition>4</interactionPosition>
@@ -2447,7 +2447,7 @@
 	</row>
 	<row>
 		<idSite>1</idSite>
-		<idVisit>73</idVisit>
+		<idVisit>72</idVisit>
 		<visitIp>175.41.191.47</visitIp>
 		
 		
@@ -2732,11 +2732,88 @@
 	</row>
 	<row>
 		<idSite>1</idSite>
-		<idVisit>68</idVisit>
+		<idVisit>61</idVisit>
 		<visitIp>173.5.0.0</visitIp>
 		
 		
 		<actionDetails>
+			<row>
+				<type>action</type>
+				<url>http://hello.example.com/hello/world/6,681965</url>
+				<pageTitle>404/URL = http%3A%2F%2Fhello.example.com%2Fhello%2Fworld%2F6%2C681965</pageTitle>
+				<pageIdAction>60</pageIdAction>
+				
+				
+				<pageId>93</pageId>
+				<bandwidth />
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
+				<generationTimeMilliseconds>359</generationTimeMilliseconds>
+				<generationTime>0.36s</generationTime>
+				<interactionPosition>2</interactionPosition>
+				<title>404/URL = http%3A%2F%2Fhello.example.com%2Fhello%2Fworld%2F6%2C681965</title>
+				<subtitle>http://hello.example.com/hello/world/6,681965</subtitle>
+				<icon />
+				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
+				
+				<customVariables>
+					<row>
+						<customVariablePageName1>Generation Time</customVariablePageName1>
+						<customVariablePageValue1>359</customVariablePageValue1>
+					</row>
+					<row>
+						<customVariablePageName2>Windows Status Code</customVariablePageName2>
+						<customVariablePageValue2>24</customVariablePageValue2>
+					</row>
+					<row>
+						<customVariablePageName3>HTTP-code</customVariablePageName3>
+						<customVariablePageValue3>404</customVariablePageValue3>
+					</row>
+				</customVariables>
+				<bandwidth_pretty>0 M</bandwidth_pretty>
+			</row>
+			<row>
+				<type>action</type>
+				<url>http://hello.example.com/hello/from/another/world/6,681965</url>
+				<pageTitle />
+				<pageIdAction>61</pageIdAction>
+				
+				
+				<pageId>83</pageId>
+				<bandwidth />
+				<timeSpent>0</timeSpent>
+				<timeSpentPretty>0s</timeSpentPretty>
+				<generationTimeMilliseconds>359</generationTimeMilliseconds>
+				<generationTime>0.36s</generationTime>
+				<interactionPosition>1</interactionPosition>
+				<title />
+				<subtitle>http://hello.example.com/hello/from/another/world/6,681965</subtitle>
+				<icon />
+				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
+				
+				<customVariables>
+					<row>
+						<customVariablePageName1>HTTP-code</customVariablePageName1>
+						<customVariablePageValue1>200</customVariablePageValue1>
+					</row>
+				</customVariables>
+				<bandwidth_pretty>0 M</bandwidth_pretty>
+			</row>
+			<row>
+				<type>goal</type>
+				<goalName>all</goalName>
+				<goalId>1</goalId>
+				
+				<revenue>5</revenue>
+				<goalPageId>83</goalPageId>
+				
+				<url>http://hello.example.com/hello/from/another/world/6,681965</url>
+				<icon>plugins/Morpheus/images/goal.png</icon>
+				<iconSVG>plugins/Morpheus/images/goal.svg</iconSVG>
+				<title>Goal conversion</title>
+				<subtitle>all ($5 revenue)</subtitle>
+				
+			</row>
 			<row>
 				<type>action</type>
 				<url>http://hello.example.com/hello/from/another/world/6,681965</url>
@@ -2748,7 +2825,7 @@
 				<bandwidth />
 				<generationTimeMilliseconds>359</generationTimeMilliseconds>
 				<generationTime>0.36s</generationTime>
-				<interactionPosition>1</interactionPosition>
+				<interactionPosition>3</interactionPosition>
 				<title />
 				<subtitle>http://hello.example.com/hello/from/another/world/6,681965</subtitle>
 				<icon />
@@ -2770,21 +2847,6 @@
 				</customVariables>
 				<bandwidth_pretty>0 M</bandwidth_pretty>
 			</row>
-			<row>
-				<type>goal</type>
-				<goalName>all</goalName>
-				<goalId>1</goalId>
-				
-				<revenue>5</revenue>
-				<goalPageId>94</goalPageId>
-				
-				<url>http://hello.example.com/hello/from/another/world/6,681965</url>
-				<icon>plugins/Morpheus/images/goal.png</icon>
-				<iconSVG>plugins/Morpheus/images/goal.svg</iconSVG>
-				<title>Goal conversion</title>
-				<subtitle>all ($5 revenue)</subtitle>
-				
-			</row>
 		</actionDetails>
 		<goalConversions>1</goalConversions>
 		<siteCurrency>USD</siteCurrency>
@@ -2800,7 +2862,7 @@
 		
 		
 		
-		<userId />
+		<userId>user2</userId>
 		<visitorType>returning</visitorType>
 		<visitorTypeIcon>plugins/Live/images/returningVisitor.png</visitorTypeIcon>
 		<visitConverted>1</visitConverted>
@@ -2810,11 +2872,11 @@
 		<visitEcommerceStatusIcon />
 		<daysSinceFirstVisit>0</daysSinceFirstVisit>
 		<daysSinceLastEcommerceOrder>0</daysSinceLastEcommerceOrder>
-		<visitDuration>1</visitDuration>
-		<visitDurationPretty>1s</visitDurationPretty>
+		<visitDuration>2</visitDuration>
+		<visitDurationPretty>2s</visitDurationPretty>
 		<searches>0</searches>
-		<actions>1</actions>
-		<interactions>1</interactions>
+		<actions>3</actions>
+		<interactions>3</interactions>
 		<referrerType>direct</referrerType>
 		<referrerTypeName>Direct Entry</referrerTypeName>
 		<referrerName />
@@ -3336,173 +3398,6 @@
 		<latitude>38</latitude>
 		<longitude>-97</longitude>
 		<visitLocalTime>17:00:00</visitLocalTime>
-		<visitLocalHour>17</visitLocalHour>
-		<daysSinceLastVisit>0</daysSinceLastVisit>
-		<customVariables>
-		</customVariables>
-		<resolution>unknown</resolution>
-		<plugins />
-		<pluginsIcons />
-	</row>
-	<row>
-		<idSite>1</idSite>
-		<idVisit>61</idVisit>
-		<visitIp>173.5.0.0</visitIp>
-		
-		
-		<actionDetails>
-			<row>
-				<type>action</type>
-				<url>http://hello.example.com/hello/world/6,681965</url>
-				<pageTitle>404/URL = http%3A%2F%2Fhello.example.com%2Fhello%2Fworld%2F6%2C681965</pageTitle>
-				<pageIdAction>60</pageIdAction>
-				
-				
-				<pageId>93</pageId>
-				<bandwidth />
-				<timeSpent>0</timeSpent>
-				<timeSpentPretty>0s</timeSpentPretty>
-				<generationTimeMilliseconds>359</generationTimeMilliseconds>
-				<generationTime>0.36s</generationTime>
-				<interactionPosition>2</interactionPosition>
-				<title>404/URL = http%3A%2F%2Fhello.example.com%2Fhello%2Fworld%2F6%2C681965</title>
-				<subtitle>http://hello.example.com/hello/world/6,681965</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<customVariables>
-					<row>
-						<customVariablePageName1>Generation Time</customVariablePageName1>
-						<customVariablePageValue1>359</customVariablePageValue1>
-					</row>
-					<row>
-						<customVariablePageName2>Windows Status Code</customVariablePageName2>
-						<customVariablePageValue2>24</customVariablePageValue2>
-					</row>
-					<row>
-						<customVariablePageName3>HTTP-code</customVariablePageName3>
-						<customVariablePageValue3>404</customVariablePageValue3>
-					</row>
-				</customVariables>
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>action</type>
-				<url>http://hello.example.com/hello/from/another/world/6,681965</url>
-				<pageTitle />
-				<pageIdAction>61</pageIdAction>
-				
-				
-				<pageId>83</pageId>
-				<bandwidth />
-				<generationTimeMilliseconds>359</generationTimeMilliseconds>
-				<generationTime>0.36s</generationTime>
-				<interactionPosition>1</interactionPosition>
-				<title />
-				<subtitle>http://hello.example.com/hello/from/another/world/6,681965</subtitle>
-				<icon />
-				<iconSVG>plugins/Morpheus/images/action.svg</iconSVG>
-				
-				<customVariables>
-					<row>
-						<customVariablePageName1>HTTP-code</customVariablePageName1>
-						<customVariablePageValue1>200</customVariablePageValue1>
-					</row>
-				</customVariables>
-				<bandwidth_pretty>0 M</bandwidth_pretty>
-			</row>
-			<row>
-				<type>goal</type>
-				<goalName>all</goalName>
-				<goalId>1</goalId>
-				
-				<revenue>5</revenue>
-				<goalPageId>83</goalPageId>
-				
-				<url>http://hello.example.com/hello/from/another/world/6,681965</url>
-				<icon>plugins/Morpheus/images/goal.png</icon>
-				<iconSVG>plugins/Morpheus/images/goal.svg</iconSVG>
-				<title>Goal conversion</title>
-				<subtitle>all ($5 revenue)</subtitle>
-				
-			</row>
-		</actionDetails>
-		<goalConversions>1</goalConversions>
-		<siteCurrency>USD</siteCurrency>
-		<siteCurrencySymbol>$</siteCurrencySymbol>
-		
-		
-		
-		
-		<siteName>Piwik test</siteName>
-		
-		
-		
-		
-		
-		
-		<userId>user2</userId>
-		<visitorType>returning</visitorType>
-		<visitorTypeIcon>plugins/Live/images/returningVisitor.png</visitorTypeIcon>
-		<visitConverted>1</visitConverted>
-		<visitConvertedIcon>plugins/Morpheus/images/goal.svg</visitConvertedIcon>
-		<visitCount>1</visitCount>
-		<visitEcommerceStatus>none</visitEcommerceStatus>
-		<visitEcommerceStatusIcon />
-		<daysSinceFirstVisit>0</daysSinceFirstVisit>
-		<daysSinceLastEcommerceOrder>0</daysSinceLastEcommerceOrder>
-		<visitDuration>1</visitDuration>
-		<visitDurationPretty>1s</visitDurationPretty>
-		<searches>0</searches>
-		<actions>2</actions>
-		<interactions>2</interactions>
-		<referrerType>direct</referrerType>
-		<referrerTypeName>Direct Entry</referrerTypeName>
-		<referrerName />
-		<referrerKeyword />
-		<referrerKeywordPosition />
-		<referrerUrl />
-		<referrerSearchEngineUrl />
-		<referrerSearchEngineIcon />
-		<referrerSocialNetworkUrl />
-		<referrerSocialNetworkIcon />
-		<languageCode />
-		<language>Unknown</language>
-		<deviceType>Desktop</deviceType>
-		<deviceTypeIcon>plugins/Morpheus/icons/dist/devices/desktop.png</deviceTypeIcon>
-		<deviceBrand>Apple</deviceBrand>
-		<deviceModel>Generic Desktop</deviceModel>
-		<operatingSystem>Mac 10.10</operatingSystem>
-		<operatingSystemName>Mac</operatingSystemName>
-		<operatingSystemIcon>plugins/Morpheus/icons/dist/os/MAC.png</operatingSystemIcon>
-		<operatingSystemCode>MAC</operatingSystemCode>
-		<operatingSystemVersion>10.10</operatingSystemVersion>
-		<browserFamily>Blink</browserFamily>
-		<browserFamilyDescription>Blink (Chrome, Opera)</browserFamilyDescription>
-		<browser>Chrome 37.0</browser>
-		<browserName>Chrome</browserName>
-		<browserIcon>plugins/Morpheus/icons/dist/browsers/CH.png</browserIcon>
-		<browserCode>CH</browserCode>
-		<browserVersion>37.0</browserVersion>
-		<totalEcommerceRevenue>0</totalEcommerceRevenue>
-		<totalEcommerceConversions>0</totalEcommerceConversions>
-		<totalEcommerceItems>0</totalEcommerceItems>
-		<totalAbandonedCartsRevenue>0</totalAbandonedCartsRevenue>
-		<totalAbandonedCarts>0</totalAbandonedCarts>
-		<totalAbandonedCartsItems>0</totalAbandonedCartsItems>
-		<events>0</events>
-		<continent>North America</continent>
-		<continentCode>amn</continentCode>
-		<country>United States</country>
-		<countryCode>us</countryCode>
-		<countryFlag>plugins/Morpheus/icons/dist/flags/us.png</countryFlag>
-		<region />
-		<regionCode />
-		<city />
-		<location>United States</location>
-		<latitude>38</latitude>
-		<longitude>-97</longitude>
-		<visitLocalTime>17:30:00</visitLocalTime>
 		<visitLocalHour>17</visitLocalHour>
 		<daysSinceLastVisit>0</daysSinceLastVisit>
 		<customVariables>
@@ -6619,7 +6514,7 @@
 	</row>
 	<row>
 		<idSite>1</idSite>
-		<idVisit>69</idVisit>
+		<idVisit>68</idVisit>
 		<visitIp>175.41.193.45</visitIp>
 		
 		
@@ -6749,7 +6644,7 @@
 	</row>
 	<row>
 		<idSite>1</idSite>
-		<idVisit>71</idVisit>
+		<idVisit>70</idVisit>
 		<visitIp>175.41.191.45</visitIp>
 		
 		
@@ -7919,7 +7814,7 @@
 	</row>
 	<row>
 		<idSite>1</idSite>
-		<idVisit>70</idVisit>
+		<idVisit>69</idVisit>
 		<visitIp>175.41.193.46</visitIp>
 		
 		
@@ -8049,7 +7944,7 @@
 	</row>
 	<row>
 		<idSite>1</idSite>
-		<idVisit>72</idVisit>
+		<idVisit>71</idVisit>
 		<visitIp>175.41.191.46</visitIp>
 		
 		

--- a/tests/PHPUnit/System/expected/test_ImportLogs__MultiSites.getAll_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__MultiSites.getAll_month.xml
@@ -2,10 +2,10 @@
 <result>
 	<row>
 		<label>Piwik test</label>
-		<nb_visits>44</nb_visits>
+		<nb_visits>43</nb_visits>
 		<nb_actions>51</nb_actions>
 		<nb_pageviews>45</nb_pageviews>
-		<revenue>200</revenue>
+		<revenue>195</revenue>
 		<visits_evolution>100%</visits_evolution>
 		<actions_evolution>100%</actions_evolution>
 		<pageviews_evolution>100%</pageviews_evolution>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__MultiSites.getOne_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__MultiSites.getOne_month.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
-	<nb_visits>44</nb_visits>
+	<nb_visits>43</nb_visits>
 	<nb_actions>51</nb_actions>
 	<visits_evolution>100%</visits_evolution>
 	<actions_evolution>100%</actions_evolution>
 	<pageviews_evolution>100%</pageviews_evolution>
 	<revenue_evolution>100%</revenue_evolution>
 	<nb_pageviews>45</nb_pageviews>
-	<revenue>200</revenue>
+	<revenue>195</revenue>
 </result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Referrers.getReferrerType_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Referrers.getReferrerType_month.xml
@@ -2,21 +2,21 @@
 <result>
 	<row>
 		<label>Direct Entry</label>
-		<nb_visits>40</nb_visits>
+		<nb_visits>39</nb_visits>
 		<nb_actions>46</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>551</sum_visit_length>
-		<bounce_count>35</bounce_count>
-		<nb_visits_converted>36</nb_visits_converted>
+		<bounce_count>34</bounce_count>
+		<nb_visits_converted>35</nb_visits_converted>
 		<goals>
 			<row idgoal='1'>
-				<nb_conversions>36</nb_conversions>
-				<nb_visits_converted>36</nb_visits_converted>
-				<revenue>180</revenue>
+				<nb_conversions>35</nb_conversions>
+				<nb_visits_converted>35</nb_visits_converted>
+				<revenue>175</revenue>
 			</row>
 		</goals>
-		<nb_conversions>36</nb_conversions>
-		<revenue>180</revenue>
+		<nb_conversions>35</nb_conversions>
+		<revenue>175</revenue>
 		<sum_daily_nb_uniq_visitors>38</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		<segment>referrerType==direct</segment>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Referrers.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Referrers.get_month.xml
@@ -2,7 +2,7 @@
 <result>
 	<Referrers_visitorsFromSearchEngines>0</Referrers_visitorsFromSearchEngines>
 	<Referrers_visitorsFromSocialNetworks>0</Referrers_visitorsFromSocialNetworks>
-	<Referrers_visitorsFromDirectEntry>40</Referrers_visitorsFromDirectEntry>
+	<Referrers_visitorsFromDirectEntry>39</Referrers_visitorsFromDirectEntry>
 	<Referrers_visitorsFromWebsites>4</Referrers_visitorsFromWebsites>
 	<Referrers_visitorsFromCampaigns>0</Referrers_visitorsFromCampaigns>
 	<Referrers_distinctSearchEngines>0</Referrers_distinctSearchEngines>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Resolution.getConfiguration_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Resolution.getConfiguration_month.xml
@@ -35,12 +35,12 @@
 	</row>
 	<row>
 		<label>Mac / Chrome / unknown</label>
-		<nb_visits>5</nb_visits>
+		<nb_visits>4</nb_visits>
 		<nb_actions>7</nb_actions>
-		<max_actions>2</max_actions>
+		<max_actions>3</max_actions>
 		<sum_visit_length>4</sum_visit_length>
-		<bounce_count>3</bounce_count>
-		<nb_visits_converted>5</nb_visits_converted>
+		<bounce_count>2</bounce_count>
+		<nb_visits_converted>4</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>3</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 	</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__Resolution.getResolution_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__Resolution.getResolution_month.xml
@@ -2,12 +2,12 @@
 <result>
 	<row>
 		<label>unknown</label>
-		<nb_visits>42</nb_visits>
+		<nb_visits>41</nb_visits>
 		<nb_actions>49</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>553</sum_visit_length>
-		<bounce_count>36</bounce_count>
-		<nb_visits_converted>38</nb_visits_converted>
+		<bounce_count>35</bounce_count>
+		<nb_visits_converted>37</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>40</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		<segment>resolution==unknown</segment>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getCity_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getCity_month.xml
@@ -2,21 +2,21 @@
 <result>
 	<row>
 		<label>Unknown</label>
-		<nb_visits>33</nb_visits>
+		<nb_visits>32</nb_visits>
 		<nb_actions>40</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>553</sum_visit_length>
-		<bounce_count>27</bounce_count>
-		<nb_visits_converted>29</nb_visits_converted>
+		<bounce_count>26</bounce_count>
+		<nb_visits_converted>28</nb_visits_converted>
 		<goals>
 			<row idgoal='1'>
-				<nb_conversions>29</nb_conversions>
-				<nb_visits_converted>29</nb_visits_converted>
-				<revenue>145</revenue>
+				<nb_conversions>28</nb_conversions>
+				<nb_visits_converted>28</nb_visits_converted>
+				<revenue>140</revenue>
 			</row>
 		</goals>
-		<nb_conversions>29</nb_conversions>
-		<revenue>145</revenue>
+		<nb_conversions>28</nb_conversions>
+		<revenue>140</revenue>
 		<sum_daily_nb_uniq_visitors>31</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		<city_name>Unknown</city_name>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getContinent_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getContinent_month.xml
@@ -23,21 +23,21 @@
 	</row>
 	<row>
 		<label>North America</label>
-		<nb_visits>12</nb_visits>
+		<nb_visits>11</nb_visits>
 		<nb_actions>15</nb_actions>
-		<max_actions>2</max_actions>
+		<max_actions>3</max_actions>
 		<sum_visit_length>6</sum_visit_length>
-		<bounce_count>9</bounce_count>
-		<nb_visits_converted>12</nb_visits_converted>
+		<bounce_count>8</bounce_count>
+		<nb_visits_converted>11</nb_visits_converted>
 		<goals>
 			<row idgoal='1'>
-				<nb_conversions>12</nb_conversions>
-				<nb_visits_converted>12</nb_visits_converted>
-				<revenue>60</revenue>
+				<nb_conversions>11</nb_conversions>
+				<nb_visits_converted>11</nb_visits_converted>
+				<revenue>55</revenue>
 			</row>
 		</goals>
-		<nb_conversions>12</nb_conversions>
-		<revenue>60</revenue>
+		<nb_conversions>11</nb_conversions>
+		<revenue>55</revenue>
 		<sum_daily_nb_uniq_visitors>10</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<code>North America</code>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getCountry_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getCountry_month.xml
@@ -26,21 +26,21 @@
 	</row>
 	<row>
 		<label>United States</label>
-		<nb_visits>11</nb_visits>
+		<nb_visits>10</nb_visits>
 		<nb_actions>14</nb_actions>
-		<max_actions>2</max_actions>
+		<max_actions>3</max_actions>
 		<sum_visit_length>6</sum_visit_length>
-		<bounce_count>8</bounce_count>
-		<nb_visits_converted>11</nb_visits_converted>
+		<bounce_count>7</bounce_count>
+		<nb_visits_converted>10</nb_visits_converted>
 		<goals>
 			<row idgoal='1'>
-				<nb_conversions>11</nb_conversions>
-				<nb_visits_converted>11</nb_visits_converted>
-				<revenue>55</revenue>
+				<nb_conversions>10</nb_conversions>
+				<nb_visits_converted>10</nb_visits_converted>
+				<revenue>50</revenue>
 			</row>
 		</goals>
-		<nb_conversions>11</nb_conversions>
-		<revenue>55</revenue>
+		<nb_conversions>10</nb_conversions>
+		<revenue>50</revenue>
 		<sum_daily_nb_uniq_visitors>9</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<code>us</code>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getRegion_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserCountry.getRegion_month.xml
@@ -2,21 +2,21 @@
 <result>
 	<row>
 		<label>Unknown</label>
-		<nb_visits>36</nb_visits>
+		<nb_visits>35</nb_visits>
 		<nb_actions>43</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>553</sum_visit_length>
-		<bounce_count>30</bounce_count>
-		<nb_visits_converted>32</nb_visits_converted>
+		<bounce_count>29</bounce_count>
+		<nb_visits_converted>31</nb_visits_converted>
 		<goals>
 			<row idgoal='1'>
-				<nb_conversions>32</nb_conversions>
-				<nb_visits_converted>32</nb_visits_converted>
-				<revenue>160</revenue>
+				<nb_conversions>31</nb_conversions>
+				<nb_visits_converted>31</nb_visits_converted>
+				<revenue>155</revenue>
 			</row>
 		</goals>
-		<nb_conversions>32</nb_conversions>
-		<revenue>160</revenue>
+		<nb_conversions>31</nb_conversions>
+		<revenue>155</revenue>
 		<sum_daily_nb_uniq_visitors>34</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		<region>xx</region>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserId.getUsers_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserId.getUsers_month.xml
@@ -29,9 +29,9 @@
 	<row>
 		<label>user2</label>
 		<nb_visits>1</nb_visits>
-		<nb_actions>2</nb_actions>
-		<max_actions>2</max_actions>
-		<sum_visit_length>1</sum_visit_length>
+		<nb_actions>3</nb_actions>
+		<max_actions>3</max_actions>
+		<sum_visit_length>2</sum_visit_length>
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>1</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserLanguage.getLanguageCode_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserLanguage.getLanguageCode_month.xml
@@ -2,12 +2,12 @@
 <result>
 	<row>
 		<label>Unknown (xx)</label>
-		<nb_visits>44</nb_visits>
+		<nb_visits>43</nb_visits>
 		<nb_actions>51</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>553</sum_visit_length>
-		<bounce_count>38</bounce_count>
-		<nb_visits_converted>40</nb_visits_converted>
+		<bounce_count>37</bounce_count>
+		<nb_visits_converted>39</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>42</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		<segment>languageCode==xx</segment>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__UserLanguage.getLanguage_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__UserLanguage.getLanguage_month.xml
@@ -2,12 +2,12 @@
 <result>
 	<row>
 		<label>Unknown</label>
-		<nb_visits>44</nb_visits>
+		<nb_visits>43</nb_visits>
 		<nb_actions>51</nb_actions>
 		<max_actions>3</max_actions>
 		<sum_visit_length>553</sum_visit_length>
-		<bounce_count>38</bounce_count>
-		<nb_visits_converted>40</nb_visits_converted>
+		<bounce_count>37</bounce_count>
+		<nb_visits_converted>39</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>42</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>3</sum_daily_nb_users>
 		<segment>languageCode==xx</segment>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitFrequency.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitFrequency.get_month.xml
@@ -13,13 +13,13 @@
 	<avg_time_on_site_new>13</avg_time_on_site_new>
 	<nb_uniq_visitors_returning>2</nb_uniq_visitors_returning>
 	<nb_users_returning>1</nb_users_returning>
-	<nb_visits_returning>3</nb_visits_returning>
+	<nb_visits_returning>2</nb_visits_returning>
 	<nb_actions_returning>4</nb_actions_returning>
-	<nb_visits_converted_returning>3</nb_visits_converted_returning>
-	<bounce_count_returning>2</bounce_count_returning>
+	<nb_visits_converted_returning>2</nb_visits_converted_returning>
+	<bounce_count_returning>1</bounce_count_returning>
 	<sum_visit_length_returning>2</sum_visit_length_returning>
-	<max_actions_returning>2</max_actions_returning>
-	<bounce_rate_returning>67%</bounce_rate_returning>
-	<nb_actions_per_visit_returning>1.3</nb_actions_per_visit_returning>
+	<max_actions_returning>3</max_actions_returning>
+	<bounce_rate_returning>50%</bounce_rate_returning>
+	<nb_actions_per_visit_returning>2</nb_actions_per_visit_returning>
 	<avg_time_on_site_returning>1</avg_time_on_site_returning>
 </result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitFrequency.get_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitFrequency.get_range.xml
@@ -9,13 +9,13 @@
 	<bounce_rate_new>84%</bounce_rate_new>
 	<nb_actions_per_visit_new>1.4</nb_actions_per_visit_new>
 	<avg_time_on_site_new>14</avg_time_on_site_new>
-	<nb_visits_returning>12</nb_visits_returning>
+	<nb_visits_returning>11</nb_visits_returning>
 	<nb_actions_returning>15</nb_actions_returning>
-	<nb_visits_converted_returning>11</nb_visits_converted_returning>
-	<bounce_count_returning>9</bounce_count_returning>
+	<nb_visits_converted_returning>10</nb_visits_converted_returning>
+	<bounce_count_returning>8</bounce_count_returning>
 	<sum_visit_length_returning>117</sum_visit_length_returning>
-	<max_actions_returning>2</max_actions_returning>
-	<bounce_rate_returning>75%</bounce_rate_returning>
-	<nb_actions_per_visit_returning>1.3</nb_actions_per_visit_returning>
-	<avg_time_on_site_returning>10</avg_time_on_site_returning>
+	<max_actions_returning>3</max_actions_returning>
+	<bounce_rate_returning>73%</bounce_rate_returning>
+	<nb_actions_per_visit_returning>1.4</nb_actions_per_visit_returning>
+	<avg_time_on_site_returning>11</avg_time_on_site_returning>
 </result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitTime.getByDayOfWeek_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitTime.getByDayOfWeek_month.xml
@@ -18,13 +18,13 @@
 	</row>
 	<row>
 		<label>Wednesday</label>
-		<nb_visits>7</nb_visits>
+		<nb_visits>6</nb_visits>
 		<nb_uniq_visitors>5</nb_uniq_visitors>
 		<nb_actions>10</nb_actions>
 		<nb_users>2</nb_users>
 		<sum_visit_length>6</sum_visit_length>
-		<bounce_count>4</bounce_count>
-		<nb_visits_converted>7</nb_visits_converted>
+		<bounce_count>3</bounce_count>
+		<nb_visits_converted>6</nb_visits_converted>
 		<day_of_week>3</day_of_week>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitTime.getVisitInformationPerLocalTime_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitTime.getVisitInformationPerLocalTime_month.xml
@@ -206,12 +206,12 @@
 	</row>
 	<row>
 		<label>17</label>
-		<nb_visits>8</nb_visits>
+		<nb_visits>7</nb_visits>
 		<nb_actions>11</nb_actions>
-		<max_actions>2</max_actions>
+		<max_actions>3</max_actions>
 		<sum_visit_length>6</sum_visit_length>
-		<bounce_count>5</bounce_count>
-		<nb_visits_converted>7</nb_visits_converted>
+		<bounce_count>4</bounce_count>
+		<nb_visits_converted>6</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<segment>visitLocalHour==17</segment>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitTime.getVisitInformationPerServerTime_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitTime.getVisitInformationPerServerTime_month.xml
@@ -287,23 +287,23 @@
 	</row>
 	<row>
 		<label>17</label>
-		<nb_visits>8</nb_visits>
+		<nb_visits>7</nb_visits>
 		<nb_actions>11</nb_actions>
-		<max_actions>2</max_actions>
+		<max_actions>3</max_actions>
 		<sum_visit_length>6</sum_visit_length>
-		<bounce_count>5</bounce_count>
-		<nb_visits_converted>7</nb_visits_converted>
+		<bounce_count>4</bounce_count>
+		<nb_visits_converted>6</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>6</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>2</sum_daily_nb_users>
 		<goals>
 			<row idgoal='1'>
-				<nb_conversions>7</nb_conversions>
-				<nb_visits_converted>7</nb_visits_converted>
-				<revenue>35</revenue>
+				<nb_conversions>6</nb_conversions>
+				<nb_visits_converted>6</nb_visits_converted>
+				<revenue>30</revenue>
 			</row>
 		</goals>
-		<nb_conversions>7</nb_conversions>
-		<revenue>35</revenue>
+		<nb_conversions>6</nb_conversions>
+		<revenue>30</revenue>
 		<segment>visitStartServerHour==17</segment>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsByDaysSinceLast_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsByDaysSinceLast_month.xml
@@ -7,7 +7,7 @@
 	</row>
 	<row>
 		<label>0 days</label>
-		<nb_visits>2</nb_visits>
+		<nb_visits>1</nb_visits>
 		<segment>daysSinceLastVisit==0</segment>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsByDaysSinceLast_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsByDaysSinceLast_range.xml
@@ -7,7 +7,7 @@
 	</row>
 	<row>
 		<label>0 days</label>
-		<nb_visits>5</nb_visits>
+		<nb_visits>4</nb_visits>
 		<segment>daysSinceLastVisit==0</segment>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsByVisitCount_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsByVisitCount_month.xml
@@ -2,7 +2,7 @@
 <result>
 	<row>
 		<label>1 visit</label>
-		<nb_visits>44</nb_visits>
+		<nb_visits>43</nb_visits>
 		<nb_visits_percentage>100%</nb_visits_percentage>
 		<segment>visitCount==1</segment>
 	</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsByVisitCount_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsByVisitCount_range.xml
@@ -2,7 +2,7 @@
 <result>
 	<row>
 		<label>1 visit</label>
-		<nb_visits>50</nb_visits>
+		<nb_visits>49</nb_visits>
 		<nb_visits_percentage>88%</nb_visits_percentage>
 		<segment>visitCount==1</segment>
 	</row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsPerPage_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsPerPage_month.xml
@@ -2,17 +2,17 @@
 <result>
 	<row>
 		<label>1 page</label>
-		<nb_visits>38</nb_visits>
+		<nb_visits>37</nb_visits>
 		<segment>actions==1</segment>
 	</row>
 	<row>
 		<label>2 pages</label>
-		<nb_visits>5</nb_visits>
+		<nb_visits>4</nb_visits>
 		<segment>actions==2</segment>
 	</row>
 	<row>
 		<label>3 pages</label>
-		<nb_visits>1</nb_visits>
+		<nb_visits>2</nb_visits>
 		<segment>actions==3</segment>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsPerPage_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsPerPage_range.xml
@@ -2,17 +2,17 @@
 <result>
 	<row>
 		<label>1 page</label>
-		<nb_visits>47</nb_visits>
+		<nb_visits>46</nb_visits>
 		<segment>actions==1</segment>
 	</row>
 	<row>
 		<label>2 pages</label>
-		<nb_visits>7</nb_visits>
+		<nb_visits>6</nb_visits>
 		<segment>actions==2</segment>
 	</row>
 	<row>
 		<label>3 pages</label>
-		<nb_visits>2</nb_visits>
+		<nb_visits>3</nb_visits>
 		<segment>actions==3</segment>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsPerVisitDuration_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsPerVisitDuration_month.xml
@@ -2,7 +2,7 @@
 <result>
 	<row>
 		<label>0-10s</label>
-		<nb_visits>41</nb_visits>
+		<nb_visits>40</nb_visits>
 		<segment>visitDuration&gt;=0;visitDuration&lt;=10</segment>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsPerVisitDuration_range.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitorInterest.getNumberOfVisitsPerVisitDuration_range.xml
@@ -2,7 +2,7 @@
 <result>
 	<row>
 		<label>0-10s</label>
-		<nb_visits>51</nb_visits>
+		<nb_visits>50</nb_visits>
 		<segment>visitDuration&gt;=0;visitDuration&lt;=10</segment>
 	</row>
 	<row>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitsSummary.getBounceCount_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitsSummary.getBounceCount_month.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<result>38</result>
+<result>37</result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitsSummary.getVisitsConverted_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitsSummary.getVisitsConverted_month.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<result>40</result>
+<result>39</result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitsSummary.getVisits_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitsSummary.getVisits_month.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<result>44</result>
+<result>43</result>

--- a/tests/PHPUnit/System/expected/test_ImportLogs__VisitsSummary.get_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs__VisitsSummary.get_month.xml
@@ -2,10 +2,10 @@
 <result>
 	<nb_uniq_visitors>42</nb_uniq_visitors>
 	<nb_users>3</nb_users>
-	<nb_visits>44</nb_visits>
+	<nb_visits>43</nb_visits>
 	<nb_actions>51</nb_actions>
-	<nb_visits_converted>40</nb_visits_converted>
-	<bounce_count>38</bounce_count>
+	<nb_visits_converted>39</nb_visits_converted>
+	<bounce_count>37</bounce_count>
 	<sum_visit_length>553</sum_visit_length>
 	<max_actions>3</max_actions>
 	<bounce_rate>86%</bounce_rate>

--- a/tests/PHPUnit/System/expected/test_ImportLogs_withEnhancedAndLast7__MultiSites.getAll_month.xml
+++ b/tests/PHPUnit/System/expected/test_ImportLogs_withEnhancedAndLast7__MultiSites.getAll_month.xml
@@ -3,11 +3,11 @@
 	<result date="2012-08">
 		<row>
 			<label>Piwik test</label>
-			<nb_visits>44</nb_visits>
+			<nb_visits>43</nb_visits>
 			<nb_actions>51</nb_actions>
 			<nb_pageviews>45</nb_pageviews>
-			<revenue>200</revenue>
-			<nb_conversions>40</nb_conversions>
+			<revenue>195</revenue>
+			<nb_conversions>39</nb_conversions>
 			<visits_evolution>100%</visits_evolution>
 			<actions_evolution>100%</actions_evolution>
 			<pageviews_evolution>100%</pageviews_evolution>
@@ -61,8 +61,8 @@
 			<visits_evolution>-97.7%</visits_evolution>
 			<actions_evolution>-80.4%</actions_evolution>
 			<pageviews_evolution>-77.8%</pageviews_evolution>
-			<revenue_evolution>-97.5%</revenue_evolution>
-			<nb_conversions_evolution>-97.5%</nb_conversions_evolution>
+			<revenue_evolution>-97.4%</revenue_evolution>
+			<nb_conversions_evolution>-97.4%</nb_conversions_evolution>
 			<idsite>1</idsite>
 			<group />
 			<main_url>http://piwik.net</main_url>


### PR DESCRIPTION
On every log_visit update it will try to update the idvisitor with the same value. In theory even if there was no other value to update then it will do `updateVisit($idVisit, array('idvisitor' => '...'))` which be unneeded. As the value in most queries won't change this PR likely doesn't have an impact but be still good to have as it would avoid the need for checking that field on every log_visit update and if no other log_visit field is needed to be updated, then it avoids the query altogether.