### PR TITLE
core:archive Avoid filesystem checks when process was set as finished

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -21,6 +21,7 @@ use Piwik\SettingsServer;
  */
 class Process
 {
+    private $finished = null;
     private $pidFile = '';
     private $timeCreation = null;
     private $isSupported = null;
@@ -81,6 +82,10 @@ class Process
 
     public function hasFinished()
     {
+        if ($this->finished) {
+            return true;
+        }
+
         $content = $this->getPidFileContent();
 
         return !$this->doesPidFileExist($content);
@@ -129,6 +134,7 @@ class Process
 
     public function finishProcess()
     {
+        $this->finished = true;
         Filesystem::deleteFileIfExists($this->pidFile);
     }
 


### PR DESCRIPTION
### Description:

Because in CliMulti we might check in a loop for every process constantly if they are finished. It won't help all that much but better to not check every time the file system when it is not needed.

There be many other things we could improve there. Will add some comments but probably best not to do them (or we'll see if it's needed later)

Technically, we could also set `$this->started=true` and avoid filesystem checks when `startProcess()` is called but shouldn't be needed at least in current code usage. It wouldn't really avoid any file system checks so far and would make it only harder to find some bugs maybe as the filesystem be avoided in the tests potentially.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
