### PR TITLE
Make sure to use matomo require when generating components

### DIFF
--- a/plugins/CoreConsole/Commands/GeneratePluginBase.php
+++ b/plugins/CoreConsole/Commands/GeneratePluginBase.php
@@ -136,9 +136,13 @@ abstract class GeneratePluginBase extends ConsoleCommand
 
         $newRequiredVersion = sprintf('>=%s,<%d.0.0-b1', $piwikVersion, $nextMajorVersion);
 
-
         if (!empty($pluginJson['require']['piwik'])) {
-            $requiredVersion = trim($pluginJson['require']['piwik']);
+            $pluginJson['require']['matomo'] = $pluginJson['require']['piwik'];
+            unset($pluginJson['require']['piwik']);
+        }
+
+        if (!empty($pluginJson['require']['matomo'])) {
+            $requiredVersion = trim($pluginJson['require']['matomo']);
 
             if ($requiredVersion === $newRequiredVersion) {
                 // there is nothing to updated
@@ -194,7 +198,7 @@ abstract class GeneratePluginBase extends ConsoleCommand
             $output->writeln(sprintf('<comment>We have updated your "%s" to require the Piwik version "%s".</comment>', $relativePluginJson, $newRequiredVersion));
         }
 
-        $pluginJson['require']['piwik'] = $newRequiredVersion;
+        $pluginJson['require']['matomo'] = $newRequiredVersion;
         file_put_contents($pluginJsonPath, $this->toJson($pluginJson));
     }
 


### PR DESCRIPTION
I generated a plugin in Matomo 4 and it created this:

![image](https://user-images.githubusercontent.com/273120/92194978-0730ed80-eec0-11ea-8453-e83624f31c6a.png)

Instead it should now always use "matomo".
