### PR TITLE
don't use create_function() anywhere

### DIFF
--- a/libs/HTML/QuickForm2/Element/Date.php
+++ b/libs/HTML/QuickForm2/Element/Date.php
@@ -171,14 +171,18 @@ class HTML_QuickForm2_Element_Date extends HTML_QuickForm2_Container_Group
                             $this->data['maxYear'],
                             $this->data['minYear'] > $this->data['maxYear']? -1: 1
                         );
-                        array_walk($options, create_function('&$v,$k','$v = substr($v,-2);'));
+                        array_walk($options, function (&$v, $k) {
+                            $v = substr($v, -2);
+                        });
                         break;
                     case 'h':
                         $options = $this->createOptionList(1, 12);
                         break;
                     case 'g':
                         $options = $this->createOptionList(1, 12);
-                        array_walk($options, create_function('&$v,$k', '$v = intval($v);'));
+                        array_walk($options, function (&$v, $k) {
+                            $v = intval($v);
+                        });
                         break;
                     case 'H':
                         $options = $this->createOptionList(0, 23);

--- a/plugins/Diagnostics/Diagnostic/PhpFunctionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/PhpFunctionsCheck.php
@@ -57,7 +57,6 @@ class PhpFunctionsCheck implements Diagnostic
     {
         return array(
             'debug_backtrace',
-            'create_function',
             'eval',
             'hash',
             'gzcompress',
@@ -100,7 +99,6 @@ class PhpFunctionsCheck implements Diagnostic
     {
         $messages = array(
             'debug_backtrace' => 'Installation_SystemCheckDebugBacktraceHelp',
-            'create_function' => 'Installation_SystemCheckCreateFunctionHelp',
             'eval'            => 'Installation_SystemCheckEvalHelp',
             'hash'            => 'Installation_SystemCheckHashHelp',
             'gzcompress'      => 'Installation_SystemCheckGzcompressHelp',

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -69,7 +69,6 @@
         "SuperUserSetupSuccess": "Super User created successfully!",
         "SystemCheck": "System Check",
         "SystemCheckAutoUpdateHelp": "Note: Matomo's One Click update requires write-permissions to the Matomo folder and its contents.",
-        "SystemCheckCreateFunctionHelp": "Matomo uses anonymous functions for callbacks.",
         "SystemCheckDatabaseExtensions": "MySQL extensions",
         "SystemCheckDatabaseHelp": "Matomo requires either the mysqli extension or both the PDO and pdo_mysql extensions.",
         "SystemCheckDatabaseSSL": "Database SSL Connection",


### PR DESCRIPTION
`create_function()` is deprecated since PHP 7.2, not needed anymore since 5.2 and removed in PHP 8. So there should be no reason to use it in Matomo 
https://www.php.net/manual/en/function.create-function.php

I did not test the functions in Date.php as honestly I don't understand what is going on there.