### PR TITLE
Add new wordtruncate twig filter and use in datatable headers

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -619,7 +619,7 @@ class Twig
             $shortenWords = [];
 
             foreach ($words as $word) {
-                $shortenWords[] = strlen($word) > $limit ? substr($word, 0, $limit) . $append : $word;
+                $shortenWords[] = strlen($word) > $limit + 1 ? substr($word, 0, $limit) . $append : $word;
             }
 
             return implode(' ', $shortenWords);

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -182,6 +182,7 @@ class Twig
         $this->addFilter_onlyDomain();
         $this->addFilter_safelink();
         $this->addFilter_implode();
+        $this->addFilter_wordTruncate();
         $this->twig->addFilter(new TwigFilter('ucwords', 'ucwords'));
         $this->twig->addFilter(new TwigFilter('lcfirst', 'lcfirst'));
         $this->twig->addFilter(new TwigFilter('ucfirst', 'ucfirst'));
@@ -609,6 +610,22 @@ class Twig
             return implode($separator, $value);
         });
         $this->twig->addFilter($implode);
+    }
+
+    function addFilter_wordTruncate()
+    {
+        $wordtruncateFilter = new TwigFilter('wordtruncate', function ($value, $limit = 8, $append = '&hellip;') {
+            $words = explode(' ', $value);
+            $shortenWords = [];
+
+            foreach ($words as $word) {
+                $shortenWords[] = strlen($word) > $limit ? substr($word, 0, $limit) . $append : $word;
+            }
+
+            return implode(' ', $shortenWords);
+        });
+
+        $this->twig->addFilter($wordtruncateFilter);
     }
 
     private function addTest_isNumeric()

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -183,6 +183,7 @@ class Twig
         $this->addFilter_safelink();
         $this->addFilter_implode();
         $this->addFilter_wordTruncate();
+        $this->addFilter_wordwrap();
         $this->twig->addFilter(new TwigFilter('ucwords', 'ucwords'));
         $this->twig->addFilter(new TwigFilter('lcfirst', 'lcfirst'));
         $this->twig->addFilter(new TwigFilter('ucfirst', 'ucfirst'));
@@ -612,7 +613,29 @@ class Twig
         $this->twig->addFilter($implode);
     }
 
-    function addFilter_wordTruncate()
+    public function addFilter_wordwrap()
+    {
+        $wordwrapFilter = new TwigFilter('wordwrap', function ($value, $length = 8, $separator = '-') {
+            // return wordwrap($value, $length, $separator, true);
+            $sentences = [];
+            $pieces = mb_split($separator, $value);
+
+            foreach ($pieces as $piece) {
+                while (mb_strlen($piece) > $length) {
+                    $sentences[] = mb_substr($piece, 0, $length);
+                    $piece = mb_substr($piece, $length, 2048);
+                }
+
+                $sentences[] = $piece;
+            }
+
+            return implode($separator, $sentences);
+        });
+
+        $this->twig->addFilter($wordwrapFilter);
+    }
+
+    private function addFilter_wordTruncate()
     {
         $wordtruncateFilter = new TwigFilter('wordtruncate', function ($value, $limit = 8, $append = '&hellip;') {
             $words = explode(' ', $value);

--- a/plugins/CoreHome/templates/_dataTableHead.twig
+++ b/plugins/CoreHome/templates/_dataTableHead.twig
@@ -12,7 +12,7 @@
                        {{ properties.metrics_documentation[column]|rawSafeDecoded|raw }}
                    </div>
                {% endif %}
-               <div id="thDIV" class="thDIV">{{ properties.translations[column]|default(column)|rawSafeDecoded|wordtruncate|raw }}</div>
+               <div id="thDIV" class="thDIV hyphenate">{{ properties.translations[column]|default(column)|rawSafeDecoded }}</div>
            </th>
        {% endfor %}
    </tr>

--- a/plugins/CoreHome/templates/_dataTableHead.twig
+++ b/plugins/CoreHome/templates/_dataTableHead.twig
@@ -12,7 +12,7 @@
                        {{ properties.metrics_documentation[column]|rawSafeDecoded|raw }}
                    </div>
                {% endif %}
-               <div id="thDIV" class="thDIV">{{ properties.translations[column]|default(column)|rawSafeDecoded }}</div>
+               <div id="thDIV" class="thDIV">{{ properties.translations[column]|default(column)|rawSafeDecoded|wordtruncate|raw }}</div>
            </th>
        {% endfor %}
    </tr>

--- a/plugins/Morpheus/stylesheets/general/_misc.less
+++ b/plugins/Morpheus/stylesheets/general/_misc.less
@@ -49,3 +49,12 @@
 .card .card-content {
   padding: 20px;
 }
+
+.hyphenate {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  hyphens: auto;
+}


### PR DESCRIPTION
### Description:

fixes #17242 

When we have very long words in the `datatable` header rows, it can cause wide columns, so the user has to scroll horizontally to see every data.
With a new twig filter, we can truncate the header string word by word. The whole word and more detailed explanation still viewable by hovering the mouse on the text.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
