### PR TITLE
Ensure correct no access message is shown

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -745,14 +745,15 @@ class Access
     {
         if (Piwik::isUserIsAnonymous() && !Request::isRootRequestApiRequest()) {
             $message = Piwik::translate('General_YouMustBeLoggedIn');
-        }
-        // Try to detect whether user was previously logged in so that we can display a different message
-        $referrer = Url::getReferrer();
-        $matomoUrl = SettingsPiwik::getPiwikUrl();
-        if ($referrer && $matomoUrl && Url::isValidHost(Url::getHostFromUrl($referrer)) &&
-            strpos($referrer, $matomoUrl) === 0
-        ) {
-            $message = Piwik::translate('General_YourSessionHasExpired');
+
+            // Try to detect whether user was previously logged in so that we can display a different message
+            $referrer = Url::getReferrer();
+            $matomoUrl = SettingsPiwik::getPiwikUrl();
+            if ($referrer && $matomoUrl && Url::isValidHost(Url::getHostFromUrl($referrer)) &&
+                strpos($referrer, $matomoUrl) === 0
+            ) {
+                $message = Piwik::translate('General_YourSessionHasExpired');
+            }
         }
 
         throw new NoAccessException($message);

--- a/plugins/IntranetMeasurable/tests/UI/IntranetMeasurable_spec.js
+++ b/plugins/IntranetMeasurable/tests/UI/IntranetMeasurable_spec.js
@@ -18,6 +18,11 @@ describe("IntranetMeasurable", function () {
         testEnvironment.save();
     });
 
+    after(async function () {
+        // ensure the newly created site is removed afterwards, so other tests reusing the fixture won't change results
+        await testEnvironment.callApi('SitesManager.deleteSite', { idSite: 64 });
+    });
+
     it("should show intranet selection", async function () {
         await page.goto(url);
         await (await page.jQuery('.SitesManager .addSite:first')).click();

--- a/plugins/Login/tests/UI/NoAccess_spec.js
+++ b/plugins/Login/tests/UI/NoAccess_spec.js
@@ -1,0 +1,61 @@
+/*!
+ * Matomo - free/libre analytics platform
+ *
+ * login & password reset screenshot tests.
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+describe("NoAccess", function () {
+    this.timeout(0);
+
+    before(async function () {
+        testEnvironment.testUseMockAuth = 0;
+        testEnvironment.overrideConfig('General', 'login_session_not_remembered_idle_timeout', 1)
+        testEnvironment.save();
+
+        await page.clearCookies();
+    });
+
+    after(async function () {
+        testEnvironment.testUseMockAuth = 1;
+        testEnvironment.save();
+
+        await page.clearCookies();
+    });
+
+    it("should login successfully with user credentials and show error when a site without access is viewed", async function() {
+        await page.clearCookies();
+        await page.goto("?idSite=2");
+        await page.waitForNetworkIdle();
+        await page.type("#login_form_login", "oliverqueen");
+        await page.type("#login_form_password", "smartypants");
+        await page.evaluate(function(){
+            $('#login_form_submit').click();
+        });
+
+        await page.waitForNetworkIdle();
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('login_noaccess');
+    });
+
+    it("should show session timeout error", async function() {
+        await page.clearCookies();
+        await page.goto("");
+        await page.waitForNetworkIdle();
+        await page.type("#login_form_login", "oliverqueen");
+        await page.type("#login_form_password", "smartypants");
+        await page.evaluate(function(){
+            $('#login_form_submit').click();
+        });
+
+        await page.waitFor(60500); // wait for session timeout
+
+        await page.click('#topmenu-corehome');
+        await page.waitForNetworkIdle();
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('login_session_timeout');
+    });
+
+});

--- a/plugins/Login/tests/UI/expected-screenshots/NoAccess_login_noaccess.png
+++ b/plugins/Login/tests/UI/expected-screenshots/NoAccess_login_noaccess.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c2bf876689974ba0e3bbd46b1dd309877f1838809344d37e28633cd4b8c0bc9
+size 31939

--- a/plugins/Login/tests/UI/expected-screenshots/NoAccess_login_session_timeout.png
+++ b/plugins/Login/tests/UI/expected-screenshots/NoAccess_login_session_timeout.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8c62cd426bd1fc44e9456bd1d7b65a424e52bb01cc919ddff6f07442abb50e1
+size 34146


### PR DESCRIPTION
### Description:

While testing I recognized, that when an access exception is thrown Matomo currently always shows a "session expired" error, even though the user might still be logged in, but simply does not have access for the current site.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
