### PR TITLE
fix random failure + update two screenshots

### DIFF
--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -84,7 +84,7 @@ class BlobReportLimitingTest extends SystemTestCase
                     // ranking query doesn't guarantee order if the main metric values are the same so the label/segment can randomly change.
                     // in this test, we only care to check that the result is being limited/aggregated correctly, so we can remove these
                     // when comparing.
-                    'xmlFieldsToRemove' => ['label', 'segment', 'url'],
+                    'xmlFieldsToRemove' => ['label', 'segment', 'url', 'exit_nb_visits', 'exit_rate'],
                 ),
             ),
         );

--- a/tests/PHPUnit/System/BlobReportLimitingTest.php
+++ b/tests/PHPUnit/System/BlobReportLimitingTest.php
@@ -84,7 +84,7 @@ class BlobReportLimitingTest extends SystemTestCase
                     // ranking query doesn't guarantee order if the main metric values are the same so the label/segment can randomly change.
                     // in this test, we only care to check that the result is being limited/aggregated correctly, so we can remove these
                     // when comparing.
-                    'xmlFieldsToRemove' => ['label', 'segment', 'url', 'exit_nb_visits', 'exit_rate'],
+                    'xmlFieldsToRemove' => ['label', 'segment', 'url', 'exit_nb_visits', 'exit_rate', 'bounce_count', 'bounce_rate'],
                 ),
             ),
         );

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d02eea401f098ddce7bdd951df45b4246abb4876c1805f339985b42e7cd1fd12
-size 4924958
+oid sha256:d4ad6725b11dd03b476a8c876f958a4264f315886daedffb54f63932af2c1b5e
+size 4934416

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4ad6725b11dd03b476a8c876f958a4264f315886daedffb54f63932af2c1b5e
-size 4934416
+oid sha256:d02eea401f098ddce7bdd951df45b4246abb4876c1805f339985b42e7cd1fd12
+size 4924958

--- a/tests/UI/expected-screenshots/UIIntegrationTest_visitors_realtime_visits.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_visitors_realtime_visits.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bfbc7d319b46ed96f028f97c494ea3a7d8a031a289258988e79518d009cbc5a9
-size 71702
+oid sha256:d092bda89e42b0279daaf7f8968d67417b51c039fec68c95d4ce8d9b0c6358c6
+size 71651


### PR DESCRIPTION
### Description:

Exclude more columns from failing BlobReportLimitingTest and update two screenshots

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
