### PR TITLE
Allow plugins to configure custom user preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
-## Matomo 3.13.7
+## Matomo 3.14.0
 
 ### New API
 

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -179,7 +179,13 @@ class API extends \Piwik\Plugin\API
     }
 
     /**
-     * Sets a user preference
+     * Sets a user preference. Plugins can add custom preference names by declaring them in their plugin config/config.php
+     * like this:
+     *
+     * ```php
+     * return array('usersmanager.user_preference_names' => DI\add(array('preference_name_1', 'preference_name_2')));
+     * ```
+     *
      * @param string $userLogin
      * @param string $preferenceName
      * @param string $preferenceValue
@@ -286,7 +292,10 @@ class API extends \Piwik\Plugin\API
             'RandomNOTREQUESTED',// for tests
             'preferenceName'// for tests
         );
-        if (!in_array($preference, $names, true)) {
+        $customPreferences = StaticContainer::get('usersmanager.user_preference_names');
+
+        if (!in_array($preference, $names, true)
+            && !in_array($preference, $customPreferences, true)) {
             throw new Exception('Not supported preference name: ' . $preference);
         }
         return $login . self::OPTION_NAME_PREFERENCE_SEPARATOR . $preference;

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -288,9 +288,6 @@ class API extends \Piwik\Plugin\API
             self::PREFERENCE_DEFAULT_REPORT_DATE,
             'isLDAPUser', // used in loginldap
             'hideSegmentDefinitionChangeMessage',// used in JS
-            'randomDoesNotExist',// for tests
-            'RandomNOTREQUESTED',// for tests
-            'preferenceName'// for tests
         );
         $customPreferences = StaticContainer::get('usersmanager.user_preference_names');
 

--- a/plugins/UsersManager/config/config.php
+++ b/plugins/UsersManager/config/config.php
@@ -1,2 +1,4 @@
 <?php
-return array();
+return array(
+    'usersmanager.user_preference_names' => []
+);

--- a/plugins/UsersManager/tests/Integration/APITest.php
+++ b/plugins/UsersManager/tests/Integration/APITest.php
@@ -1033,6 +1033,7 @@ class APITest extends IntegrationTestCase
     {
         return array(
             'Piwik\Access' => new FakeAccess(),
+            'usersmanager.user_preference_names' => \DI\add(['randomDoesNotExist', 'RandomNOTREQUESTED', 'preferenceName']),
             'observers.global' => \DI\add([
                 ['Access.Capability.addCapabilities', function (&$capabilities) {
                     $capabilities[] = new TestCap1();


### PR DESCRIPTION
Just in case some plugins use custom preference names then they can still use them by declaring them in the settings. 
