### PR TITLE
Do not cache core updater oneClickUpdate page in browser

### DIFF
--- a/core/View/OneClickDone.php
+++ b/core/View/OneClickDone.php
@@ -62,7 +62,7 @@ class OneClickDone
         @Common::stripHeader('Pragma');
         @Common::stripHeader('Expires');
         @Common::sendHeader('Content-Type: text/html; charset=UTF-8');
-        @Common::sendHeader('Cache-Control: must-revalidate');
+        @Common::sendHeader('Cache-Control: no-store');
         @Common::sendHeader('X-Frame-Options: deny');
 
         $error = htmlspecialchars($this->error, ENT_QUOTES, 'UTF-8');


### PR DESCRIPTION
This will prevent the caching in all modern browsers.

Otherwise Matomo might show a cached result and not actually update 
![image](https://user-images.githubusercontent.com/273120/94088267-2938e280-fe64-11ea-88ca-50e0be7ede49.png)
