### PR TITLE
Allow nonce checks to provide custom required referrer URL. 

### DIFF
--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -99,7 +99,8 @@ class Nonce
         return true;
     }
 
-    private static function isReferrerHostValid($referrer, $expectedReferrerHost)
+    // public for tests
+    public static function isReferrerHostValid($referrer, $expectedReferrerHost)
     {
         if (empty($referrer)) {
             return false;

--- a/tests/PHPUnit/Unit/NonceTest.php
+++ b/tests/PHPUnit/Unit/NonceTest.php
@@ -42,4 +42,27 @@ class NonceTest extends \PHPUnit\Framework\TestCase
         Config::getInstance()->General['trusted_hosts'] = array('example.com');
         $this->assertEquals($expected, Nonce::getAcceptableOrigins(), $host);
     }
+
+    /**
+     * @dataProvider getTestDataForIsReferrerHostValid
+     * @group Core
+     */
+    public function test_isReferrerHostValid($referrer, $expectedHost, $expectedResult)
+    {
+        $result = Nonce::isReferrerHostValid($referrer, $expectedHost);
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function getTestDataForIsReferrerHostValid()
+    {
+        return [
+            ['http://referrer.com', 'someotherreferrer.com', false],
+            ['http://referrer.com/referrer/path', 'referrer.com', true],
+            ['http://areferrer.com', 'referrer.com', false],
+            ['http://sub.referrer.com', 'referrer.com', true],
+            ['http://sub.referrer.com', 'sub.referrer.com', true],
+            ['http://sub.referrer.com', 'a.sub.referrer.com', false],
+            ['http://sub.referrer.com', 'sub2.referrer.com', false],
+        ];
+    }
 }


### PR DESCRIPTION
### Description:

For the GoogleAnalyticsImporter the oauth nonce check fails since the referrer is google. In this case we want to ensure it is from google and not a local URL.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
