### PR TITLE
Invalidate archives after deleting a visit to prevent race conditions

### DIFF
--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -107,12 +107,12 @@ class DataSubjects
          */
         Piwik::postEvent('PrivacyManager.deleteDataSubjects', array(&$results, $visits));
 
-        $this->invalidateArchives($visits);
-
         $logTables = $this->getLogTablesToDeleteFrom();
         $deleteCounts = $this->deleteLogDataFrom($logTables, function ($tableToSelectFrom) use ($visits) {
             return $this->visitsToWhereAndBind($tableToSelectFrom, $visits);
         });
+
+        $this->invalidateArchives($visits);
 
         $results = array_merge($results, $deleteCounts);
         krsort($results); // make sure test results are always in same order

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -107,22 +107,22 @@ class DataSubjects
          */
         Piwik::postEvent('PrivacyManager.deleteDataSubjects', array(&$results, $visits));
 
+        $datesToInvalidateByIdSite = $this->getDatesToInvalidate($visits);
+
         $logTables = $this->getLogTablesToDeleteFrom();
         $deleteCounts = $this->deleteLogDataFrom($logTables, function ($tableToSelectFrom) use ($visits) {
             return $this->visitsToWhereAndBind($tableToSelectFrom, $visits);
         });
 
-        $this->invalidateArchives($visits);
+        $this->invalidateArchives($datesToInvalidateByIdSite);
 
         $results = array_merge($results, $deleteCounts);
         krsort($results); // make sure test results are always in same order
         return $results;
     }
 
-    private function invalidateArchives($visits)
+    private function invalidateArchives($datesToInvalidateByIdSite)
     {
-        $datesToInvalidateByIdSite = $this->getDatesToInvalidate($visits);
-
         $invalidator = StaticContainer::get('Piwik\Archive\ArchiveInvalidator');
 
         foreach ($datesToInvalidateByIdSite as $idSite => $visitDates) {


### PR DESCRIPTION
### Description:

The deletion of visits can take a while. To prevent any possible race condition we should invalidate archives only after the visits were deleted.

We recently deleted few visits and noticed the reports are still showing the wrong data. Not sure if this was the problem but be still good to change.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
