### PR TITLE
fix potential error in reports purge query

### DIFF
--- a/plugins/PrivacyManager/ReportsPurger.php
+++ b/plugins/PrivacyManager/ReportsPurger.php
@@ -274,8 +274,13 @@ class ReportsPurger
     {
         $maxIdArchive = Db::fetchOne("SELECT MAX(idarchive) FROM $table");
 
+        $blobTableWhere = $this->getBlobTableWhereExpr($oldNumericTables, $table);
+        if (empty($blobTableWhere)) {
+            return 0;
+        }
+
         $sql = "SELECT COUNT(*) FROM $table
-                 WHERE " . $this->getBlobTableWhereExpr($oldNumericTables, $table) . "
+                 WHERE " . $blobTableWhere . "
                    AND idarchive >= ?
                    AND idarchive < ?";
 

--- a/plugins/PrivacyManager/tests/System/PurgeDataTest.php
+++ b/plugins/PrivacyManager/tests/System/PurgeDataTest.php
@@ -141,6 +141,28 @@ class PurgeDataTest extends SystemTestCase
         $this->assertHasNoDownload('year');
     }
 
+    public function test_purgeData_shouldPurgeEverything_IfNoPeriodToKeepIsGivenAndBasicMetricsNotKeptSegmentsKept()
+    {
+        $this->assertHasOneDownload('day');
+        $this->assertHasOneDownload('week');
+        $this->assertHasOneDownload('month');
+        $this->assertHasOneDownload('year');
+
+        $deleteReportsOlderThan = 1;
+        $keepBasicMetrics       = false;
+        $reportPeriodsToKeep    = array();
+        $this->purgeData($deleteReportsOlderThan, $reportPeriodsToKeep, $keepBasicMetrics, true);
+
+        $this->assertNumVisits(0, 'day');
+        $this->assertNumVisits(0, 'week');
+        $this->assertNumVisits(0, 'month');
+        $this->assertNumVisits(0, 'year');
+        $this->assertHasNoDownload('day');
+        $this->assertHasNoDownload('week');
+        $this->assertHasNoDownload('month');
+        $this->assertHasNoDownload('year');
+    }
+
     private function assertNumVisits($expectedNumVisits, $period)
     {
         $url = 'method=VisitsSummary.getVisits'
@@ -176,14 +198,14 @@ class PurgeDataTest extends SystemTestCase
              . '&format=original';
     }
 
-    private function purgeData($deleteReportsOlderThan, $reportPeriodsToKeep, $keepBasicMetrics)
+    private function purgeData($deleteReportsOlderThan, $reportPeriodsToKeep, $keepBasicMetrics, $keepSegmentReports = false)
     {
         $metricsToKeep           = PrivacyManager::getAllMetricsToKeep();
         $maxRowsToDeletePerQuery = 100000;
-        $keepSegmentReports      = false;
 
         $purger = new ReportsPurger($deleteReportsOlderThan, $keepBasicMetrics, $reportPeriodsToKeep,
                                     $keepSegmentReports, $metricsToKeep, $maxRowsToDeletePerQuery);
+        $purger->getPurgeEstimate();
         $purger->purgeData();
     }
 }


### PR DESCRIPTION
### Description:

should fix https://github.com/matomo-org/matomo/issues/16978

Thought it was a PHP 8 issue but looks like it's actually always been a bug maybe. I tweaked the code to reproduce this but in the end I think it happens maybe when you enable report purging but don't keep any periods or so.

Noticed must be this query because it says: `near &#039;AND idarchive &gt;= ?                   AND idarchive &lt; ?&#039; at line 3',`

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
