### PR TITLE
Improvements on prepending a plus sign to evolutions

### DIFF
--- a/core/DataTable/Filter/CalculateEvolutionFilter.php
+++ b/core/DataTable/Filter/CalculateEvolutionFilter.php
@@ -12,6 +12,7 @@ use Piwik\Common;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 use Piwik\NumberFormatter;
+use Piwik\Piwik;
 use Piwik\Site;
 
 /**
@@ -151,17 +152,24 @@ class CalculateEvolutionFilter extends ColumnCallbackAddColumnPercentage
      *                                      from this value to $currentValue.
      * @param float|int $quotientPrecision The quotient precision to round to.
      * @param bool $appendPercentSign Whether to append a '%' sign to the end of the number or not.
+     * @param bool $prependPlusSignWhenPositive Whether to prepend a '+' sign before the number if it's not negative.
      *
      * @return string The evolution percent, eg `'15%'`.
      */
-    public static function calculate($currentValue, $pastValue, $quotientPrecision = 0, $appendPercentSign = true)
+    public static function calculate($currentValue, $pastValue, $quotientPrecision = 0, $appendPercentSign = true, $prependPlusSignWhenPositive = false)
     {
         $number = self::getPercentageValue($currentValue - $pastValue, $pastValue, $quotientPrecision);
         if ($appendPercentSign) {
-            return NumberFormatter::getInstance()->formatPercent($number, $quotientPrecision);
+            $formatted = NumberFormatter::getInstance()->formatPercent($number, $quotientPrecision);
+        } else {
+            $formatted = NumberFormatter::getInstance()->format($number, $quotientPrecision);
         }
 
-        return NumberFormatter::getInstance()->format($number, $quotientPrecision);
+        if ($prependPlusSignWhenPositive && $number >= 0) {
+            $formatted = Piwik::translate('Intl_NumberSymbolPlus') . $formatted;
+        }
+
+        return $formatted;
     }
 
     public static function appendPercentSign($number)
@@ -171,8 +179,8 @@ class CalculateEvolutionFilter extends ColumnCallbackAddColumnPercentage
 
     public static function prependPlusSignToNumber($number)
     {
-        if ($number > 0) {
-            $number = '+' . $number;
+        if ((float) $number > 0) {
+            return '+' . $number;
         }
 
         return $number;

--- a/plugins/API/Filter/DataComparisonFilter.php
+++ b/plugins/API/Filter/DataComparisonFilter.php
@@ -521,12 +521,7 @@ class DataComparisonFilter
         $valueToCompare = $fromRow ? $fromRow->getColumn($columnName) : 0;
         $valueToCompare = $valueToCompare ?: 0;
 
-        $change = DataTable\Filter\CalculateEvolutionFilter::calculate($value, $valueToCompare, $precision = 1, $appendPercent = false);
-
-        if ($change >= 0) {
-            $change = '+' . $change;
-        }
-        $change .= '%';
+        $change = DataTable\Filter\CalculateEvolutionFilter::calculate($value, $valueToCompare, $precision = 1, true, true);
 
         return $change;
     }

--- a/plugins/API/RowEvolution.php
+++ b/plugins/API/RowEvolution.php
@@ -411,8 +411,8 @@ class RowEvolution
                 continue;
             }
 
-            $change = CalculateEvolutionFilter::calculate($last, $first, $quotientPrecision = 0);
-            $change = CalculateEvolutionFilter::prependPlusSignToNumber($change);
+            $change = CalculateEvolutionFilter::calculate($last, $first, $quotientPrecision = 0, true, true);
+
             $metricsResult[$metric]['change'] = $change;
         }
 

--- a/tests/PHPUnit/System/expected/test_RowEvolution_LabelReservedCharactersHierarchical__API.getRowEvolution_day.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_LabelReservedCharactersHierarchical__API.getRowEvolution_day.xml
@@ -258,7 +258,7 @@
 				<logo>plugins/Morpheus/icons/dist/searchEngines/google.com.png</logo>
 				<min>1</min>
 				<max>1</max>
-				<change>0%</change>
+				<change>+0%</change>
 			</nb_visits_3>
 		</metrics>
 		<dimension>Search Engine</dimension>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_goals_visitsUntilConversion_WithoutLabels__API.getRowEvolution_day.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_goals_visitsUntilConversion_WithoutLabels__API.getRowEvolution_day.xml
@@ -183,7 +183,7 @@
 				<name>1 visit (Conversions)</name>
 				<min>2</min>
 				<max>2</max>
-				<change>0%</change>
+				<change>+0%</change>
 			</nb_conversions_0>
 			<nb_conversions_1>
 				<name>2 visits (Conversions)</name>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_goals_visitsUntilConversion__API.getRowEvolution_day.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_goals_visitsUntilConversion__API.getRowEvolution_day.xml
@@ -183,7 +183,7 @@
 				<name>1 visit (Conversions)</name>
 				<min>2</min>
 				<max>2</max>
-				<change>0%</change>
+				<change>+0%</change>
 			</nb_conversions_0>
 			<nb_conversions_1>
 				<name> 2 visits (Conversions)</name>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_multiWithFilterLimit__API.getRowEvolution_day.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_multiWithFilterLimit__API.getRowEvolution_day.xml
@@ -51,7 +51,7 @@
 				<name>www.referrer0.com (Visits)</name>
 				<min>0</min>
 				<max>1</max>
-				<change>0%</change>
+				<change>+0%</change>
 			</nb_visits_0>
 			<nb_visits_1>
 				<name>www.referrer4.com (Visits)</name>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_pageTitlesMulti__API.getRowEvolution_week.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_pageTitlesMulti__API.getRowEvolution_week.xml
@@ -39,7 +39,7 @@
 				<name>incredible title 0 (Pageviews)</name>
 				<min>2</min>
 				<max>3</max>
-				<change>0%</change>
+				<change>+0%</change>
 			</nb_hits_0>
 			<nb_hits_1>
 				<name>incredible title 2 (Pageviews)</name>

--- a/tests/PHPUnit/System/expected/test_RowEvolution_pageTitles__API.getRowEvolution_week.xml
+++ b/tests/PHPUnit/System/expected/test_RowEvolution_pageTitles__API.getRowEvolution_week.xml
@@ -54,13 +54,13 @@
 				<name>Pageviews</name>
 				<min>2</min>
 				<max>3</max>
-				<change>0%</change>
+				<change>+0%</change>
 			</nb_hits>
 			<nb_visits>
 				<name>Unique Pageviews</name>
 				<min>2</min>
 				<max>3</max>
-				<change>0%</change>
+				<change>+0%</change>
 			</nb_visits>
 			<avg_time_on_page>
 				<name>Avg. time on page</name>
@@ -69,13 +69,13 @@
 				<name>Bounce Rate</name>
 				<min>100</min>
 				<max>100</max>
-				<change>0%</change>
+				<change>+0%</change>
 			</bounce_rate>
 			<exit_rate>
 				<name>Exit rate</name>
 				<min>100</min>
 				<max>100</max>
-				<change>0%</change>
+				<change>+0%</change>
 			</exit_rate>
 			<avg_time_generation>
 				<name>Avg. generation time</name>


### PR DESCRIPTION
### Description:

When showing evolution (comparison or row evolution) we currently prepend a plus sign to positive evolutions.
This PR improves the handling for that and fixes some issues:

* Unifies the handling between comparison mode and row evolution
   Having a change of `0` will now always show `+0%`, before row evolution didn't prepend the `+`
* Handle i18n correctly
  Some languages actually don't use a normal `+` sign for numbers. So use `Intl_NumberSymbolPlus` instead
* Current comparison doesn't work on PHP8, causing + sign to be always prepended (refs #16897 )

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
