### PR TITLE
Add convenience method for rescheduling archiving for a single plugin.

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -8,6 +8,8 @@
  */
 namespace Piwik;
 
+use Piwik\Archive\ArchiveInvalidator;
+use Piwik\Container\StaticContainer;
 use Piwik\Plugin\Dependency;
 use Piwik\Plugin\Manager;
 use Piwik\Plugin\MetadataLoader;
@@ -461,6 +463,38 @@ class Plugin
         ));
     }
 
+    /**
+     * Schedules re-archiving of this plugin's reports from when this plugin was last
+     * deactivated to now. If the last time core:archive was run is earlier than the
+     * plugin's last deactivation time, then we use that time instead.
+     *
+     * Note: this only works for CLI archiving setups.
+     *
+     * Note: the time frame is limited by the `[General] rearchive_reports_in_past_last_n_months`
+     * INI config value.
+     *
+     * @throws \DI\DependencyException
+     * @throws \DI\NotFoundException
+     */
+    public function schedulePluginReArchiving()
+    {
+        $lastDeactivationTime = $this->getPluginLastDeactivationTime();
+
+        $dateTime = null;
+
+        $lastCronArchiveTime = (int) Option::get(CronArchive::OPTION_ARCHIVING_FINISHED_TS);
+        if (empty($lastCronArchiveTime)) {
+            $dateTime = $lastDeactivationTime;
+        } else if (empty($lastDeactivationTime)) {
+            $dateTime = $lastCronArchiveTime;
+        } else {
+            $lastCronArchiveTime = Date::factory($lastCronArchiveTime);
+            $dateTime = $lastDeactivationTime->isEarlier($lastCronArchiveTime) ? $lastDeactivationTime : $lastCronArchiveTime;
+        }
+
+        $archiveInvalidator = StaticContainer::get(ArchiveInvalidator::class);
+        $archiveInvalidator->scheduleReArchiving('all', $this->getPluginName(), $report = null, $dateTime);
+    }
 
     /**
      * Extracts the plugin name from a backtrace array. Returns `false` if we can't find one.

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -486,7 +486,7 @@ class Plugin
         if (empty($lastCronArchiveTime)) {
             $dateTime = $lastDeactivationTime;
         } else if (empty($lastDeactivationTime)) {
-            $dateTime = $lastCronArchiveTime;
+            $dateTime = Date::factory($lastCronArchiveTime);
         } else {
             $lastCronArchiveTime = Date::factory($lastCronArchiveTime);
             $dateTime = $lastDeactivationTime->isEarlier($lastCronArchiveTime) ? $lastDeactivationTime : $lastCronArchiveTime;

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -492,6 +492,10 @@ class Plugin
             $dateTime = $lastDeactivationTime->isEarlier($lastCronArchiveTime) ? $lastDeactivationTime : $lastCronArchiveTime;
         }
 
+        if (empty($dateTime)) { // sanity check
+            $dateTime = null;
+        }
+
         $archiveInvalidator = StaticContainer::get(ArchiveInvalidator::class);
         $archiveInvalidator->scheduleReArchiving('all', $this->getPluginName(), $report = null, $dateTime);
     }

--- a/tests/PHPUnit/Integration/PluginTest.php
+++ b/tests/PHPUnit/Integration/PluginTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace PHPUnit\Integration;
+
+use Piwik\Common;
+use Piwik\CronArchive;
+use Piwik\CronArchive\ReArchiveList;
+use Piwik\Date;
+use Piwik\Db;
+use Piwik\Option;
+use Piwik\Plugin;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+class PluginTest extends IntegrationTestCase
+{
+    protected static function beforeTableDataCached()
+    {
+        parent::beforeTableDataCached();
+
+        Fixture::createWebsite('2020-03-04 00:00:00');
+    }
+
+    public function test_schedulePluginReArchiving_shouldReArchiveFromLastDeactivationTime()
+    {
+        $time = Date::today()->subDay(3);
+        Option::set(Plugin\Manager::LAST_PLUGIN_DEACTIVATION_TIME_OPTION_PREFIX . 'ExamplePlugin', $time->getTimestamp());
+
+        $plugin = new Plugin('ExamplePlugin');
+        $plugin->schedulePluginReArchiving();
+
+        $date = $this->getDateFromReArchiveList();
+        $this->assertEquals($time->getDatetime(), $date);
+    }
+
+    public function test_schedulePluginReArchiving_shouldReArchiveFromLastCoreArchiveTimeIfEarlier()
+    {
+        $time = Date::today()->subDay(3);
+        Option::set(Plugin\Manager::LAST_PLUGIN_DEACTIVATION_TIME_OPTION_PREFIX . 'ExamplePlugin', $time->getTimestamp());
+
+        $cronTime = Date::today()->subDay(5);
+        Option::set(CronArchive::OPTION_ARCHIVING_FINISHED_TS, $cronTime->getTimestamp());
+
+        $plugin = new Plugin('ExamplePlugin');
+        $plugin->schedulePluginReArchiving();
+
+        $date = $this->getDateFromReArchiveList();
+        $this->assertEquals($cronTime->getDatetime(), $date);
+    }
+
+    public function test_schedulePluginReArchiving_shouldReArchiveFromNMonthsAgo_IfNoDecativationTimeOrCronTimeExists()
+    {
+        $plugin = new Plugin('ExamplePlugin');
+        $plugin->schedulePluginReArchiving();
+
+        $date = $this->getDateFromReArchiveList();
+        $this->assertNull($date);
+    }
+
+    private function getDateFromReArchiveList()
+    {
+        $list = new ReArchiveList();
+        $items = $list->getAll();
+
+        $item = reset($items);
+        $item = json_decode($item, $assocc = true);
+
+        $date = end($item);
+        if (empty($date)) {
+            return $date;
+        }
+
+        return Date::factory($date)->getDatetime();
+    }
+
+}

--- a/tests/PHPUnit/Integration/PluginTest.php
+++ b/tests/PHPUnit/Integration/PluginTest.php
@@ -55,6 +55,18 @@ class PluginTest extends IntegrationTestCase
         $this->assertEquals($cronTime->getDatetime(), $date);
     }
 
+    public function test_schedulePluginReArchiving_shouldReArchiveFromLastCoreArchiveTimeIfNoDeactivation()
+    {
+        $cronTime = Date::today()->subDay(5);
+        Option::set(CronArchive::OPTION_ARCHIVING_FINISHED_TS, $cronTime->getTimestamp());
+
+        $plugin = new Plugin('ExamplePlugin');
+        $plugin->schedulePluginReArchiving();
+
+        $date = $this->getDateFromReArchiveList();
+        $this->assertEquals($cronTime->getDatetime(), $date);
+    }
+
     public function test_schedulePluginReArchiving_shouldReArchiveFromNMonthsAgo_IfNoDecativationTimeOrCronTimeExists()
     {
         $plugin = new Plugin('ExamplePlugin');


### PR DESCRIPTION
### Description:

Add new method Plugin::schedulePluginReArchiving() to allow rescheduling archiving for a plugin.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
