### PR TITLE
Add new validator class - alpha numeric spaces

### DIFF
--- a/core/Validators/AlphaNumSpaces.php
+++ b/core/Validators/AlphaNumSpaces.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Validators;
+
+use Piwik\Piwik;
+
+class AlphaNumSpaces extends BaseValidator
+{
+    public function validate($value)
+    {
+        if ($this->isValueBare($value)) {
+            return;
+        }
+
+        if (! is_string($value) && ! is_numeric($value)) {
+            throw new Exception(Piwik::translate('General_ValidatorErrorNoValidAlphaNumSpaces', array($value)));
+        }
+
+        if (@preg_match('/^[\pL\pM\pN ]+$/u', $value) === 0) {
+            throw new Exception(Piwik::translate('General_ValidatorErrorNoValidAlphaNumSpaces', array($value)));
+        }
+    }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -482,6 +482,7 @@
         "ValidatorErrorNotUrlLike": "The value \"%s\" does not look like a URL.",
         "ValidatorErrorNotEmailLike": "The value \"%s\" does not look like a valid email.",
         "ValidatorErrorNoValidRegex": "The value \"%s\" is not a valid regular expression.",
+        "ValidatorErrorNoValidAlphaNumSpaces": "The value \"%s\" may only contain letters, numbers and spaces.",
         "ValidatorErrorXNotWhitelisted": "The value \"%1$s\" is not allowed, use one of: %2$s.",
         "ValidatorErrorInvalidDateTimeFormat": "The date \"%1$s\" does not have the correct format, please use %2$s",
         "WarningFileIntegrityNoManifest": "File integrity check could not be performed due to missing manifest.inc.php.",

--- a/tests/PHPUnit/Unit/Validator/AlphaNumSpacesTest.php
+++ b/tests/PHPUnit/Unit/Validator/AlphaNumSpacesTest.php
@@ -18,12 +18,21 @@ use Piwik\Validators\AlphaNumSpaces;
  */
 class AlphaNumSpacesTest extends TestCase
 {
-    public function test_validate_success_strings()
+    public function test_validate_success_english_strings()
     {
         $this->validate('onlyalpha');
         $this->validate(123);
         $this->validate('abc 123');
-        $this->validate('abc 123 and 0');
+        $this->validate('ABC 123 and 0');
+
+        $this->assertTrue(true);
+    }
+
+    public function test_validate_success_special_chars()
+    {
+        $this->validate('Äpfel äpfel und stühle');
+        $this->validate('워드  信件 λέξη từ ngữ');
+        $this->validate('áâäæãåāëíûî');
 
         $this->assertTrue(true);
     }

--- a/tests/PHPUnit/Unit/Validator/AlphaNumSpacesTest.php
+++ b/tests/PHPUnit/Unit/Validator/AlphaNumSpacesTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Translation\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Piwik\Validators\AlphaNumSpaces;
+
+/**
+ * @group Validator
+ * @group AlphaNumSpaces
+ * @group AlphaNumSpacesTest
+ */
+class AlphaNumSpacesTest extends TestCase
+{
+    public function test_validate_success_strings()
+    {
+        $this->validate('onlyalpha');
+        $this->validate(123);
+        $this->validate('abc 123');
+        $this->validate('abc 123 and 0');
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @dataProvider wrongStrings
+     */
+    public function test_validate_fail_with_wrong_strings($string)
+    {
+        $this->expectException(\Piwik\Validators\Exception::class);
+        $this->expectExceptionMessage('General_ValidatorErrorNoValidAlphaNumSpaces');
+
+        $this->validate($string);
+    }
+
+    public function wrongStrings()
+    {
+        return [
+            ['!'],
+            ['abc!'],
+            ['12-12'],
+            ['something / &'],
+            ['not_ok']
+        ];
+    }
+
+    private function validate($value)
+    {
+        $validator = new AlphaNumSpaces();
+        $validator->validate($value);
+    }
+}


### PR DESCRIPTION
### Description:

This new class will check if the validated field only contains alphanumeric characters and spaces. No special characters allowed.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
