### PR TITLE
Don't update tracker js files while testing

### DIFF
--- a/plugins/CustomJsTracker/CustomJsTracker.php
+++ b/plugins/CustomJsTracker/CustomJsTracker.php
@@ -16,6 +16,10 @@ class CustomJsTracker extends Plugin
 {
     public function registerEvents()
     {
+        if (!StaticContainer::get('CustomJsTracker.enableUpdates')) {
+            return []; // don't listen to event if updates are disabled (mostly while testing)
+        }
+
         return array(
             'CoreUpdater.update.end' => 'updateTracker',
             'PluginManager.pluginActivated' => 'updateTracker',

--- a/plugins/CustomJsTracker/TrackerUpdater.php
+++ b/plugins/CustomJsTracker/TrackerUpdater.php
@@ -124,7 +124,7 @@ class TrackerUpdater
      */
     public function update()
     {
-        if (!$this->toFile->hasWriteAccess() || !$this->fromFile->hasReadAccess()) {
+        if (!StaticContainer::get('CustomJsTracker.enableUpdates') || !$this->toFile->hasWriteAccess() || !$this->fromFile->hasReadAccess()) {
             return;
         }
 

--- a/plugins/CustomJsTracker/config/config.php
+++ b/plugins/CustomJsTracker/config/config.php
@@ -4,4 +4,5 @@ return array(
     'diagnostics.optional' => DI\add(array(
         DI\get('Piwik\Plugins\CustomJsTracker\Diagnostic\TrackerJsCheck'),
     )),
+    'CustomJsTracker.enableUpdates' => true
 );

--- a/plugins/CustomJsTracker/config/test.php
+++ b/plugins/CustomJsTracker/config/test.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'CustomJsTracker.enableUpdates' => false
+];

--- a/plugins/CustomJsTracker/tests/Integration/TrackerUpdaterTest.php
+++ b/plugins/CustomJsTracker/tests/Integration/TrackerUpdaterTest.php
@@ -240,6 +240,7 @@ var myArray = [];
                     $this->trackerJsChangedEventPath = $path;
                 })],
             ]),
+            'CustomJsTracker.enableUpdates' => true
         ];
     }
 }

--- a/tests/PHPUnit/Fixtures/JSTrackingUIFixture.php
+++ b/tests/PHPUnit/Fixtures/JSTrackingUIFixture.php
@@ -56,4 +56,11 @@ class JSTrackingUIFixture extends Fixture
         $this->testEnvironment->pluginsToLoad = $this->extraPluginsToLoad;
         $this->testEnvironment->save();
     }
+
+    public function provideContainerConfig()
+    {
+        return [
+            'CustomJsTracker.enableUpdates' => true
+        ];
+    }
 }

--- a/tests/javascript/index.php
+++ b/tests/javascript/index.php
@@ -31,6 +31,8 @@ try {
 use \Piwik\Plugins\CustomJsTracker\TrackerUpdater;
 use \Piwik\Plugins\CustomJsTracker\TrackingCode\JsTestPluginTrackerFiles;
 
+\Piwik\Container\StaticContainer::getContainer()->set('CustomJsTracker.enableUpdates', true);
+
 $targetFileName = '/tests/resources/matomo.test.js';
 $sourceFile = PIWIK_DOCUMENT_ROOT . TrackerUpdater::DEVELOPMENT_PIWIK_JS;
 $targetFile = PIWIK_DOCUMENT_ROOT . $targetFileName;


### PR DESCRIPTION
### Description:

The `CustomTrackerJS` plugin is enabled by default and tries to update the tracker js files whenever certain events are triggered. Those events include the creation of a site and other events that are triggered a lot while testing.
This PR disables the event listening for that plugin while testing, and only enables it for those tests where it is actually needed.
This should speed up the tests as it also avoids a lot file operations.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
