### PR TITLE
Load correct url for multisites when clicked in site selector

### DIFF
--- a/plugins/CoreHome/angularjs/siteselector/siteselector-model.service.js
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector-model.service.js
@@ -99,7 +99,12 @@
 
         function loadSite(idsite) {
             if (idsite == 'all') {
-                piwik.broadcast.propagateNewPage('module=MultiSites&action=index');
+                document.location.href = piwikHelper.getCurrentQueryStringWithParametersModified(piwikHelper.getQueryStringFromParameters({
+                    module: 'MultiSites',
+                    action: 'index',
+                    date: piwik.currentDateString,
+                    period: piwik.period
+                }));
             } else {
                 piwik.broadcast.propagateNewPage('segment=&idSite=' + idsite, false);
             }


### PR DESCRIPTION
### Description:

As MultiSites dashboard should not be loaded with any additional parameters we should not load it using `propagateNewPage`, as that manipulates the hash only. Simply changing the location should be fine in this case.

fixes #16879

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
