### PR TITLE
Clear all cache directly after an update instead of in oneClickResults().

### DIFF
--- a/plugins/CoreUpdater/Controller.php
+++ b/plugins/CoreUpdater/Controller.php
@@ -182,7 +182,11 @@ class Controller extends \Piwik\Plugin\Controller
 
         $view->feedbackMessages = $messages;
         $this->addCustomLogoInfo($view);
-        return $view->render();
+        $result = $view->render();
+
+        Filesystem::deleteAllCacheOnUpdate();
+
+        return $result;
     }
 
     public function oneClickUpdatePartTwo()
@@ -229,8 +233,6 @@ class Controller extends \Piwik\Plugin\Controller
         if (!SettingsPiwik::isAutoUpdateEnabled()) {
             throw new Exception('Auto updater is disabled');
         }
-
-        Filesystem::deleteAllCacheOnUpdate();
 
         $httpsFail = (bool) Common::getRequestVar('httpsFail', 0, 'int', $_POST);
         $error = Common::getRequestVar('error', '', 'string', $_POST);


### PR DESCRIPTION
### Description:

Minor tweak

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
