### PR TITLE
Ensure site is selected in siteselector if only one site is available

### DIFF
--- a/plugins/CoreHome/angularjs/siteselector/siteselector-model.service.js
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector-model.service.js
@@ -122,7 +122,7 @@
                 return;
             }
 
-            searchSite('%').then(function () {
+            return searchSite('%').then(function () {
                 initialSites = model.sites;
                 model.isInitialized = true
             });

--- a/plugins/CoreHome/angularjs/siteselector/siteselector.controller.js
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.controller.js
@@ -13,7 +13,11 @@
 
         $scope.model = siteSelectorModel;
 
-        $scope.model.loadInitialSites();
+        $scope.model.loadInitialSites().then(function(){
+            if (!$scope.selectedSite && !$scope.model.hasMultipleSites() && $scope.model.sites[0]) {
+                $scope.selectedSite = {id: $scope.model.sites[0].idsite, name: $scope.model.sites[0].name};
+            }
+        });
 
         $scope.autocompleteMinSites = AUTOCOMPLETE_MIN_SITES;
         $scope.activeSiteId = piwik.idSite;


### PR DESCRIPTION
### Description:

When only one site is available the site selector does no longer provide the possibility to choose one. In this case this site should be automatically set as the selected one.

regression from #16972

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
