### PR TITLE
wrong escaping of cookie path

### DIFF
--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -153,7 +153,7 @@ class Cookie
 
         $header = 'Set-Cookie: ' . rawurlencode($Name) . '=' . rawurlencode($Value)
             . (empty($Expires) ? '' : '; expires=' . gmdate('D, d-M-Y H:i:s', $Expires) . ' GMT')
-            . (empty($Path) ? '' : '; path=' . rawurlencode($Path))
+            . (empty($Path) ? '' : '; path=' . $Path)
             . (empty($Domain) ? '' : '; domain=' . rawurlencode($Domain))
             . (!$Secure ? '' : '; secure')
             . (!$HTTPOnly ? '' : '; HttpOnly')


### PR DESCRIPTION
Since this commit has been merged, setting the cookie path is broken.
https://github.com/matomo-org/matomo/pull/15185/commits/3b69290a957e3ff68176481b8b0e63dd704e5d76
https://github.com/matomo-org/matomo/pull/15185

Cookie path in the Set-Cookie header must not be escaped, or the browser will fall back to the current URL path.

For example:
If $Path === '/' and the cookie is set from /js/tracker.php, the browser will save the cookie path as "/js" and not "/".

Reading the docu here https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie, I think we should not escape the path at all.
Same applies for the domain, but since the dot is not escaped by rawurlencode, I think it does not hurt
