### PR TITLE
Generate segment string even if label value is 0

### DIFF
--- a/core/DataTable/Filter/AddSegmentByLabel.php
+++ b/core/DataTable/Filter/AddSegmentByLabel.php
@@ -66,7 +66,7 @@ class AddSegmentByLabel extends BaseFilter
             foreach ($table->getRowsWithoutSummaryRow() as $key => $row) {
                 $label = $row->getColumn('label');
 
-                if (!empty($label)) {
+                if (!empty($label) || $label === 0 || $label === '0') {
                     $row->setMetadata('segment', $segment . '==' . urlencode($label));
                 }
             }
@@ -76,7 +76,7 @@ class AddSegmentByLabel extends BaseFilter
 
             foreach ($table->getRowsWithoutSummaryRow() as $key => $row) {
                 $label = $row->getColumn('label');
-                if (!empty($label)) {
+                if (!empty($label) || $label === 0 || $label === '0') {
                     $parts = explode($this->delimiter, $label);
 
                     if (count($parts) === $numSegments) {


### PR DESCRIPTION
Noticed in a custom report the "segmented visitor log" was missing for a custom report with a dimension "Server time hour" where in this case the value of the label was `'0'`.