### PR TITLE
Don't deactivate a core plugin during update

### DIFF
--- a/core/Updater.php
+++ b/core/Updater.php
@@ -498,6 +498,9 @@ class Updater
                     if ($name == 'core') {
                         $coreError = true;
                         break;
+                    } elseif ($pluginManager->isPluginActivated($name) && $pluginManager->isPluginBundledWithCore($name)) {
+                        $coreError = true;
+                        break;
                     } elseif ($pluginManager->isPluginActivated($name)) {
                         $pluginManager->deactivatePlugin($name);
                         $deactivatedPlugins[] = $name;


### PR DESCRIPTION
### Description:

refs https://github.com/matomo-org/matomo/issues/17181

Basically, we should stop the updater if there is an error with a core plugin. Eg when adding a referrer column we shouldn't simply disable the `referrer` plugin as it can cause unexpected issues as Matomo doesn't always work when disabling a core plugin.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
