### PR TITLE
Ensure login allow list is not checked for authenticated tracking requests

### DIFF
--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -45,7 +45,7 @@ class CoreHome extends \Piwik\Plugin
             'AssetManager.filterMergedJavaScripts'   => 'filterMergedJavaScripts',
             'Translate.getClientSideTranslationKeys' => 'getClientSideTranslationKeys',
             'Metric.addComputedMetrics'              => 'addComputedMetrics',
-            'Request.initAuthenticationObject' => 'initAuthenticationObject',
+            'Request.initAuthenticationObject' => 'checkAllowedIpsOnAuthentication',
             'AssetManager.addStylesheets' => 'addStylesheets',
             'Request.dispatchCoreAndPluginUpdatesScreen' => 'initAuthenticationObject',
             'Tracker.setTrackerCacheGeneral' => 'setTrackerCacheGeneral',
@@ -73,7 +73,7 @@ class CoreHome extends \Piwik\Plugin
         $mergedContent = $themeStyles->toLessCode() . "\n" . $mergedContent;
     }
 
-    public function initAuthenticationObject()
+    public function checkAllowedIpsOnAuthentication()
     {
         if (SettingsServer::isTrackerApiRequest()) {
             // authenticated tracking requests should always work

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -75,9 +75,14 @@ class CoreHome extends \Piwik\Plugin
 
     public function initAuthenticationObject()
     {
+        if (SettingsServer::isTrackerApiRequest()) {
+            // authenticated tracking requests should always work
+            return;
+        }
+
         $isApi = Piwik::getModule() === 'API' && (Piwik::getAction() == '' || Piwik::getAction() == 'index');
 
-        if (!SettingsServer::isTrackerApiRequest() && $isApi) {
+        if ($isApi) {
             // will be checked in API itself to make sure we return an API response in the proper format.
             return;
         }

--- a/plugins/CoreHome/CoreHome.php
+++ b/plugins/CoreHome/CoreHome.php
@@ -47,7 +47,7 @@ class CoreHome extends \Piwik\Plugin
             'Metric.addComputedMetrics'              => 'addComputedMetrics',
             'Request.initAuthenticationObject' => 'checkAllowedIpsOnAuthentication',
             'AssetManager.addStylesheets' => 'addStylesheets',
-            'Request.dispatchCoreAndPluginUpdatesScreen' => 'initAuthenticationObject',
+            'Request.dispatchCoreAndPluginUpdatesScreen' => 'checkAllowedIpsOnAuthentication',
             'Tracker.setTrackerCacheGeneral' => 'setTrackerCacheGeneral',
         );
     }

--- a/tests/PHPUnit/System/TrackerDisallowedIpTest.php
+++ b/tests/PHPUnit/System/TrackerDisallowedIpTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\System;
+
+use Piwik\Config;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group Core
+ * @group Tracker
+ * @group TrackerDisallowedIp
+ */
+class TrackerDisallowedIpTest extends IntegrationTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Fixture::createWebsite('2014-02-04');
+        Fixture::createSuperUser(false);
+    }
+
+    public function test_authenticateSuperUserOrAdmin_ShouldWorkWithIpNotOnLoginWhitelist()
+    {
+        $tracker = Fixture::getTracker(1, '2021-02-02 16:00:00', $defaultInit = true, $useLocalTracker = false);
+        $tracker->setTokenAuth(Fixture::getTokenAuth());
+        Fixture::checkResponse($tracker->doTrackPageView('test'));
+    }
+
+    public static function provideContainerConfigBeforeClass()
+    {
+        return [
+            'observers.global' => \DI\add(array(
+                array('Environment.bootstrapped', \DI\value(function () {
+                    // ensure tracking request uses an IP that is not local or on allow list
+                    $_SERVER['REMOTE_ADDR'] = '3.3.3.3';
+                }))
+            )),
+            Config::class => \DI\decorate(function (Config $config) {
+                $config->General['login_allowlist_ip'] = ['1.1.1.1'];
+                return $config;
+            }),
+        ];
+    }
+
+}


### PR DESCRIPTION
### Description:

fixes https://github.com/matomo-org/plugin-VisitorGenerator/issues/66

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
