### PR TITLE
allow plugins to customize the system checks page

### DIFF
--- a/plugins/Diagnostics/Diagnostic/DiagnosticResult.php
+++ b/plugins/Diagnostics/Diagnostic/DiagnosticResult.php
@@ -28,6 +28,11 @@ class DiagnosticResult
     /**
      * @var string
      */
+    private $icon;
+
+    /**
+     * @var string
+     */
     private $longErrorMessage = '';
 
     /**
@@ -35,9 +40,10 @@ class DiagnosticResult
      */
     private $items = array();
 
-    public function __construct($label)
+    public function __construct($label, $icon = '')
     {
         $this->label = $label;
+        $this->icon = $icon;
     }
 
     /**
@@ -77,6 +83,14 @@ class DiagnosticResult
     public function getLabel()
     {
         return $this->label;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIcon()
+    {
+        return $this->icon;
     }
 
     /**

--- a/plugins/Installation/templates/_systemCheckSection.twig
+++ b/plugins/Installation/templates/_systemCheckSection.twig
@@ -1,4 +1,5 @@
 {% import _self as local %}
+{{ postEvent('Installation.topSystemCheckPage') }}
 <p>{{ 'Installation_CopyBelowInfoForSupport'|translate }}
     <br/> <br/>
     <a href="javascript:void(0);"
@@ -66,7 +67,7 @@
 
     {% for result in results %}
         <tr>
-            <td>{{ result.label }}</td>
+            <td>{% if result.icon %}<span class="icon-{{ result.icon }}"></span> {% endif %}{{ result.label }}</td>
             <td>
                 {% for item in result.items %}
 


### PR DESCRIPTION
I'm not sure if this is the best solution, but at the moment it isn't possible for a plugin to change how the system checks are displayed. Ideally one could dynamically add groups like "Optional", but that sounds very complex for a minor thing.

So the easiest solution to differentiate checks from different plugins I could think of is adding icons to the label.

In addition, I added an event to the top of the page (e.g. to add a warning, notice, disclaimer, etc.). This slows things down a bit, but this is already the slowest page due to tons of I/O, so it shouldn't matter much in comparison.

If someone has a better way to do this, I'm open to suggestions.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
