### PR TITLE
Add test for config set migration

### DIFF
--- a/tests/PHPUnit/Integration/Updater/Migration/Config/SetTest.php
+++ b/tests/PHPUnit/Integration/Updater/Migration/Config/SetTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Integration\Updater\Migration\Config;
+
+use Piwik\Config;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Updater\Migration\Config\Set;
+
+/**
+ * @group Core
+ * @group Updater
+ * @group Migration
+ */
+class SetTest extends IntegrationTestCase
+{
+    public function test_toString()
+    {
+        $config = $this->configSet('General', 'foo', 'bar');
+
+        $this->assertSame('./console config:set --section="General" --key="foo" --value="bar"', '' . $config);
+    }
+
+    public function test_exec_knownSectionKnownKey()
+    {
+        $this->configSet('General', 'time_before_today_archive_considered_outdated', 876)->exec();
+
+        $general = Config::getInstance()->General;
+        $this->assertEquals('876', $general['time_before_today_archive_considered_outdated']);
+    }
+
+    public function test_exec_knownSectionUnknownKey()
+    {
+        $this->configSet('General', 'foobar', '192')->exec();
+        $general = Config::getInstance()->General;
+        $this->assertEquals('192', $general['foobar']);
+    }
+
+    public function test_exec_unknownCategory()
+    {
+        $this->configSet('foobar', 'baz', 'hello')->exec();
+
+        $baz = Config::getInstance()->foobar;
+        $this->assertEquals('hello', $baz['baz']);
+    }
+
+    private function configSet($section, $key, $value)
+    {
+        return new Set($section, $key, $value);
+    }
+
+
+}


### PR DESCRIPTION
Was adding some tests to make sure config migration works. There used to be some issues where we needed to update configs like this

```php
        $config = Config::getInstance();
        $section = $config->{$this->section};
        if (!is_array($section)) {
            $section = array();
        }
        $section[$this->key] = $this->value;
        $config->{$this->section} = $section;
        $config->forceSave();
```

instead of this (which is current implementation of `Config\Set` class)

```php
        $config = Config::getInstance();
        $config->{$this->section}[$this->key] = $this->value;
```

Because the value used to be only updated in the array but not in the underlying config because the `Config::__set` or so would not be triggered. Looks like everything is now passed by referenced and seems to work so no actual change is needed by the looks. I also tested with my PHP 7.4 it seems to work fine and updating the config directly does seem to work now.