### PR TITLE
add a new stale action

### DIFF
--- a/.github/workflows/follow-up-reviews.yml
+++ b/.github/workflows/follow-up-reviews.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          debug-only: true
+          debug-only: false
           start-date: '2021-03-01T00:00:00Z'
           days-before-pr-stale: 7
           days-before-pr-close: -1

--- a/.github/workflows/follow-up-reviews.yml
+++ b/.github/workflows/follow-up-reviews.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          debug-only: false
+          debug-only: true
           start-date: 2021-03-01T00:00:00Z
           days-before-pr-stale: 7
           days-before-pr-close: -1

--- a/.github/workflows/follow-up-reviews.yml
+++ b/.github/workflows/follow-up-reviews.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/stale@v3
         with:
           debug-only: false
-          start-date: '2021-03-01T00:00:00Z'
+          start-date: 2021-03-01T00:00:00Z
           days-before-pr-stale: 7
           days-before-pr-close: -1
-          only-pr-labels: 'Needs Review'
+          only-pr-labels: Needs Review
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          stale-pr-message: 'This issue is in "needs review" but there has been no activity for 7 days. ping @tsteur @sgiehl @diosmosis @flamisz'
-          stale-pr-label: 'Stale'
+          stale-pr-message: This issue is in "needs review" but there has been no activity for 7 days. ping @tsteur @sgiehl @diosmosis @flamisz
+          stale-pr-label: Stale

--- a/.github/workflows/inactive-prs-closing-message.yaml
+++ b/.github/workflows/inactive-prs-closing-message.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          debug-only: false
+          debug-only: true
           start-date: 2021-03-01T00:00:00Z
           days-before-pr-stale: 42
           days-before-pr-close: -1

--- a/.github/workflows/inactive-prs-closing-message.yaml
+++ b/.github/workflows/inactive-prs-closing-message.yaml
@@ -1,4 +1,4 @@
-name: 'Handle inactive PRs'
+name: 'Handle inactive PRs - closing message'
 on:
   schedule:
     - cron: '30 1 * * *'
@@ -11,10 +11,10 @@ jobs:
         with:
           debug-only: false
           start-date: 2021-03-01T00:00:00Z
-          days-before-pr-stale: 14
+          days-before-pr-stale: 42
           days-before-pr-close: -1
           days-before-issue-stale: -1
           days-before-issue-close: -1
           exempt-pr-labels: Do not close
-          stale-pr-message: If you don't want this PR to be closed automatically in 28 days then you need to assign the label 'Do not close'.
-          stale-pr-label: Stale
+          stale-pr-message: This PR was last updated more than one month ago, maybe it's time to close it. Please check if there is anything we still can do or close this PR. ping @tsteur @sgiehl @diosmosis @flamisz
+          stale-pr-label: Stale for long

--- a/.github/workflows/inactive-prs.yaml
+++ b/.github/workflows/inactive-prs.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          debug-only: false
+          debug-only: true
           start-date: 2021-03-01T00:00:00Z
           days-before-pr-stale: 14
           days-before-pr-close: -1

--- a/.github/workflows/inactive-prs.yaml
+++ b/.github/workflows/inactive-prs.yaml
@@ -10,12 +10,12 @@ jobs:
       - uses: actions/stale@v3
         with:
           debug-only: false
-          start-date: '2021-03-01T00:00:00Z'
+          start-date: 2021-03-01T00:00:00Z
           days-before-pr-stale: 14
           days-before-pr-close: 42
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          exempt-pr-labels: 'Do not close'
-          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
-          stale-pr-label: 'Stale'
-          close-pr-message: 'Thank you for this proposed pull request. Because it was last updated more than one month ago, it is our policy to close pull requests opened for a long time without updates. If you would like to continue work on the pull request, please simply ping us to have it re-opened (after you have pushed a new commit). We hope you understand this and we look forward to seeing an update from you on this pull request or another one! Thanks.'
+          exempt-pr-labels: Do not close
+          stale-pr-message: If you don't want this PR to be closed automatically in 28 days then you need to assign the label 'Do not close'.
+          stale-pr-label: Stale
+          close-pr-message: Thank you for this proposed pull request. Because it was last updated more than one month ago, it is our policy to close pull requests opened for a long time without updates. If you would like to continue work on the pull request, please simply ping us to have it re-opened (after you have pushed a new commit). We hope you understand this and we look forward to seeing an update from you on this pull request or another one! Thanks.

--- a/.github/workflows/inactive-prs.yaml
+++ b/.github/workflows/inactive-prs.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          debug-only: true
+          debug-only: false
           start-date: '2021-03-01T00:00:00Z'
           days-before-pr-stale: 14
           days-before-pr-close: 42


### PR DESCRIPTION
### Description:

refs #17318 #17344 

I checked the logs of the dry runs and actually did not find any when actually it would comment on any or. The current setup checks only PRs (not issues) and only PRs were created after 2021-03-01.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
