### PR TITLE
Allow overwriting rows_to_display property to ensure storing viewDatable settings works

### DIFF
--- a/core/ViewDataTable/Config.php
+++ b/core/ViewDataTable/Config.php
@@ -128,6 +128,7 @@ class   Config
         'show_offset_information',
         'hide_annotations_view',
         'columns_to_display',
+        'rows_to_display',
         'segmented_visitor_log_segment_suffix',
     );
 


### PR DESCRIPTION
fixes https://github.com/matomo-org/plugin-TreemapVisualization/issues/23