### PR TITLE
Tests no memory limit

### DIFF
--- a/tests/PHPUnit/System/ConsoleTest.php
+++ b/tests/PHPUnit/System/ConsoleTest.php
@@ -145,6 +145,16 @@ class ConsoleTest extends ConsoleCommandTestCase
 
     public function test_Console_handlesFatalErrorsCorrectly()
     {
+        $cliPhp = new CliPhp();
+        $php = $cliPhp->findPhpBinary();
+        $command = $php . " -i | grep 'memory_limit => -1'";
+
+        $output = shell_exec($command);
+
+        if ($output == "memory_limit => -1 => -1\n") {
+            $this->markTestSkipped("no memory limit in php-cli");
+        }
+
         $command = Fixture::getCliCommandBase();
         $command .= ' test-command-with-fatal-error';
         $command .= ' 2>&1';
@@ -175,16 +185,6 @@ END;
 
     public function test_Console_handlesExceptionsCorrectly()
     {
-        $cliPhp = new CliPhp();
-        $php = $cliPhp->findPhpBinary();
-        $command = $php . " -i | grep 'memory_limit => -1'";
-
-        $output = shell_exec($command);
-
-        if ($output == "memory_limit => -1 => -1\n") {
-            $this->markTestSkipped("no memory limit in php-cli");
-        }
-
         $command = Fixture::getCliCommandBase();
         $command .= ' test-command-with-exception';
         $command .= ' 2>&1';

--- a/tests/PHPUnit/System/ConsoleTest.php
+++ b/tests/PHPUnit/System/ConsoleTest.php
@@ -175,6 +175,16 @@ END;
 
     public function test_Console_handlesExceptionsCorrectly()
     {
+        $cliPhp = new CliPhp();
+        $php = $cliPhp->findPhpBinary();
+        $command = $php . " -i | grep 'memory_limit => -1'";
+
+        $output = shell_exec($command);
+
+        if ($output == "memory_limit => -1 => -1\n") {
+            $this->markTestSkipped("no memory limit in php-cli");
+        }
+
         $command = Fixture::getCliCommandBase();
         $command .= ' test-command-with-exception';
         $command .= ' 2>&1';


### PR DESCRIPTION
While testing around with php8, I stumbled across https://github.com/matomo-org/matomo/pull/15472/commits/79603337e81a1a7cfe889c34fdb4e9cb740d253f which is a test that tries to force a `PHP Fatal error:  Allowed memory size of X bytes exhausted` on php-cli.

Unfortunately, on my system (and probably others too) php-cli has a memory_limit of `-1` which means the PC will run out of memory before one can notice what command is running.

This PR adds a slight hack to skip this test in this case.