### PR TITLE
Allow invalidating empty site

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -272,12 +272,6 @@ class ArchiveInvalidator
             list($plugin) = explode('.', $name);
         }
 
-        // remove sites w/ no visits
-        $trackerModel = new TrackerModel();
-        $idSites = array_filter($idSites, function ($idSite) use ($trackerModel) {
-            return !$trackerModel->isSiteEmpty($idSite);
-        });
-
         if ($plugin
             && !Manager::getInstance()->isPluginActivated($plugin)
         ) {

--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -142,7 +142,11 @@ class Loader
         // we don't create an archive in this case, because the archive may be in progress in some way, so a 0
         // visits archive can be inaccurate in the long run.
         if ($this->canSkipThisArchive()) {
-            return [false, 0];
+            if (!empty($idArchives)) {
+                return [$idArchives, $visits];
+            } else {
+                return [false, 0];
+            }
         }
 
         if (SettingsServer::isArchivePhpTriggered()) {

--- a/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
@@ -33,6 +33,14 @@ use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
+class MockCronArchive extends CronArchive
+{
+    public function invalidateArchivedReportsForSitesThatNeedToBeArchivedAgain($idSiteToInvalidate)
+    {
+        // empty (skip in these tests so we don't invalidate today)
+    }
+}
+
 class QueueConsumerTest extends IntegrationTestCase
 {
     public function test_invalidateConsumeOrder()
@@ -54,7 +62,7 @@ class QueueConsumerTest extends IntegrationTestCase
             $idSites[] = 2;
         });
 
-        $cronArchive = new CronArchive();
+        $cronArchive = new MockCronArchive();
         $cronArchive->init();
 
         $archiveFilter = $this->makeTestArchiveFilter();
@@ -385,7 +393,7 @@ class QueueConsumerTest extends IntegrationTestCase
             $idSites[] = 1;
         });
 
-        $cronArchive = new CronArchive();
+        $cronArchive = new MockCronArchive();
         $cronArchive->init();
 
         $archiveFilter = $this->makeTestArchiveFilter(null, null, null, false, true);


### PR DESCRIPTION
### Description:

Some sites can legitimately have 0 visits, like sites imported from google. While debugging the GoogleAnalyticsImporter test failures I noticed nothing was being invalidated because of this check. Removing it in this PR.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
