### PR TITLE
Remove ExampleTheme plugin on update

### DIFF
--- a/core/Updates/4.0.1-b1.php
+++ b/core/Updates/4.0.1-b1.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Config;
+use Piwik\Container\StaticContainer;
+use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\Date;
+use Piwik\DbHelper;
+use Piwik\Plugin\ReleaseChannels;
+use Piwik\SettingsPiwik;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+class Updates_4_0_1_b1 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = [];
+        if (SettingsPiwik::isGitDeployment()) {
+            return $migrations;
+        }
+
+        $migrations[] = $this->migration->plugin->uninstall('ExampleTheme');
+        return $migrations;
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '4.0.0';
+    const VERSION = '4.0.1-b1';
     const MAJOR_VERSION = 4;
 
     public function isStableVersion($version)


### PR DESCRIPTION
We already deactivate the plugin but it looks like we actually need to fully remove the plugin. It should only be removed if it was not installed through git as in git we still have it.

fix https://github.com/matomo-org/matomo/issues/16804

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
