### PR TITLE
Provide way to extend visitorProfilePopup

### DIFF
--- a/plugins/Live/templates/getVisitorProfilePopup.twig
+++ b/plugins/Live/templates/getVisitorProfilePopup.twig
@@ -60,7 +60,7 @@
 
                 {{ profileSummary|raw }}
 
-                {{ postEvent('Template.afterVisitorProfileOverview') }}
+                {{ postEvent('Template.afterVisitorProfileOverview', visitorData) }}
             </div>
             <div class="visitor-profile-visits-info">
                 <div class="visitor-profile-visits-container">


### PR DESCRIPTION
### Description:

We find it hard to add custom HTML related to visitor info(userId etc.) in visitorProfilePopup via plugins. Because it doesn't provide any postEvents with visitor info or plugin API to add custom item.

Supplying visitorData to Template.afterVisitorProfileOverview could solve this problem. Making visitorProfilePopup more customizable.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
