### PR TITLE
Fix today archive is not being archived

### DIFF
--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -92,7 +92,7 @@ class ArchiveSelector
             return [false, $visits, $visitsConverted, true, $tsArchived];
         }
 
-        if (!empty($minDatetimeArchiveProcessedUTC) && (!is_object($minDatetimeArchiveProcessedUTC) || !$minDatetimeArchiveProcessedUTC instanceof Date)) {
+        if (!empty($minDatetimeArchiveProcessedUTC) && !is_object($minDatetimeArchiveProcessedUTC)) {
             $minDatetimeArchiveProcessedUTC = Date::factory($minDatetimeArchiveProcessedUTC);
         }
 

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -92,10 +92,14 @@ class ArchiveSelector
             return [false, $visits, $visitsConverted, true, $tsArchived];
         }
 
+        if (!empty($minDatetimeArchiveProcessedUTC) && (!is_object($minDatetimeArchiveProcessedUTC) || !$minDatetimeArchiveProcessedUTC instanceof Date)) {
+            $minDatetimeArchiveProcessedUTC = Date::factory($minDatetimeArchiveProcessedUTC);
+        }
+
         // the archive is too old
         if ($minDatetimeArchiveProcessedUTC
             && isset($result['idarchive'])
-            && Date::factory($tsArchived)->isEarlier(Date::factory($minDatetimeArchiveProcessedUTC))
+            && Date::factory($tsArchived)->isEarlier($minDatetimeArchiveProcessedUTC)
         ) {
             return [false, $visits, $visitsConverted, true, $tsArchived];
         }


### PR DESCRIPTION
@diosmosis  Noticed an error that today wasn't being archived while testing again https://github.com/matomo-org/matomo/pull/15991 . Eg I had set config to:

```ini
enable_general_settings_admin=0
time_before_today_archive_considered_outdated = 1
```

Timezone of the site: `America/Los_Angeles`

I would have expected that the archive is being invalidated every time I execute the console archive command but this wasn't happening. Then noticed `$minDatetimeArchiveProcessedUTC` was already a date and therefore somehow converted again resulting in a different time.

See screenshot where the archive should have been ignored because `ts_archived` is older but it wasn't ignored. 
![image](https://user-images.githubusercontent.com/273120/83070293-614f3500-a0bf-11ea-909a-e93769567891.png)

See what happened to the date after passing it again to `date::factory`:
![image](https://user-images.githubusercontent.com/273120/83070408-8e034c80-a0bf-11ea-9df4-ff1a2716b4a6.png)

Looks actually a bit like a bug to me that `Date::factory` would set time to `00:00:00`.

Another potential bug maybe @diosmosis ... the last line in that method returns `return [$idArchive, $visits, $visitsConverted, true, $tsArchived];`. Should the ignore parameter really be set to `true`?