### PR TITLE
SMS evolution metrics might be formatted incorrectly on PHP 8

### DIFF
--- a/plugins/MobileMessaging/ReportRenderer/Sms.php
+++ b/plugins/MobileMessaging/ReportRenderer/Sms.php
@@ -88,15 +88,13 @@ class Sms extends ReportRenderer
         // evolution metrics formatting :
         //  - remove monetary, percentage and white spaces to shorten SMS content
         //    (this is also needed to be able to test $value != 0 and see if there is an evolution at all in SMSReport.twig)
-        //  - adds a plus sign
         $reportData->filter(
             'ColumnCallbackReplace',
             array(
                  $evolutionMetrics,
                  function ($value) use ($floatRegex) {
                      $matched = preg_match($floatRegex, $value, $matches);
-                     $formatted = $matched ? sprintf("%+d", $matches[0]) : $value;
-                     return \Piwik\NumberFormatter::getInstance()->formatPercentEvolution($formatted);
+                     return $matched ? (float) $matches[0] : $value;
                  }
             )
         );


### PR DESCRIPTION
### Description:

On PHP 8 the sms report test [are failing](https://travis-ci.com/github/matomo-org/matomo/jobs/475578654#L1153):
```
1) Piwik\Plugins\Ecommerce\tests\System\EcommerceOrderWithItemsTest::testApi with data set #43 ('ScheduledReports.generateReport', array('_schedrep_via_sms_one_site', '2011-04-05 00:11:42', array('week'), 'original', 'sms.txt', array(2, 4, 0)))
Piwik\Plugins\Ecommerce\tests\System\EcommerceOrderWithItemsTest: Differences with expected in '/home/travis/build/matomo-org/matomo/plugins/Ecommerce/tests/System/processed/test_ecommerceOrderWithItems_schedrep_via_sms_one_site__ScheduledReports.generateReport_week.original.sms.txt'
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'week April 4 – 10, 2011. 5 Visits (+100%), 16 Actions (+100%), Revenue: $130 (+100%), 5 Goal conversions (+100%), Product Revenue: $130 (+100%), 4 Ecommerce Orders (+100%)'
+'week April 4 – 10, 2011. 5 Visits (+-100%), 16 Actions (+-100%), Revenue: $130 (+-100%), 5 Goal conversions (+-100%), Product Revenue: $130 (+-100%), 4 Ecommerce Orders (+-100%)'
```

While digging deeper into the failure I realized that the numbers are actually formatted twice. As there are some numeric checks in the sms template we actually can't format the metrics before. That used to work for PHP 7, but it doesn't for PHP 8. Formatting in the template only should be enough nevertheless.

I've tested those changes on another branch where tests are running against PHP 8. See https://travis-ci.com/github/matomo-org/matomo/jobs/475638482

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
