### PR TITLE
Harden check for numeric array indices

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1522,7 +1522,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         }
         if ($thisIsNotThatSimple === false) {
             // case when the array is indexed by the default numeric index
-            if (array_keys($array) == array_keys(array_fill(0, count($array), true))) {
+            if (array_keys($array) === array_keys(array_fill(0, count($array), true))) {
                 foreach ($array as $row) {
                     $this->addRow(new Row(array(Row::COLUMNS => array($row))));
                 }

--- a/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/CSVTest.php
@@ -459,7 +459,7 @@ b,d,f,g';
         $render = new Csv();
         $render->setTable($data);
         $render->convertToUnicode = false;
-        $expected = 'b';
+        $expected = "a\nb";
 
         $this->assertEquals($expected, $render->render());
     }

--- a/tests/PHPUnit/Unit/DataTable/Renderer/ConsoleTest.php
+++ b/tests/PHPUnit/Unit/DataTable/Renderer/ConsoleTest.php
@@ -140,7 +140,7 @@ class ConsoleTest extends \PHPUnit\Framework\TestCase
 
         $render = new Console();
         $render->setTable($data);
-        $expected = "- 1 ['0' => 'b'] [] [idsubtable = ]<br />
+        $expected = "- 1 ['a' => 'b'] [] [idsubtable = ]<br />
 ";
 
         $this->assertEquals($expected, $render->render());


### PR DESCRIPTION
### Description:

Some of the tests actually had results that are not fully correct. 

This peace of code actually returns `true` on PHP7 while it returns `false` on PHP 8:

```php
$array = ['a' => 'b'];

return array_keys($array) == array_keys(array_fill(0, count($array), true)); // ['a'] == [0]
```

Comparing with `===` instead should have the same result on both versions.

If I understand the code correct it tries to check for default numeric indices. Comparing with `===` requires the keys to be of the same type and in the same order. Imho that should be correct as an array with shuffled order should imho not be handled as having default indices.

refs #16897

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
