### PR TITLE
console (cli): Add config:delete to delete a key #16576

### DIFF
--- a/plugins/CoreAdminHome/Commands/DeleteConfig.php
+++ b/plugins/CoreAdminHome/Commands/DeleteConfig.php
@@ -25,20 +25,16 @@ class DeleteConfig extends ConsoleCommand
     {
         $this->setName('config:delete');
         $this->setDescription('Delete one or more config settings in the file config/config.ini.php');
-        $this->addArgument('assignment', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, "List of config setting assignments, eg, section or section.config_setting_key");
+        $this->addArgument('assignment', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, "List of config setting assignments, eg, section.config_setting_key");
         $this->addOption('section', null, InputOption::VALUE_REQUIRED, 'The section the INI config setting belongs to.');
         $this->addOption('key', null, InputOption::VALUE_REQUIRED, 'The name of the INI config setting.');
         $this->setHelp("This command can be used to remove INI config settings on a Piwik instance.
 
 You can remove config values two ways, via --section, --key or by command arguments.
 
-To use --section, --key, simply supply those options. You can remove one whole section or one key inside the section.
+To use --section, --key, simply supply those options.
 
 To use arguments, supply one or more arguments in the following format:
-
-Remove section:
-$ ./console config:delete 'section'
-'section' is the name of the section,
 
 Remove setting inside section
 $ ./console config:delete 'section.config_setting_key'
@@ -64,17 +60,6 @@ $ ./console config:delete 'section.config_setting_key'
         $config = Config::getInstance();
 
         foreach ($manipulations as $manipulation) {
-            /** @var ConfigDeletingManipulation $manipulation */
-            if ($manipulation->isSectionDeletion()) {
-                $helper = $this->getHelper('question');
-                $question = new ConfirmationQuestion('<question>Do you want to remove the section "' . $manipulation->getSectionName() . '"? (y/n)</question> ' , false);
-
-                if (!$helper->ask($input, $output, $question)) {
-                    $output->writeln( "<comment>\"".$manipulation->getSectionName()."\" will not be deleted</comment>");
-                    continue;
-                }
-            }
-
             try {
                 $manipulation->manipulate($config);
 
@@ -101,8 +86,8 @@ $ ./console config:delete 'section.config_setting_key'
         $section = $input->getOption('section');
         $setting_key = $input->getOption('key');
 
-        if (!empty($section)) {
-            $manipulations[] = new ConfigDeletingManipulation($section, $setting_key, empty($setting_key));
+        if (!empty($section) && !empty($setting_key)) {
+            $manipulations[] = new ConfigDeletingManipulation($section, $setting_key);
         }
 
         return $manipulations;

--- a/plugins/CoreAdminHome/Commands/DeleteConfig.php
+++ b/plugins/CoreAdminHome/Commands/DeleteConfig.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\Commands;
+
+use Piwik\Config;
+use Piwik\Plugin\ConsoleCommand;
+use Piwik\Plugins\CoreAdminHome\Commands\DeleteConfig\ConfigDeletingManipulation;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DeleteConfig extends ConsoleCommand
+{
+    protected function configure()
+    {
+        $this->setName('config:delete');
+        $this->setDescription('Delete one or more config settings in the file config/config.ini.php');
+        $this->addArgument('assignment', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, "List of config setting assignments, eg, section, section.config_setting_key or section.config_setting_key[position]");
+        $this->addOption('section', null, InputOption::VALUE_REQUIRED, 'The section the INI config setting belongs to.');
+        $this->addOption('key', null, InputOption::VALUE_REQUIRED, 'The name of the INI config setting.');
+        $this->setHelp("This command can be used to remove INI config settings on a Piwik instance.
+
+You can remove config values two ways, via --section, --key or by command arguments.
+
+To use --section, --key, simply supply those options. You can remove one whole section or one key inside the section.
+
+To use arguments, supply one or more arguments in the following format:
+
+Remove section:
+$ ./console config:delete 'section'
+'section' is the name of the section,
+
+Remove setting inside section
+$ ./console config:delete 'section.config_setting_key'
+'section' is the name of the section,
+'config_setting_key' the name of the setting
+
+To remove an array setting position, supply an argument like this:
+$ ./console config:set 'section.config_setting_key[position]'
+'position' is the array position if the section.config_setting_key is an array. Goes from 0 to section.config_setting_key.length-1
+");
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int|void|null
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $manipulations = $this->getManipulations($input);
+
+        if (empty($manipulations)) {
+            throw new \InvalidArgumentException("Nothing to remove. Add key as arguments or use the ". "--section and --key options.");
+        }
+
+        $config = Config::getInstance();
+
+        foreach ($manipulations as $manipulation) {
+            $manipulation->manipulate($config);
+
+            $output->write("<info>Removing [{$manipulation->getSectionName()}] {$manipulation->getName()}...</info>");
+            $output->writeln("<info> done.</info>");
+        }
+
+        $config->forceSave();
+    }
+
+    /**
+     * @param InputInterface $input
+     *
+     * @return ConfigSettingManipulation[]
+     */
+    private function getManipulations(InputInterface $input): array
+    {
+        $manipulations = $this->getAssignments($input);
+
+        $section = $input->getOption('section');
+        $setting_key = $input->getOption('key');
+
+        if (!empty($section)) {
+            $manipulations[] = new ConfigDeletingManipulation($section, $setting_key, empty($setting_key));
+        }
+
+        return $manipulations;
+    }
+
+    /**
+     * @param InputInterface $input
+     *
+     * @return ConfigSettingManipulation[]
+     */
+    private function getAssignments(InputInterface $input):array
+    {
+        $assignments = $input->getArgument('assignment');
+
+        $result = [];
+        foreach ($assignments as $assignment) {
+            $result[] = ConfigDeletingManipulation::make($assignment);
+        }
+
+        return $result;
+    }
+}

--- a/plugins/CoreAdminHome/Commands/DeleteConfig.php
+++ b/plugins/CoreAdminHome/Commands/DeleteConfig.php
@@ -23,7 +23,7 @@ class DeleteConfig extends ConsoleCommand
     {
         $this->setName('config:delete');
         $this->setDescription('Delete one or more config settings in the file config/config.ini.php');
-        $this->addArgument('assignment', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, "List of config setting assignments, eg, section, section.config_setting_key or section.config_setting_key[position]");
+        $this->addArgument('assignment', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, "List of config setting assignments, eg, section or section.config_setting_key");
         $this->addOption('section', null, InputOption::VALUE_REQUIRED, 'The section the INI config setting belongs to.');
         $this->addOption('key', null, InputOption::VALUE_REQUIRED, 'The name of the INI config setting.');
         $this->setHelp("This command can be used to remove INI config settings on a Piwik instance.
@@ -42,10 +42,6 @@ Remove setting inside section
 $ ./console config:delete 'section.config_setting_key'
 'section' is the name of the section,
 'config_setting_key' the name of the setting
-
-To remove an array setting position, supply an argument like this:
-$ ./console config:set 'section.config_setting_key[position]'
-'position' is the array position if the section.config_setting_key is an array. Goes from 0 to section.config_setting_key.length-1
 ");
     }
 

--- a/plugins/CoreAdminHome/Commands/DeleteConfig/ConfigDeletingManipulation.php
+++ b/plugins/CoreAdminHome/Commands/DeleteConfig/ConfigDeletingManipulation.php
@@ -1,0 +1,229 @@
+<?php declare(strict_types=1);
+
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\Commands\DeleteConfig;
+
+use \RuntimeException;
+use \InvalidArgumentException;
+use Piwik\Config;
+
+/**
+ * Representation of a INI config manipulation operation. Only supports three types
+ * of manipulations: removing a config array, remove a config or remove a config array position.
+ */
+class ConfigDeletingManipulation
+{
+    /**
+     * @var string
+     */
+    private $sectionName;
+
+    /**
+     * @var string|null
+     */
+    private $name;
+
+    /**
+     * @var bool
+     */
+    private $isSectionDeletion;
+
+    /**
+     * @var int|null
+     */
+    private $settingPositionToDelete;
+
+    /**
+     * @param string      $sectionName
+     * @param string|null $name
+     * @param bool        $isSectionDeletion
+     * @param int|null    $settingPositionToDelete
+     */
+    public function __construct(string $sectionName, ?string $name, bool $isSectionDeletion = false, ?int $settingPositionToDelete = null)
+    {
+        $this->sectionName = $sectionName;
+        $this->name = $name;
+        $this->isSectionDeletion = $isSectionDeletion;
+        $this->settingPositionToDelete = $settingPositionToDelete;
+    }
+
+    /**
+     * Performs the INI config manipulation.
+     *
+     * @param Config $config
+     * @throws RuntimeException If trying to delete not existing section, config or config array position
+     */
+    public function manipulate(Config $config): void
+    {
+        if ($this->isSectionDeletion) {
+            $this->deleteConfigSection($config);
+        } elseif ($this->settingPositionToDelete) {
+            $this->deleteConfigSettingPosition($config);
+        } else {
+            $this->deleteConfigSetting($config);
+        }
+    }
+
+    /**
+     * @param Config $config
+     *
+     * @throws RuntimeException When trying to delete not existing section in config
+     */
+    private function deleteConfigSection(Config $config): void
+    {
+        $sectionName = $this->sectionName;
+        $section = $config->$sectionName;
+
+        if (empty($section)) {
+            throw new RuntimeException("Trying to delete not existing config section ".$this->getSettingString().".");
+        }
+
+        $config->$sectionName = null;
+    }
+
+    /**
+     * @param Config $config
+     *
+     * @throws RuntimeException When trying to delete not existing config or not existing config array position in config
+     */
+    private function deleteConfigSettingPosition(Config $config): void
+    {
+        $sectionName = $this->sectionName;
+        $section = $config->$sectionName;
+
+        if (!isset($section[$this->name]) || !is_array($section[$this->name])) {
+            throw new RuntimeException("Trying to delete not existing config in array setting ".$this->getSettingString().".");
+        }
+
+        if (!array_key_exists($this->settingPositionToDelete, $section[$this->name])) {
+            throw new RuntimeException("Trying to delete not existing position in array setting ".$this->getSettingString().".");
+        }
+
+        unset($section[$this->name][$this->settingPositionToDelete]);
+
+        $config->$sectionName = $section;
+    }
+
+    /**
+     * @param Config $config
+     *
+     * @throws RuntimeException When trying to delete not existing config or not existing config array position in config
+     */
+    private function deleteConfigSetting(Config $config): void
+    {
+        $sectionName = $this->sectionName;
+        $section = $config->$sectionName;
+
+        if (!isset($section[$this->name])) {
+            throw new RuntimeException("Trying to delete not existing config in array setting ".$this->getSettingString().".");
+        }
+
+        unset($section[$this->name]);
+
+        $config->$sectionName = $section;
+    }
+
+    /**
+     * Creates a ConfigSettingManipulation instance from a string like:
+     *
+     * `sectionName`
+     *
+     * or
+     *
+     * `sectionName.setting_name[]`
+     *
+     * or
+     *
+     * `sectionName.setting_name[position]`
+     *
+     * The position must be numeric from 0 to sectionName.setting_name.length-1
+     *
+     * @param string $assignment
+     *
+     * @return self
+     */
+    public static function make(string $assignment): self
+    {
+        if (!preg_match("/^(?'section'[\w]+)\.?(?'setting_key'[\w]+)?(?:\[(?'setting_key_position'[a-zA-Z0-9_-]+)\])?/", $assignment, $matches)) {
+            throw new InvalidArgumentException("Invalid assignment string '$assignment': expected section, section.config_setting_key or section.config_setting_key[position]");
+        }
+
+        $section = $matches['section'];
+        $setting_key = $matches['setting_key'] ?? null;
+        $settingPositionToDelete = isset($matches['setting_key_position']) ? self::getSettingPositionToDeleteArgument($matches['setting_key_position']) : null;
+        $isSectionDeletion = empty($matches['setting_key']);
+
+        return new self($section, $setting_key, $isSectionDeletion, $settingPositionToDelete);
+    }
+
+    /**
+     * @param string $position
+     *
+     * @return int|null
+     */
+    private static function getSettingPositionToDeleteArgument(string $position):?int {
+        if (!is_numeric($position)) {
+            throw new InvalidArgumentException("Setting positions can only be numeric");
+        }
+
+        $position = (int)$position;
+
+        if (0 > $position) {
+            throw new InvalidArgumentException("Setting positions can only go from 0 to section.config_setting_key.length-1");
+        }
+
+        return $position;
+    }
+
+    /**
+     * @return string
+     */
+    private function getSettingString(): string
+    {
+        $string = "[{$this->sectionName}] {$this->name}";
+
+        if (!is_null($this->settingPositionToDelete)) {
+            $string.= "[{$this->settingPositionToDelete}]";
+        }
+
+        return $string;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSectionName(): string
+    {
+        return $this->sectionName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isSectionDeletion(): bool
+    {
+        return $this->isSectionDeletion;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getSettingPositionToDelete():?int
+    {
+        return $this->settingPositionToDelete;
+    }
+}

--- a/plugins/CoreAdminHome/Commands/DeleteConfig/ConfigDeletingManipulation.php
+++ b/plugins/CoreAdminHome/Commands/DeleteConfig/ConfigDeletingManipulation.php
@@ -30,20 +30,13 @@ class ConfigDeletingManipulation
     private $name;
 
     /**
-     * @var bool
-     */
-    private $isSectionDeletion;
-
-    /**
      * @param string      $sectionName
      * @param string|null $name
-     * @param bool        $isSectionDeletion
      */
-    public function __construct(string $sectionName, ?string $name, bool $isSectionDeletion = false)
+    public function __construct(string $sectionName, string $name)
     {
         $this->sectionName = $sectionName;
         $this->name = $name;
-        $this->isSectionDeletion = $isSectionDeletion;
     }
 
     /**
@@ -54,28 +47,7 @@ class ConfigDeletingManipulation
      */
     public function manipulate(Config $config): void
     {
-        if ($this->isSectionDeletion) {
-            $this->deleteConfigSection($config);
-        } else {
-            $this->deleteConfigSetting($config);
-        }
-    }
-
-    /**
-     * @param Config $config
-     *
-     * @throws RuntimeException When trying to delete not existing section in config
-     */
-    private function deleteConfigSection(Config $config): void
-    {
-        $sectionName = $this->sectionName;
-        $section = $config->$sectionName;
-
-        if (empty($section)) {
-            throw new RuntimeException("Trying to delete not existing config section ".$this->getSettingString().".");
-        }
-
-        $config->$sectionName = null;
+        $this->deleteConfigSetting($config);
     }
 
     /**
@@ -112,11 +84,7 @@ class ConfigDeletingManipulation
             throw new InvalidArgumentException("Invalid assignment string '$assignment': expected section or section.config_setting_key");
         }
 
-        $section = $matches['section'];
-        $setting_key = $matches['setting_key'] ?? null;
-        $isSectionDeletion = empty($matches['setting_key']);
-
-        return new self($section, $setting_key, $isSectionDeletion);
+        return new self($matches['section'], $matches['setting_key']);
     }
 
     /**
@@ -141,13 +109,5 @@ class ConfigDeletingManipulation
     public function getName(): ?string
     {
         return $this->name;
-    }
-
-    /**
-     * @return boolean
-     */
-    public function isSectionDeletion(): bool
-    {
-        return $this->isSectionDeletion;
     }
 }

--- a/plugins/CoreAdminHome/tests/Unit/DeleteConfig/ConfigDeletingManipulationTest.php
+++ b/plugins/CoreAdminHome/tests/Unit/DeleteConfig/ConfigDeletingManipulationTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\tests\Unit\Commands\DeleteConfig;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Config;
+use Piwik\Plugins\CoreAdminHome\Commands\DeleteConfig\ConfigDeletingManipulation;
+use Piwik\Plugins\CoreAdminHome\Commands\SetConfig\ConfigSettingManipulation;
+
+// phpunit mocks can't return references, so we need a manual one
+class DumbMockConfig extends Config
+{
+    /**
+     * @var array
+     */
+    public $mockConfigData;
+
+    public function __construct()
+    {
+        // empty
+    }
+
+    public function &__get($sectionName)
+    {
+        if (!isset($this->mockConfigData[$sectionName])) {
+            $this->mockConfigData[$sectionName] = array();
+        }
+
+        $result =& $this->mockConfigData[$sectionName];
+        return $result;
+    }
+
+    public function __set($sectionName, $section)
+    {
+        $this->mockConfigData[$sectionName] = $section;
+    }
+}
+
+/**
+ * @group CoreAdminHome
+ * @group CoreAdminHome_Unit
+ */
+class ConfigDeletingManipulationTest extends TestCase
+{
+    /**
+     * @var Config
+     */
+    private $mockConfig;
+
+    /**
+     * @var array
+     */
+    private $mockConfigData;
+
+    public function setUp(): void
+    {
+        $this->mockConfig = new DumbMockConfig();
+        $this->mockConfigData = array();
+
+        foreach ($this->getTestConfig() as [$sectionName, $name, $value, $isArrayAppend]){
+            $manipulation = new ConfigSettingManipulation($sectionName, $name, $value, $isArrayAppend);
+            $manipulation->manipulate($this->mockConfig);
+        }
+    }
+
+    public function getTestConfig(): array
+    {
+        return array(
+            // normal assign (string, int, array, bool)
+            array("Section", "config_setting", "stringvalue", false),
+            array("Section", "config_setting_two", 25, false),
+            array("Section", "config_setting_three", array('a', 'b'), false),
+            array("Section", "config_setting_for", false, false),
+        );
+    }
+
+    /**
+     * @dataProvider getTestDataForMake
+     *
+     * @param $assignmentString
+     * @param $expectedSectionName
+     * @param $expectedSettingName
+     * @param $expectedIsSectionDeletion
+     * @param $expectedSettingPositionToDelete
+     */
+    public function test_make_CreatesCorrectManipulation($assignmentString, $expectedSectionName, $expectedSettingName, $expectedIsSectionDeletion, $expectedSettingPositionToDelete): void
+    {
+        $manipulation = ConfigDeletingManipulation::make($assignmentString);
+
+        $this->assertEquals($expectedSectionName, $manipulation->getSectionName());
+        $this->assertEquals($expectedSettingName, $manipulation->getName());
+        $this->assertEquals($expectedIsSectionDeletion, $manipulation->isSectionDeletion());
+        $this->assertEquals($expectedSettingPositionToDelete, $manipulation->getSettingPositionToDelete());
+    }
+
+    public function getTestDataForMake(): array
+    {
+        return array(
+            // Setting Delete
+            array("General.myconfig", "General", "myconfig", false, null),
+
+            // Setting position delete
+            array("General.myconfig[2]", "General", 'myconfig', false, 2),
+
+            // Section delete
+            array("General", "General", null, true, null),
+
+        );
+    }
+
+    public function test_manipulate_ThrowIfSectionDoesntExists(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Trying to delete not existing config section [General]');
+
+        $manipulation = new ConfigDeletingManipulation("General", null, true);
+        $manipulation->manipulate($this->mockConfig);
+    }
+
+    public function test_manipulate_ThrowIfConfigArrayPositionDoesntExists(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Trying to delete not existing position in array setting [Section] config_setting_three[3].');
+
+        $manipulation = new ConfigDeletingManipulation("Section", 'config_setting_three', false, 3);
+        $manipulation->manipulate($this->mockConfig);
+    }
+
+    public function test_manipulate_ThrowIfConfigArrayDoesntExistForSettingPosition(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Trying to delete not existing config in array setting [Section] config_setting_two[3].');
+
+        $manipulation = new ConfigDeletingManipulation("Section", 'config_setting_two', false, 3);
+        $manipulation->manipulate($this->mockConfig);
+    }
+
+    public function test_manipulate_ThrowIfConfigSettingDoesntExists(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Trying to delete not existing config in array setting [Section] config_setting_five.');
+
+        $manipulation = new ConfigDeletingManipulation("Section", 'config_setting_five');
+        $manipulation->manipulate($this->mockConfig);
+    }
+
+    /**
+     * @dataProvider getTestDataForManipulate
+     *
+     * @param $sectionName
+     * @param $name
+     * @param $isSectionDeletion
+     * @param $settingPositionToDelete
+     * @param $expectedConfig
+     */
+    public function test_manipulate_CorrectlyManipulatesConfig($sectionName, $name, $isSectionDeletion, $settingPositionToDelete, $expectedConfig): void
+    {
+        $manipulation = new ConfigDeletingManipulation($sectionName, $name, $isSectionDeletion, $settingPositionToDelete);
+        $manipulation->manipulate($this->mockConfig);
+
+        $this->assertEquals($expectedConfig, $this->mockConfig->mockConfigData);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getTestDataForManipulate():array
+    {
+        return array(
+            // Section delete (string, string, bool, int)
+            array("Section", null, true, null, array("Section" => null)),
+            // Setting delete
+            array("Section", 'config_setting_two', false, null, array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_three' => array('a', 'b'), 'config_setting_for' => false))),
+            // Array setting delete
+            array("Section", 'config_setting_three', false, null, array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_two' => 25, 'config_setting_for' => false))),
+            // Array setting position delete
+            array("Section", 'config_setting_three', false, 1, array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_two' => 25, 'config_setting_three' => array('a'), 'config_setting_for' => false))),
+        );
+    }
+}

--- a/plugins/CoreAdminHome/tests/Unit/DeleteConfig/ConfigDeletingManipulationTest.php
+++ b/plugins/CoreAdminHome/tests/Unit/DeleteConfig/ConfigDeletingManipulationTest.php
@@ -87,29 +87,24 @@ class ConfigDeletingManipulationTest extends TestCase
      * @param $expectedSectionName
      * @param $expectedSettingName
      * @param $expectedIsSectionDeletion
-     * @param $expectedSettingPositionToDelete
      */
-    public function test_make_CreatesCorrectManipulation($assignmentString, $expectedSectionName, $expectedSettingName, $expectedIsSectionDeletion, $expectedSettingPositionToDelete): void
+    public function test_make_CreatesCorrectManipulation($assignmentString, $expectedSectionName, $expectedSettingName, $expectedIsSectionDeletion): void
     {
         $manipulation = ConfigDeletingManipulation::make($assignmentString);
 
         $this->assertEquals($expectedSectionName, $manipulation->getSectionName());
         $this->assertEquals($expectedSettingName, $manipulation->getName());
         $this->assertEquals($expectedIsSectionDeletion, $manipulation->isSectionDeletion());
-        $this->assertEquals($expectedSettingPositionToDelete, $manipulation->getSettingPositionToDelete());
     }
 
     public function getTestDataForMake(): array
     {
         return array(
             // Setting Delete
-            array("General.myconfig", "General", "myconfig", false, null),
-
-            // Setting position delete
-            array("General.myconfig[2]", "General", 'myconfig', false, 2),
+            array("General.myconfig", "General", "myconfig", false),
 
             // Section delete
-            array("General", "General", null, true, null),
+            array("General", "General", null, true),
 
         );
     }
@@ -120,24 +115,6 @@ class ConfigDeletingManipulationTest extends TestCase
         $this->expectExceptionMessage('Trying to delete not existing config section [General]');
 
         $manipulation = new ConfigDeletingManipulation("General", null, true);
-        $manipulation->manipulate($this->mockConfig);
-    }
-
-    public function test_manipulate_ThrowIfConfigArrayPositionDoesntExists(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Trying to delete not existing position in array setting [Section] config_setting_three[3].');
-
-        $manipulation = new ConfigDeletingManipulation("Section", 'config_setting_three', false, 3);
-        $manipulation->manipulate($this->mockConfig);
-    }
-
-    public function test_manipulate_ThrowIfConfigArrayDoesntExistForSettingPosition(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Trying to delete not existing config in array setting [Section] config_setting_two[3].');
-
-        $manipulation = new ConfigDeletingManipulation("Section", 'config_setting_two', false, 3);
         $manipulation->manipulate($this->mockConfig);
     }
 
@@ -179,8 +156,6 @@ class ConfigDeletingManipulationTest extends TestCase
             array("Section", 'config_setting_two', false, null, array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_three' => array('a', 'b'), 'config_setting_for' => false))),
             // Array setting delete
             array("Section", 'config_setting_three', false, null, array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_two' => 25, 'config_setting_for' => false))),
-            // Array setting position delete
-            array("Section", 'config_setting_three', false, 1, array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_two' => 25, 'config_setting_three' => array('a'), 'config_setting_for' => false))),
         );
     }
 }

--- a/plugins/CoreAdminHome/tests/Unit/DeleteConfig/ConfigDeletingManipulationTest.php
+++ b/plugins/CoreAdminHome/tests/Unit/DeleteConfig/ConfigDeletingManipulationTest.php
@@ -86,36 +86,21 @@ class ConfigDeletingManipulationTest extends TestCase
      * @param $assignmentString
      * @param $expectedSectionName
      * @param $expectedSettingName
-     * @param $expectedIsSectionDeletion
      */
-    public function test_make_CreatesCorrectManipulation($assignmentString, $expectedSectionName, $expectedSettingName, $expectedIsSectionDeletion): void
+    public function test_make_CreatesCorrectManipulation($assignmentString, $expectedSectionName, $expectedSettingName): void
     {
         $manipulation = ConfigDeletingManipulation::make($assignmentString);
 
         $this->assertEquals($expectedSectionName, $manipulation->getSectionName());
         $this->assertEquals($expectedSettingName, $manipulation->getName());
-        $this->assertEquals($expectedIsSectionDeletion, $manipulation->isSectionDeletion());
     }
 
     public function getTestDataForMake(): array
     {
         return array(
             // Setting Delete
-            array("General.myconfig", "General", "myconfig", false),
-
-            // Section delete
-            array("General", "General", null, true),
-
+            array("General.myconfig", "General", "myconfig"),
         );
-    }
-
-    public function test_manipulate_ThrowIfSectionDoesntExists(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Trying to delete not existing config section [General]');
-
-        $manipulation = new ConfigDeletingManipulation("General", null, true);
-        $manipulation->manipulate($this->mockConfig);
     }
 
     public function test_manipulate_ThrowIfConfigSettingDoesntExists(): void
@@ -132,13 +117,11 @@ class ConfigDeletingManipulationTest extends TestCase
      *
      * @param $sectionName
      * @param $name
-     * @param $isSectionDeletion
-     * @param $settingPositionToDelete
      * @param $expectedConfig
      */
-    public function test_manipulate_CorrectlyManipulatesConfig($sectionName, $name, $isSectionDeletion, $settingPositionToDelete, $expectedConfig): void
+    public function test_manipulate_CorrectlyManipulatesConfig($sectionName, $name, $expectedConfig): void
     {
-        $manipulation = new ConfigDeletingManipulation($sectionName, $name, $isSectionDeletion, $settingPositionToDelete);
+        $manipulation = new ConfigDeletingManipulation($sectionName, $name);
         $manipulation->manipulate($this->mockConfig);
 
         $this->assertEquals($expectedConfig, $this->mockConfig->mockConfigData);
@@ -150,12 +133,10 @@ class ConfigDeletingManipulationTest extends TestCase
     public function getTestDataForManipulate():array
     {
         return array(
-            // Section delete (string, string, bool, int)
-            array("Section", null, true, null, array("Section" => null)),
             // Setting delete
-            array("Section", 'config_setting_two', false, null, array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_three' => array('a', 'b'), 'config_setting_for' => false))),
+            array("Section", 'config_setting_two', array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_three' => array('a', 'b'), 'config_setting_for' => false))),
             // Array setting delete
-            array("Section", 'config_setting_three', false, null, array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_two' => 25, 'config_setting_for' => false))),
+            array("Section", 'config_setting_three', array("Section" =>  array('config_setting' => "stringvalue", 'config_setting_two' => 25, 'config_setting_for' => false))),
         );
     }
 }


### PR DESCRIPTION
This PR tries to add the delete command for config file. For array positions deletion, just admit numeric number because if  the code removes one labeled position from the array, all other keys are lost (dumpConfig method related), so I preferred to avoid bad config generation. 