### PR TITLE
 Manage Dimensions: Sorting by ID is not numeric

### DIFF
--- a/plugins/CustomDimensions/angularjs/manage/list.directive.html
+++ b/plugins/CustomDimensions/angularjs/manage/list.directive.html
@@ -32,7 +32,7 @@
                 <tr ng-show="scope.numSlotsUsed == 0 && !dimensionsList.model.isLoading">
                     <td colspan="5">{{ 'CustomDimensions_NoCustomDimensionConfigured'|translate }}</td>
                 </tr>
-                <tr ng-repeat="customDimension in dimensionsList.model.customDimensions|filter:{scope: scope.value}|orderBy:'idcustomdimension'"
+                <tr ng-repeat="customDimension in dimensionsList.model.customDimensions|filter:{scope: scope.value}|orderBy:'idcustomdimension.parseInt()'"
                     class="customdimension" ng-class="customDimension.idcustomdimension">
                     <td class="index">{{ customDimension.idcustomdimension }}</td>
                     <td class="name">{{ customDimension.name }}</td>


### PR DESCRIPTION
For some reason custom dimension ids are passed around as strings, and there is at least one place in the plugin JS code where they are converted to integers as needed - perhaps there is a good reason to keep them as strings almost everywhere else. According to AngularJS documentation, a getter function or an expression can be used instead of a field to order by, so I have added a .parseInt() method so that the ids are sorted properly. The performance hit of that is minimal given there won't be hundreds, or even dozens of custom dimensions in a typical Matomo setup.

fixes https://github.com/matomo-org/matomo/issues/16155