### PR TITLE
more private Referrer-Policy: use strict-origin-when-cross-origin 

### DIFF
--- a/core/View.php
+++ b/core/View.php
@@ -296,7 +296,7 @@ class View implements ViewInterface
                 Common::sendHeader('Referrer-Policy: same-origin');
             } else {
                 // always send explicit default header
-                Common::sendHeader('Referrer-Policy: no-referrer-when-downgrade');
+                Common::sendHeader('Referrer-Policy: strict-origin-when-cross-origin');
             }
         }
 


### PR DESCRIPTION
related to https://github.com/matomo-org/matomo/issues/17381, https://github.com/matomo-org/matomo/pull/15673 and https://github.com/matomo-org/matomo-nginx/pull/61

At the moment we are sending a less private Referrer-Policy than the one that would be used if we didn't send one.

So now 
- the full referrer is sent to the same origin
- just the domain is sent to another origin (as long as it is using HTTPS)
- nothing is sent to HTTP sites
(as long as `$this->useStrictReferrerPolicy` is not set in which case nothing is sent to other origins)

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
