### PR TITLE
speed up integration tests by not using DbHelper::getTablesInstalled()

### DIFF
--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -726,9 +726,13 @@ abstract class SystemTestCase extends TestCase
         DbHelper::truncateAllTables();
 
         // insert data
+        $archiveTables = Db::fetchAll("SHOW TABLES LIKE '%archive_%'");
+        if (!empty($archiveTables)) {
+            $archiveTables = array_column($archiveTables, key($archiveTables[0]));
+        }
         foreach ($tables as $table => $rows) {
             // create table if it's an archive table
-            if (strpos($table, 'archive_') !== false && !DbHelper::tableExists($table)) {
+            if (strpos($table, 'archive_') !== false && !in_array($table, $archiveTables)) {
                 $tableType = strpos($table, 'archive_numeric') !== false ? 'archive_numeric' : 'archive_blob';
 
                 $createSql = DbHelper::getTableCreateSql($tableType);

--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -726,10 +726,9 @@ abstract class SystemTestCase extends TestCase
         DbHelper::truncateAllTables();
 
         // insert data
-        $existingTables = DbHelper::getTablesInstalled();
         foreach ($tables as $table => $rows) {
             // create table if it's an archive table
-            if (strpos($table, 'archive_') !== false && !in_array($table, $existingTables)) {
+            if (strpos($table, 'archive_') !== false && !DbHelper::tableExists($table)) {
                 $tableType = strpos($table, 'archive_numeric') !== false ? 'archive_numeric' : 'archive_blob';
 
                 $createSql = DbHelper::getTableCreateSql($tableType);


### PR DESCRIPTION
### Description:

Now in DbHelper::getTablesInstalled() we post an event and force load all activated plugins: https://github.com/matomo-org/matomo/blob/4.x-dev/core/Db/Schema/Mysql.php#L453-L458

This is quite a bit more work, it seems. Locally it slows each individual integration test case by about 14s. Removing it speeds the LoaderTest, for example, from 10mins to finish to 1min.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
