### PR TITLE
fixing build 

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -713,8 +713,8 @@ class Http
             @fclose($file);
 
             $fileSize = filesize($destinationPath);
-            if ((($contentLength > 0) && ($fileLength != $contentLength))
-                || ($fileSize != $fileLength)
+            if ($contentLength > 0
+                && $fileSize != $contentLength
             ) {
                 throw new Exception('File size error: ' . $destinationPath . '; expected ' . $contentLength . ' bytes; received ' . $fileLength . ' bytes; saved ' . $fileSize . ' bytes to file');
             }

--- a/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_bulk_access_set.png
+++ b/plugins/UsersManager/tests/UI/expected-screenshots/UsersManager_permissions_bulk_access_set.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb07b7cfb06bb8914e350956875eae3fa6aa8ca2a966696808902877bdee3ddd
-size 108527
+oid sha256:1adc0aefc0706ecf254950a24e77bc6af1fe8368b029d815f86767aab21d26aa
+size 108545

--- a/tests/UI/expected-screenshots/UIIntegrationTest_actions_outlinks_vlog.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_actions_outlinks_vlog.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c4b68a2792ba76873fa4572caa396347b3f9c04ec5259165d610aa5374fa9b80
-size 79583
+oid sha256:e846f1e69127e2d179caf84a1deade044cc901314faa59c6231370b742e73039
+size 76835

--- a/tests/UI/expected-screenshots/UIIntegrationTest_actions_site_search.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_actions_site_search.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23f54d5258b9ff2a7d8901bc70c5205b9e6a0ea67d267e39a6b41a6fe6cb22d6
+oid sha256:bd159c81c029f73c06dbf53e7e7261c88ef2239975eab38b63e0f26cd6ac879e
 size 110772

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1fcd06de4d36e51b3f0762ade52096d286dd150f984a6aee2e14d2531a130dac
-size 4612208
+oid sha256:2650e153647af05e78ffc82354752ab207d836042cfa58f1766ff336f3ebc1fc
+size 4640245


### PR DESCRIPTION
### Description:

Update screenshots + fix issue introduced by using `CURLOPT_ENCODING => ""`. W/ this option it's possible for curl to get gzip encoded data, where `$fileSize` != `$fileLength` (where fileLength is the data returned in the stream_. Instead now we only compare `$fileSize` and `$contentLength`.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
