### PR TITLE
Ignore plugin timings when matomo is not installed yet

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -527,7 +527,8 @@ class Manager
 
         // execute deactivate() to let the plugin do cleanups
         $this->executePluginDeactivate($pluginName);
-        $this->savePluginDeactivationTime($pluginName);
+
+        $this->savePluginTime(self::LAST_PLUGIN_DEACTIVATION_TIME_OPTION_PREFIX, $pluginName);
 
         $this->unloadPluginFromMemory($pluginName);
 
@@ -692,7 +693,7 @@ class Manager
         $this->installPluginIfNecessary($plugin);
         $plugin->activate();
 
-        $this->savePluginActivationTime($pluginName);
+        $this->savePluginTime(self::LAST_PLUGIN_ACTIVATION_TIME_OPTION_PREFIX, $pluginName);
 
         EventDispatcher::getInstance()->postPendingEventsTo($plugin);
 
@@ -1669,16 +1670,19 @@ class Manager
         }
     }
 
-    private function savePluginActivationTime($pluginName)
+    private function savePluginTime($timingName, $pluginName)
     {
-        $optionName = self::LAST_PLUGIN_ACTIVATION_TIME_OPTION_PREFIX . $pluginName;
-        Option::set($optionName, time());
+        $optionName = $timingName . $pluginName;
+
+        try {
+            Option::set($optionName, time());
+        } catch (\Exception $e) {
+            if (SettingsPiwik::isMatomoInstalled()) {
+                throw $e;
+            }
+            // we ignore any error while Matomo is not installed yet. refs #16741
+        }
     }
 
-    private function savePluginDeactivationTime($pluginName)
-    {
-        $optionName = self::LAST_PLUGIN_DEACTIVATION_TIME_OPTION_PREFIX . $pluginName;
-        Option::set($optionName, time());
-    }
 }
 


### PR DESCRIPTION
### Description:

refs https://github.com/matomo-org/matomo/issues/16741

Not sure if it will fix the issue as I don't know how ExtraTools works. Figured this might still be good to have though maybe just in case to prevent possible install errors. Could maybe even skip saving the timing while Matomo is not installed yet maybe but be good to have them if/when possible. Might be useful for cloud too haven't checked yet (edit: tested and cloud setup still works normal)

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
