### PR TITLE
Fix ArgumentCountError: mysqli_stmt::bind_param() does not accept unknown named parameters

### DIFF
--- a/core/Db/BatchInsert.php
+++ b/core/Db/BatchInsert.php
@@ -35,6 +35,7 @@ class BatchInsert
         $ignore    = $ignoreWhenDuplicate ? 'IGNORE' : '';
 
         foreach ($values as $row) {
+            $row = array_values($row);
             $query = "INSERT $ignore INTO " . $tableName . "
 					  $fieldList
 					  VALUES (" . Common::getSqlStringFieldsArray($row) . ")";


### PR DESCRIPTION
fix https://github.com/matomo-org/matomo/issues/16885

It was basically an array like `array('idarchive'=> '', '', ...)` when it should be `[1,'name']`

Wondering though if the better fix would be in https://github.com/matomo-org/matomo/blob/4.0.4/core/DataAccess/Model.php#L228-L237 to make sure it's a regular array there?

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
