### PR TITLE
Set cookie domain if configured on ignore cookie

### DIFF
--- a/core/Tracker/IgnoreCookie.php
+++ b/core/Tracker/IgnoreCookie.php
@@ -58,6 +58,12 @@ class IgnoreCookie
     public static function setIgnoreCookie()
     {
         $ignoreCookie = self::getIgnoreCookie();
+        
+        $domain = TrackerConfig::getConfigValue('cookie_domain');
+        if (!empty($domain)) {
+            $ignoreCookie->setDomain($domain);
+        }
+
         if ($ignoreCookie->isCookieFound()) {
             $ignoreCookie->delete();
         } else {


### PR DESCRIPTION
fix #15778 

tracker cookie name and path was already set, but not the cookie domain.