### PR TITLE
Fix min archive time not correctly respected

### DIFF
--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -90,10 +90,14 @@ class ArchiveSelector
             return [false, $visits, $visitsConverted, true];
         }
 
+        if (!empty($minDatetimeArchiveProcessedUTC) && !is_object($minDatetimeArchiveProcessedUTC)) {
+            $minDatetimeArchiveProcessedUTC = Date::factory($minDatetimeArchiveProcessedUTC);
+        }
+
         // the archive is too old
         if ($minDatetimeArchiveProcessedUTC
             && isset($result['idarchive'])
-            && Date::factory($result['ts_archived'])->isEarlier(Date::factory($minDatetimeArchiveProcessedUTC))
+            && Date::factory($result['ts_archived'])->isEarlier($minDatetimeArchiveProcessedUTC)
         ) {
             return [false, $visits, $visitsConverted, true];
         }


### PR DESCRIPTION
See https://github.com/matomo-org/matomo/pull/15996#issue-424105586 for explanation. 

Figured this might be good for Matomo 3.X as it looks to me like we might sometimes not archive today's reports as much as we should since we always check if it was last archived at `00:00:00`