### PR TITLE
Allow configuring segments to not be rearchived when rearchiving reports in the past.

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -769,6 +769,9 @@ enable_tracking_failures_notification = 1
 ; doing this (such as CustomReports). Set to 0 to disable the feature. Default is 6.
 rearchive_reports_in_past_last_n_months = last6
 
+; If set to 1, when rearchiving reports in the past we do not rearchive segment data with those reports. Default is 0.
+rearchive_reports_in_past_exclude_segments = 0
+
 [Tracker]
 
 ; When enabled and a userId is set, then the visitorId will be automatically set based on the userId. This allows to

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -502,7 +502,9 @@ class ArchiveInvalidator
         }
 
         $this->markArchivesAsInvalidated($idSites, $dates, 'day', $segment, $cascadeDown = false, $forceInvalidateRanges = false, $name);
-        if (empty($segment)) {
+        if (empty($segment)
+            && Rules::shouldProcessSegmentsWhenReArchivingReports()
+        ) {
             foreach ($idSites as $idSite) {
                 foreach (Rules::getSegmentsToProcess([$idSite]) as $segment) {
                     $this->markArchivesAsInvalidated($idSites, $dates, 'day', new Segment($segment, [$idSite]),
@@ -576,7 +578,7 @@ class ArchiveInvalidator
 
                 $idSites = Site::getIdSitesFromIdSitesString($entry['idSites']);
                 $this->reArchiveReport(
-                    $entry['idSites'],
+                    $idSites,
                     $entry['pluginName'],
                     $entry['report'],
                     !empty($entry['startDate']) ? Date::factory((int) $entry['startDate']) : null,

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -338,4 +338,9 @@ class Rules
 
         return !empty($_GET['pluginOnly']) || !empty($_POST['pluginOnly']);
     }
+
+    public static function shouldProcessSegmentsWhenReArchivingReports()
+    {
+        return Config::getInstance()->General['rearchive_reports_in_past_exclude_segments'] != 1;
+    }
 }


### PR DESCRIPTION
### Description:

FYI @tsteur

Adds new INI config option `rearchive_reports_in_past_exclude_segments` to disallow archiving segments when rearchiving in past. Should be fine for things like plugin activations and entity creation, but I can see one issue w/ updating an entity. If there is already segment data for the old entity, then that will be displayed as if it is new. Perhaps this should also be paired w/ a new feature that doesn't use archive data if it is older than the entity last update time? This would require being able to set the last update time in, eg, a Report or ViewDataTable class and checking this against the `ts_archived`. I imagine there would be support requests if we just show the old data.

Also includes a small bug fix (processed $idSites value not being used in applyScheduledRearchiving).

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
