### PR TITLE
Fix notice "Trying to access array offset on value of type int" in WP

### DIFF
--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -25,7 +25,7 @@ class Adapter
     public static function factory($adapterName, & $dbInfos, $connect = true)
     {
         if ($connect) {
-            if ($dbInfos['port'][0] == '/') {
+            if (isset($dbInfos['port']) && is_string($dbInfos['port']) && $dbInfos['port'][0] == '/') {
                 $dbInfos['unix_socket'] = $dbInfos['port'];
                 unset($dbInfos['host']);
                 unset($dbInfos['port']);


### PR DESCRIPTION
Triggers a notice in Matomo for WP as we're passing an integer there. Could also be the case in On-Premise when configuring DB on demand.