### PR TITLE
Do not use Date class in Loader::getMinVisitTimesPerSite() to avoid using Dates w/ strange visit data.

### DIFF
--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -417,7 +417,7 @@ class Loader
 
         $timezone = Site::getTimezoneFor($idSite);
         list($date1, $date2) = $period->getBoundsInTimezone($timezone);
-        if ($date2->isEarlier($minVisitTimesPerSite)) {
+        if ($date2->getTimestamp() < $minVisitTimesPerSite) {
             return false;
         }
 
@@ -435,10 +435,6 @@ class Loader
             if (!empty($value)) {
                 $cache->save($cacheKey, $value, $ttl = self::MIN_VISIT_TIME_TTL);
             }
-        }
-
-        if (!empty($value)) {
-            $value = Date::factory($value);
         }
 
         return $value;


### PR DESCRIPTION
### Description:

Fixes #16937 

The user had a visit with a visit_last_action_time of 2. Opted to not use the Date class at all to keep the relevant query as simple as possible.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
