### PR TITLE
When embedding reports (widgets) into a site, it is no longer possible to use authentication tokens of users with at least write access 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ These are only recommendations (because we will keep backward compatibility for 
 
 ### Other Breaking changes
 
+* When embedding reports (widgets) into a different site, it is no longer possible to use authentication tokens of users with at least write access 
 * The log importer in `misc/log-analytics` now supports Python 3 (3.5, 3.6, 3.7 or 3.8), it will no longer run with Python 2. If you have any automated scripts that run the importer, you will have to change them to use the Python 3 executable instead.
 * Matomo now uses the SERVER_NAME for host validation and no longer the HOST header. If you're running Matomo behind a load balancer or a proxy you need to ensure that SERVER_NAME is set correctly.
 * Deprecated `piwik` font was removed. Use `matomo` font instead

--- a/plugins/Widgetize/Controller.php
+++ b/plugins/Widgetize/Controller.php
@@ -33,7 +33,9 @@ class Controller extends \Piwik\Plugin\Controller
     {
         $token_auth = Common::getRequestVar('token_auth', '', 'string');
 
-        if (!empty($token_auth) && Access::getInstance()->isUserHasSomeAdminAccess() && !defined('PIWIK_TEST_MODE')) {
+        if ($token_auth !== ''
+            && Access::getInstance()->isUserHasSomeAdminAccess()
+            && !defined('PIWIK_TEST_MODE')) {
             throw new \Exception(Piwik::translate('Widgetize_ViewAccessRequired'));
         }
 

--- a/plugins/Widgetize/lang/en.json
+++ b/plugins/Widgetize/lang/en.json
@@ -2,6 +2,7 @@
     "Widgetize": {
         "OpenInNewWindow": "Open in a new window",
         "PluginDescription": "Display any Matomo report in your website or app with a simple Embed HTML tag.",
+        "ViewAccessRequired": "This user has at least some write access. Only tokens of users who have only view access can be used.",
         "TopLinkTooltip": "Export Matomo Reports as Widgets and embed the Dashboard in your app as an iframe."
     }
 }


### PR DESCRIPTION
Added missing changelog entry and translation key.

It's based on https://github.com/matomo-org/matomo/pull/16263 which I don't get to pass right now so thought to create this simpler change extra while figuring out how to make the other one work