### PR TITLE
Use Python 3 for Log Analytics

### DIFF
--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -125,14 +125,14 @@ class Fixture extends \PHPUnit\Framework\Assert
     protected static function getPythonBinary()
     {
         if (SettingsServer::isWindows()) {
-            return "C:\Python27\python.exe";
+            return "C:\Python3\python3.exe";
         }
 
         if (SystemTestCase::isTravisCI()) {
-            return 'python2.7';
+            return 'python3';
         }
 
-        return 'python';
+        return 'python3';
     }
 
     public static function getCliCommandBase()


### PR DESCRIPTION
With Matomo 4 we should consider dropping the support for Python2 in log analytics completely.

This PR is based on the changes of https://github.com/matomo-org/matomo-log-analytics/pull/267
And is primarily there to prove all Matomo tests are running smoothly with Python 3