### PR TITLE
Ensure correct rowaction instances are used

### DIFF
--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1809,7 +1809,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         if (!trs || !trs.length || !trs[0]) {
             return;
         }
-        var parent = $(trs[0]).parents('table');
+        var parent = $(trs[0]).closest('table');
 
         var self = this;
 


### PR DESCRIPTION
### Description:

It took me a while debugging to figure out where the reason for #17374 was. It turned out that when loading a subtable handling the row actions was not only called for the subtable, but also for the parent table (caused by using `.parents` instead of `.closest`).
Due to this the `actionInstances` used to bind the events were bound multiple times for the parent table, causing some weird behavior where sometimes the wrong datatable was used to trigger the row action.

fixes #17374
fixes matomo-org/plugin-MarketingCampaignsReporting#61

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
