### PR TITLE
Prevent possible warning during GeoIP2 update if providers aren't initialised

### DIFF
--- a/plugins/GeoIp2/GeoIP2AutoUpdater.php
+++ b/plugins/GeoIp2/GeoIP2AutoUpdater.php
@@ -321,7 +321,7 @@ class GeoIP2AutoUpdater extends Task
             }
 
             // ensure the cached location providers do no longer block any files on windows
-            foreach (LocationProvider::$providers as $provider) {
+            foreach (LocationProvider::getAllProviders() as $provider) {
                 if ($provider instanceof Php) {
                     $provider->clearCachedInstances();
                 }


### PR DESCRIPTION
### Description:

refs https://wordpress.org/support/topic/repeated-php-warnings-on-cron-execution/

It should be better to use the method anyway instead of hard coding the variable.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
