### PR TITLE
No need to check if column exists in conversion table when running days to seconds update

### DIFF
--- a/core/Updates/4.0.0-b1.php
+++ b/core/Updates/4.0.0-b1.php
@@ -179,7 +179,7 @@ class Updates_4_0_0_b1 extends PiwikUpdates
         $logConvColumns = $tableMetadata->getColumns(Common::prefixTable('log_conversion'));
         $hasDaysColumnInConv = in_array('visitor_days_since_first', $logConvColumns);
 
-        if ($hasDaysColumnInVisit && $hasDaysColumnInConv) {
+        if ($hasDaysColumnInVisit) {
             $migrations[] = $this->migration->db->sql("UPDATE " . Common::prefixTable('log_visit')
                 . " SET visitor_seconds_since_first = visitor_days_since_first * 86400, 
                     visitor_seconds_since_order = visitor_days_since_order * 86400,


### PR DESCRIPTION
It won't really make any difference as it should always exist initially in both tables anyway but thought I still change it just in case. I don't think it's needed to check the column exists in both tables?