### PR TITLE
MobileMessaging twig fix for 'Variable "ajax" does not exist.'

### DIFF
--- a/plugins/MobileMessaging/templates/index.twig
+++ b/plugins/MobileMessaging/templates/index.twig
@@ -153,6 +153,7 @@
                     </div>
                 {% endfor %}
 
+                {% import 'ajaxMacros.twig' as ajax %}
                 {{ ajax.errorDiv('invalidVerificationCodeAjaxError') }}
 
                 <div piwik-activity-indicator loading="managePhoneNumber.isChangingPhoneNumber"></div>


### PR DESCRIPTION
> A fatal error occurred
> The following error just broke Matomo (v4.0.0-b3):
> 
> Variable "ajax" does not exist.
> in /home/lukas/public_html/matomophp8/plugins/MobileMessaging/templates/index.twig line 156            

I am not sure if a twig update broke this or it never worked anyway