### PR TITLE
DB-IP URL is automatically updated in the options

### DIFF
--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -102,12 +102,13 @@ class GeoIP2AutoUpdater extends Task
             $locUrl = Option::get(self::LOC_URL_OPTION_NAME);
             if (!empty($locUrl)) {
                 $this->downloadFile('loc', $locUrl);
-                $this->updateDbIpUrlOption($locUrl);
+                $this->updateDbIpUrlOption(self::LOC_URL_OPTION_NAME, $locUrl);
             }
 
             $ispUrl = Option::get(self::ISP_URL_OPTION_NAME);
             if (!empty($ispUrl)) {
                 $this->downloadFile('isp', $ispUrl);
+                $this->updateDbIpUrlOption(self::ISP_URL_OPTION_NAME, $ispUrl);
             }
         } catch (Exception $ex) {
             // message will already be prefixed w/ 'GeoIP2AutoUpdater: '
@@ -806,18 +807,23 @@ class GeoIP2AutoUpdater extends Task
      * instead of the one that was set when Matomo was installed months
      * or even years ago.
      *
-     * @param  string  $url The URL retrieved from the options
+     * @param  string  $option The option to check and update: either
+     * self::LOC_URL_OPTION_NAME or self::ISP_URL_OPTION_NAME
+     *
+     * @param  string  $url  The URL retrieved from the options
      */
-    protected function updateDbIpUrlOption(string $url): void
+    protected function updateDbIpUrlOption(string $option, string $url): void
     {
         $url = trim($url);
 
-        if (self::isDbIpUrl($url))
-        {
+        if (
+            self::isDbIpUrl($url)
+            && ($option === self::LOC_URL_OPTION_NAME || $option === self::ISP_URL_OPTION_NAME)
+        ) {
             $latestUrl = $this->getDbIpUrlWithLatestDate($url);
 
             if($url !== $latestUrl) {
-                Option::set(self::LOC_URL_OPTION_NAME, $latestUrl);
+                Option::set($option, $latestUrl);
             }
         }
     }

--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -102,6 +102,7 @@ class GeoIP2AutoUpdater extends Task
             $locUrl = Option::get(self::LOC_URL_OPTION_NAME);
             if (!empty($locUrl)) {
                 $this->downloadFile('loc', $locUrl);
+                $this->updateDbIpUrlOption($locUrl);
             }
 
             $ispUrl = Option::get(self::ISP_URL_OPTION_NAME);
@@ -797,5 +798,27 @@ class GeoIP2AutoUpdater extends Task
     protected function fetchUrl($url)
     {
         return Http::fetchRemoteFile($url);
+    }
+
+    /**
+     * Updates the DB-IP URL option value so that users see
+     * the updated link in the "Download URL" field on the plugin page
+     * instead of the one that was set when Matomo was installed months
+     * or even years ago.
+     *
+     * @param  string  $url The URL retrieved from the options
+     */
+    protected function updateDbIpUrlOption(string $url): void
+    {
+        $url = trim($url);
+
+        if (self::isDbIpUrl($url))
+        {
+            $latestUrl = $this->getDbIpUrlWithLatestDate($url);
+
+            if($url !== $latestUrl) {
+                Option::set(self::LOC_URL_OPTION_NAME, $latestUrl);
+            }
+        }
     }
 }

--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -102,13 +102,13 @@ class GeoIP2AutoUpdater extends Task
             $locUrl = Option::get(self::LOC_URL_OPTION_NAME);
             if (!empty($locUrl)) {
                 $this->downloadFile('loc', $locUrl);
-                $this->updateDbIpUrlOption(self::LOC_URL_OPTION_NAME, $locUrl);
+                $this->updateDbIpUrlOption(self::LOC_URL_OPTION_NAME);
             }
 
             $ispUrl = Option::get(self::ISP_URL_OPTION_NAME);
             if (!empty($ispUrl)) {
                 $this->downloadFile('isp', $ispUrl);
-                $this->updateDbIpUrlOption(self::ISP_URL_OPTION_NAME, $ispUrl);
+                $this->updateDbIpUrlOption(self::ISP_URL_OPTION_NAME);
             }
         } catch (Exception $ex) {
             // message will already be prefixed w/ 'GeoIP2AutoUpdater: '
@@ -809,17 +809,17 @@ class GeoIP2AutoUpdater extends Task
      *
      * @param  string  $option The option to check and update: either
      * self::LOC_URL_OPTION_NAME or self::ISP_URL_OPTION_NAME
-     *
-     * @param  string  $url  The URL retrieved from the options
      */
-    protected function updateDbIpUrlOption(string $option, string $url): void
+    protected function updateDbIpUrlOption(string $option): void
     {
-        $url = trim($url);
+        if ($option !== self::LOC_URL_OPTION_NAME && $option !== self::ISP_URL_OPTION_NAME)
+        {
+            return;
+        }
 
-        if (
-            self::isDbIpUrl($url)
-            && ($option === self::LOC_URL_OPTION_NAME || $option === self::ISP_URL_OPTION_NAME)
-        ) {
+        $url = trim(Option::get($option));
+
+        if (self::isDbIpUrl($url)) {
             $latestUrl = $this->getDbIpUrlWithLatestDate($url);
 
             if($url !== $latestUrl) {


### PR DESCRIPTION
### Description:

Added a method called by the updater task that updates the DB-IP URL if needed to the latest downloaded one instead of the one set in the options when Matomo was initially installed. This removes much of the confusion at seeing a seemingly outdated URL being used on the GeoIP2 plugin page.

Would love to contribute a test as well but need to make sure I add the right test in the right place - I think a system test would be the right one for this method as I'd need to make sure an option was changed?

Tested the changes by manually setting the `geoip2.loc_db_url` option to `https://download.db-ip.com/free/dbip-city-lite-2020-05.mmdb.gz` in the database, then running the updater task with

```bash
./console core:run-scheduled-tasks "Piwik\Plugins\GeoIp2\GeoIP2AutoUpdater.update"
```
Result - option set to `https://download.db-ip.com/free/dbip-city-lite-2020-11.mmdb.gz` and the plugin page now displays the latest URL in the "Download URL" field.

Fixes #16618.

### Review

* [x] Functional review done
* [x] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] Code review done
* [ ] Tests were added if useful/possible
* [x] Reviewed for breaking changes
* [x] Developer changelog updated if needed
* [x] Documentation added if needed
* [x] Existing documentation updated if needed
