### PR TITLE
Use empty nonce if not md5

### DIFF
--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -99,22 +99,6 @@ class Nonce
         return true;
     }
 
-
-    /**
-     * Returns if a nonce is valid md5.
-     *
-     * @param string $md5
-     * @return bool
-     */
-    public static function isValidMd5($md5)
-    {
-        if (preg_match('/^[a-f0-9]{32}$/', $md5)) {
-            return true;
-        }
-
-        return false;
-    }
-
     // public for tests
     public static function isReferrerHostValid($referrer, $expectedReferrerHost)
     {

--- a/core/Nonce.php
+++ b/core/Nonce.php
@@ -99,6 +99,22 @@ class Nonce
         return true;
     }
 
+
+    /**
+     * Returns if a nonce is valid md5.
+     *
+     * @param string $md5
+     * @return bool
+     */
+    public static function isValidMd5($md5)
+    {
+        if (preg_match('/^[a-f0-9]{32}$/', $md5)) {
+            return true;
+        }
+
+        return false;
+    }
+
     // public for tests
     public static function isReferrerHostValid($referrer, $expectedReferrerHost)
     {

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -172,10 +172,13 @@ class OptOutManager
 
         $setCookieInNewWindow = Common::getRequestVar('setCookieInNewWindow', false, 'int');
         if ($setCookieInNewWindow) {
+            $requestNonce = Common::getRequestVar('nonce', false);
+            $nonce = Nonce::isValidMd5($requestNonce) ? $requestNonce : '';
+
             $reloadUrl = Url::getCurrentQueryStringWithParametersModified(array(
                 'showConfirmOnly' => 1,
                 'setCookieInNewWindow' => 0,
-                'nonce' => Common::getRequestVar('nonce')
+                'nonce' => $nonce
             ));
         } else {
             $reloadUrl = false;
@@ -232,7 +235,7 @@ class OptOutManager
         $cssbody = 'body { ';
 
         $hexstrings = array(
-            'fontColor' => $cssfontcolour, 
+            'fontColor' => $cssfontcolour,
             'backgroundColor' => $cssbackgroundcolor
         );
         foreach ($hexstrings as $key => $testcase) {
@@ -242,7 +245,7 @@ class OptOutManager
         }
 
         if ($cssfontsize && (preg_match("/^[0-9]+[\.]?[0-9]*(px|pt|em|rem|%)$/", $cssfontsize))) {
-            $cssbody .= 'font-size: ' . $cssfontsize . '; '; 
+            $cssbody .= 'font-size: ' . $cssfontsize . '; ';
         } else if ($cssfontsize) {
             throw new \Exception("The URL parameter fontSize value of '$cssfontsize' is not valid. Expected value is for example '15pt', '1.2em' or '13px'.\n");
         }

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -172,10 +172,9 @@ class OptOutManager
 
         $setCookieInNewWindow = Common::getRequestVar('setCookieInNewWindow', false, 'int');
         if ($setCookieInNewWindow) {
-            $requestNonce = Common::getRequestVar('nonce', false);
-            $nonce = $requestNonce !== false ? $requestNonce : '';
+            $nonce = Common::getRequestVar('nonce', false);
 
-            if ($requestNonce !== false && !Nonce::verifyNonce('Piwik_OptOut', $requestNonce)) {
+            if ($nonce !== false && !Nonce::verifyNonce('Piwik_OptOut', $nonce)) {
                 Nonce::discardNonce('Piwik_OptOut');
                 $nonce = '';
             }
@@ -183,7 +182,7 @@ class OptOutManager
             $reloadUrl = Url::getCurrentQueryStringWithParametersModified(array(
                 'showConfirmOnly' => 1,
                 'setCookieInNewWindow' => 0,
-                'nonce' => $nonce
+                'nonce' => $nonce ? $nonce : ''
             ));
         } else {
             $reloadUrl = false;

--- a/plugins/CoreAdminHome/OptOutManager.php
+++ b/plugins/CoreAdminHome/OptOutManager.php
@@ -173,7 +173,12 @@ class OptOutManager
         $setCookieInNewWindow = Common::getRequestVar('setCookieInNewWindow', false, 'int');
         if ($setCookieInNewWindow) {
             $requestNonce = Common::getRequestVar('nonce', false);
-            $nonce = Nonce::isValidMd5($requestNonce) ? $requestNonce : '';
+            $nonce = $requestNonce !== false ? $requestNonce : '';
+
+            if ($requestNonce !== false && !Nonce::verifyNonce('Piwik_OptOut', $requestNonce)) {
+                Nonce::discardNonce('Piwik_OptOut');
+                $nonce = '';
+            }
 
             $reloadUrl = Url::getCurrentQueryStringWithParametersModified(array(
                 'showConfirmOnly' => 1,


### PR DESCRIPTION
### Description:

If the nonce parameter is valid, ignore it.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
