### PR TITLE
Bind param values manually since PDOStatement::execute() will assume …

### DIFF
--- a/libs/Zend/Db/Statement/Pdo.php
+++ b/libs/Zend/Db/Statement/Pdo.php
@@ -225,10 +225,12 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
     {
         try {
             if ($params !== null) {
-                return $this->_stmt->execute($params);
-            } else {
-                return $this->_stmt->execute();
+                foreach (array_values($params) as $index => $paramValue) {
+                    $this->_stmt->bindValue($index + 1, $paramValue, $paramValue === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+                }
             }
+
+            return $this->_stmt->execute();
         } catch (PDOException $e) {
             // require_once 'Zend/Db/Statement/Exception.php';
             throw new Zend_Db_Statement_Exception($e->getMessage(), (int) $e->getCode(), $e);

--- a/tests/PHPUnit/Integration/DbTest.php
+++ b/tests/PHPUnit/Integration/DbTest.php
@@ -34,6 +34,30 @@ class DbTest extends IntegrationTestCase
         parent::tearDown();
     }
 
+    // this test is for PDO which will fail if execute() is called w/ a null param value
+    public function test_insertWithNull()
+    {
+        $GLOBALS['abc']=1;
+        $table = Common::prefixTable('testtable');
+        Db::exec("CREATE TABLE `$table` (
+                      testid BIGINT NOT NULL AUTO_INCREMENT,
+                      testvalue BIGINT NULL,
+                      PRIMARY KEY (testid)
+                  )");
+
+        Db::query("INSERT INTO `$table` (testvalue) VALUES (?)", ['a' => 4]);
+        Db::query("INSERT INTO `$table` (testvalue) VALUES (?)", ['b' => null]);
+
+        $values = Db::fetchAll("SELECT testid, testvalue FROM `$table`");
+
+        $expected = [
+            ['testid' => 1, 'testvalue' => 4],
+            ['testid' => 2, 'testvalue' => null],
+        ];
+
+        $this->assertEquals($expected, $values);
+    }
+
     public function test_getColumnNamesFromTable()
     {
         $this->assertColumnNames('access', array('idaccess', 'login', 'idsite', 'access'));
@@ -171,29 +195,6 @@ class DbTest extends IntegrationTestCase
 
         $result = $db->query('select 21');
         $this->assertEquals(1, $db->rowCount($result));
-    }
-
-    // this test is for PDO which will fail if execute() is called w/ a null param value
-    public function test_insertWithNull()
-    {
-        $table = Common::prefixTable('testtable');
-        Db::exec("CREATE TABLE `$table` (
-                      testid INT NOT NULL AUTO_INCREMENT,
-                      testvalue INT NULL,
-                      PRIMARY KEY (testid)
-                  )");
-
-        Db::query("INSERT INTO `$table` (testvalue) VALUES (?)", [4]);
-        Db::query("INSERT INTO `$table` (testvalue) VALUES (?)", [null]);
-
-        $values = Db::fetchAll("SELECT testid, testvalue FROM `$table`");
-
-        $expected = [
-            ['testid' => 1, 'testvalue' => 4],
-            ['testid' => 2, 'testvalue' => null],
-        ];
-
-        $this->assertEquals($expected, $values);
     }
 
     public function getDbAdapter()

--- a/tests/PHPUnit/Integration/DbTest.php
+++ b/tests/PHPUnit/Integration/DbTest.php
@@ -173,6 +173,29 @@ class DbTest extends IntegrationTestCase
         $this->assertEquals(1, $db->rowCount($result));
     }
 
+    // this test is for PDO which will fail if execute() is called w/ a null param value
+    public function test_insertWithNull()
+    {
+        $table = Common::prefixTable('testtable');
+        Db::exec("CREATE TABLE `$table` (
+                      testid INT NOT NULL AUTO_INCREMENT,
+                      testvalue INT NULL,
+                      PRIMARY KEY (testid)
+                  )");
+
+        Db::query("INSERT INTO `$table` (testvalue) VALUES (?)", [4]);
+        Db::query("INSERT INTO `$table` (testvalue) VALUES (?)", [null]);
+
+        $values = Db::fetchAll("SELECT testid, testvalue FROM `$table`");
+
+        $expected = [
+            ['testid' => 1, 'testvalue' => 4],
+            ['testid' => 2, 'testvalue' => null],
+        ];
+
+        $this->assertEquals($expected, $values);
+    }
+
     public function getDbAdapter()
     {
         return array(


### PR DESCRIPTION
…params are all strings. This causes null values to not be bound correctly.

I checked and mysqli appears to be fine.