### PR TITLE
Keep JSON2 format in Matomo 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The signature of `Dimension::configureSegments()` has been changed. Similar to configuring Metrics it now takes two parameters `SegmentsList $segmentsList` and `DimensionSegmentFactory $dimensionSegmentFactory`.
 * The method `Dimension::addSegment()` has been removed. See new implementation of `DimensionSegmentFactory::createSegment` for a replacement
 * The signature of the event `Segment.addSegments` has been changed. It now has one parameter `SegmentsList $list`, which allows adding new segments to the list
-* The json2 API format is now removed, and the json renderer now behaves as the json2 renderer did. This means when `format=json` is used, arrays like `['a' => 0, 'b' => 1]` will be rendered in JSON as `{"a":0,"b":1}` instead of `[{"a":0,"b":1}]`.
+* The json2 API format has now been deprecated, and the json renderer now behaves as the json2 renderer did. This means when `format=json` is used, arrays like `['a' => 0, 'b' => 1]` will be rendered in JSON as `{"a":0,"b":1}` instead of `[{"a":0,"b":1}]`. The JSON2 renderer will be removed in Matomo 5 and we recommend switching to it.
 * The event `Live.getAllVisitorDetails` has been removed. Use a `VisitorDetails` class instead (see Live plugin).
 * Zend_Validate and all subclasses have been completely removed.
 * Added support for campaign name parameter `matomo_campaign` / `mtm_campaign` and campaign keyword parameter `matomo_kwd` / `mtm_kwd`

--- a/core/API/ApiRenderer.php
+++ b/core/API/ApiRenderer.php
@@ -120,6 +120,9 @@ abstract class ApiRenderer
      */
     public static function factory($format, $request)
     {
+        if (Common::mb_strtolower($format) === 'json2') {
+            $format = 'json';
+        }
         $formatToCheck = '\\' . ucfirst(strtolower($format));
 
         $rendererClassnames = Plugin\Manager::getInstance()->findMultipleComponents('Renderer', 'Piwik\\API\\ApiRenderer');

--- a/tests/PHPUnit/Unit/API/ApiRendererTest.php
+++ b/tests/PHPUnit/Unit/API/ApiRendererTest.php
@@ -27,6 +27,9 @@ class ApiRendererTest extends \PHPUnit\Framework\TestCase
         $renderer = ApiRenderer::factory('xml', array());
         $this->assertInstanceOf('Piwik\Plugins\API\Renderer\Xml', $renderer);
 
+        $renderer = ApiRenderer::factory('JSON2', array());
+        $this->assertInstanceOf('Piwik\Plugins\API\Renderer\Json', $renderer);
+
         $renderer = ApiRenderer::factory('XML', array());
         $this->assertInstanceOf('Piwik\Plugins\API\Renderer\Xml', $renderer);
 


### PR DESCRIPTION
Created follow up issue to remove the format in Matomo 5 see https://github.com/matomo-org/matomo/issues/16028

We keep it to not break API there yet and to give users time to migrate to JSON format