### PR TITLE
Make method signature compatible with PHP 8

### DIFF
--- a/core/Singleton.php
+++ b/core/Singleton.php
@@ -24,7 +24,7 @@ class Singleton
     {
     }
 
-    final private function __clone()
+    final protected function __clone()
     {
     }
 


### PR DESCRIPTION
Having that method protected should have the same effect. But is compatible with PHP 8...

refs #16183