### PR TITLE
Updater: Check if column exist only shortly before it is needed

### DIFF
--- a/core/Updates/4.0.0-b1.php
+++ b/core/Updates/4.0.0-b1.php
@@ -194,15 +194,15 @@ class Updates_4_0_0_b1 extends PiwikUpdates
         $logVisitColumns = $tableMetadata->getColumns(Common::prefixTable('log_visit'));
         $hasDaysColumnInVisit = in_array('visitor_days_since_first', $logVisitColumns);
 
-        $logConvColumns = $tableMetadata->getColumns(Common::prefixTable('log_conversion'));
-        $hasDaysColumnInConv = in_array('visitor_days_since_first', $logConvColumns);
-
         if ($hasDaysColumnInVisit) {
             $migrations[] = $this->migration->db->sql("UPDATE " . Common::prefixTable('log_visit')
                 . " SET visitor_seconds_since_first = visitor_days_since_first * 86400, 
                     visitor_seconds_since_order = visitor_days_since_order * 86400,
                     visitor_seconds_since_last = visitor_days_since_last * 86400");
         }
+
+        $logConvColumns = $tableMetadata->getColumns(Common::prefixTable('log_conversion'));
+        $hasDaysColumnInConv = in_array('visitor_days_since_first', $logConvColumns);
 
         if ($hasDaysColumnInConv) {
             $migrations[] = $this->migration->db->sql("UPDATE " . Common::prefixTable('log_conversion')


### PR DESCRIPTION
Just in case there are multiple updates running at the same time (eg when 2 users click on `update` in the UI or this might also happen in Matomo for WordPress). Then the update on `log_visit...SET visitor_seconds_since_first = visitor_days_since_first * 86400, ` might take a while and meanwhile another concurrent job has removed that column already. Bit hard to explain but basically we want to get this information only shortly before it is needed