### PR TITLE
Improve newly added dimensions/metrics

### DIFF
--- a/plugins/DevicePlugins/Columns/DevicePluginColumn.php
+++ b/plugins/DevicePlugins/Columns/DevicePluginColumn.php
@@ -8,6 +8,8 @@
  */
 namespace Piwik\Plugins\DevicePlugins\Columns;
 
+use Piwik\Columns\DimensionMetricFactory;
+use Piwik\Columns\MetricsList;
 use Piwik\Plugin\Dimension\VisitDimension;
 
 /**
@@ -22,4 +24,8 @@ abstract class DevicePluginColumn extends VisitDimension
      * set a custom icon not included in Piwik Core
      */
     public $columnIcon = null;
+
+    public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)
+    {
+    }
 }

--- a/plugins/DevicePlugins/Columns/DevicePluginColumn.php
+++ b/plugins/DevicePlugins/Columns/DevicePluginColumn.php
@@ -10,6 +10,7 @@ namespace Piwik\Plugins\DevicePlugins\Columns;
 
 use Piwik\Columns\DimensionMetricFactory;
 use Piwik\Columns\MetricsList;
+use Piwik\Piwik;
 use Piwik\Plugin\Dimension\VisitDimension;
 
 /**
@@ -27,5 +28,9 @@ abstract class DevicePluginColumn extends VisitDimension
 
     public function configureMetrics(MetricsList $metricsList, DimensionMetricFactory $dimensionMetricFactory)
     {
+        $name = Piwik::translate('General_VisitsWith', [$this->getName()]);
+
+        $metric = $dimensionMetricFactory->createCustomMetric('nb_visits_with_'.$this->getMetricId(), $name, 'sum(%s)');
+        $metricsList->addMetric($metric);
     }
 }

--- a/plugins/UserCountry/Columns/Provider.php
+++ b/plugins/UserCountry/Columns/Provider.php
@@ -19,8 +19,7 @@ class Provider extends Base
     protected $columnName = 'location_provider';
     protected $type = self::TYPE_TEXT;
     protected $category = 'UserCountry_VisitLocation';
-    protected $nameSingular = 'UserCountry_InternetServiceProvider';
-    protected $namePlural = 'UserCountry_InternetServiceProviderPlural';
+
     /**
      * @param Request $request
      * @param Visitor $visitor

--- a/plugins/UserCountry/lang/en.json
+++ b/plugins/UserCountry/lang/en.json
@@ -42,8 +42,6 @@
         "ToGeolocateOldVisits": "To get location data for your old visits, use the script described %1$shere%2$s.",
         "WidgetLocation": "Visitor Location",
         "GeoIpDbIpAccuracyNote": "Note: the DBIP databases are free and can be downloaded automatically, but geolocation results (specifically city results) are not as accurate as MaxMind's. MaxMind, however, requires that you create an account even for the free database. If you want to use MaxMind's geolocation database, you can start the process %1$shere%2$s",
-        "MaxMindLinkExplanation": "If you are using MaxMind's geolocation databases and you do not already know how to generate your download URL, %1$sclick here to learn how%2$s.",
-        "InternetServiceProvider": "Internet Service Provider",
-        "InternetServiceProviderPlural": "Internet Service Providers"
+        "MaxMindLinkExplanation": "If you are using MaxMind's geolocation databases and you do not already know how to generate your download URL, %1$sclick here to learn how%2$s."
     }
 }


### PR DESCRIPTION
### Description:

Due to #16684 some dimensions are not showing up in custom reports and have automatically configured metrics. Some of them are not useful:

* The Provider column shouldn't have a name, as it should not appear as dimension at all. It's already available through Provider plugin and will/should be moved there in the future.

* All browser plugin dimensions are currently having automatically configured metrics. But metrics such as `Avg. Plugin (Java) Per Visit` doesn't make sense. So only configure a useful metric for each plugin.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
