### PR TITLE
Do not parse plugin details with angular in marketplace overlay

### DIFF
--- a/plugins/Marketplace/templates/plugin-details.twig
+++ b/plugins/Marketplace/templates/plugin-details.twig
@@ -65,17 +65,17 @@
                                     <div class="alert alert-warning">{{ 'Marketplace_PluginLicenseExceededDescription'|translate }}</div>
                                 {% endif %}
 
-                                {{ latestVersion.readmeHtml.description|raw }}
+                                <div ng-non-bindable>{{ latestVersion.readmeHtml.description|raw }}</div>
                             </div>
 
                             {% if latestVersion.readmeHtml.faq %}
-                                <div id="tabs-faq" class="tab-content col s12">
+                                <div id="tabs-faq" class="tab-content col s12" ng-non-bindable>
                                     {{ latestVersion.readmeHtml.faq|raw }}
                                 </div>
                             {% endif %}
 
                             {% if latestVersion.readmeHtml.documentation %}
-                                <div id="tabs-documentation" class="tab-content col s12">
+                                <div id="tabs-documentation" class="tab-content col s12" ng-non-bindable>
                                     {{ latestVersion.readmeHtml.documentation|raw }}
                                 </div>
                             {% endif %}


### PR DESCRIPTION
### Description:

As the content should not contain any angular related stuff, we can simply disable parsing for those elements, which should also save some time.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
