### PR TITLE
Generated tracking code should init window._paq and only use async

### DIFF
--- a/plugins/Morpheus/templates/javascriptCode.twig
+++ b/plugins/Morpheus/templates/javascriptCode.twig
@@ -1,6 +1,6 @@
 <!-- Matomo -->
 <script type="text/javascript">
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
 {$options}  _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
@@ -9,7 +9,7 @@
     {$optionsBeforeTrackerUrl}_paq.push(['setTrackerUrl', u+'{$matomoPhpFilename}']);
     _paq.push(['setSiteId', '{$idSite}']);
     {% if loadAsync %}var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'{$matomoJsFilename}'; s.parentNode.insertBefore(g,s);{% endif %}
+    g.type='text/javascript'; g.async=true; g.src=u+'{$matomoJsFilename}'; s.parentNode.insertBefore(g,s);{% endif %}
 
   })();
 </script>

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager_after3_7_0__SitesManager.getJavascriptTag.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager_after3_7_0__SitesManager.getJavascriptTag.xml
@@ -10,7 +10,7 @@
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;!-- End Matomo Code --&gt;

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager_after3_7_0__SitesManager.getJavascriptTag.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager_after3_7_0__SitesManager.getJavascriptTag.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0__SitesManager.getJavascriptTag.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0__SitesManager.getJavascriptTag.xml
@@ -10,7 +10,7 @@
     _paq.push(['setTrackerUrl', u+'piwik.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;!-- End Matomo Code --&gt;

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0__SitesManager.getJavascriptTag.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0__SitesManager.getJavascriptTag.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0_but_forced__SitesManager.getJavascriptTag.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0_but_forced__SitesManager.getJavascriptTag.xml
@@ -10,7 +10,7 @@
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;!-- End Matomo Code --&gt;

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0_but_forced__SitesManager.getJavascriptTag.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0_but_forced__SitesManager.getJavascriptTag.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);

--- a/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
+++ b/tests/PHPUnit/Integration/Tracker/TrackerCodeGeneratorTest.php
@@ -39,7 +39,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
 
         $expected = "&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   _paq.push([\"setCookieDomain\", \"*.localhost\"]);
@@ -60,7 +60,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;noscript&gt;&lt;p&gt;&lt;img src=&quot;//piwik-server/piwik/matomo.php?idsite=1&amp;amp;rec=1&quot; style=&quot;border:0;&quot; alt=&quot;&quot; /&gt;&lt;/p&gt;&lt;/noscript&gt;
@@ -78,7 +78,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
 
         $expected = "&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
@@ -87,7 +87,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;!-- End Matomo Code --&gt;
@@ -116,7 +116,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
 
         $expected = "&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   // you can set up to 5 custom variables for each visitor
@@ -134,7 +134,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;!-- End Matomo Code --&gt;
@@ -163,7 +163,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
 
         $expected = "&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   // you can set up to 5 custom variables for each visitor
@@ -182,7 +182,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;!-- End Matomo Code --&gt;
@@ -207,7 +207,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
 
         $expected = "&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push([\"setDocumentTitle\", document.domain + \"/\" + document.title]);
   _paq.push(['trackPageView']);
@@ -244,7 +244,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
 
         $expected = '&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
   // you can set up to 5 custom variables for each visitor
@@ -260,7 +260,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     _paq.push([\'setTrackerUrl\', u+\'matomo.php\']);
     _paq.push([\'setSiteId\', \'1\']);
     var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
-    g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src=u+\'matomo.js\'; s.parentNode.insertBefore(g,s);
+    g.type=\'text/javascript\'; g.async=true; g.src=u+\'matomo.js\'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;!-- End Matomo Code --&gt;
@@ -278,7 +278,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
 
         $expected = '&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push([\'trackPageView\']);
   _paq.push([\'enableLinkTracking\']);
@@ -287,7 +287,7 @@ class TrackerCodeGeneratorTest extends IntegrationTestCase
     _paq.push([\'setTrackerUrl\', u+\'matomo.php\']);
     _paq.push([\'setSiteId\', \'1\']);
     var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
-    g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src=u+\'matomo.js\'; s.parentNode.insertBefore(g,s);
+    g.type=\'text/javascript\'; g.async=true; g.src=u+\'matomo.js\'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;!-- End Matomo Code --&gt;

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
@@ -10,7 +10,7 @@
     _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '1']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 &lt;/script&gt;
 &lt;!-- End Matomo Code --&gt;

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__SitesManager.getJavascriptTag.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>&lt;!-- Matomo --&gt;
 &lt;script type=&quot;text/javascript&quot;&gt;
-  var _paq = window._paq || [];
+  var _paq = window._paq = window._paq || [];
   /* tracker methods like &quot;setCustomDimension&quot; should be called before &quot;trackPageView&quot; */
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);

--- a/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard.png
+++ b/tests/UI/expected-screenshots/EmptySite_emptySiteDashboard.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de697c64644277ab5881df9ef5f61e6b1b11b1354dedd8e269283a5a0b440491
-size 301464
+oid sha256:cf7743fd4dc10bc2d7159e874299ba25fcd37e1b78d48841b4eeabe2a9e23ce6
+size 301862

--- a/tests/UI/expected-screenshots/OneClickUpdate_login.png
+++ b/tests/UI/expected-screenshots/OneClickUpdate_login.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc51c04af8628082dc40b503a91a2b3abbb25dacc173afdb286017b86d053f71
-size 268939
+oid sha256:1d2427ebf97d60b4dd64480ec740a0abf42d45ad8c5d8fad678087f8c2ee98f2
+size 269165

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_manage_tracking_code.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_manage_tracking_code.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23693cc87b6fcec46d4afc7928834b1169a643c18f602daac0f643490a809c6b
-size 440883
+oid sha256:684f4d3f37b1ef77ea902219df5da700a97013e04e15611bc6408b3a4cf5b0ab
+size 441304


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/16189
fix https://github.com/matomo-org/matomo/issues/16055

@Findus23 can you have a look? 

I'm still using `var _paq` to keep the tracking code short. As otherwise would need to prefix every _paq.push code but could also instead prefix every variable with `_paq`. Once merged will need to update the docs on the developer site to use same style. Tested it in IE6 and it worked for me.

refs https://github.com/matomo-org/matomo/pull/13674