### PR TITLE
allow skipping system check entries

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -791,6 +791,9 @@ rearchive_reports_in_past_last_n_months = 6
 ; If set to 1, when rearchiving reports in the past we do not rearchive segment data with those reports. Default is 0.
 rearchive_reports_in_past_exclude_segments = 0
 
+; Add the class of a system check diagnostic here to skip it
+; system_check_ignored_reports[] = "Piwik\Plugins\Diagnostics\Diagnostic\CronArchivingCheck"
+
 [Tracker]
 
 ; When enabled and a userId is set, then the visitorId will be automatically set based on the userId. This allows to

--- a/plugins/Diagnostics/DiagnosticService.php
+++ b/plugins/Diagnostics/DiagnosticService.php
@@ -7,6 +7,7 @@
  */
 namespace Piwik\Plugins\Diagnostics;
 
+use Piwik\Config;
 use Piwik\Plugins\Diagnostics\Diagnostic\Diagnostic;
 use Piwik\Plugins\Diagnostics\Diagnostic\DiagnosticResult;
 
@@ -63,8 +64,12 @@ class DiagnosticService
     private function run(array $diagnostics)
     {
         $results = array();
-
+        $general = Config::getInstance()->General;
+        $ignoredReports = $general['system_check_ignored_reports'];
         foreach ($diagnostics as $diagnostic) {
+            if (in_array(get_class($diagnostic), $ignoredReports)) {
+                continue;
+            }
             $results = array_merge($results, $diagnostic->execute());
         }
 


### PR DESCRIPTION
suggested in https://forum.matomo.org/t/how-to-ignore-system-integrity-warnings/41368

I'm not entirely sure if this is useful to a lot of people and if this is the best way to implement it, but it seemed like a nice thing for people to be able to ignore specific warnings in their setup and not having to ignore them (and potentially miss others).

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
