### PR TITLE
CustomLogo upload not working with PHP8

### DIFF
--- a/plugins/CoreAdminHome/CustomLogo.php
+++ b/plugins/CoreAdminHome/CustomLogo.php
@@ -279,7 +279,7 @@ class CustomLogo
                 return false;
         }
 
-        if (!is_resource($image)) {
+         if (!is_resource($image) && !($image instanceof \GdImage)) {
             return false;
         }
 

--- a/plugins/CoreAdminHome/CustomLogo.php
+++ b/plugins/CoreAdminHome/CustomLogo.php
@@ -279,7 +279,7 @@ class CustomLogo
                 return false;
         }
 
-         if (!is_resource($image) && !($image instanceof \GdImage)) {
+        if (!is_resource($image) && !($image instanceof \GdImage)) {
             return false;
         }
 
@@ -310,4 +310,3 @@ class CustomLogo
     }
 
 }
-


### PR DESCRIPTION
Fix for PHP 8.0 compatibility: In PHP 8 GdImage class objects replace GD image resources.  Custom logo upload was not working.

### Description:

Using PHP 8.0 dos not allow custom logo upload, because GdImage class objects replace GD image resources.
Proposed fix checks for GDImage class object too and custom logo is working.

### Review

* [x] Functional review done
* [x] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] Code review done
* [x] Tests were added if useful/possible
* [x] Reviewed for breaking changes
* [x] Developer changelog updated if needed
* [x] Documentation added if needed
* [x] Existing documentation updated if needed
