### PR TITLE
Add link to new FAQ how to make the diagnostic “Managing processes via CLI” show Ok

### DIFF
--- a/plugins/Diagnostics/Diagnostic/CronArchivingCheck.php
+++ b/plugins/Diagnostics/Diagnostic/CronArchivingCheck.php
@@ -78,7 +78,7 @@ class CronArchivingCheck implements Diagnostic
             $comment .= $this->translator->translate('Installation_NotSupported')
                 . ' ' . $this->translator->translate('Goals_Optional')
                 . ' (' . $this->translator->translate('General_Reasons') . ': ' . $reasonText . ')'
-                . $this->translator->translate('General_LearnMore', [' <a target="_blank" href="https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/">', '</a>'])
+                . $this->translator->translate('General_LearnMore', [' <a target="_blank" href="https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/">', '</a>']);
             $status = DiagnosticResult::STATUS_INFORMATIONAL;
         }
 

--- a/plugins/Diagnostics/Diagnostic/CronArchivingCheck.php
+++ b/plugins/Diagnostics/Diagnostic/CronArchivingCheck.php
@@ -77,7 +77,8 @@ class CronArchivingCheck implements Diagnostic
             }
             $comment .= $this->translator->translate('Installation_NotSupported')
                 . ' ' . $this->translator->translate('Goals_Optional')
-                . ' (' . $this->translator->translate('General_Reasons') . ': ' . $reasonText . ')';
+                . ' (' . $this->translator->translate('General_Reasons') . ': ' . $reasonText . ')'
+                . $this->translator->translate('General_LearnMore', [' <a target="_blank" href="https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/">', '</a>'])
             $status = DiagnosticResult::STATUS_INFORMATIONAL;
         }
 

--- a/plugins/Diagnostics/Diagnostic/DiagnosticResult.php
+++ b/plugins/Diagnostics/Diagnostic/DiagnosticResult.php
@@ -8,6 +8,8 @@
 
 namespace Piwik\Plugins\Diagnostics\Diagnostic;
 
+use Piwik\Common;
+
 /**
  * The result of a diagnostic.
  *
@@ -55,20 +57,23 @@ class DiagnosticResult
 
     /**
      * @param string $label
-     * @param string $status
      * @param string $comment
+     * @param bool $escapeComment
      * @return DiagnosticResult
      */
-    public static function informationalResult($label, $comment = '')
+    public static function informationalResult($label, $comment = '', $escapeComment = true)
     {
         if ($comment === true) {
             $comment = '1';
         } elseif ($comment === false) {
             $comment = '0';
         }
-        $result = new self($label);
-        $result->addItem(new DiagnosticResultItem(self::STATUS_INFORMATIONAL, $comment));
-        return $result;
+
+        if ($escapeComment) {
+            $comment = Common::sanitizeInputValue($comment);
+        }
+
+        return self::singleResult($label, self::STATUS_INFORMATIONAL, $comment);
     }
 
     /**

--- a/plugins/Installation/templates/_systemCheckSection.twig
+++ b/plugins/Installation/templates/_systemCheckSection.twig
@@ -79,7 +79,7 @@
                     {% elseif item.status == warning %}
                         {{ warningIcon }} {{ item.comment|raw }}
                     {% elseif item.status == informational %}
-                        {{ infoIcon }} {{ item.comment }}
+                        {{ infoIcon }} {{ item.comment|raw }}
                     {% else %}
                         {{ okIcon }} {{ item.comment|raw }}
                     {% endif %}


### PR DESCRIPTION
NOTE: Had to add the risky `|raw` to the item.comment, which may have security risks if some of the "Informational" diagnostics will contain random content that may be injectable by someone or the system. Maybe we should audit all informational diagnostics?

The new FAQ is: https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/

Here is what it looks like:
![Screenshot from 2021-05-06 17-01-20](https://user-images.githubusercontent.com/466765/117244808-d7dae200-ae8d-11eb-927b-b7d3dd4ba326.png)


### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
