### PR TITLE
don't install unneeded polyfills with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,14 @@
         "symfony/var-dumper": "~2.6.0",
         "symfony/yaml": "~2.6.0"
     },
+    "replace": {
+        "symfony/polyfill-php54": "*",
+        "symfony/polyfill-php55": "*",
+        "symfony/polyfill-php56": "*",
+        "symfony/polyfill-php70": "*",
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-php72": "*"
+    },
     "repositories": [
         {
             "type": "package",


### PR DESCRIPTION
see https://github.com/symfony/polyfill/blob/main/README.md#design

This removes `symfony/polyfill-php56` on the next `composer install`