### PR TITLE
Update wikimedia/less.php dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.2.5"
+            "php": "7.2.9"
         },
         "prepend-autoloader": false,
         "sort-packages": true
@@ -57,7 +57,7 @@
         "tecnickcom/tcpdf": "~6.0",
         "tedivm/jshrink": "dev-master#aed09eace9d498e18d48a5b62a7e5a97dfc0e55d",
         "twig/twig": "^3.0",
-        "wikimedia/less.php": "^2.0"
+        "wikimedia/less.php": "^3.0"
     },
     "require-dev": {
         "lox/xhprof": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79aedd52470e03e3ab883affab84ce48",
+    "content-hash": "78bcf8d713875ccb984d130f8a16fc9e",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2217,23 +2217,27 @@
         },
         {
             "name": "wikimedia/less.php",
-            "version": "v2.0.0",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/less.php.git",
-                "reference": "c1affb4d4472c9e100fc80bf456b4334862ace3c"
+                "reference": "a486d78b9bd16b72f237fc6093aa56d69ce8bd13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/c1affb4d4472c9e100fc80bf456b4334862ace3c",
-                "reference": "c1affb4d4472c9e100fc80bf456b4334862ace3c",
+                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/a486d78b9bd16b72f237fc6093aa56d69ce8bd13",
+                "reference": "a486d78b9bd16b72f237fc6093aa56d69ce8bd13",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2.9"
             },
             "require-dev": {
-                "phpunit/phpunit": "7.5.14"
+                "mediawiki/mediawiki-codesniffer": "34.0.0",
+                "mediawiki/minus-x": "1.0.0",
+                "php-parallel-lint/php-console-highlighter": "0.5.0",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpunit/phpunit": "^8.5"
             },
             "bin": [
                 "bin/lessc"
@@ -2276,9 +2280,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wikimedia/less.php/issues",
-                "source": "https://github.com/wikimedia/less.php/tree/v2.0.0"
+                "source": "https://github.com/wikimedia/less.php/tree/v3.1.0"
             },
-            "time": "2020-02-04T22:36:29+00:00"
+            "time": "2020-12-11T19:33:31+00:00"
         }
     ],
     "packages-dev": [
@@ -4053,7 +4057,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.5"
+        "php": "7.2.9"
     },
     "plugin-api-version": "2.0.0"
 }

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -924,6 +924,7 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
 
             if(strpos($file, 'vendor/php-di/php-di/website/') !== false
                 || strpos($file, 'vendor/phpmailer/phpmailer/language/') !== false
+                || strpos($file, 'vendor/vendor/wikimedia/less.php/') !== false
                 || strpos($file, 'node_modules/') !== false
                 || strpos($file, 'plugins/VisitorGenerator/vendor/fzaninotto/faker/src/Faker/Provider/') !== false) {
                 continue;


### PR DESCRIPTION
### Description:

We need to update wikimedia/less.php as the new release has some fixes for PHP 8.

I had to overwrite the composer platform config to PHP 7.2.9, as wikimedia/less.php requires PHP 7.2.9.
It should work with 7.2.5 as well, see https://github.com/wikimedia/less.php/issues/50#issuecomment-747566164

refs #16897

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
