### PR TITLE
Print error message when activating a plugin

### DIFF
--- a/plugins/CorePluginsAdmin/Commands/ActivatePlugin.php
+++ b/plugins/CorePluginsAdmin/Commands/ActivatePlugin.php
@@ -43,8 +43,13 @@ class ActivatePlugin extends ConsoleCommand
                 continue;
             }
 
-            $pluginManager->activatePlugin($plugin);
-
+            try {
+                $pluginManager->activatePlugin($plugin);
+            } catch (\Exception $e) {
+                $output->writeln(sprintf('Could not activate plugin %s. Message: %s Trace %s', $plugin, $e->getMessage(), ExceptionToTextProcessor::getWholeBacktrace($e)));
+                throw $e;
+            }
+            
             $output->writeln("Activated plugin <info>$plugin</info>");
         }
     }


### PR DESCRIPTION
I know the error message should be printed anyway when the exception is triggered but we can't easily get the error on the cloud.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
