### PR TITLE
Check if config loaded in getHostname()

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -225,8 +225,17 @@ class Config
      */
     public static function getHostname()
     {
+        $checkIfTrusted = true;
+        
+        try {
+            // this fails before the config was initialized
+            Config::getInstance()->existsLocalConfig();
+        } catch (\Exception $e) {
+            $checkIfTrusted = false;
+        }
+        
         // Check trusted requires config file which is not ready yet
-        $host = Url::getHost($checkIfTrusted = false);
+        $host = Url::getHost($checkIfTrusted);
 
         // Remove any port number to get actual hostname
         $host = Url::getHostSanitized($host);

--- a/core/Config.php
+++ b/core/Config.php
@@ -220,21 +220,13 @@ class Config
 
     /**
      * Returns the hostname of the current request (without port number)
+     * @param bool $checkIfTrusted Check trusted requires config which is maybe not ready yet,
+     *                             make sure the config is ready when you call with true
      *
      * @return string
      */
-    public static function getHostname()
+    public static function getHostname($checkIfTrusted = false)
     {
-        $checkIfTrusted = true;
-
-        try {
-            // this fails before the config was initialized
-            Config::getInstance();
-        } catch (\Exception $e) {
-            $checkIfTrusted = false;
-        }
-
-        // Check trusted requires config file which is not ready yet
         $host = Url::getHost($checkIfTrusted);
 
         // Remove any port number to get actual hostname

--- a/core/Config.php
+++ b/core/Config.php
@@ -139,7 +139,7 @@ class Config
         if (!empty($GLOBALS['CONFIG_INI_PATH_RESOLVER']) && is_callable($GLOBALS['CONFIG_INI_PATH_RESOLVER'])) {
             return call_user_func($GLOBALS['CONFIG_INI_PATH_RESOLVER']);
         }
-        
+
         $path = self::getByDomainConfigPath();
         if ($path) {
             return $path;
@@ -226,14 +226,14 @@ class Config
     public static function getHostname()
     {
         $checkIfTrusted = true;
-        
+
         try {
             // this fails before the config was initialized
-            Config::getInstance()->existsLocalConfig();
+            Config::getInstance();
         } catch (\Exception $e) {
             $checkIfTrusted = false;
         }
-        
+
         // Check trusted requires config file which is not ready yet
         $host = Url::getHost($checkIfTrusted);
 
@@ -318,7 +318,7 @@ class Config
     public function deleteLocalConfig()
     {
         $configLocal = $this->getLocalPath();
-        
+
         if(file_exists($configLocal)){
             @unlink($configLocal);
         }
@@ -354,7 +354,7 @@ class Config
     {
         return $this->settings->getIniFileChain()->getFrom($this->getCommonPath(), $name);
     }
-    
+
     /**
      * @api
      */

--- a/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
+++ b/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
@@ -17,6 +17,7 @@ use Piwik\Option;
 use Piwik\Plugins\Intl\DateTimeFormatProvider;
 use Piwik\SettingsPiwik;
 use Piwik\Translation\Translator;
+use Piwik\Url;
 
 /**
  * Check if cron archiving has run in the last 24-48 hrs.
@@ -90,8 +91,13 @@ class CronArchivingLastRunCheck implements Diagnostic
 
     private function getArchivingCommand()
     {
-        $domain = Config::getHostname($checkIfTrusted = true);
-        return PIWIK_INCLUDE_PATH . '/console --matomo-domain=' . $domain . ' core:archive';
+        if (Url::isValidHost()) {
+            $domain = Config::getHostname($checkIfTrusted = true);
+
+            return PIWIK_INCLUDE_PATH . '/console --matomo-domain=' . $domain . ' core:archive';
+        }
+
+        return PIWIK_INCLUDE_PATH . '/console core:archive';
     }
 
     public static function getTimeSinceLastSuccessfulRun($lastRunTime = null)

--- a/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
+++ b/plugins/Diagnostics/Diagnostic/CronArchivingLastRunCheck.php
@@ -90,7 +90,7 @@ class CronArchivingLastRunCheck implements Diagnostic
 
     private function getArchivingCommand()
     {
-        $domain = Config::getHostname();
+        $domain = Config::getHostname($checkIfTrusted = true);
         return PIWIK_INCLUDE_PATH . '/console --matomo-domain=' . $domain . ' core:archive';
     }
 


### PR DESCRIPTION
### Description:

If the config already loaded when we use the `getHostname()` method, we can use the `$checkIfTrusted` as true when getting the host.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
