### PR TITLE
Adjustments for CustomReports plugin

### DIFF
--- a/core/Columns/Dimension.php
+++ b/core/Columns/Dimension.php
@@ -418,7 +418,7 @@ abstract class Dimension
             case Dimension::TYPE_BOOL:
                 return !empty($value) ? '1' : '0';
             case Dimension::TYPE_DURATION_MS:
-                return number_format($value / 1000, 2); // because we divide we need to group them and cannot do this in formatting step
+                return number_format($value / 1000, 2) * 1000; // because we divide we need to group them and cannot do this in formatting step
         }
         return $value;
     }

--- a/core/Plugin/ArchivedMetric.php
+++ b/core/Plugin/ArchivedMetric.php
@@ -198,6 +198,10 @@ class ArchivedMetric extends Metric
 
         $column = $this->dbTable . '.'  . $this->dimension->getColumnName();
 
+        if ($this->dimension->getSqlSegment()) {
+            $column = str_replace($this->dimension->getDbTableName(), $this->dbTable, $this->dimension->getSqlSegment());
+        }
+
         if (!empty($this->aggregation)) {
             return sprintf($this->aggregation, $column);
         }

--- a/plugins/PagePerformance/Columns/TimeDomCompletion.php
+++ b/plugins/PagePerformance/Columns/TimeDomCompletion.php
@@ -58,6 +58,7 @@ class TimeDomCompletion extends ActionDimension
 
         $metric3 = $dimensionMetricFactory->createMetric('sum(if(%s is null, 0, 1))');
         $metric3->setName('pageviews_with_time_dom_completion');
+        $metric3->setType(self::TYPE_NUMBER);
         $metric3->setTranslatedName(Piwik::translate('PagePerformance_ColumnViewsWithTimeDomCompletion'));
         $metricsList->addMetric($metric3);
 

--- a/plugins/PagePerformance/Columns/TimeDomProcessing.php
+++ b/plugins/PagePerformance/Columns/TimeDomProcessing.php
@@ -58,6 +58,7 @@ class TimeDomProcessing extends ActionDimension
 
         $metric3 = $dimensionMetricFactory->createMetric('sum(if(%s is null, 0, 1))');
         $metric3->setName('pageviews_with_time_dom_processing');
+        $metric3->setType(self::TYPE_NUMBER);
         $metric3->setTranslatedName(Piwik::translate('PagePerformance_ColumnViewsWithTimeDomProcessing'));
         $metricsList->addMetric($metric3);
 

--- a/plugins/PagePerformance/Columns/TimeNetwork.php
+++ b/plugins/PagePerformance/Columns/TimeNetwork.php
@@ -58,6 +58,7 @@ class TimeNetwork extends ActionDimension
 
         $metric3 = $dimensionMetricFactory->createMetric('sum(if(%s is null, 0, 1))');
         $metric3->setName('pageviews_with_time_network');
+        $metric3->setType(self::TYPE_NUMBER);
         $metric3->setTranslatedName(Piwik::translate('PagePerformance_ColumnViewsWithTimeNetwork'));
         $metricsList->addMetric($metric3);
 

--- a/plugins/PagePerformance/Columns/TimeOnLoad.php
+++ b/plugins/PagePerformance/Columns/TimeOnLoad.php
@@ -58,6 +58,7 @@ class TimeOnLoad extends ActionDimension
 
         $metric3 = $dimensionMetricFactory->createMetric('sum(if(%s is null, 0, 1))');
         $metric3->setName('pageviews_with_time_on_load');
+        $metric3->setType(self::TYPE_NUMBER);
         $metric3->setTranslatedName(Piwik::translate('PagePerformance_ColumnViewsWithTimeOnLoad'));
         $metricsList->addMetric($metric3);
 

--- a/plugins/PagePerformance/Columns/TimeServer.php
+++ b/plugins/PagePerformance/Columns/TimeServer.php
@@ -58,6 +58,7 @@ class TimeServer extends ActionDimension
 
         $metric3 = $dimensionMetricFactory->createMetric('sum(if(%s is null, 0, 1))');
         $metric3->setName('pageviews_with_time_server');
+        $metric3->setType(self::TYPE_NUMBER);
         $metric3->setTranslatedName(Piwik::translate('PagePerformance_ColumnViewsWithTimeServer'));
         $metricsList->addMetric($metric3);
 

--- a/plugins/PagePerformance/Columns/TimeTransfer.php
+++ b/plugins/PagePerformance/Columns/TimeTransfer.php
@@ -58,6 +58,7 @@ class TimeTransfer extends ActionDimension
 
         $metric3 = $dimensionMetricFactory->createMetric('sum(if(%s is null, 0, 1))');
         $metric3->setName('pageviews_with_time_transfer');
+        $metric3->setType(self::TYPE_NUMBER);
         $metric3->setTranslatedName(Piwik::translate('PagePerformance_ColumnViewsWithTimeTransfer'));
         $metricsList->addMetric($metric3);
 


### PR DESCRIPTION
While making CustomReport plugin compatible with Matomo 4, I've noticed a few dimensions/metrics having incorrect values.

* Metrics using a custom sqlSegment like `daysSinceFirstVisit` are archived incorrectly. As archiving currently uses the plain field value all metrics using custom sqlSegments and those based on them are incorrect. Using the `sqlSegment` in ArchiveMetrics::getSql() fixes that problem.

* Dimensions in milliseconds like the new performance metrics are showing 0 values (when used as dimension), as they are grouped incorrectly. The grouping already divided them by 1000, causing the formatting to 0 the values, as it divides them another time. Grouping them in 1000 segments instead seems more correct.

* The pagviews with performance timings metrics had an incorrect type, causing them formatted as time instead of number