### PR TITLE
Fix language selector in mobile menu is not visible

### DIFF
--- a/plugins/CoreHome/stylesheets/layout.less
+++ b/plugins/CoreHome/stylesheets/layout.less
@@ -48,8 +48,13 @@ nav {
     &:hover {
       background-color: rgba(0,0,0,0.1);
     }
-    .title {
-      color: @theme-color-header-text;
+  }
+
+  ul:not(#mobile-top-menu) {
+    .languageSelection {
+      .title {
+        color: @theme-color-header-text;
+      }
     }
   }
 


### PR DESCRIPTION
When being anonymous, and opening the top menu in the mobile view then nothing is readable because it's white on light grey