### PR TITLE
Make sure to initialize a session for the anonymous user

### DIFF
--- a/core/FrontController.php
+++ b/core/FrontController.php
@@ -21,6 +21,7 @@ use Piwik\Http\ControllerResolver;
 use Piwik\Http\Router;
 use Piwik\Plugins\CoreAdminHome\CustomLogo;
 use Piwik\Session\SessionAuth;
+use Piwik\Session\SessionInitializer;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -401,7 +402,18 @@ class FrontController extends Singleton
         // ... if session auth fails try normal auth (which will login the anonymous user)
         if (!$loggedIn) {
             $authAdapter = $this->makeAuthenticator();
-            Access::getInstance()->reloadAccess($authAdapter);
+            $success = Access::getInstance()->reloadAccess($authAdapter);
+
+            if ($success
+                && Piwik::isUserIsAnonymous()
+                && $authAdapter->getLogin() === 'anonymous' //double checking the login
+                && Piwik::isUserHasSomeViewAccess()
+                && Session::isSessionStarted()) { // only if session was started, don't do it eg for API
+                // usually the session would be started when someone logs in using login controller. But in this
+                // case we need to init session here for anoynymous users
+                $init = StaticContainer::get(SessionInitializer::class);
+                $init->initSession($authAdapter);
+            }
         } else {
             $this->makeAuthenticator($sessionAuth); // Piwik\Auth must be set to the correct Login plugin
         }


### PR DESCRIPTION
What happened is that every time an anonymous user would view a widget or report in the Matomo UI it would log a failed authentication (for brute force check) and eventually the anonymous user would be blocked. This is because of the code here: https://github.com/matomo-org/matomo/blob/4.0.0-a1/core/Access.php#L171-L174 

The session auth always thinks that the session is expired because for anonymous user we had actually never started a session. When someone logs in, we would start the session in the login controller in https://github.com/matomo-org/matomo/blob/4.0.0-a1/plugins/Login/Controller.php#L309 but for anonymous users there is no log in.

Therefore initialising the session now when needed in the frontcontroller.