### PR TITLE
Backport userId to overwrite visitorId feature

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -755,6 +755,8 @@ enable_tracking_failures_notification = 1
 
 [Tracker]
 
+enable_userid_overwrites_visitorid = 0
+
 ; Matomo uses "Privacy by default" model. When one of your users visit multiple of your websites tracked in this Matomo,
 ; Matomo will create for this user a fingerprint that will be different across the multiple websites.
 ; If you want to track unique users across websites you may set this setting to 1.

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -751,6 +751,17 @@ class Request
     {
         $found = false;
 
+        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid')) {
+            // If User ID is set it takes precedence
+            $userId = $this->getForcedUserId();
+            if ($userId) {
+                $userIdHashed = $this->getUserIdHashed($userId);
+                $idVisitor = $this->truncateIdAsVisitorId($userIdHashed);
+                Common::printDebug("Request will be recorded for this user_id = " . $userId . " (idvisitor = $idVisitor)");
+                $found = true;
+            }
+        }
+
         // Was a Visitor ID "forced" (@see Tracking API setVisitorId()) for this request?
         if (!$found) {
             $idVisitor = $this->getForcedVisitorId();

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -562,7 +562,18 @@ class Visit implements VisitInterface
             // Might update the idvisitor when it was forced or overwritten for this visit
             $valuesToUpdate['idvisitor'] = $this->request->getVisitorId(); 
         }
-        
+
+        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid')) {
+            // User ID takes precedence and overwrites idvisitor value
+            $userId = $this->request->getForcedUserId();
+            if ($userId) {
+                $userIdHash = $this->request->getUserIdHashed($userId);
+                $binIdVisitor = Common::hex2bin($userIdHash);
+                $this->visitProperties->setProperty('idvisitor', $binIdVisitor);
+                $valuesToUpdate['idvisitor'] = $binIdVisitor;
+            }
+        }
+
         return $valuesToUpdate;
     }
 

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -17,6 +17,7 @@ use Piwik\Tracker\Cache;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\RequestProcessor;
 use Piwik\Tracker\Settings;
+use Piwik\Tracker\TrackerConfig;
 use Piwik\Tracker\Visit\VisitProperties;
 use Piwik\Tracker\VisitExcluded;
 use Piwik\Tracker\VisitorRecognizer;
@@ -189,7 +190,8 @@ class VisitRequestProcessor extends RequestProcessor
             return true;
         }
 
-        if (!$this->lastUserIdWasSetAndDoesMatch($visitProperties, $request)) {
+        if (!TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid')
+            && !$this->lastUserIdWasSetAndDoesMatch($visitProperties, $request)) {
             Common::printDebug("Visitor detected, but last user_id does not match...");
             return true;
         }

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1541e3be9d9bd63c8f43bce5a775770438d51edd28db485526ea2b7719a00a50
-size 4392052
+oid sha256:eac410b554a5f086f5d743bde65eef2f4eb787b5900854fdbb2e5ac3f13a7a79
+size 4395540


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/15593 

based on https://github.com/matomo-org/matomo/pull/16124

not adding any extra tests as default behaviour doesn't change and we have added tests in Matomo 4 already for both config values (enabled / disabled)