### PR TITLE
core:archive Remember if process ever started

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -25,6 +25,7 @@ class Process
     private $timeCreation = null;
     private $isSupported = null;
     private $pid = null;
+    private $started = null;
 
     public function __construct($pid)
     {
@@ -60,6 +61,16 @@ class Process
     }
 
     public function hasStarted($content = null)
+    {
+        if (!$this->started) {
+            $this->started = $this->checkPidIfHasStarted($content);
+        }
+        // PID will be deleted when process has finished so we want to remember this process started at some point. Otherwise we might return false here once the process finished.
+        // therefore we want to "cache" a successful start
+        return $this->started;
+    }
+
+    private function checkPidIfHasStarted($content = null)
     {
         if (is_null($content)) {
             $content = $this->getPidFileContent();

--- a/tests/PHPUnit/Integration/CliMulti/ProcessTest.php
+++ b/tests/PHPUnit/Integration/CliMulti/ProcessTest.php
@@ -121,11 +121,20 @@ class ProcessTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->process->hasFinished());
     }
 
-    public function test_hasStarted()
+    public function test_hasStarted_startedWhenContentFalse()
     {
         $this->assertTrue($this->process->hasStarted(false));
-        $this->assertTrue($this->process->hasStarted('6341'));
+    }
 
+    public function test_hasStarted_startedWhenPidGiven()
+    {
+        $this->assertTrue($this->process->hasStarted('6341'));
+        // remembers the process was started at some point
+        $this->assertTrue($this->process->hasStarted(''));
+    }
+
+    public function test_hasStarted_notStartedYetEmptyContentInPid()
+    {
         $this->assertFalse($this->process->hasStarted(''));
     }
 


### PR DESCRIPTION
This can potentially bring a performance improvement as I think sometimes the system would wait for 8 seconds before declaring a process as finished even if it finished after 1s.

What happens is in https://github.com/matomo-org/matomo/blob/4.0.5/core/CliMulti.php#L217-L222 it checks if the process has started by checking if the PID file exists.

However, the `RequestCommand` deletes the PID file as soon as the process finished to signal "it finished". That means when we check in that loop whether the process has started, it would think it hasn't started yet and simply continue until 8s have past and then it would set the process as finished. Vs we can simply remember that once we say once "the process has started" flag then we can always remember this.

Actually now seeing this wouldn't mean a performance improvement as it only continues after 8s and doesn't wait for 8s. I reckon it's still good to have this change though just to prevent some potential edge cases.

Actually now seeing again this might be a performance improvement because it would simply say "not finished" yet if it thinks the process hasn't started yet. Only after 8s then it would declare it as finished

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
