### PR TITLE
Use full segment data to rearchive segment

### DIFF
--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -280,7 +280,8 @@ class API extends \Piwik\Plugin\API
         $segmentDefinitionChanged = $segment['definition'] !== $definition;
 
         if ($segmentDefinitionChanged && $autoArchive && !Rules::isBrowserTriggerEnabled()) {
-            $this->segmentArchiving->reArchiveSegment($bind);
+            $updatedSegment = $this->getModel()->getSegment($idSegment);
+            $this->segmentArchiving->reArchiveSegment($updatedSegment);
         }
 
         Cache::getEagerCache()->flushAll();
@@ -327,7 +328,8 @@ class API extends \Piwik\Plugin\API
             && !Rules::isBrowserTriggerEnabled()
             && $this->processNewSegmentsFrom != SegmentArchiving::CREATION_TIME
         ) {
-            $this->segmentArchiving->reArchiveSegment($bind);
+            $addedSegment = $this->getModel()->getSegment($id);
+            $this->segmentArchiving->reArchiveSegment($addedSegment);
         }
 
         return $id;

--- a/plugins/SegmentEditor/tests/Integration/SegmentEditorTest.php
+++ b/plugins/SegmentEditor/tests/Integration/SegmentEditorTest.php
@@ -165,7 +165,7 @@ class SegmentEditorTest extends IntegrationTestCase
         );
 
         $this->assertReArchivesQueued([
-            ['idSites' => [1], 'pluginName' => null, 'report' => null, 'segment' => $updatedSegment['definition'], 'startDate' => null],
+            ['idSites' => [1], 'pluginName' => null, 'report' => null, 'segment' => $updatedSegment['definition'], 'startDate' => Date::factory('2013-01-01 00:00:00')->getTimestamp()],
         ]);
 
         $newSegment = API::getInstance()->get($idSegment2);


### PR DESCRIPTION
### Description:

Rearchiving segments expects the full segment dataset. Currently when adding / updating a segment only the changed/added data is given to the rearchiving method. This can result in unexpected behavior.

refs L3-63

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
