### PR TITLE
better systemcheck error boxes

### DIFF
--- a/plugins/Installation/stylesheets/systemCheckPage.less
+++ b/plugins/Installation/stylesheets/systemCheckPage.less
@@ -2,20 +2,21 @@
     width: 40%;
 }
 
-.error {
-    color: red;
-    font-size: 100%;
-    font-weight: bold;
-    border: 2px solid red;
-    width: 550px;
-    padding: 20px;
-    margin-bottom: 10px;
-}
-
-.error img {
-    border: 0;
-    float: right;
-    margin: 10px;
+.system-check {
+    td.error {
+        color: red;
+        font-size: 100%;
+        font-weight: bold;
+        border: 2px solid red!important;
+        width: 550px;
+        padding: 20px;
+        margin-bottom: 10px;
+        img {
+            border: 0;
+            float: right;
+            margin: 10px;
+        }
+    }
 }
 
 .system-check .icon-ok {


### PR DESCRIPTION
The system check `LongErrorMessage`-boxes were missing the bottom border making them look a bit weird:
![image](https://user-images.githubusercontent.com/6266037/113213859-fccdab00-9278-11eb-9614-98d68f9a775d.png)

There is unfortunately a pretty specific rule from another part of Matomo:
```css
table.entityTable tbody tr td {
     border-bottom: 1px solid #f2f2f2 !important;
}
```
so to make this look correct I also had to make the error rule more specific. 
Hopefully the .error class is used nowhere else in Matomo

But I think it should be fine as it is generally defined here:
https://github.com/matomo-org/matomo/blob/703ed9402e4aada544ec94e789021df86575ad15/plugins/Morpheus/stylesheets/simple_structure.css#L188-L193

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
