### PR TITLE
Fix: Logo being displayed too small on IE 11

### DIFF
--- a/plugins/Morpheus/stylesheets/uibase/_header.less
+++ b/plugins/Morpheus/stylesheets/uibase/_header.less
@@ -18,17 +18,6 @@
   }
 }
 
-// IE 10+
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  #root #logo {
-    width: 80px;
-  }
-
-  #root #logo img.default-piwik-logo {
-    width: 100%;
-  }
-}
-
 #javascriptDisabled,
 #javascriptDisabled a {
   font-weight: bold;


### PR DESCRIPTION
On IE 11 the logo is displayed too small, due to a IE special rule.

![image](https://user-images.githubusercontent.com/1579355/82797153-f6abb880-9e76-11ea-8bd5-b761aaee73cc.png)

Removing that rule fixed that for me.