### PR TITLE
Better anonymising of data

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -455,20 +455,6 @@ class Twig
             if (SettingsPiwik::isMatomoInstalled()) {
                 $string = str_replace(SettingsPiwik::getPiwikUrl(), '$MATOMO_URL', $string);
                 $string = str_replace(SettingsPiwik::getSalt(), '$MATOMO_SALT', $string);
-
-                $config = Config::getInstance();
-                $db = $config->database;
-                $checks = [
-                    '$DB_USERNAME'=> $db['username'],
-                    '$DB_PASSWORD'=> $db['password'],
-                    '$DB_HOST'=> $db['host'],
-                    '$DB_NAME'=> $db['dbname']
-                ];
-                foreach ($checks as $replacement => $value) {
-                    if ($string === $value) {
-                        $string = $replacement;
-                    }
-                }
             }
             return $string;
         });

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -458,10 +458,17 @@ class Twig
 
                 $config = Config::getInstance();
                 $db = $config->database;
-                $string = str_replace($db['username'], '$DB_USERNAME', $string);
-                $string = str_replace($db['password'], '$DB_PASSWORD', $string);
-                $string = str_replace($db['host'], '$DB_HOST', $string);
-                $string = str_replace($db['dbname'], '$DB_NAME', $string);
+                $checks = [
+                    '$DB_USERNAME'=> $db['username'],
+                    '$DB_PASSWORD'=> $db['password'],
+                    '$DB_HOST'=> $db['host'],
+                    '$DB_NAME'=> $db['dbname']
+                ];
+                foreach ($checks as $replacement => $value) {
+                    if ($string === $value) {
+                        $string = $replacement;
+                    }
+                }
             }
             return $string;
         });


### PR DESCRIPTION
### Description:

This anonymise filter is used in the system check page where the user can copy an anonymised version of the system report.

I noticed for example should the DB prefix be `matomo_` and the DB user be `matomo`, then the system check would actually say `DB Prefix: $DB_USERNAME_` and thus exposing that the DB username is `matomo`. In a similar way if say the DB host is `localhost`, and some value in the system check page includes `localhost` when this would be replaced with `$DB_HOST` and therefore exposing the host.

I now changed it to an equals so `$DB_USERNAME` or `$DB_HOST` will only be shown when the value matches, not contains. This can be still an issue though eg when the DB prefix is `matomo` or a value in the system check page is `localhost`. So maybe we should actually just remove the replacement of these DB related variables to not accidentally leak any information. Will change this in the following commit to no longer do any such replacement.

I guess it was there just in case someone would add print DB User in a system check entry or through some kind of backtrace or something but thinking about it, it should not be an issue.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
