### PR TITLE
fix "learn more" link on DB Usage summary

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1817,7 +1817,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
     },
 
     handleSummaryRow: function (domElem) {
-        var details = _pk_translate('General_LearnMore', [' (<a href="https://matomo.org/faq/how-to/faq_54/" rel="noreferrer noopener" target="_blank">', '</a>)']);
+        var details = _pk_translate('General_LearnMore', [' (<a href="https://matomo.org/docs/managing-your-databases-size/" rel="noreferrer noopener" target="_blank">', '</a>)']);
 
         domElem.find('tr.summaryRow').each(function () {
             var labelSpan = $(this).find('.label .value').filter(function(index, elem){


### PR DESCRIPTION
This PR attempts to fix and close #16339, by changing the URL that is linked to on the Database Usage summary table to the [right](https://matomo.org/docs/managing-your-databases-size/) one.

The change introduced follows Findus23's comment / hint on said issue.