### PR TITLE
Introduce PHP CS to improve code quality

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,17 @@
+name: PHPCS check
+
+on: pull_request
+
+jobs:
+  phpcs:
+    name: PHPCS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: composer install --dev --prefer-dist --no-progress --no-suggest
+      - name: PHPCS check
+        uses: chekalsky/phpcs-action@v1
+        with:
+          phpcs_bin_path: './vendor/bin/phpcs'
+          enable_warnings: true

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,9 @@
     },
     "require-dev": {
         "lox/xhprof": "dev-master",
+        "mayflower/mo4-coding-standard": "~6.0",
         "phpunit/phpunit": "~8.5",
+        "squizlabs/php_codesniffer": "^3.5",
         "symfony/var-dumper": "~2.6.0",
         "symfony/yaml": "~2.6.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "78bcf8d713875ccb984d130f8a16fc9e",
+    "content-hash": "cc0a7b18fe50435386d42c10f2f91967",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1037,16 +1037,16 @@
         },
         {
             "name": "pear/archive_tar",
-            "version": "1.4.10",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "bbb4f10f71a1da2715ec6d9a683f4f23c507a49b"
+                "reference": "17d355cb7d3c4ff08e5729f29cd7660145208d9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/bbb4f10f71a1da2715ec6d9a683f4f23c507a49b",
-                "reference": "bbb4f10f71a1da2715ec6d9a683f4f23c507a49b",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/17d355cb7d3c4ff08e5729f29cd7660145208d9d",
+                "reference": "17d355cb7d3c4ff08e5729f29cd7660145208d9d",
                 "shasum": ""
             },
             "require": {
@@ -1103,7 +1103,7 @@
                 "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Archive_Tar",
                 "source": "https://github.com/pear/Archive_Tar"
             },
-            "time": "2020-09-15T14:13:23+00:00"
+            "time": "2020-11-19T22:10:24+00:00"
         },
         {
             "name": "pear/console_getopt",
@@ -2287,6 +2287,76 @@
     ],
     "packages-dev": [
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-06-25T14:57:39+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -2356,6 +2426,63 @@
             "time": "2020-11-10T18:47:58+00:00"
         },
         {
+            "name": "escapestudios/symfony2-coding-standard",
+            "version": "3.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/djoos/Symfony-coding-standard.git",
+                "reference": "78e3b0b6832c88cf7c0240b4abcd61430030d8c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/djoos/Symfony-coding-standard/zipball/78e3b0b6832c88cf7c0240b4abcd61430030d8c3",
+                "reference": "78e3b0b6832c88cf7c0240b4abcd61430030d8c3",
+                "shasum": ""
+            },
+            "require": {
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "<3 || >=4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Joos",
+                    "email": "iam@davidjoos.com"
+                },
+                {
+                    "name": "Community contributors",
+                    "homepage": "https://github.com/djoos/Symfony-coding-standard/graphs/contributors"
+                }
+            ],
+            "description": "CodeSniffer ruleset for the Symfony 2+ coding standard",
+            "homepage": "https://github.com/djoos/Symfony-coding-standard",
+            "keywords": [
+                "Coding Standard",
+                "Symfony2",
+                "phpcs",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/djoos/Symfony-coding-standard/issues",
+                "source": "https://github.com/djoos/Symfony-coding-standard"
+            },
+            "time": "2020-01-22T10:27:47+00:00"
+        },
+        {
             "name": "lox/xhprof",
             "version": "dev-master",
             "source": {
@@ -2397,6 +2524,60 @@
                 "source": "https://github.com/lox/xhprof/tree/master"
             },
             "time": "2015-08-31T22:07:48+00:00"
+        },
+        {
+            "name": "mayflower/mo4-coding-standard",
+            "version": "v6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mayflower/mo4-coding-standard.git",
+                "reference": "53e5b5cf2718c1e6eb32a1c4e8482f94a648ce4b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mayflower/mo4-coding-standard/zipball/53e5b5cf2718c1e6eb32a1c4e8482f94a648ce4b",
+                "reference": "53e5b5cf2718c1e6eb32a1c4e8482f94a648ce4b",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "~0.7",
+                "escapestudios/symfony2-coding-standard": "^3.10.0",
+                "php": "~7.2",
+                "slevomat/coding-standard": "^6.2.0",
+                "squizlabs/php_codesniffer": "^3.5.8"
+            },
+            "require-dev": {
+                "phan/phan": "^3.1.0",
+                "phpstan/phpstan": "^0.12.33",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^7.0",
+                "vimeo/psalm": "^3.8"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Xaver Loppenstedt",
+                    "email": "xaver@loppenstedt.de"
+                }
+            ],
+            "description": "PHP CodeSniffer ruleset implementing the MO4 coding standards extending the Symfony coding standards.",
+            "homepage": "https://github.com/mayflower/mo4-coding-standard",
+            "keywords": [
+                "mo4",
+                "phpcs",
+                "psr",
+                "standards",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/mayflower/mo4-coding-standard/issues",
+                "source": "https://github.com/mayflower/mo4-coding-standard"
+            },
+            "time": "2020-10-29T02:39:22+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2790,6 +2971,59 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.12.1"
             },
             "time": "2020-09-29T09:10:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3823,6 +4057,123 @@
                 "source": "https://github.com/sebastianbergmann/version/tree/master"
             },
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "symfony/var-dumper",

--- a/core/Common.php
+++ b/core/Common.php
@@ -319,6 +319,7 @@ class Common
     public static function safe_unserialize($string, $allowedClasses = [], $rethrow = false)
     {
         try {
+            // phpcs:ignore Generic.PHP.ForbiddenFunctions
             return unserialize($string, ['allowed_classes' => empty($allowedClasses) ? false : $allowedClasses]);
         } catch (\Throwable $e) {
             if ($rethrow) {

--- a/core/Updates/3.8.0-b3.php
+++ b/core/Updates/3.8.0-b3.php
@@ -49,7 +49,7 @@ class Updates_3_8_0_b3 extends PiwikUpdates
 
         if (Plugin\Manager::getInstance()->isPluginActivated('GoogleAuthenticator')) {
             foreach (Option::getLike('GoogleAuthentication.%') as $name => $value) {
-                $value = @unserialize($value);
+                $value = @Common::safe_unserialize($value);
                 if (!empty($value['isActive']) && !empty($value['secret'])) {
                     $login = str_replace('GoogleAuthentication.', '', $name);
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,6 +11,7 @@
 
     <exclude-pattern>tests/PHPUnit/proxy/*</exclude-pattern>
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/libs/*</exclude-pattern>
 
     <!-- Forbid other line endings than \n -->
     <rule ref="Generic.Files.LineEndings">
@@ -21,6 +22,9 @@
 
     <!-- Forbid short open tags -->
     <rule ref="Generic.PHP.DisallowShortOpenTag.Found" />
+
+    <!-- Forbid inline control structures -->
+    <rule ref="Generic.ControlStructures.InlineControlStructure" />
 
     <!-- Forbid some functions that should not be used (directly) -->
     <rule ref="Generic.PHP.ForbiddenFunctions">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="matomo">
+
+    <description>Matomo Coding Standard</description>
+
+    <arg name="extensions" value="php" />
+
+    <file>core</file>
+    <file>plugins</file>
+    <file>tests/PHPUnit</file>
+
+    <exclude-pattern>tests/PHPUnit/proxy/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+
+    <!-- Forbid other line endings than \n -->
+    <rule ref="Generic.Files.LineEndings">
+        <properties>
+            <property name="eolChar" value="\n" />
+        </properties>
+    </rule>
+
+    <!-- Forbid short open tags -->
+    <rule ref="Generic.PHP.DisallowShortOpenTag.Found" />
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -21,4 +21,17 @@
 
     <!-- Forbid short open tags -->
     <rule ref="Generic.PHP.DisallowShortOpenTag.Found" />
+
+    <!-- Forbid some functions that should not be used (directly) -->
+    <rule ref="Generic.PHP.ForbiddenFunctions">
+        <properties>
+            <property name="forbiddenFunctions" type="array">
+                <element key="eval" value="null"/>
+                <element key="create_function" value="null"/>
+                <element key="unserialize" value="\Piwik\Common::safe_unserialize"/>
+            </property>
+        </properties>
+        <!-- still allow those functions in tests -->
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
 </ruleset>

--- a/plugins/API/ProcessedReport.php
+++ b/plugins/API/ProcessedReport.php
@@ -358,7 +358,9 @@ class ProcessedReport
                                                        'idSubtable' => $idSubtable,
                                                   ));
 
-        if (!empty($segment)) $parameters['segment'] = $segment;
+        if (!empty($segment)) {
+            $parameters['segment'] = $segment;
+        }
 
         if (!empty($reportMetadata['processedMetrics'])
             && !empty($reportMetadata['metrics']['nb_visits'])

--- a/plugins/CoreHome/DataTableRowAction/RowEvolution.php
+++ b/plugins/CoreHome/DataTableRowAction/RowEvolution.php
@@ -95,7 +95,9 @@ class RowEvolution
         }
         $this->label = Common::unsanitizeInputValue($this->label[0]);
 
-        if ($this->label === '') throw new Exception("Parameter label not set.");
+        if ($this->label === '') {
+            throw new Exception("Parameter label not set.");
+        }
 
         $this->period = Common::getRequestVar('period', '', 'string');
         PeriodFactory::checkPeriodIsEnabled($this->period);

--- a/plugins/ImageGraph/StaticGraph/GridGraph.php
+++ b/plugins/ImageGraph/StaticGraph/GridGraph.php
@@ -140,7 +140,9 @@ abstract class GridGraph extends StaticGraph
         // rounding top scale value to the next multiple of 10
         if ($maxOrdinateValue > 10) {
             $modTen = $maxOrdinateValue % 10;
-            if ($modTen) $maxOrdinateValue += 10 - $modTen;
+            if ($modTen) {
+                $maxOrdinateValue += 10 - $modTen;
+            }
         }
 
         $gridColor = $this->gridColor;

--- a/plugins/MobileMessaging/SMSProvider.php
+++ b/plugins/MobileMessaging/SMSProvider.php
@@ -188,7 +188,9 @@ abstract class SMSProvider
         $maxCharsAllowed = self::maxCharsAllowed($maximumNumberOfConcatenatedSMS, $smsContentContainsUCS2Chars);
         $sizeOfSMSContent = self::sizeOfSMSContent($string, $smsContentContainsUCS2Chars);
 
-        if ($sizeOfSMSContent <= $maxCharsAllowed) return $string;
+        if ($sizeOfSMSContent <= $maxCharsAllowed) {
+            return $string;
+        }
 
         $smsContentContainsUCS2Chars = $smsContentContainsUCS2Chars || self::containsUCS2Characters($appendedString);
         $maxCharsAllowed = self::maxCharsAllowed($maximumNumberOfConcatenatedSMS, $smsContentContainsUCS2Chars);
@@ -214,7 +216,9 @@ abstract class SMSProvider
 
     private static function sizeOfSMSContent($smsContent, $containsUCS2Chars)
     {
-        if ($containsUCS2Chars) return Common::mb_strlen($smsContent);
+        if ($containsUCS2Chars) {
+            return Common::mb_strlen($smsContent);
+        }
 
         $sizeOfSMSContent = 0;
         foreach (self::mb_str_split($smsContent) as $char) {

--- a/plugins/ScheduledReports/Menu.php
+++ b/plugins/ScheduledReports/Menu.php
@@ -35,8 +35,9 @@ class Menu extends \Piwik\Plugin\Menu
     function getTopMenuTranslationKey()
     {
         // if MobileMessaging is not activated, display 'Email reports'
-        if (!\Piwik\Plugin\Manager::getInstance()->isPluginActivated('MobileMessaging'))
+        if (!\Piwik\Plugin\Manager::getInstance()->isPluginActivated('MobileMessaging')) {
             return self::PDF_REPORTS_TOP_MENU_TRANSLATION_KEY;
+        }
 
         if (Piwik::isUserIsAnonymous()) {
             return self::MOBILE_MESSAGING_TOP_MENU_TRANSLATION_KEY;

--- a/plugins/ScheduledReports/tests/Integration/ApiTest.php
+++ b/plugins/ScheduledReports/tests/Integration/ApiTest.php
@@ -742,7 +742,9 @@ class ApiTest extends IntegrationTestCase
     private function assertReportsEqual($report, $data)
     {
         foreach ($data as $key => $value) {
-            if ($key == 'description') $value = substr($value, 0, 250);
+            if ($key == 'description') {
+                $value = substr($value, 0, 250);
+            }
             $this->assertEquals($value, $report[$key], "Error for $key for report " . var_export($report, true) . " and data " . var_export($data, true));
         }
     }

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -927,6 +927,7 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
                 || strpos($file, 'vendor/phpmailer/phpmailer/language/') !== false
                 || strpos($file, 'vendor/wikimedia/less.php/') !== false
                 || strpos($file, 'node_modules/') !== false
+                || strpos($file, 'vendor/mayflower/mo4-coding-standard/') !== false
                 || strpos($file, 'plugins/VisitorGenerator/vendor/fzaninotto/faker/src/Faker/Provider/') !== false) {
                 continue;
             }

--- a/tests/PHPUnit/Unit/AssetManager/PluginManagerMock.php
+++ b/tests/PHPUnit/Unit/AssetManager/PluginManagerMock.php
@@ -41,9 +41,11 @@ class PluginManagerMock extends Manager
 
     public function getLoadedPlugin($name)
     {
-        foreach($this->plugins as $plugin)
-            if($plugin->getPluginName() == $name)
+        foreach ($this->plugins as $plugin) {
+            if ($plugin->getPluginName() == $name) {
                 return $plugin;
+            }
+        }
 
         return null;
     }
@@ -57,8 +59,9 @@ class PluginManagerMock extends Manager
     {
         $pluginNames = array();
 
-        foreach($this->plugins as $plugin)
+        foreach($this->plugins as $plugin) {
             $pluginNames[] = $plugin->getPluginName();
+        }
 
         return $pluginNames;
     }


### PR DESCRIPTION
### Description:

In order to improve our code quality a bit, it would imho be awesome by stating to introduce automatic PHPCS checks.
I've started with a very basic ruleset, that only disallows the usage of short open tags and forces using \n as line endings.

There is also a new workflow, that will automatically run for Pull Requests, so it can be directly seen if a PR breaks any coding rules. 

If that PR get's merged I would add some other rules step by step and directly provide fixes for code that doesn't comply. Maybe anyone else also has some suggestions for rules we should use.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
