### PR TITLE
Prevent possible error when accessing an index

### DIFF
--- a/core/ProfessionalServices/Advertising.php
+++ b/core/ProfessionalServices/Advertising.php
@@ -117,7 +117,10 @@ class Advertising
      */
     public static function isAdsEnabledInConfig($configGeneralSection)
     {
-        $oldSettingValue = @$configGeneralSection['piwik_pro_ads_enabled'];
+        $oldSettingValue = false;
+        if (isset($configGeneralSection['piwik_pro_ads_enabled'])) {
+            $oldSettingValue = @$configGeneralSection['piwik_pro_ads_enabled'];
+        }
         $newSettingValue = @$configGeneralSection['piwik_professional_support_ads_enabled'];
         return (bool) ($newSettingValue || $oldSettingValue);
     }


### PR DESCRIPTION

### Description:

see https://wordpress.org/support/topic/undefined-index-piwik_pro_ads_enabled/

I think this should fix the issue. It's technically only a workaround. Not sure why this would show up as an error. I will try to find out more to see if there's a general issue there.


### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
