### PR TITLE
Show site selector as text only when only one site is available

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -751,7 +751,11 @@ abstract class Controller
 
         $pluginManager = Plugin\Manager::getInstance();
         $view->relativePluginWebDirs = (object) $pluginManager->getWebRootDirectoriesForCustomPluginDirs();
-        $view->isMultiSitesEnabled = Manager::getInstance()->isPluginActivated('MultiSites');
+        $view->isMultiSitesEnabled = $pluginManager->isPluginActivated('MultiSites');
+        $view->isSingleSite = Access::doAsSuperUser(function() {
+            $allSites = Request::processRequest('SitesManager.getAllSitesId', [], []);
+            return count($allSites) === 1;
+        });
 
         if (isset($this->site) && is_object($this->site) && $this->site instanceof Site) {
             $view->siteName = $this->site->getName();

--- a/plugins/CoreHome/angularjs/siteselector/siteselector-model.service.js
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector-model.service.js
@@ -23,7 +23,8 @@
             updateWebsitesList: updateWebsitesList,
             searchSite: searchSite,
             loadSite: loadSite,
-            loadInitialSites: loadInitialSites
+            loadInitialSites: loadInitialSites,
+            hasMultipleSites: hasMultipleSites
         };
 
         return model;
@@ -122,8 +123,13 @@
             }
 
             searchSite('%').then(function () {
-                initialSites = model.sites
+                initialSites = model.sites;
+                model.isInitialized = true
             });
+        }
+
+        function hasMultipleSites() {
+            return initialSites && initialSites.length > 1;
         }
     }
 })();

--- a/plugins/CoreHome/angularjs/siteselector/siteselector.controller.js
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.controller.js
@@ -13,6 +13,8 @@
 
         $scope.model = siteSelectorModel;
 
+        $scope.model.loadInitialSites();
+
         $scope.autocompleteMinSites = AUTOCOMPLETE_MIN_SITES;
         $scope.activeSiteId = piwik.idSite;
 

--- a/plugins/CoreHome/angularjs/siteselector/siteselector.directive.html
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.directive.html
@@ -1,6 +1,6 @@
 <div piwik-focus-anywhere-but-here="view.showSitesList=false"
      class="siteSelector piwikSelector borderedControl"
-     ng-class="{'expanded': view.showSitesList}">
+     ng-class="{'expanded': view.showSitesList, 'disabled': !model.hasMultipleSites()}">
 
     <script type="text/ng-template" id="siteselector_allsiteslink.html">
         <div ng-click="switchSite({idsite: 'all', name: allSitesText}, $event);view.showSitesList=false;"
@@ -13,10 +13,10 @@
 
     <input ng-if="inputName" type="hidden" name="{{ inputName }}" ng-value="selectedSite.id"/>
 
-    <a ng-click="view.showSitesList=!view.showSitesList; view.showSitesList && !model.isLoading && model.loadInitialSites();"
+    <a ng-click="model.hasMultipleSites() && (view.showSitesList=!view.showSitesList) && !model.isLoading && model.loadInitialSites();"
        piwik-onenter="view.showSitesList=!view.showSitesList; view.showSitesList && !model.isLoading && model.loadInitialSites();"
        href="javascript:void(0)"
-       title="{{ 'CoreHome_ChangeCurrentWebsite'|translate:((selectedSite.name || model.firstSiteName)) }}"
+       ng-attr-title="{{ model.hasMultipleSites() ? _pk_translate('CoreHome_ChangeCurrentWebsite', (selectedSite.name || model.firstSiteName)) : '' }}"
        ng-class="{'loading': model.isLoading}"
        class="title" tabindex="4">
         <span class="icon icon-arrow-bottom"

--- a/plugins/CoreHome/angularjs/siteselector/siteselector.directive.less
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.directive.less
@@ -167,3 +167,19 @@
   white-space: normal;
   text-align: left;
 }
+
+.siteSelector.disabled {
+  a.title {
+    cursor: default !important;
+
+    .icon {
+      display: none !important;
+    }
+  }
+
+  &.borderedControl {
+    &:hover {
+      background-color: @theme-color-background-base!important;
+    }
+  }
+}

--- a/plugins/CoreHome/templates/_siteSelectHeader.twig
+++ b/plugins/CoreHome/templates/_siteSelectHeader.twig
@@ -1,3 +1,5 @@
+{% if not isSingleSite %}
 <div class="top_bar_sites_selector piwikTopControl">
     <div piwik-siteselector show-selected-site="true" show-all-sites-item="{{ isMultiSitesEnabled ? 'true' : 'false' }}" class="sites_autocomplete"></div>
 </div>
+{% endif %}

--- a/plugins/Morpheus/tests/UI/expected-screenshots/Morpheus_load.png
+++ b/plugins/Morpheus/tests/UI/expected-screenshots/Morpheus_load.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8f6009eb0af31e96c7df196e5d7e2d88a0eb265f2f69a9051d3fa56490de09b
-size 1666022
+oid sha256:eb7c3bf2681e8aeaa54d403be9882c0f6f7e8f3cfffee9e851da23029a818de5
+size 1667809

--- a/tests/UI/expected-screenshots/Menus_mobile_top.png
+++ b/tests/UI/expected-screenshots/Menus_mobile_top.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb200247352a9738c0af076cd650970ed1c9dd7d975dccd1ac14034532e64709
-size 173014
+oid sha256:69ebaf22839ac8b87956ffae8c2a2e9daa17f0abf5512ef4f5081a87a88e48ea
+size 172960

--- a/tests/UI/expected-screenshots/Theme_demo.png
+++ b/tests/UI/expected-screenshots/Theme_demo.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c44afafb8cb239b6c1eadd9ef7e5f6806bf4d7975557493fef2b1aa452baf7f
-size 1666005
+oid sha256:8eee37d56dbe16c4518f64a3f2cfbe22b24fe35612a258f981786884e6738df4
+size 1667830


### PR DESCRIPTION
### Description:

When only one website is available, the site selector will no longer work as selector. Instead all highlight effects are removed and the dropdown arrow is hidden as well. (Let me know if the UI should be modified even more.)

The site selector will also be shown this way while the list of available sites is loaded.
The list of sites will now be loaded automatically when the site selector is initialized. Before that was done on open only.

fixes #16789

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
