### PR TITLE
Make sure confirmPassword uses the currently active login plugin, not always "Login".

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -222,9 +222,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             }
         }
 
-        return $this->renderTemplate('confirmPassword', array(
+        return $this->renderTemplate('@Login/confirmPassword', array(
             'nonce' => Nonce::getNonce($nonceKey),
-            'AccessErrorString' => $messageNoAccess
+            'AccessErrorString' => $messageNoAccess,
+            'loginPlugin' => Piwik::getLoginPluginName(),
         ));
     }
 

--- a/plugins/Login/templates/confirmPassword.twig
+++ b/plugins/Login/templates/confirmPassword.twig
@@ -17,7 +17,7 @@
                 {% endif %}
             </div>
 
-            <form action="{{ linkTo({'module': 'Login', 'action': 'confirmPassword'}) }}" ng-non-bindable method="post">
+            <form action="{{ linkTo({'module': loginPlugin, 'action': 'confirmPassword'}) }}" ng-non-bindable method="post">
                 <div class="row">
                     <div class="col s12 input-field">
                         <input type="hidden" name="nonce" id="login_form_nonce" value="{{ nonce }}"/>


### PR DESCRIPTION
Two factor auth on 4.x-dev w/ LoginLdap fails currently due to the confirm password workflow. The code will try to use the current login plugin's twig template for `confirmPassword` (since custom login controllers must inherit from Login's Controller). Usually this isn't defined.

This change forces use of `@Login/confirmPassword` and sends the request to the currently configured Login plugin. Tested with LoginLdap using an LDAP user and it appears to work.