### PR TITLE
Prevent some archiving notes being printed for each site

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -765,6 +765,11 @@ class CronArchive
             return;
         }
 
+        if (empty($this->segmentArchiving)) {
+            // might not be initialised if init is not called
+            $this->segmentArchiving = new SegmentArchiving($this->processNewSegmentsFrom, $this->dateLastForced);
+        }
+
         $this->logger->debug("Checking for queued invalidations...");
 
         // invalidate remembered site/day pairs

--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -114,7 +114,6 @@ class Tasks extends \Piwik\Plugin\Tasks
 
         $idSites = Request::processRequest('SitesManager.getAllSitesId');
         $cronArchive = new CronArchive();
-        $cronArchive->init();
         foreach ($idSites as $idSite) {
             $cronArchive->invalidateArchivedReportsForSitesThatNeedToBeArchivedAgain($idSite);
         }

--- a/plugins/CoreAdminHome/Tasks.php
+++ b/plugins/CoreAdminHome/Tasks.php
@@ -113,9 +113,9 @@ class Tasks extends \Piwik\Plugin\Tasks
         }
 
         $idSites = Request::processRequest('SitesManager.getAllSitesId');
+        $cronArchive = new CronArchive();
+        $cronArchive->init();
         foreach ($idSites as $idSite) {
-            $cronArchive = new CronArchive();
-            $cronArchive->init();
             $cronArchive->invalidateArchivedReportsForSitesThatNeedToBeArchivedAgain($idSite);
         }
     }


### PR DESCRIPTION
### Description:

No longer print the archive init notes for each site.

See 
![image](https://user-images.githubusercontent.com/273120/99582183-a472db00-2a46-11eb-8d87-928e01f03728.png)



### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
