### PR TITLE
core:archive when looking for other climulti processes, also make sure idSite is same

### DIFF
--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -407,6 +407,7 @@ class QueueConsumer
             if (!empty($archiveBeingProcessed['segment'])
                 && !empty($archiveToProcess['segment'])
                 && $archiveBeingProcessed['segment'] != $archiveToProcess['segment']
+                && urldecode($archiveBeingProcessed['segment']) != $archiveToProcess['segment']
             ) {
                 continue;
             }

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -397,8 +397,8 @@ class QueueConsumer
                 continue;
             }
 
-            if (empty($inProgressArchives['idSite'])
-                || $inProgressArchives['idSite'] != $archiveToProcess['idsite']
+            if (empty($archiveBeingProcessed['idSite'])
+                || $archiveBeingProcessed['idSite'] != $archiveToProcess['idsite']
             ) {
                 continue; // different site
             }

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -397,6 +397,12 @@ class QueueConsumer
                 continue;
             }
 
+            if (empty($inProgressArchives['idSite'])
+                || $inProgressArchives['idSite'] != $archiveToProcess['idsite']
+            ) {
+                continue; // different site
+            }
+
             // we don't care about lower periods being concurrent if they are for different segments (that are not "all visits")
             if (!empty($archiveBeingProcessed['segment'])
                 && !empty($archiveToProcess['segment'])
@@ -408,7 +414,7 @@ class QueueConsumer
             $archiveBeingProcessed['periodObj'] = PeriodFactory::build($archiveBeingProcessed['period'], $archiveBeingProcessed['date']);
 
             if ($this->isArchiveOfLowerPeriod($archiveToProcess, $archiveBeingProcessed)) {
-                return "lower period in progress (period = {$archiveBeingProcessed['period']}, date = {$archiveBeingProcessed['date']})";
+                return "lower or same period in progress in another local climulti process (period = {$archiveBeingProcessed['period']}, date = {$archiveBeingProcessed['date']})";
             }
 
             if ($this->isArchiveNonSegmentAndInProgressArchiveSegment($archiveToProcess, $archiveBeingProcessed)) {


### PR DESCRIPTION
### Description:

As title. This is in case there are multiple archivers running on the same machine, we can pick up climulti requests for other sites.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
