### PR TITLE
Add event tags to top and bottom of body

### DIFF
--- a/plugins/Morpheus/templates/layout.twig
+++ b/plugins/Morpheus/templates/layout.twig
@@ -31,6 +31,7 @@
         {% endblock %}
     </head>
     <body id="{{ bodyId|default('') }}" ng-app="app" class="{{ bodyClass|default('') }}">
+        {{ postEvent('Template.bodyTop' ) }}
 
     {% block body %}
 
@@ -53,5 +54,7 @@
         </div>
 
         {% include "@CoreHome/_adblockDetect.twig" %}
+
+        {{ postEvent('Template.bodyBottom' ) }}
     </body>
 </html>


### PR DESCRIPTION
### Description:

I am currently developing a plugin that appends html to the top and bottom of the body. These two tags would be helpful in my plugin development.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
