### PR TITLE
Removes double escaping in siteselector tooltip

### DIFF
--- a/plugins/CoreHome/angularjs/siteselector/siteselector.directive.html
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.directive.html
@@ -16,7 +16,7 @@
     <a ng-click="view.showSitesList=!view.showSitesList; view.showSitesList && !model.isLoading && model.loadInitialSites();"
        piwik-onenter="view.showSitesList=!view.showSitesList; view.showSitesList && !model.isLoading && model.loadInitialSites();"
        href="javascript:void(0)"
-       title="{{ 'CoreHome_ChangeCurrentWebsite'|translate:((selectedSite.name || model.firstSiteName)|escape) }}"
+       title="{{ 'CoreHome_ChangeCurrentWebsite'|translate:((selectedSite.name || model.firstSiteName)) }}"
        ng-class="{'loading': model.isLoading}"
        class="title" tabindex="4">
         <span class="icon icon-arrow-bottom"


### PR DESCRIPTION
checked with website titles like `<b>test</b>` or `{{CONSTRUCTOR.CONSTRUCTOR("_X()")()}}` if removing the escape opens up some html or angular execution, but seems the content is still encoded once.

fixes #16072