### PR TITLE
Use exceptions to provide more context to warning logs in Row.php

### DIFF
--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -756,7 +756,7 @@ class Row extends \ArrayObject
                 implode(", ", $this->getColumns()),
                 $this->getIdSubDataTable()
             ));
-            StaticContainer::get(LoggerInterface::class)->warning("{exception}", ['ex' => $ex]);
+            StaticContainer::get(LoggerInterface::class)->warning("{exception}", ['exception' => $ex]);
         }
     }
 
@@ -770,7 +770,7 @@ class Row extends \ArrayObject
                 $columnName,
                 $this->__toString()
             ));
-            Log::warning("{exception}", ['ex' => $ex]);
+            StaticContainer::get(LoggerInterface::class)->warning("{exception}", ['exception' => $ex]);
         }
     }
 }

--- a/core/DataTable/Row.php
+++ b/core/DataTable/Row.php
@@ -9,9 +9,11 @@
 namespace Piwik\DataTable;
 
 use Exception;
+use Piwik\Container\StaticContainer;
 use Piwik\DataTable;
 use Piwik\Log;
 use Piwik\Metrics;
+use Psr\Log\LoggerInterface;
 
 /**
  * This is what a {@link Piwik\DataTable} is composed of.
@@ -748,25 +750,27 @@ class Row extends \ArrayObject
     private function warnIfSubtableAlreadyExists()
     {
         if (!is_null($this->subtableId)) {
-            Log::warning(
+            $ex = new \Exception(sprintf(
                 "Row with label '%s' (columns = %s) has already a subtable id=%s but it was not loaded - overwriting the existing sub-table.",
                 $this->getColumn('label'),
                 implode(", ", $this->getColumns()),
                 $this->getIdSubDataTable()
-            );
+            ));
+            StaticContainer::get(LoggerInterface::class)->warning("{exception}", ['ex' => $ex]);
         }
     }
 
     protected function warnWhenSummingTwoStrings($thisColumnValue, $columnToSumValue, $columnName = null)
     {
         if (is_string($columnToSumValue)) {
-            Log::warning(
+            $ex = new \Exception(sprintf(
                 "Trying to add two strings in DataTable\Row::sumRowArray: %s + %s for column %s in row %s",
                 $thisColumnValue,
                 $columnToSumValue,
                 $columnName,
                 $this->__toString()
-            );
+            ));
+            Log::warning("{exception}", ['ex' => $ex]);
         }
     }
 }


### PR DESCRIPTION
### Description:

The warning logs in Row.php are pretty vague about what is actually going on to cause them, making them hard to reproduce and debug. Using exceptions, however, we can get stack traces in the right context.

Looks a bit odd, but it seems to work.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
