### PR TITLE
WP optimize is not a Matomo plugin

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1466,6 +1466,7 @@ class Manager
             'PluginMarketplace', //defines a plugin.json but 1.x Piwik plugin
             'DoNotTrack', // Removed in 2.0.3
             'AnonymizeIP', // Removed in 2.0.3
+            'wp-optimize', // a WP plugin that has a plugin.json file but is not a matomo plugin
         );
         return in_array($pluginName, $bogusPlugins);
     }


### PR DESCRIPTION
Just noticed wordpress found wp-optimize which has a plugin.json but a custom plugin.json and then it was throwing an exception that it's not a valid plugin name because of the dash.

Was only visible on the command line so far so might not be an issue. If this happens again I will find a better generic solution for it.

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
