### PR TITLE
Only use provider to detect country if IP is not anonymized and lookup is not explicitly disabled (?dp=1)

### DIFF
--- a/plugins/UserCountry/Columns/Country.php
+++ b/plugins/UserCountry/Columns/Country.php
@@ -96,7 +96,19 @@ class Country extends Base
             return strtolower($country);
         }
 
-        $country = $this->getCountryUsingProviderExtensionIfValid($userInfo['ip']);
+        // Detecting the country based on the provider info, requires a DNS reverse lookup
+        // which will slow down tracking.
+        // Only attempt if IP is not anonymized and provider lookups are not explicitly
+        // disabled for this request (?dp=1).
+        $anonymizedIP = substr($userInfo['ip'], -2, 2) == '.0';
+        $providerLookupDisabled = !empty($request->getParam('dp'));
+
+        if (!$anonymizedIP && !$providerLookupDisabled) {
+            $country = $this->getCountryUsingProviderExtensionIfValid($userInfo['ip']);
+        }
+        else {
+            Common::printDebug(sprintf("Skip country detection based on provider - reason %s", $providerLookupDisabled ? "Provider lookup is disabled for the request (dp=1)" : "IP is anonymized"));
+        }
 
         if (!empty($country)) {
             return $country;


### PR DESCRIPTION
Looking up provider information requires a DNS reverse lookup which can severely
slow down bulk tracking.
Only try if IP is **not anonymized** and provider lookups are not explicitly disabled for the request (**?dp=1**).

### Description:

The import_logs.py server log analytics import script allows to disable reverse DNS lookups to speed up bulk imports using the query parameter `dp=1`. While the `Provider` plugin does properly respect the parameter and skips any lookups if the parameter is set, the `UserCountry` plugin ignores the parameter.
In my case this adds about 0.4s for each imported hit.

The only workaround would be to disable the `UserCountry` plugin completely which is not great, since it should still be used for standard website tracking.

In addition, in my case the IP addresses were already sent anonymized and again, while the `Provider` properly skips any reverse lookups – that would fail – if the IP is anonymized, the `UserCountry` plugin takes any IP to try to detect the country based on provider information.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
