### PR TITLE
Fix notice value might not be defined in alexa

### DIFF
--- a/plugins/SEO/Metric/Alexa.php
+++ b/plugins/SEO/Metric/Alexa.php
@@ -32,6 +32,7 @@ class Alexa implements MetricsProvider
 
     public function getMetrics($domain)
     {
+        $value = null;
         try {
             $response = Http::sendHttpRequest(self::URL . urlencode($domain), $timeout = 10, @$_SERVER['HTTP_USER_AGENT']);
             $dom = new \DomDocument();


### PR DESCRIPTION
> WARNING: plugins/SEO/Metric/Alexa.php(52): Notice - Undefined variable: value - Matomo 4.0.0 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already) (Module: SEO, Action: getRank, In CLI mode: false)

Was getting above error. Probably because of:

> WARNING: Error while getting Alexa SEO stats via fallback method: curl_exec: Resolving timed out after 10069 milliseconds. Hostname requested was: www.alexa.com (Module: SEO, Action: getRank, In CLI mode: false)

fyi @sgiehl will merge this