### PR TITLE
Fix details overlay for links in overlay mode

### DIFF
--- a/plugins/Overlay/client/translations.js
+++ b/plugins/Overlay/client/translations.js
@@ -12,7 +12,7 @@ var Piwik_Overlay_Translations = (function () {
         initialize: function (callback) {
             // Load translation data
             Piwik_Overlay_Client.api('getTranslations', function (data) {
-                translations = data[0];
+                translations = data;
                 callback();
             });
         },


### PR DESCRIPTION
One overlay test (showing the link details) was failing for a while now. Just checked the reason and it turns out that was also caused by the switch to JSON2 as default, as the api result seems no longer wrapped in an array.

refs #16008, #16009, #8566 