### PR TITLE
Fix background color for active and focused tab

### DIFF
--- a/plugins/Morpheus/stylesheets/ui/_tabs.less
+++ b/plugins/Morpheus/stylesheets/ui/_tabs.less
@@ -11,6 +11,10 @@
           opacity: 0.7;
         }
 
+        &:focus, &:focus.active {
+          background-color: transparent;
+        }
+
         color: @theme-color-link;
       }
     }


### PR DESCRIPTION
This seems to have regressed with the materialize css update.
Focusing the active tab, currently looks like this:

![image](https://user-images.githubusercontent.com/1579355/90732344-427dca80-e2cb-11ea-9e74-9c2593592bcd.png)

Removed the background color to restore the behavior it had in 3.x