### PR TITLE
Fix GeoIP2 autoupdate

### DIFF
--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -590,7 +590,7 @@ class GeoIP2AutoUpdater extends Task
             // test the provider. on error, we rename the broken DB.
             try {
                 // check database directly, as location provider ignores invalid database errors
-                $pathToDb = LocationProviderGeoIp2::getPathToGeoIpDatabase($customNames);
+                $pathToDb = LocationProviderGeoIp2::getPathToGeoIpDatabase($customNames[$type]);
                 $reader = new Reader($pathToDb);
 
                 $location = $provider->getLocation(array('ip' => LocationProviderGeoIp2::TEST_IP));


### PR DESCRIPTION
Autoupdating the GeoIP2 database failed for me locally on 4.x-dev with

```
WARNING [2020-05-06 13:03:00] 27405  /srv/matomo/plugins/GeoIp2/LocationProvider/GeoIp2.php(109): Warning - strpos() expects parameter 1 to be string, array given - Matomo 4.0.0-b1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)
WARNING [2020-05-06 13:03:00] 27405  /srv/matomo/plugins/GeoIp2/LocationProvider/GeoIp2.php(109): Warning - file_exists() expects parameter 1 to be a valid path, array given - Matomo 4.0.0-b1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)
WARNING [2020-05-06 13:03:00] 27405  /srv/matomo/plugins/GeoIp2/LocationProvider/GeoIp2.php(113): Notice - Array to string conversion - Matomo 4.0.0-b1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)
```

Seems that was the reason...

Regression from #15521 