### PR TITLE
Tracker API speed: avoid DB query when recording historical data or other authenticated tracking requests

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -198,6 +198,19 @@ class Request
             return false;
         }
 
+        // Now checking the list of admin token_auth cached in the Tracker config file
+        if (!empty($idSite) && $idSite > 0) {
+            $website = Cache::getCacheWebsiteAttributes($idSite);
+            $userModel = new \Piwik\Plugins\UsersManager\Model();
+            $tokenAuth = $userModel->hashTokenAuth($tokenAuth);
+            $hashedToken = UsersManager::hashTrackingToken((string) $tokenAuth, $idSite);
+
+            if (array_key_exists('tracking_token_auth', $website)
+                && in_array($hashedToken, $website['tracking_token_auth'], true)) {
+                return true;
+            }
+        }
+        
         Piwik::postEvent('Request.initAuthenticationObject');
 
         /** @var \Piwik\Auth $auth */
@@ -210,19 +223,6 @@ class Request
 
         if (!empty($access) && $access->hasSuperUserAccess()) {
             return true;
-        }
-
-        // Now checking the list of admin token_auth cached in the Tracker config file
-        if (!empty($idSite) && $idSite > 0) {
-            $website = Cache::getCacheWebsiteAttributes($idSite);
-            $userModel = new \Piwik\Plugins\UsersManager\Model();
-            $tokenAuth = $userModel->hashTokenAuth($tokenAuth);
-            $hashedToken = UsersManager::hashTrackingToken((string) $tokenAuth, $idSite);
-
-            if (array_key_exists('tracking_token_auth', $website)
-                && in_array($hashedToken, $website['tracking_token_auth'], true)) {
-                return true;
-            }
         }
 
         Common::printDebug("WARNING! token_auth = $tokenAuth is not valid, Super User / Admin / Write was NOT authenticated");

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -202,8 +202,8 @@ class Request
         if (!empty($idSite) && $idSite > 0) {
             $website = Cache::getCacheWebsiteAttributes($idSite);
             $userModel = new \Piwik\Plugins\UsersManager\Model();
-            $tokenAuth = $userModel->hashTokenAuth($tokenAuth);
-            $hashedToken = UsersManager::hashTrackingToken((string) $tokenAuth, $idSite);
+            $tokenAuthHashed = $userModel->hashTokenAuth($tokenAuth);
+            $hashedToken = UsersManager::hashTrackingToken((string) $tokenAuthHashed, $idSite);
 
             if (array_key_exists('tracking_token_auth', $website)
                 && in_array($hashedToken, $website['tracking_token_auth'], true)) {


### PR DESCRIPTION
Was just looking into https://github.com/matomo-org/wp-matomo/issues/288 and then noticed we always first issue a query against the user table before actually checking the cached data.

Should a token be used with admin or write permission, then we actually save the user query.

It shouldn't cause any security issue cause if the token is not a valid `admin` or `write` permission token, then below code would be still executed and eg the brute force check should be executed just like before.