### PR TITLE
allow forcing backtrace to print in exceptiontotextprocessor

### DIFF
--- a/plugins/Monolog/Processor/ExceptionToTextProcessor.php
+++ b/plugins/Monolog/Processor/ExceptionToTextProcessor.php
@@ -100,12 +100,13 @@ class ExceptionToTextProcessor
         }
 
         if (is_array($exception)) {
+            $message = $exception['message'] ?? '';
             if ($shouldPrintBacktrace && isset($exception['backtrace'])) {
                 $trace = $exception['backtrace'];
                 $trace = self::replaceSensitiveValues($trace);
-                return $trace;
+                return $message . "\n" . $trace;
             } else {
-                return '';
+                return $message;
             }
         }
 

--- a/plugins/Monolog/Processor/ExceptionToTextProcessor.php
+++ b/plugins/Monolog/Processor/ExceptionToTextProcessor.php
@@ -20,6 +20,13 @@ use Piwik\SettingsPiwik;
  */
 class ExceptionToTextProcessor
 {
+    private $forcePrintBacktrace = false;
+
+    public function __construct($forcePrintBacktrace = false)
+    {
+        $this->forcePrintBacktrace = $forcePrintBacktrace;
+    }
+
     public function __invoke(array $record)
     {
         if (! $this->contextContainsException($record)) {
@@ -34,10 +41,9 @@ class ExceptionToTextProcessor
         }
 
         $exceptionStr = sprintf(
-            "%s(%d): %s\n%s",
+            "%s(%d): %s",
             $exception instanceof \Exception ? $exception->getFile() : $exception['file'],
             $exception instanceof \Exception ? $exception->getLine() : $exception['line'],
-            $this->getMessage($exception),
             $this->getStackTrace($exception)
         );
 
@@ -79,7 +85,7 @@ class ExceptionToTextProcessor
 
     private function getStackTrace($exception)
     {
-        return Log::$debugBacktraceForTests ?: self::getMessageAndWholeBacktrace($exception);
+        return Log::$debugBacktraceForTests ?: self::getMessageAndWholeBacktrace($exception, $this->forcePrintBacktrace ? true : null);
     }
 
     /**

--- a/plugins/Monolog/tests/Integration/LogTest.php
+++ b/plugins/Monolog/tests/Integration/LogTest.php
@@ -31,7 +31,7 @@ class LogTest extends IntegrationTestCase
     public static $expectedExceptionOutput = '[Monolog] [%s] LogTest.php(112): dummy error message
   dummy backtrace';
 
-    public static $expectedErrorOutput = '[Monolog] [%s] dummyerrorfile.php(145): Unknown error (102) - dummy error string
+    public static $expectedErrorOutput = '[Monolog] [%s] dummyerrorfile.php(145): dummy error message
   dummy backtrace';
 
     public function setUp(): void
@@ -41,7 +41,7 @@ class LogTest extends IntegrationTestCase
         Log::unsetInstance();
 
         @unlink(self::getLogFileLocation());
-        Log::$debugBacktraceForTests = "dummy backtrace";
+        Log::$debugBacktraceForTests = "dummy error message\ndummy backtrace";
     }
 
     public function tearDown(): void

--- a/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
@@ -87,7 +87,7 @@ class ExceptionToTextProcessorTest extends \PHPUnit\Framework\TestCase
     public function it_should_add_severity_for_errors()
     {
         $processor = new ExceptionToTextProcessor();
-        Log::$debugBacktraceForTests = '[stack trace]';
+        Log::$debugBacktraceForTests = '[message and stack trace]';
 
         $exception = new \ErrorException('Hello world', 0, 1, 'file.php', 123);
         $record = array(
@@ -99,7 +99,7 @@ class ExceptionToTextProcessorTest extends \PHPUnit\Framework\TestCase
         $result = $processor($record);
 
         $expected = array(
-            'message' => "file.php(123): Error - Hello world\n[stack trace]",
+            'message' => "file.php(123): Error - [message and stack trace]",
             'context' => array(
                 'exception' => $exception,
             ),

--- a/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
@@ -240,6 +240,7 @@ EOI;
         $wholeTrace = ExceptionToTextProcessor::getMessageAndWholeBacktrace($exArray);
 
         $expected = <<<EOI
+themessage
 thestacktrace
 EOI;
 
@@ -255,7 +256,7 @@ EOI;
 
         $wholeTrace = ExceptionToTextProcessor::getMessageAndWholeBacktrace($exArray);
 
-        $expected = '';
+        $expected = 'themessage';
 
         $this->assertEquals($expected, $wholeTrace);
     }

--- a/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
+++ b/plugins/Monolog/tests/Unit/Processor/ExceptionToTextProcessorTest.php
@@ -60,7 +60,7 @@ class ExceptionToTextProcessorTest extends \PHPUnit\Framework\TestCase
     public function it_should_replace_message_with_formatted_exception()
     {
         $processor = new ExceptionToTextProcessor();
-        Log::$debugBacktraceForTests = '[stack trace]';
+        Log::$debugBacktraceForTests = '[message and stack trace]';
 
         $exception = new \Exception('Hello world');
         $record = array(
@@ -72,7 +72,7 @@ class ExceptionToTextProcessorTest extends \PHPUnit\Framework\TestCase
         $result = $processor($record);
 
         $expected = array(
-            'message' => __FILE__ . "(65): Hello world\n[stack trace]",
+            'message' => __FILE__ . "(65): [message and stack trace]",
             'context' => array(
                 'exception' => $exception,
             ),
@@ -99,7 +99,7 @@ class ExceptionToTextProcessorTest extends \PHPUnit\Framework\TestCase
         $result = $processor($record);
 
         $expected = array(
-            'message' => "file.php(123): Error - [message and stack trace]",
+            'message' => "file.php(123): [message and stack trace]",
             'context' => array(
                 'exception' => $exception,
             ),


### PR DESCRIPTION
### Description:

Allow forcing the backtrace to print in ExceptionToTextProcessor + a fix: remove the redundant message that gets printed when including the backtrace. The processor printed the message + the stack trace, but the stack trace includes the messages of all exceptions, so it's redundant. We could also always use the result of `getMessageAndWholeBacktrace()`, but I didn't want to change that much code for a small change.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
