### PR TITLE
Fix download of scheduled reports

### DIFF
--- a/plugins/ScheduledReports/templates/_listReports.twig
+++ b/plugins/ScheduledReports/templates/_listReports.twig
@@ -84,6 +84,7 @@
                       id="downloadReportForm_{{ report.idreport|e('html_attr') }}"
                 >
                     <input type="hidden" name="token_auth" value="{{ token_auth|e('html_attr') }}">
+                    <input type="hidden" name="force_api_session" value="1">
                 </form>
                 <a href="javascript:void(0)"
                    ng-click="manageScheduledReport.displayReport({{ report.idreport|json_encode }})"

--- a/tests/UI/expected-screenshots/UIIntegrationTest_email_reports_download.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_email_reports_download.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1863444f361ce1013c81c6b49541ad115b372faea03b890501831b3a30c903e
+size 99867

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -921,7 +921,18 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             expect(await pageWrap.screenshot()).to.matchImage('email_reports');
         });
 
+        it('should show the generated report when clicking the download button', async function () {
+            await page.evaluate(function () {
+                $('#downloadReportForm_7').attr('target', ''); // do not open the download in new windows
+            });
+            await page.click('#downloadReportForm_7 + a');
+            await page.waitForNetworkIdle();
+
+            expect(await page.screenshot({fullPage: true})).to.matchImage('email_reports_download');
+        });
+
         it('should load the scheduled reports when Edit button is clicked', async function () {
+            await page.goto("?" + generalParams + "&module=ScheduledReports&action=index");
             await page.click('.entityTable tr:nth-child(4) button[title="Edit"]');
 
             pageWrap = await page.$('.pageWrap');


### PR DESCRIPTION
Downloading report didn't work cause of missing `force_api_session` parameter.
Also added a simple UI tests to check that keeps working in the future