### PR TITLE
Remove token_auth column in user table during upgrade

### DIFF
--- a/core/Updates/4.0.0-b1.php
+++ b/core/Updates/4.0.0-b1.php
@@ -70,15 +70,7 @@ class Updates_4_0_0_b1 extends PiwikUpdates
         }
 
         $migrations[] = $this->migration->db->dropColumn('user', 'alias');
-
-        // we don't delete the token_auth column so users can still downgrade to 3.X if they want to. However, the original
-        // token_auth will be regenerated for security reasons to no longer have it in plain text. So this column will be no longer used
-        // unless someone downgrades to 3.x
-        $columns = DbHelper::getTableColumns(Common::prefixTable('user'));
-        if (isset($columns['token_auth'])) {
-            $sql = sprintf('UPDATE %s set token_auth = MD5(CONCAT(NOW(), UUID()))', Common::prefixTable('user'));
-            $migrations[] = $this->migration->db->sql($sql, Updater\Migration\Db::ERROR_CODE_UNKNOWN_COLUMN);
-        }
+        $migrations[] = $this->migration->db->dropColumn('user', 'token_auth');
 
         /** APP SPECIFIC TOKEN END */
 


### PR DESCRIPTION
As mentioned it won't be possible to easily downgrade to Matomo 3 anyway therefore removing the column.

Added needed SQLs to downgrade to Matomo 3 to https://github.com/matomo-org/matomo/wiki/Matomo-4.0.0-release-notes#downgrading-to-matomo-3

