### PR TITLE
Make “Compare To” translatable

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -32,6 +32,7 @@
         "ChooseLanguage": "Choose language",
         "ChoosePeriod": "Choose period",
         "ClickHere": "Click here for more information.",
+        "CompareTo": "Compare to:",
         "DoubleClickToChangePeriod": "Double click to apply this period.",
         "Close": "Close",
         "ClickToSearch": "Click to search",

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -453,6 +453,7 @@ class CoreHome extends \Piwik\Plugin
         $translationKeys[] = 'General_DoubleClickToChangePeriod';
         $translationKeys[] = 'General_Apply';
         $translationKeys[] = 'General_Period';
+        $translationKeys[] = 'General_CompareTo';
         $translationKeys[] = 'CoreHome_DateInvalid';
         $translationKeys[] = 'CoreHome_EnterZenMode';
         $translationKeys[] = 'CoreHome_ExitZenMode';

--- a/plugins/CoreHome/angularjs/period-selector/period-selector.directive.html
+++ b/plugins/CoreHome/angularjs/period-selector/period-selector.directive.html
@@ -72,7 +72,7 @@
                         type="checkbox"
                         ng-model="periodSelector.isComparing"
                 />
-                <span>Compare to:</span>
+                <span>{{ 'General_CompareTo'|translate }}</span>
             </label>
 
             <div


### PR DESCRIPTION
### Description:

The string “Compare To” in the period dialog is not translateable.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
