### PR TITLE
Destroy temporarily created table in customdimensions archiver

### DIFF
--- a/plugins/CustomDimensions/Archiver.php
+++ b/plugins/CustomDimensions/Archiver.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\CustomDimensions;
 
+use Piwik\Common;
 use Piwik\Config;
 use Piwik\Metrics;
 use Piwik\Plugins\Actions\Metrics as ActionsMetrics;
@@ -123,6 +124,9 @@ class Archiver extends \Piwik\Plugin\Archiver
 
             $recordName = self::buildRecordNameForCustomDimensionId($dimension['idcustomdimension']);
             $this->getProcessor()->insertBlobRecord($recordName, $blob);
+
+            Common::destroy($table);
+            unset($this->dataArray);
         }
     }
 


### PR DESCRIPTION
### Description:

The table isn't ever destroyed in the Archiver (it will automatically destroyed by some PluginsArchiver code, though).

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
