### PR TITLE
Add plugin.json files for some internal plugins

### DIFF
--- a/plugins/CustomVariables/plugin.json
+++ b/plugins/CustomVariables/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "CustomVariables",
+  "description": "Custom Variables are (name, value) pairs that you can assign using the Javascript API to visitors or any of their action. Matomo will then report how many visits, pages, conversions for each of these custom names and values. View the detailed Custom Variables for each user and action in the Visitor Log. This plugin is required to use Ecommerce Analytics feature!",
+  "version": "3.14.1",
+  "theme": false,
+  "require": {
+    "piwik": ">=3.0.0,<4.0.0-b1"
+  },
+  "authors": [
+    {
+      "name": "Matomo",
+      "email": "hello@matomo.org",
+      "homepage": "https:\/\/matomo.org"
+    }
+  ],
+  "homepage": "https:\/\/matomo.org",
+  "license": "GPL v3+",
+  "keywords": [
+    "custom variables"
+  ]
+}

--- a/plugins/Provider/plugin.json
+++ b/plugins/Provider/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "Provider",
+  "description": "Reports the Internet Service Provider of the visitors.",
+  "version": "3.14.1",
+  "theme": false,
+  "require": {
+    "piwik": ">=3.0.0,<4.0.0-b1"
+  },
+  "authors": [
+    {
+      "name": "Matomo",
+      "email": "hello@matomo.org",
+      "homepage": "https:\/\/matomo.org"
+    }
+  ],
+  "homepage": "https:\/\/matomo.org",
+  "license": "GPL v3+",
+  "keywords": [
+    "provider"
+  ]
+}


### PR DESCRIPTION
This makes sure when updating eg from Matomo 3.x to Matomo 4.x that these plugins won't be detected as bogus and ensures they will be updated. 

The version number needs to be set to fix otherwise the plugins will later be assumed to have the same version as core and potentially no update would be found on the marketplace. It's fine to set a fixed number we won't need to change it again in 3.X since it would be only needed if they defined their own plugin updates.

I'll later look into creating separate updates for 4.X to handle it for instances that don't upgrade from most recent 3.X version. Will work on this in eg https://github.com/matomo-org/matomo/compare/plugincheck?expand=1