### PR TITLE
fix parameter order in quickform

### DIFF
--- a/libs/HTML/QuickForm2/Node.php
+++ b/libs/HTML/QuickForm2/Node.php
@@ -678,7 +678,7 @@ abstract class HTML_QuickForm2_Node extends HTML_Common2
         return $value;
     }
 
-    protected static function applyFilter(&$value, $key = null, $filter)
+    protected static function applyFilter(&$value, $key, $filter)
     {
         $callback = $filter[0];
         $options  = $filter[1];


### PR DESCRIPTION
Just saw the deprecation warning when testing PHP 8

> PHP Deprecated:  Required parameter $filter follows optional parameter $key in /var/www/matomo/libs/HTML/QuickForm2/Node.php on line 681

It is only called in those two lines:
https://github.com/matomo-org/matomo/blob/0d661042eccc028079732ade3244bb102550655d/libs/HTML/QuickForm2/Node.php#L670-L676

The second one is safe, I am not too sure about the first one.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
