### PR TITLE
Fix initializing anonymous session

### DIFF
--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -114,10 +114,6 @@ class Auth implements \Piwik\Auth
     {
         $user = $this->userModel->getUserByTokenAuth($token);
 
-        if (empty($user) && $login === 'anonymous') {
-            $user = $this->userModel->getUser('anonymous');
-        }
-
         if (!empty($user['login']) && $user['login'] === $login) {
             $this->userModel->setTokenAuthWasUsed($token, Date::now()->getDatetime());
             return $this->authenticationSuccess($user);

--- a/plugins/Login/Auth.php
+++ b/plugins/Login/Auth.php
@@ -114,6 +114,10 @@ class Auth implements \Piwik\Auth
     {
         $user = $this->userModel->getUserByTokenAuth($token);
 
+        if (empty($user) && $login === 'anonymous') {
+            $user = $this->userModel->getUser('anonymous');
+        }
+
         if (!empty($user['login']) && $user['login'] === $login) {
             $this->userModel->setTokenAuthWasUsed($token, Date::now()->getDatetime());
             return $this->authenticationSuccess($user);

--- a/plugins/UsersManager/Model.php
+++ b/plugins/UsersManager/Model.php
@@ -427,6 +427,10 @@ class Model
 
     public function getUserByTokenAuth($tokenAuth)
     {
+        if ($tokenAuth === 'anonymous') {
+            return $this->getUser('anonymous');
+        }
+
         $token = $this->getTokenByTokenAuthIfNotExpired($tokenAuth);
         if (!empty($token)) {
             $db = $this->getDb();


### PR DESCRIPTION
### Description:

I've debug for quite a while now, but actually couldn't find the change that actually caused the problem.
Even going a few hundreds commits back in history didn't fix the issue locally, so it seems to be there for a while.
Which actually makes it even more strange that it still works on demo.

Nevertheless, for some reason the Authentication does never return a success state for `anonymous` user. So the Auth object holds no login, and the list of available sites stays empty

fixes #17077

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
