### PR TITLE
Add page performance query only if page performance plugin is activated

### DIFF
--- a/plugins/Actions/VisitorDetails.php
+++ b/plugins/Actions/VisitorDetails.php
@@ -14,6 +14,7 @@ use Piwik\Date;
 use Piwik\Db;
 use Piwik\Metrics\Formatter;
 use Piwik\Piwik;
+use Piwik\Plugin;
 use Piwik\Plugins\Live\VisitorDetailsAbstract;
 use Piwik\Site;
 use Piwik\Tracker\Action;
@@ -269,6 +270,16 @@ class VisitorDetails extends VisitorDetailsAbstract
 
         // The second join is a LEFT join to allow returning records that don't have a matching page title
         // eg. Downloads, Outlinks. For these, idaction_name is set to 0
+        $pagePerformanceSelect = '';
+        if (Plugin\Manager::getInstance()->isPluginActivated('PagePerformance')) {
+            $pagePerformanceSelect = '( log_link_visit_action.time_network +
+					log_link_visit_action.time_server +
+					log_link_visit_action.time_transfer +
+					log_link_visit_action.time_dom_completion +
+					log_link_visit_action.time_dom_processing +
+					log_link_visit_action.time_on_load ) AS pageLoadTime,';
+        }
+
         $sql           = "
 				SELECT
 					log_link_visit_action.idvisit,
@@ -283,12 +294,7 @@ class VisitorDetails extends VisitorDetailsAbstract
 					log_link_visit_action.time_spent_ref_action as timeSpentRef,
 					log_link_visit_action.idlink_va AS pageId,
 					log_link_visit_action.custom_float,
-					( log_link_visit_action.time_network +
-					log_link_visit_action.time_server +
-					log_link_visit_action.time_transfer +
-					log_link_visit_action.time_dom_completion +
-					log_link_visit_action.time_dom_processing +
-					log_link_visit_action.time_on_load ) AS pageLoadTime,
+					$pagePerformanceSelect
 					log_link_visit_action.pageview_position,
 					log_link_visit_action.search_cat,
 					log_link_visit_action.search_count


### PR DESCRIPTION
fixes an error in case the plugin was never activated 

![image](https://user-images.githubusercontent.com/273120/94761985-fb731100-0402-11eb-9e1c-ad58b1e4ce52.png)

Also this way, if the Matomo 4 upgrade takes a very long time, the real time reports might start working as soon as the `interaction_position` column was renamed to `pageview_position`. 