### PR TITLE
Show invalidation information in system check

### DIFF
--- a/plugins/Diagnostics/Diagnostic/ReportInformational.php
+++ b/plugins/Diagnostics/Diagnostic/ReportInformational.php
@@ -8,6 +8,7 @@
 namespace Piwik\Plugins\Diagnostics\Diagnostic;
 
 use Piwik\Access;
+use Piwik\Archive\ArchiveInvalidator;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Common;
 use Piwik\CronArchive;
@@ -47,9 +48,25 @@ class ReportInformational implements Diagnostic
             $results[] = DiagnosticResult::informationalResult('Had visits in last 5 days', $this->hadVisitsInLastDays(5));
             $results[] = DiagnosticResult::informationalResult('Archive Time Last Started', Option::get(CronArchive::OPTION_ARCHIVING_STARTED_TS));
             $results[] = DiagnosticResult::informationalResult('Archive Time Last Finished', Option::get(CronArchive::OPTION_ARCHIVING_FINISHED_TS));
+            $numQueued = $this->getNumInvalidationEntries(ArchiveInvalidator::INVALIDATION_STATUS_QUEUED);
+            $numInProgress = $this->getNumInvalidationEntries(ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS);
+            $results[] = DiagnosticResult::informationalResult('Num invalidations', sprintf('%s queued, %s in progress', $numQueued, $numInProgress));
         }
 
         return $results;
+    }
+
+    private function getNumInvalidationEntries($status)
+    {
+        $table = Common::prefixTable('archive_invalidations');
+
+        try {
+            $numEntries = Db::fetchOne('SELECT count(*) from ' . $table . ' WHERE status = ?' , $status);
+        } catch ( \Exception $e ) {
+            $numEntries = '';
+        }
+
+        return $numEntries;
     }
 
     private function hadVisitsInLastDays($numDays)

--- a/plugins/Diagnostics/Diagnostic/ReportInformational.php
+++ b/plugins/Diagnostics/Diagnostic/ReportInformational.php
@@ -61,7 +61,7 @@ class ReportInformational implements Diagnostic
         $table = Common::prefixTable('archive_invalidations');
 
         try {
-            $numEntries = Db::fetchOne('SELECT count(*) from ' . $table . ' WHERE status = ?' , $status);
+            $numEntries = Db::fetchOne('SELECT count(*) from ' . $table . ' WHERE `status` = ?' , $status);
         } catch ( \Exception $e ) {
             $numEntries = '';
         }

--- a/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
+++ b/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c76ce7fafabe97279dcb89cd95bd565242486a5ce61ba5a3415bc82430f9c67b
-size 377534
+oid sha256:cf45155d18d773995af6800df3aea2b1a6f481b61a2087bf3f3eaf3596f5cf51
+size 381947


### PR DESCRIPTION
### Description:

refs https://github.com/matomo-org/matomo/issues/16689 adds information about archive invalidation entries to the informational system check output so we don't need to ask users to run queries. Can help understand archiving issues.
fyi @diosmosis  maybe something else be useful too?

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
