### PR TITLE
If available, use SERVER_PORT variable as well as SERVER_NAME.

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -823,7 +823,7 @@ abstract class Controller
             $validHost = $validHosts[0];
 
             if (!empty($_SERVER['SERVER_NAME'])) {
-                $invalidHost = Common::sanitizeInputValue($_SERVER['SERVER_NAME']);
+                $invalidHost = Common::sanitizeInputValue(Url::getHostFromServerNameVar());
             } else {
                 $invalidHost = Common::sanitizeInputValue($_SERVER['HTTP_HOST']);
             }

--- a/core/Url.php
+++ b/core/Url.php
@@ -208,7 +208,7 @@ class Url
         }
 
         if ($host === false) {
-            $host = @$_SERVER['SERVER_NAME'];
+            $host = self::getHostFromServerNameVar();
             if (empty($host)) {
                 // fallback to old behaviour
                 $host = @$_SERVER['HTTP_HOST'];
@@ -301,17 +301,8 @@ class Url
      */
     public static function getHost($checkIfTrusted = true)
     {
-        if (isset($_SERVER['SERVER_NAME'])
-            && strlen($host = $_SERVER['SERVER_NAME'])) {
+        if (strlen($host = self::getHostFromServerNameVar())) {
             // if server_name is set we don't want to look at HTTP_HOST
-
-            if (strpos($host, ':') === false
-                && !empty($_SERVER['SERVER_PORT'])
-                && $_SERVER['SERVER_PORT'] != 80
-                && $_SERVER['SERVER_PORT'] != 443
-            ) {
-                $host .= ':' . $_SERVER['SERVER_PORT'];
-            }
 
             if (!$checkIfTrusted || self::isValidHost($host)) {
                return $host;
@@ -779,5 +770,20 @@ class Url
     {
         $assume_secure_protocol = @Config::getInstance()->General['assume_secure_protocol'];
         return (bool) $assume_secure_protocol;
+    }
+
+    public static function getHostFromServerNameVar()
+    {
+        $host = @$_SERVER['SERVER_NAME'];
+        if (!empty($host)) {
+            if (strpos($host, ':') === false
+                && !empty($_SERVER['SERVER_PORT'])
+                && $_SERVER['SERVER_PORT'] != 80
+                && $_SERVER['SERVER_PORT'] != 443
+            ) {
+                $host .= ':' . $_SERVER['SERVER_PORT'];
+            }
+        }
+        return $host;
     }
 }

--- a/core/Url.php
+++ b/core/Url.php
@@ -305,8 +305,10 @@ class Url
             && strlen($host = $_SERVER['SERVER_NAME'])) {
             // if server_name is set we don't want to look at HTTP_HOST
 
-            if (strpos($host, ':') === false &&
-                !empty($_SERVER['SERVER_PORT'])
+            if (strpos($host, ':') === false
+                && !empty($_SERVER['SERVER_PORT'])
+                && $_SERVER['SERVER_PORT'] != 80
+                && $_SERVER['SERVER_PORT'] != 443
             ) {
                 $host .= ':' . $_SERVER['SERVER_PORT'];
             }

--- a/core/Url.php
+++ b/core/Url.php
@@ -333,6 +333,7 @@ class Url
     {
         $_SERVER['SERVER_NAME'] = $host;
         $_SERVER['HTTP_HOST'] = $host;
+        unset($_SERVER['SERVER_PORT']);
     }
 
     /**

--- a/core/Url.php
+++ b/core/Url.php
@@ -305,6 +305,12 @@ class Url
             && strlen($host = $_SERVER['SERVER_NAME'])) {
             // if server_name is set we don't want to look at HTTP_HOST
 
+            if (strpos($host, ':') === false &&
+                !empty($_SERVER['SERVER_PORT'])
+            ) {
+                $host .= ':' . $_SERVER['SERVER_PORT'];
+            }
+
             if (!$checkIfTrusted || self::isValidHost($host)) {
                return $host;
             }

--- a/plugins/ScheduledReports/config/tcpdf_config.php
+++ b/plugins/ScheduledReports/config/tcpdf_config.php
@@ -59,14 +59,7 @@ if (!defined('K_TCPDF_EXTERNAL_CONFIG')) {
             } else {
                 $k_path_url = 'http://';
             }
-            $k_path_url .= $_SERVER['SERVER_NAME'];
-            if (strpos($k_path_url, ':') === false
-                && !empty($_SERVER['SERVER_PORT'])
-                && $_SERVER['SERVER_PORT'] != 80
-                && $_SERVER['SERVER_PORT'] != 443
-            ) {
-                $k_path_url .= ':' . $_SERVER['SERVER_PORT'];
-            }
+            $k_path_url .= \Piwik\Url::getHostFromServerNameVar();
             $k_path_url .= str_replace('\\', '/', substr(K_PATH_MAIN, (strlen($_SERVER['DOCUMENT_ROOT']) - 1)));
         } elseif (isset($_SERVER['HTTP_HOST']) AND (!empty($_SERVER['HTTP_HOST']))) {
             if (isset($_SERVER['HTTPS']) AND (!empty($_SERVER['HTTPS'])) AND strtolower($_SERVER['HTTPS']) != 'off') {

--- a/plugins/ScheduledReports/config/tcpdf_config.php
+++ b/plugins/ScheduledReports/config/tcpdf_config.php
@@ -60,6 +60,13 @@ if (!defined('K_TCPDF_EXTERNAL_CONFIG')) {
                 $k_path_url = 'http://';
             }
             $k_path_url .= $_SERVER['SERVER_NAME'];
+            if (strpos($k_path_url, ':') === false
+                && !empty($_SERVER['SERVER_PORT'])
+                && $_SERVER['SERVER_PORT'] != 80
+                && $_SERVER['SERVER_PORT'] != 443
+            ) {
+                $k_path_url .= ':' . $_SERVER['SERVER_PORT'];
+            }
             $k_path_url .= str_replace('\\', '/', substr(K_PATH_MAIN, (strlen($_SERVER['DOCUMENT_ROOT']) - 1)));
         } elseif (isset($_SERVER['HTTP_HOST']) AND (!empty($_SERVER['HTTP_HOST']))) {
             if (isset($_SERVER['HTTPS']) AND (!empty($_SERVER['HTTPS'])) AND strtolower($_SERVER['HTTPS']) != 'off') {


### PR DESCRIPTION
Otherwise an install on a non-standard port will not pass the trusted hosts check.