### PR TITLE
Fix error when primary key is required

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -298,7 +298,15 @@ class LogAggregator
             ) {
                 $createTableSql = str_replace($tempTableIdVisitColumn, $tempTableIdVisitColumn . ', PRIMARY KEY (`idvisit`)', $createTableSql);
 
-                $readerDb->query($createTableSql);
+                try {
+                    $readerDb->query($createTableSql);
+                } catch (\Exception $e) {
+                    if ($readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_TABLE_EXISTS)) {
+                        return;
+                    } else {
+                        throw $e;
+                    }
+                }
             } else {
                 throw $e;
             }

--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -294,7 +294,9 @@ class LogAggregator
             if ($readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_TABLE_EXISTS)) {
                 return;
             } elseif ($readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_REQUIRES_PRIMARY_KEY)
-                || $readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_UNABLE_CREATE_TABLE_WITHOUT_PRIMARY_KEY)
+                || $readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_UNABLE_CREATE_TABLE_WITHOUT_PRIMARY_KEY
+                || stripos($e->getMessage(), 'requires a primary key') !== false
+                || stripos($e->getMessage(), 'table without a primary key') !== false)
             ) {
                 $createTableSql = str_replace($tempTableIdVisitColumn, $tempTableIdVisitColumn . ', PRIMARY KEY (`idvisit`)', $createTableSql);
 

--- a/core/Updater/Migration/Db.php
+++ b/core/Updater/Migration/Db.php
@@ -68,6 +68,16 @@ abstract class Db extends Migration
     const ERROR_CODE_TABLE_NOT_EXISTS = 1146;
 
     /**
+     * This table type requires a primary key SQL: CREATE TEMPORARY TABLE %s
+     */
+    const ERROR_CODE_REQUIRES_PRIMARY_KEY = 1173;
+
+    /**
+     * General error: 3750 Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set.
+     */
+    const ERROR_CODE_UNABLE_CREATE_TABLE_WITHOUT_PRIMARY_KEY = 3750;
+
+    /**
      * Query execution was interrupted, maximum statement execution time exceeded
      */
     const ERROR_CODE_MAX_EXECUTION_TIME_EXCEEDED_QUERY_INTERRUPTED = 3024;

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -155,9 +155,20 @@ class LogAggregatorTest extends IntegrationTestCase
         } catch (\Exception $e) {
             if ($this->logAggregator->getDb()->isErrNo($e, 1193)) {
                 // ignore General error: 1193 Unknown system variable 'sql_require_primary_key'
-                return;
+                try {
+                    // on mariadb this might work
+                    $this->logAggregator->getDb()->exec('SET SESSION innodb_force_primary_key=' . $val);
+                } catch (\Exception $e) {
+                    if ($this->logAggregator->getDb()->isErrNo($e, 1193)) {
+                        // ignore General error: 1193 Unknown system variable 'sql_require_primary_key'
+                        return;
+                    } else {
+                        throw $e;
+                    }
+                }
+            } else {
+                throw $e;
             }
-            throw $e;
         }
     }
 

--- a/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/LogAggregatorTest.php
@@ -41,19 +41,29 @@ class LogAggregatorTest extends IntegrationTestCase
      */
     private $logAggregator;
 
+    /**
+     * @var Site
+     */
+    private $site;
+
+    /**
+     * @var Period
+     */
+    private $period;
+
     public function setUp(): void
     {
         parent::setUp();
 
         $idSite = 1;
 
-        $site = new Site($idSite);
+        $this->site = new Site($idSite);
         $date = Date::factory('2010-03-06');
-        $period = Period\Factory::build('month', $date);
-        $segment = new Segment('', array($site->getId()));
+        $this->period = Period\Factory::build('month', $date);
+        $segment = new Segment('', array($this->site->getId()));
 
 
-        $params = new Parameters($site, $period, $segment);
+        $params = new Parameters($this->site, $this->period, $segment);
         $this->logAggregator = new LogAggregator($params);
     }
 
@@ -75,6 +85,94 @@ class LogAggregatorTest extends IntegrationTestCase
                 0 => '2010-03-01 00:00:00',
                 1 => '2010-03-31 23:59:59',
                 2 => 1
+            )
+        );
+        $this->assertSame($expected, $query);
+    }
+
+    public function test_generateQuery_withSegment_shouldNotUseTmpTableWhenNotEnabled()
+    {
+        $segment = new Segment('userId==1', array($this->site->getId()));
+
+        $params = new Parameters($this->site, $this->period, $segment);
+        $this->logAggregator = new LogAggregator($params);
+
+        $query = $this->logAggregator->generateQuery('test, test2', 'log_visit', '1=1', false, '5');
+
+        $expected = array(
+            'sql' => 'SELECT /* 2010-03-01,2010-03-31 sites 1 segmenthash 4eaf469650796451c610972d0ca1e9e8 */
+				test, test2
+			FROM
+				log_visit AS log_visit
+			WHERE
+				( 1=1 )
+                AND
+                ( log_visit.user_id = ? )
+			ORDER BY
+				5',
+            'bind' => array (
+                '2010-03-01 00:00:00',
+                '2010-03-31 23:59:59',
+                1,
+                '1'
+            )
+        );
+        $this->assertSame($expected, $query);
+    }
+
+    public function test_generateQuery_withSegment_shouldUseTmpTableWhenEnabled()
+    {
+        $segment = new Segment('userId==1', array($this->site->getId()));
+
+        $params = new Parameters($this->site, $this->period, $segment);
+        $this->logAggregator = new LogAggregator($params);
+        $this->logAggregator->allowUsageSegmentCache();
+
+        $query = $this->logAggregator->generateQuery('test, test2', 'log_visit', '1=1', false, '5');
+
+        $expected = array(
+            'sql' => 'SELECT /* 2010-03-01,2010-03-31 sites 1 segmenthash 4eaf469650796451c610972d0ca1e9e8 */
+				test, test2
+			FROM
+				logtmpsegment0e053be69df974017fba4276a0d4347d AS logtmpsegment0e053be69df974017fba4276a0d4347d INNER JOIN log_visit AS log_visit ON log_visit.idvisit = logtmpsegment0e053be69df974017fba4276a0d4347d.idvisit
+			WHERE
+				1=1
+			ORDER BY
+				5',
+            'bind' => array (
+                '2010-03-01 00:00:00',
+                '2010-03-31 23:59:59',
+                1,
+            )
+        );
+        $this->assertSame($expected, $query);
+    }
+
+    public function test_generateQuery_withSegment_shouldUseTmpTableWhenEnabledAndPrimaryKeyRequired()
+    {
+        $segment = new Segment('userId==2', array($this->site->getId()));
+
+        $params = new Parameters($this->site, $this->period, $segment);
+        $this->logAggregator = new LogAggregator($params);
+        $this->logAggregator->allowUsageSegmentCache();
+        $this->logAggregator->getDb()->exec('SET SESSION sql_require_primary_key=1');
+
+        $query = $this->logAggregator->generateQuery('test, test2', 'log_visit', '1=1', false, '5');
+
+        $this->logAggregator->getDb()->exec('SET SESSION sql_require_primary_key=0');// reset variable
+        $expected = array(
+            'sql' => 'SELECT /* 2010-03-01,2010-03-31 sites 1 segmenthash 4a4d16d6897e7fed2d5d151016a5a19c */
+				test, test2
+			FROM
+				logtmpsegment4ef74412006a3160b17ca5fe99a5f866 AS logtmpsegment4ef74412006a3160b17ca5fe99a5f866 INNER JOIN log_visit AS log_visit ON log_visit.idvisit = logtmpsegment4ef74412006a3160b17ca5fe99a5f866.idvisit
+			WHERE
+				1=1
+			ORDER BY
+				5',
+            'bind' => array (
+                '2010-03-01 00:00:00',
+                '2010-03-31 23:59:59',
+                1,
             )
         );
         $this->assertSame($expected, $query);


### PR DESCRIPTION
refs https://wordpress.org/support/topic/error-in-visits-over-time/

refs https://forum.matomo.org/t/matomo-on-digitalocean-managed-database-cluster-mysql-8-sql-require-primary-key-error/37623

Putting this into Matomo 4 since it is required for Matomo for WordPress as people can't change DB settings on wordpress.com etc.