### PR TITLE
Fix live widget does not refresh under circumstances

### DIFF
--- a/plugins/Live/javascripts/live.js
+++ b/plugins/Live/javascripts/live.js
@@ -74,6 +74,8 @@
                     that._parseResponse(r);
                 }
 
+                that.options.interval = parseInt(that.options.interval, 10);
+
                 // add default interval to last interval if not updated or reset to default if so
                 if (!that.updated) {
                     that.currentInterval += that.options.interval;
@@ -168,7 +170,7 @@
                 return;
             }
 
-            this.currentInterval = this.options.interval;
+            this.currentInterval = parseInt(this.options.interval, 10);
 
             if (0 === $(this.element).parents('.widget').length) {
                 var $rootScope = piwikHelper.getAngularDependency('$rootScope');


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/15978

The problem was actually that the interval was a `string` and therefore it was always adding the new interval on top of the other one instead of summing it. So it resulted in `050005000`, then `0500050005000`... instead of just making it `10000`

![image](https://user-images.githubusercontent.com/273120/82855090-6f397480-9f5e-11ea-886a-654d80c426f5.png)
