### PR TITLE
do not update token usage in tracking requests

### DIFF
--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -19,6 +19,7 @@ use Piwik\Plugins\SitesManager\SitesManager;
 use Piwik\Plugins\UsersManager\Sql\SiteAccessFilter;
 use Piwik\Plugins\UsersManager\Sql\UserTableFilter;
 use Piwik\SettingsPiwik;
+use Piwik\SettingsServer;
 use Piwik\Validators\BaseValidator;
 use Piwik\Validators\CharacterLength;
 use Piwik\Validators\NotEmpty;
@@ -386,6 +387,10 @@ class Model
 
     public function setTokenAuthWasUsed($tokenAuth, $dateLastUsed)
     {
+        if (SettingsServer::isTrackerApiRequest()) {
+            return; // do not update usage in tracking requests as this can cause trouble during log import
+        }
+
         $token = $this->getTokenByTokenAuth($tokenAuth);
         if (!empty($token)) {
             $this->updateTokenAuthTable($token['idusertokenauth'], array(

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -387,12 +387,17 @@ class Model
 
     public function setTokenAuthWasUsed($tokenAuth, $dateLastUsed)
     {
-        if (SettingsServer::isTrackerApiRequest()) {
-            return; // do not update usage in tracking requests as this can cause trouble during log import
-        }
-
         $token = $this->getTokenByTokenAuth($tokenAuth);
         if (!empty($token)) {
+
+            $lastUsage = strtotime($token['last_used']);
+            $newUsage = strtotime($dateLastUsed);
+
+            // update token usage only every 10 minutes
+            if ($lastUsage > $newUsage - 600) {
+                return;
+            }
+
             $this->updateTokenAuthTable($token['idusertokenauth'], array(
                 'last_used' => $dateLastUsed
             ));

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -390,10 +390,11 @@ class Model
         $token = $this->getTokenByTokenAuth($tokenAuth);
         if (!empty($token)) {
 
-            $lastUsage = strtotime($token['last_used']);
+            $lastUsage = !empty($token['last_used']) ? strtotime($token['last_used']) : 0;
             $newUsage = strtotime($dateLastUsed);
 
-            // update token usage only every 10 minutes
+            // update token usage only every 10 minutes to avoid table locks when multiple requests with the same token are made
+            // see https://github.com/matomo-org/matomo/issues/16924
             if ($lastUsage > $newUsage - 600) {
                 return;
             }

--- a/plugins/UsersManager/tests/Integration/ModelTest.php
+++ b/plugins/UsersManager/tests/Integration/ModelTest.php
@@ -333,10 +333,23 @@ class ModelTest extends IntegrationTestCase
 
         $tokens = $this->model->getAllNonSystemTokensForLogin($this->login);
         $this->assertSame('2025-01-02 03:04:05', $tokens[0]['last_used']);
+
+        // this should not update the token usage again, as it's within 10 minutes
+        $this->model->setTokenAuthWasUsed('token2',  '2025-01-02 03:08:05');
+
+        $tokens = $this->model->getAllNonSystemTokensForLogin($this->login);
+        $this->assertSame('2025-01-02 03:04:05', $tokens[0]['last_used']);
+
+        // this should update the token usage again, as it's after 10 minutes
+        $this->model->setTokenAuthWasUsed('token2',  '2025-01-02 03:15:05');
+
+        $tokens = $this->model->getAllNonSystemTokensForLogin($this->login);
+        $this->assertSame('2025-01-02 03:15:05', $tokens[0]['last_used']);
     }
 
     public function test_setTokenAuthWasUsed_doesNotFailWhenTokenNotExists()
     {
+        $this->expectNotToPerformAssertions();
         $this->model->setTokenAuthWasUsed('tokenFooBar',  '2025-01-02 03:04:05');
     }
 


### PR DESCRIPTION
### Description:

Seems updating the usage timestamp of a token might cause issues when using log import.
Not sure if we need to update the usage at all in this case. If so we maybe could also update it every 10 minutes only or so, but that would at least require an additional read request to check that.

fixes #16924

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
