### PR TITLE
Add methods to remove invalidations.

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -506,6 +506,24 @@ class ArchiveInvalidator
     }
 
     /**
+     * Remove invalidations for a specific report or all invalidations for a specific plugin. If your plugin supports
+     * archiving data in the past, you may want to call this method to remove any pending invalidations if, for example,
+     * your plugin is deactivated or a report deleted.
+     *
+     * @param int $idSite
+     * @param string $string
+     * @param string|null $report
+     */
+    public function removeInvalidations($idSite, $plugin, $report = null)
+    {
+        if (empty($report)) {
+            $this->model->removeInvalidationsLike($idSite, $plugin);
+        } else {
+            $this->model->removeInvalidations($idSite, $plugin, $report);
+        }
+    }
+
+    /**
      * @param int[] $idSites
      * @param string[][][] $dates
      * @throws \Exception

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -22,6 +22,7 @@ use Piwik\Period;
 use Piwik\Period\Factory as PeriodFactory;
 use Piwik\Piwik;
 use Piwik\Plugin\Manager;
+use Piwik\Plugins\SitesManager\API;
 use Piwik\Segment;
 use Piwik\Site;
 use Piwik\Timer;
@@ -122,6 +123,12 @@ class QueueConsumer
 
     public function getNextArchivesToProcess()
     {
+        // in case a site is deleted while archiving is running
+        if (!empty($this->idSite) && !$this->isSiteExists($this->idSite)) {
+            $this->logger->debug("Site ID = {$this->idSite} was deleted during archiving process, moving on.");
+            $this->idSite = null;
+        }
+
         if (empty($this->idSite)) {
             $this->idSite = $this->getNextIdSiteToArchive();
             if (empty($this->idSite)) { // no sites left to archive, stop
@@ -540,5 +547,11 @@ class QueueConsumer
 
         $idArchive = $archiveIdAndVisits[0];
         return !empty($idArchive);
+    }
+
+    private function isSiteExists($idSite)
+    {
+        $site = API::getInstance()->getSiteFromId($idSite);
+        return !empty($site);
     }
 }

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -699,6 +699,22 @@ class Model
         Db::query($sql);
     }
 
+    public function removeInvalidationsLike($idSite, $start)
+    {
+        $table = Common::prefixTable('archive_invalidations');
+        $sql = "DELETE FROM `$table` WHERE idsite = ? AND `name` LIKE ?";
+
+        Db::query($sql, [$idSite, 'done.' . str_replace('_', "\\_", $start) . '%']);
+    }
+
+    public function removeInvalidations($idSite, $plugin, $report)
+    {
+        $table = Common::prefixTable('archive_invalidations');
+        $sql = "DELETE FROM `$table` WHERE idsite = ? AND `name` = ? AND report = ?";
+
+        Db::query($sql, [$idSite, 'done.' . $plugin, $report]);
+    }
+
     /**
      * Returns true if there is an archive that exists that can be used when aggregating an archive for $period.
      *

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -744,4 +744,22 @@ class Model
         }
         return false;
     }
+
+    public function deleteInvalidationsForSites(array $idSites)
+    {
+        $idSites = array_map('intval', $idSites);
+
+        $table = Common::prefixTable('archive_invalidations');
+        $sql = "DELETE FROM `$table` WHERE idsite IN (" . implode(',', $idSites) . ")";
+
+        Db::query($sql);
+    }
+
+    public function deleteInvalidationsForDeletedSites()
+    {
+        $siteTable = Common::prefixTable('site');
+        $table = Common::prefixTable('archive_invalidations');
+        $sql = "DELETE a FROM `$table` a LEFT JOIN `$siteTable` s ON a.idsite = s.idsite WHERE s.idsite IS NULL";
+        Db::query($sql);
+    }
 }

--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -18,6 +18,7 @@ use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\CronArchive;
 use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\DataAccess\Model as CoreModel;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\Http;
@@ -75,6 +76,7 @@ class Tasks extends \Piwik\Plugin\Tasks
 
         // general data purge on invalidated archive records, executed daily
         $this->daily('purgeInvalidatedArchives', null, self::LOW_PRIORITY);
+        $this->daily('purgeInvalidationsForDeletedSites', null, self::LOW_PRIORITY);
 
         $this->weekly('purgeOrphanedArchives', null, self::NORMAL_PRIORITY);
 
@@ -90,6 +92,12 @@ class Tasks extends \Piwik\Plugin\Tasks
         }
 
         $this->scheduleTrackingCodeReminderChecks();
+    }
+
+    public function purgeInvalidationsForDeletedSites()
+    {
+        $coreModel = new CoreModel();
+        $coreModel->deleteInvalidationsForDeletedSites();
     }
 
     public function deleteOldFingerprintSalts()

--- a/plugins/CoreAdminHome/tests/Integration/TasksTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/TasksTest.php
@@ -136,6 +136,7 @@ class TasksTest extends IntegrationTestCase
             'deleteOldFingerprintSalts.',
             'purgeOutdatedArchives.',
             'purgeInvalidatedArchives.',
+            'purgeInvalidationsForDeletedSites.',
             'purgeOrphanedArchives.',
             'optimizeArchiveTable.',
             'cleanupTrackingFailures.',

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -34,6 +34,7 @@ use Piwik\Tracker\TrackerCodeGenerator;
 use Piwik\Measurable\Type;
 use Piwik\Url;
 use Piwik\UrlHelper;
+use Piwik\DataAccess\Model as CoreModel;
 
 /**
  * The SitesManager API gives you full control on Websites in Matomo (create, update and delete), and many methods to retrieve websites based on various attributes.
@@ -781,6 +782,9 @@ class API extends \Piwik\Plugin\API
         }
 
         $this->getModel()->deleteSite($idSite);
+
+        $coreModel = new CoreModel();
+        $coreModel->deleteInvalidationsForSites([$idSite]);
 
         /**
          * Triggered after a site has been deleted.

--- a/tests/PHPUnit/Integration/DataAccess/ModelTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ModelTest.php
@@ -14,6 +14,7 @@ use Piwik\DataAccess\ArchiveWriter;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\Period\Factory;
+use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Piwik\DataAccess\Model;
 
@@ -480,6 +481,25 @@ class ModelTest extends IntegrationTestCase
         $actual = $this->model->getNextInvalidatedArchive(1, null, $useLimit = false);
 
         $this->assertEquals($expected, $actual);
+    }
+
+    public function test_deleteInvalidationsForDeletedSites()
+    {
+        Fixture::createWebsite('2014-01-01 00:00:00');
+
+        $this->insertInvalidations([
+            ['idsite' => 1, 'date1' => '2014-02-03', 'date2' => '2014-02-03', 'period' => 1, 'name' => 'done'],
+            ['idsite' => 2, 'date1' => '2014-02-01', 'date2' => '2014-02-28', 'period' => 2, 'name' => 'done'],
+            ['idsite' => 2, 'date1' => '2014-02-01', 'date2' => '2014-02-01', 'period' => 1, 'name' => 'done'],
+            ['idsite' => 3, 'date1' => '2014-02-01', 'date2' => '2014-02-01', 'period' => 1, 'name' => 'done'],
+        ]);
+
+        $this->model->deleteInvalidationsForDeletedSites();
+
+        $invalidations = Db::fetchAll("SELECT idsite, idinvalidation FROM " . Common::prefixTable('archive_invalidations'));
+        $this->assertEquals([
+            ['idsite' => 1, 'idinvalidation' => 1],
+        ], $invalidations);
     }
 
     private function insertArchiveData($archivesToInsert)

--- a/tests/PHPUnit/Integration/DataAccess/ModelTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ModelTest.php
@@ -520,7 +520,7 @@ class ModelTest extends IntegrationTestCase
         $table = Common::prefixTable('archive_invalidations');
         foreach ($invalidations as $invalidation) {
             $sql = "INSERT INTO `$table` (idsite, date1, date2, period, `name`) VALUES (?, ?, ?, ?, ?)";
-            Db::query($sql, [1, $invalidation['date1'], $invalidation['date2'], $invalidation['period'], $invalidation['name']]);
+            Db::query($sql, [$invalidation['idsite'] ?? 1, $invalidation['date1'], $invalidation['date2'], $invalidation['period'], $invalidation['name']]);
         }
     }
 }

--- a/tests/PHPUnit/Integration/DataAccess/ModelTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ModelTest.php
@@ -496,7 +496,8 @@ class ModelTest extends IntegrationTestCase
 
         $this->model->deleteInvalidationsForDeletedSites();
 
-        $invalidations = Db::fetchAll("SELECT idsite, idinvalidation FROM " . Common::prefixTable('archive_invalidations'));
+        $invalidations = Db::fetchAll("SELECT idsite, idinvalidation FROM " . Common::prefixTable('archive_invalidations') .
+            " ORDER BY idinvalidation ASC");
         $this->assertEquals([
             ['idsite' => 1, 'idinvalidation' => 1],
         ], $invalidations);


### PR DESCRIPTION
Will be used to, for example, remove pending invalidations when a custom report is deleted. This will prevent starting climulti:requests for these custom report IDs.