### PR TITLE
Avoid parsing notification messages with angular

### DIFF
--- a/plugins/CoreHome/javascripts/notification.js
+++ b/plugins/CoreHome/javascripts/notification.js
@@ -139,7 +139,7 @@
             }
         }
 
-        html += '>' + message + '</div>';
+        html += '><div ng-non-bindable>' + message + '</div></div>';
 
         return html;
     }

--- a/plugins/UsersManager/tests/UI/UsersManager_spec.js
+++ b/plugins/UsersManager/tests/UI/UsersManager_spec.js
@@ -442,7 +442,7 @@ describe("UsersManager", function () {
 
         await page.waitFor('.notification-error', { visible: true });
 
-        const notificationHtml = await page.evaluate(() => $('.notification-error>div').html());
+        const notificationHtml = await page.evaluate(() => $('.notification-error>div>div').html());
         expect(notificationHtml).to.equal('The current password you entered is not correct.');
     });
 


### PR DESCRIPTION
### Description:

Notifications shouldn't contain any angular content, so don't try to parse them at all.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
