### PR TITLE
Better check for getmypid to potentially avoid warnings

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -181,7 +181,8 @@ class Process
             return false;
         }
 
-        if (!in_array(getmypid(), self::getRunningProcesses())) {
+        $pid = @getmypid();
+        if (empty($pid) || !in_array($pid, self::getRunningProcesses())) {
             return false;
         }
 


### PR DESCRIPTION
### Description:

refs https://wordpress.org/support/topic/warning-getmypid-has-been-disabled/

Might not make a difference but could (because third parameter in in_array is not true). This way we might better detect that getmypid is not supported although in the user's case likely the problem is that `getmypid` is supported in web and not CLI.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
