### PR TITLE
Show segment hash in segmenteditor.getAll output to aid debugging.

### DIFF
--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -363,6 +363,14 @@ class API extends \Piwik\Plugin\API
 
         $segments = $this->sortSegmentsCreatedByUserFirst($segments);
 
+        $model = new \Piwik\Plugins\SitesManager\Model();
+        $allSites = $model->getSitesId();
+        foreach ($segments as &$segment) {
+            $idSites = !empty($segment['enable_only_idsite']) ? [(int)$segment['enable_only_idsite']] : $allSites;
+            $segmentObj = new Segment($segment['definition'], $idSites);
+            $segment['hash'] = $segmentObj->getHash();
+        }
+
         return $segments;
     }
 

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -367,7 +367,7 @@ class API extends \Piwik\Plugin\API
         $allSites = $model->getSitesId();
         foreach ($segments as &$segment) {
             $idSites = !empty($segment['enable_only_idsite']) ? [(int)$segment['enable_only_idsite']] : $allSites;
-            $segmentObj = new Segment($segment['definition'], $idSites);
+            $segmentObj = new Segment(urlencode($segment['definition']), $idSites);
             $segment['hash'] = $segmentObj->getHash();
         }
 

--- a/plugins/SegmentEditor/tests/Integration/ApiTest.php
+++ b/plugins/SegmentEditor/tests/Integration/ApiTest.php
@@ -42,6 +42,27 @@ class ApiTest extends IntegrationTestCase
 
     }
 
+    public function test_getll_returnsCorrectHashes()
+    {
+        $this->createAdminUser();
+        $this->createSegments();
+        $this->setSuperUser();
+
+        $segments = $this->api->getAll();
+        $hashes = array_column($segments, 'hash', 'name');
+        $expectedHashes = [
+            'segment 4' => '2831795f8d5a6c8c2ef96c6ec35a35a6',
+            'segment 5' => '6ae79eae41a5ce05e5d137ae056029ca',
+            'segment 6' => '9fdd40fa3d8317f4883bbc616fff3957',
+            'segment 9' => '2831795f8d5a6c8c2ef96c6ec35a35a6',
+            'segment 1' => '9fdd40fa3d8317f4883bbc616fff3957',
+            'segment 2' => '37d1b27c81afefbcf0961472b9abdb0f',
+            'segment 3' => '9fdd40fa3d8317f4883bbc616fff3957',
+            'segment 7' => '9fdd40fa3d8317f4883bbc616fff3957',
+            'segment 8' => '9fdd40fa3d8317f4883bbc616fff3957',
+        ];
+        $this->assertEquals($expectedHashes, $hashes);
+    }
     public function test_getAll_forOneWebsite_returnsSortedSegments()
     {
         $this->createAdminUser();
@@ -161,7 +182,7 @@ class ApiTest extends IntegrationTestCase
 
         $this->setSuperUser();
         $this->api->add('segment 4', 'countryCode!=fr', $idSite = false, $autoArchive = false, $enableAllUsers = false);
-        $this->api->add('segment 5', 'countryCode!=fr', $idSite = 1, $autoArchive = false, $enableAllUsers = true);
+        $this->api->add('segment 5', 'pageUrl!=' . urlencode(urlencode('http://somepage.com/some/path')), $idSite = 1, $autoArchive = false, $enableAllUsers = true);
         $this->api->add('segment 6', 'visitCount<2', $idSite = 2, $autoArchive = true, $enableAllUsers = true);
 
         $this->setAdminUser();


### PR DESCRIPTION
### Description:

In case a user does not want to reveal a segment due to it having sensitive information, it can be hard to figure out exactly what the hash for a segment is (especially when there is an encoding or related problem). So adding it to the API output can be useful for debugging.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
