### PR TITLE
always send an "Accept-Encoding" header with HTTP requests

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -595,7 +595,6 @@ class Http
                 // curl options (sorted oldest to newest)
                 CURLOPT_URL            => $aUrl,
                 CURLOPT_USERAGENT      => $userAgent,
-                CURLOPT_ENCODING       => "",
                 CURLOPT_HTTPHEADER     => array_merge(array(
                     $xff,
                     $via,
@@ -609,6 +608,11 @@ class Http
 
             if ($rangeBytes) {
                 curl_setopt($ch, CURLOPT_RANGE, $rangeBytes);
+            } else {
+                // see https://github.com/matomo-org/matomo/pull/17009 for more info
+                // NOTE: we only do this when CURLOPT_RANGE is not being used, because when using both the
+                // response is empty.
+                $curl_options[CURLOPT_ENCODING] = "";
             }
 
             // Case core:archive command is triggering archiving on https:// and the certificate is not valid

--- a/core/Http.php
+++ b/core/Http.php
@@ -587,7 +587,7 @@ class Http
                     @curl_setopt($ch, CURLOPT_PROXYUSERPWD, $proxyUser . ':' . $proxyPassword);
                 }
             }
-
+            var_dump($userAgent);
             $curl_options = array(
                 // internal to ext/curl
                 CURLOPT_BINARYTRANSFER => is_resource($file),
@@ -595,6 +595,7 @@ class Http
                 // curl options (sorted oldest to newest)
                 CURLOPT_URL            => $aUrl,
                 CURLOPT_USERAGENT      => $userAgent,
+                CURLOPT_ENCODING       => "",
                 CURLOPT_HTTPHEADER     => array_merge(array(
                     $xff,
                     $via,

--- a/core/Http.php
+++ b/core/Http.php
@@ -587,7 +587,7 @@ class Http
                     @curl_setopt($ch, CURLOPT_PROXYUSERPWD, $proxyUser . ':' . $proxyPassword);
                 }
             }
-            var_dump($userAgent);
+
             $curl_options = array(
                 // internal to ext/curl
                 CURLOPT_BINARYTRANSFER => is_resource($file),


### PR DESCRIPTION
This fixes a fun issue reported in https://forum.matomo.org/t/error-array-offset-on-bool-in-securityinfo-matomo-4-1-0/39986

I originally blamed `safe_unserialize` to be broken, but it turned out that even a `Http::sendHttpRequest('https://php.net/releases/?json=1&version=7', $timeout);` was only returning garbled output.

It turns out that whatever server the PHP team uses, assumes that when you use Firefox, you are always able to uncompress gzip-encoded content, even if it was not requested. (and Matomo forwards the User Agent of the user for its HTTP requests).

```bash
➜  ~ curl 'https://www.php.net/releases/?json=1&version=7' 
{"announcement":true,"tags":[],"date":"26 Nov 2020","source":[{"filename":"php-7.4.13.tar.gz","name":"PHP 7.4.13 (tar.gz)","sha256":"0865cff41e7210de2537bcd5750377cfe09a9312b9b44c1a166cf372d5204b8f","date":"26 Nov 2020"},{"filename":"php-7.4.13.tar.bz2","name":"PHP 7.4.13 (tar.bz2)","sha256":"15a339857e11c92eb47fddcd0dfe8aaa951a9be7c57ab7230ccd497465a31fda","date":"26 Nov 2020"},{"filename":"php-7.4.13.tar.xz","name":"PHP 7.4.13 (tar.xz)","sha256":"aead303e3abac23106529560547baebbedba0bb2943b91d5aa08fff1f41680f4","date":"26 Nov 2020"}],"version":"7.4.13"}%
➜  ~ curl 'https://www.php.net/releases/?json=1&version=7' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:84.0) Gecko/20100101 Firefox/84.0'                                                          
Warning: Binary output can mess up your terminal. Use "--output -" to tell 
Warning: curl to output it to your terminal anyway, or consider "--output 
Warning: <FILE>" to save to a file.
➜  ~ curl 'https://www.php.net/releases/?json=1&version=7' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:84.0) Gecko/20100101 Firefox/84.0' -H "Accept-Encoding: idendity"                           
{"announcement":true,"tags":[],"date":"26 Nov 2020","source":[{"filename":"php-7.4.13.tar.gz","name":"PHP 7.4.13 (tar.gz)","sha256":"0865cff41e7210de2537bcd5750377cfe09a9312b9b44c1a166cf372d5204b8f","date":"26 Nov 2020"},{"filename":"php-7.4.13.tar.bz2","name":"PHP 7.4.13 (tar.bz2)","sha256":"15a339857e11c92eb47fddcd0dfe8aaa951a9be7c57ab7230ccd497465a31fda","date":"26 Nov 2020"},{"filename":"php-7.4.13.tar.xz","name":"PHP 7.4.13 (tar.xz)","sha256":"aead303e3abac23106529560547baebbedba0bb2943b91d5aa08fff1f41680f4","date":"26 Nov 2020"}],"version":"7.4.13"}% 
```

So PHP curl recieved a gziped response even though it didn't request it and therefore didn't automatically unpack it. Adding `CURLOPT_ENCODING => ""`  tells curl to always request all encodings it supports and therefore be able to handle any gzipped response.

> |CURLOPT_ENCODING |The contents of the "Accept-Encoding: " header. This enables decoding of the response. Supported encodings are "identity", "deflate", and "gzip". If an empty string, "", is set, a header containing all supported encoding types is sent. |Added in cURL 7.10.|
> |---|---|---|
>
> https://www.php.net/manual/en/function.curl-setopt.php


### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
