### PR TITLE
Add one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ See https://matomo.org/docs/installation/.
 
 (When using Matomo for development you need to [install Matomo from the Git repository](https://matomo.org/faq/how-to-install/faq_18271/)).
 
+## One Click Deployment
+
+You can deploy a Matomo server and MySQL database, hosted on Render, with a single click using the `Deploy to Render` button.
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/matomo)
+
+Learn more at: https://render.com/docs/deploy-matomo
+
 ## Free trial 
 
 If you do not have a server or don't want to host yourself you can use our Matomo Cloud partner service (21 day free trial): https://matomo.org/start-free-analytics-trial/


### PR DESCRIPTION
Hello. I work at [Render](https://render.com/). We recently set up a one-click deployment button and guide that allows your users to get up and running with a Matomo server and MySQL database in just a couple minutes. We are looking to make it as seamless as possible to self-host your software. I was hoping you would be willing to add this as an option in your setup guide.  Also, would be open to mentioning us as an option on your [on-pemise](https://matomo.org/matomo-on-premise/) page?   

I'm happy to address and questions or concerns!