### PR TITLE
Fix spelling of "Pie chart"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -340,7 +340,7 @@
         "ParameterMustIntegerBetween": "Parameter %1$s must be an integer value between %2$s and %3$s.",
         "Password": "Password",
         "Period": "Period",
-        "Piechart": "Piechart",
+        "Piechart": "Pie chart",
         "Print": "Print",
         "Profiles": "Profiles",
         "MatomoIsACollaborativeProjectYouCanContributeAndDonateNextRelease": "%1$sMatomo%2$s, formerly known as Piwik, is a collaborative project brought to you by the %7$sMatomo team%8$s members as well as many other contributors around the globe. <br/> If you're a fan of Matomo, you can help: find out %3$sHow to participate in Matomo%4$s, or %5$sdonate now%6$s to help fund the next great Matomo release!",


### PR DESCRIPTION
Pie chart should be two words instead of one.

### Description:

@mattab advised to open issue re pie chart wording. 

### Review

None. This looks like it should work, but not sure how you specifically manage string translation.
