### PR TITLE
Make sure to update plugin information before disabling plugins

### DIFF
--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -298,6 +298,12 @@ class Updater
 
     private function disableIncompatiblePlugins($version)
     {
+        $pluginManager = PluginManager::getInstance();
+        $plugins = $pluginManager->getLoadedPlugins();
+        foreach ($plugins as $plugin) {
+            $plugin->reloadPluginInformation();
+        }
+
         $incompatiblePlugins = $this->getIncompatiblePlugins($version);
         $disabledPluginNames = array();
 

--- a/plugins/CustomVariables/plugin.json
+++ b/plugins/CustomVariables/plugin.json
@@ -4,6 +4,7 @@
   "version": "3.14.1",
   "theme": false,
   "require": {
+    "piwik": ">=3.0.0,<4.0.0-b1"
   },
   "authors": [
     {

--- a/plugins/CustomVariables/plugin.json
+++ b/plugins/CustomVariables/plugin.json
@@ -4,7 +4,6 @@
   "version": "3.14.1",
   "theme": false,
   "require": {
-    "piwik": ">=3.0.0,<4.0.0-b1"
   },
   "authors": [
     {


### PR DESCRIPTION
I upgraded 3.14.1 to Matomo 4.

Somehow Custom Variables was disabled afterwards. Then noticed:

* We update core 
* We update plugins in a different request `action=oneClickUpdatePartTwo`
* Then we check if there are incompatible plugins but I'm not sure if ever the updated plugin information is ever reloaded after updating the plugins in the previous action?

I'm not sure though. According to this theory I would have also expected that other plugins would have been disabled that were updated through the marketplace. Not sure how it worked for the marketplace plugins but not this one. There must be maybe some extra logic somewhere.

I think this used to work because when the marketplace plugin was updated, it used to reload the plugin see https://github.com/matomo-org/matomo/blob/3.14.1-rc1/plugins/CorePluginsAdmin/PluginInstaller.php#L73-L77

This used to be done in the same request. But since moving this out into a second request, the information is no longer updated. I think this is a regression from https://github.com/matomo-org/matomo/pull/15770