### PR TITLE
Ensure redirects in HTTP class are only done to allowed protocols (for cURL)

### DIFF
--- a/core/Http.php
+++ b/core/Http.php
@@ -646,10 +646,19 @@ class Http
              * in safe_mode or open_basedir is set
              */
             if ((string)ini_get('safe_mode') == '' && ini_get('open_basedir') == '') {
+                $protocols = 0;
+
+                foreach (explode(',', $allowedProtocols) as $protocol) {
+                    if (defined('CURLPROTO_' . strtoupper(trim($protocol)))) {
+                        $protocols |= constant('CURLPROTO_' . strtoupper(trim($protocol)));
+                    }
+                }
+
                 $curl_options = array(
                     // curl options (sorted oldest to newest)
-                    CURLOPT_FOLLOWLOCATION => true,
-                    CURLOPT_MAXREDIRS      => 5,
+                    CURLOPT_FOLLOWLOCATION  => true,
+                    CURLOPT_REDIR_PROTOCOLS => $protocols,
+                    CURLOPT_MAXREDIRS       => 5,
                 );
                 if ($forcePost) {
                     $curl_options[CURLOPT_POSTREDIR] = CURL_REDIR_POST_ALL;

--- a/tests/resources/redirector.php
+++ b/tests/resources/redirector.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Script used to test redirects. If no redirect is left, the script will simply output the current url
+ */
+
+$redirect = $_GET['redirects'] ?? 0;
+$target = $_GET['target'] ?? '';
+
+$url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ?
+        "https" : "http") . "://" . $_SERVER['HTTP_HOST'] .
+    $_SERVER['REQUEST_URI'];
+
+if ($target) {
+    header('HTTP/1.1 302 Found');
+    header('Location: ' . $target);
+    exit;
+}
+
+if ($redirect > 0) {
+    header('HTTP/1.1 302 Found');
+    header('Location: ' . preg_replace('/(redirects=[0-9]+)/', 'redirects=' . ($redirect-1), $url));
+    exit;
+}
+
+echo $url;


### PR DESCRIPTION
### Description:



### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
