### PR TITLE
Reorganise Matomo 4 updates for better performance

### DIFF
--- a/core/Updater/Migration/Db/DropColumns.php
+++ b/core/Updater/Migration/Db/DropColumns.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+namespace Piwik\Updater\Migration\Db;
+
+use Piwik\Db;
+use Piwik\DbHelper;
+
+/**
+ * @see Factory::dropColumn()
+ * @ignore
+ */
+class DropColumns extends Sql
+{
+    public function __construct($tableName, $columnNames)
+    {
+        $table = DbHelper::getTableColumns($tableName);
+
+        // we need to remove all not existing columns. Otherwise if only one of the columns doesn't exist, all of
+        // the columns wouldn't be removed
+        $columnNames = array_filter($columnNames, function ($columnName) use ($table) {
+            return isset($table[$columnName]);
+        });
+
+        if (empty($columnNames)) {
+            parent::__construct('', static::ERROR_CODE_COLUMN_NOT_EXISTS);
+        } else {
+            $columnNames = array_unique($columnNames);
+            $dropColumns = array_map(function ($columnName) {
+                return sprintf('DROP COLUMN `%s`', $columnName);
+            }, $columnNames);
+
+            $sql = sprintf("ALTER TABLE `%s` %s", $tableName, implode(', ', $dropColumns));
+            parent::__construct($sql, static::ERROR_CODE_COLUMN_NOT_EXISTS);
+        }
+
+    }
+
+}

--- a/core/Updater/Migration/Db/Factory.php
+++ b/core/Updater/Migration/Db/Factory.php
@@ -177,6 +177,22 @@ class Factory
     }
 
     /**
+     * Drops an existing database table column.
+     *
+     * @param string $table  Unprefixed database table name, eg 'log_visit'.
+     * @param array $columnName  An array of column names that should be dropped eg ['column1', 'column2'].
+     * @return DropColumns
+     */
+    public function dropColumns($table, $columnNames)
+    {
+        $table = $this->prefixTable($table);
+
+        return $this->container->make('Piwik\Updater\Migration\Db\DropColumns', array(
+            'tableName' => $table, 'columnNames' => $columnNames
+        ));
+    }
+
+    /**
      * Changes the column name and column type of an existing database table column.
      *
      * @param string $table  Unprefixed database table name, eg 'log_visit'.

--- a/core/Updater/Migration/Db/Sql.php
+++ b/core/Updater/Migration/Db/Sql.php
@@ -83,7 +83,7 @@ class Sql extends DbMigration
     {
         $sql = $this->sql;
 
-        if (!Common::stringEndsWith($sql, ';')) {
+        if (!empty($sql) && !Common::stringEndsWith($sql, ';')) {
             $sql .= ';';
         }
 
@@ -92,6 +92,8 @@ class Sql extends DbMigration
 
     public function exec()
     {
-        Db::exec($this->sql);
+        if (!empty($this->sql)) {
+            Db::exec($this->sql);
+        }
     }
 }

--- a/core/Updates/4.0.0-b1.php
+++ b/core/Updates/4.0.0-b1.php
@@ -149,7 +149,7 @@ class Updates_4_0_0_b1 extends PiwikUpdates
 
         if (Manager::getInstance()->isPluginInstalled('CustomVariables')) {
             $visitActionTable = Common::prefixTable('log_link_visit_action');
-            $migrations[]     = $this->migration->db->sql("UPDATE $visitActionTable SET search_cat = if(custom_var_k4 = '_pk_scat', custom_var_v4, search_cat), search_count = if(custom_var_v5 = '_pk_scount', custom_var_v5, search_count) WHERE custom_var_k4 = '_pk_scat' or custom_var_k5 = '_pk_scount'");
+            $migrations[]     = $this->migration->db->sql("UPDATE $visitActionTable SET search_cat = if(custom_var_k4 = '_pk_scat', custom_var_v4, search_cat), search_count = if(custom_var_k5 = '_pk_scount', custom_var_v5, search_count) WHERE custom_var_k4 = '_pk_scat' or custom_var_k5 = '_pk_scount'");
         }
 
         if ($this->usesGeoIpLegacyLocationProvider()) {

--- a/core/Updates/4.0.0-b1.php
+++ b/core/Updates/4.0.0-b1.php
@@ -49,8 +49,6 @@ class Updates_4_0_0_b1 extends PiwikUpdates
         $migrations = [];
         $migrations[] = $this->migration->db->changeColumnType('log_action', 'name', 'VARCHAR(4096)');
         $migrations[] = $this->migration->db->changeColumnType('log_conversion', 'url', 'VARCHAR(4096)');
-        $migrations[] = $this->migration->db->dropColumn('log_visit', 'config_gears');
-        $migrations[] = $this->migration->db->dropColumn('log_visit', 'config_director');
         $migrations[] = $this->migration->db->changeColumn('log_link_visit_action', 'interaction_position', 'pageview_position', 'MEDIUMINT UNSIGNED DEFAULT NULL');
 
         /** APP SPECIFIC TOKEN START */
@@ -151,8 +149,7 @@ class Updates_4_0_0_b1 extends PiwikUpdates
 
         if (Manager::getInstance()->isPluginInstalled('CustomVariables')) {
             $visitActionTable = Common::prefixTable('log_link_visit_action');
-            $migrations[]     = $this->migration->db->sql("UPDATE $visitActionTable SET search_cat = custom_var_v4 WHERE custom_var_k4 = '_pk_scat'");
-            $migrations[]     = $this->migration->db->sql("UPDATE $visitActionTable SET search_count = custom_var_v5 WHERE custom_var_k5 = '_pk_scount'");
+            $migrations[]     = $this->migration->db->sql("UPDATE $visitActionTable SET search_cat = if(custom_var_k4 = '_pk_scat', custom_var_v4, search_cat), search_count = if(custom_var_v5 = '_pk_scount', custom_var_v5, search_count) WHERE custom_var_k4 = '_pk_scat' or custom_var_k5 = '_pk_scount'");
         }
 
         if ($this->usesGeoIpLegacyLocationProvider()) {
@@ -184,12 +181,17 @@ class Updates_4_0_0_b1 extends PiwikUpdates
         }
 
         // remove old days_to_... columns
-        $migrations[] = $this->migration->db->dropColumn('log_visit', 'visitor_days_since_first');
-        $migrations[] = $this->migration->db->dropColumn('log_visit', 'visitor_days_since_order');
-        $migrations[] = $this->migration->db->dropColumn('log_visit', 'visitor_days_since_last');
-
-        $migrations[] = $this->migration->db->dropColumn('log_conversion', 'visitor_days_since_first');
-        $migrations[] = $this->migration->db->dropColumn('log_conversion', 'visitor_days_since_order');
+        $migrations[] = $this->migration->db->dropColumns('log_visit', [
+            'config_gears',
+            'config_director',
+            'visitor_days_since_first',
+            'visitor_days_since_order',
+            'visitor_days_since_last',
+        ]);
+        $migrations[] = $this->migration->db->dropColumns('log_conversion', [
+            'visitor_days_since_first',
+            'visitor_days_since_order',
+        ]);
 
         $config = Config::getInstance();
 

--- a/plugins/CoreUpdater/Commands/Update.php
+++ b/plugins/CoreUpdater/Commands/Update.php
@@ -174,7 +174,10 @@ class Update extends ConsoleCommand
         $output->writeln(array("    *** ".Piwik::translate('CoreUpdater_DryRun')." ***", ""));
 
         foreach ($migrationQueries as $query) {
-            $output->writeln("    " . $query->__toString());
+            $result = $query->__toString();
+            if (!empty($result)) {
+                $output->writeln("    " . $result);
+            }
         }
 
         $output->writeln(array("", "    *** " . Piwik::translate('CoreUpdater_DryRunEnd') . " ***", ""));

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/DropColumnsTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/DropColumnsTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Updater\Migration\Db;
+
+use Piwik\Common;
+use Piwik\Db;
+use Piwik\DbHelper;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Updater\Migration\Db\DropColumns;
+
+/**
+ * @group Core
+ * @group Updater
+ * @group Migration
+ * @group DropColumns
+ * @group DropColumnsTest
+ */
+class DropColumnsTest extends IntegrationTestCase
+{
+    private $tableName;
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tableName = 'foobar';
+        DbHelper::createTable($this->tableName, 'barbaz VARCHAR(1), foobaz VARCHAR(1), foobaz2 VARCHAR(1)');
+    }
+
+    public function tearDown(): void
+    {
+        Db::exec('DROP TABLE IF EXISTS ' . Common::prefixTable($this->tableName));
+        parent::tearDown();
+    }
+
+    public function test_validAndInvalidColumnsAndDuplicateColumns()
+    {
+        $sql = $this->dropColumns(array('barbaz', 'notexstis', 'barbaz'));
+
+        $this->assertQueryWorks($sql, 'ALTER TABLE `foobar` DROP COLUMN `barbaz`;');
+    }
+
+    public function test_onlyInvalidColumns()
+    {
+        $sql = $this->dropColumns(array('notexstis', 'foobar1234'));
+
+        $this->assertQueryWorks($sql, '');
+    }
+
+    public function test_onlyOneColumn()
+    {
+        $sql = $this->dropColumns(array('foobaz'));
+
+        $this->assertQueryWorks($sql, 'ALTER TABLE `foobar` DROP COLUMN `foobaz`;');
+    }
+
+    public function test_multipleColumns()
+    {
+        $sql = $this->dropColumns(array('barbaz', 'notexstis', 'barbaz', 'foobaz'));
+
+        $this->assertQueryWorks($sql, 'ALTER TABLE `foobar` DROP COLUMN `barbaz`, DROP COLUMN `foobaz`;');
+    }
+
+    private function assertQueryWorks(DropColumns $dropColumns, $expectedQuery)
+    {
+        $this->assertSame($dropColumns->__toString(), $expectedQuery);
+        $this->assertNull($dropColumns->exec()); // query should be valid
+    }
+
+    private function dropColumns($columnNames)
+    {
+        return new DropColumns(Common::prefixTable($this->tableName), $columnNames);
+    }
+
+
+}

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
@@ -242,6 +242,14 @@ class MigrationsTest extends IntegrationTestCase
         $this->assertTableIsNotInstalled();
     }
 
+    public function test_dropColumns()
+    {
+        DbHelper::createTable('foobarbaz', 'barbaz VARCHAR(1), foobaz VARCHAR(1), foobaz2 VARCHAR(1)');
+        $this->factory->dropColumns('foobarbaz', array('column10', 'barbaz', 'column3', 'foobaz'))->exec();
+
+        $this->assertSame(array('foobaz2'), $this->getInstalledColumnNames());
+    }
+
     private function fetchRow()
     {
         return Db::fetchRow("SELECT * FROM {$this->testTablePrefixed}");

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
@@ -247,7 +247,7 @@ class MigrationsTest extends IntegrationTestCase
         DbHelper::createTable('foobarbaz', 'barbaz VARCHAR(1), foobaz VARCHAR(1), foobaz2 VARCHAR(1)');
         $this->factory->dropColumns('foobarbaz', array('column10', 'barbaz', 'column3', 'foobaz'))->exec();
 
-        $columns = DbHelper::getTableColumns($this->testTablePrefixed);
+        $columns = DbHelper::getTableColumns(Common::prefixTable('foobarbaz'));
         $columns = array_keys($columns);
 
         $this->assertSame(array('foobaz2'), $columns);

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/MigrationsTest.php
@@ -247,7 +247,10 @@ class MigrationsTest extends IntegrationTestCase
         DbHelper::createTable('foobarbaz', 'barbaz VARCHAR(1), foobaz VARCHAR(1), foobaz2 VARCHAR(1)');
         $this->factory->dropColumns('foobarbaz', array('column10', 'barbaz', 'column3', 'foobaz'))->exec();
 
-        $this->assertSame(array('foobaz2'), $this->getInstalledColumnNames());
+        $columns = DbHelper::getTableColumns($this->testTablePrefixed);
+        $columns = array_keys($columns);
+
+        $this->assertSame(array('foobaz2'), $columns);
     }
 
     private function fetchRow()

--- a/tests/PHPUnit/Integration/Updater/Migration/Db/SqlTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Db/SqlTest.php
@@ -35,6 +35,20 @@ class SqlTest extends IntegrationTestCase
         $this->assertSame($this->testQuery . ';', '' . $sql);
     }
 
+    public function test_toString_shouldNotAppendSemicolonIfNoQueryGiven()
+    {
+        $sql = $this->sql('');
+
+        $this->assertSame('', '' . $sql);
+    }
+
+    public function test_exec_shouldNotFailWhenNoQueryGiven()
+    {
+        $sql = $this->sql('');
+
+        $this->assertNull($sql->exec());
+    }
+
     public function test_constructor_shouldConvertErrorCodeToArray_IfNeeded()
     {
         $sql = $this->sql($this->testQuery, 1091);


### PR DESCRIPTION
For better performance we should combine as many queries into one ALTER table statement where possible. Technically there are also 2 drop user columns that could be combined but this table will be fast anyway and executing them individually may be better.

technically could also add all `add columns and drop columns` for each table together but not sure how much this impacts performance but would potentially make it quite a bit more difficult to implement maybe.

Any other thoughts?