### PR TITLE
Limit GeoIP downloads to certain hosts only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Matomo 4.2.0
+
+### New config.ini.php settings
+
+* A config setting `geolocation_download_from_trusted_hosts` was introduced. Downloading GeoIP databases will now be limited to those configured hosts only.
+
 ## Matomo 4.1.1
 
 ### Changed config.ini.php settings

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -404,6 +404,11 @@ force_ssl = 0
 ; This can add an additional layer of security as SERVER_NAME can not be manipulated by sending custom host headers when configure correctly.
 host_validation_use_server_name = 0
 
+; This list defines the hostnames that a valid sources to download GeoIP databases from. Subdomains of those hostnames will be accepted automatically.
+geolocation_download_from_trusted_hosts[] = maxmind.com
+geolocation_download_from_trusted_hosts[] = db-ip.com
+geolocation_download_from_trusted_hosts[] = ip2location.com
+
 ; Session garbage collection on (as on some operating systems, i.e. Debian, it may be off by default)
 session_gc_probability = 1
 

--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -462,7 +462,7 @@ class GeoIP2AutoUpdater extends Task
         $isValidHost = false;
 
         foreach ($validHosts as $validHost) {
-            if (substr($host, -strlen($validHost)) === $validHost) {
+            if (preg_match('/(^|\.)' . preg_quote($validHost) . '$/i', $host)) {
                 $isValidHost = true;
                 break;
             }

--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\GeoIp2;
 use Exception;
 use GeoIp2\Database\Reader;
 use Piwik\Common;
+use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Http;
@@ -415,9 +416,9 @@ class GeoIP2AutoUpdater extends Task
 
             $url = $options[$optionKey];
             $url = self::removeDateFromUrl($url);
-            if (!empty($url) && strpos(Common::mb_strtolower($url), 'https://') !== 0 && strpos(Common::mb_strtolower($url), 'http://') !== 0) {
-                throw new Exception('Invalid download URL for geoip ' . $optionKey . ': ' . $url);
-            }
+
+            self::checkGeoIPUpdateUrl($url);
+
             Option::set($optionName, $url);
         }
 
@@ -440,6 +441,28 @@ class GeoIP2AutoUpdater extends Task
             $scheduler = StaticContainer::getContainer()->get('Piwik\Scheduler\Scheduler');
 
             $scheduler->rescheduleTaskAndRunTomorrow(new GeoIP2AutoUpdater());
+        }
+    }
+
+    protected static function checkGeoIPUpdateUrl($url)
+    {
+        if (!empty($url) && strpos(Common::mb_strtolower($url), 'https://') !== 0 && strpos(Common::mb_strtolower($url), 'http://') !== 0) {
+            throw new Exception('Invalid download URL for geoip: ' . $url);
+        }
+
+        $validHosts = Config::getInstance()->General['geolocation_download_from_trusted_hosts'];
+        $host = @parse_url($url, PHP_URL_HOST);
+        $isValidHost = false;
+
+        foreach ($validHosts as $validHost) {
+            if (substr($host, -strlen($validHost)) === $validHost) {
+                $isValidHost = true;
+                break;
+            }
+        }
+
+        if (true !== $isValidHost) {
+            throw new Exception('Host specified for geoip download not in list of valid hosts: ' . $url);
         }
     }
 
@@ -632,7 +655,7 @@ class GeoIP2AutoUpdater extends Task
                 }
 
                 // get the current filename for the DB and an available new one to rename it to
-                list($oldPath, $newPath) = $this->getOldAndNewPathsForBrokenDb($customNames[$type]);
+                [$oldPath, $newPath] = $this->getOldAndNewPathsForBrokenDb($customNames[$type]);
 
                 // rename the DB so tracking will not fail
                 if ($oldPath !== false

--- a/plugins/GeoIp2/lang/en.json
+++ b/plugins/GeoIp2/lang/en.json
@@ -44,6 +44,8 @@
     "LocationProviderDesc_Php_WithExtension": "This location provider is speeded up by the installed %1$smaxminddb%2$s extension.",
     "LocationProviderDesc_ServerModule": "This location provider uses the GeoIP 2 module that has been installed in your HTTP server. This provider is fast and accurate, but %1$scan only be used with normal browser tracking.%2$s",
     "LocationProviderDesc_ServerModule2": "If you have to import log files or do something else that requires setting IP addresses, use the %3$sPHP GeoIP 2 implementation%4$s and install %1$smaxminddb extension%2$s.",
+    "MalFormedUpdateUrl": "The url %1$s seems invalid. Please ensure to input a valid url starting with http:// or https://",
+    "InvalidGeoIPUpdateHost": "The host of the GeoIP update url %1$s is not trusted. To allow downloading GeoIP updates from hosts other than %2$s please adjust the setting for %3$s in config. ",
     "NotManagingGeoIPDBs": "Matomo is currently not managing any DBIP or MaxMind databases.",
     "UnsupportedArchiveType": "Encountered unsupported archive type %1$s.",
     "UpdaterHasNotBeenRun": "The updater has never been run.",

--- a/plugins/GeoIp2/tests/Unit/GeoIP2AutoUpdaterTest.php
+++ b/plugins/GeoIp2/tests/Unit/GeoIP2AutoUpdaterTest.php
@@ -9,8 +9,6 @@
 namespace Piwik\Plugins\GeoIp2\tests\Unit;
 
 use Piwik\Config;
-use Piwik\DataTable;
-use Piwik\DataTable\Row;
 use Piwik\Plugins\GeoIp2\GeoIP2AutoUpdater;
 
 class public_GeoIP2AutoUpdater extends GeoIP2AutoUpdater
@@ -155,7 +153,8 @@ class GeoIP2AutoUpdaterTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getUpdaterUrlOptions
      */
-    public function testInvalidUpdateOptions($url, $valid) {
+    public function testInvalidUpdateOptions($url, $valid)
+    {
         if (!$valid) {
             $this->expectException(\Exception::class);
         } else {
@@ -173,6 +172,8 @@ class GeoIP2AutoUpdaterTest extends \PHPUnit\Framework\TestCase
             ['https://db-ip.com/account/ad446bf4cb9a44e5ff3f215deabc710f12f3/db/ip-to-country/mmdb', true],
             ['https://www.ip2location.com/download/?token={DOWNLOAD_TOKEN}&file={DATABASE_CODE}', true],
             ['https://download.maxmind.com.fake.org/app/geoip_download?edition_id=GeoLite2-ASN&license_key=YOUR_LICENSE_KEY&suffix=tar.gz', false],
+            ['https://fakemaxmind.com/ad446bf4cb9a44e4fff3f215deabc710f12f3.mmdb', false],
+            ['https://fake-db-ip.com/account/ad446bf4cb9a44e5ff3f215deabc710f12f3/db/ip-to-country/mmdb', false],
             ['http://my.custom.host/download.tar.gz', false],
             ['phar://local/input.file', false],
             ['ftp://db-ip.com/account/ad446bf4cb9a44e4fff3f215deabc710f12f3/db/ip-to-country/mmdb', false],

--- a/plugins/GeoIp2/tests/Unit/GeoIP2AutoUpdaterTest.php
+++ b/plugins/GeoIp2/tests/Unit/GeoIP2AutoUpdaterTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\GeoIp2\tests\Unit;
 
+use Piwik\Config;
 use Piwik\DataTable;
 use Piwik\DataTable\Row;
 use Piwik\Plugins\GeoIp2\GeoIP2AutoUpdater;
@@ -22,6 +23,10 @@ class public_GeoIP2AutoUpdater extends GeoIP2AutoUpdater
     public function fetchPaidDbIpUrl($url)
     {
         return parent::fetchPaidDbIpUrl($url);
+    }
+
+    public static function checkGeoIPUpdateUrl($url) {
+        return parent::checkGeoIPUpdateUrl($url);
     }
 }
 
@@ -145,5 +150,40 @@ class GeoIP2AutoUpdaterTest extends \PHPUnit\Framework\TestCase
         $determinedUrl = $mock->fetchPaidDbIpUrl($url);
 
         $this->assertEquals('https://download.db-ip.com/key/ad446bf4cb9a44e4fff3f215deabc710f12f3.mmdb', $determinedUrl);
+    }
+
+    /**
+     * @dataProvider getUpdaterUrlOptions
+     */
+    public function testInvalidUpdateOptions($url, $valid) {
+        if (!$valid) {
+            $this->expectException(\Exception::class);
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+        public_GeoIP2AutoUpdater::checkGeoIPUpdateUrl($url);
+    }
+
+    public function getUpdaterUrlOptions()
+    {
+        return [
+            ['https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=YOUR_LICENSE_KEY&suffix=tar.gz', true],
+            ['https://download.db-ip.com/key/ad446bf4cb9a44e4fff3f215deabc710f12f3.mmdb', true],
+            ['https://download.db-ip.com/free/dbip-city-lite-2020-01.mmdb.gz', true],
+            ['https://db-ip.com/account/ad446bf4cb9a44e5ff3f215deabc710f12f3/db/ip-to-country/mmdb', true],
+            ['https://www.ip2location.com/download/?token={DOWNLOAD_TOKEN}&file={DATABASE_CODE}', true],
+            ['https://download.maxmind.com.fake.org/app/geoip_download?edition_id=GeoLite2-ASN&license_key=YOUR_LICENSE_KEY&suffix=tar.gz', false],
+            ['http://my.custom.host/download.tar.gz', false],
+            ['phar://local/input.file', false],
+            ['ftp://db-ip.com/account/ad446bf4cb9a44e4fff3f215deabc710f12f3/db/ip-to-country/mmdb', false],
+            ['http://matomo.org/download/geoip.mmdb', false],
+        ];
+    }
+
+    public function testsAdditionalGeoIPHostConfig()
+    {
+        $this->expectNotToPerformAssertions();
+        Config::getInstance()->General['geolocation_download_from_trusted_hosts'][] = 'matomo.org';
+        public_GeoIP2AutoUpdater::checkGeoIPUpdateUrl('http://matomo.org/download/geoip.mmdb');
     }
 }


### PR DESCRIPTION
### Description:

It's currently possible to configure any url for downloading GeoIP databases from. Even though this option can be only changed by a super user and only if the GeoIP admin is enabled, limiting those options to only trusted hosts makes Matomo a little more secure. If someone needs to use the autoupdater to download files from somewhere else he can simply adjust the config.

For now the check is only done when setting the downloader option. Not sure if we should check that directly before download as well. Didn't add that yet, to prevent failures after a Matomo update if someone already has configured something else.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
