### PR TITLE
disable generate:travis-yml when development mode is not enabled

### DIFF
--- a/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
+++ b/plugins/TestRunner/Commands/GenerateTravisYmlFile.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\TestRunner\Commands;
 
+use Piwik\Development;
 use Piwik\Plugin\ConsoleCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,6 +21,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 class GenerateTravisYmlFile extends ConsoleCommand
 {
     const COMMAND_NAME = 'generate:travis-yml';
+
+    public function isEnabled()
+    {
+        return Development::isEnabled();
+    }
 
     protected function configure()
     {


### PR DESCRIPTION
https://github.com/johsin18/DevicePixelRatioMatomoPlugin/issues/1#issuecomment-690887786

This makes the `generate:travis-yml` command only available when development mode is enabled just like all other development-related commands.