### PR TITLE
Use correct social and search engines list when internet is disabled

### DIFF
--- a/plugins/Referrers/SearchEngine.php
+++ b/plugins/Referrers/SearchEngine.php
@@ -12,6 +12,7 @@ use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Option;
 use Piwik\Piwik;
+use Piwik\SettingsPiwik;
 use Piwik\Singleton;
 use Piwik\UrlHelper;
 
@@ -53,7 +54,7 @@ class SearchEngine extends Singleton
             // Read first from the auto-updated list in database
             $list = Option::get(self::OPTION_STORAGE_NAME);
 
-            if ($list) {
+            if ($list && SettingsPiwik::isInternetEnabled()) {
                 $this->definitionList = Common::safe_unserialize(base64_decode($list));
             } else {
                 // Fallback to reading the bundled list

--- a/plugins/Referrers/Social.php
+++ b/plugins/Referrers/Social.php
@@ -11,6 +11,7 @@ use Piwik\Cache;
 use Piwik\Common;
 use Piwik\Option;
 use Piwik\Piwik;
+use Piwik\SettingsPiwik;
 use Piwik\Singleton;
 
 /**
@@ -51,7 +52,7 @@ class Social extends Singleton
             // Read first from the auto-updated list in database
             $list = Option::get(self::OPTION_STORAGE_NAME);
 
-            if ($list) {
+            if ($list && SettingsPiwik::isInternetEnabled()) {
                 $this->definitionList = Common::safe_unserialize(base64_decode($list));
             } else {
                 // Fallback to reading the bundled list


### PR DESCRIPTION
Ignore any saved value in the options table for social and search engines list when internet is disabled. Technically, the list stored in the options table could still be newer when disabling internet but it would become outdated as soon as there's a Matomo update. Mentioned in the issue we could also alternatively delete the option entry on update but somehow thought it might be easier this way.

fix https://github.com/matomo-org/matomo/issues/15923
