### PR TITLE
Do not try to remove webserver config files

### DIFF
--- a/plugins/Installation/ServerFilesGenerator.php
+++ b/plugins/Installation/ServerFilesGenerator.php
@@ -16,12 +16,8 @@ class ServerFilesGenerator
 {
     public static function createFilesForSecurity()
     {
-        self::deleteHtAccessFiles();
         self::createHtAccessFiles();
-
-        self::deleteWebConfigFiles();
         self::createWebConfigFiles();
-
         self::createWebRootFiles();
     }
 


### PR DESCRIPTION
### Description:

The files are overwritten if possible nevertheless, so removing them before shouldn't be needed at all.

fixes #17290

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
