### PR TITLE
core:archive Only mark process as finished after fully sending the output

### DIFF
--- a/core/CliMulti/RequestCommand.php
+++ b/core/CliMulti/RequestCommand.php
@@ -78,12 +78,12 @@ class RequestCommand extends ConsoleCommand
 
         require_once PIWIK_INCLUDE_PATH . $indexFile;
 
-        if (!empty($process)) {
-            $process->finishProcess();
-        }
-
         while (ob_get_level()) {
            echo ob_get_clean();
+        }
+        
+        if (!empty($process)) {
+            $process->finishProcess();
         }
     }
 


### PR DESCRIPTION
### Description:

Otherwise there could be a race condition in cli multi where it thinks the process is finished, but the output hasn't been sent and written yet. Thus ending up with an "empty response" error under circumstances or only reading a partial output. This should only affect Matomo for WordPress though

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
