### PR TITLE
Do not allow uninstalling custom variables and provider for a while

### DIFF
--- a/core/Application/Kernel/PluginList.php
+++ b/core/Application/Kernel/PluginList.php
@@ -44,7 +44,9 @@ class PluginList
         'ExampleReport',
         'ExampleAPI',
         'MobileAppMeasurable',
-        'TagManager'
+        'TagManager',
+        'CustomVariables',
+        'Provider'
     );
 
     // Themes bundled with core package, disabled by default

--- a/core/Application/Kernel/PluginList.php
+++ b/core/Application/Kernel/PluginList.php
@@ -44,9 +44,7 @@ class PluginList
         'ExampleReport',
         'ExampleAPI',
         'MobileAppMeasurable',
-        'TagManager',
-        'CustomVariables',
-        'Provider'
+        'TagManager'
     );
 
     // Themes bundled with core package, disabled by default

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -866,7 +866,7 @@ class Manager
     {
         return $this->isPluginEnabledByDefault($name)
         || in_array($name, $this->pluginList->getCorePluginsDisabledByDefault())
-        || $name == self::DEFAULT_THEME;
+        || $name == self::DEFAULT_THEME || $name === 'CustomVariables' || $name === 'Provider';
     }
 
     /**

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -666,7 +666,7 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
         $numTestedCorePlugins = 0;
 
         // eg these plugins are managed in a submodule and they are installing all tables/columns as part of their plugin install method etc.
-        $corePluginsThatAreIndependent = array('TagManager');
+        $corePluginsThatAreIndependent = array('TagManager', 'Provider', 'CustomVariables');
 
         foreach ($plugins as $pluginName => $info) {
             if ($manager->isPluginBundledWithCore($pluginName) && !in_array($pluginName, $corePluginsThatAreIndependent)) {

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15e7af3dd4c54248b70a95c565d6e3e705a74eea6c913141a482a367177eb5df
-size 1069526
+oid sha256:51248a0424c5e36335d36274c7f8569dc2d627fece4c689e8fb2fbbd8f2ceb62
+size 1067191

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins_no_internet.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_plugins_no_internet.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aaa3bfb7b4addb2dc837fbbe76cd0916f73292355519d7b668040b5cfdf644a2
-size 1070728
+oid sha256:8c402f9b50e7ed1d29e0ee290e9d6f47b776701649984573519cabd15c37b96c
+size 1069721

--- a/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_fatal_error_safemode.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:297a1d0fa8f939582f441dd401d3654dc57a8ee4d09993bc8819e57ca56fe27a
-size 170116
+oid sha256:0f0f3276be14dce36f52ee9d56e2a1d74fedda4bdee6b8a79a0bf20e926370a5
+size 163454


### PR DESCRIPTION
### Description:

fix https://github.com/matomo-org/matomo/issues/16517 as discussed in the issue

### Review

* [x] Functional review done
* [x] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] Code review done
* [x] Tests were added if useful/possible
* [x] Reviewed for breaking changes
* [x] Developer changelog updated if needed
* [x] Documentation added if needed
* [x] Existing documentation updated if needed
