### PR TITLE
Improve host validation: now using the SERVER_NAME and no longer the HOST header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ The following changes are recommendations and don't have to be done as we will s
 ### Other Breaking changes
 
 * The log importer in `misc/log-analytics` now supports Python 3 (3.5, 3.6, 3.7 or 3.8), it will no longer run with Python 2. If you have any automated scripts that run the importer, you will have to change them to use the Python 3 executable instead.
+* Matomo now uses the SERVER_NAME for host validation and no longer the HOST header. If you're running Matomo behind a load balancer or a proxy you need to ensure that SERVER_NAME is set correctly.
 * Deprecated `piwik` font was removed. Use `matomo` font instead
 * The JavaScript AjaxHelper does not longer support synchronous requests. All requests will be sent async instead.
 * The console option `--piwik-domain` has been removed. Use `--matomo-domain` instead

--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -821,7 +821,12 @@ abstract class Controller
             // invalid host, so display warning to user
             $validHosts = Url::getTrustedHostsFromConfig();
             $validHost = $validHosts[0];
-            $invalidHost = Common::sanitizeInputValue($_SERVER['HTTP_HOST']);
+
+            if (!empty($_SERVER['SERVER_NAME'])) {
+                $invalidHost = Common::sanitizeInputValue($_SERVER['SERVER_NAME']);
+            } else {
+                $invalidHost = Common::sanitizeInputValue($_SERVER['HTTP_HOST']);
+            }
 
             $emailSubject = rawurlencode(Piwik::translate('CoreHome_InjectedHostEmailSubject', $invalidHost));
             $emailBody = rawurlencode(Piwik::translate('CoreHome_InjectedHostEmailBody'));

--- a/core/Profiler.php
+++ b/core/Profiler.php
@@ -294,9 +294,10 @@ class Profiler
                 Profiler::aggregateXhprofRuns($runs, $profilerNamespace, $saveTo = $runId);
 
                 $baseUrlStored = SettingsPiwik::getPiwikUrl();
+                $host = Url::getHost();
 
                 $out = "\n\n";
-                $baseUrl = "http://" . @$_SERVER['HTTP_HOST'] . "/" . @$_SERVER['REQUEST_URI'];
+                $baseUrl = "http://" . $host . "/" . @$_SERVER['REQUEST_URI'];
                 if (strlen($baseUrlStored) > strlen($baseUrl)) {
                     $baseUrl = $baseUrlStored;
                 }

--- a/core/Url.php
+++ b/core/Url.php
@@ -208,11 +208,14 @@ class Url
         }
 
         if ($host === false) {
-            $host = @$_SERVER['HTTP_HOST'];
+            $host = @$_SERVER['SERVER_NAME'];
             if (empty($host)) {
-                // if no current host, assume valid
-
-                return true;
+                // fallback to old behaviour
+                $host = @$_SERVER['HTTP_HOST'];
+                if (empty($host)) {
+                    // if no current host, assume valid
+                    return true;
+                }
             }
         }
 
@@ -298,12 +301,19 @@ class Url
      */
     public static function getHost($checkIfTrusted = true)
     {
-        // HTTP/1.1 request
-        if (isset($_SERVER['HTTP_HOST'])
+        if (isset($_SERVER['SERVER_NAME'])
+            && strlen($host = $_SERVER['SERVER_NAME'])) {
+            // if server_name is set we don't want to look at HTTP_HOST
+
+            if (!$checkIfTrusted || self::isValidHost($host)) {
+               return $host;
+            }
+        } elseif (isset($_SERVER['HTTP_HOST'])
             && strlen($host = $_SERVER['HTTP_HOST'])
             && (!$checkIfTrusted
                 || self::isValidHost($host))
         ) {
+            // HTTP/1.1 request
             return $host;
         }
 
@@ -322,6 +332,7 @@ class Url
      */
     public static function setHost($host)
     {
+        $_SERVER['SERVER_NAME'] = $host;
         $_SERVER['HTTP_HOST'] = $host;
     }
 

--- a/plugins/ScheduledReports/config/tcpdf_config.php
+++ b/plugins/ScheduledReports/config/tcpdf_config.php
@@ -53,7 +53,15 @@ if (!defined('K_TCPDF_EXTERNAL_CONFIG')) {
     if (!defined('K_PATH_URL')) {
         // Automatic calculation for the following K_PATH_URL constant
         $k_path_url = K_PATH_MAIN; // default value for console mode
-        if (isset($_SERVER['HTTP_HOST']) AND (!empty($_SERVER['HTTP_HOST']))) {
+        if (isset($_SERVER['SERVER_NAME']) AND (!empty($_SERVER['SERVER_NAME']))) {
+            if (isset($_SERVER['HTTPS']) AND (!empty($_SERVER['HTTPS'])) AND strtolower($_SERVER['HTTPS']) != 'off') {
+                $k_path_url = 'https://';
+            } else {
+                $k_path_url = 'http://';
+            }
+            $k_path_url .= $_SERVER['SERVER_NAME'];
+            $k_path_url .= str_replace('\\', '/', substr(K_PATH_MAIN, (strlen($_SERVER['DOCUMENT_ROOT']) - 1)));
+        } elseif (isset($_SERVER['HTTP_HOST']) AND (!empty($_SERVER['HTTP_HOST']))) {
             if (isset($_SERVER['HTTPS']) AND (!empty($_SERVER['HTTPS'])) AND strtolower($_SERVER['HTTPS']) != 'off') {
                 $k_path_url = 'https://';
             } else {

--- a/tests/PHPUnit/Integration/Config/CacheTest.php
+++ b/tests/PHPUnit/Integration/Config/CacheTest.php
@@ -11,6 +11,7 @@ use Piwik\Config;
 use Piwik\Config\Cache;
 use Piwik\Config\IniFileChain;
 use Piwik\Tests\Integration\Settings\IntegrationTestCase;
+use Piwik\Url;
 
 /**
  * @group Core
@@ -24,11 +25,14 @@ class CacheTest extends IntegrationTestCase
 
     private $testHost = 'analytics.test.matomo.org';
 
+    private $originalHost = '';
+
     public function setUp(): void
     {
         unset($GLOBALS['ENABLE_CONFIG_PHP_CACHE']);
         $this->setTrustedHosts();
-        $_SERVER['HTTP_HOST'] = $this->testHost;
+        $this->originalHost = Url::getHost(false);
+        Url::setHost($this->testHost);
         $this->cache = new Cache();
         $this->cache->doDelete(IniFileChain::CONFIG_CACHE_KEY);
         parent::setUp();
@@ -43,7 +47,7 @@ class CacheTest extends IntegrationTestCase
     {
         $this->setTrustedHosts();
         $this->cache->doDelete(IniFileChain::CONFIG_CACHE_KEY);
-        unset($_SERVER['HTTP_HOST']);
+        Url::setHost($this->originalHost);
         parent::tearDown();
     }
 
@@ -61,7 +65,7 @@ class CacheTest extends IntegrationTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Unsupported host');
 
-        $_SERVER['HTTP_HOST'] = $host;
+        Url::setHost($host);
         new Cache();
     }
 

--- a/tests/PHPUnit/Unit/NonceTest.php
+++ b/tests/PHPUnit/Unit/NonceTest.php
@@ -10,6 +10,7 @@ namespace Piwik\Tests\Unit;
 
 use Piwik\Config;
 use Piwik\Nonce;
+use Piwik\Url;
 
 /**
  * @backupGlobals enabled
@@ -37,7 +38,7 @@ class NonceTest extends \PHPUnit\Framework\TestCase
     public function test_getAcceptableOrigins($host, $expected)
     {
         Config::getInstance()->General['enable_trusted_host_check'] = 0;
-        $_SERVER['HTTP_HOST'] = $host;
+        Url::setHost($host);
         Config::getInstance()->General['trusted_hosts'] = array('example.com');
         $this->assertEquals($expected, Nonce::getAcceptableOrigins(), $host);
     }

--- a/tests/PHPUnit/Unit/UrlTest.php
+++ b/tests/PHPUnit/Unit/UrlTest.php
@@ -64,7 +64,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetCurrentHost($description, $test)
     {
-        $_SERVER['HTTP_HOST'] = $test[0];
+        Url::setHost($test[0]);
         $_SERVER['HTTP_X_FORWARDED_HOST'] = $test[1];
         Config::getInstance()->General['proxy_host_headers'] = array($test[2]);
         Config::getInstance()->General['proxy_ips'] = array($test[3]);
@@ -201,7 +201,7 @@ class UrlTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsLocalUrl($httphost, $scripturi, $requesturi, $testurl, $result)
     {
-        $_SERVER['HTTP_HOST'] = $httphost;
+        Url::setHost($httphost);
         $_SERVER['SCRIPT_URI'] = $scripturi;
         $_SERVER['REQUEST_URI'] = $requesturi;
         Config::getInstance()->General['enable_trusted_host_check'] = 1;

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -54,6 +54,7 @@ function setPiwikDomainFromEnvVar()
     $piwikDomain = getenv('PIWIK_DOMAIN');
     if (!empty($piwikDomain)) {
         $_SERVER['HTTP_HOST'] = $piwikDomain;
+        $_SERVER['SERVER_NAME'] = $piwikDomain;
     }
 }
 

--- a/tests/resources/install-matomo.php
+++ b/tests/resources/install-matomo.php
@@ -150,6 +150,7 @@ function getTokenAuth()
 }
 
 $_SERVER['HTTP_HOST'] = $host;
+$_SERVER['SERVER_NAME'] = $host;
 $dbConfig['dbname'] = 'latest_stable';
 
 file_put_contents(PIWIK_INCLUDE_PATH . "/config/config.ini.php", '');


### PR DESCRIPTION
Should there be any issues coming up we might add config flags to restore old behaivour