### PR TITLE
icon for informational system check

### DIFF
--- a/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
+++ b/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:537abc41c9f56eb9bf976d5105834a4d4eaa6fc4b9718cdd3a8be71d50ab0c93
-size 426942
+oid sha256:3abab46bf7c8af3bb587a8162cc33e0b3f77dee3b78fef43a539066d70d5a4a6
+size 440859

--- a/plugins/Installation/stylesheets/installation.css
+++ b/plugins/Installation/stylesheets/installation.css
@@ -121,6 +121,10 @@ p.next-step:first-child {
     color: #D73F36;
     margin-right: 10px;
 }
+.system-check .icon-info2, .system-check-legend .icon-info2 {
+    color: #00bcd4;
+    margin-right: 10px;
+}
 
 .system-check-legend {
     font-size: 13px;

--- a/plugins/Installation/stylesheets/systemCheckPage.less
+++ b/plugins/Installation/stylesheets/systemCheckPage.less
@@ -30,6 +30,10 @@
     color: #D73F36;
     margin-right: 10px;
 }
+.system-check .icon-info2 {
+    color: #00bcd4;
+    margin-right: 10px;
+}
 
 .widgetBody.system-check {
     .icon-ok,

--- a/plugins/Installation/templates/_systemCheckSection.twig
+++ b/plugins/Installation/templates/_systemCheckSection.twig
@@ -63,6 +63,7 @@
     {% set errorIcon %} <span class="icon-error"></span> {% endset %}
     {% set warningIcon %} <span class="icon-warning"></span> {% endset %}
     {% set okIcon %} <span class="icon-ok"></span> {% endset %}
+    {% set infoIcon %} <span class="icon-info2"></span> {% endset %}
 
     {% for result in results %}
         <tr>
@@ -75,7 +76,7 @@
                     {% elseif item.status == warning %}
                         {{ warningIcon }} {{ item.comment|raw }}
                     {% elseif item.status == informational %}
-                        {{ item.comment }}
+                        {{ infoIcon }} {{ item.comment }}
                     {% else %}
                         {{ okIcon }} {{ item.comment|raw }}
                     {% endif %}

--- a/plugins/Installation/tests/UI/expected-screenshots/Installation_system_check.png
+++ b/plugins/Installation/tests/UI/expected-screenshots/Installation_system_check.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:212df273f5a832f6a7aa52b5ec9f544ef385f94492e3a1b224de947e8df93f1f
-size 270335
+oid sha256:f20ab8e58403358f7eac9fa3f7e39879a623c9ce376a1af7875ce2d71b37f968
+size 273195


### PR DESCRIPTION
This is quite subjective, but I think it looks nicer if there is also an icon for informational entries

Before:
![grafik](https://user-images.githubusercontent.com/6266037/112368347-44818f00-8cdb-11eb-906a-bf8dff9b857a.png)

Now:
![grafik](https://user-images.githubusercontent.com/6266037/112368376-4f3c2400-8cdb-11eb-918e-72f7e0c40516.png)

One could use icon-info instead as it looks a bit nicer, but it doesn't fit the style of the other icons.

### Review

* [x] Functional review done
* [x] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] Code review done
* [ ] Tests were added if useful/possible
* [x] Reviewed for breaking changes
* [x] Developer changelog updated if needed
* [x] Documentation added if needed
* [x] Existing documentation updated if needed
