### PR TITLE
don't use zoom: 1 in CSS

### DIFF
--- a/plugins/Morpheus/stylesheets/base/mixins.less
+++ b/plugins/Morpheus/stylesheets/base/mixins.less
@@ -1,6 +1,4 @@
 .clearfix {
-  *zoom: 1;
-
   &::after {
     content: "";
     display: table;

--- a/plugins/SegmentEditor/stylesheets/segmentation.less
+++ b/plugins/SegmentEditor/stylesheets/segmentation.less
@@ -394,10 +394,6 @@ a.metric_category {
     border: 1px solid #D4D4D4 !important;
 }
 
-.clearfix {
-    zoom: 1;
-}
-
 .clearfix:after {
     display: block;
     visibility: hidden;


### PR DESCRIPTION
opening Matomo in Firefox 80 shows the following warning in the console:
> This page uses the non standard property “zoom”. Consider using calc() in the relevant property values, or using “transform” along with “transform-origin: 0 0”.

It seems like this was only [needed](https://stackoverflow.com/a/27517427/4398037) in IE 6/7 and can therefore be simply removed.