### PR TITLE
Ignore errors while updating session ids

### DIFF
--- a/core/Updates/4.0.0-b1.php
+++ b/core/Updates/4.0.0-b1.php
@@ -264,7 +264,11 @@ class Updates_4_0_0_b1 extends PiwikUpdates
         foreach ($sessions as $session) {
             if (!empty($session['id']) && Common::mb_strlen($session['id']) != 128) {
                 $bind = [ hash('sha512', $session['id'] . $salt), $session['id'] ];
-                Db::query(sprintf('UPDATE %s SET id = ? WHERE id = ?', Common::prefixTable('session')), $bind);
+                try {
+                    Db::query(sprintf('UPDATE %s SET id = ? WHERE id = ?', Common::prefixTable('session')), $bind);
+                } catch (\Exception $e) {
+                    // ignore possible duplicate key errors
+                }
             }
         }
 


### PR DESCRIPTION
### Description:

we could also check each key for duplicate before inserting it, but guess it's not worth the effort, as in worst case someone get logged out only

refs #16824

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
