### PR TITLE
don't mention PHP5 in messages

### DIFF
--- a/core/CliMulti/CliPhp.php
+++ b/core/CliMulti/CliPhp.php
@@ -50,10 +50,6 @@ class CliPhp
         }
 
         if (!$this->isValidPhpType($bin)) {
-            $bin = shell_exec('which php5');
-        }
-
-        if (!$this->isValidPhpType($bin)) {
             return false;
         }
 

--- a/core/testMinimumPhpVersion.php
+++ b/core/testMinimumPhpVersion.php
@@ -49,9 +49,9 @@ if ($minimumPhpInvalid) {
     }
 
     if (!function_exists('json_encode')) {
-        $piwik_errorMessage .= "<p><strong>Matomo requires the php5-json extension which provides the functions <code>json_encode()</code> and <code>json_decode()</code></strong></p>
-					<p>It appears your PHP has not yet installed the php5-json extension.
-					To use Matomo, please ask your web host to install php5-json or install it yourself, for example on debian system: <code>sudo apt-get install php5-json</code>. <br/>Then restart your webserver and refresh this page.</p>";
+        $piwik_errorMessage .= "<p><strong>Matomo requires the php-json extension which provides the functions <code>json_encode()</code> and <code>json_decode()</code></strong></p>
+					<p>It appears your PHP has not yet installed the php-json extension.
+					To use Matomo, please ask your web host to install php-json or install it yourself, for example on debian system: <code>sudo apt-get install php-json</code>. <br/>Then restart your webserver and refresh this page.</p>";
     }
 
     if (!file_exists(PIWIK_VENDOR_PATH . '/autoload.php')) {

--- a/misc/cron/archive.sh
+++ b/misc/cron/archive.sh
@@ -2,7 +2,7 @@
 # =======================================================================
 # WARNING: this script archive.sh is DEPRECATED!
 #
-# => Replace your cron with `/usr/bin/php5 /path/to/piwik/console core:archive --url=http://example.org/piwik/`
+# => Replace your cron with `/usr/bin/php /path/to/piwik/console core:archive --url=http://example.org/piwik/`
 #
 # See documentation at https://piwik.org/setup-auto-archiving/
 # =======================================================================

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -95,7 +95,7 @@
         "SystemCheckGzuncompressHelp": "You need to enable the zlib extension and gzuncompress function.",
         "SystemCheckHashHelp": "You need to configure and rebuild PHP with hash() support enabled by excluding the option --disable-hash.",
         "SystemCheckIconvHelp": "You need to configure and rebuild PHP with \"iconv\" support enabled, --with-iconv.",
-        "SystemCheckJsonHelp": "The php5-json extension is required for Matomo to read and write JSON data.",
+        "SystemCheckJsonHelp": "The php-json extension is required for Matomo to read and write JSON data.",
         "SystemCheckMailHelp": "Feedback and Lost Password messages will not be sent without mail().",
         "SystemCheckMbstring": "mbstring",
         "SystemCheckMbstringHelp": "The mbstring extension is required to handle multibyte characters in the User interface and API responses. Also, please check that mbstring.func_overload is set to \"0\" in php.ini.",


### PR DESCRIPTION
When looking at https://github.com/matomo-org/matomo/pull/16536 I noticed that php5 was still mentioned in a few places, so I replaced them with a general `php`.