### PR TITLE
Do not check if any archive is running when a segment is forced

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -2119,6 +2119,12 @@ class CronArchive
 
     public function isAlreadyArchivingUrl($url, $idSite, $period, $date)
     {
+        if (!empty($this->segmentsToForce)) {
+            // we ignore checking for any running command in the background so a user can launch multiple cronjob entries
+            // at the same time where each of them forces a differet segment
+            return false;
+        }
+
         $periodInProgress = $this->isAlreadyArchivingAnyLowerOrThisPeriod($idSite, $period);
         if ($periodInProgress) {
             $this->logger->info("- skipping archiving for period '{period}' because processing the period '{periodcheck}' is already in progress.", array('period' => $period, 'periodcheck' => $periodInProgress));


### PR DESCRIPTION
From a support request. eg user has

```crontab
6 * * * * * console core:archive --force-idsegment=1
6 * * * * * console core:archive --force-idsegment=2
6 * * * * * console core:archive --force-idsegment=3
```

Then currently it would skip some segments because it checks if any archive is already running. After the launching the first one for segment 1, an archive is already running and would probably never launch 2nd and 3rd segment AFAIK.

@mattab 