### PR TITLE
remove optional parameter before required one

### DIFF
--- a/plugins/Actions/ArchivingHelper.php
+++ b/plugins/Actions/ArchivingHelper.php
@@ -371,7 +371,7 @@ class ArchivingHelper
      * @param array $actionsTablesByType
      * @return DataTable\Row
      */
-    public static function getActionRow($actionName, $actionType, $urlPrefix = null, &$actionsTablesByType)
+    public static function getActionRow($actionName, $actionType, $urlPrefix, &$actionsTablesByType)
     {
         // we work on the root table of the given TYPE (either ACTION_URL or DOWNLOAD or OUTLINK etc.)
         /* @var DataTable $currentTable */


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/16183 (PHP 8 support)

> [17-Aug-2020 14:19:19 UTC] PHP Deprecated:  Required parameter $actionsTablesByType follows optional parameter $urlPrefix in /home/lukas/public_html/matomophp8/plugins/Actions/ArchivingHelper.php on line 374

As this is only called in one place, this should not break anything. If there is an easier way to fix this, let me know.

