### PR TITLE
Fix a plugin that enriches the tracker needed to mark plugin as tracker

### DIFF
--- a/plugins/CustomPiwikJs/TrackingCode/PluginTrackerFiles.php
+++ b/plugins/CustomPiwikJs/TrackingCode/PluginTrackerFiles.php
@@ -41,9 +41,7 @@ class PluginTrackerFiles
         $dirs = array();
         $manager = Plugin\Manager::getInstance();
         foreach ($manager->getPluginsLoadedAndActivated() as $pluginName => $plugin) {
-            if ($plugin->isTrackerPlugin()) {
-                $dirs[$pluginName] = rtrim(Plugin\Manager::getPluginDirectory($pluginName), '/') . '/';
-            }
+            $dirs[$pluginName] = rtrim(Plugin\Manager::getPluginDirectory($pluginName), '/') . '/';
         }
         return $dirs;
     }


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/11572#issuecomment-607172575

This was actually a regression in https://github.com/matomo-org/matomo/commit/a19d8cf6a4251644c4e9d24c4be23b61a409ed03#diff-bd3c3d13cfeffe365775c155d287ccdbL52-L70 as there shouldn't be a need to mark a plugin as a tracker just because it defines a `tracker.js`. Defining it as a tracker is not needed unless it would actually do something during tracking server side. Some plugins that extend tracker might only track additional events or other things though so it's not needed to mark the plugin as a tracker to keep tracking fast and not load unneeded plugins.

Documented the tracker.js itself in https://github.com/matomo-org/developer-documentation/pull/345 (which needs a review)