### PR TITLE
Fix deprecated implode warning

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -181,7 +181,7 @@ class Twig
         $this->addFilter_md5();
         $this->addFilter_onlyDomain();
         $this->addFilter_safelink();
-        $this->twig->addFilter(new TwigFilter('implode', 'implode'));
+        $this->addFilter_implode();
         $this->twig->addFilter(new TwigFilter('ucwords', 'ucwords'));
         $this->twig->addFilter(new TwigFilter('lcfirst', 'lcfirst'));
         $this->twig->addFilter(new TwigFilter('ucfirst', 'ucfirst'));
@@ -608,6 +608,14 @@ class Twig
             return $url;
         });
         $this->twig->addFilter($safelink);
+    }
+
+    private function addFilter_implode()
+    {
+        $implode = new TwigFilter('implode', function ($value, $separator) {
+            return implode($separator, $value);
+        });
+        $this->twig->addFilter($implode);
     }
 
     private function addTest_isNumeric()


### PR DESCRIPTION
In `plugins/Ecommerce/templates/_actionTooltip.twig` we use `{{ action.productViewCategories|implode(', ') }}` which causes `Deprecated - implode(): Passing glue string after array is deprecated. Swap the parameters - Matomo 4.0.0-b3 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already) (Module: Live, Action: getLastVisitsDetails, In CLI mode: false)`.
