### PR TITLE
When token is anonymous do not append force api session

### DIFF
--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -128,7 +128,11 @@ class DocumentationGenerator
 
     protected function addExamples($class, $methodName, $prefixUrls)
     {
-        $token_auth = "&token_auth=" . Piwik::getCurrentUserTokenAuth() . "&force_api_session=1";
+        $token = Piwik::getCurrentUserTokenAuth();
+        $token_auth_URL = "&token_auth=" . $token;
+        if ($token !== 'anonymous') {
+            $token_auth_URL .= "&force_api_session=1";
+        }
         $parametersToSet = array(
             'idSite' => Common::getRequestVar('idSite', 1, 'int'),
             'period' => Common::getRequestVar('period', 'day', 'string'),
@@ -141,13 +145,13 @@ class DocumentationGenerator
             $lastNUrls = '';
             if (preg_match('/(&period)|(&date)/', $exampleUrl)) {
                 $exampleUrlRss = $prefixUrls . $this->getExampleUrl($class, $methodName, array('date' => 'last10', 'period' => 'day') + $parametersToSet);
-                $lastNUrls = ", RSS of the last <a target='_blank' href='$exampleUrlRss&format=rss$token_auth&translateColumnNames=1'>10 days</a>";
+                $lastNUrls = ", RSS of the last <a target='_blank' href='$exampleUrlRss&format=rss$token_auth_URL&translateColumnNames=1'>10 days</a>";
             }
             $exampleUrl = $prefixUrls . $exampleUrl;
             $str .= " [ Example in
-                                                                    <a target='_blank' href='$exampleUrl&format=xml$token_auth'>XML</a>,
-                                                                    <a target='_blank' href='$exampleUrl&format=JSON$token_auth'>Json</a>,
-                                                                    <a target='_blank' href='$exampleUrl&format=Tsv$token_auth&translateColumnNames=1'>Tsv (Excel)</a>
+                                                                    <a target='_blank' href='$exampleUrl&format=xml$token_auth_URL'>XML</a>,
+                                                                    <a target='_blank' href='$exampleUrl&format=JSON$token_auth_URL'>Json</a>,
+                                                                    <a target='_blank' href='$exampleUrl&format=Tsv$token_auth_URL&translateColumnNames=1'>Tsv (Excel)</a>
                                                                     $lastNUrls
                                                                     ]";
         } else {

--- a/core/API/DocumentationGenerator.php
+++ b/core/API/DocumentationGenerator.php
@@ -129,9 +129,9 @@ class DocumentationGenerator
     protected function addExamples($class, $methodName, $prefixUrls)
     {
         $token = Piwik::getCurrentUserTokenAuth();
-        $token_auth_URL = "&token_auth=" . $token;
+        $token_auth_url = "&token_auth=" . $token;
         if ($token !== 'anonymous') {
-            $token_auth_URL .= "&force_api_session=1";
+            $token_auth_url .= "&force_api_session=1";
         }
         $parametersToSet = array(
             'idSite' => Common::getRequestVar('idSite', 1, 'int'),
@@ -145,13 +145,13 @@ class DocumentationGenerator
             $lastNUrls = '';
             if (preg_match('/(&period)|(&date)/', $exampleUrl)) {
                 $exampleUrlRss = $prefixUrls . $this->getExampleUrl($class, $methodName, array('date' => 'last10', 'period' => 'day') + $parametersToSet);
-                $lastNUrls = ", RSS of the last <a target='_blank' href='$exampleUrlRss&format=rss$token_auth_URL&translateColumnNames=1'>10 days</a>";
+                $lastNUrls = ", RSS of the last <a target='_blank' href='$exampleUrlRss&format=rss$token_auth_url&translateColumnNames=1'>10 days</a>";
             }
             $exampleUrl = $prefixUrls . $exampleUrl;
             $str .= " [ Example in
-                                                                    <a target='_blank' href='$exampleUrl&format=xml$token_auth_URL'>XML</a>,
-                                                                    <a target='_blank' href='$exampleUrl&format=JSON$token_auth_URL'>Json</a>,
-                                                                    <a target='_blank' href='$exampleUrl&format=Tsv$token_auth_URL&translateColumnNames=1'>Tsv (Excel)</a>
+                                                                    <a target='_blank' href='$exampleUrl&format=xml$token_auth_url'>XML</a>,
+                                                                    <a target='_blank' href='$exampleUrl&format=JSON$token_auth_url'>Json</a>,
+                                                                    <a target='_blank' href='$exampleUrl&format=Tsv$token_auth_url&translateColumnNames=1'>Tsv (Excel)</a>
                                                                     $lastNUrls
                                                                     ]";
         } else {


### PR DESCRIPTION
### Description:

When viewing the list of API's in Matomo otherwise the example URL looks like https://demo.matomo.cloud/?module=API&method=DevicesDetection.getModel&idSite=1&period=day&date=yesterday&format=JSON&token_auth=anonymous&force_api_session=1

By not appending the `force_api_session=1` when token is anonymous users can more easily tweak the token and don't have to manually remove the URL parameter. see eg https://developer.matomo.org/api-reference/reporting-api#CustomAlerts

When the token is anonymous the force_api_session is not needed.

### Review

* [x] Functional review done
* [x] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] Code review done
* [x] Tests were added if useful/possible
* [x] Reviewed for breaking changes
* [x] Developer changelog updated if needed
* [x] Documentation added if needed
* [x] Existing documentation updated if needed
