### PR TITLE
Do not index the opt out iframe in search engines

### DIFF
--- a/plugins/CoreAdminHome/templates/optOut.twig
+++ b/plugins/CoreAdminHome/templates/optOut.twig
@@ -8,6 +8,7 @@
     {% if reloadUrl %}
         <meta http-equiv="refresh" content="0; url={{ reloadUrl }}" />
     {% endif %}
+    <meta name="robots" content="noindex" />
 
     {% if stylesheets.external|length > 0 %}
         {% for style in stylesheets.external %}


### PR DESCRIPTION
As suggested by a user. There shouldn't be a need to index it