### PR TITLE
Rename composer package to matomo/matomo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "piwik/piwik",
+    "name": "matomo/matomo",
     "type": "application",
     "description": "the leading free/libre analytics platform",
     "keywords": ["piwik","matomo","web","analytics"],


### PR DESCRIPTION
All packages should still be available as piwik/piwik, as this repo should still be used for updating that package.
After this PR was merged, we need to submit the package with the new name on packagist, so it will be available.

refs #12519