### PR TITLE
archiving: look for all usable done flag types when checking for existing child periods

### DIFF
--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -847,7 +847,12 @@ class Model
         while ($date->isEarlier($period->getDateEnd()->addPeriod(1, 'month'))) {
             $archiveTable = ArchiveTableCreator::getNumericTable($date);
 
+            // we look for any archive that can be used to compute this one. this includes invalidated archives, since it is possible
+            // under certain circumstances for them to exist, when archiving a higher period that includes them. the main example being
+            // the GoogleAnalyticsImporter which disallows the recomputation of invalidated archives for imported data, since that would
+            // essentially get rid of the imported data.
             $usableDoneFlags = [ArchiveWriter::DONE_OK, ArchiveWriter::DONE_INVALIDATED, ArchiveWriter::DONE_PARTIAL, ArchiveWriter::DONE_OK_TEMPORARY];
+
             $sql = "SELECT idarchive
                   FROM `$archiveTable`
                  WHERE idsite = ? AND date1 >= ? AND date2 <= ? AND period < ? AND `name` LIKE 'done%' AND `value` IN (" . implode(', ', $usableDoneFlags) . ")

--- a/core/DataAccess/Model.php
+++ b/core/DataAccess/Model.php
@@ -847,9 +847,10 @@ class Model
         while ($date->isEarlier($period->getDateEnd()->addPeriod(1, 'month'))) {
             $archiveTable = ArchiveTableCreator::getNumericTable($date);
 
+            $usableDoneFlags = [ArchiveWriter::DONE_OK, ArchiveWriter::DONE_INVALIDATED, ArchiveWriter::DONE_PARTIAL, ArchiveWriter::DONE_OK_TEMPORARY];
             $sql = "SELECT idarchive
                   FROM `$archiveTable`
-                 WHERE idsite = ? AND date1 >= ? AND date2 <= ? AND period < ? AND `name` LIKE 'done%' AND `value` = " . ArchiveWriter::DONE_OK . "
+                 WHERE idsite = ? AND date1 >= ? AND date2 <= ? AND period < ? AND `name` LIKE 'done%' AND `value` IN (" . implode(', ', $usableDoneFlags) . ")
                  LIMIT 1";
             $bind = [$idSite, $period->getDateStart()->getDatetime(), $period->getDateEnd()->getDatetime(), $period->getId()];
 

--- a/tests/PHPUnit/Integration/DataAccess/ModelTest.php
+++ b/tests/PHPUnit/Integration/DataAccess/ModelTest.php
@@ -274,6 +274,25 @@ class ModelTest extends IntegrationTestCase
                 'year',
                 true,
             ],
+            [
+                [
+                    ['date1' => '2015-04-01', 'date2' => '2015-04-01', 'period' => 1, 'name' => 'done', 'value' => 4],
+                ],
+                1,
+                '2015-02-04',
+                'year',
+                true,
+            ],
+            [
+                [
+                    ['date1' => '2015-04-01', 'date2' => '2015-04-01', 'period' => 1, 'name' => 'done', 'value' => 5],
+                    ['date1' => '2014-04-01', 'date2' => '2014-04-01', 'period' => 1, 'name' => 'done', 'value' => 1],
+                ],
+                1,
+                '2015-02-04',
+                'year',
+                true,
+            ],
 
             // range period w/ day child
             [


### PR DESCRIPTION
### Description:

When checking for child periods we can use when archiving there might be invalidated archives that could be used which we should also detect. This mostly affects sites that use the tracker and can have no visits, but day archives with data, and no other higher archives. To my knowledge this just includes sites imported from google.

### Review

* [ ] Functional review done
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
