### PR TITLE
in cache buster only look at activated plugins, not loaded plugins

### DIFF
--- a/core/AssetManager/UIAssetCacheBuster.php
+++ b/core/AssetManager/UIAssetCacheBuster.php
@@ -33,14 +33,17 @@ class UIAssetCacheBuster extends Singleton
 
             $masterFile     = PIWIK_INCLUDE_PATH . '/.git/refs/heads/master';
             $currentGitHash = file_exists($masterFile) ? @file_get_contents($masterFile) : null;
+            $manager = Manager::getInstance();
 
-            $plugins = !$pluginNames ? Manager::getInstance()->getLoadedPluginsName() : $pluginNames;
+            $plugins = !$pluginNames ? $manager->getActivatedPlugins() : $pluginNames;
             sort($plugins);
 
             $pluginsInfo = '';
             foreach ($plugins as $pluginName) {
-                $plugin      = Manager::getInstance()->getLoadedPlugin($pluginName);
-                $pluginsInfo .= $plugin->getPluginName() . $plugin->getVersion() . ',';
+                if ($manager->isPluginLoaded($pluginName)) {
+                    $plugin      = $manager->getLoadedPlugin($pluginName);
+                    $pluginsInfo .= $plugin->getPluginName() . $plugin->getVersion() . ',';
+                }
             }
 
             $cacheBuster = md5($pluginsInfo . PHP_VERSION . Version::VERSION . trim($currentGitHash));
@@ -51,7 +54,7 @@ class UIAssetCacheBuster extends Singleton
 
             $cachedCacheBuster = $cacheBuster;
         }
-
+        
         return $cachedCacheBuster;
     }
 


### PR DESCRIPTION
### Description:

This might fix https://github.com/matomo-org/matomo/issues/16672 . We could see if it then happens again. There's probably not much point in writing a test for it because it wouldn't really test the real scenario I suppose. Generally the thought is cache buster should only include active plugins, not loaded plugins. Maybe tag manager was loaded for this user but not activated.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
