### PR TITLE
core:archive command new parameter --force-report to only process invalidations for a specific report in a specific plugin.

### DIFF
--- a/core/CronArchive/ArchiveFilter.php
+++ b/core/CronArchive/ArchiveFilter.php
@@ -53,6 +53,13 @@ class ArchiveFilter
      */
     private $skipSegmentsForToday = false;
 
+    /**
+     * If enabled, the only invalidations that will be processed are for the specific plugin and report specified
+     * here. Must be in the format "MyPlugin.myReport".
+     * @var string|null
+     */
+    private $forceReport = null;
+
     public function __construct()
     {
         $this->setRestrictToPeriods('');
@@ -100,6 +107,14 @@ class ArchiveFilter
             && !in_array($periodLabel, $this->restrictToPeriods)
         ) {
             return "period is not specified in --force-periods";
+        }
+
+        if (!empty($this->forceReport)
+            && (empty($archive['plugin'])
+                || empty($archive['report'])
+                || $archive['plugin'] . '.' . $archive['report'] != $this->forceReport)
+        ) {
+            return "report is not the same as value specified in --force-report";
         }
 
         return false;
@@ -222,6 +237,11 @@ class ArchiveFilter
     public function isSkipSegmentsForToday(): bool
     {
         return $this->skipSegmentsForToday;
+    }
+
+    public function setForceReport($forceReport)
+    {
+        $this->forceReport = $forceReport;
     }
 
     /**

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -49,6 +49,7 @@ class CoreArchiver extends ConsoleCommand
         $archiveFilter->setRestrictToDateRange($input->getOption("force-date-range"));
         $archiveFilter->setRestrictToPeriods($input->getOption("force-periods"));
         $archiveFilter->setSkipSegmentsForToday($input->getOption('skip-segments-today'));
+        $archiveFilter->setForceReport($input->getOption('force-report'));
 
         $segmentIds = $input->getOption('force-idsegments');
         $segmentIds = explode(',', $segmentIds);
@@ -109,5 +110,6 @@ class CoreArchiver extends ConsoleCommand
             . "useful if you specified --url=https://... or if you are using Piwik with force_ssl=1");
         $command->addOption('php-cli-options', null, InputOption::VALUE_OPTIONAL, 'Forwards the PHP configuration options to the PHP CLI command. For example "-d memory_limit=8G". Note: These options are only applied if the archiver actually uses CLI and not HTTP.', $default = '');
         $command->addOption('force-all-websites', null, InputOption::VALUE_NONE, 'Force archiving all websites.');
+        $command->addOption('force-report', null, InputOption::VALUE_NONE, 'If specified, only processes invalidations for a specific report in a specific plugin. Value must be in the format of "MyPlugin.myReport".');
     }
 }

--- a/tests/PHPUnit/Integration/CronArchive/ArchiveFilterTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/ArchiveFilterTest.php
@@ -7,7 +7,7 @@
  *
  */
 
-namespace PHPUnit\Unit\CronArchive;
+namespace PHPUnit\Integration\CronArchive;
 
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\CronArchive\ArchiveFilter;
@@ -16,8 +16,33 @@ use Piwik\Plugins\SegmentEditor\API as SegmentAPI;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 
+/**
+ * @group Core
+ */
 class ArchiveFilterTest extends IntegrationTestCase
 {
+
+    public function test_archiveFilter_filtersOutArchivesWhenForceReportIsSpecified()
+    {
+        $filter = new ArchiveFilter();
+        $filter->setForceReport('MyPlugin.myName');
+
+        $result = $filter->filterArchive(['date1' => '2020-03-04', 'date2' => '2020-03-04', 'period' => 1]);
+        $this->assertEquals('report is not the same as value specified in --force-report', $result);
+
+        $result = $filter->filterArchive(['date1' => '2020-03-04', 'date2' => '2020-03-04', 'period' => 1, 'plugin' => 'MyPlugin']);
+        $this->assertEquals('report is not the same as value specified in --force-report', $result);
+
+        $result = $filter->filterArchive(['date1' => '2020-03-04', 'date2' => '2020-03-04', 'period' => 1, 'plugin' => 'MyPlugin', 'report' => 'myOtherName']);
+        $this->assertEquals('report is not the same as value specified in --force-report', $result);
+
+        $result = $filter->filterArchive(['date1' => '2020-03-04', 'date2' => '2020-03-04', 'period' => 1, 'plugin' => 'MyOtherPlugin', 'report' => 'myName']);
+        $this->assertEquals('report is not the same as value specified in --force-report', $result);
+
+        $result = $filter->filterArchive(['date1' => '2020-03-04', 'date2' => '2020-03-04', 'period' => 1, 'plugin' => 'MyPlugin', 'report' => 'myName']);
+        $this->assertFalse($result);
+    }
+
     public function test_setSegmentsToForceFromSegmentIds_CorrectlyGetsSegmentDefinitions_FromSegmentIds()
     {
         Rules::setBrowserTriggerArchiving(false);


### PR DESCRIPTION
FYI @tsteur 

### Description:

Allow filtering for a specific report so we can launch core:archive and only archive that report.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
