### PR TITLE
Optional userLogin in getUserPreference API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ## Matomo 3.13.6
 
-### New API
+### API Changes
 * The first parameter `userLogin` in the `UsersManager.getUserPreference` method is now optional and defaults to the currently authenticated user login.
 
 ## Matomo 3.13.5
@@ -858,6 +858,7 @@ We are using `@since` annotations in case we are introducing new API's to make i
 
 ### Breaking Changes
 ### Deprecations
+### API Changes
 ### New features
 ### New APIs
 ### New commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Matomo 3.13.6
+
+### New API
+* The first parameter `userLogin` in the `UsersManager.getUserPreference` method is now optional and defaults to the currently authenticated user login.
+
 ## Matomo 3.13.5
 
 ### New API

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -193,12 +193,18 @@ class API extends \Piwik\Plugin\API
 
     /**
      * Gets a user preference
-     * @param string $userLogin
+     * @param string $userLogin  Optional, defaults to current user log in.
      * @param string $preferenceName
      * @return bool|string
      */
-    public function getUserPreference($userLogin, $preferenceName)
+    public function getUserPreference($userLogin = false, $preferenceName)
     {
+        if ($userLogin === false) {
+            // the default value for first parameter is there to have it an optional parameter in the HTTP API
+            // in PHP it won't be optional. Could move parameter to the end of the method but did not want to break
+            // BC
+            $userLogin = Piwik::getCurrentUserLogin();
+        }
         Piwik::checkUserHasSuperUserAccessOrIsTheUser($userLogin);
 
         $optionValue = $this->getPreferenceValue($userLogin, $preferenceName);

--- a/plugins/UsersManager/tests/System/ApiTest.php
+++ b/plugins/UsersManager/tests/System/ApiTest.php
@@ -8,6 +8,9 @@
 
 namespace Piwik\Plugins\UsersManager\tests\System;
 
+use Piwik\API\Request;
+use Piwik\Piwik;
+use Piwik\Plugins\UsersManager\API;
 use Piwik\Plugins\UsersManager\tests\Fixtures\ManyUsers;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 
@@ -42,6 +45,35 @@ class ApiTest extends SystemTestCase
 
             $this->runAnyApiTest($api, $apiId . '_' . $appendix, $params, array('xmlFieldsToRemove' => $xmlFieldsToRemove));
         }
+    }
+
+    public function test_getUserPreference_loginIsOptional()
+    {
+        $response = Request::processRequest('UsersManager.getUserPreference', array(
+            'preferenceName' => API::PREFERENCE_DEFAULT_REPORT
+        ));
+        $this->assertEquals('1', $response);
+
+        $response = Request::processRequest('UsersManager.getUserPreference', array(
+            'preferenceName' => API::PREFERENCE_DEFAULT_REPORT_DATE
+        ));
+        $this->assertEquals('yesterday', $response);
+    }
+
+    public function test_getUserPreference_loginCanBeSet()
+    {
+        $response = Request::processRequest('UsersManager.getUserPreference', array(
+            'userLogin' => Piwik::getCurrentUserLogin(),
+            'preferenceName' => API::PREFERENCE_DEFAULT_REPORT_DATE
+        ));
+        $this->assertEquals('yesterday', $response);
+
+        // user not exists
+        $response = Request::processRequest('UsersManager.getUserPreference', array(
+            'userLogin' => 'foo',
+            'preferenceName' => API::PREFERENCE_DEFAULT_REPORT_DATE
+        ));
+        $this->assertEquals('yesterday', $response);
     }
 
     public function getApiForTesting()

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_listing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fba29ae0960d5f150636b462d060d3407573d9aa31e4467e98b5d80a38e94ecb
-size 4943071
+oid sha256:b4668beaae48a9761a8833a3d0cb57df6765a0d8f404ea29d7dac0434b7891f1
+size 4943329


### PR DESCRIPTION
Needed this for https://github.com/matomo-org/matomo-mobile-2/pull/5406

We're now allowing users to log in using their token auth. This way for example people using 
* LoginLdap
* Two factor authentication
* Matomo for WordPress (to be confirmed)

can also use the mobile app. It basically looks like this:

![image](https://user-images.githubusercontent.com/273120/83471877-f005ec80-a4d9-11ea-82d3-80c711c791ca.png)

Because the user is no longer logging in with username/password, I no longer have a username to pass to the `getUserPreference` method. We call this API in the mobile app to find out which site to load by default and which date to show by default.

There was no API method to get the userLogin for an auth token. Could have added such an API but that would mean we always have two API calls when instead the method could simply default to the current user log in. 

Adding this to 3.X since the same Matomo mobile app will be used for Matomo 3 and Matomo 4 and by making this work in the latest 3.X we will have less issues with users trying to log in using token auth. This way we also don't need to wait for months to release this new update as people will be able to use it right away. (if they use a recent Matomo version)
