### PR TITLE
add check for dangling invalidations

### DIFF
--- a/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
+++ b/tests/PHPUnit/Unit/DeprecatedMethodsTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Unit;
 
+use Piwik\CronArchive;
 use Piwik\Date;
 use Piwik\Version;
 use ReflectionClass;
@@ -84,6 +85,9 @@ class DeprecatedMethodsTest extends \PHPUnit\Framework\TestCase
 
         $this->assertDeprecatedMethodIsRemovedInPiwik4('Piwik\SettingsPiwik', 'isPiwikInstalled');
         $this->assertDeprecatedMethodIsRemovedInPiwik4('Piwik\Piwik', 'doAsSuperUser');
+
+        $validTill = '2021-03-01';
+        $this->assertDeprecatedMethodIsRemovedBeforeDate(CronArchive::class, 'checkNoDanglingInvalidations', $validTill);
     }
 
 


### PR DESCRIPTION
### Description:

Temporarily include check for dangling invalidations in case there's some issue w/ core:archive's finishing/removal of invalidations. refs https://github.com/matomo-org/matomo/issues/16689

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
