### PR TITLE
Fix Javascript error in JS global template causing side effects

### DIFF
--- a/plugins/Morpheus/templates/_jsGlobalVariables.twig
+++ b/plugins/Morpheus/templates/_jsGlobalVariables.twig
@@ -16,7 +16,7 @@
         symbolDecimal: "{{ 'Intl_NumberSymbolDecimal'|translate }}"
     };
 
-    piwik.relativePluginWebDirs = {{ relativePluginWebDirs|json_encode|raw }}
+    piwik.relativePluginWebDirs = {{ relativePluginWebDirs|json_encode|raw }};
 
     {% if userLogin %}piwik.userLogin = "{{ userLogin|e('js')}}";{% endif %}
 


### PR DESCRIPTION
fix https://github.com/matomo-org/wp-matomo/issues/236
fix https://wordpress.org/support/topic/security-string-token-invalid/#topic-12754303-replies

Seems some WP plugins might remove white space causing then errors:
![image](https://user-images.githubusercontent.com/273120/80924604-fa02d580-8ddd-11ea-8c13-2474f7e6208d.png)
