### PR TITLE
Allow invalidating non-day periods even if the period is for a date that had logs purged

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -701,14 +701,17 @@ class ArchiveInvalidator
      */
     private function removeDatesThatHaveBeenPurged($dates, $period, InvalidationResult $invalidationInfo)
     {
+        $period = $period ?: 'day';
+
         $this->findOlderDateWithLogs($invalidationInfo);
 
         $result = array();
         foreach ($dates as $date) {
-            $periodObj = $this->makePeriod($date, $period ?: 'day');
+            $periodObj = $this->makePeriod($date, $period);
 
             // we should only delete reports for dates that are more recent than N days
-            if ($invalidationInfo->minimumDateWithLogs
+            if ($period == 'day'
+                && $invalidationInfo->minimumDateWithLogs
                 && ($periodObj->getDateEnd()->isEarlier($invalidationInfo->minimumDateWithLogs)
                     || $periodObj->getDateStart()->isEarlier($invalidationInfo->minimumDateWithLogs))
             ) {


### PR DESCRIPTION
### Description:

When invalidating data, we check for dates that are before the configured log data deletion month count, and ignore them. This is a safety mechanism to make sure we do not invalidate day periods that have archive data, but for whom log data was deleted. This safety mechanism, however, breaks the GoogleAnalyticsImporter, when importing data that is before log data deletion threshold.

The importer imports day periods, then invalidates week periods and above to calculate the rest. If the data is before the log deletion threshold, the higher periods are never recomputed.

Fixed in this PR by only applying the check for day periods. If a week period is invalidated and there is no log data, the day periods should used.

TODO: check if week periods will trigger rearchiving of the day if the day is for some reason invalidated.

FYI @tsteur

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
