### PR TITLE
Warning in 2fa setting: gmdate() expects parameter 2 to be int

### DIFF
--- a/core/Cookie.php
+++ b/core/Cookie.php
@@ -152,7 +152,7 @@ class Cookie
         }
 
         $header = 'Set-Cookie: ' . rawurlencode($Name) . '=' . rawurlencode($Value)
-            . (empty($Expires) ? '' : '; expires=' . gmdate('D, d-M-Y H:i:s', $Expires) . ' GMT')
+            . (empty($Expires) ? '' : '; expires=' . gmdate('D, d-M-Y H:i:s', (int) $Expires) . ' GMT')
             . (empty($Path) ? '' : '; path=' . $Path)
             . (empty($Domain) ? '' : '; domain=' . rawurlencode($Domain))
             . (!$Secure ? '' : '; secure')


### PR DESCRIPTION
see https://forum.matomo.org/t/problem-with-the-two-factor-authentication-setting/41128/12?

> WARNING: /Piwik/core/Cookie.php(155): Warning - gmdate() expects parameter 2 to be int, float given - Matomo 4.1.1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already) (Module: UsersManager, Action: setIgnoreCookie, In CLI mode: false)

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
