### PR TITLE
Fix falsely assumes session was already started

### DIFF
--- a/libs/Zend/Session.php
+++ b/libs/Zend/Session.php
@@ -478,13 +478,6 @@ class Zend_Session extends Zend_Session_Abstract
                . " output started in {$filename}/{$linenum}");
         }
 
-        // See http://www.php.net/manual/en/ref.session.php for explanation
-        if (!self::$_unitTestEnabled && defined('SID')) {
-            /** @see Zend_Session_Exception */
-            // require_once 'Zend/Session/Exception.php';
-            throw new Zend_Session_Exception('session has already been started by session.auto-start or session_start()');
-        }
-
         /**
          * Hack to throw exceptions on start instead of php errors
          * @see http://framework.zend.com/issues/browse/ZF-1325


### PR DESCRIPTION
fix https://wordpress.org/support/topic/an-error-occurred-session-already-started/#topic-12961322-replies

refs https://github.com/matomo-org/wp-matomo/pull/304

Adding this to 3.X as needed for Matomo for WordPress.

The removed code should actually not be needed as we added a while ago `session_status()` to correctly check if a session is already active or not. SID constant is not reliable.

In this case problem was this https://3v4l.org/bpUFK

Basically a session was started by some other plugin causing the SID constant to be set. The plugin also directly closed the session again so we still attempted to start the session (which is correct). But then Zend falsely assumes session is started because of the SID constant when there is actually no session.

SID is not reliable for this purpose and be better to rely on `session_status()` which we added a while back