### PR TITLE
Custom tracking timestamp should return an integer to prevent HTTP 500 tracking error

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -543,7 +543,7 @@ class Request
             }
         }
 
-        return $cdt;
+        return (int) $cdt;
     }
 
     /**

--- a/tests/PHPUnit/Integration/Tracker/RequestTest.php
+++ b/tests/PHPUnit/Integration/Tracker/RequestTest.php
@@ -257,7 +257,7 @@ class RequestTest extends IntegrationTestCase
         $request = $this->buildRequest(array('cdt' => '' . ($this->time - 5)));
         $request->setCurrentTimestamp($this->time);
 
-        $this->assertSame('' . ($this->time - 5), $request->getCurrentTimestamp());
+        $this->assertSame(($this->time - 5), $request->getCurrentTimestamp());
     }
 
     public function test_cdt_ShouldReturnTheCustomTimestamp_IfAuthenticatedAndValid()
@@ -265,7 +265,7 @@ class RequestTest extends IntegrationTestCase
         $request = $this->buildRequest(array('cdt' => '' . ($this->time - 86500)));
         $request->setCurrentTimestamp($this->time);
         $request->setIsAuthenticated();
-        $this->assertSame('' . ($this->time - 86500), $request->getCurrentTimestamp());
+        $this->assertSame(($this->time - 86500), $request->getCurrentTimestamp());
     }
 
     public function test_cdt_ShouldReturnTheCustomTimestamp_IfTimestampIsInFuture()


### PR DESCRIPTION

### Description:

Eg 
```
curl -i -X POST -d '{"requests":["?idsite=1&rec=1&idgoal=21&apiv=1&_id=50d60fcd18ff0c7e&cdt=1610168419&revenue=0&send_image=0","?idsite=1&rec=1&idgoal=21&apiv=1&_id=50d60fcd18ff0c7e&cdt=1610168419&revenue=0&send_image=0"]}' http://your.site/matomo.php
```

Can trigger an HTTP 500 error when the request is authenticated (or when using a recent timestamp). That's because when for example A/B tests are configured, then it does a `Date::factory($request->getCurrentTimestamp))` where the timestamp is a `string` and thus the Date class would trigger an exception.

Making sure we return an integer will fix all possible uses.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
