### PR TITLE
Update .gitignore to exclude misc/user/.htaccess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ php_errors.log
 /lang/.htaccess
 /libs/.htaccess
 /misc/.htaccess
+/misc/user/.htaccess
 /misc/cron/.htaccess
 /plugins/.htaccess
 /tests/resources/overlay-test-site-real/


### PR DESCRIPTION
### Description:

When I installed and run Matomo locally, the `/matomo/misc/user/.htaccess` file was generated. This is not included in the `.gitignore`.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
