### PR TITLE
core:archive add note message when continuing an existing queue

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -308,6 +308,10 @@ class CronArchive
         $this->allWebsites = $websitesIds;
         $this->websiteIdArchiveList = $this->makeWebsiteIdArchiveList($websitesIds);
 
+        if ($this->websiteIdArchiveList->isContinuingPreviousRun()) {
+            $this->logger->info("- Continuing ongoing archiving run by pulling from shared idSite queue.");
+        }
+
         if ($this->archiveFilter) {
             $this->archiveFilter->logFilterInfo($this->logger);
         }
@@ -999,11 +1003,6 @@ class CronArchive
             $dateLast = time() - $this->lastSuccessRunTimestamp;
             $this->logger->info("- Archiving was last executed without error "
                 . $this->formatter->getPrettyTimeFromSeconds($dateLast, true) . " ago");
-        }
-
-
-        if ($this->websiteIdArchiveList->isContinuingPreviousRun()) {
-            $this->logger->info("- Continuing ongoing archiving run by pulling from shared idSite queue.");
         }
     }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -308,7 +308,9 @@ class CronArchive
         $this->allWebsites = $websitesIds;
         $this->websiteIdArchiveList = $this->makeWebsiteIdArchiveList($websitesIds);
 
-        if ($this->websiteIdArchiveList->isContinuingPreviousRun()) {
+        if (method_exists($this->websiteIdArchiveList, 'isContinuingPreviousRun') &&
+            $this->websiteIdArchiveList->isContinuingPreviousRun()
+        ) {
             $this->logger->info("- Continuing ongoing archiving run by pulling from shared idSite queue.");
         }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -345,7 +345,6 @@ class CronArchive
             return;
         }
 
-
         $this->logger->debug("Applying queued rearchiving...");
         $this->invalidator->applyScheduledReArchiving();
 
@@ -1000,6 +999,11 @@ class CronArchive
             $dateLast = time() - $this->lastSuccessRunTimestamp;
             $this->logger->info("- Archiving was last executed without error "
                 . $this->formatter->getPrettyTimeFromSeconds($dateLast, true) . " ago");
+        }
+
+
+        if ($this->websiteIdArchiveList->isContinuingPreviousRun()) {
+            $this->logger->info("- Continuing ongoing archiving run by pulling from shared idSite queue.");
         }
     }
 

--- a/core/CronArchive/FixedSiteIds.php
+++ b/core/CronArchive/FixedSiteIds.php
@@ -62,4 +62,12 @@ class FixedSiteIds
 
         return null;
     }
+
+    /**
+     * @return bool
+     */
+    public function isContinuingPreviousRun(): bool
+    {
+        return false;
+    }
 }

--- a/core/CronArchive/SharedSiteIds.php
+++ b/core/CronArchive/SharedSiteIds.php
@@ -30,6 +30,7 @@ class SharedSiteIds
     private $currentSiteId;
     private $done = false;
     private $numWebsitesLeftToProcess;
+    private $isContinuingPreviousRun = false;
 
     public function __construct($websiteIds, $optionName = self::OPTION_DEFAULT)
     {
@@ -46,6 +47,7 @@ class SharedSiteIds
             $existingWebsiteIds = $self->getAllSiteIdsToArchive();
 
             if (!empty($existingWebsiteIds)) {
+                $this->isContinuingPreviousRun = true;
                 return $existingWebsiteIds;
             }
 
@@ -198,5 +200,13 @@ class SharedSiteIds
     public static function isSupported()
     {
         return Process::isSupported();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isContinuingPreviousRun(): bool
+    {
+        return $this->isContinuingPreviousRun;
     }
 }


### PR DESCRIPTION
### Description:

Noticed core:archive no longer says when it's continuing an existing archive run (if it ever did). Found it confusing for it to just pick up a different queue locally, so thought this message might be useful.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
