### PR TITLE
take into account broken archive invalidations when resetting failed jobs

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -871,7 +871,7 @@ class Model
     public function resetFailedArchivingJobs()
     {
         $table = Common::prefixTable('archive_invalidations');
-        $sql = "UPDATE $table SET status = ? WHERE status = ? AND ts_started IS NOT NULL AND ts_started < ?";
+        $sql = "UPDATE $table SET status = ? WHERE status = ? AND (ts_started IS NULL OR ts_started < ?)";
 
         $bind = [
             ArchiveInvalidator::INVALIDATION_STATUS_QUEUED,


### PR DESCRIPTION
### Description:

Refs #16689 

Take into account broken archive invalidations that do not have ts_started set (since they were added before ts_started was introduced).

cc @tsteur 

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
