### PR TITLE
Allow configuration of a shorter lock wait time in tracker mode (new INI setting innodb_lock_wait_timeout)

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -886,6 +886,13 @@ enable_sql_profiler = 0
 ; Enables using referrer spam blacklist.
 enable_spam_filter = 1
 
+; If a value greater than 0 is configured, Matomo will configure MySQL with the set lock wait timeout in seconds during a
+; tracking request. This can be useful if you have a high concurrency load on your server and want to reduce the time of
+; lock wait times. For example configuring a value of 2 or 3 seconds may give your Matomo a performance boost if you have
+; many concurrent tracking requests for the same visitor. When enabling this feature, make sure the MySQL
+; variable "innodb_rollback_on_timeout" is turned off.
+innodb_lock_wait_timeout = 0
+
 [Segments]
 ; Reports with segmentation in API requests are processed in real time.
 ; On high traffic websites it is recommended to pre-process the data

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -888,9 +888,10 @@ enable_spam_filter = 1
 
 ; If a value greater than 0 is configured, Matomo will configure MySQL with the set lock wait timeout in seconds during a
 ; tracking request. This can be useful if you have a high concurrency load on your server and want to reduce the time of
-; lock wait times. For example configuring a value of 2 or 3 seconds may give your Matomo a performance boost if you have
+; lock wait times. For example configuring a value of 3-10 seconds may give your Matomo a performance boost if you have
 ; many concurrent tracking requests for the same visitor. When enabling this feature, make sure the MySQL
-; variable "innodb_rollback_on_timeout" is turned off.
+; variable "innodb_rollback_on_timeout" is turned off. Only configure if really needed. The lower the value the more tracking
+; requests may be discarded due to too low lock wait time.
 innodb_lock_wait_timeout = 0
 
 [Segments]

--- a/core/Tracker/Db.php
+++ b/core/Tracker/Db.php
@@ -280,6 +280,12 @@ abstract class Db
         $db = self::factory($configDb);
         $db->connect();
 
+        $trackerConfig = Config::getInstance()->Tracker;
+        if (!empty($trackerConfig['innodb_lock_wait_timeout']) && $trackerConfig['innodb_lock_wait_timeout'] > 0){
+            // we set this here because we only want to set this config if a connection is actually created.
+            $time = (int) $trackerConfig['innodb_lock_wait_timeout'];
+            $db->query('SET @@innodb_lock_wait_timeout = ' . $time);
+        }
         return $db;
     }
 }

--- a/core/Tracker/Db/Pdo/Mysql.php
+++ b/core/Tracker/Db/Pdo/Mysql.php
@@ -12,6 +12,7 @@ use Exception;
 use PDO;
 use PDOException;
 use PDOStatement;
+use Piwik\Config;
 use Piwik\Tracker\Db;
 use Piwik\Tracker\Db\DbException;
 
@@ -106,8 +107,6 @@ class Mysql extends Db
         // See #6296 why this is important in tracker
         $this->mysqlOptions[PDO::MYSQL_ATTR_FOUND_ROWS] = true;
         $this->mysqlOptions[PDO::ATTR_ERRMODE] = PDO::ERRMODE_EXCEPTION;
-        
-
 
         $this->connection = @new PDO($this->dsn, $this->username, $this->password, $this->mysqlOptions);
 

--- a/core/Tracker/Handler.php
+++ b/core/Tracker/Handler.php
@@ -52,16 +52,7 @@ class Handler
     public function process(Tracker $tracker, RequestSet $requestSet)
     {
         foreach ($requestSet->getRequests() as $request) {
-            try {
-                $tracker->trackRequest($request);
-            } catch (Exception $e) {
-                if (stripos($e->getMessage(), 'Lock wait timeout exceeded')
-                    || Tracker::getDatabase()->isErrNo($e, 1205)) {
-                    continue;
-                } else {
-                    throw $e;
-                }
-            }
+            $tracker->trackRequest($request);
         }
     }
 

--- a/core/Tracker/Handler.php
+++ b/core/Tracker/Handler.php
@@ -52,7 +52,16 @@ class Handler
     public function process(Tracker $tracker, RequestSet $requestSet)
     {
         foreach ($requestSet->getRequests() as $request) {
-            $tracker->trackRequest($request);
+            try {
+                $tracker->trackRequest($request);
+            } catch (Exception $e) {
+                if (stripos($e->getMessage(), 'Lock wait timeout exceeded')
+                    || Tracker::getDatabase()->isErrNo($e, 1205)) {
+                    continue;
+                } else {
+                    throw $e;
+                }
+            }
         }
     }
 

--- a/plugins/BulkTracking/Tracker/Handler.php
+++ b/plugins/BulkTracking/Tracker/Handler.php
@@ -60,6 +60,13 @@ class Handler extends Tracker\Handler
                 $invalidRequests[] = $index;
             } catch (InvalidRequestParameterException $ex) {
                 $invalidRequests[] = $index;
+            } catch (Exception $e) {
+                if (stripos($e->getMessage(), 'Lock wait timeout exceeded')
+                    || Tracker::getDatabase()->isErrNo($e, 1205)) {
+                    continue;
+                } else {
+                    throw $e;
+                }
             }
         }
 

--- a/tests/PHPUnit/Integration/Tracker/DbTest.php
+++ b/tests/PHPUnit/Integration/Tracker/DbTest.php
@@ -9,8 +9,11 @@
 namespace Piwik\Tests\Integration\Tracker;
 
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\Db;
+use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Timer;
 use Piwik\Tracker;
 
 /**
@@ -28,6 +31,44 @@ class DbTest extends IntegrationTestCase
         $this->tableName = Common::prefixTable('option');
     }
 
+    public function test_innodb_lock_wait_timeout()
+    {
+        $idSite1 = Fixture::createWebsite('2020-01-01 02:02:02');
+        $idSite2 = Fixture::createWebsite('2020-01-01 02:02:02');
+
+        // we expect it does not take more than 3s for the lock exceeded time to happen
+        // usually be like 30-50 seconds
+        $tracker = Config::getInstance()->Tracker;
+        $tracker['innodb_lock_wait_timeout'] = 3;
+        Config::getInstance()->Tracker = $tracker;
+
+        $db1 = Tracker\Db::connectPiwikTrackerDb();
+        $db2 = Tracker\Db::connectPiwikTrackerDb();
+
+        $timer = new Timer();
+
+        $db1->beginTransaction();
+        $db2->beginTransaction();
+
+        $site = Common::prefixTable('site');
+        $db1->query("UPDATE $site SET name = ? WHERE idsite = ?", ['foo', $idSite1]);
+        $db2->query("UPDATE $site SET name = ? WHERE idsite = ?", ['foo', $idSite2]);
+
+        try {
+            $db1->query("UPDATE $site SET name = ? WHERE idsite = ?", ['bar', $idSite2]);
+        } catch (\Exception $e) {
+            $this->assertStringContainsString('Lock wait timeout exceeded; try restarting transaction', $e->getMessage());
+            $this->assertStringContainsString(' 1205 ', $e->getMessage()); // mysql error code
+            $this->assertTrue($db1->isErrNo($e, 1205));
+            $this->assertTrue($e instanceof Tracker\Db\DbException);
+        }
+
+        $ms = $timer->getTimeMs();
+
+        $this->assertGreaterThan(3000, $ms);
+        $this->assertLessThan(5000, $ms);
+
+    }
     public function test_rowCount_whenUpdating_returnsAllMatchedRowsNotOnlyUpdatedRows()
     {
         $db = Tracker::getDatabase();


### PR DESCRIPTION
MySQL wait locks can cause some performance issues on high traffic/concurrency loads. For example the following scenario:

* There's a bulk request `#1` updating various entries in a transaction
* Another tracking request `#2` eg for same visitor comes in
* There may be a lock wait time for `#2` because it's waiting for the transaction in `#1` to finish.
* By default, the tracking request may wait to get the lock for 30 to 50 seconds (MySQL default). 
 * More and more requests might be coming in for the same visitor and suddenly you have say a few hundred or thousands requests waiting for 30 to 50 seconds and/or failing which could make an auto scaling system think the servers or instances aren't healthy and considers them all as unhealthy

To address this issue, the thought is to configure a shorter lock wait time so these locks aren't held for too long.

When an error `1205 Lock wait timeout exceeded; try restarting transaction` happens, then MySQL rolls back the current statement. Because there might be multiple inserts or updates within one tracking request we can't really safely replay the entire tracking request (unless `innodb_rollback_on_timeout=1` was enabled). This means for now the behaviour be as follows:

* For a single tracking request we don't do anything and simply fail
* For a request within the bulk tracking request we skip the request that had a lock wait time compared to previous behaviour where it would have failed all tracking requests and rolled back everything.

We need to see later if we maybe need to respond with a success tracking request when this happens but that's to be seen (to avoid having too many error requests making instances unhealthy). If any possible we don't want to do this.

### A note on deadlocks
Thought I also quickly go into deadlocks in case someone thinks that's related which it isn't quite related.

This change does not affect deadlocks which may happen as part of bulk requests from the JS tracker. Deadlocks usually don't happen for log analytics or queued tracking because they don't send bulk requests in parallel for the same visitor but process them one after another.

Depending on the MySQL distribution (MySQL, MariaDB, RDS, Aurora, ...) or version these might be detected immediately without waiting for a few seconds. For some MySQL instances this behaviour depends on the MySQL `innodb_deadlock_detect` variable. FYI: Having this variable enabled can slow down performance on a high load MySQL.
 
When a deadlock happens, MySQL rolls back the entire transactions. This means the current behaviour is that the tracking request fails and nothing in the DB is changed. It's like the bulk request didn't happen.

We could eventually catch deadlock errors and try to reply them once. This would be probably a separate PR.

You can also workaround by configuring `[Tracker]bulk_requests_use_transaction=0` in Matomo but then you need to expect more DB CPU usage and slower average response times cause more indexes are written etc.

### How can a lock wait timeout happen? 

* session 1: `start transaction`
* session 1: `update site set name = '...' where idsite = 1`
* session 2: `update site set name = '...' where idsite = 1`

Because the session 1 is not committed yet, the `session 2` needs to wait for the `session 1` to finish before it can have the row lock to update the site.

###  How does a deadlock happen?

Basically deadlocks happen when there are two DB sessions and they both wait for a lock that the other one holds. Basically they both want the same locks but they get them in the opposite order like this:

* session 1: `start transaction`
* session 2: `start transaction`
* session 1: `update site set name = '...' where idsite = 1`
* session 2: `update site set name = '...' where idsite = 2`
* session 1: `update site set name = '...' where idsite = 2`
* session 2: `update site set name = '...' where idsite = 1`

Basically `session 2` waits for the lock to update `site 1` which `session 1` holds, but `session 1` waits at the same time for a lock to update `site 2` which `session 2` has.

This is my understanding of how things work. I might be wrong :)