### PR TITLE
use localized country names for segment selector

### DIFF
--- a/plugins/UserCountry/Columns/Country.php
+++ b/plugins/UserCountry/Columns/Country.php
@@ -53,8 +53,9 @@ class Country extends Base
         $regionDataProvider = StaticContainer::get('Piwik\Intl\Data\Provider\RegionDataProvider');
         $countryList = $regionDataProvider->getCountryList();
         array_walk($countryList, function(&$item, $key) {
-            $item = Piwik::translate('Intl_Country_'.strtoupper($key), [], 'en');
+            $item = Piwik::translate('Intl_Country_'.strtoupper($key));
         });
+        asort($countryList); // order by localized name
 
         $segment->setSqlFilterValue(function ($val) use ($countryList) {
             $result   = array_search($val, $countryList);


### PR DESCRIPTION
There might be a reason why this wasn't done initially, but I personally find it more accessible for people to see the country names in their language and ordered alphabetically instead of by country code

Before:
![grafik](https://user-images.githubusercontent.com/6266037/91657096-acae2080-eabe-11ea-9ee7-ecd5affcde3c.png)

After:
![grafik](https://user-images.githubusercontent.com/6266037/91657134-06aee600-eabf-11ea-8c00-22111ed234c9.png)

If this is intentional, then you can simply close this PR.