### PR TITLE
Let plugin developers modify the password confirmation view: new Template.confirmPasswordContent event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ These are only recommendations (because we will keep backward compatibility for 
 #### New PHP events
 
 * Added new event `Db.getTablesInstalled`, plugins should use to register the tables they create.
+* Added new event `Template.confirmPasswordContent`, plugins can inject HTML content to the password confirmation view.
 
 #### Breaking changes in PHP events
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ These are only recommendations (because we will keep backward compatibility for 
 #### New PHP events
 
 * Added new event `Db.getTablesInstalled`, plugins should use to register the tables they create.
-* Added new event `Template.confirmPasswordContent`, plugins can inject HTML content to the password confirmation view.
 
 #### Breaking changes in PHP events
 

--- a/plugins/Login/templates/confirmPassword.twig
+++ b/plugins/Login/templates/confirmPassword.twig
@@ -7,6 +7,7 @@
         {% embed 'contentBlock.twig' with {'title': ('Login_ConfirmPasswordToContinue'|translate)} %}
         {% block content %}
 
+            {{ postEvent("Template.confirmPasswordContent", "top") }}
             <div class="message_container">
                 {% if AccessErrorString %}
                     <div piwik-notification
@@ -36,6 +37,8 @@
                 </div>
 
             </form>
+            {{ postEvent("Template.confirmPasswordContent", "bottom") }}
+
         {% endblock %}
         {% endembed %}
     </div>


### PR DESCRIPTION
Similar to the `Template.loginNav` event it would be useful to inject custom elements to the password confirmation view as well.

The event consists of two parts, where the parameter is either `top` or `bottom`, same as in the [Login Template](https://github.com/matomo-org/matomo/blob/4.x-dev/plugins/Login/templates/login.twig#L60-L63)