### PR TITLE
Make number fields look the same as text fields

### DIFF
--- a/plugins/CorePluginsAdmin/angularjs/form-field/field-number.html
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/field-number.html
@@ -1,13 +1,11 @@
-<div>
-    <label for="{{ formField.name }}" ng-bind-html="formField.title"></label>
-    <input
-            class="control_{{ formField.uiControl }}"
-            type="{{ formField.uiControl }}"
-            id="{{ formField.name }}"
-            name="{{ formField.name }}"
-            ng-model="formField.value"
-            string-to-number
-            ng-value="formField.value"
-            piwik-attributes="{{formField.uiControlAttributes}}"
-    >
-</div>
+<input
+        class="control_{{ formField.uiControl }}"
+        type="{{ formField.uiControl }}"
+        id="{{ formField.name }}"
+        name="{{ formField.name }}"
+        ng-model="formField.value"
+        string-to-number
+        ng-value="formField.value"
+        piwik-attributes="{{formField.uiControlAttributes}}"
+>
+<label for="{{ formField.name }}" ng-bind-html="formField.title"></label>


### PR DESCRIPTION
Having a field of type text and number on the same line currently lets the fields look slightly different.

![image](https://user-images.githubusercontent.com/1579355/91720859-18b08780-eb98-11ea-89d8-8ef56e697d40.png)
