### PR TITLE
Fix methods to get plugin de-/activation time.

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -524,7 +524,7 @@ class Plugin
         if (empty($time)) {
             return null;
         }
-        return Date::factory($time);
+        return Date::factory((int) $time);
     }
 
     /**
@@ -538,7 +538,7 @@ class Plugin
         if (empty($time)) {
             return null;
         }
-        return Date::factory($time);
+        return Date::factory((int) $time);
     }
 
     /**


### PR DESCRIPTION
### Description:

Getting plugin de/activation time might throw an exception if option value is returned as string instead of integer.
Came across that while testing #16702 with one of the plugin PRs. Might be depending on the database configuration, as the tests pass locally. But when using the methods in a plugin the option value is returned as a string resulting in an exception: `Date format must be: YYYY-MM-DD, or 'today' or 'yesterday' or any keyword supported by the strtotime function (see http://php.net/strtotime for more information)`

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
