### PR TITLE
Fix check for invalid image sizes

### DIFF
--- a/plugins/ImageGraph/StaticGraph/GridGraph.php
+++ b/plugins/ImageGraph/StaticGraph/GridGraph.php
@@ -146,7 +146,7 @@ abstract class GridGraph extends StaticGraph
             }
         }
 
-        if (($bottomRightYValue - $topLeftYValue) <= ($ordinateAxisLength / 2)) {
+        if ($ordinateAxisLength <= 0 || $bottomRightYValue - $topLeftYValue <= 0) {
             throw new InvalidDimensionException('Error: the graph dimension is not valid. Please try larger width and height values or use 0 for default values.');
         }
 


### PR DESCRIPTION
### Description:

Seems I've merged #17320 too early. Afterwards some system tests generating image started to fail, as an exception was thrown even though the dimension should be valid.

Debugged a bit through the code, and I think the new condition should prevent any modulo error but still show an image if it is possible.

@flamisz  maybe you could have a quick look and merge if it's fine.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
