### PR TITLE
Remove update script for new profilable dimension

### DIFF
--- a/core/Updates/4.0.0-b1.php
+++ b/core/Updates/4.0.0-b1.php
@@ -155,10 +155,6 @@ class Updates_4_0_0_b1 extends PiwikUpdates
             $migrations[]     = $this->migration->db->sql("UPDATE $visitActionTable SET search_count = custom_var_v5 WHERE custom_var_k5 = '_pk_scount'");
         }
 
-        $logVisit = Common::prefixTable('log_visit');
-        // until 3.14.0 config_cookie was always 0 if cookies were disabled so for most visits this will be fairly accurate.
-        $migrations[] = $this->migration->db->sql("UPDATE $logVisit SET profilable = config_cookie WHERE profilable is null");
-
         if ($this->usesGeoIpLegacyLocationProvider()) {
             // activate GeoIp2 plugin for users still using GeoIp2 Legacy (others might have it disabled on purpose)
             $migrations[] = $this->migration->plugin->activate('GeoIp2');


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/pull/16217/files#r456216141
refs https://github.com/matomo-org/matomo/issues/16192

Thought it's better to remove this update as the value might be set wrongly in case someone updates from 3.14.0 to 4.0.0. Wanted to remove this in the PR directly but forgot to do it. Think it's better to have the dimension unset before setting it potentially wrongly.  see https://github.com/matomo-org/matomo/pull/16217/files#r456216141

Was also thinking of changing it to `"UPDATE $logVisit SET profilable = config_cookie WHERE profilable is null and visit_last_action_time < 2020-07-08"` because nobody could have used 3.14.0 before first beta was released on 8th July but it would mean some visits have this dimension set while others don't and then it maybe becomes inconsistent. Could also add the date though.