### PR TITLE
Trim multiple hashes from cli archive response

### DIFF
--- a/core/CliMulti/Output.php
+++ b/core/CliMulti/Output.php
@@ -64,7 +64,7 @@ class Output
         if (!empty($content)
             && is_string($content)
             && Common::mb_substr(trim($content), 0, strlen($search)) === $search) {
-            $content = trim(Common::mb_substr(trim($content), strlen($search)));
+            $content = trim(Common::mb_substr(trim($content), strlen($search)), " \t\n\r\0\x0B#");
         }
         return $content;
     }

--- a/tests/PHPUnit/Integration/CliMulti/OutputTest.php
+++ b/tests/PHPUnit/Integration/CliMulti/OutputTest.php
@@ -115,7 +115,7 @@ class OutputTest extends \PHPUnit\Framework\TestCase
 
     public function test_get_write_shouldRemoveHashBang()
     {
-        $anyContent = "\n#!/usr/bin/env php {}";
+        $anyContent = "\n###!/usr/bin/env php {}";
         $this->output->write($anyContent);
 
         $this->assertEquals('{}', $this->output->get());


### PR DESCRIPTION
refs https://github.com/matomo-org/matomo/issues/16327

Noticed in the issue there was a user where the response had `###!/usr/bin/env php` in the beginning for some reason. It won't fix the actual issue but figured it's quick to handle it in case others have this issue too.