### PR TITLE
Update PHP requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Matomo is released under the GPL v3 (or later) license, see [LICENSE](LICENSE).
 
 ## Requirements
 
-  * PHP 5.5.9 or greater
+  * PHP 7.2.5 or greater
   * MySQL version 5.5 or greater, or MariaDB 
   * PHP extension pdo and pdo_mysql, or the MySQLi extension
   * Matomo is OS / server independent


### PR DESCRIPTION
### Description:

Guess doesn't make sense to show PHP 5.5 as requirement, even though Matomo 3 will be in LTS for a while... 

We also should maybe update this page so the commands at least install php 7.2: https://matomo.org/docs/requirements/#recommended-configuration

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
