### PR TITLE
Delete remembered archived only for one specific site when a site is deleted

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -188,7 +188,7 @@ class ArchiveInvalidator
 
     public function forgetRememberedArchivedReportsToInvalidateForSite($idSite)
     {
-        $id = $this->buildRememberArchivedReportIdForSite($idSite);
+        $id = $this->buildRememberArchivedReportIdForSite($idSite) . '\_';
         $this->deleteOptionLike($id);
         Cache::clearCacheGeneral();
     }


### PR DESCRIPTION
Noticed this while looking at https://github.com/matomo-org/matomo/issues/16204

When deleting idSite 11, then it would do basically `delete from option where option_name like '%report_to_invalidate_11%`

But this would also delete entries like `111`, `112`, etc.