### PR TITLE
add documentation to the GetLanguage and GetLanguageCode reports

### DIFF
--- a/plugins/CustomDimensions/tests/System/expected/test___API.getReportMetadata_day.xml
+++ b/plugins/CustomDimensions/tests/System/expected/test___API.getReportMetadata_day.xml
@@ -256,6 +256,7 @@
 		<module>UserLanguage</module>
 		<action>getLanguage</action>
 		<dimension>Language</dimension>
+		<documentation>This report shows which language the visitor's browsers are using. (e.g. "English")</documentation>
 		<metrics>
 			<nb_visits>Visits</nb_visits>
 			<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>
@@ -334,6 +335,7 @@
 		<module>UserLanguage</module>
 		<action>getLanguageCode</action>
 		<dimension>Language</dimension>
+		<documentation>This report shows which exact language code the visitor's browsers is set to. (e.g. "German - Austria (de-at)")</documentation>
 		<metrics>
 			<nb_visits>Visits</nb_visits>
 			<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>

--- a/plugins/UserLanguage/Reports/GetLanguage.php
+++ b/plugins/UserLanguage/Reports/GetLanguage.php
@@ -20,7 +20,7 @@ class GetLanguage extends Base
         parent::init();
         $this->dimension     = new Language();
         $this->name          = Piwik::translate('UserLanguage_BrowserLanguage');
-        $this->documentation = ''; // TODO
+        $this->documentation = Piwik::translate('UserLanguage_getLanguageDocumentation');
         $this->order = 8;
     }
 

--- a/plugins/UserLanguage/Reports/GetLanguageCode.php
+++ b/plugins/UserLanguage/Reports/GetLanguageCode.php
@@ -19,7 +19,7 @@ class GetLanguageCode extends GetLanguage
         parent::init();
         $this->dimension     = new Language();
         $this->name          = Piwik::translate('UserLanguage_LanguageCode');
-        $this->documentation = '';
+        $this->documentation = Piwik::translate('UserLanguage_getLanguageCodeDocumentation');
         $this->order = 11;
     }
 

--- a/plugins/UserLanguage/lang/en.json
+++ b/plugins/UserLanguage/lang/en.json
@@ -3,7 +3,7 @@
         "BrowserLanguage": "Browser language",
         "LanguageCode": "Language code",
         "PluginDescription": "Reports the language used by your visitors' browsers.",
-        "getLanguageDocumentation": "This report shows which Language the visitor's browsers are using. (e.g. \"English\")",
-        "getLanguageCodeDocumentation": "This report shows which exact Language code the visitor's browsers is set to. (e.g. \"German - Austria (de-at)\")"
+        "getLanguageDocumentation": "This report shows which language the visitor's browsers are using. (e.g. \"English\")",
+        "getLanguageCodeDocumentation": "This report shows which exact language code the visitor's browsers is set to. (e.g. \"German - Austria (de-at)\")"
     }
 }

--- a/plugins/UserLanguage/lang/en.json
+++ b/plugins/UserLanguage/lang/en.json
@@ -2,6 +2,8 @@
     "UserLanguage": {
         "BrowserLanguage": "Browser language",
         "LanguageCode": "Language code",
-        "PluginDescription": "Reports the language used by your visitors' browsers."
+        "PluginDescription": "Reports the language used by your visitors' browsers.",
+        "getLanguageDocumentation": "This report shows which Language the visitor's browsers are using. (e.g. \"English\")",
+        "getLanguageCodeDocumentation": "This report shows which exact Language code the visitor's browsers is set to. (e.g. \"German - Austria (de-at)\")"
     }
 }

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getGlossaryReports.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getGlossaryReports.xml
@@ -13,6 +13,10 @@
 		<documentation>This report shows your visitors' browsers broken down into browser engines. &lt;br /&gt; The most important information for web developers is what kind of rendering engine their visitors are using. The labels contain the names of the engines followed by the most common browser using that engine in brackets.</documentation>
 	</row>
 	<row>
+		<name>Browser language (Visitors)</name>
+		<documentation>This report shows which language the visitor's browsers are using. (e.g. &quot;English&quot;)</documentation>
+	</row>
+	<row>
 		<name>Browsers (Visitors)</name>
 		<documentation>This report contains information about what kind of browser your visitors were using. Each browser version is listed separately.</documentation>
 	</row>
@@ -69,6 +73,10 @@
 	<row>
 		<name>Keywords (Referrers)</name>
 		<documentation>This report shows which keywords users were searching for before they were referred to your website. &lt;br /&gt;&lt;br /&gt; By clicking on a row in the table, you can see the distribution of search engines that were queried for the keyword.&lt;br /&gt;&lt;br /&gt;Note: This report lists most keywords as not defined, because most search engines do not send the exact keyword used on the search engine.</documentation>
+	</row>
+	<row>
+		<name>Language code (Visitors)</name>
+		<documentation>This report shows which exact language code the visitor's browsers is set to. (e.g. &quot;German - Austria (de-at)&quot;)</documentation>
 	</row>
 	<row>
 		<name>Length of Visits (Actions)</name>

--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportMetadata_day.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata__API.getReportMetadata_day.xml
@@ -256,6 +256,7 @@
 		<module>UserLanguage</module>
 		<action>getLanguage</action>
 		<dimension>Language</dimension>
+		<documentation>This report shows which language the visitor's browsers are using. (e.g. "English")</documentation>
 		<metrics>
 			<nb_visits>Visits</nb_visits>
 			<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>
@@ -334,6 +335,7 @@
 		<module>UserLanguage</module>
 		<action>getLanguageCode</action>
 		<dimension>Language</dimension>
+		<documentation>This report shows which exact language code the visitor's browsers is set to. (e.g. "German - Austria (de-at)")</documentation>
 		<metrics>
 			<nb_visits>Visits</nb_visits>
 			<nb_uniq_visitors>Unique visitors</nb_uniq_visitors>


### PR DESCRIPTION
see https://forum.matomo.org/t/browser-language-language-code/38540

It seems like those two reports never got a documentation. If someone has an idea on how to improve the wording, just comment.