### PR TITLE
Fix theme rewrite removes src attribute when custom plugin directory is used

### DIFF
--- a/core/Theme.php
+++ b/core/Theme.php
@@ -146,7 +146,7 @@ class Theme
         foreach (Manager::getAlternativeWebRootDirectories() as $absDir => $webRootDirectory) {
             $withoutPlugins = str_replace('plugins/', '', $pathAsset);
             if (file_exists($absDir . '/' . $withoutPlugins)) {
-                return $webRootDirectory . $withoutPlugins;
+	            return str_replace($pathAsset, $webRootDirectory . $withoutPlugins, $source);
             }
         }
 


### PR DESCRIPTION
Noticed this in Matomo for WordPress which makes use of the ability to define custom plugin directories.

Matomo was supposed to rewrite this `img src` path

![image](https://user-images.githubusercontent.com/273120/82375629-faa19a00-9a74-11ea-987f-33632382d4fe.png)

to this:

![image](https://user-images.githubusercontent.com/273120/82375658-04c39880-9a75-11ea-8b38-37ed42c0bfce.png)

but I got this:

![image](https://user-images.githubusercontent.com/273120/82375679-0db46a00-9a75-11ea-9a84-0794d2c1c000.png)

and as a result the images weren't shown

![image](https://user-images.githubusercontent.com/273120/82375691-13aa4b00-9a75-11ea-9f1d-15f140cdc654.png)

While debugging I noticed it was returning a path `../../plugins/...` when it should have returned `src="../../plugins/.."` see content of `$source`

![image](https://user-images.githubusercontent.com/273120/82375800-389ebe00-9a75-11ea-803a-5a4f7eff824b.png)

With the patch things work. Not sure how this worked before and if it actually worked.
