### PR TITLE
Add legacy autoloader to support Matomo namespaces in 3.X 

### DIFF
--- a/LegacyAutoloader.php
+++ b/LegacyAutoloader.php
@@ -17,7 +17,7 @@ class LegacyAutoloader
         if (strpos($className, 'Matomo\\') === 0) {
             $newName = 'Piwik' . substr($className, 6);
             if (class_exists($newName)) {
-                class_alias($newName, $className);
+                @class_alias($newName, $className);
             }
         }
     }

--- a/LegacyAutoloader.php
+++ b/LegacyAutoloader.php
@@ -1,0 +1,26 @@
+<?php
+
+class LegacyAutoloader
+{
+    public function __construct()
+    {
+        spl_autoload_register(array($this, 'load_class'));
+    }
+
+    public static function register()
+    {
+        new LegacyAutoloader();
+    }
+
+    public function load_class($className)
+    {
+        if (strpos($className, 'Matomo\\') === 0) {
+            $newName = 'Piwik' . substr($className, 6);
+            if (class_exists($newName)) {
+                class_alias($newName, $className);
+            }
+        }
+    }
+}
+
+LegacyAutoloader::register();

--- a/LegacyAutoloader.php
+++ b/LegacyAutoloader.php
@@ -22,7 +22,7 @@ class LegacyAutoloader
         } elseif (strpos($className, 'Piwik\\') === 0) {
             $newName = 'Matomo' . substr($className, 5);
             if (class_exists($newName)) {
-                class_alias($newName, $className);
+                @class_alias($newName, $className);
             }
         }
     }

--- a/LegacyAutoloader.php
+++ b/LegacyAutoloader.php
@@ -16,12 +16,12 @@ class LegacyAutoloader
     {
         if (strpos($className, 'Matomo\\') === 0) {
             $newName = 'Piwik' . substr($className, 6);
-            if (class_exists($newName)) {
+            if (class_exists($newName) && !class_exists($className, false)) {
                 @class_alias($newName, $className);
             }
         } elseif (strpos($className, 'Piwik\\') === 0) {
             $newName = 'Matomo' . substr($className, 5);
-            if (class_exists($newName)) {
+            if (class_exists($newName) && !class_exists($className, false)) {
                 @class_alias($newName, $className);
             }
         }

--- a/LegacyAutoloader.php
+++ b/LegacyAutoloader.php
@@ -19,6 +19,11 @@ class LegacyAutoloader
             if (class_exists($newName)) {
                 @class_alias($newName, $className);
             }
+        } elseif (strpos($className, 'Piwik\\') === 0) {
+            $newName = 'Matomo' . substr($className, 5);
+            if (class_exists($newName)) {
+                class_alias($newName, $className);
+            }
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,8 @@
             "HTML_": "libs/",
             "PEAR_": "libs/",
             "Archive_": "libs/"
-        }
+        },
+        "files": ["LegacyAutoloader.php"]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Refs https://github.com/matomo-org/matomo/issues/12420#issuecomment-644254519

The purpose is to make updates to a future Matomo version smoother where we maybe use `Matomo` namespace instead of `Piwik`

Tested it eg in 3.x-dev by adding a file `core/Foo.php` with content 

```php
<?php
namespace Matomo;

class Foo {
    public function get()
    {
        return '42';
    }
}
```

then in `core/dispatch.php` tested it using 

```php
$x = new \Piwik\Foo();
echo $x->get();
```
 and using 

```php
$x = new \Matomo\Foo();
echo $x->get();
```

In all cases the class was resolved correctly with no issues.