### PR TITLE
Fix error getSegmentArchivesToInvalidateForNewSegments() on null

### DIFF
--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -115,6 +115,7 @@ class Tasks extends \Piwik\Plugin\Tasks
         $idSites = Request::processRequest('SitesManager.getAllSitesId');
         foreach ($idSites as $idSite) {
             $cronArchive = new CronArchive();
+            $cronArchive->init();
             $cronArchive->invalidateArchivedReportsForSitesThatNeedToBeArchivedAgain($idSite);
         }
     }


### PR DESCRIPTION
fix `Uncaught exception: Error: Call to a member function getSegmentArchivesToInvalidateForNewSegments() on null in core/CronArchive.php:818`