### PR TITLE
Replaced 'Piwik' with 'Matomo' in console output when creating extra Custom Dimensions

### DIFF
--- a/plugins/CustomDimensions/Commands/AddCustomDimension.php
+++ b/plugins/CustomDimensions/Commands/AddCustomDimension.php
@@ -66,7 +66,7 @@ class AddCustomDimension extends ConsoleCommand
         $numDimensionsAvailable = $tracking->getNumInstalledIndexes();
 
         $this->writeSuccessMessage($output, array(
-            sprintf('Your Piwik is now configured for up to %d Custom Dimensions in scope %s.', $numDimensionsAvailable, $scope)
+            sprintf('Your Matomo is now configured for up to %d Custom Dimensions in scope %s.', $numDimensionsAvailable, $scope)
         ));
     }
 

--- a/plugins/CustomDimensions/Commands/RemoveCustomDimension.php
+++ b/plugins/CustomDimensions/Commands/RemoveCustomDimension.php
@@ -90,7 +90,7 @@ class RemoveCustomDimension extends ConsoleCommand
         $numDimensionsAvailable = $tracking->getNumInstalledIndexes();
 
         $this->writeSuccessMessage($output, array(
-            sprintf('Your Piwik is now configured for up to %d Custom Dimensions in scope %s.', $numDimensionsAvailable, $scope)
+            sprintf('Your Matomo is now configured for up to %d Custom Dimensions in scope %s.', $numDimensionsAvailable, $scope)
         ));
     }
 

--- a/plugins/CustomDimensions/tests/Commands/AddCustomDimensionTest.php
+++ b/plugins/CustomDimensions/tests/Commands/AddCustomDimensionTest.php
@@ -78,7 +78,7 @@ class AddCustomDimensionTest extends IntegrationTestCase
         self::assertStringContainsString('Adding 3 Custom Dimension(s) in scope action.', $result);
         self::assertStringContainsString('Are you sure you want to perform this action?', $result);
         self::assertStringContainsString('Starting to add Custom Dimension(s)', $result);
-        self::assertStringContainsString('Your Piwik is now configured for up to 8 Custom Dimensions in scope action.', $result);
+        self::assertStringContainsString('Your Matomo is now configured for up to 8 Custom Dimensions in scope action.', $result);
 
         $logVisit = new LogTable(CustomDimensions::SCOPE_VISIT);
         $this->assertSame(range(1,5), $logVisit->getInstalledIndexes());
@@ -106,7 +106,7 @@ class AddCustomDimensionTest extends IntegrationTestCase
         self::assertStringContainsString('Adding 2 Custom Dimension(s) in scope visit.', $result);
         self::assertStringContainsString('Are you sure you want to perform this action?', $result);
         self::assertStringContainsString('Starting to add Custom Dimension(s)', $result);
-        self::assertStringContainsString('Your Piwik is now configured for up to 7 Custom Dimensions in scope visit.', $result);
+        self::assertStringContainsString('Your Matomo is now configured for up to 7 Custom Dimensions in scope visit.', $result);
 
         $logVisit = new LogTable(CustomDimensions::SCOPE_VISIT);
         $this->assertSame(range(1,7), $logVisit->getInstalledIndexes());

--- a/plugins/CustomDimensions/tests/Commands/RemoveCustomDimensionTest.php
+++ b/plugins/CustomDimensions/tests/Commands/RemoveCustomDimensionTest.php
@@ -86,7 +86,7 @@ class RemoveCustomDimensionTest extends IntegrationTestCase
         self::assertStringContainsString('Remove Custom Dimension at index 3 in scope action.', $result);
         self::assertStringContainsString('Are you sure you want to perform this action?', $result);
         self::assertStringContainsString('Starting to remove this Custom Dimension', $result);
-        self::assertStringContainsString('Your Piwik is now configured for up to 4 Custom Dimensions in scope action.', $result);
+        self::assertStringContainsString('Your Matomo is now configured for up to 4 Custom Dimensions in scope action.', $result);
 
         $logVisit = new LogTable(CustomDimensions::SCOPE_VISIT);
         $this->assertSame(range(1,5), $logVisit->getInstalledIndexes());
@@ -111,7 +111,7 @@ class RemoveCustomDimensionTest extends IntegrationTestCase
         self::assertStringContainsString('Remove Custom Dimension at index 2 in scope visit', $result);
         self::assertStringContainsString('Are you sure you want to perform this action?', $result);
         self::assertStringContainsString('Starting to remove this Custom Dimension', $result);
-        self::assertStringContainsString('Your Piwik is now configured for up to 4 Custom Dimensions in scope visit.', $result);
+        self::assertStringContainsString('Your Matomo is now configured for up to 4 Custom Dimensions in scope visit.', $result);
 
         $logVisit = new LogTable(CustomDimensions::SCOPE_VISIT);
         $this->assertSame(array(1,3,4,5), $logVisit->getInstalledIndexes());


### PR DESCRIPTION
While adding extra custom dimensions to reproduce #16155, I noticed that the output from the console command still says "Your Piwik..." instead of "Your Matomo...". Updated the copy both in the output and in the corresponding tests. 