### PR TITLE
Fix escaping in site selection for anonymous user configuration

### DIFF
--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -433,7 +433,7 @@ class Controller extends ControllerAdmin
             $site = Request::processRequest('SitesManager.getSiteFromId', array('idSite' => $idSite));
             // Work around manual website deletion
             if (!empty($site)) {
-                $anonymousSites[] = array('key' => $idSite, 'value' => $site['name']);
+                $anonymousSites[] = array('key' => $idSite, 'value' => Common::unsanitizeInputValue($site['name']));
             }
         }
         $view->anonymousSites = $anonymousSites;


### PR DESCRIPTION
The site selection currently shows the escaped values that are stored in the database:

![image](https://user-images.githubusercontent.com/1579355/88053983-efdeb080-cb5c-11ea-9f9a-f3dea5713305.png)

Unsanitizing the site names let the display correctly:

![image](https://user-images.githubusercontent.com/1579355/88054168-359b7900-cb5d-11ea-8d79-bf0b17e34f26.png)
