### PR TITLE
Show different message in password confirmation email to reduce confusion

### DIFF
--- a/plugins/UsersManager/lang/en.json
+++ b/plugins/UsersManager/lang/en.json
@@ -177,6 +177,7 @@
         "EmailChangedEmail1": "The email address associated with your account has been changed to %1$s",
         "EmailChangedEmail2": "This change was initiated from the following device: %1$s (IP address = %2$s).",
         "IfThisWasYouIgnoreIfNot": "If this was you, feel free to ignore this email. If this was not you, please login, correct your email address, change your password and contact your Matomo administrator.",
+        "IfThisWasYouPasswordChange": "If this was you, feel free to ignore this email. If this was not you, please contact your Matomo administrator immediately, as your account might have been compromised!",
         "PasswordChangeNotificationSubject": "Your Matomo account's password has just been changed",
         "PasswordChangedEmail": "Your password has just been changed. The change was initiated from the following device: %1$s (IP address = %2$s).",
         "NewsletterSignupTitle": "Newsletter Signup",

--- a/plugins/UsersManager/templates/_userInfoChangedEmail.twig
+++ b/plugins/UsersManager/templates/_userInfoChangedEmail.twig
@@ -7,7 +7,7 @@
 {% elseif type == 'password' %}
 <p>{{ 'UsersManager_PasswordChangedEmail'|translate(deviceDescription, ipAddress) }}</p>
 
-<p>{{ 'UsersManager_IfThisWasYouIgnoreIfNot'|translate }}</p>
+<p>{{ 'UsersManager_IfThisWasYouPasswordChange'|translate }}</p>
 {% endif %}
 
 <p>{{ 'General_ThankYouForUsingMatomo'|translate }}!


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/16119