### PR TITLE
Fix API example links

### DIFF
--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -128,7 +128,7 @@ class DocumentationGenerator
 
     protected function addExamples($class, $methodName, $prefixUrls)
     {
-        $token_auth = "&token_auth=" . Piwik::getCurrentUserTokenAuth();
+        $token_auth = "&token_auth=" . Piwik::getCurrentUserTokenAuth() . "&force_api_session=1";
         $parametersToSet = array(
             'idSite' => Common::getRequestVar('idSite', 1, 'int'),
             'period' => Common::getRequestVar('period', 'day', 'string'),


### PR DESCRIPTION
Currently the API example links don't work as they are using the session token_auth. Appending a `force_api_session=1` should make the links working again. At least within the current session.