### PR TITLE
Simplify updater further should climulti not work

### DIFF
--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -172,11 +172,9 @@ class Controller extends \Piwik\Plugin\Controller
         return $view->render();
     }
 
-    public function oneClickUpdatePartTwo($sendHeader = true)
+    public function oneClickUpdatePartTwo()
     {
-        if ($sendHeader) {
-            Json::sendHeaderJSON();
-        }
+        Json::sendHeaderJSON();
 
         $task = "Couldn't update Marketplace plugins.";
 

--- a/plugins/CoreUpdater/Updater.php
+++ b/plugins/CoreUpdater/Updater.php
@@ -146,15 +146,9 @@ class Updater
                 // in case this works. For explample $response is in this case not an array but a string because the "communcation"
                 // with the controller went wrong: "Got invalid response from API request: https://ABC/?module=CoreUpdater&action=oneClickUpdatePartTwo&nonce=ABC. Response was \'curl_exec: SSL certificate problem: unable to get local issuer certificate. Hostname requested was: ABC"
                 try {
-                    $response = null;
-                    Context::executeWithQueryParameters(array('nonce' => $nonce), function () use (&$response) {
-                        $response = FrontController::getInstance()->dispatch('CoreUpdater', 'oneClickUpdatePartTwo', array($sendHeader = false));
-                    });
-                    if (!empty($response)) {
-                        $response = @json_decode($response, $assoc = true);
-                        if (!empty($response) && is_array($response)) {
-                            $messages = array_merge($messages, $response);
-                        }
+                    $response = $this->oneClickUpdatePartTwo($newVersion);
+                    if (!empty($response) && is_array($response)) {
+                        $messages = array_merge($messages, $response);
                     }
                 } catch (Exception $e) {
                     // ignore any error should this fail too. this might be the case eg if
@@ -178,7 +172,7 @@ class Updater
         return $messages;
     }
 
-    public function oneClickUpdatePartTwo()
+    public function oneClickUpdatePartTwo($newVersion = null)
     {
         $messages = [];
 
@@ -188,7 +182,9 @@ class Updater
             return $messages;
         }
 
-        $newVersion = Version::VERSION;
+        if (empty($newVersion)) {
+            $newVersion = Version::VERSION;
+        }
 
         // we also need to make sure to create a new instance here as otherwise we would change the "global"
         // environment, but we only want to change piwik version temporarily for this task here


### PR DESCRIPTION
There should be actually no reason to go through the dispatch process and instead we can directly call the method. This prevents various events being triggered during frontcontroller dispatch which may involve the API proxy etc.

@diosmosis can you have a look at this as well?