### PR TITLE
show correct transitions info in "Did you know?" section

### DIFF
--- a/plugins/Transitions/templates/transitions.twig
+++ b/plugins/Transitions/templates/transitions.twig
@@ -43,9 +43,9 @@
     <div class="alert alert-info">
         {{ 'Transitions_AvailableInOtherReports'|translate }}
         {{ 'Actions_PageUrls'|translate }}, {{ 'Actions_SubmenuPageTitles'|translate }},
-        {{ 'Actions_SubmenuPagesEntry'|translate }},
-        {{ 'Actions_SubmenuPagesExit'|translate }},
-        {{ 'General_Outlinks'|translate }}, {{ 'General_And'|translate }} {{ 'General_Downloads'|translate }}.
+        {{ 'Actions_SubmenuPagesEntry'|translate }}
+        {{ 'General_And'|translate }}
+        {{ 'Actions_SubmenuPagesExit'|translate }}.
         {{ 'Transitions_AvailableInOtherReports2'|translate('<span class="icon-transition"></span>')|raw }}
     </div>
 </div>


### PR DESCRIPTION
fix #16331

@KarthikRaja1388, can you make sure the information is now correct?

![grafik](https://user-images.githubusercontent.com/6266037/90876179-87c0fb80-e3a2-11ea-846b-b38d3386a742.png)
