### PR TITLE
small archiving invalidation loop optimization

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -401,6 +401,7 @@ class CronArchive
         $this->logSection("SUMMARY");
         $this->logger->info("Processed $numArchivesFinished archives.");
         $this->logger->info("Total API requests: {$this->requests}");
+        $this->logger->info("Total invalidation loop iterations: {$queueConsumer->getTotalIterations()}");
 
         $this->logger->info("done: " .
             $this->requests . " req, " . round($timer->getTimeMs()) . " ms, " .

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -346,7 +346,6 @@ class QueueConsumer
 
             $isSegmentArchiveInArchivesToProcess = $this->isSegmentArchiveInArchivesToProcess($archivesToProcess);
             if ($isSegmentArchiveInArchivesToProcess) {
-                // TODO
                 $nextArchive = $this->model->getNextInvalidatedArchive($idSite, $this->currentSiteArchivingStartTime, $invalidationsToExclude,
                     $onlySelectSegmentArchives = true, $archivesToProcess[0]);
             } else {

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -767,7 +767,7 @@ class Model
         if ($onlySelectSegmentArchives) {
             // we select only segment archiving by looking for archive done flags that have a length > 32. this works since the done flag
             // for a segment archive will contain its hash
-            $sql .= " AND CHAR_LENGTH(name) > 32 AND date1 = ? AND date2 = ? AND period = ?";
+            $sql .= " AND CHAR_LENGTH(SUBSTRING_INDEX(name, '.', 1)) > 32 AND date1 = ? AND date2 = ? AND period = ?";
             $bind = array_merge($bind, [$archiveParamsToMatch['date1'], $archiveParamsToMatch['date2'], $archiveParamsToMatch['period']]);
         }
 

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -741,10 +741,15 @@ class Model
     /**
      * Gets the next invalidated archive that should be archived in a table.
      *
-     * @param int $idSite
-     * @param string $archivingStartTime
-     * @param int[]|null $idInvalidationsToExclude
+     * @param int $idSite the ID of the site to get an invalidation for
+     * @param string $archivingStartTime the start time of archiving for this site
+     * @param int[]|null $idInvalidationsToExclude idinvalidations to not look at
+     * @param bool $onlySelectSegmentArchives if true, we only select segment archives for a single period
+     * @param null $archiveParamsToMatch the archive period params to use if $onlySelectSegmentArchives is true. should
+     *                                   contain 'period', 'date1', 'date2' elements.
      * @param bool $useLimit Whether to limit the result set to one result or not. Used in tests only.
+     * @return array
+     * @throws Exception
      */
     public function getNextInvalidatedArchive($idSite, $archivingStartTime, $idInvalidationsToExclude = null, $onlySelectSegmentArchives = false,
                                               $archiveParamsToMatch = null, $useLimit = true)
@@ -760,6 +765,8 @@ class Model
         ];
 
         if ($onlySelectSegmentArchives) {
+            // we select only segment archiving by looking for archive done flags that have a length > 32. this works since the done flag
+            // for a segment archive will contain its hash
             $sql .= " AND CHAR_LENGTH(name) > 32 AND date1 = ? AND date2 = ? AND period = ?";
             $bind = array_merge($bind, [$archiveParamsToMatch['date1'], $archiveParamsToMatch['date2'], $archiveParamsToMatch['period']]);
         }

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -746,7 +746,8 @@ class Model
      * @param int[]|null $idInvalidationsToExclude
      * @param bool $useLimit Whether to limit the result set to one result or not. Used in tests only.
      */
-    public function getNextInvalidatedArchive($idSite, $archivingStartTime, $idInvalidationsToExclude = null, $useLimit = true)
+    public function getNextInvalidatedArchive($idSite, $archivingStartTime, $idInvalidationsToExclude = null, $onlySelectSegmentArchives = false,
+                                              $archiveParamsToMatch = null, $useLimit = true)
     {
         $table = Common::prefixTable('archive_invalidations');
         $sql = "SELECT idinvalidation, idarchive, idsite, date1, date2, period, `name`, report, ts_invalidated
@@ -757,6 +758,11 @@ class Model
             ArchiveInvalidator::INVALIDATION_STATUS_IN_PROGRESS,
             $archivingStartTime,
         ];
+
+        if ($onlySelectSegmentArchives) {
+            $sql .= " AND CHAR_LENGTH(name) > 32 AND date1 = ? AND date2 = ? AND period = ?";
+            $bind = array_merge($bind, [$archiveParamsToMatch['date1'], $archiveParamsToMatch['date2'], $archiveParamsToMatch['period']]);
+        }
 
         if (!empty($idInvalidationsToExclude)) {
             $idInvalidationsToExclude = array_map('intval', $idInvalidationsToExclude);

--- a/tests/PHPUnit/Integration/DataAccess/ModelTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ModelTest.php
@@ -269,8 +269,8 @@ class ModelTest extends IntegrationTestCase
             ['date1' => '2015-03-29', 'date2' => '2015-03-29', 'period' => 1, 'name' => 'done' . md5('testsegment2')],
             ['date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => 3, 'name' => 'done'],
             ['date1' => '2015-04-15', 'date2' => '2015-04-24', 'period' => 5, 'name' => 'done'],
-            ['date1' => '2015-04-06', 'date2' => '2015-04-06', 'period' => 1, 'name' => 'done'],
-            ['date1' => '2015-04-06', 'date2' => '2015-04-06', 'period' => 1, 'name' => 'done' . md5('testsegment3')],
+            ['date1' => '2015-04-06', 'date2' => '2015-04-06', 'period' => 1, 'name' => 'done.SomePluginWithAVeryLongNameThatIsLongerThanThirtyTwoCharacters'],
+            ['date1' => '2015-04-06', 'date2' => '2015-04-06', 'period' => 1, 'name' => 'done' . md5('testsegment3') . '.SomePlugin'],
             ['date1' => '2015-04-03', 'date2' => '2015-04-03', 'period' => 1, 'name' => 'done'],
             ['date1' => '2015-04-05', 'date2' => '2015-04-05', 'period' => 1, 'name' => 'done'],
             ['date1' => '2015-03-30', 'date2' => '2015-04-05', 'period' => 2, 'name' => 'done'],
@@ -294,23 +294,23 @@ class ModelTest extends IntegrationTestCase
                 'report' => null,
             ),
             array (
-                'idinvalidation' => '12',
-                'idarchive' => NULL,
-                'idsite' => '1',
-                'date1' => '2015-04-06',
-                'date2' => '2015-04-06',
-                'period' => '1',
-                'name' => 'done',
-                'report' => null,
-            ),
-            array (
                 'idinvalidation' => '13',
                 'idarchive' => NULL,
                 'idsite' => '1',
                 'date1' => '2015-04-06',
                 'date2' => '2015-04-06',
                 'period' => '1',
-                'name' => 'done764644a7142bdcbedaab92f9dedef5e5',
+                'name' => 'done764644a7142bdcbedaab92f9dedef5e5.SomePlugin',
+                'report' => null,
+            ),
+            array (
+                'idinvalidation' => '12',
+                'idarchive' => NULL,
+                'idsite' => '1',
+                'date1' => '2015-04-06',
+                'date2' => '2015-04-06',
+                'period' => '1',
+                'name' => 'done.SomePluginWithAVeryLongNameThatIsLongerThanThirtyTwoCharacters',
                 'report' => null,
             ),
             array (
@@ -505,7 +505,66 @@ class ModelTest extends IntegrationTestCase
             ),
         );
 
-        $actual = $this->model->getNextInvalidatedArchive(1, '2030-01-01 00:00:00', null, $useLimit = false);
+        $actual = $this->model->getNextInvalidatedArchive(1, '2030-01-01 00:00:00', null, false, null, $useLimit = false);
+        foreach ($actual as &$item) {
+            unset($item['ts_invalidated']);
+        }
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function test_getNextInvalidatedArchive_selectsOnlySegmentsCorrectly()
+    {
+        $this->insertInvalidations([
+            ['date1' => '2015-03-30', 'date2' => '2015-03-30', 'period' => 1, 'name' => 'done' . md5('testsegment8')],
+            ['date1' => '2015-04-01', 'date2' => '2015-04-01', 'period' => 1, 'name' => 'done'],
+            ['date1' => '2015-04-02', 'date2' => '2015-04-02', 'period' => 1, 'name' => 'done' . md5('testsegment1')],
+            ['date1' => '2015-01-01', 'date2' => '2015-12-31', 'period' => 4, 'name' => 'done'],
+            ['date1' => '2015-04-06', 'date2' => '2015-04-12', 'period' => 2, 'name' => 'done' . md5('testsegment3')],
+            ['date1' => '2015-03-29', 'date2' => '2015-03-29', 'period' => 1, 'name' => 'done'],
+            ['date1' => '2015-03-30', 'date2' => '2015-03-30', 'period' => 1, 'name' => 'done'],
+            ['date1' => '2015-04-04', 'date2' => '2015-04-04', 'period' => 1, 'name' => 'done'],
+            ['date1' => '2015-04-02', 'date2' => '2015-04-02', 'period' => 1, 'name' => 'done' . md5('testsegment2')],
+            ['date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => 3, 'name' => 'done'],
+            ['date1' => '2015-04-02', 'date2' => '2015-04-02', 'period' => 1, 'name' => 'done.SomePluginWithAVeryLongNameThatIsLongerThanThirtyTwoCharacters'],
+            ['date1' => '2015-04-06', 'date2' => '2015-04-06', 'period' => 1, 'name' => 'done'],
+            ['date1' => '2015-04-06', 'date2' => '2015-04-06', 'period' => 1, 'name' => 'done' . md5('testsegment3') . '.SomePlugin'],
+            ['date1' => '2015-04-03', 'date2' => '2015-04-03', 'period' => 1, 'name' => 'done'],
+            ['date1' => '2015-04-05', 'date2' => '2015-04-05', 'period' => 1, 'name' => 'done'],
+            ['date1' => '2015-03-30', 'date2' => '2015-04-05', 'period' => 2, 'name' => 'done'],
+            ['date1' => '2015-04-01', 'date2' => '2015-04-30', 'period' => 3, 'name' => 'done' . md5('testsegment1')],
+            ['date1' => '2015-03-01', 'date2' => '2015-03-24', 'period' => 1, 'name' => 'done'],
+            ['date1' => '2015-04-06', 'date2' => '2015-04-12', 'period' => 2, 'name' => 'done'],
+            ['date1' => '2015-04-02', 'date2' => '2015-04-02', 'period' => 1, 'name' => 'done'],
+            ['date1' => '2015-03-01', 'date2' => '2015-03-31', 'period' => 3, 'name' => 'done'],
+            ['date1' => '2015-03-31', 'date2' => '2015-03-31', 'period' => 1, 'name' => 'done'],
+        ]);
+
+        $expected = array (
+            [
+                'idinvalidation' => '9',
+                'idarchive' => null,
+                'idsite' => '1',
+                'date1' => '2015-04-02',
+                'date2' => '2015-04-02',
+                'period' => '1',
+                'name' => 'doneb321434abb5a139c17dadf08c9d2e315',
+                'report' => null,
+            ],
+            [
+                'idinvalidation' => '3',
+                'idarchive' => null,
+                'idsite' => '1',
+                'date1' => '2015-04-02',
+                'date2' => '2015-04-02',
+                'period' => '1',
+                'name' => 'done67564f109e3f4bba6b185a5343ff2bb0',
+                'report' => null,
+            ],
+        );
+
+        $actual = $this->model->getNextInvalidatedArchive(1, '2030-01-01 00:00:00', null,
+            true, ['date1' => '2015-04-02', 'date2' => '2015-04-02', 'period' => 1], $useLimit = false);
         foreach ($actual as &$item) {
             unset($item['ts_invalidated']);
         }


### PR DESCRIPTION
### Description:

Select less invalidations when we know were archiving segments for a specific period + add total iterations counter to output.

When we're archiving an "All Visits" archive, we know we won't be adding segments to it, so every segment archive we query will be skipped. So it's pointless to query for them all. This PR avoids selecting them so we don't have to go through the loop for them. May provide a visible performance boost in cases where there are many segments for a site.

FYI @tsteur 

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
