### PR TITLE
Rename referrer spam list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -718,7 +718,7 @@ The folder containing expected screenshots was renamed from `expected-ui-screens
 
 ### Internal changes
 
-* The referrer spam filter has moved from the `referrer_urls_spam` INI option (in `global.ini.php`) to a separate package (see [https://github.com/matomo-org/referrer-spam-blacklist](https://github.com/matomo-org/referrer-spam-blacklist)).
+* The referrer spam filter has moved from the `referrer_urls_spam` INI option (in `global.ini.php`) to a separate package (see [https://github.com/matomo-org/referrer-spam-list](https://github.com/matomo-org/referrer-spam-list)).
 
 ## Piwik 2.12.0
 

--- a/core/Tracker/VisitExcluded.php
+++ b/core/Tracker/VisitExcluded.php
@@ -135,7 +135,7 @@ class VisitExcluded
                 }
             }
         } else {
-            Common::printDebug("Spam blacklist is disabled.");
+            Common::printDebug("Spam list is disabled.");
         }
 
         // Check if request URL is excluded

--- a/core/Tracker/VisitExcluded.php
+++ b/core/Tracker/VisitExcluded.php
@@ -131,7 +131,7 @@ class VisitExcluded
             if (!$excluded) {
                 $excluded = $this->isReferrerSpamExcluded();
                 if ($excluded) {
-                    Common::printDebug("Referrer URL is blacklisted as spam.");
+                    Common::printDebug("Referrer URL is listed as spam.");
                 }
             }
         } else {

--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -86,7 +86,7 @@ class Tasks extends \Piwik\Plugin\Tasks
 
         $generalConfig = Config::getInstance()->Tracker;
         if((SettingsPiwik::isInternetEnabled() === true) && $generalConfig['enable_spam_filter']){
-            $this->weekly('updateSpammerBlacklist');
+            $this->weekly('updateSpammerList');
         }
 
         $this->scheduleTrackingCodeReminderChecks();
@@ -303,11 +303,11 @@ class Tasks extends \Piwik\Plugin\Tasks
     /**
      * Update the referrer spam blacklist
      *
-     * @see https://github.com/matomo-org/referrer-spam-blacklist
+     * @see https://github.com/matomo-org/referrer-spam-list
      */
-    public function updateSpammerBlacklist()
+    public function updateSpammerList()
     {
-        $url = 'https://raw.githubusercontent.com/matomo-org/referrer-spam-blacklist/master/spammers.txt';
+        $url = 'https://raw.githubusercontent.com/matomo-org/referrer-spam-list/master/spammers.txt';
         $list = Http::sendHttpRequest($url, 30);
         $list = preg_split("/\r\n|\n|\r/", $list);
         if (count($list) < 10) {

--- a/plugins/CoreAdminHome/tests/Integration/TasksTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/TasksTest.php
@@ -140,7 +140,7 @@ class TasksTest extends IntegrationTestCase
             'optimizeArchiveTable.',
             'cleanupTrackingFailures.',
             'notifyTrackingFailures.',
-            'updateSpammerBlacklist.',
+            'updateSpammerList.',
             'checkSiteHasTrackedVisits.2',
             'checkSiteHasTrackedVisits.3',
             'checkSiteHasTrackedVisits.4',


### PR DESCRIPTION
refs https://github.com/matomo-org/referrer-spam-list/issues/1224

Note: the composer package still has the same name for now.