### PR TITLE
Use relative URLs for svgBasePath so proxy url doesn't need to be configured to make real time map work

### DIFF
--- a/plugins/UserCountryMap/Controller.php
+++ b/plugins/UserCountryMap/Controller.php
@@ -224,7 +224,7 @@ class Controller extends \Piwik\Plugin\Controller
 
         $view->config = array(
             'metrics'            => array(),
-            'svgBasePath'        => $view->piwikUrl . 'plugins/UserCountryMap/svg/',
+            'svgBasePath'        => 'plugins/UserCountryMap/svg/',
             'liveRefreshAfterMs' => $liveRefreshAfterMs,
             '_'                  => $locale,
             'reqParams'          => $reqParams,


### PR DESCRIPTION
refs https://github.com/matomo-org/wp-matomo/issues/335 and https://github.com/matomo-org/matomo/issues/12623

This way it isn't needed to configure proxy headers for the real time map. The regular map seems to already use the relative path like this.

It won't fix the Matomo `logo.svg` not being loaded correctly and `getMatomoUrl()` would still return the wrong URL if not configured properly (eg in emails) but at least this way it's not always needed to configure it as at least the reporting works without configuring proxy headers.