### PR TITLE
Remove custom variables requirement hint for site search categories

### DIFF
--- a/plugins/Goals/VisitorDetails.php
+++ b/plugins/Goals/VisitorDetails.php
@@ -9,16 +9,7 @@
 namespace Piwik\Plugins\Goals;
 
 use Piwik\Common;
-use Piwik\Config;
-use Piwik\Date;
-use Piwik\Db;
-use Piwik\Metrics\Formatter;
-use Piwik\Piwik;
-use Piwik\Plugins\CustomVariables\CustomVariables;
 use Piwik\Plugins\Live\VisitorDetailsAbstract;
-use Piwik\Site;
-use Piwik\Tracker\Action;
-use Piwik\Tracker\PageUrl;
 
 class VisitorDetails extends VisitorDetailsAbstract
 {

--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
@@ -86,9 +86,6 @@
 
         var saveSite = function() {
 
-            var sendSiteSearchKeywordParams = $scope.site.sitesearch == '1' && !$scope.site.useDefaultSiteSearchParams;
-            var sendSearchCategoryParameters = sendSiteSearchKeywordParams && $scope.customVariablesActivated;
-
             var values = {
                 siteName: $scope.site.name,
                 timezone: $scope.site.timezone,

--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
@@ -37,7 +37,6 @@
             initSelectLists();
             initUtcTime();
             initUserIP();
-            initCustomVariablesActivated();
             initIsTimezoneSupportEnabled();
             initGlobalParams();
 
@@ -152,18 +151,6 @@
 
                     $scope.timezones = scopeTimezones;
                 }
-            );
-        };
-
-        var initCustomVariablesActivated = function() {
-
-            coreAPI.isPluginActivated(
-
-                function (customVariablesActivated) {
-                    $scope.customVariablesActivated = customVariablesActivated;
-                },
-
-                {pluginName: 'CustomVariables'}
             );
         };
 

--- a/plugins/SitesManager/templates/global-settings.html
+++ b/plugins/SitesManager/templates/global-settings.html
@@ -68,12 +68,7 @@
          inline-help="{{ 'SitesManager_SearchKeywordParametersDesc' | translate }}">
     </div>
 
-    <div ng-hide="customVariablesActivated" class="alert alert-info">
-        Note: you could also track your Internal Search Engine Categories, but the plugin Custom Variables is required. Please enable the plugin CustomVariables (or ask your Piwik admin).
-    </div>
-
     <div piwik-field uicontrol="text" name="searchCategoryParametersGlobal" var-type="array"
-         ng-show="customVariablesActivated"
          ng-model="globalSettings.searchCategoryParametersGlobal"
          data-title="{{ 'SitesManager_SearchCategoryLabel'|translate }}"
          inline-help="{{ 'Goals_Optional'|translate }} {{ 'SitesManager_SearchCategoryDesc'|translate }} {{ 'SitesManager_SearchCategoryParametersDesc'|translate }}">

--- a/plugins/SitesManager/templates/sites-list/site-search-field.html
+++ b/plugins/SitesManager/templates/sites-list/site-search-field.html
@@ -51,7 +51,7 @@
             <input ng-list ng-model="site.sitesearch_keyword_parameters">
         </div>
 
-        <div ng-show="customVariablesActivated" class="form-group">
+        <div class="form-group">
             <label>{{ 'SitesManager_SearchCategoryLabel' | translate }}</label>
             <div class="form-help">
                 {{ 'Goals_Optional' | translate }} {{ 'SitesManager_SearchCategoryParametersDesc' | translate }}

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager__SitesManager.getSiteSettings.xml
@@ -195,7 +195,7 @@ https://www.example.org/</placeholder>
 				<inlineHelp>(optional)&lt;br /&gt;&lt;br /&gt;You may enter a comma-separated list of query parameters specifying the search category.</inlineHelp>
 				<templateFile />
 				<introduction />
-				<condition>1 &amp;&amp; sitesearch &amp;&amp; !use_default_site_search_params</condition>
+				<condition>sitesearch &amp;&amp; !use_default_site_search_params</condition>
 			</row>
 			<row>
 				<name>ecommerce</name>

--- a/plugins/WebsiteMeasurable/MeasurableSettings.php
+++ b/plugins/WebsiteMeasurable/MeasurableSettings.php
@@ -322,8 +322,7 @@ class MeasurableSettings extends \Piwik\Settings\Measurable\MeasurableSettings
                 . '<br /><br />'
                 . Piwik::translate('SitesManager_SearchCategoryParametersDesc');
 
-            $hasCustomVars = (int) $pluginManager->isPluginActivated('CustomVariables');
-            $field->condition = $hasCustomVars . ' && sitesearch && !use_default_site_search_params';
+            $field->condition = 'sitesearch && !use_default_site_search_params';
         });
     }
 

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getAvailableMeasurableTypes.xml
@@ -198,7 +198,7 @@ https://www.example.org/</placeholder>
 						<inlineHelp>(optional)&lt;br /&gt;&lt;br /&gt;You may enter a comma-separated list of query parameters specifying the search category.</inlineHelp>
 						<templateFile />
 						<introduction />
-						<condition>1 &amp;&amp; sitesearch &amp;&amp; !use_default_site_search_params</condition>
+						<condition>sitesearch &amp;&amp; !use_default_site_search_params</condition>
 					</row>
 					<row>
 						<name>ecommerce</name>
@@ -445,7 +445,7 @@ https://www.example.org/</placeholder>
 						<inlineHelp>(optional)&lt;br /&gt;&lt;br /&gt;You may enter a comma-separated list of query parameters specifying the search category.</inlineHelp>
 						<templateFile />
 						<introduction />
-						<condition>1 &amp;&amp; sitesearch &amp;&amp; !use_default_site_search_params</condition>
+						<condition>sitesearch &amp;&amp; !use_default_site_search_params</condition>
 					</row>
 					<row>
 						<name>ecommerce</name>


### PR DESCRIPTION
Seems removing that hint was missed in #12072 