### PR TITLE
Document StaticContainer considered no longer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 * The class `\Piwik\ScheduledTask` has been removed. Use `\Piwik\Scheduler\Task` instead.
 * The class `\Piwik\Translate` has been removed. Use `\Piwik\Translation\Translator` instead.
 * The class `\Piwik\Plugins\Login\SessionInitializer` is no longer considered API as it is no longer needed.
+* The class `\Piwik\Container\StaticContainer` still exists but we no longer consider it an API and constructor injection should be used instead where possible.
 * The method `Piwik\Columns\Dimension::factory` has been removed. Use `DimensionsProvider::factory` instead.
 * The method `Piwik\Config::reset` has been removed. Use the `reload` method instead.
 * The method `Piwik\Config::init` has been removed. Use the `reload()` method instead.


### PR DESCRIPTION
Forgot to document this one earlier. If somewhere constructor injection doesn't work, we'll need to either try to make it work there or tell them to still use staticcontainer for now. But it might just work for most plugins.

FYI will merge right away. Feel free to comment if I should change anything.