### PR TITLE
Ensure oneClickUpdatePartTwo always returns json

### DIFF
--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -175,11 +175,19 @@ class Controller extends \Piwik\Plugin\Controller
 
     public function oneClickUpdatePartTwo()
     {
-        Piwik::checkUserHasSuperUserAccess();
-
         Json::sendHeaderJSON();
 
-        $messages = $this->updater->oneClickUpdatePartTwo();
+        $messages = [];
+
+        try {
+            Piwik::checkUserHasSuperUserAccess();
+            $messages = $this->updater->oneClickUpdatePartTwo();
+        } catch (UpdaterException $e) {
+            $messages = $e->getUpdateLogMessages();
+            $messages[] = $e->getMessage();
+        } catch (Exception $e) {
+            $messages[] = $e->getMessage();
+        }
 
         echo json_encode($messages);
     }

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -131,7 +131,9 @@ class Updater
         $response = Http::sendHttpRequest($partTwoUrl, 300);
         $response = @json_decode($response, $assoc = true);
 
-        $messages = array_merge($messages, $response);
+        if (!empty($response)) {
+            $messages = array_merge($messages, $response);
+        }
 
         try {
             $disabledPluginNames = $this->disableIncompatiblePlugins($newVersion);


### PR DESCRIPTION
That actually solves the issue and should show the exception message in the updater log. 
Or should we throw an exception if `oneClickUpdatePartTwo ` didn't work?

fixes #15876 