### PR TITLE
Fix AngularJS tests

### DIFF
--- a/tests/angularjs/package.json
+++ b/tests/angularjs/package.json
@@ -11,7 +11,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-shell": "^0.7.0",
     "mocha": "1.18.2",
-    "karma": ">= 0.12.1",
+    "karma": ">= 0.12.1, < 6.0.0",
     "karma-chrome-launcher": ">= 0.1.2",
     "karma-firefox-launcher": ">= 0.1.3",
     "karma-jshint-preprocessor": ">= 0.0.2",


### PR DESCRIPTION
AngularJS tests are currently always failing as PhantomJS doesn't seem to start up correctly.

Seems there was a new release of Karma (6.0.0), which causes the problem. As we are currently requiring Karama `>= 0.12.1` only, it automatically used the new version for testing.

I've added a `< 6.0.0` for the Karma requirement. This ensures the version 5.2 is used again. 
Will merge this for now, so tests are running again.

@tsteur @diosmosis Not sure if we should have a look somewhen why it actually doesn't work with Karma 6. Feel free to create an issue if that is something we should look into...
