### PR TITLE
Configure device detector cache through DI

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -79,6 +79,8 @@ return array(
     'Piwik\Translation\Loader\LoaderInterface' => DI\object('Piwik\Translation\Loader\LoaderCache')
         ->constructor(DI\get('Piwik\Translation\Loader\JsonFileLoader')),
 
+    'DeviceDetector\Cache\Cache' => DI\object('Piwik\DeviceDetector\DeviceDetectorCache')->constructor(86400),
+
     'observers.global' => array(),
 
     /**

--- a/core/DeviceDetector/DeviceDetectorFactory.php
+++ b/core/DeviceDetector/DeviceDetectorFactory.php
@@ -52,7 +52,7 @@ class DeviceDetectorFactory
     {
         $deviceDetector = new DeviceDetector($userAgent);
         $deviceDetector->discardBotInformation();
-        $deviceDetector->setCache(new DeviceDetectorCache(86400));
+        $deviceDetector->setCache(StaticContainer::get('DeviceDetector\Cache\Cache'));
         $deviceDetector->parse();
         return $deviceDetector;
     }

--- a/plugins/API/Menu.php
+++ b/plugins/API/Menu.php
@@ -8,7 +8,7 @@
  */
 namespace Piwik\Plugins\API;
 
-use Piwik\DeviceDetector\DeviceDetectorCache;
+use Piwik\Container\StaticContainer;
 use Piwik\Menu\MenuAdmin;
 use Piwik\Menu\MenuTop;
 use Piwik\Piwik;
@@ -51,7 +51,7 @@ class Menu extends \Piwik\Plugin\Menu
         }
 
         $ua = new OperatingSystem($_SERVER['HTTP_USER_AGENT']);
-        $ua->setCache(new DeviceDetectorCache(86400));
+        $ua->setCache(StaticContainer::get('DeviceDetector\Cache\Cache'));
         $parsedOS = $ua->parse();
 
         if (!empty($parsedOS['short_name']) && in_array($parsedOS['short_name'], array(self::DD_SHORT_NAME_ANDROID, self::DD_SHORT_NAME_IOS))) {


### PR DESCRIPTION
Lets someone customise the cache. Eg different TTL or store the caches in a different directory which can be beneficial if you run many Matomo instances. Say you have 500K instances, and each create 1 MB  tracker cache files, then you have 500GB cache files for device detector that are all the same and you'd want to have this all in opcache which is obviously not easily doable.