### PR TITLE
Fix Marketplace falsely thinks a plugin is installed when it is not

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1600,13 +1600,22 @@ class Manager
     }
 
     /**
-     * @param $pluginName
+     * @param string $pluginName
+     * @param bool $checkPluginExistsInFilesystem if enabled, it won't rely on the information in the config file only
+     *                                            but also check the filesystem if the plugin really is installed.
+     *                                            For performance reasons this is not the case by default.
      * @return bool
      */
-    public function isPluginInstalled($pluginName)
+    public function isPluginInstalled($pluginName, $checkPluginExistsInFilesystem = false)
     {
         $pluginsInstalled = $this->getInstalledPluginsName();
-        return in_array($pluginName, $pluginsInstalled);
+        $isInstalledInConfig = in_array($pluginName, $pluginsInstalled);
+
+        if ($isInstalledInConfig && $checkPluginExistsInFilesystem) {
+            return $this->isPluginInFilesystem($pluginName);
+        }
+
+        return $isInstalledInConfig;
     }
 
     private function removeInstalledVersionFromOptionTable($name)

--- a/plugins/Marketplace/Controller.php
+++ b/plugins/Marketplace/Controller.php
@@ -245,7 +245,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         if (SettingsPiwik::isAutoUpdatePossible()) {
             foreach ($paidPlugins as $paidPlugin) {
                 if ($this->canPluginBeInstalled($paidPlugin)
-                    || ($this->pluginManager->isPluginInstalled($paidPlugin['name'])
+                    || ($this->pluginManager->isPluginInstalled($paidPlugin['name'], true)
                         && !$this->pluginManager->isPluginActivated($paidPlugin['name']))) {
                     $paidPluginsToInstallAtOnce[] = $paidPlugin['name'];
                 }
@@ -489,7 +489,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         $pluginName = $plugin['name'];
 
-        $isAlreadyInstalled = $this->pluginManager->isPluginInstalled($pluginName)
+        $isAlreadyInstalled = $this->pluginManager->isPluginInstalled($pluginName, true)
             || $this->pluginManager->isPluginLoaded($pluginName)
             || $this->pluginManager->isPluginActivated($pluginName);
 

--- a/plugins/Marketplace/Plugins.php
+++ b/plugins/Marketplace/Plugins.php
@@ -235,7 +235,7 @@ class Plugins
             return true;
         }
 
-        return $this->pluginManager->isPluginInstalled($pluginName);
+        return $this->pluginManager->isPluginInstalled($pluginName, true);
     }
 
     private function enrichPluginInformation($plugin)

--- a/tests/PHPUnit/Integration/Plugin/ManagerTest.php
+++ b/tests/PHPUnit/Integration/Plugin/ManagerTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Integration\Plugin;
 
+use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Db;
 use Piwik\Http\ControllerResolver;
@@ -134,6 +135,25 @@ class ManagerTest extends IntegrationTestCase
                 }
             }
         }
+    }
+
+    public function test_isPluginInstalled_corePluginThatExists()
+    {
+        $this->assertTrue($this->manager->isPluginInstalled('CoreAdminHome', true));
+        $this->assertTrue($this->manager->isPluginInstalled('CoreAdminHome', false));
+    }
+
+    public function test_isPluginInstalled_pluginNotExists()
+    {
+        $this->assertFalse($this->manager->isPluginInstalled('FooBarBaz', true));
+        $this->assertFalse($this->manager->isPluginInstalled('FooBarBaz', false));
+    }
+
+    public function test_isPluginInstalled_pluginInstalledConfigButNotExists()
+    {
+        Config::getInstance()->PluginsInstalled['PluginsInstalled'][] = 'FooBarBaz';
+        $this->assertFalse($this->manager->isPluginInstalled('FooBarBaz', true));
+        $this->assertTrue($this->manager->isPluginInstalled('FooBarBaz', false));
     }
 
     /**


### PR DESCRIPTION
### Description:

Notices this earlier on demo2. We had removed various plugins from the disk but the config still had the plugins marked as installed. Then I wanted to reinstall the plugins but the marketplace wouldn't let me install it because it was thinking the plugin is already installed. That's because it was only looking at `PluginsInstalled[]` entries in the config but not if the plugin actually still existed in the file system.

This change now makes plugins installable again in such a case. I noticed few other usages of `isPluginInstalled()` but not always would we actually want to check if the plugin is in the filesystem. Either from a performance point of view (eg in the component update checker) or because the logic doesn't need/want it.

For now just wanted to fix this specific case. Seems there are no tests so far for the plugin manager but can add one if needed.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
