### PR TITLE
Apache 2.4+ compatibility for misc/cron/.htaccess

### DIFF
--- a/misc/cron/.htaccess
+++ b/misc/cron/.htaccess
@@ -1,15 +1,27 @@
 # Allow direct web access to Web cron
-# Apache 2.2
-<IfModule !authz_core_module>
-        <Files "archive.php">
-                Order Allow,Deny
-                Allow from all
-        </Files>
+<IfModule mod_version.c>
+        <IfVersion < 2.4>
+                <Files "archive.php">
+                        Order Allow,Deny
+                        Allow from all
+                </Files>
+        </IfVersion>
+        <IfVersion >= 2.4>
+                <Files "archive.php">
+                        Require all granted
+                </Files>
+	</IfVersion>
 </IfModule>
-
-# Apache 2.4+
-<IfModule authz_core_module>
-        <Files "archive.php">
-                Require all granted
-        </Files>
+<IfModule !mod_version.c>
+        <IfModule !mod_authz_core.c>
+                <Files "archive.php">
+                        Order Allow,Deny
+                        Allow from all
+                </Files>
+        </IfModule>
+	<IfModule mod_authz_core.c>
+                <Files "archive.php">
+                        Require all granted
+                </Files>
+        </IfModule>
 </IfModule>

--- a/misc/cron/.htaccess
+++ b/misc/cron/.htaccess
@@ -1,5 +1,15 @@
 # Allow direct web access to Web cron
-<Files "archive.php">
-	Order Allow,Deny
-	Allow from all
-</Files>
+# Apache 2.2
+<IfModule !authz_core_module>
+        <Files "archive.php">
+                Order Allow,Deny
+                Allow from all
+        </Files>
+</IfModule>
+
+# Apache 2.4+
+<IfModule authz_core_module>
+        <Files "archive.php">
+                Require all granted
+        </Files>
+</IfModule>


### PR DESCRIPTION
### Description:

In Apache 2.4+, the syntax for access control has changed. This causes the cron script to return a 500 error when running on Apache 2.4+. This PR checks which version of Apache is used and uses the right syntax.

See also: [https://httpd.apache.org/docs/2.4/upgrading.html](https://httpd.apache.org/docs/2.4/upgrading.html)

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [x] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [x] Developer changelog updated if needed
* [x] Documentation added if needed
* [x] Existing documentation updated if needed
