### PR TITLE
Fix plugins not being updated when updating core

### DIFF
--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -15,6 +15,7 @@ use Piwik\Filechecks;
 use Piwik\Filesystem;
 use Piwik\Http;
 use Piwik\Option;
+use Piwik\Piwik;
 use Piwik\Plugin\Manager as PluginManager;
 use Piwik\Plugin\ReleaseChannels;
 use Piwik\Plugins\CorePluginsAdmin\PluginInstaller;
@@ -126,6 +127,7 @@ class Updater
 
         $partTwoUrl = Url::getCurrentUrlWithoutQueryString() . Url::getCurrentQueryStringWithParametersModified([
             'action' => 'oneClickUpdatePartTwo',
+            'token_auth' => Piwik::getCurrentUserTokenAuth()
         ]);
 
         $response = Http::sendHttpRequest($partTwoUrl, 300);


### PR DESCRIPTION
Seems to have regressed in https://github.com/matomo-org/matomo/pull/15770

Haven't tested it yet but this should work. We'll then also need to fix this in Matomo 4 separately because the token_auth check wouldn't work there because it would check against the new app specific token auth table which wouldn't exist yet at the time this is executed.

Unfortunately this will basically only work on the next update. So if people update to 3.14.1 it will only work when they update from that version. It won't work yet from 3.14.0 to 3.14.1 since the old code would be used there.