### PR TITLE
Fix metric format for page performance sparklines

### DIFF
--- a/plugins/PagePerformance/Reports/Get.php
+++ b/plugins/PagePerformance/Reports/Get.php
@@ -32,9 +32,7 @@ class Get extends \Piwik\Plugin\Report
         $this->name = Piwik::translate('PagePerformance_Overview');
         $this->documentation = '';
         $this->onlineGuideUrl = 'https://matomo.org/docs/page-performance/';
-        $this->processedMetrics = [
-            // none
-        ];
+        $this->processedMetrics = Metrics::getAllPagePerformanceMetrics();
         $this->metrics = Metrics::getAllPagePerformanceMetrics();
     }
 
@@ -61,20 +59,6 @@ class Get extends \Piwik\Plugin\Report
             && $view instanceof Sparklines
         ) {
             $this->addSparklineColumns($view);
-
-            $numberFormatter = new Formatter\Html();
-            $metrics = $this->getMetrics();
-            $view->config->filters[] = function (DataTable $table) use ($numberFormatter, $metrics) {
-                $firstRow = $table->getFirstRow();
-                if ($firstRow) {
-                    foreach ($metrics as $metric => $name) {
-                        $metricValue = $firstRow->getColumn($metric);
-                        if (false !== $metricValue) {
-                            $firstRow->setColumn($metric, $numberFormatter->getPrettyTimeFromSeconds($metricValue));
-                        }
-                    }
-                }
-            };
 
             $view->config->columns_to_display = array_keys(Metrics::getAllPagePerformanceMetrics());
             $view->config->setNotLinkableWithAnyEvolutionGraph();


### PR DESCRIPTION
In some languages (like German) the time format includes non breaking characters (`&nbsp;`). With the current way the metrics are formatted it results in `&nbsp;` displayed in the UI.

![image](https://user-images.githubusercontent.com/1579355/84172839-beae9300-aa7c-11ea-8a5d-93d6775f9fea.png)

Defining processed metrics seems to move the formatting to another place and fixes that issue.