### PR TITLE
remove same previousPage function

### DIFF
--- a/plugins/MultiSites/angularjs/dashboard/dashboard-model.service.js
+++ b/plugins/MultiSites/angularjs/dashboard/dashboard-model.service.js
@@ -103,11 +103,6 @@
             return parseInt(end, 10);
         }
 
-        function previousPage() {
-            model.currentPage = model.currentPage - 1;
-            fetchAllSites();
-        }
-
         function sortBy(metric) {
             if (model.sortColumn == metric) {
                 model.reverse = !model.reverse;


### PR DESCRIPTION
This is a small fix.
Since the same one is defined, I deleted it.

https://github.com/matomo-org/matomo/blob/4.x-dev/plugins/MultiSites/angularjs/dashboard/dashboard-model.service.js#L106-L123