### PR TITLE
recreate all webserver config on updates

### DIFF
--- a/core/Updater.php
+++ b/core/Updater.php
@@ -331,7 +331,7 @@ class Updater
         $this->markComponentSuccessfullyUpdated($componentName, $updatedVersion);
 
         $this->executeListenerHook('onComponentUpdateFinished', array($componentName, $updatedVersion, $warningMessages));
-        ServerFilesGenerator::createHtAccessFiles();
+        ServerFilesGenerator::createFilesForSecurity();
         return $warningMessages;
     }
 
@@ -514,7 +514,7 @@ class Updater
         }
 
         Filesystem::deleteAllCacheOnUpdate();
-        ServerFilesGenerator::createHtAccessFiles();
+        ServerFilesGenerator::createFilesForSecurity();
 
         $result = array(
             'warnings'  => $warnings,


### PR DESCRIPTION
It seems like the full `createFilesForSecurity` that also creates the files for IIS is only run on install and some updates and not on the normal update.
```bash
➜  ~/public_html/matomo git:(4.x-dev) ✗ rg "createFilesForSecurity"
core/Updates/4.0.0-b1.php
261:        ServerFilesGenerator::createFilesForSecurity();

core/Updates/3.13.4-b1.php
21:        ServerFilesGenerator::createFilesForSecurity();

core/Updates/3.0.0-b4.php
56:        ServerFilesGenerator::createFilesForSecurity();

core/Updates/2.16.3-b1.php
20:        ServerFilesGenerator::createFilesForSecurity();

core/Updates/3.0.1-b1.php
22:        ServerFilesGenerator::createFilesForSecurity();

plugins/Installation/Controller.php
313:        ServerFilesGenerator::createFilesForSecurity();

plugins/Installation/ServerFilesGenerator.php
17:    public static function createFilesForSecurity()
```

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
