### PR TITLE
no links in copy-paste system check

### DIFF
--- a/plugins/Installation/templates/_systemCheckSection.twig
+++ b/plugins/Installation/templates/_systemCheckSection.twig
@@ -17,11 +17,11 @@
 
 #### {{ result.label }}:
 {% for item in result.items -%}
-{%- if item.status == error -%} &#9888; Error: {{ item.comment|anonymiseSystemInfo|striptags }}{% elseif item.status == warning %} &#9888; Warning: {{ item.comment|anonymiseSystemInfo|striptags }}{% elseif item.status == informational %} {{ item.comment|anonymiseSystemInfo|striptags }}{% else %} &#10004; {{ item.comment|anonymiseSystemInfo|striptags }}{% endif -%}
+{%- if item.status == error -%} &#9888; Error: {{ item.comment|anonymiseSystemInfo|striptags('<br><p><strong><code>') }}{% elseif item.status == warning %} &#9888; Warning: {{ item.comment|anonymiseSystemInfo|striptags('<br><p><strong><code>') }}{% elseif item.status == informational %} {{ item.comment|anonymiseSystemInfo|striptags('<br><p><strong><code>') }}{% else %} &#10004; {{ item.comment|anonymiseSystemInfo|striptags('<br><p><strong><code>') }}{% endif -%}
 {%- endfor %}
 
 {% if result.longErrorMessage -%}
-{{ result.longErrorMessage|striptags }}
+{{ result.longErrorMessage|striptags('<br><p><strong><code>') }}
 {%- endif -%}
     {%- endfor -%}
 {%- endmacro %}

--- a/plugins/Installation/templates/_systemCheckSection.twig
+++ b/plugins/Installation/templates/_systemCheckSection.twig
@@ -17,11 +17,11 @@
 
 #### {{ result.label }}:
 {% for item in result.items -%}
-{%- if item.status == error -%} &#9888; Error: {{ item.comment|anonymiseSystemInfo }}{% elseif item.status == warning %} &#9888; Warning: {{ item.comment|anonymiseSystemInfo }}{% elseif item.status == informational %} {{ item.comment|anonymiseSystemInfo }}{% else %} &#10004; {{ item.comment|anonymiseSystemInfo }}{% endif -%}
+{%- if item.status == error -%} &#9888; Error: {{ item.comment|anonymiseSystemInfo|striptags }}{% elseif item.status == warning %} &#9888; Warning: {{ item.comment|anonymiseSystemInfo|striptags }}{% elseif item.status == informational %} {{ item.comment|anonymiseSystemInfo|striptags }}{% else %} &#10004; {{ item.comment|anonymiseSystemInfo|striptags }}{% endif -%}
 {%- endfor %}
 
 {% if result.longErrorMessage -%}
-{{ result.longErrorMessage }}
+{{ result.longErrorMessage|striptags }}
 {%- endif -%}
     {%- endfor -%}
 {%- endmacro %}


### PR DESCRIPTION
related to #17421
inspired by https://forum.matomo.org/t/no-website-was-found-in-this-matomo-installation/41659/9?u=lukas

Some error messages in the system check contain `<a href="">`. In the plaintext/markdown version those are mostly useless and also trigger the forum limit of max two links per new user. 

Unless I am missing something, this should easily fix this.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
