### PR TITLE
backport confirm password fix for loginldap on 3.x

### DIFF
--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -223,9 +223,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
             }
         }
 
-        return $this->renderTemplate('confirmPassword', array(
+        return $this->renderTemplate('@Login/confirmPassword', array(
             'nonce' => Nonce::getNonce($nonceKey),
-            'AccessErrorString' => $messageNoAccess
+            'AccessErrorString' => $messageNoAccess,
+            'loginPlugin' => Piwik::getLoginPluginName(),
         ));
     }
 

--- a/plugins/Login/PasswordVerifier.php
+++ b/plugins/Login/PasswordVerifier.php
@@ -189,7 +189,7 @@ class PasswordVerifier
         $sessionNamespace->setExpirationSeconds(self::VERIFY_VALID_FOR_MINUTES * 60 * 5, 'redirectParams');
 
         if ($this->enableRedirect) {
-            Piwik::redirectToModule('Login', 'confirmPassword');
+            Piwik::redirectToModule(Piwik::getLoginPluginName(), 'confirmPassword');
         }
     }
 }

--- a/plugins/Login/templates/confirmPassword.twig
+++ b/plugins/Login/templates/confirmPassword.twig
@@ -17,7 +17,7 @@
                 {% endif %}
             </div>
 
-            <form action="{{ linkTo({'module': 'Login', 'action': 'confirmPassword'}) }}" ng-non-bindable method="post">
+            <form action="{{ linkTo({'module': loginPlugin, 'action': 'confirmPassword'}) }}" ng-non-bindable method="post">
                 <div class="row">
                     <div class="col s12 input-field">
                         <input type="hidden" name="nonce" id="login_form_nonce" value="{{ nonce }}"/>


### PR DESCRIPTION
### Description:

Use activated login plugin method in confirm password workflow, not Login since it will be deactivated when another login plugin exists.

### Todo

* [ ] after merge and release, release new LoginLdap 3.x series

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
