### PR TITLE
allow forcing Archive to not initiate archiving for child archives

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -168,6 +168,14 @@ class Archive implements ArchiveQuery
     private static $cache;
 
     /**
+     * If true, this Archive instance will not launch the archiving process, even if the current request
+     * is authorized to.
+     *
+     * @var bool
+     */
+    private $forceFetchingWithoutLaunchingArchiving;
+
+    /**
      * @param Parameters $params
      * @param bool $forceIndexedBySite Whether to force index the result of a query by site ID.
      * @param bool $forceIndexedByDate Whether to force index the result of a query by period.
@@ -557,7 +565,9 @@ class Archive implements ArchiveQuery
 
         // cache id archives for plugins we haven't processed yet
         if (!empty($archiveGroups)) {
-            if (!Rules::isArchivingDisabledFor($this->params->getIdSites(), $this->params->getSegment(), $this->getPeriodLabel())) {
+            if (!Rules::isArchivingDisabledFor($this->params->getIdSites(), $this->params->getSegment(), $this->getPeriodLabel())
+                && !$this->forceFetchingWithoutLaunchingArchiving
+            ) {
                 $this->cacheArchiveIdsAfterLaunching($archiveGroups, $plugins);
             } else {
                 $this->cacheArchiveIdsWithoutLaunching($plugins);
@@ -851,5 +861,10 @@ class Archive implements ArchiveQuery
     public static function clearStaticCache()
     {
         self::$cache = null;
+    }
+
+    public function forceFetchingWithoutLaunchingArchiving()
+    {
+        $this->forceFetchingWithoutLaunchingArchiving = true;
     }
 }

--- a/core/ArchiveProcessor.php
+++ b/core/ArchiveProcessor.php
@@ -116,6 +116,11 @@ class ArchiveProcessor
             $subPeriods = $this->params->getSubPeriods();
             $idSites    = $this->params->getIdSites();
             $this->archive = Archive::factory($this->params->getSegment(), $subPeriods, $idSites);
+
+            /**
+             * @internal
+             */
+            Piwik::postEvent('ArchiveProcessor.getArchive', [$this->archive]);
         }
 
         return $this->archive;


### PR DESCRIPTION
### Description:

So we can disallow archiving of child archives when generating archives of a higher period. (Not public API)

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
