### PR TITLE
New version available plugins will be updated confusing

### DIFF
--- a/plugins/CoreUpdater/templates/newVersionAvailable.twig
+++ b/plugins/CoreUpdater/templates/newVersionAvailable.twig
@@ -36,7 +36,7 @@
 
             <ul>
                 {% for plugin in incompatiblePlugins %}
-                    <li>{{ plugin.getMissingDependenciesAsString(piwik_new_version) }}</li>
+                    <li>{{ plugin.pluginName }}</li>
                 {% endfor %}
             </ul>
         {% endif %}


### PR DESCRIPTION
We've had 3 issues where people thought that a plugin is not compatible with Matomo 4 because of this screen that is misleading as it shows the current plugin dependencies:
![image](https://user-images.githubusercontent.com/273120/101269833-c6ef4d00-37d7-11eb-8df1-755686435938.png)


For simplicity lets simply only show the name of the plugin as mostly plugins are only compatible with the same major version number anyway and there isn't much value in showing the current required information. Of course we could check if there is actually a version on the marketplace available etc but it would require more work.

refs https://github.com/matomo-org/plugin-LoginLdap/issues/221

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
