### PR TITLE
Pass string parameters to DB query instead of object

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -377,7 +377,7 @@ class Model
 
         $sql = "SELECT idarchive FROM `$numericTable` WHERE idsite = ? AND date1 = ? AND date2 = ? AND period = ? AND name = ? AND ts_archived < ? AND idarchive < ?";
 
-        $idArchives = Db::fetchAll($sql, [$params->getSite()->getId(), $dateStart, $dateEnd, $params->getPeriod()->getId(), $name, $tsArchived, $idArchive]);
+        $idArchives = Db::fetchAll($sql, [$params->getSite()->getId(), $dateStart . '', $dateEnd . '', $params->getPeriod()->getId(), $name, $tsArchived, $idArchive]);
         $idArchives = array_column($idArchives, 'idarchive');
         if (empty($idArchives)) {
             return;

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -377,7 +377,7 @@ class Model
 
         $sql = "SELECT idarchive FROM `$numericTable` WHERE idsite = ? AND date1 = ? AND date2 = ? AND period = ? AND name = ? AND ts_archived < ? AND idarchive < ?";
 
-        $idArchives = Db::fetchAll($sql, [$params->getSite()->getId(), $dateStart . '', $dateEnd . '', $params->getPeriod()->getId(), $name, $tsArchived, $idArchive]);
+        $idArchives = Db::fetchAll($sql, [$params->getSite()->getId(), $dateStart->getDatetime(), $dateEnd->getDatetime(), $params->getPeriod()->getId(), $name, $tsArchived, $idArchive]);
         $idArchives = array_column($idArchives, 'idarchive');
         if (empty($idArchives)) {
             return;


### PR DESCRIPTION
In Matomo for WordPress this caused the tests to fail.  I have now worked around this to ensure it won't cause any issues in Matomo for WordPress anymore (https://github.com/matomo-org/wp-matomo/commit/ffe92d138555bcea5ad4f2fcde9a2caac80b8fa5#diff-c4e75ddbbcdde3ba408b5a87e273371dd3420a5d0b90a87bb4295e81787cdc31R242-R244) when this happens again but figured it be still good to pass strings directly here just in case it somehow causes other issues somehow :)