### PR TITLE
Added whitespace to the bottom of email template

### DIFF
--- a/plugins/CoreHome/templates/_htmlEmailHeader.twig
+++ b/plugins/CoreHome/templates/_htmlEmailHeader.twig
@@ -31,4 +31,4 @@
     </tr>
 </table>
 
-<div style="margin:0 20px;">
+<div style="margin:0 20px 25px 20px;">


### PR DESCRIPTION
### Description:

The issue was that the div element that wrapped the contents of the email had both top and bottom margins set to zero. There is spacing between the email text and the (dark blue) header thanks to the 25px bottom margin on the header. Added a matching 25px bottom margin on the wrapper div.

Fixes #13953.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
