### PR TITLE
Throw invalid dimension exception during rendering graph with wrong height/width values

### DIFF
--- a/core/Exception/InvalidDimensionException.php
+++ b/core/Exception/InvalidDimensionException.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+namespace Piwik\Exception;
+
+class InvalidDimensionException extends Exception
+{
+}

--- a/plugins/ImageGraph/API.php
+++ b/plugins/ImageGraph/API.php
@@ -14,6 +14,7 @@ use Piwik\Archive\DataTableFactory;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\DataTable\Map;
+use Piwik\Exception\InvalidDimensionException;
 use Piwik\Filesystem;
 use Piwik\Period;
 use Piwik\Piwik;
@@ -493,6 +494,8 @@ class API extends \Piwik\Plugin\API
 
             // render graph
             $graph->renderGraph();
+        } catch (InvalidDimensionException $e) {
+            throw new Exception('Error: the graph dimension is not valid. Please try larger width and height values or use 0 for default values.');
         } catch (\Exception $e) {
 
             $graph = new \Piwik\Plugins\ImageGraph\StaticGraph\Exception();

--- a/plugins/ImageGraph/API.php
+++ b/plugins/ImageGraph/API.php
@@ -495,7 +495,7 @@ class API extends \Piwik\Plugin\API
             // render graph
             $graph->renderGraph();
         } catch (InvalidDimensionException $e) {
-            throw new Exception('Error: the graph dimension is not valid. Please try larger width and height values or use 0 for default values.');
+            throw $e;
         } catch (\Exception $e) {
 
             $graph = new \Piwik\Plugins\ImageGraph\StaticGraph\Exception();

--- a/plugins/ImageGraph/StaticGraph/GridGraph.php
+++ b/plugins/ImageGraph/StaticGraph/GridGraph.php
@@ -147,7 +147,7 @@ abstract class GridGraph extends StaticGraph
         }
 
         if (($bottomRightYValue - $topLeftYValue) <= ($ordinateAxisLength / 2)) {
-            throw new InvalidDimensionException();
+            throw new InvalidDimensionException('Error: the graph dimension is not valid. Please try larger width and height values or use 0 for default values.');
         }
 
         $gridColor = $this->gridColor;

--- a/plugins/ImageGraph/StaticGraph/GridGraph.php
+++ b/plugins/ImageGraph/StaticGraph/GridGraph.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\ImageGraph\StaticGraph;
 
 use Piwik\Plugins\ImageGraph\StaticGraph;
+use Piwik\Log;
 
 /**
  *
@@ -127,7 +128,8 @@ abstract class GridGraph extends StaticGraph
 
         $ordinateAxisLength =
             $horizontalGraph ? $bottomRightXValue - $topLeftXValue : $this->getGraphHeight($horizontalGraph, $verticalLegend);
-
+// $ordinateAxisLength = 1;
+            Log::debug('ordinatee ' . $ordinateAxisLength);
         $maxOrdinateValue = 0;
         foreach ($this->ordinateSeries as $column => $data) {
             $currentMax = $this->pData->getMax($column);
@@ -144,7 +146,7 @@ abstract class GridGraph extends StaticGraph
                 $maxOrdinateValue += 10 - $modTen;
             }
         }
-
+$ordinateAxisLength = $ordinateAxisLength < 2 ? 10 : $ordinateAxisLength;
         $gridColor = $this->gridColor;
         $this->pImage->drawScale(
             array(
@@ -373,6 +375,9 @@ abstract class GridGraph extends StaticGraph
 
     protected function getGraphHeight($horizontalGraph, $verticalLegend)
     {
+        Log::debug('a ' . $this->getGraphBottom($horizontalGraph));
+        Log::debug('a ' . $this->getGridTopMargin($horizontalGraph, $verticalLegend));
+
         return $this->getGraphBottom($horizontalGraph) - $this->getGridTopMargin($horizontalGraph, $verticalLegend);
     }
 

--- a/plugins/ImageGraph/StaticGraph/GridGraph.php
+++ b/plugins/ImageGraph/StaticGraph/GridGraph.php
@@ -8,8 +8,8 @@
  */
 namespace Piwik\Plugins\ImageGraph\StaticGraph;
 
+use Piwik\Exception\InvalidDimensionException;
 use Piwik\Plugins\ImageGraph\StaticGraph;
-use Piwik\Log;
 
 /**
  *
@@ -128,8 +128,7 @@ abstract class GridGraph extends StaticGraph
 
         $ordinateAxisLength =
             $horizontalGraph ? $bottomRightXValue - $topLeftXValue : $this->getGraphHeight($horizontalGraph, $verticalLegend);
-// $ordinateAxisLength = 1;
-            Log::debug('ordinatee ' . $ordinateAxisLength);
+
         $maxOrdinateValue = 0;
         foreach ($this->ordinateSeries as $column => $data) {
             $currentMax = $this->pData->getMax($column);
@@ -146,7 +145,11 @@ abstract class GridGraph extends StaticGraph
                 $maxOrdinateValue += 10 - $modTen;
             }
         }
-$ordinateAxisLength = $ordinateAxisLength < 2 ? 10 : $ordinateAxisLength;
+
+        if (($bottomRightYValue - $topLeftYValue) <= ($ordinateAxisLength / 2)) {
+            throw new InvalidDimensionException();
+        }
+
         $gridColor = $this->gridColor;
         $this->pImage->drawScale(
             array(
@@ -375,9 +378,6 @@ $ordinateAxisLength = $ordinateAxisLength < 2 ? 10 : $ordinateAxisLength;
 
     protected function getGraphHeight($horizontalGraph, $verticalLegend)
     {
-        Log::debug('a ' . $this->getGraphBottom($horizontalGraph));
-        Log::debug('a ' . $this->getGridTopMargin($horizontalGraph, $verticalLegend));
-
         return $this->getGraphBottom($horizontalGraph) - $this->getGridTopMargin($horizontalGraph, $verticalLegend);
     }
 


### PR DESCRIPTION
### Description:

fixes #17092 

The package we use for rendering graphs has a bug. To avoid run into that bug, we can check the values we send to the package and if the values would cause the modulo zero error we throw an exception instead. 
Our plugin throws the exceptions as an image by default, but for this error it's not that useful, because usually it happens when the height value is too small, so the user wouldn't be able to read the error message. 
For this specific exception I used the default way.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
