### PR TITLE
Allow execution of core and plugin specific JS tests only

### DIFF
--- a/tests/javascript/README.md
+++ b/tests/javascript/README.md
@@ -8,3 +8,7 @@ The tests will create a database named `tracker_tests` and store several trackin
 ## Execute
 
 Either open http://piwik.example.com/tests/javascript/ in a browser or execute `phantomjs testrunner.js` on the command line. You can download PhantomJS here: http://phantomjs.org/
+
+To execute tests for a specific module use the `module` URL parameter, for example `&module=core`.
+
+If you are developing multiple tracker plugin and want to only include tests for a specific tracker plugin (like Travis would do) use the URL parameter `plugin` as in `&plugin=MyPluginName`.

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -14,11 +14,11 @@ $cacheBuster = md5(uniqid(mt_rand(), true));
 //$cacheBuster= 'nocb'; // uncomment to debug
 
 $root = dirname(__FILE__) . '/../..';
-$testPluginOnly = '*';
+$testPluginPath = '*';
 if (!empty($_GET['plugin'])
     && ctype_alnum($_GET['plugin'])
     && is_dir($root . '/plugins/' . $_GET['plugin'])) {
-    $testPluginOnly = $_GET['plugin'];
+    $testPluginPath = $_GET['plugin'];
 }
 
 try {
@@ -99,9 +99,16 @@ testTrackPageViewAsync();
 
     <?php
     include_once $root . '/core/Filesystem.php';
-    $files = \Piwik\Filesystem::globr($root . '/plugins/'.$testPluginOnly.'/tests/javascript', 'head.php');
+    $files = \Piwik\Filesystem::globr($root . '/plugins/'.$testPluginPath.'/tests/javascript', 'head.php');
     foreach ($files as $file) {
         include_once $file;
+    }
+    if ($testPluginPath !== '*') {
+        // Travis would always include tag manager
+        $files = \Piwik\Filesystem::globr($root . '/plugins/TagManager/tests/javascript', 'head.php');
+        foreach ($files as $file) {
+            include_once $file;
+        }
     }
     ?>
 <style>
@@ -2276,6 +2283,7 @@ function PiwikTest() {
         equal(Piwik.getAsyncTracker().getTrackerUrl(), asyncTracker.getTrackerUrl(), 'async same getTrackerUrl()');
 
         wait(2000);
+
         var delayedTracker = Piwik.getTracker();
         var delayedVisitorId = delayedTracker.getVisitorId();
         equal(Piwik.getAsyncTracker().getVisitorId(), delayedVisitorId, 'delayedVisitorId ' + delayedVisitorId + ' should be the same as ' + Piwik.getAsyncTracker().getVisitorId());
@@ -5138,9 +5146,16 @@ function customAddEventListener(element, eventType, eventHandler, useCapture) {
  
 <?php
     include_once $root . '/core/Filesystem.php';
-    $files = \Piwik\Filesystem::globr($root . '/plugins/'.$testPluginOnly.'/tests/javascript', 'index.php');
+    $files = \Piwik\Filesystem::globr($root . '/plugins/'.$testPluginPath.'/tests/javascript', 'index.php');
     foreach ($files as $file) {
         include_once $file;
+    }
+    if ($testPluginPath !== '*') {
+        // Travis would always include tag manager
+        $files = \Piwik\Filesystem::globr($root . '/plugins/TagManager/tests/javascript', 'index.php');
+        foreach ($files as $file) {
+            include_once $file;
+        }
     }
 ?>
 

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -8,11 +8,18 @@
 
 $cacheBuster = md5(uniqid(mt_rand(), true));
 
+
 // Note: when you want to debug the piwik.js during the tests, you need to set a cache buster that is always the same
 // between requests so the browser knows it is the same file and know where to breakpoint.
 //$cacheBuster= 'nocb'; // uncomment to debug
 
 $root = dirname(__FILE__) . '/../..';
+$testPluginOnly = '*';
+if (!empty($_GET['plugin'])
+    && ctype_alnum($_GET['plugin'])
+    && is_dir($root . '/plugins/' . $_GET['plugin'])) {
+    $testPluginOnly = $_GET['plugin'];
+}
 
 try {
     $mysql = include_once $root . "/tests/PHPUnit/bootstrap.php";
@@ -92,7 +99,7 @@ testTrackPageViewAsync();
 
     <?php
     include_once $root . '/core/Filesystem.php';
-    $files = \Piwik\Filesystem::globr($root . '/plugins/*/tests/javascript', 'head.php');
+    $files = \Piwik\Filesystem::globr($root . '/plugins/'.$testPluginOnly.'/tests/javascript', 'head.php');
     foreach ($files as $file) {
         include_once $file;
     }
@@ -5131,7 +5138,7 @@ function customAddEventListener(element, eventType, eventHandler, useCapture) {
  
 <?php
     include_once $root . '/core/Filesystem.php';
-    $files = \Piwik\Filesystem::globr($root . '/plugins/*/tests/javascript', 'index.php');
+    $files = \Piwik\Filesystem::globr($root . '/plugins/'.$testPluginOnly.'/tests/javascript', 'index.php');
     foreach ($files as $file) {
         include_once $file;
     }


### PR DESCRIPTION
eg by executing `http://domain/tests/javascript/?plugin=HeatmapSessionRecording`. In the past I always patched the `index.php` code manually but figured it be easier to have an option for this. That's because some plugin tests might not be compatible with each other as every JS adds different HTML code to the test. Eg when it runs Form Analytics, Heatmaps, Ab Tests, etc all in one go then the tests might not pass but they pass when executed independently. It doesn't fail because of any JS logic but because of the extra HTML they add to the file. It's possible this could be fixed but might be a bit of work. Will see first if I can get them to pass altogether.

Nonetheless sometimes it might be useful to have this opportunity to only add specific tests to the test page. It lets you eg execute tests just like Travis would do (when it runs the tests only for one plugin but not all plugins)