### PR TITLE
save archive start time and check if visits since start time before invalidating and archiving

### DIFF
--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -77,7 +77,7 @@ class ArchiveSelector
 
         $results = self::getModel()->getArchiveIdAndVisits($numericTable, $idSite, $period, $dateStartIso, $dateEndIso, null, $doneFlags);
         if (empty($results)) { // no archive found
-            return [false, false, false, false, false];
+            return [false, false, false, false, false, false];
         }
 
         $result = self::findArchiveDataWithLatestTsArchived($results, $requestedPluginDoneFlags);
@@ -85,6 +85,9 @@ class ArchiveSelector
         $tsArchived = isset($result['ts_archived']) ? $result['ts_archived'] : false;
         $visits = isset($result['nb_visits']) ? $result['nb_visits'] : false;
         $visitsConverted = isset($result['nb_visits_converted']) ? $result['nb_visits_converted'] : false;
+
+        $tsArchiveStart = $result[ArchiveWriter::ARCHIVE_START_TIME] ?? false;
+        $tsArchiveStart = (int) $tsArchiveStart;
 
         $result['idarchive'] = empty($result['idarchive']) ? [] : [$result['idarchive']];
         if (isset($result['partial'])) {
@@ -94,7 +97,7 @@ class ArchiveSelector
         if (isset($result['value'])
             && !in_array($result['value'], $doneFlagValues)
         ) { // the archive cannot be considered valid for this request (has wrong done flag value)
-            return [false, $visits, $visitsConverted, true, $tsArchived];
+            return [false, $visits, $visitsConverted, true, $tsArchived, $tsArchiveStart];
         }
 
         if (!empty($minDatetimeArchiveProcessedUTC) && !is_object($minDatetimeArchiveProcessedUTC)) {
@@ -106,12 +109,12 @@ class ArchiveSelector
             && !empty($result['idarchive'])
             && Date::factory($tsArchived)->isEarlier($minDatetimeArchiveProcessedUTC)
         ) {
-            return [false, $visits, $visitsConverted, true, $tsArchived];
+            return [false, $visits, $visitsConverted, true, $tsArchived, $tsArchiveStart];
         }
 
         $idArchives = !empty($result['idarchive']) ? $result['idarchive'] : false;
 
-        return [$idArchives, $visits, $visitsConverted, true, $tsArchived];
+        return [$idArchives, $visits, $visitsConverted, true, $tsArchived, $tsArchiveStart];
     }
 
     /**

--- a/core/DataAccess/ArchiveWriter.php
+++ b/core/DataAccess/ArchiveWriter.php
@@ -63,6 +63,8 @@ class ArchiveWriter
      */
     const DONE_PARTIAL = 5;
 
+    const ARCHIVE_START_TIME = 'archive_start_time';
+
     protected $fields = array('idarchive',
         'idsite',
         'date1',
@@ -153,6 +155,7 @@ class ArchiveWriter
     public function initNewArchive()
     {
         $idArchive = $this->allocateNewArchiveId();
+        $this->insertRecord(self::ARCHIVE_START_TIME, Date::now()->getTimestamp());
         $this->logArchiveStatusAsIncomplete();
         return $idArchive;
     }

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -404,10 +404,12 @@ class Model
         }
 
         // NOTE: we can't predict how many segments there will be so there could be lots of nb_visits/nb_visits_converted rows... have to select everything.
-        $sqlQuery = "SELECT arc1.idarchive, arc1.value, arc1.name, arc1.ts_archived, arc1.date1 as startDate, arc2.value as " . ArchiveSelector::NB_VISITS_RECORD_LOOKED_UP . ", arc3.value as " . ArchiveSelector::NB_VISITS_CONVERTED_RECORD_LOOKED_UP . "
+        $sqlQuery = "SELECT arc1.idarchive, arc1.value, arc1.name, arc1.ts_archived, arc1.date1 as startDate, arc2.value as " . ArchiveSelector::NB_VISITS_RECORD_LOOKED_UP
+                        . ", arc3.value as " . ArchiveSelector::NB_VISITS_CONVERTED_RECORD_LOOKED_UP . ", arc4.value as " . ArchiveWriter::ARCHIVE_START_TIME . "
                      FROM $numericTable arc1
                      LEFT JOIN $numericTable arc2 on arc2.idarchive = arc1.idarchive and (arc2.name = '" . ArchiveSelector::NB_VISITS_RECORD_LOOKED_UP . "')
                      LEFT JOIN $numericTable arc3 on arc3.idarchive = arc1.idarchive and (arc3.name = '" . ArchiveSelector::NB_VISITS_CONVERTED_RECORD_LOOKED_UP . "')
+                     LEFT JOIN $numericTable arc4 on arc4.idarchive = arc1.idarchive and (arc4.name = '" . ArchiveWriter::ARCHIVE_START_TIME . "')
                      WHERE arc1.idsite = ?
                          AND arc1.date1 = ?
                          AND arc1.date2 = ?


### PR DESCRIPTION
### Description:

@tsteur thought of this possible optimization while checking the ttl change. Checks for visits from start time of last archive to end of period, and if not found, doesn't invalidate/archive. If you think it's worth finishing I can finish it.

Should only be applied to periods that include today (I think that's not the case currently in the PR, it also applies to yesterday, but it's WIP)...

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
