### PR TITLE
Fix UI tests using embedded widgets

### DIFF
--- a/plugins/Overlay/tests/UI/Overlay_spec.js
+++ b/plugins/Overlay/tests/UI/Overlay_spec.js
@@ -152,8 +152,7 @@ describe("Overlay", function () {
         testEnvironment.overrideConfig('General', 'enable_framed_pages', 1);
         testEnvironment.save();
 
-        console.log(`[Note: token auth is ${testEnvironment.tokenAuth}]`);
-        await page.goto(baseUrl + '&token_auth=' + testEnvironment.tokenAuth + hash);
+        await page.goto(baseUrl + '&token_auth=a4ca4238a0b923820dcc509a6f75849f' + hash);
         await page.waitFor('.overlayMainMetrics,.overlayNoData');
 
         await removeOptOutIframe();

--- a/plugins/TwoFactorAuth/tests/Fixtures/TwoFactorFixture.php
+++ b/plugins/TwoFactorAuth/tests/Fixtures/TwoFactorFixture.php
@@ -78,7 +78,7 @@ class TwoFactorFixture extends Fixture
         foreach ([$this->userWith2Fa, $this->userWithout2Fa, $this->userWith2FaDisable, $this->userNo2Fa] as $user) {
             \Piwik\Plugins\UsersManager\API::getInstance()->addUser($user, $this->userPassword, $user . '@matomo.org');
             // we cannot set superuser as logme won't work for super user
-            UsersAPI::getInstance()->setUserAccess($user, 'admin', [$this->idSite, $this->idSite2]);
+            UsersAPI::getInstance()->setUserAccess($user, 'view', [$this->idSite, $this->idSite2]);
 
             if ($this->userWith2Fa === $user) {
                 $userModel = new Model();

--- a/plugins/TwoFactorAuth/tests/UI/TwoFactorAuth_spec.js
+++ b/plugins/TwoFactorAuth/tests/UI/TwoFactorAuth_spec.js
@@ -86,7 +86,7 @@ describe("TwoFactorAuth", function () {
     }
 
     it('a user with 2fa can open the widgetized view by token without needing to verify', async function () {
-        await page.goto('?module=Widgetize&action=iframe&moduleToWidgetize=Actions&actionToWidgetize=getPageUrls&date=2018-03-04&token_auth=c4ca4238a0b923820dcc509a6f75849b&' + generalParams);
+        await page.goto('?module=Widgetize&action=iframe&moduleToWidgetize=Actions&actionToWidgetize=getPageUrls&date=2018-03-04&token_auth=a4ca4238a0b923820dcc509a6f75849b&' + generalParams);
         expect(await page.screenshotSelector('.widget')).to.matchImage('widgetized_no_verify');
     });
 

--- a/tests/PHPUnit/Fixtures/UITestFixture.php
+++ b/tests/PHPUnit/Fixtures/UITestFixture.php
@@ -133,7 +133,7 @@ class UITestFixture extends SqlDump
 
         if (empty($user)) {
             $model->addUser(self::VIEW_USER_LOGIN, self::VIEW_USER_PASSWORD, 'hello2@example.org', Date::now()->getDatetime());
-            $model->addUserAccess(self::VIEW_USER_LOGIN, 'view', array(1));
+            $model->addUserAccess(self::VIEW_USER_LOGIN, 'view', array(1, 3));
         } else {
             $model->updateUser(self::VIEW_USER_LOGIN, self::VIEW_USER_PASSWORD, 'hello2@example.org');
         }

--- a/tests/UI/expected-screenshots/enable_framed_pages_embed_whole_app.png
+++ b/tests/UI/expected-screenshots/enable_framed_pages_embed_whole_app.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:17a7b0c35c4fdc1e018cdb4357f96eb3de42bbca896c6730016f3b05f252c9cb
-size 149447
+oid sha256:346fa9d954f83d435fd89f8a4baf9ae13ce1cf0c40aae66eedc94421aa6d1e5a
+size 232130

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -1094,7 +1094,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         });
 
         it('should allow embedding the entire app', async function () {
-            var url = "tests/resources/embed-file.html#" + encodeURIComponent(page.baseUrl + 'index.php?' + urlBase + '&token_auth=' + testEnvironment.tokenAuth);
+            var url = "tests/resources/embed-file.html#" + encodeURIComponent(page.baseUrl + 'index.php?' + urlBase + '&token_auth=a4ca4238a0b923820dcc509a6f75849f');
             await page.goto(url);
             await page.waitForNetworkIdle();
 


### PR DESCRIPTION
Some UI tests were trying to embed widgets using a token_auth with more than view access.
Due to #16263 and #16264 that is only allowed for users with view access now.