### PR TITLE
Fix saving of personal settings

### DIFF
--- a/plugins/UsersManager/angularjs/personal-settings/personal-settings.controller.js
+++ b/plugins/UsersManager/angularjs/personal-settings/personal-settings.controller.js
@@ -87,7 +87,11 @@
                 return;
             }
 
-            angular.element('#confirmChangesWithPassword').modal("close");
+            var modal = M.Modal.getInstance(angular.element('#confirmChangesWithPassword'));
+
+            if (modal) {
+                modal.close();
+            }
 
             var postParams = {
                 email: this.email,


### PR DESCRIPTION
Saving the personal settings currently fails when the password isn't changed (and thus no modal is opened)

guess that's a regression from #14082