### PR TITLE
more markdown friendly system checks

### DIFF
--- a/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
+++ b/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2309d685fd01b038da53083ca4de25ded74d733347074bad3bf417165bddbe7
-size 440958
+oid sha256:f5efb505ffa5d1e68f7bffc50701391c69d3d1d866dc8268ce9ecef939623a06
+size 445467

--- a/plugins/Installation/templates/_systemCheckSection.twig
+++ b/plugins/Installation/templates/_systemCheckSection.twig
@@ -15,11 +15,10 @@
 {% set informational = constant('Piwik\\Plugins\\Diagnostics\\Diagnostic\\DiagnosticResult::STATUS_INFORMATIONAL') %}
 {%- for result in results %}
 
-## {{ result.label -}}:
-{%- for item in result.items -%}
+#### {{ result.label }}:
+{% for item in result.items -%}
 {%- if item.status == error -%} &#9888; Error: {{ item.comment|anonymiseSystemInfo }}{% elseif item.status == warning %} &#9888; Warning: {{ item.comment|anonymiseSystemInfo }}{% elseif item.status == informational %} {{ item.comment|anonymiseSystemInfo }}{% else %} &#10004; {{ item.comment|anonymiseSystemInfo }}{% endif -%}
 {%- endfor %}
-
 
 {% if result.longErrorMessage -%}
 {{ result.longErrorMessage }}
@@ -28,14 +27,18 @@
 {%- endmacro %}
 <textarea style="width:100%;height: 200px;" readonly
           id="matomo_system_check_info">
-# Mandatory checks
+<details>
+<summary>Click to view System Check</summary>
+
+### Mandatory checks
 {{ local.diagnosticInfo(diagnosticReport.getMandatoryDiagnosticResults()) }}
 
-# Optional checks
+### Optional checks
 {{ local.diagnosticInfo(diagnosticReport.getOptionalDiagnosticResults()) }}
 
-# Informational results
+### Informational results
 {{ local.diagnosticInfo(diagnosticReport.getInformationalResults()) }}
+</details>
 </textarea>
 
 <table class="entityTable system-check" id="systemCheckRequired" piwik-content-table>

--- a/plugins/Installation/tests/UI/expected-screenshots/Installation_system_check.png
+++ b/plugins/Installation/tests/UI/expected-screenshots/Installation_system_check.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f20ab8e58403358f7eac9fa3f7e39879a623c9ce376a1af7875ce2d71b37f968
-size 273195
+oid sha256:06e0d2d6da9a0b54d49aae32d0edb42e0110cb8626f8bd56c56a5e719bc8d815
+size 278939


### PR DESCRIPTION
While the new copyable system check output is really nice, it also takes up a lot of space in Github issues (e.g. https://github.com/matomo-org/matomo/issues/17420). (same on the forum)

I try to change three things to make the reports more readable when interpreted as Markdown (as on Github and the forum).

- smaller headings (as otherwise they use a lot of space)
- put output into a separate line (this way it isn't also formatted as the heading)
- wrap everything in a `<details>` (this way one doesn't have to scroll past everything when looking at a Github issue)

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
