### PR TITLE
remove support for old format of adding custom search engines

### DIFF
--- a/plugins/Referrers/SearchEngine.php
+++ b/plugins/Referrers/SearchEngine.php
@@ -65,27 +65,7 @@ class SearchEngine extends Singleton
 
         Piwik::postEvent('Referrer.addSearchEngineUrls', array(&$this->definitionList));
 
-        $this->convertLegacyDefinitions();
-
         return $this->definitionList;
-    }
-
-    /**
-     * @deprecated remove in 3.0
-     */
-    protected function convertLegacyDefinitions()
-    {
-        foreach ($this->definitionList as $url => $definition) {
-            if (!array_key_exists('name', $definition) && isset($definition[0]) && isset($definition[1])) {
-                $this->definitionList[$url] = array(
-                    'name' => $definition[0],
-                    'params' => $definition[1],
-                    'backlink' => @$definition[2],
-                    'charsets' => @$definition[3]
-                );
-            }
-        }
-
     }
 
     /**


### PR DESCRIPTION
Guess that shouldn't be needed anymore. Before Piwik 2.15 we used to have another array format for defining search engines. So if anyone would still use this old format with the event `Referrer.addSearchEngineUrls`, that might not work anymore. But as that event is not even marked as API, I guess that should be fine.

refs #8567