### PR TITLE
During installation, open link to DB-IP page in a new tab

### DIFF
--- a/plugins/GeoIp2/GeoIp2.php
+++ b/plugins/GeoIp2/GeoIp2.php
@@ -68,7 +68,7 @@ class GeoIp2 extends \Piwik\Plugin
     {
         $form->addElement('checkbox', 'setup_geoip2', null,
             [
-                'content' => '<div class="form-help">' . Piwik::translate('GeoIp2_AutomaticSetupDescription', ['<a rel="noreferrer noopener" href="https://db-ip.com/?refid=mtm">','</a>']) . '</div> &nbsp;&nbsp;' . Piwik::translate('GeoIp2_AutomaticSetup')
+                'content' => '<div class="form-help">' . Piwik::translate('GeoIp2_AutomaticSetupDescription', ['<a rel="noreferrer noopener" target="_blank" href="https://db-ip.com/db/lite.php?refid=mtm">','</a>']) . '</div> &nbsp;&nbsp;' . Piwik::translate('GeoIp2_AutomaticSetup')
             ]
         );
 


### PR DESCRIPTION
also changed the link to https://db-ip.com/db/lite.php which is the DB-IP package that would be installed

![Screenshot from 2020-09-25 09-25-43](https://user-images.githubusercontent.com/466765/94202089-1b8d6680-ff11-11ea-96aa-ecf0c6b9c989.png)
