### PR TITLE
Use category display name for segment metadata

### DIFF
--- a/plugins/API/SegmentMetadata.php
+++ b/plugins/API/SegmentMetadata.php
@@ -51,6 +51,7 @@ class SegmentMetadata
             if (!isset($this->categoryOrder[$segment['category']])) {
                 $category = $categoryList->getCategory($categoryId);
                 if (!empty($category)) {
+                    $segment['category'] = $category->getDisplayName();
                     $this->categoryOrder[$segment['category']] = $category->getOrder();
                 } else {
                     $this->categoryOrder[$segment['category']] = 999;

--- a/plugins/CustomDimensions/tests/System/expected/test___API.getSegmentsMetadata.xml
+++ b/plugins/CustomDimensions/tests/System/expected/test___API.getSegmentsMetadata.xml
@@ -528,19 +528,19 @@
 	</row>
 	<row>
 		<type>metric</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Bandwidth</name>
 		<segment>bandwidth</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Action Type</name>
 		<segment>actionType</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Action URL</name>
 		<segment>actionUrl</segment>
 		<unionOfSegments>
@@ -552,115 +552,115 @@
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Clicked Outlink</name>
 		<segment>outlinkUrl</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Content Interaction</name>
 		<segment>contentInteraction</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Content Name</name>
 		<segment>contentName</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Content Piece</name>
 		<segment>contentPiece</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Content Target</name>
 		<segment>contentTarget</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Download URL</name>
 		<segment>downloadUrl</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Entry Page URL</name>
 		<segment>entryPageUrl</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Entry Page title</name>
 		<segment>entryPageTitle</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Exit Page Title</name>
 		<segment>exitPageTitle</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Exit Page URL</name>
 		<segment>exitPageUrl</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Keyword (Site Search)</name>
 		<segment>siteSearchKeyword</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Keyword count (Site Search)</name>
 		<segment>siteSearchCount</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>MyName3</name>
 		<segment>dimension3</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>MyName5</name>
 		<segment>dimension5</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Page Title</name>
 		<segment>pageTitle</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Page URL</name>
 		<segment>pageUrl</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Search Category</name>
 		<segment>siteSearchCategory</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Server time - hour</name>
 		<segment>actionServerHour</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Server time - minute</name>
 		<segment>actionServerMinute</segment>
 	</row>
@@ -696,25 +696,25 @@
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Referrers</category>
+		<category>Acquisition</category>
 		<name>Channel Type</name>
 		<segment>referrerType</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Referrers</category>
+		<category>Acquisition</category>
 		<name>Keyword</name>
 		<segment>referrerKeyword</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Referrers</category>
+		<category>Acquisition</category>
 		<name>Referrer Name</name>
 		<segment>referrerName</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Referrers</category>
+		<category>Acquisition</category>
 		<name>Referrer URL</name>
 		<segment>referrerUrl</segment>
 	</row>

--- a/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
+++ b/plugins/SegmentEditor/tests/UI/SegmentSelectorEditor_spec.js
@@ -86,7 +86,7 @@ describe("SegmentSelectorEditorTest", function () {
     });
 
     it("should update segment expression when selecting different segment", async function() {
-        await selectDimension('.segmentRow0', 'Actions', 'Action URL');
+        await selectDimension('.segmentRow0', 'Behaviour', 'Action URL');
         await page.waitForNetworkIdle();
         expect(await page.screenshotSelector(selectorsToCapture)).to.matchImage('dimension_drag_drop');
     });
@@ -106,7 +106,7 @@ describe("SegmentSelectorEditorTest", function () {
     });
 
     it("should add an OR condition when a segment dimension is selected in the OR placeholder section", async function() {
-        await selectDimension('.segmentRow0 .segment-row:last', 'Actions', 'Clicked Outlink');
+        await selectDimension('.segmentRow0 .segment-row:last', 'Behaviour', 'Clicked Outlink');
         await page.waitForNetworkIdle();
         expect(await page.screenshotSelector(selectorsToCapture)).to.matchImage('drag_or_condition');
     });
@@ -119,7 +119,7 @@ describe("SegmentSelectorEditorTest", function () {
     });
 
     it("should add an AND condition when a segment dimension is dragged to the AND placeholder section", async function() {
-        await selectDimension('.segmentRow1', 'Actions', 'Clicked Outlink');
+        await selectDimension('.segmentRow1', 'Behaviour', 'Clicked Outlink');
         await page.waitForNetworkIdle();
         expect(await page.screenshotSelector(selectorsToCapture)).to.matchImage('drag_and_condition');
     });

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getSegmentsMetadata.xml
@@ -556,21 +556,21 @@
 	</row>
 	<row>
 		<type>metric</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Bandwidth</name>
 		<segment>bandwidth</segment>
 		<acceptedValues>Any number in bytes, eg. 1000</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Action Type</name>
 		<segment>actionType</segment>
 		<acceptedValues>A type of action, such as: pageviews, contents, sitesearches, events, outlinks, downloads</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Action URL</name>
 		<segment>actionUrl</segment>
 		<unionOfSegments>
@@ -582,108 +582,108 @@
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Clicked Outlink</name>
 		<segment>outlinkUrl</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Content Interaction</name>
 		<segment>contentInteraction</segment>
 		<acceptedValues>The type of interaction with the content. For instance &quot;click&quot; or &quot;submit&quot;.</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Content Name</name>
 		<segment>contentName</segment>
 		<acceptedValues>The name of a content block, for instance &quot;Ad Sale&quot;</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Content Piece</name>
 		<segment>contentPiece</segment>
 		<acceptedValues>The actual content. For instance &quot;ad.jpg&quot; or &quot;My text ad&quot;</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Content Target</name>
 		<segment>contentTarget</segment>
 		<acceptedValues>For instance the URL of a landing page: &quot;http://landingpage.example.com&quot;</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Download URL</name>
 		<segment>downloadUrl</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Entry Page URL</name>
 		<segment>entryPageUrl</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Entry Page title</name>
 		<segment>entryPageTitle</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Exit Page Title</name>
 		<segment>exitPageTitle</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Exit Page URL</name>
 		<segment>exitPageUrl</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Keyword (Site Search)</name>
 		<segment>siteSearchKeyword</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Keyword count (Site Search)</name>
 		<segment>siteSearchCount</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Page Title</name>
 		<segment>pageTitle</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Page URL</name>
 		<segment>pageUrl</segment>
 		<acceptedValues>All these segments must be URL encoded, for example: http%3A%2F%2Fexample.com%2Fpath%2Fpage%3Fquery</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Search Category</name>
 		<segment>siteSearchCategory</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Server time - hour</name>
 		<segment>actionServerHour</segment>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Actions</category>
+		<category>Behaviour</category>
 		<name>Server time - minute</name>
 		<segment>actionServerMinute</segment>
 		<acceptedValues>0, 1, 2, 3, ..., 56, 57, 58, 59</acceptedValues>
@@ -721,28 +721,28 @@
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Referrers</category>
+		<category>Acquisition</category>
 		<name>Channel Type</name>
 		<segment>referrerType</segment>
 		<acceptedValues>direct, search, website, campaign</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Referrers</category>
+		<category>Acquisition</category>
 		<name>Keyword</name>
 		<segment>referrerKeyword</segment>
 		<acceptedValues>Encoded%20Keyword, keyword</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Referrers</category>
+		<category>Acquisition</category>
 		<name>Referrer Name</name>
 		<segment>referrerName</segment>
 		<acceptedValues>twitter.com, www.facebook.com, Bing, Google, Yahoo, CampaignName</acceptedValues>
 	</row>
 	<row>
 		<type>dimension</type>
-		<category>Referrers</category>
+		<category>Acquisition</category>
 		<name>Referrer URL</name>
 		<segment>referrerUrl</segment>
 		<acceptedValues>http%3A%2F%2Fwww.example.org%2Freferer-page.htm</acceptedValues>


### PR DESCRIPTION
The display name of some categories have been changed in the past. e.g. Referrers was changed to Acquisition. The Segment selector still show Referrers at the moment, as the display name is not yet used there. 

ping @tsteur @mattab 

refs https://github.com/matomo-org/plugin-MarketingCampaignsReporting/issues/46