### PR TITLE
Do not use DbHelper::getTablesInstalled() in integration test setup …

### DIFF
--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -731,7 +731,11 @@ abstract class SystemTestCase extends TestCase
     protected static function getDbTablesWithData()
     {
         $result = array();
-        foreach (DbHelper::getTablesInstalled() as $tableName) {
+        $tables = Db::fetchAll('SHOW TABLES'); // tests should be in a clean database, so we can just get all tables
+        if (!empty($tables)) {
+            $tables = array_column($tables, key($tables[0]));
+        }
+        foreach ($tables as $tableName) {
             $result[$tableName] = Db::fetchAll("SELECT * FROM `$tableName`");
         }
         return $result;


### PR DESCRIPTION
### Description:

… since it posts event that loads all activated plugins. Locally this speeds tests up by ~12s (all in the test startup phase).

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
