### PR TITLE
don't log silenced errors in php8

### DIFF
--- a/core/ErrorHandler.php
+++ b/core/ErrorHandler.php
@@ -133,7 +133,7 @@ class ErrorHandler
     public static function errorHandler($errno, $errstr, $errfile, $errline)
     {
         // if the error has been suppressed by the @ we don't handle the error
-        if (error_reporting() == 0) {
+        if (!(error_reporting() & $errno)) {
             return;
         }
 


### PR DESCRIPTION
When testing with PHP 8, I was wondering why I was seeing so many errors in the matomo.log like

> WARNING Ecommerce[2020-08-17 15:42:06 UTC] [56b55] /home/lukas/public_html/matomophp8/core/Plugin/Report.php(924): Warning - Undefined array key "items"

that when taking a closer look should be silenced with an `@`.

https://github.com/matomo-org/matomo/blob/688373e4d3a34bef647c3a681db4268afd226e95/core/Plugin/Report.php#L924

It turns out that `https://github.com/php/php-src/pull/3685` caused a change:
> Error handlers that want to only handle non-silenced errors may have to be adjusted. A common pattern I found in our own tests if checks for error_reporting() != 0 to detect silencing. This should be changed to error_reporting() & $err_no to detect whether the specific error type is silenced.

