### PR TITLE
better Windows detection

### DIFF
--- a/core/SettingsServer.php
+++ b/core/SettingsServer.php
@@ -91,6 +91,9 @@ class SettingsServer
      */
     public static function isWindows()
     {
+        if (PHP_OS_FAMILY == "Unknown") {
+            return DIRECTORY_SEPARATOR === '\\';
+        }
         return PHP_OS_FAMILY === "Windows";
     }
 

--- a/core/SettingsServer.php
+++ b/core/SettingsServer.php
@@ -91,7 +91,7 @@ class SettingsServer
      */
     public static function isWindows()
     {
-        return DIRECTORY_SEPARATOR === '\\';
+        return PHP_OS_FAMILY === "Windows";
     }
 
     /**


### PR DESCRIPTION
Not related to any actual issue, but I just came across this constant which should be more reliable and now with PHP 7.2 available for everyone.

> **`PHP_OS_FAMILY`** (string)
>
> The operating system family PHP was built for. One of `'Windows'` , `'BSD'` , `'Darwin'` , `'Solaris'` , `'Linux'` or `'Unknown'` . Available as of PHP 7.2.0.
> https://www.php.net/manual/en/reserved.constants.php

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
