### PR TITLE
don't specify optional parameters before required parameters

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -139,7 +139,7 @@ class Http
      *@throws Exception
      */
     public static function sendHttpRequestBy(
-        $method = 'socket',
+        $method,
         $aUrl,
         $timeout,
         $userAgent = null,


### PR DESCRIPTION
This is deprecated since PHP 8 (https://php.watch/versions/8.0/deprecate-required-param-after-optional) and didn't make much more sense before.