### PR TITLE
Add new command to update marketplace plugins via console

### DIFF
--- a/plugins/Marketplace/Commands/UpdateMarketplacePlugins.php
+++ b/plugins/Marketplace/Commands/UpdateMarketplacePlugins.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Marketplace\Commands;
+
+use Piwik\Container\StaticContainer;
+use Piwik\Plugin\ConsoleCommand;
+use Piwik\Plugins\CoreUpdater\Updater;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateMarketplacePlugins extends ConsoleCommand
+{
+
+    protected function configure()
+    {
+        $this->setName('marketplace:update-plugins');
+        $this->setDescription('Migrates a measurable/website from one Matomo instance to another Matomo');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $updater = StaticContainer::get(Updater::class);
+        $messages = $updater->oneClickUpdatePartTwo();
+
+        foreach ($messages as $message) {
+            $output->writeln($message);
+        }
+    }
+
+}


### PR DESCRIPTION
This was useful when updating Matomo through git.

In this case I did basically 

```bash
git checkout matomo.js
git checkout piwik.js
rm -rf plugins/CustomDimensions
git checkout 4.x-dev
php composer.phar install 
git submodule update --recursive
 git submodule init &&  git submodule update
./console core:update
./console marketplace:update-plugins
```

Otherwise the marketplace plugins would not have been updated and would have been potentially disabled. Should only be interesting if someone updates Matomo in a production system through git (which we don't really recommend since it is less secure etc)

fyi @mattab