### PR TITLE
Include report column in duplicate check when inserting archive invalidations.

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -228,7 +228,7 @@ class Model
                 $date1 = $period->getDateStart()->toString();
                 $date2 = $period->getDateEnd()->toString();
 
-                $key = $this->makeExistingInvalidationArrayKey($idSite, $date1, $date2, $period->getId(), $doneFlag);
+                $key = $this->makeExistingInvalidationArrayKey($idSite, $date1, $date2, $period->getId(), $doneFlag, $name);
                 if (!empty($existingInvalidations[$key])) {
                     continue; // avoid adding duplicates where possible
                 }
@@ -262,7 +262,7 @@ class Model
 
         $idSites = array_map('intval', $idSites);
 
-        $sql = "SELECT idsite, date1, date2, period, name, COUNT(*) as `count` FROM `$table`
+        $sql = "SELECT idsite, date1, date2, period, name, report, COUNT(*) as `count` FROM `$table`
                  WHERE idsite IN (" . implode(',', $idSites) . ") AND status = " . ArchiveInvalidator::INVALIDATION_STATUS_QUEUED . "
                        $periodCondition AND $nameCondition
               GROUP BY idsite, date1, date2, period, name";
@@ -270,15 +270,15 @@ class Model
 
         $invalidations = [];
         foreach ($rows as $row) {
-            $key = $this->makeExistingInvalidationArrayKey($row['idsite'], $row['date1'], $row['date2'], $row['period'], $row['name']);
+            $key = $this->makeExistingInvalidationArrayKey($row['idsite'], $row['date1'], $row['date2'], $row['period'], $row['name'], $row['report']);
             $invalidations[$key] = $row['count'];
         }
         return $invalidations;
     }
 
-    private function makeExistingInvalidationArrayKey($idSite, $date1, $date2, $period, $name)
+    private function makeExistingInvalidationArrayKey($idSite, $date1, $date2, $period, $name, $report)
     {
-        return implode('.', [$idSite, $date1, $date2, $period, $name]);
+        return implode('.', [$idSite, $date1, $date2, $period, $name, $report]);
     }
 
     /**

--- a/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ArchiveInvalidatorTest.php
@@ -1224,12 +1224,17 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
             ['name' => 'done' . $segmentHash, 'idsite' => 1, 'date1' => '2020-05-10', 'date2' => '2020-05-10', 'period' => 1, 'report' => null],
 
             ['name' => 'done' . $segmentHash, 'idsite' => 1, 'date1' => '2020-05-01', 'date2' => '2020-05-31', 'period' => 3, 'report' => null],
+
+            ['name' => 'done' . $segmentHash, 'idsite' => 1, 'date1' => '2020-05-01', 'date2' => '2020-05-31', 'period' => 4, 'report' => 'aReport'],
+            ['name' => 'done' . $segmentHash, 'idsite' => 1, 'date1' => '2020-05-01', 'date2' => '2020-05-31', 'period' => 4, 'report' => 'anotherReport'],
         ];
 
         $this->insertInvalidations($existingInvalidations);
 
         $archiveInvalidator->markArchivesAsInvalidated([1], ['2020-03-04', '2020-05-06'], 'week',
             $segment, $cascadeDown = true, false);
+        $archiveInvalidator->markArchivesAsInvalidated([1], ['2020-05-01'], 'year',
+            $segment, $cascadeDown = false, 'aReport');
 
         $expectedInvalidations = [
             array (
@@ -1312,6 +1317,24 @@ class ArchiveInvalidatorTest extends IntegrationTestCase
                 'period' => '3',
                 'name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc',
                 'report' => NULL,
+            ),
+            array (
+                'idarchive' => null,
+                'idsite' => '1',
+                'date1' => '2020-05-01',
+                'date2' => '2020-05-31',
+                'period' => '4',
+                'name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc',
+                'report' => 'aReport',
+            ),
+            array (
+                'idarchive' => null,
+                'idsite' => '1',
+                'date1' => '2020-05-01',
+                'date2' => '2020-05-31',
+                'period' => '4',
+                'name' => 'done5f4f9bafeda3443c3c2d4b2ef4dffadc',
+                'report' => 'anotherReport',
             ),
             array (
                 'idarchive' => NULL,


### PR DESCRIPTION
### Description:

When checking for duplicates we have to include the report, otherwise reArchiveReport w/ a custom report name may not work correctly.

@sgiehl this should fix the CustomReports test failure. It's a simple change so merging it now.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
