### PR TITLE
Make Matomo more compatible with jQuery 3

### DIFF
--- a/plugins/CoreHome/angularjs/reporting-page/reportingpage.directive.html
+++ b/plugins/CoreHome/angularjs/reporting-page/reportingpage.directive.html
@@ -1,6 +1,6 @@
 <div class="reporting-page">
 
-    <div piwik-activity-indicator loading="loading"/>
+    <div piwik-activity-indicator loading="loading"></div>
 
     <div ng-show="hasNoPage">{{ 'CoreHome_NoSuchPage'|translate }}</div>
 

--- a/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.html
+++ b/plugins/CoreHome/angularjs/widget-loader/widgetloader.directive.html
@@ -1,5 +1,5 @@
 <div>
-    <div piwik-activity-indicator loading-message="loadingMessage" loading="loading"/>
+    <div piwik-activity-indicator loading-message="loadingMessage" loading="loading"></div>
 
     <div ng-show="loadingFailed">
         <h2 ng-if="widgetName">{{widgetName}}</h2>


### PR DESCRIPTION
refs https://github.com/matomo-org/wp-matomo/issues/314

Tested Matomo for WordPress with jQuery 3 but nothing was shown until I made these two changes. I added jQuery migrate to find this problem. JQuery migrate complained about this:

```
"HTML tags must be properly nested and closed: <div class="reporting-page">

    <div piwik-activity-indicator loading="loading"/>

    <div ng-show="hasNoPage">{{ 'CoreHome_NoSuchPage'|translate }}</div>
```

Once I made these two changes, Matomo seems to work nicely with jQuery 1, jQuery 2 and jQuery 3.

Whether we upgrade to jQuery 3, while still using jQuery 1 in Matomo for WordPress is still to be seen. I didn't do a full test so can't guarantee that everything works with jQuery 1 and 3 but it's a step in the right direction.