### PR TITLE
Add testdox to phpunit.xml

### DIFF
--- a/tests/PHPUnit/phpunit.xml.dist
+++ b/tests/PHPUnit/phpunit.xml.dist
@@ -15,6 +15,7 @@
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
+         testdox="true"
          verbose="true">
 
 <testsuites>


### PR DESCRIPTION
### Description:

I had a failing test in another PR and it was hard to understand why and where it is happening. Modifying the `phpunit.xml` can help investigate failing tests easier. 

Instead of only dots, we have some information about what's going on, and if a build fails, we can see which one was the last test. 

An example:

```
Api Get Report Metadata (Piwik\Tests\System\ApiGetReportMetadata)
 ✔ Api with data set #0 [548.94 ms]
 ✔ Api with data set #1 [26.24 ms]
 ✔ Api with data set #2 [28.44 ms]
 ✔ Api with data set #3 [29.22 ms]
 ✔ Api with data set #4 [7.41 ms]
 ✔ Api with data set #5 [3.97 ms]
```

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
