### PR TITLE
Workaround shell_exec being disabled

### DIFF
--- a/core/CliMulti/CliPhp.php
+++ b/core/CliMulti/CliPhp.php
@@ -45,8 +45,8 @@ class CliPhp
             $bin = $this->getPhpCommandIfValid($possiblePhpPath);
         }
 
-        if (!$this->isValidPhpType($bin)) {
-            $bin = shell_exec('which php');
+        if (!$this->isValidPhpType($bin) && function_exists('shell_exec')) {
+            $bin = @shell_exec('which php');
         }
 
         if (!$this->isValidPhpType($bin)) {
@@ -73,7 +73,7 @@ class CliPhp
     {
         global $piwik_minimumPHPVersion;
         $cliVersion = $this->getPhpVersion($bin);
-        $isCliVersionValid = version_compare($piwik_minimumPHPVersion, $cliVersion) <= 0;
+        $isCliVersionValid = $cliVersion && version_compare($piwik_minimumPHPVersion, $cliVersion) <= 0;
         return $isCliVersionValid;
     }
 
@@ -107,7 +107,10 @@ class CliPhp
     private function getPhpVersion($bin)
     {
         $command = sprintf("%s -r 'echo phpversion();'", $bin);
-        $version = shell_exec($command);
+        $version = null;
+        if (function_exists('shell_exec')) {
+            $version = @shell_exec($command);
+        }
         return $version;
     }
 }


### PR DESCRIPTION
### Description:

Prevent error like this:
> Backtrace from warning 'shell_exec() has been disabled for security reasons' at /wp-content/plugins/matomo/app/core/CliMulti/CliPhp.php 43:

in WordPress System Report. There are probably few other shell_exec usages but probably not needed to adjust these for now.


### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
