### PR TITLE
Add dimension "Action URL"

### DIFF
--- a/plugins/Actions/Columns/ActionUrl.php
+++ b/plugins/Actions/Columns/ActionUrl.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\Actions\Columns;
 
 use Piwik\Columns\DimensionSegmentFactory;
+use Piwik\Columns\Join\ActionNameJoin;
 use Piwik\Plugin\Dimension\ActionDimension;
 use Piwik\Plugins\Actions\Segment;
 use Piwik\Segment\SegmentsList;
@@ -16,6 +17,13 @@ use Piwik\Segment\SegmentsList;
 class ActionUrl extends ActionDimension
 {
     protected $nameSingular = 'Actions_ColumnActionURL';
+    protected $columnName = 'idaction_url';
+    protected $type = self::TYPE_URL;
+
+    public function getDbColumnJoin()
+    {
+        return new ActionNameJoin();
+    }
 
     public function configureSegments(SegmentsList $segmentsList, DimensionSegmentFactory $dimensionSegmentFactory)
     {


### PR DESCRIPTION
refs DEV-1983

Note that this would need to be used usually with a segment filter because it would also include non-action URLs technically such as content impression URLs but content impressions/interactions aren't actions.