### PR TITLE
When no deactivation date found, then rearchive as much as allowed

### DIFF
--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -486,7 +486,7 @@ class Plugin
         if (empty($lastCronArchiveTime)) {
             $dateTime = $lastDeactivationTime;
         } else if (empty($lastDeactivationTime)) {
-            $dateTime = Date::factory($lastCronArchiveTime);
+            $dateTime = null; // use default earliest time
         } else {
             $lastCronArchiveTime = Date::factory($lastCronArchiveTime);
             $dateTime = $lastDeactivationTime->isEarlier($lastCronArchiveTime) ? $lastDeactivationTime : $lastCronArchiveTime;

--- a/tests/PHPUnit/Integration/PluginTest.php
+++ b/tests/PHPUnit/Integration/PluginTest.php
@@ -64,7 +64,7 @@ class PluginTest extends IntegrationTestCase
         $plugin->schedulePluginReArchiving();
 
         $date = $this->getDateFromReArchiveList();
-        $this->assertEquals($cronTime->getDatetime(), $date);
+        $this->assertNull($date);
     }
 
     public function test_schedulePluginReArchiving_shouldReArchiveFromNMonthsAgo_IfNoDecativationTimeOrCronTimeExists()


### PR DESCRIPTION
### Description:

Otherwise it would only rearchive max 1 day back (assuming archiving ran today or yesterday) when activating the plugin for the first time

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
