### PR TITLE
Minor performance improvement when invalidating archives

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -59,7 +59,7 @@ class Model
                   FROM `$archiveTable`
                  WHERE name LIKE 'done%'
                    AND `value` NOT IN (" . ArchiveWriter::DONE_ERROR . ")
-              GROUP BY idsite, date1, date2, period, name";
+              GROUP BY idsite, date1, date2, period, name HAVING count(*) > 1";
 
         $archiveIds = array();
 


### PR DESCRIPTION
Just debugging some memory issues around archiving and noticed here it returned in one case over 300K rows. When adding the count > 1 it returned only 1000 rows. This should make it a lot faster and consume bit less memory etc. It's only a minor tweak though.