### PR TITLE
core:archive If one process' output is "abnormal", don't declare all other concurrently running processes as finished

### DIFF
--- a/core/CliMulti.php
+++ b/core/CliMulti.php
@@ -231,7 +231,7 @@ class CliMulti
             foreach ($this->outputs as $output) {
                 if ($output->getOutputId() === $pid && $output->isAbnormal()) {
                     $process->finishProcess();
-                    return true;
+                    continue;
                 }
             }
 


### PR DESCRIPTION
### Description:

Instead still wait for all the other commands to finish.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
