### PR TITLE
Try to avoid ui test failures due to CSS loading failures

### DIFF
--- a/core/ProxyHttp.php
+++ b/core/ProxyHttp.php
@@ -286,6 +286,10 @@ class ProxyHttp
             $data = gzencode($data, 9);
         }
 
+        if (false === $data) {
+            throw new \Exception('compressing file '.$fileToCompress.' failed');
+        }
+
         file_put_contents($compressedFilePath, $data);
     }
 }

--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_loaded_token_auth.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_loaded_token_auth.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de5ea31d38bc002b7fbec28d3ce78d0f9f749d330a6cd6d6d0e16289a85305a4
-size 734292
+oid sha256:a5fdd3bc28347e7faa84b36ad92068f802bce1836b4ea6ac33efd9b016762a4a
+size 734293

--- a/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_loaded_token_auth.png
+++ b/plugins/Dashboard/tests/UI/expected-screenshots/Dashboard_loaded_token_auth.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5fdd3bc28347e7faa84b36ad92068f802bce1836b4ea6ac33efd9b016762a4a
-size 734293
+oid sha256:de5ea31d38bc002b7fbec28d3ce78d0f9f749d330a6cd6d6d0e16289a85305a4
+size 734292

--- a/plugins/Installation/tests/UI/expected-screenshots/Installation_superuser_de.png
+++ b/plugins/Installation/tests/UI/expected-screenshots/Installation_superuser_de.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f1f4176f46a9ff2d47c7320ec7ffd21fbc442be44e2bd82e5589be7c0f4fe0c
-size 105242
+oid sha256:ee3e1076c8a741687e3297c540030ad81e6cd7a64af38b73d7c2f39bb7dd6afc
+size 104090

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -321,10 +321,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
         this._logMessage(msgStack.join('\n'));
     });
 
-    var cssReloaded = false;
-
     this.webpage.on('load', () => {
-        cssReloaded = false;
         this.webpage.evaluate(function () {
             var $ = window.jQuery;
             if ($) {
@@ -394,11 +391,14 @@ PageRenderer.prototype._setupWebpageEvents = function () {
             this._logMessage('Unable to load resource (URL:' + request.url() + '): ' + errorMessage);
         }
 
-        if (request.url().indexOf('action=getCss') !== -1 && !cssReloaded) {
-            console.log('Loading CSS failed... Try adding it with another style tag.');
-            cssReloaded = true;
-            await this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
-            await this.webpage.waitFor(200);
+        if (request.url().indexOf('action=getCss')) {
+            if (request.url().indexOf('&reload=1') === -1) {
+                console.log('Loading CSS failed... Try adding it with another style tag.');
+                await this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
+                await this.webpage.waitFor(1000);
+            } else {
+                console.log('Reloading CSS failed.');
+            }
         }
     });
 
@@ -414,11 +414,14 @@ PageRenderer.prototype._setupWebpageEvents = function () {
 
         // if response of css request does not start with /*, we assume it had an error and try to load it again
         // Note: We can't do that in requestfailed only, as the response code might be 200 even if it throws an exception
-        if (request.url().indexOf('action=getCss') !== -1 && !cssReloaded && (await response.buffer()).toString().substring(0, 2) !== '/*') {
-            console.log('Loading CSS failed... Try adding it with another style tag.');
-            cssReloaded = true;
-            await this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
-            await this.webpage.waitFor(200);
+        if (request.url().indexOf('action=getCss') !== -1 && (await response.buffer()).toString().substring(0, 2) !== '/*') {
+            if (request.url().indexOf('&reload=1') === -1) {
+                console.log('Loading CSS failed... Try adding it with another style tag.');
+                await this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
+                await this.webpage.waitFor(1000);
+            } else {
+                console.log('Reloading CSS failed.');
+            }
         }
     });
 

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -408,7 +408,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
         // if response of css request does not start with /*, we assume it had an error and try to load it again
         // Note: We can't do that in requestfailed, as the response code might be 200 even if it throws an exception
         if (request.url().indexOf('action=getCss') !== -1 && !cssReloaded && (await response.buffer()).toString().substring(0, 2) !== '/*') {
-            this._logMessage('Loading CSS failed... Try adding it with another style tag.');
+            console.log('Loading CSS failed... Try adding it with another style tag.');
             cssReloaded = true;
             this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
         }

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -393,6 +393,12 @@ PageRenderer.prototype._setupWebpageEvents = function () {
             const errorMessage = failure ? failure.errorText : 'Unknown error';
             this._logMessage('Unable to load resource (URL:' + request.url() + '): ' + errorMessage);
         }
+
+        if (request.url().indexOf('action=getCss') !== -1 && !cssReloaded) {
+            console.log('Loading CSS failed... Try adding it with another style tag.');
+            cssReloaded = true;
+            this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
+        }
     });
 
     this.webpage.on('requestfinished', async (request) => {
@@ -406,7 +412,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
         }
 
         // if response of css request does not start with /*, we assume it had an error and try to load it again
-        // Note: We can't do that in requestfailed, as the response code might be 200 even if it throws an exception
+        // Note: We can't do that in requestfailed only, as the response code might be 200 even if it throws an exception
         if (request.url().indexOf('action=getCss') !== -1 && !cssReloaded && (await response.buffer()).toString().substring(0, 2) !== '/*') {
             console.log('Loading CSS failed... Try adding it with another style tag.');
             cssReloaded = true;

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -321,7 +321,10 @@ PageRenderer.prototype._setupWebpageEvents = function () {
         this._logMessage(msgStack.join('\n'));
     });
 
+    var cssReloaded = false;
+
     this.webpage.on('load', () => {
+        cssReloaded = false;
         this.webpage.evaluate(function () {
             var $ = window.jQuery;
             if ($) {
@@ -400,6 +403,14 @@ PageRenderer.prototype._setupWebpageEvents = function () {
             const body = await response.buffer();
             const message = 'Response (size "' + body.length + '", status "' + response.status() + '"): ' + request.url() + "\n" + body.toString();
             this._logMessage(message);
+        }
+
+        // if response of css request does not start with /*, we assume it had an error and try to load it again
+        // Note: We can't do that in requestfailed, as the response code might be 200 even if it throws an exception
+        if (request.url().indexOf('action=getCss') !== -1 && !cssReloaded && (await response.buffer()).toString().substring(0, 2) !== '/*') {
+            this._logMessage('Loading CSS failed... Try adding it with another style tag.');
+            cssReloaded = true;
+            this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
         }
     });
 

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -385,7 +385,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
     });
 
     // TODO: self.aborted?
-    this.webpage.on('requestfailed', (request) => {
+    this.webpage.on('requestfailed', async (request) => {
         --this.activeRequestCount;
 
         if (!VERBOSE) {
@@ -397,7 +397,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
         if (request.url().indexOf('action=getCss') !== -1 && !cssReloaded) {
             console.log('Loading CSS failed... Try adding it with another style tag.');
             cssReloaded = true;
-            this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
+            await this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
         }
     });
 
@@ -416,7 +416,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
         if (request.url().indexOf('action=getCss') !== -1 && !cssReloaded && (await response.buffer()).toString().substring(0, 2) !== '/*') {
             console.log('Loading CSS failed... Try adding it with another style tag.');
             cssReloaded = true;
-            this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
+            await this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
         }
     });
 

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -398,6 +398,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
             console.log('Loading CSS failed... Try adding it with another style tag.');
             cssReloaded = true;
             await this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
+            await this.webpage.waitFor(200);
         }
     });
 
@@ -417,6 +418,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
             console.log('Loading CSS failed... Try adding it with another style tag.');
             cssReloaded = true;
             await this.webpage.addStyleTag({url: request.url() + '&reload=1'}); // add another get parameter to ensure browser doesn't use cache
+            await this.webpage.waitFor(200);
         }
     });
 

--- a/tests/lib/screenshot-testing/support/page-renderer.js
+++ b/tests/lib/screenshot-testing/support/page-renderer.js
@@ -429,7 +429,7 @@ PageRenderer.prototype._setupWebpageEvents = function () {
             } else {
                 console.log('Reloading CSS failed.');
             }
-            console.log('Response (size "' + body.length + '", status "' + response.status() + '"): ' + request.url() + "\n" + body.toString());
+            console.log('Response (size "' + body.length + '", status "' + response.status() + ', headers "' + JSON.stringify(response.headers()) + '"): ' + request.url() + "\n" + body.toString());
         }
     });
 


### PR DESCRIPTION
There are a lot builds failing because the CSS seems not to be loaded. In most cases the test logs even don't have any notes, that loading the CSS failed. The reason for that is simple. We always return a HTTP 200 on the error page (as long as the message does not include database keywords). So if merging the CSS throws an exception the error page is served instead (with HTTP Status 200).

To avoid too many test failures when the CSS isn't loaded correctly I've build some code that automatically tries to add another style tag to the page to load the CSS again. [In most cases](https://travis-ci.org/github/matomo-org/matomo/jobs/702070073#L1072) that helps and the tests are running, but sometimes even [that reload fails](https://travis-ci.org/github/matomo-org/matomo/jobs/702070073#L880).

Nevertheless I think that might help to have a more stable build.