### PR TITLE
Require authentication when sending custom ip with tracking requests

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -892,7 +892,7 @@ class Request
 
         if (!$this->isAuthenticated()) {
             Common::printDebug("WARN: Tracker API 'cip' was used with invalid token_auth");
-            return IP::getIpFromHeader();
+            throw new InvalidRequestParameterException("Tracker API 'cip' was used, requires valid token_auth");
         }
 
         return $cip;

--- a/tests/PHPUnit/Integration/Tracker/VisitTest.php
+++ b/tests/PHPUnit/Integration/Tracker/VisitTest.php
@@ -34,6 +34,7 @@ class VisitTest extends IntegrationTestCase
         // setup the access layer
         FakeAccess::$superUser = true;
 
+        Fixture::createSuperUser(true);
         Manager::getInstance()->loadTrackerPlugins();
         $pluginNames = array_keys(Manager::getInstance()->getLoadedPlugins());
         $pluginNames[] = 'SitesManager';

--- a/tests/PHPUnit/Unit/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestTest.php
@@ -9,6 +9,7 @@
 namespace Piwik\Tests\Unit\Tracker;
 
 use Piwik\Cookie;
+use Piwik\Exception\InvalidRequestParameterException;
 use Matomo\Network\IPUtils;
 use Piwik\Piwik;
 use Piwik\Plugins\CustomVariables\CustomVariables;
@@ -435,6 +436,8 @@ class RequestTest extends UnitTestCase
 
     public function test_getIpString_ShouldDefaultToServerAddress_IfCustomIpIsSetButNotAuthenticated()
     {
+        $this->expectException(InvalidRequestParameterException::class);
+        $this->expectExceptionMessage('requires valid token_auth');
         $request = $this->buildRequest(array('cip' => '192.192.192.192'));
         $this->assertEquals($_SERVER['REMOTE_ADDR'], $request->getIpString());
     }


### PR DESCRIPTION
fixes #13471 

Note: matomo-php-tracker already only sends cip param when token_auth is provided. See https://github.com/matomo-org/matomo-php-tracker/blob/ed2de26b2a5710292d09436a246998d1e28b5760/MatomoTracker.php#L1737,L1739