### PR TITLE
Fix when there are dimension updates they aren't shown in the update screen

### DIFF
--- a/core/Columns/Updater.php
+++ b/core/Columns/Updater.php
@@ -55,6 +55,16 @@ class Updater extends \Piwik\Updates
 
     /**
      * @param PiwikUpdater $updater
+     * @return Migration[]
+     * @api
+     */
+    public function getMigrations(PiwikUpdater $updater)
+    {
+        return $this->getMigrationQueries($updater);
+    }
+    
+    /**
+     * @param PiwikUpdater $updater
      * @return Migration\Db[]
      */
     public function getMigrationQueries(PiwikUpdater $updater)


### PR DESCRIPTION

To test it change eg the option_value of the `option_name=version_log_visit.referer_type` entry. Then reload Matomo. Without this update the SQL queries aren't shown.