### PR TITLE
add visitfrequency archiver to archive dependent archives

### DIFF
--- a/core/Updates/4.1.2-b1.php
+++ b/core/Updates/4.1.2-b1.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Archive\ArchiveInvalidator;
+use Piwik\ArchiveProcessor\Rules;
+use Piwik\Container\StaticContainer;
+use Piwik\Date;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+class Updates_4_1_2_b1 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = [];
+
+        if (!Rules::isBrowserTriggerEnabled()) {
+            $dateOfMatomo4Release = Date::factory('2020-11-23');
+
+            $cmdStr = $this->getInvalidateCommand($dateOfMatomo4Release);
+
+            $migrations[] = new Updater\Migration\Custom(function () use ($dateOfMatomo4Release) {
+                $invalidator = StaticContainer::get(ArchiveInvalidator::class);
+                $invalidator->scheduleReArchiving('all', 'VisitFrequency', null, $dateOfMatomo4Release);
+            }, $cmdStr);
+        }
+
+        return $migrations;
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+
+    private function getInvalidateCommand(Date $dateOfMatomo4Release)
+    {
+        $command = "php " . PIWIK_INCLUDE_PATH . '/console core:invalidate-report-data --sites=all';
+        $command .= ' --dates=' . $dateOfMatomo4Release->toString() . ',' . Date::factory('today')->toString();
+        $command .= ' --plugin=VisitFrequency';
+        return $command;
+    }
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '4.1.1';
+    const VERSION = '4.1.2-b1';
     const MAJOR_VERSION = 4;
 
     public function isStableVersion($version)

--- a/plugins/VisitFrequency/Archiver.php
+++ b/plugins/VisitFrequency/Archiver.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Plugins\VisitFrequency;
+
+use Piwik\Plugins\VisitFrequency\API as VisitFrequencyAPI;
+
+class Archiver extends \Piwik\Plugin\Archiver
+{
+    public function aggregateDayReport()
+    {
+        $this->getProcessor()->processDependentArchive('VisitsSummary', VisitFrequencyAPI::NEW_VISITOR_SEGMENT);
+        $this->getProcessor()->processDependentArchive('VisitsSummary', VisitFrequencyAPI::RETURNING_VISITOR_SEGMENT);
+    }
+
+    public function aggregateMultipleReports()
+    {
+        $this->getProcessor()->processDependentArchive('VisitsSummary', VisitFrequencyAPI::NEW_VISITOR_SEGMENT);
+        $this->getProcessor()->processDependentArchive('VisitsSummary', VisitFrequencyAPI::RETURNING_VISITOR_SEGMENT);
+    }
+}


### PR DESCRIPTION
### Description:

Fixes #17123 

@tsteur found the fix. The cause is since we call `CoreAdminHome.archiveReports` now instead of `API.get`, the dependent archive isn't implicitly created. Adding an archiver for VisitFrequency fixes this, though I'm not sure if we want to maintain the old behavior.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
