### PR TITLE
Tracking requests on PHP 8 might fail if an invalid encoding is sent

### DIFF
--- a/core/Tracker/PageUrl.php
+++ b/core/Tracker/PageUrl.php
@@ -237,9 +237,14 @@ class PageUrl
     {
         if (is_string($value)) {
             $decoded = urldecode($value);
-            if (function_exists('mb_check_encoding')
-                && @mb_check_encoding($decoded, $encoding)) {
-                $value = urlencode(mb_convert_encoding($decoded, 'UTF-8', $encoding));
+            try {
+                if (function_exists('mb_check_encoding')
+                    && @mb_check_encoding($decoded, $encoding)) {
+                    $value = urlencode(mb_convert_encoding($decoded, 'UTF-8', $encoding));
+                }
+            } catch (\Error $e) {
+                // mb_check_encoding might throw an ValueError on PHP 8 if the given encoding does not exist
+                // we can't simply catch ValueError as it was introduced in PHP 8
             }
         }
 


### PR DESCRIPTION
### Description:

On PHP 8 some tests for different encodings in tracking [are failing](https://travis-ci.com/github/matomo-org/matomo/jobs/475638482#L1305):
```
1) Piwik\Tests\System\NonUnicodeTest::testApi
Failed to setup fixture: Expected GIF beacon, got: <br/>
'<br />
<b>Fatal error</b>:  Uncaught ValueError: mb_check_encoding(): Argument #2 ($encoding) must be a valid encoding, &quot;GTF-42&quot; given in /home/travis/build/matomo-org/matomo/core/Tracker/PageUrl.php:241
Stack trace:
#0 /home/travis/build/matomo-org/matomo/core/Tracker/PageUrl.php(241): mb_check_encoding(\'param\', \'GTF-42\')
#1 /home/travis/build/matomo-org/matomo/core/Tracker/PageUrl.php(255): Piwik\\Tracker\\PageUrl::reencodeParameterValue(\'param\', \'GTF-42\')
#2 /home/travis/build/matomo-org/matomo/core/Tracker/PageUrl.php(286): Piwik\\Tracker\\PageUrl::reencodeParametersArray(Array, \'GTF-42\')
#3 /home/travis/build/matomo-org/matomo/plugins/Actions/Actions/ActionSiteSearch.php(143): Piwik\\Tracker\\PageUrl::reencodeParameters(Array, \'GTF-42\')
#4 /home/travis/build/matomo-org/matomo/plugins/Actions/Actions/ActionSiteSearch.php(251): Piwik\\Plugins\\Actions\\Actions\\ActionSiteSearch::detectSiteSearchFromUrl(Array, Array, \'GTF-42\')
#5 /home/travis/build/matomo-org/matomo/plugins/Actions/Actions/ActionSiteSearch.php(45): Piwik\\Plugins\\Actions\\Actions\\ActionSiteSearch-&gt;detectSiteSearch(\'http://example....\')
#6 /home/travis/build/matomo-org/matomo/core/Tracker/Action.php(163): Piwik\\Plugins\\Actions\\Actions\\ActionSiteSearch::shouldHandle(Object(Piwik\\Tracker\\Request))
#7 /home/travis/build/matomo-org/matomo/core/Tracker/Action.php(93): Piwik\\Tracker\\Action::getAllActions(Object(Piwik\\Tracker\\Request))
#8 /home/travis/build/matomo-org/matomo/plugins/Actions/Tracker/ActionsRequestProcessor.php(51): Piwik\\Tracker\\Action::factory(Object(Piwik\\Tracker\\Request))
#9 /home/travis/build/matomo-org/matomo/core/Tracker/Visit.php(163): Piwik\\Plugins\\Actions\\Tracker\\ActionsRequestProcessor-&gt;processRequestParams(Object(Piwik\\Tracker\\Visit\\VisitProperties), Object(Piwik\\Tracker\\Request))
#10 /home/travis/build/matomo-org/matomo/core/Tracker.php(160): Piwik\\Tracker\\Visit-&gt;handle()
#11 /home/travis/build/matomo-org/matomo/core/Tracker/Handler.php(55): Piwik\\Tracker-&gt;trackRequest(Object(Piwik\\Tracker\\Request))
#12 /home/travis/build/matomo-org/matomo/core/Tracker.php(140): Piwik\\Tracker\\Handler-&gt;process(Object(Piwik\\Tracker), Object(Piwik\\Tracker\\RequestSet))
#13 /home/travis/build/matomo-org/matomo/core/Tracker.php(115): Piwik\\Tracker-&gt;track(Object(Piwik\\Tracker\\Handler), Object(Piwik\\Tracker\\RequestSet))
#14 /home/travis/build/matomo-org/matomo/piwik.php(73): Piwik\\Tracker-&gt;main(Object(Piwik\\Tracker\\Handler), Object(Piwik\\Tracker\\RequestSet))
#15 /home/travis/build/matomo-org/matomo/matomo.php(13): include(\'/home/travis/bu...\')
#16 /home/travis/build/matomo-org/matomo/tests/PHPUnit/proxy/piwik.php(36): include(\'/home/travis/bu...\')
#17 /home/travis/build/matomo-org/matomo/tests/PHPUnit/proxy/matomo.php(9): include(\'/home/travis/bu...\')
#18 {main}
  thrown in <b>/home/travis/build/matomo-org/matomo/core/Tracker/PageUrl.php</b> on line <b>241</b><br />
'
 If you are stuck, you can enable [Tracker] debug=1; in config.ini.php to get more debug info.
```

This failure is caused by an internal change in `mb_detect_encoding`. While PHP 7 simply did nothing or failed silently when an invaid encoding was given, PHP 8 now starts throwing a newly introduced `ValueError`.
For PHP 8 that means a tracking request would fail completely as soon as an invalid encoding is sent with the request. Not sure if that should happen that often, but maybe it might be the case if someone defines an invalid encoding for his website.

I've tested those changes on another branch where tests are running against PHP 8. See https://travis-ci.com/github/matomo-org/matomo/jobs/477061001

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
