### PR TITLE
Fix segment update scripts

### DIFF
--- a/core/Updates/4.3.0-b3.php
+++ b/core/Updates/4.3.0-b3.php
@@ -36,13 +36,6 @@ class Updates_4_3_0_b3 extends PiwikUpdates
         $migrations = [];
 
         $migrations[] = $this->migration->db->addColumn('segment', 'hash', 'CHAR(32) NULL', 'definition');
-
-        $segmentTable = Common::prefixTable('segment');
-        $segments = Db::fetchAll("SELECT idsegment, definition FROM $segmentTable WHERE deleted = ?", [0]);
-        foreach ($segments as $segment) {
-            $hash = md5(urldecode($segment['definition']));
-            $migrations[] = $this->migration->db->sql("UPDATE `$segmentTable` SET `hash` = '$hash' WHERE `idsegment` = '{$segment['idsegment']}'");
-        }
         return $migrations;
     }
 

--- a/core/Updates/4.3.0-b4.php
+++ b/core/Updates/4.3.0-b4.php
@@ -36,7 +36,7 @@ class Updates_4_3_0_b4 extends PiwikUpdates
         $migrations = [];
 
         $segmentTable = Common::prefixTable('segment');
-        $segments = Db::fetchAll("SELECT idsegment, hash, definition FROM $segmentTable");
+        $segments = Db::fetchAll("SELECT * FROM $segmentTable");
         foreach ($segments as $segment) {
             if (empty($segment['hash'])) {
                 $hash = md5(urldecode($segment['definition']));


### PR DESCRIPTION
### Description:

Updating Matomo might currently fail, as the update script for 4.3.0-b4 tries to use the `hash` column, which is created in update for 4.3.0-b3. As the migrations are all gathered before they are executed, the hash column does not exist and the query fails.
This also happen for our updater UI test. See https://travis-ci.com/github/matomo-org/matomo/jobs/503575602#L1700

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
