### PR TITLE
Add additional test for fingerprint salt date string generator

### DIFF
--- a/tests/PHPUnit/Integration/Tracker/FingerprintSaltTest.php
+++ b/tests/PHPUnit/Integration/Tracker/FingerprintSaltTest.php
@@ -57,6 +57,21 @@ class FingerprintSaltTest extends IntegrationTestCase
         $this->assertSame('2020-05-05',$this->fingerprintSalt->getDateString($date, 'Europe/Berlin'));
     }
 
+    public function test_getDateString_doubleCheckingWeAreGeneratingRightString()
+    {
+        for ($i = 0; $i <= 23; $i++) {
+            $d  = '2020-05-05 ' . $i.':04:05';
+            $date = Date::factory($d);
+            // double checking using the logic used in CoreHome::VisitRequestProcesser::wasLastActionNotToday where we detect midnight
+            // in timezone just to double check we return the correct date string for the given timezone. Should anything change and test not pass
+            // then we might have a problem that we would generate a different fingerprint for the same visitor even though it is not midnight
+            // just yet. Meaning during the day we would suddenly change the fingerprint hash causing additional visits to be created when not needed yet
+            $this->assertSame($this->fingerprintSalt->getDateString($date, 'Pacific/Auckland'), Date::factory($d, 'Pacific/Auckland')->toString());
+            $this->assertSame($this->fingerprintSalt->getDateString($date, 'Europe/Berlin'), Date::factory($d, 'Europe/Berlin')->toString());
+            $this->assertSame($this->fingerprintSalt->getDateString($date, 'America/Los_Angeles'), Date::factory($d, 'America/Los_Angeles')->toString());
+        }
+    }
+
     public function test_getSalt_remembersSaltPerSite()
     {
         $salt05_1 = $this->fingerprintSalt->getSalt('2020-05-05', $idSite = 1);


### PR DESCRIPTION
Wanted to make sure this works correctly to not create accidentally additional visits when cookies are disabled.