### PR TITLE
PHP8 compatibility improvements

### DIFF
--- a/plugins/Installation/ServerFilesGenerator.php
+++ b/plugins/Installation/ServerFilesGenerator.php
@@ -101,7 +101,7 @@ Header set Cache-Control \"Cache-Control: private, no-cache, no-store\"
      * @param bool $overwrite whether to overwrite an existing file or not
      * @param string $content
      */
-    protected static function createHtAccess($path, $overwrite = true, $content)
+    protected static function createHtAccess($path, $overwrite, $content)
     {
         $file = $path . '/.htaccess';
 


### PR DESCRIPTION
just testing our WP plugin with PHP8 and noticed this.
>r: Required parameter $content follows optional parameter $overwrite => ServerFilesGenerator.php:104;
### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
