### PR TITLE
Set httpOnly flag for session language cookie

### DIFF
--- a/plugins/LanguagesManager/LanguagesManager.php
+++ b/plugins/LanguagesManager/LanguagesManager.php
@@ -237,6 +237,7 @@ class LanguagesManager extends \Piwik\Plugin
         $cookie = new Cookie($cookieName, 0);
         $cookie->set('language', $languageCode);
         $cookie->setSecure(ProxyHttp::isHttps());
+        $cookie->setHttpOnly(true);
         $cookie->save('Lax');
         return true;
     }


### PR DESCRIPTION
### Description:

Seems the `matomo_lang` cookie is only used in PHP scripts and not in any javascripts. So should be fine to add the httpOnly flag I guess.

fixes #17270

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
