### PR TITLE
More rigorous checks for non-existant site so archiving wont fail if …

### DIFF
--- a/core/Archive/ArchivePurger.php
+++ b/core/Archive/ArchivePurger.php
@@ -139,10 +139,10 @@ class ArchivePurger
             $this->logger->debug("No outdated archives found in archive numeric table for {date}.", array('date' => $dateStart));
         }
 
-        $this->logger->debug("Purging temporary archives: done [ purged archives older than {date} in {yearMonth} ] [Deleted IDs: {deletedIds}]", array(
+        $this->logger->debug("Purging temporary archives: done [ purged archives older than {date} in {yearMonth} ] [Deleted IDs count: {deletedIds}]", array(
             'date' => $purgeArchivesOlderThan,
             'yearMonth' => $dateStart->toString('Y-m'),
-            'deletedIds' => implode(',', $idArchivesToDelete)
+            'deletedIds' => count($idArchivesToDelete),
         ));
 
         return $deletedRowCount;
@@ -191,8 +191,8 @@ class ArchivePurger
                 )
             );
 
-            $this->logger->debug("[Deleted IDs: {deletedIds}]", array(
-                'deletedIds' => implode(',', $idArchivesToDelete)
+            $this->logger->debug("[Deleted IDs count: {deletedIds}]", array(
+                'deletedIds' => count($idArchivesToDelete),
             ));
         } else {
             $this->logger->debug(


### PR DESCRIPTION
…a site is deleted + tweaks to some debug logs

### Description:

Deleted some sites while a canceled/failed archive had been run before, and the next core:archive run would keep failing since the sites in the list didn't exist. Added some more checks for whether the site exists or not and fixed the existing check method.

FYI @tsteur 

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
