### PR TITLE
"Back to content" link overlaps with the logo, fix skip-to-content offset

### DIFF
--- a/plugins/CoreHome/stylesheets/coreHome.less
+++ b/plugins/CoreHome/stylesheets/coreHome.less
@@ -56,7 +56,7 @@
 .accessibility-skip-to-content:focus {
     display: block;
     position: absolute;
-    left: 140px;
+    left: 200px;
 }
 
 /* Calendar*/


### PR DESCRIPTION
before it was always stuck inside the logo
![grafik](https://user-images.githubusercontent.com/6266037/92935353-f72d8680-f448-11ea-807f-d0988f573bc5.png)
