### PR TITLE
Fix download test

### DIFF
--- a/tests/PHPUnit/Integration/HttpTest.php
+++ b/tests/PHPUnit/Integration/HttpTest.php
@@ -304,7 +304,7 @@ class HttpTest extends \PHPUnit\Framework\TestCase
     {
         $result = Http::sendHttpRequestBy(
             $method,
-            'https://tools.ietf.org/html/rfc7233',
+            'https://builds.matomo.org/matomo.zip',
             300,
             null,
             null,
@@ -317,7 +317,7 @@ class HttpTest extends \PHPUnit\Framework\TestCase
         /**
          * The last arg above asked the server to limit the response sent back to bytes 0->50.
          * The RFC for HTTP Range Requests says that these headers can be ignored, so the test
-         * depends on a server that will respect it - we are requesting the RFC itself, which does.
+         * depends on a server that will respect it - we are requesting our build download, which does.
          */
         $this->assertEquals(51, strlen($result));
     }


### PR DESCRIPTION
### Description:

The test that tries downloading something from `https://tools.ietf.org/html/rfc7233` currently fails quite often due to connectivity issues of their servers. Using our build download instead hopefully works better...

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
