### PR TITLE
Adjust archive_invalidations index

### DIFF
--- a/core/Db/Schema/Mysql.php
+++ b/core/Db/Schema/Mysql.php
@@ -322,7 +322,7 @@ class Mysql implements SchemaInterface
                                             status TINYINT(1) UNSIGNED DEFAULT 0,
                                             `report` VARCHAR(255) NULL,
                                             PRIMARY KEY(idinvalidation),
-                                            INDEX index_idsite_dates_period_name(idsite, date1, period, name)
+                                            INDEX index_idsite_dates_period_name(idsite, date1, period)
                                         ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 


### PR DESCRIPTION
### Description:

The index actually differs from the one defined in the update script: 
https://github.com/matomo-org/matomo/blob/1fa10c628c751d43b346a909e68833d26d5c08ff/core/Updates/4.0.0-b1.php#L105

Not sure if the index on `name` was on purpose. If so we need to limit the field or the index

fixes #16811

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
