### PR TITLE
Add legacy autoloader for 2.x-dev for smoother upgrades

### DIFF
--- a/LegacyAutoloader.php
+++ b/LegacyAutoloader.php
@@ -1,0 +1,31 @@
+<?php
+
+class LegacyAutoloader
+{
+    public function __construct()
+    {
+        spl_autoload_register(array($this, 'load_class'));
+    }
+
+    public static function register()
+    {
+        new LegacyAutoloader();
+    }
+
+    public function load_class($className)
+    {
+        if (strpos($className, 'Matomo\\') === 0) {
+            $newName = 'Piwik' . substr($className, 6);
+            if (class_exists($newName) && !class_exists($className, false)) {
+                @class_alias($newName, $className);
+            }
+        } elseif (strpos($className, 'Piwik\\') === 0) {
+            $newName = 'Matomo' . substr($className, 5);
+            if (class_exists($newName) && !class_exists($className, false)) {
+                @class_alias($newName, $className);
+            }
+        }
+    }
+}
+
+LegacyAutoloader::register();

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,8 @@
             "HTML_": "libs/",
             "PEAR_": "libs/",
             "Archive_": "libs/"
-        }
+        },
+        "files": ["LegacyAutoloader.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/core/Plugin/ControllerAdmin.php
+++ b/core/Plugin/ControllerAdmin.php
@@ -207,7 +207,7 @@ abstract class ControllerAdmin extends Controller
      */
     private static function getNextRequiredMinimumPHP()
     {
-        return '5.5.9';
+        return '7.2.5';
     }
 
     private static function isUsingPhpVersionCompatibleWithNextPiwik()

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Piwik version.
      * @var string
      */
-    const VERSION = '2.18.1';
+    const VERSION = '2.18.1-b1';
 
     public function isStableVersion($version)
     {

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Piwik version.
      * @var string
      */
-    const VERSION = '2.18.0';
+    const VERSION = '2.18.1';
 
     public function isStableVersion($version)
     {


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/12420 see https://github.com/matomo-org/matomo/pull/16069 for explanation.


We need to create a new 2.X release for this.