### PR TITLE
Set referrer policy on default img tracking code

### DIFF
--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -182,7 +182,7 @@ class API extends \Piwik\Plugin\API
 
         $url = (ProxyHttp::isHttps() ? "https://" : "http://") . rtrim($piwikUrl, '/') . '/'.$matomoPhp.'?' . Url::getQueryStringFromParameters($urlParams);
         $html = "<!-- Matomo Image Tracker-->
-<img src=\"" . htmlspecialchars($url, ENT_COMPAT, 'UTF-8') . "\" style=\"border:0\" alt=\"\" />
+<img referrerpolicy=\"no-referrer-when-downgrade\" src=\"" . htmlspecialchars($url, ENT_COMPAT, 'UTF-8') . "\" style=\"border:0\" alt=\"\" />
 <!-- End Matomo -->";
         return htmlspecialchars($html, ENT_COMPAT, 'UTF-8');
     }

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager_after3_7_0__SitesManager.getImageTrackingCode.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager_after3_7_0__SitesManager.getImageTrackingCode.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>&lt;!-- Matomo Image Tracker--&gt;
-&lt;img src=&quot;http://http://example.org/piwik/matomo.php?idsite=1&amp;amp;rec=1&quot; style=&quot;border:0&quot; alt=&quot;&quot; /&gt;
+&lt;img referrerpolicy="no-referrer-when-downgrade" src=&quot;http://http://example.org/piwik/matomo.php?idsite=1&amp;amp;rec=1&quot; style=&quot;border:0&quot; alt=&quot;&quot; /&gt;
 &lt;!-- End Matomo --&gt;</result>

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0__SitesManager.getImageTrackingCode.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0__SitesManager.getImageTrackingCode.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>&lt;!-- Matomo Image Tracker--&gt;
-&lt;img src=&quot;http://http://example.org/piwik/piwik.php?idsite=1&amp;amp;rec=1&quot; style=&quot;border:0&quot; alt=&quot;&quot; /&gt;
+&lt;img referrerpolicy="no-referrer-when-downgrade" src=&quot;http://http://example.org/piwik/piwik.php?idsite=1&amp;amp;rec=1&quot; style=&quot;border:0&quot; alt=&quot;&quot; /&gt;
 &lt;!-- End Matomo --&gt;</result>

--- a/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0_but_forced__SitesManager.getImageTrackingCode.xml
+++ b/plugins/SitesManager/tests/System/expected/test_SitesManager_prior3_7_0_but_forced__SitesManager.getImageTrackingCode.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>&lt;!-- Matomo Image Tracker--&gt;
-&lt;img src=&quot;http://http://example.org/piwik/matomo.php?idsite=1&amp;amp;rec=1&quot; style=&quot;border:0&quot; alt=&quot;&quot; /&gt;
+&lt;img referrerpolicy="no-referrer-when-downgrade" src=&quot;http://http://example.org/piwik/matomo.php?idsite=1&amp;amp;rec=1&quot; style=&quot;border:0&quot; alt=&quot;&quot; /&gt;
 &lt;!-- End Matomo --&gt;</result>

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_manage_tracking_code.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_manage_tracking_code.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3fca9a36e5b681064c279a8dcd1d7f83cd530e4946ecc72b2646483a54b624a
-size 439730
+oid sha256:8bcaedd927c9fff0659e8f0f67b92106bb88cb5583608e5ef08761f2055dc3a6
+size 440607


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/15845 I can reproduce this when using this script

```php
<?php header('referrer-policy: same-origin');?>
<html>
<head>

</head><body>
<img src="//YOURDOMAIN.com/matomo.php?idsite=1&rec=1" referrerpolicy="no-referrer-when-downgrade" style="border:0;" alt="" />
</body>
</html>
```

This scripts need to be placed on a different domain than the Matomo domain. Without the referrerpolicy, the tracking quest would not include any information and track a request without any page URL. With the attribute, it tracks the request and includes the referrer.

The downgrade part shouldn't be any issue because should a website be HTTPS, and Matomo HTTP, then the request would likely not be executed anyway.  For more information see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy 

![image](https://user-images.githubusercontent.com/273120/88244434-fbaaae00-cce7-11ea-99da-6301cbbeeac0.png)
