### PR TITLE
dieWithHtmlErrorPage() should default to http 500

### DIFF
--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -75,6 +75,8 @@ class ExceptionHandler
             && $exception->getCode() > 0
         ) {
             http_response_code($exception->getCode());
+        } else {
+            http_response_code(500);
         }
 
         self::logException($exception);


### PR DESCRIPTION
### Description:

This is a possible solution for this issue. https://github.com/matomo-org/matomo/issues/10881
"Error page served with HTTP 200 status"

Prior to this PR dieWithHtmlErrorPage() defaults to returning a http 200 if the caught exception doesn't have a code set on it. This PR instead causes dieWithHtmlErrorPage() to default to returning a http 500 unless another code is set.

This is the URL I have been using. Note the invalid date parameter. the error page is identical however its http status code is now 500 instead of 200.
http://localhost/matomo/index.php?module=CoreHome&action=index&idSite=1&period=day&date=INVALID

I am still working through getting the tests working locally. I get a few failures even before I make any changes. Despite that I wanted to put this PR up now just to see if this approach is fundamentally a problem in some way :)

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
