### PR TITLE
get idtokenauth from $_GET if present since the password confirm page forwards params as GET

### DIFF
--- a/plugins/UsersManager/Controller.php
+++ b/plugins/UsersManager/Controller.php
@@ -307,7 +307,7 @@ class Controller extends ControllerAdmin
     {
         Piwik::checkUserIsNotAnonymous();
 
-        $idTokenAuth = Common::getRequestVar('idtokenauth', '', 'string', $_POST);
+        $idTokenAuth = Common::getRequestVar('idtokenauth', '', 'string');
 
         if (!empty($idTokenAuth)) {
             $params = array(


### PR DESCRIPTION
Noticed that the 'delete all tokens' button didn't work when a password confirmation was needed, due to the password confirm form forwarding params as GET params. This is a quick fix for that.