### PR TITLE
Documentation generator: remove duplicate assignment

### DIFF
--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -278,7 +278,6 @@ class DocumentationGenerator
         $aParameters['hideColumns'] = false;
         $aParameters['hideColumnsRecursively'] = false;
         $aParameters['showColumns'] = false;
-        $aParameters['filter_pattern_recursive'] = false;
         $aParameters['pivotBy'] = false;
         $aParameters['pivotByColumn'] = false;
         $aParameters['pivotByColumnLimit'] = false;


### PR DESCRIPTION
`$aParameters['filter_pattern_recursive']` was already assigned on line 276.