### PR TITLE
Archiver: do not create done flags like "done."

### DIFF
--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -51,7 +51,9 @@ class Rules
      */
     public static function getDoneStringFlagFor(array $idSites, $segment, $periodLabel, $plugin)
     {
-        if (!self::shouldProcessReportsAllPlugins($idSites, $segment, $periodLabel)) {
+        if (!empty($plugin)
+            && !self::shouldProcessReportsAllPlugins($idSites, $segment, $periodLabel)
+        ) {
             return self::getDoneFlagArchiveContainsOnePlugin($segment, $plugin);
         }
         return self::getDoneFlagArchiveContainsAllPlugins($segment);

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -81,7 +81,8 @@ class ArchiveSelector
             return [false, false, false, false, false];
         }
 
-        $result = self::findArchiveDataWithLatestTsArchived($results, $requestedPluginDoneFlags);
+        $result = self::findArchiveDataWithLatestTsArchived($results,
+            array_merge($requestedPluginDoneFlags, [Rules::getDoneFlagArchiveContainsAllPlugins($segment)]));
 
         $tsArchived = isset($result['ts_archived']) ? $result['ts_archived'] : false;
         $visits = isset($result['nb_visits']) ? $result['nb_visits'] : false;
@@ -395,10 +396,10 @@ class ArchiveSelector
      * - the doneFlag value for the latest archive
      *
      * @param $results
-     * @param $requestedPluginDoneFlags
+     * @param $doneFlags
      * @return array
      */
-    private static function findArchiveDataWithLatestTsArchived($results, $requestedPluginDoneFlags)
+    private static function findArchiveDataWithLatestTsArchived($results, $doneFlags)
     {
         // find latest idarchive for each done flag
         $idArchives = [];
@@ -417,7 +418,7 @@ class ArchiveSelector
         ];
 
         foreach ($results as $result) {
-            if (in_array($result['name'], $requestedPluginDoneFlags)
+            if (in_array($result['name'], $doneFlags)
                 && in_array($result['idarchive'], $idArchives)
             ) {
                 $archiveData = $result;

--- a/core/DataAccess/ArchiveSelector.php
+++ b/core/DataAccess/ArchiveSelector.php
@@ -70,9 +70,10 @@ class ArchiveSelector
         $requestedPlugin = $params->getRequestedPlugin();
         $segment         = $params->getSegment();
         $plugins = array("VisitsSummary", $requestedPlugin);
+        $plugins = array_filter($plugins);
 
         $doneFlags      = Rules::getDoneFlags($plugins, $segment);
-        $requestedPluginDoneFlags = Rules::getDoneFlags([$requestedPlugin], $segment);
+        $requestedPluginDoneFlags = empty($requestedPlugin) ? [] : Rules::getDoneFlags([$requestedPlugin], $segment);
         $doneFlagValues = Rules::getSelectableDoneFlagValues($includeInvalidated === null ? true : $includeInvalidated, $params, $includeInvalidated === null);
 
         $results = self::getModel()->getArchiveIdAndVisits($numericTable, $idSite, $period, $dateStartIso, $dateEndIso, null, $doneFlags);

--- a/core/Updates/4.1.2-b2.php
+++ b/core/Updates/4.1.2-b2.php
@@ -41,7 +41,7 @@ class Updates_4_1_2_b2 extends PiwikUpdates
     {
         $migrations = [];
 
-        $tables = ArchiveTableCreator::getTablesArchivesInstalled('numeric', $forceReload = true);
+        $tables = ArchiveTableCreator::getTablesArchivesInstalled('numeric');
         foreach ($tables as $table) {
             $migrations[] = $this->migration->db->sql("UPDATE `$table` SET `name` = 'done' WHERE `name` = 'done.'");
         }

--- a/core/Updates/4.1.2-b2.php
+++ b/core/Updates/4.1.2-b2.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Container\StaticContainer;
+use Piwik\CronArchive;
+use Piwik\DataAccess\ArchiveTableCreator;
+use Piwik\Date;
+use Piwik\Plugins\SegmentEditor\API;
+use Piwik\Archive\ArchiveInvalidator;
+use Piwik\ArchiveProcessor\Rules;
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+class Updates_4_1_2_b2 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = [];
+
+        $tables = ArchiveTableCreator::getTablesArchivesInstalled('numeric', $forceReload = true);
+        foreach ($tables as $table) {
+            $migrations[] = $this->migration->db->sql("UPDATE `$table` SET `name` = 'done' WHERE `name` = 'done.'");
+        }
+
+        return $migrations;
+    }
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '4.1.2-b1';
+    const VERSION = '4.1.2-b2';
     const MAJOR_VERSION = 4;
 
     public function isStableVersion($version)


### PR DESCRIPTION
### Description:

Noticed calling `getDoneStringFlagFor` w/ `$plugin = false` when `pluginOnly=1` can result in done flags like `done.`.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
