### PR TITLE
Fix selectable metrics in pie/bar charts for Events and Contents reports

### DIFF
--- a/plugins/Contents/Reports/Base.php
+++ b/plugins/Contents/Reports/Base.php
@@ -54,6 +54,10 @@ abstract class Base extends Report
             array_keys($this->getProcessedMetrics())
         );
 
+        if (property_exists($view->config, 'selectable_columns')) {
+            $view->config->selectable_columns = $this->metrics;
+        }
+
         $view->requestConfig->filter_sort_column = 'nb_impressions';
 
         if ($this->hasSubtableId()) {

--- a/plugins/Contents/Reports/GetContentNames.php
+++ b/plugins/Contents/Reports/GetContentNames.php
@@ -9,10 +9,8 @@
 namespace Piwik\Plugins\Contents\Reports;
 
 use Piwik\Piwik;
-use Piwik\Plugin\Report;
 use Piwik\Plugins\Contents\Columns\ContentName;
 use Piwik\Plugins\Contents\Columns\Metrics\InteractionRate;
-use Piwik\View;
 
 /**
  * This class defines a new report.

--- a/plugins/Contents/Reports/GetContentPieces.php
+++ b/plugins/Contents/Reports/GetContentPieces.php
@@ -9,10 +9,8 @@
 namespace Piwik\Plugins\Contents\Reports;
 
 use Piwik\Piwik;
-use Piwik\Plugin\Report;
 use Piwik\Plugins\Contents\Columns\ContentPiece;
 use Piwik\Plugins\Contents\Columns\Metrics\InteractionRate;
-use Piwik\View;
 
 /**
  * This class defines a new report.

--- a/plugins/Events/Reports/Base.php
+++ b/plugins/Events/Reports/Base.php
@@ -52,6 +52,10 @@ abstract class Base extends \Piwik\Plugin\Report
             $view->requestConfig->overridableProperties = array_values($view->requestConfig->overridableProperties);
         }
 
+        if (property_exists($view->config, 'selectable_columns')) {
+            $view->config->selectable_columns = ['nb_events', 'nb_visits', 'sum_event_value', 'nb_events_with_value'];
+        }
+
         $this->configureFooterMessage($view);
     }
 


### PR DESCRIPTION
When switching Events or Content reports to a pie or bar chart the metric selection in the report currently only has `Visits` as option, which is actually not even available in some of the reports.
Reason is, that selectable columns is filled with defaults if nothing is set. 

Note: This might already have been an issue in Matomo 3.x