### PR TITLE
Remove no longer shipped example plugins during update

### DIFF
--- a/core/Updates/4.0.4-b1.php
+++ b/core/Updates/4.0.4-b1.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\SettingsPiwik;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+class Updates_4_0_4_b1 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = [];
+
+        if (SettingsPiwik::isGitDeployment()) {
+            return $migrations;
+        }
+
+        $migrations[] = $this->migration->plugin->deactivate('ExamplePlugin');
+        $migrations[] = $this->migration->plugin->deactivate('ExampleLogTables');
+        $migrations[] = $this->migration->plugin->deactivate('ExampleUI');
+
+        $migrations[] = $this->migration->plugin->uninstall('ExamplePlugin');
+        $migrations[] = $this->migration->plugin->uninstall('ExampleLogTables');
+        $migrations[] = $this->migration->plugin->uninstall('ExampleUI');
+        return $migrations;
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+
+}

--- a/core/Updates/4.0.4-b1.php
+++ b/core/Updates/4.0.4-b1.php
@@ -37,10 +37,22 @@ class Updates_4_0_4_b1 extends PiwikUpdates
         $migrations[] = $this->migration->plugin->deactivate('ExamplePlugin');
         $migrations[] = $this->migration->plugin->deactivate('ExampleLogTables');
         $migrations[] = $this->migration->plugin->deactivate('ExampleUI');
+        $migrations[] = $this->migration->plugin->deactivate('ExampleReport');
+        $migrations[] = $this->migration->plugin->deactivate('ExampleAPI');
+        $migrations[] = $this->migration->plugin->deactivate('ExampleCommand');
+        $migrations[] = $this->migration->plugin->deactivate('ExampleSettingsPlugin');
+        $migrations[] = $this->migration->plugin->deactivate('ExampleTracker');
+        $migrations[] = $this->migration->plugin->deactivate('ExampleVisualization');
 
         $migrations[] = $this->migration->plugin->uninstall('ExamplePlugin');
         $migrations[] = $this->migration->plugin->uninstall('ExampleLogTables');
         $migrations[] = $this->migration->plugin->uninstall('ExampleUI');
+        $migrations[] = $this->migration->plugin->uninstall('ExampleReport');
+        $migrations[] = $this->migration->plugin->uninstall('ExampleAPI');
+        $migrations[] = $this->migration->plugin->uninstall('ExampleCommand');
+        $migrations[] = $this->migration->plugin->uninstall('ExampleSettingsPlugin');
+        $migrations[] = $this->migration->plugin->uninstall('ExampleTracker');
+        $migrations[] = $this->migration->plugin->uninstall('ExampleVisualization');
         return $migrations;
     }
 

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '4.0.3';
+    const VERSION = '4.0.4';
     const MAJOR_VERSION = 4;
 
     public function isStableVersion($version)


### PR DESCRIPTION
### Description:

fix https://github.com/matomo-org/matomo/issues/16857

this affects basically all example plugins that have a version constraint defined in their plugin.json. However, it is better to remove all of them because eventually these plugins will become incompatible (as we stopped shipping them at some point during Matomo 3.X).

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
