### PR TITLE
Add new user preference

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -280,6 +280,7 @@ class API extends \Piwik\Plugin\API
         $names = array(
             self::PREFERENCE_DEFAULT_REPORT,
             self::PREFERENCE_DEFAULT_REPORT_DATE,
+            'isLDAPUser', // used in loginldap
             'hideSegmentDefinitionChangeMessage',// used in JS
             'randomDoesNotExist',// for tests
             'RandomNOTREQUESTED',// for tests


### PR DESCRIPTION
isLDAPUser  is used in LoginLDAP. Eventually we'll let plugins define custom preference names.