### PR TITLE
Add diagnostic that checks if server directories that should be private are accessible

### DIFF
--- a/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
+++ b/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Diagnostics\Diagnostic;
+
+use Piwik\Common;
+use Piwik\Filesystem;
+use Piwik\Http;
+use Piwik\Piwik;
+use Piwik\Plugins\HeatmapSessionRecording\HeatmapSessionRecording;
+use Piwik\SettingsPiwik;
+use Piwik\Translation\Translator;
+
+/**
+ * TODO: describe
+ */
+class RequiredPrivateDirectories implements Diagnostic
+{
+    /**
+     * @var Translator
+     */
+    private $translator;
+
+    public function __construct(Translator $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function execute()
+    {
+        // TODO: translations
+        $label = $this->translator->translate('Diagnostics_RequiredPrivateDirectories');
+
+        // TODO: test manually for configurations that allow these w/ nginx. post nginx config used to reproduce.
+        $privatePaths = [
+            'tmp/',
+            'tmp/empty', // created by this diagnostic
+            '.git/',
+            '.git/config',
+        ];
+
+        // create test file to check if tmp/empty exists
+        Filesystem::mkdir(PIWIK_INCLUDE_PATH . '/tmp');
+        file_put_contents(PIWIK_INCLUDE_PATH . '/tmp/', 'test');
+
+        $baseUrl = SettingsPiwik::getPiwikUrl();
+        if (!Common::stringEndsWith($baseUrl, '/')) {
+            $baseUrl .= '/';
+        }
+
+        $errorResult = $this->translator->translate('Diagnostics_ConfigsPhpErrorResult');
+        $manualCheck = $this->translator->translate('Diagnostics_ConfigsPhpManualCheck');
+
+        $isInternetEnabled = SettingsPiwik::isInternetEnabled();
+        foreach ($privatePaths as $path) {
+            if (!file_exists($path)) {
+                continue;
+            }
+
+            $testUrl = $baseUrl . $path;
+
+            if (!$isInternetEnabled) {
+                $unknown = $this->translator->translate('Diagnostics_ConfigsInternetDisabled', $testUrl) . ' ' . $manualCheck;
+                return array(DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_WARNING, $unknown));
+            }
+
+            try {
+                $response = Http::sendHttpRequest($testUrl, $timeout = 2, null, null, 0, false, false, true);
+
+                // TODO: check response
+            } catch (\Exception $e) {
+                $error = $e->getMessage();
+            }
+        }
+        // TODO: Implement execute() method.
+    }
+}

--- a/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
+++ b/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
@@ -31,6 +31,10 @@ class RequiredPrivateDirectories implements Diagnostic
 
     public function execute()
     {
+        if (!SettingsPiwik::isMatomoInstalled()) {
+            return [];
+        }
+
         $label = $this->translator->translate('Diagnostics_RequiredPrivateDirectories');
 
         $privatePaths = [

--- a/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
+++ b/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
@@ -71,6 +71,10 @@ class RequiredPrivateDirectories implements Diagnostic
 
             try {
                 $response = Http::sendHttpRequest($testUrl, $timeout = 2, null, null, 0, false, false, true);
+                $status = $response['status'];
+                if ($status >= 400 && $status < 500) {
+                    // TODO
+                }
 
                 // TODO: check response
             } catch (\Exception $e) {

--- a/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
+++ b/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
@@ -40,7 +40,7 @@ class RequiredPrivateDirectories implements Diagnostic
 
         // create test file to check if tmp/empty exists
         Filesystem::mkdir(PIWIK_INCLUDE_PATH . '/tmp');
-        file_put_contents(PIWIK_INCLUDE_PATH . '/tmp/', 'test');
+        file_put_contents(PIWIK_INCLUDE_PATH . '/tmp/empty', 'test');
 
         $baseUrl = SettingsPiwik::getPiwikUrl();
         if (!Common::stringEndsWith($baseUrl, '/')) {

--- a/plugins/Diagnostics/config/config.php
+++ b/plugins/Diagnostics/config/config.php
@@ -1,6 +1,7 @@
 <?php
 
 use Piwik\Plugins\Diagnostics\Diagnostic\CronArchivingLastRunCheck;
+use Piwik\Plugins\Diagnostics\Diagnostic\RequiredPrivateDirectories;
 
 return array(
     // Diagnostics for everything that is required for Piwik to run
@@ -15,6 +16,7 @@ return array(
     ),
     // Diagnostics for recommended features
     'diagnostics.optional' => array(
+        DI\get(RequiredPrivateDirectories::class),
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\FileIntegrityCheck'),
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\TrackerCheck'),
         DI\get('Piwik\Plugins\Diagnostics\Diagnostic\MemoryLimitCheck'),

--- a/plugins/Diagnostics/lang/en.json
+++ b/plugins/Diagnostics/lang/en.json
@@ -20,6 +20,10 @@
         "CronArchivingRunDetails": "Please check that you have setup a crontab calling the %1$s console command, and that you have configured a %2$s to receive errors by email if archiving fails. You can also try to run the console command to archive your reports manually: %3$s. %4$sLearn more.%5$s",
         "CronArchivingRanSuccessfullyXAgo": "The archiving process completed successfully %1$s ago.",
         "BrowserTriggeredArchivingEnabled": "For optimal performance and a speedy Matomo, it is highly recommended to set up a crontab to automatically archive your reports, and to disable browser triggering in the Matomo settings. %1$sLearn more.%2$s",
-        "NoDataForReportArchivingNotRun": "The archiving of your reports hasn't been executed recently, %1$slearn more about how to generate your reports.%2$s"
+        "NoDataForReportArchivingNotRun": "The archiving of your reports hasn't been executed recently, %1$slearn more about how to generate your reports.%2$s",
+        "RequiredPrivateDirectories": "Required Private Directories",
+        "PrivateDirectoryManualCheck": "Please open the URL manually in a browser to see if you can access it. If you can, you might need to modify your server configuration as this file/directory should not be accessible via a browser from the Internet or Intranet.",
+        "PrivateDirectoryInternetDisabled": "We couldn't check if '%s' is accessible because the internet connection is disabled on this Matomo.",
+        "PrivateDirectoryIsAccessible": "We found the URL '%s' is accessible via the browser, but it should NOT be. Allowing it to be accessed can pose a potential security risk since the contents can provide information about your server and potentially users. Please restrict access to it."
     }
 }

--- a/plugins/Diagnostics/lang/en.json
+++ b/plugins/Diagnostics/lang/en.json
@@ -22,8 +22,10 @@
         "BrowserTriggeredArchivingEnabled": "For optimal performance and a speedy Matomo, it is highly recommended to set up a crontab to automatically archive your reports, and to disable browser triggering in the Matomo settings. %1$sLearn more.%2$s",
         "NoDataForReportArchivingNotRun": "The archiving of your reports hasn't been executed recently, %1$slearn more about how to generate your reports.%2$s",
         "RequiredPrivateDirectories": "Required Private Directories",
-        "PrivateDirectoryManualCheck": "Please open the URL manually in a browser to see if you can access it. If you can, you might need to modify your server configuration as this file/directory should not be accessible via a browser from the Internet or Intranet.",
-        "PrivateDirectoryInternetDisabled": "We couldn't check if '%s' is accessible because the internet connection is disabled on this Matomo.",
-        "PrivateDirectoryIsAccessible": "We found the URL '%s' is accessible via the browser, but it should NOT be. Allowing it to be accessed can pose a potential security risk since the contents can provide information about your server and potentially users. Please restrict access to it."
+        "PrivateDirectoryManualCheck": "Please open the URLs manually in a browser to see if you can access it. If you can, you might need to modify your server configuration as these files/directories should not be accessible via a browser from the Internet or Intranet.",
+        "PrivateDirectoryInternetDisabled": "We couldn't check if the following URLs are accessible because internet features are disabled on this Matomo.",
+        "PrivateDirectoryIsAccessible": "We found that the above URLs are accessible via the browser, but they should NOT be. Allowing them to be accessed can pose a potential security risk since the contents can provide information about your server and potentially your users. Please restrict access to them.",
+        "ConfigIniAccessible": "We also found that Matomo's config directory is publicly accessible. While attackers can't read the config now, if your webserver stops executing PHP files for some reason, your MySQL credentials and other information will be available to anyone. Please check your webserver config and deny access to this directory.",
+        "AllPrivateDirectoriesAreInaccessible": "All private directories are inaccessible from the internet."
     }
 }

--- a/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
+++ b/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c586102da6a34417c4868ca3d4762f813962dcd2001c6ce283ae373972510aa6
-size 444934
+oid sha256:8809c4c3142064eb43329a7c9dddaeaaf8edf97c78c8e55b4615a0324562be29
+size 452174

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_home.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_home.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dfb254b3c24287222662cb325e68224dfef0244b078c04ae39a045cad1c32ee2
-size 159023
+oid sha256:c1fb912bbfe145347437b99234c7e88d9a5315d82dab61208e0e1bccb325ee53
+size 161482

--- a/tests/UI/expected-screenshots/UIIntegrationTest_api_error.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_api_error.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dfb254b3c24287222662cb325e68224dfef0244b078c04ae39a045cad1c32ee2
-size 159023
+oid sha256:c1fb912bbfe145347437b99234c7e88d9a5315d82dab61208e0e1bccb325ee53
+size 161482


### PR DESCRIPTION
_###_ Description:

Adds a new diagnostic that checks that the tmp/ directory is not accessible, and checks that, if present, the .git/ directory is not accessible.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
