### PR TITLE
support demo.matomo.cloud as demo url

### DIFF
--- a/plugins/CoreHome/templates/_headerMessage.twig
+++ b/plugins/CoreHome/templates/_headerMessage.twig
@@ -1,7 +1,7 @@
 {# testing, remove test_ from var names #}
 {% set test_latest_version_available="4.0.0" %}
 {% set test_piwikUrl='https://demo.matomo.org/' %}
-{% set isPiwikDemo %}{{ piwikUrl == 'http://demo.matomo.org/' or piwikUrl == 'https://demo.matomo.org/' or piwikUrl == 'https://demo.matomo.cloud/' or  or piwikUrl == 'http://demo.matomo.cloud/' }}{% endset %}
+{% set isPiwikDemo %}{{ piwikUrl == 'http://demo.matomo.org/' or piwikUrl == 'https://demo.matomo.org/' or piwikUrl == 'https://demo.matomo.cloud/' or piwikUrl == 'http://demo.matomo.cloud/' }}{% endset %}
 
 {% set updateCheck %}
     <span id="updateCheckLinkContainer">

--- a/plugins/CoreHome/templates/_headerMessage.twig
+++ b/plugins/CoreHome/templates/_headerMessage.twig
@@ -1,7 +1,7 @@
 {# testing, remove test_ from var names #}
 {% set test_latest_version_available="4.0.0" %}
 {% set test_piwikUrl='https://demo.matomo.org/' %}
-{% set isPiwikDemo %}{{ piwikUrl == 'http://demo.matomo.org/' or piwikUrl == 'https://demo.matomo.org/' }}{% endset %}
+{% set isPiwikDemo %}{{ piwikUrl == 'http://demo.matomo.org/' or piwikUrl == 'https://demo.matomo.org/' or piwikUrl == 'https://demo.matomo.cloud/' or  or piwikUrl == 'http://demo.matomo.cloud/' }}{% endset %}
 
 {% set updateCheck %}
     <span id="updateCheckLinkContainer">


### PR DESCRIPTION
There is also some usage in api controller re `prefixUrl` but not sure what it is used and won't change it for now. Will create separate PR if needed