### PR TITLE
Ignore query failure in Matomo for WordPress when checking if logtmptable exists

### DIFF
--- a/core/DataAccess/LogAggregator.php
+++ b/core/DataAccess/LogAggregator.php
@@ -240,7 +240,7 @@ class LogAggregator
     {
         try {
             // using DROP TABLE IF EXISTS would not work on a DB reader if the table doesn't exist...
-            $this->getDb()->fetchOne('SELECT 1 FROM ' . $segmentTablePrefixed . ' LIMIT 1');
+            $this->getDb()->fetchOne('SELECT /* WP IGNORE ERROR */ 1 FROM ' . $segmentTablePrefixed . ' LIMIT 1');
             $tableExists = true;
         } catch (\Exception $e) {
             $tableExists = false;


### PR DESCRIPTION

### Description:

Needed this in https://github.com/matomo-org/wp-matomo/pull/417 and documented it in https://github.com/matomo-org/wp-matomo/wiki/Database

refs https://github.com/matomo-org/wp-matomo/issues/416
refs https://wordpress.org/support/topic/error-in-php-log-after-manual-update-to-v4-1-2/
refs https://wordpress.org/support/topic/archive-warning-error-unserializing-wp_matomo_logtmpsegment/
refs https://wordpress.org/support/topic/php-error-with-vn-4-1-2/

Previously, I had detected this query like this: https://github.com/matomo-org/wp-matomo/pull/417/files#diff-c4e75ddbbcdde3ba408b5a87e273371dd3420a5d0b90a87bb4295e81787cdc31L365 but now it looks like `SELECT /*+MAX_EXECUTION_TIME....` and it's quite hard to detect it without trying to reconstruct the query or using regex. This way it'll be more future proof

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
