### PR TITLE
Fixes downloading files in chunks when not using curl

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -534,6 +534,10 @@ class Http
                     $status = (int)$m[2];
                 }
 
+                foreach ($http_response_header as $line) {
+                    self::parseHeaderLine($headers, $line);
+                }
+		    
                 if (!$status && $response === false) {
                     $error = error_get_last();
                     throw new \Exception($error['message']);

--- a/core/Http.php
+++ b/core/Http.php
@@ -533,16 +533,16 @@ class Http
                 if (isset($http_response_header) && preg_match('~^HTTP/(\d\.\d)\s+(\d+)(\s*.*)?~', implode("\n", $http_response_header), $m)) {
                     $status = (int)$m[2];
                 }
-
-                foreach ($http_response_header as $line) {
-                    self::parseHeaderLine($headers, $line);
-                }
 		    
                 if (!$status && $response === false) {
                     $error = error_get_last();
                     throw new \Exception($error['message']);
                 }
                 $fileLength = strlen($response);
+            }
+
+            foreach ($http_response_header as $line) {
+                self::parseHeaderLine($headers, $line);
             }
 
             // restore the socket_timeout value


### PR DESCRIPTION
Hi Guys,

I was having some issues when downloading files as the response headers were not set when php-curl isn’t installed.

Instead of opening an issue, I decided to create a simple patch that fixes the file download bug and set the response headers correctly.

Kind regards,

Steve