### PR TITLE
Ensure dialogs can be moved smoothly

### DIFF
--- a/plugins/Morpheus/stylesheets/ui/_popups.less
+++ b/plugins/Morpheus/stylesheets/ui/_popups.less
@@ -1,8 +1,3 @@
-.ui-dialog {
-  left: 50%;
-  transform: translateX(-50%);
-}
-
 .ui-dialog-title {
   color: @theme-color-text;
   font-weight: normal;


### PR DESCRIPTION
When trying to move a dialog (like row evolution) with the mouse, the dialog currently flips to the left before it's actually moved.

Guess that's a regression from #14082 