### PR TITLE
Hide unique visitors email in VisitsSummary.get if not enabled in config.

### DIFF
--- a/plugins/VisitsSummary/Reports/Get.php
+++ b/plugins/VisitsSummary/Reports/Get.php
@@ -43,12 +43,17 @@ class Get extends \Piwik\Plugin\Report
             new AverageTimeOnSite()
         );
         $this->metrics = array(
-            'nb_uniq_visitors',
             'nb_visits',
             $this->usersColumn,
             'nb_actions',
             'max_actions'
         );
+
+        $period = Common::getRequestVar('period', 'day');
+        if (SettingsPiwik::isUniqueVisitorsEnabled($period)) {
+            $this->metrics = array_merge(['nb_uniq_visitors'], $this->metrics);
+        }
+
         $this->subcategoryId = 'General_Overview';
         // Used to process metrics, not displayed/used directly
 //								'sum_visit_length',


### PR DESCRIPTION
### Description:

Fixes #16222 

The only instance of unique visitors I could find when processing was disabled was in VisitsSummary.get, and I noticed the metric is enabled everywhere in this case. This removes the metric everywhere if processing is disabled.

Note: this will also remove the metric even if there is existing data. So if a user computes it for months initially, then disables it for months, the old data won't be visible. Not sure if this is desired (cc @tsteur/@mattab).

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
