### PR TITLE
Set longer ignore cookie expiry time

### DIFF
--- a/core/Tracker/IgnoreCookie.php
+++ b/core/Tracker/IgnoreCookie.php
@@ -55,8 +55,10 @@ class IgnoreCookie
     {
         $cookie_name = @Config::getInstance()->Tracker['ignore_visits_cookie_name'];
         $cookie_path = @Config::getInstance()->Tracker['cookie_path'];
+        
+        $thiryYears = time() + (86400 * 365 * 30);
 
-        $cookie = new Cookie($cookie_name, null, $cookie_path, false, false);
+        $cookie = new Cookie($cookie_name, $thiryYears, $cookie_path, false, false);
         
         $domain = @Config::getInstance()->Tracker['cookie_domain'];
         if (!empty($domain)) {


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/13042

By default two years was set.