### PR TITLE
Save profiling metadata

### DIFF
--- a/core/Profiler.php
+++ b/core/Profiler.php
@@ -270,6 +270,17 @@ class Profiler
                     $outputDir . DIRECTORY_SEPARATOR . $runId . '.' . $profilerNamespace . '.xhprof',
                     serialize($xhprofData)
                 );
+                $meta = array('time' => time(), 'instance' => SettingsPiwik::getPiwikInstanceId());
+                if (!empty($_GET)) {
+                    $meta['get'] = $_GET;
+                }
+                if (!empty($_POST)) {
+                    $meta['post'] = $_POST;
+                }
+                file_put_contents(
+                    $outputDir . DIRECTORY_SEPARATOR . $runId . '.' . $profilerNamespace . '.meta',
+                    serialize($meta)
+                );
             }
 
             if (empty($runId)) {


### PR DESCRIPTION
Was needing this on production as otherwise I don't have any clue for what request the profile was created, for whom, and when. This helps better understand the profile and later reproduce the same issue etc.