### PR TITLE
Bugfix: BruteForceDetection check for whitelist ip before blacklist

### DIFF
--- a/plugins/Login/Security/BruteForceDetection.php
+++ b/plugins/Login/Security/BruteForceDetection.php
@@ -61,12 +61,12 @@ class BruteForceDetection {
 
     public function isAllowedToLogin($ipAddress)
     {
-        if ($this->settings->isBlacklistedIp($ipAddress)) {
-            return false;
-        }
-
         if ($this->settings->isWhitelistedIp($ipAddress)) {
             return true;
+        }
+
+        if ($this->settings->isBlacklistedIp($ipAddress)) {
+            return false;
         }
 
         $db = Db::get();


### PR DESCRIPTION
A fix for the BruteForceDetection module on Login/Security plugin. When the configs are set to disable login from all ips but never block some ips, the user gets blocked from being able to login because the first check is done on the blacklist instead of the whitelist to allow the user to login from the whitelist ips.

Check this post for your reference:
https://forum.matomo.org/t/cannot-login-because-of-blocked-ip/35446/5