### PR TITLE
Fix plugins might not be updated when updating core

### DIFF
--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -154,6 +154,8 @@ class FrontController extends Singleton
             return;
         }
 
+
+
         $filter = new Router();
         $redirection = $filter->filterUrl(Url::getCurrentUrl());
         if ($redirection !== null) {

--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -153,9 +153,7 @@ class FrontController extends Singleton
         if (self::$enableDispatch === false) {
             return;
         }
-
-
-
+        
         $filter = new Router();
         $redirection = $filter->filterUrl(Url::getCurrentUrl());
         if ($redirection !== null) {

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -222,10 +222,10 @@ class Controller extends \Piwik\Plugin\Controller
         } elseif ($error) {
             $view = new View('@CoreUpdater/updateHttpError');
             $view->error = $error;
-            $view->feedbackMessages = safe_unserialize(Common::unsanitizeInputValue(Common::getRequestVar('messages', '', 'string', $_POST)));
         } else {
             $view = new View('@CoreUpdater/updateSuccess');
         }
+        $view->feedbackMessages = safe_unserialize(Common::unsanitizeInputValue(Common::getRequestVar('messages', '', 'string', $_POST)));
 
         $this->addCustomLogoInfo($view);
         $this->setBasicVariablesView($view);

--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -225,7 +225,11 @@ class Controller extends \Piwik\Plugin\Controller
         } else {
             $view = new View('@CoreUpdater/updateSuccess');
         }
-        $view->feedbackMessages = safe_unserialize(Common::unsanitizeInputValue(Common::getRequestVar('messages', '', 'string', $_POST)));
+        $messages = safe_unserialize(Common::unsanitizeInputValue(Common::getRequestVar('messages', '', 'string', $_POST)));
+        if (!is_array($messages)) {
+            $messages = array();
+        }
+        $view->feedbackMessages = $messages;
 
         $this->addCustomLogoInfo($view);
         $this->setBasicVariablesView($view);

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -130,8 +130,6 @@ class Updater
         $nonce = Common::generateUniqId();
         Option::set('NonceOneClickUpdatePartTwo', json_encode(['nonce' => $nonce, 'ttl' => $validFor10Minutes]));
 
-        PiwikCache::flushAll();
-
         $cliMulti = new CliMulti();
         $responses = $cliMulti->request(['?module=CoreUpdater&action=oneClickUpdatePartTwo&nonce=' . $nonce]);
         if (!empty($responses)) {

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\CoreUpdater;
 
 use Exception;
 use Piwik\ArchiveProcessor\Rules;
+use Piwik\Cache as PiwikCache;
 use Piwik\CliMulti;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
@@ -25,7 +26,6 @@ use Piwik\Plugins\Marketplace\Marketplace;
 use Piwik\SettingsServer;
 use Piwik\Translation\Translator;
 use Piwik\Unzip;
-use Piwik\Url;
 use Piwik\Version;
 
 class Updater
@@ -130,7 +130,7 @@ class Updater
         $nonce = Common::generateUniqId();
         Option::set('NonceOneClickUpdatePartTwo', json_encode(['nonce' => $nonce, 'ttl' => $validFor10Minutes]));
 
-        Filesystem::deleteAllCacheOnUpdate();
+        PiwikCache::flushAll();
 
         $cliMulti = new CliMulti();
         $responses = $cliMulti->request(['?module=CoreUpdater&action=oneClickUpdatePartTwo&nonce=' . $nonce]);

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -14,8 +14,10 @@ use Piwik\Cache as PiwikCache;
 use Piwik\CliMulti;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
+use Piwik\Context;
 use Piwik\Filechecks;
 use Piwik\Filesystem;
+use Piwik\FrontController;
 use Piwik\Http;
 use Piwik\Option;
 use Piwik\Plugin\Manager as PluginManager;
@@ -132,11 +134,35 @@ class Updater
 
         $cliMulti = new CliMulti();
         $responses = $cliMulti->request(['?module=CoreUpdater&action=oneClickUpdatePartTwo&nonce=' . $nonce]);
+
         if (!empty($responses)) {
-            $response = array_shift($responses);
-            $response = @json_decode($response, $assoc = true);
-            if (!empty($response) && is_array($response)) {
-                $messages = array_merge($messages, $response);
+            $responseCliMulti = array_shift($responses);
+            $responseCliMulti = @json_decode($responseCliMulti, $assoc = true);
+            if (is_array($responseCliMulti)) {
+                // we expect a json encoded array response from oneClickUpdatePartTwo. Otherwise something went wrong.
+                $messages = array_merge($messages, $responseCliMulti);
+            } else {
+                // there was likely an error eg such as an invalid ssl certificate... let's try executing it directly
+                // in case this works. For explample $response is in this case not an array but a string because the "communcation"
+                // with the controller went wrong: "Got invalid response from API request: https://ABC/?module=CoreUpdater&action=oneClickUpdatePartTwo&nonce=ABC. Response was \'curl_exec: SSL certificate problem: unable to get local issuer certificate. Hostname requested was: ABC"
+                try {
+                    $response = null;
+                    Context::executeWithQueryParameters(array('nonce' => $nonce), function () use (&$response) {
+                        $response = FrontController::getInstance()->dispatch('CoreUpdater', 'oneClickUpdatePartTwo', array($sendHeader = false));
+                    });
+                    if (!empty($response)) {
+                        $response = @json_decode($response, $assoc = true);
+                        if (!empty($response) && is_array($response)) {
+                            $messages = array_merge($messages, $response);
+                        }
+                    }
+                } catch (Exception $e) {
+                    // ignore any error should this fail too. this might be the case eg if
+                    // the user upgrades from one major version to another major version
+                    if (is_string($responseCliMulti)) {
+                        $messages[] = $responseCliMulti; // show why the original request failed eg invalid ssl certificate
+                    }
+                }
             }
         }
 
@@ -156,6 +182,12 @@ class Updater
     {
         $messages = [];
 
+        if (!Marketplace::isMarketplaceEnabled()) {
+            $messages[] = 'Marketplace is disabled. Not updating any plugins.';
+            // prevent error Entry "Piwik\Plugins\Marketplace\Api\Client" cannot be resolved: Entry "Piwik\Plugins\Marketplace\Api\Service" cannot be resolved
+            return $messages;
+        }
+
         $newVersion = Version::VERSION;
 
         // we also need to make sure to create a new instance here as otherwise we would change the "global"
@@ -168,23 +200,20 @@ class Updater
         ));
 
         try {
+            $messages[] = $this->translator->translate('CoreUpdater_CheckingForPluginUpdates');
+            $pluginManager = PluginManager::getInstance();
+            $pluginManager->loadAllPluginsAndGetTheirInfo();
+            $loadedPlugins = $pluginManager->getLoadedPlugins();
 
-            if (Marketplace::isMarketplaceEnabled()) {
-                $messages[] = $this->translator->translate('CoreUpdater_CheckingForPluginUpdates');
-                $pluginManager = PluginManager::getInstance();
-                $pluginManager->loadAllPluginsAndGetTheirInfo();
-                $loadedPlugins = $pluginManager->getLoadedPlugins();
+            $marketplaceClient->clearAllCacheEntries();
+            $pluginsWithUpdate = $marketplaceClient->checkUpdates($loadedPlugins);
 
-                $marketplaceClient->clearAllCacheEntries();
-                $pluginsWithUpdate = $marketplaceClient->checkUpdates($loadedPlugins);
-
-                foreach ($pluginsWithUpdate as $pluginWithUpdate) {
-                    $pluginName = $pluginWithUpdate['name'];
-                    $messages[] = $this->translator->translate('CoreUpdater_UpdatingPluginXToVersionY',
-                        array($pluginName, $pluginWithUpdate['version']));
-                    $pluginInstaller = new PluginInstaller($marketplaceClient);
-                    $pluginInstaller->installOrUpdatePluginFromMarketplace($pluginName);
-                }
+            foreach ($pluginsWithUpdate as $pluginWithUpdate) {
+                $pluginName = $pluginWithUpdate['name'];
+                $messages[] = $this->translator->translate('CoreUpdater_UpdatingPluginXToVersionY',
+                    array($pluginName, $pluginWithUpdate['version']));
+                $pluginInstaller = new PluginInstaller($marketplaceClient);
+                $pluginInstaller->installOrUpdatePluginFromMarketplace($pluginName);
             }
         } catch (MarketplaceApi\Exception $e) {
             // there is a problem with the connection to the server, ignore for now

--- a/plugins/CoreUpdater/lang/en.json
+++ b/plugins/CoreUpdater/lang/en.json
@@ -7,6 +7,7 @@
         "DisablingIncompatiblePlugins": "Disabling incompatible plugins: %s",
         "DownloadingUpdateFromX": "Downloading update from %s",
         "DownloadX": "Download %s",
+        "UpdateLog": "Update log",
         "EmptyDatabaseError": "Database %s is empty. You must edit or remove your Matomo configuration file.",
         "ErrorDIYHelp": "If you are an advanced user and encounter an error in the database upgrade:",
         "ErrorDIYHelp_1": "identify and correct the source of the problem (e.g., memory_limit or max_execution_time)",

--- a/plugins/CoreUpdater/templates/updateSuccess.twig
+++ b/plugins/CoreUpdater/templates/updateSuccess.twig
@@ -36,6 +36,7 @@
             </div>
         </div>
 
+        {% if feedbackMessages is defined and feedbackMessages is not empty %}
         <h2>{{ 'CoreUpdater_UpdateLog'|translate }}</h2>
         <div class="row">
             <div class="col s12">
@@ -46,6 +47,7 @@
                 </code></pre>
             </div>
         </div>
+        {% endif %}
 
     </div>
 

--- a/plugins/CoreUpdater/templates/updateSuccess.twig
+++ b/plugins/CoreUpdater/templates/updateSuccess.twig
@@ -36,6 +36,17 @@
             </div>
         </div>
 
+        <h2>{{ 'CoreUpdater_UpdateLog'|translate }}</h2>
+        <div class="row">
+            <div class="col s12">
+                <pre style="margin-top: 0;"><code>
+                    {%- for message in feedbackMessages %}
+&#10003; {{ message }}
+{% endfor -%}
+                </code></pre>
+            </div>
+        </div>
+
     </div>
 
     <div class="footer">

--- a/tests/UI/expected-screenshots/OneClickUpdate_update_success.png
+++ b/tests/UI/expected-screenshots/OneClickUpdate_update_success.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:73e1130c2f80bfab81a0e430d1cece5b2b26b4e5d4c9d11f47ecca1e2940b9c3
-size 224408
+oid sha256:480f606ff26a4021d6296f014155d8c295e96510ab9ab072973a9dbf26d26c48
+size 244116


### PR DESCRIPTION
Seems to have regressed in #15770

Haven't tested it yet fully but this should work. We'll then also need to merge this into Matomo 4. The previous token_auth check wouldn't work there because it would check against the new app specific token auth table which wouldn't exist yet at the time this is executed. Therefore using an nonce which is better in general anyway so the action can be only called when initiated by the first update step.

Unfortunately this will basically only work on the next update. So if people update to 3.14.1 it will only work when they update from that version. It won't work yet from 3.14.0 to 3.14.1 since the old code would be used there.