### PR TITLE
Prevent memory error when using PHP8 and a session error happens

### DIFF
--- a/libs/Zend/Session/Exception.php
+++ b/libs/Zend/Session/Exception.php
@@ -54,7 +54,7 @@ class Zend_Session_Exception extends Zend_Exception
      * @param  string $errstr
      * @return void
      */
-    static public function handleSessionStartError($errno, $errstr, $errfile, $errline, $errcontext)
+    static public function handleSessionStartError($errno, $errstr, $errfile, $errline, $errcontext = '')
     {
         $message = $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr;
         if (E_ERROR === $errno || E_CORE_ERROR === $errno || E_COMPILE_ERROR === $errno) {
@@ -72,7 +72,7 @@ class Zend_Session_Exception extends Zend_Exception
      * @param  string $errstr
      * @return void
      */
-    static public function handleSilentWriteClose($errno, $errstr, $errfile, $errline, $errcontext)
+    static public function handleSilentWriteClose($errno, $errstr, $errfile, $errline, $errcontext = '')
     {
         self::$sessionStartError .= PHP_EOL . $errfile . '(Line:' . $errline . '): Error #' . $errno . ' ' . $errstr;
     }


### PR DESCRIPTION
### Description:

Noticed it exceeded 512MB, then 2GB, ...

It was running in an endless loop because 

> PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Zend_Session_Exception::handleSessionStartError(), 4 passed and exactly 5 expected i

See https://www.php.net/manual/en/function.set-error-handler.php

> Since PHP 8: errcontext was removed, and will no longer be passed to user callbacks.

There might be also other places where we maybe use error handler

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
