### PR TITLE
Optimize Translator.php call and EventDispatcher.php

### DIFF
--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -80,14 +80,14 @@ class EventDispatcher
      *
      * @param string $eventName The name of the event, ie, API.getReportMetadata.
      * @param array $params The parameters to pass to each callback when executing.
-     * @param bool $pending Whether this event should be posted again for plugins
+     * @param bool|null $pending Whether this event should be posted again for plugins
      *                      loaded after the event is fired.
      * @param array|null $plugins The plugins to post events to. If null, the event
      *                            is posted to all plugins. The elements of this array
      *                            can be either the Plugin objects themselves
      *                            or their string names.
      */
-    public function postEvent(string $eventName, array $params, bool $pending = false, ?array $plugins = null)
+    public function postEvent(string $eventName, array $params, ?bool $pending = false, ?array $plugins = null)
     {
         if ($pending) {
             $this->pendingEvents[] = array($eventName, $params);

--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -26,9 +26,9 @@ class EventDispatcher
     }
 
     // implementation details for postEvent
-    const EVENT_CALLBACK_GROUP_FIRST = 0;
-    const EVENT_CALLBACK_GROUP_SECOND = 1;
-    const EVENT_CALLBACK_GROUP_THIRD = 2;
+    public const EVENT_CALLBACK_GROUP_FIRST = 0;
+    public const EVENT_CALLBACK_GROUP_SECOND = 1;
+    public const EVENT_CALLBACK_GROUP_THIRD = 2;
 
     /**
      * Array of observers (callbacks attached to events) that are not methods
@@ -62,6 +62,8 @@ class EventDispatcher
 
     /**
      * Constructor.
+     * @param Plugin\Manager $pluginManager
+     * @param array $observers
      */
     public function __construct(Plugin\Manager $pluginManager, array $observers = array())
     {
@@ -85,7 +87,7 @@ class EventDispatcher
      *                            can be either the Plugin objects themselves
      *                            or their string names.
      */
-    public function postEvent($eventName, $params, $pending = false, $plugins = null)
+    public function postEvent(string $eventName, array $params, bool $pending = false, ?array $plugins = null)
     {
         if ($pending) {
             $this->pendingEvents[] = array($eventName, $params);
@@ -101,7 +103,7 @@ class EventDispatcher
 
         // collect all callbacks to execute
         foreach ($plugins as $pluginName) {
-            if (!is_string($pluginName)) {
+            if (!\is_string($pluginName)) {
                 $pluginName = $pluginName->getPluginName();
             }
 
@@ -115,7 +117,7 @@ class EventDispatcher
             if (isset($hooks[$eventName])) {
                 list($pluginFunction, $callbackGroup) = $this->getCallbackFunctionAndGroupNumber($hooks[$eventName]);
 
-                if (is_string($pluginFunction)) {
+                if (\is_string($pluginFunction)) {
                     $plugin = $manager->getLoadedPlugin($pluginName);
                     $callbacks[$callbackGroup][] = array($plugin, $pluginFunction) ;
                 } else {
@@ -133,12 +135,12 @@ class EventDispatcher
         }
 
         // sort callbacks by their importance
-        ksort($callbacks);
+        \ksort($callbacks);
 
         // execute callbacks in order
         foreach ($callbacks as $callbackGroup) {
             foreach ($callbackGroup as $callback) {
-                call_user_func_array($callback, $params);
+                \call_user_func_array($callback, $params);
             }
         }
     }
@@ -163,7 +165,7 @@ class EventDispatcher
      *                        before normal & 'after' ones. If 'after' then it
      *                        will be executed after normal ones.
      */
-    public function addObserver($eventName, $callback)
+    public function addObserver(string $eventName, $callback)
     {
         $this->extraObservers[$eventName][] = $callback;
     }
@@ -173,7 +175,7 @@ class EventDispatcher
      *
      * @param Plugin $plugin
      */
-    public function postPendingEventsTo($plugin)
+    public function postPendingEventsTo(Plugin $plugin)
     {
         foreach ($this->pendingEvents as $eventInfo) {
             list($eventName, $eventParams) = $eventInfo;
@@ -181,9 +183,9 @@ class EventDispatcher
         }
     }
 
-    private function getCallbackFunctionAndGroupNumber($hookInfo)
+    private function getCallbackFunctionAndGroupNumber($hookInfo): array
     {
-        if (is_array($hookInfo)
+        if (\is_array($hookInfo)
             && !empty($hookInfo['function'])
         ) {
             $pluginFunction = $hookInfo['function'];

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -587,7 +587,7 @@ class FrontController extends Singleton
          */
         Piwik::postEvent(sprintf('Controller.%s.%s', $module, $action), array(&$parameters));
 
-        $result = call_user_func_array($controller, $parameters);
+        $result = \call_user_func_array($controller, $parameters);
 
         /**
          * Triggered after a controller action is successfully called.

--- a/core/Translation/Loader/JsonFileLoader.php
+++ b/core/Translation/Loader/JsonFileLoader.php
@@ -47,7 +47,7 @@ class JsonFileLoader implements LoaderInterface
         $data = file_get_contents($filename);
         $translations = json_decode($data, true);
 
-        if (is_null($translations) && Common::hasJsonErrorOccurred()) {
+        if (\is_null($translations) && Common::hasJsonErrorOccurred()) {
             throw new \Exception(sprintf(
                 'Not able to load translation file %s: %s',
                 $filename,
@@ -55,7 +55,7 @@ class JsonFileLoader implements LoaderInterface
             ));
         }
 
-        if (!is_array($translations)) {
+        if (!\is_array($translations)) {
             return array();
         }
 

--- a/core/Translation/Loader/LoaderCache.php
+++ b/core/Translation/Loader/LoaderCache.php
@@ -44,7 +44,7 @@ class LoaderCache implements LoaderInterface
 
         $translations = $this->cache->fetch($cacheKey);
 
-        if (empty($translations) || !is_array($translations)) {
+        if (empty($translations) || !\is_array($translations)) {
             $translations = $this->loader->load($language, $directories);
 
             $this->cache->save($cacheKey, $translations, 43200); // ttl=12hours

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -82,21 +82,21 @@ class Translator
      * @return string The translated string or `$translationId`.
      * @api
      */
-    public function translate($translationId, $args = array(), $language = null)
+    public function translate(string $translationId, $args = array(), ?string $language = null)
     {
-        $args = is_array($args) ? $args : array($args);
+        $args = \is_array($args) ? $args : array($args);
 
-        if (strpos($translationId, "_") !== false) {
-            list($plugin, $key) = explode("_", $translationId, 2);
-            $language = is_string($language) ? $language : $this->currentLanguage;
+        if (\strpos($translationId, "_") !== false) {
+            list($plugin, $key) = \explode("_", $translationId, 2);
+            $language = $language ?? $this->currentLanguage;
 
             $translationId = $this->getTranslation($translationId, $language, $plugin, $key);
         }
 
-        if (count($args) == 0) {
-            return str_replace('%%', '%', $translationId);
+        if (\count($args) === 0) {
+            return \str_replace('%%', '%', $translationId);
         }
-        return vsprintf($translationId, $args);
+        return \vsprintf($translationId, $args);
     }
 
     /**
@@ -254,7 +254,7 @@ class Translator
          * Fallback for keys moved to new Intl plugin to avoid untranslated string in non core plugins
          * @todo remove this in Piwik 3.0
          */
-        if ($plugin != 'Intl') {
+        if ($plugin !== 'Intl') {
             if (isset($this->translations[$lang]['Intl'])
                 && isset($this->translations[$lang]['Intl'][$key])
             ) {

--- a/core/Translation/Translator.php
+++ b/core/Translation/Translator.php
@@ -82,7 +82,7 @@ class Translator
      * @return string The translated string or `$translationId`.
      * @api
      */
-    public function translate(string $translationId, $args = array(), ?string $language = null)
+    public function translate(?string $translationId, $args = array(), ?string $language = null)
     {
         $args = \is_array($args) ? $args : array($args);
 


### PR DESCRIPTION
TAKE WITH CAUTION.

I inspect what function have lot of own time in matomo
I see this :  
![Screenshot from 2020-05-26 12-03-00](https://user-images.githubusercontent.com/768394/82888041-22976e80-9f49-11ea-8211-752401e6d17c.png)
After some modification "own time" decreased (the 3 columns, time in ms) 
![Screenshot from 2020-05-26 12-02-18](https://user-images.githubusercontent.com/768394/82888044-23c89b80-9f49-11ea-9dab-c93582b15344.png)

cause some functions like count, is_array, is_string ... if you add \ before PHP optimize this call.

the bench is made in this page. I refresh and aggregates 8 cachegrind files
![Screenshot from 2020-05-26 12-07-32](https://user-images.githubusercontent.com/768394/82889138-95551980-9f4a-11ea-9f64-6d745abd074c.png)
 