### PR TITLE
7051: DataTable Renderer should discard the key of a single value table

### DIFF
--- a/core/DataTable/Renderer.php
+++ b/core/DataTable/Renderer.php
@@ -415,15 +415,6 @@ abstract class Renderer extends BaseFactory
             $flatArray = $this->convertSimpleTable($dataTable);
 
             reset($flatArray);
-            $firstKey = key($flatArray);
-
-            // if we return only one numeric value then we print out the result in a simple <result> tag
-            // keep it simple!
-            if (count($flatArray) == 1
-                && $firstKey !== DataTable\Row::COMPARISONS_METADATA_NAME
-            ) {
-                $flatArray = current($flatArray);
-            }
         } // A normal DataTable needs to be handled specifically
         else {
             $array = $this->convertTable($dataTable);

--- a/core/DataTable/Renderer/Json.php
+++ b/core/DataTable/Renderer/Json.php
@@ -48,18 +48,10 @@ class Json extends Renderer
                     || $tab instanceof DataTable
                     || $tab instanceof DataTable\Simple) {
                     $array[$key] = $this->convertDataTableToArray($tab);
-
-                    if (!is_array($array[$key])) {
-                        $array[$key] = array('value' => $array[$key]);
-                    }
                 }
             }
         } else {
             $array = $this->convertDataTableToArray($table);
-        }
-
-        if (!is_array($array)) {
-            $array = array('value' => $array);
         }
 
         // convert datatable column/metadata values

--- a/core/DataTable/Renderer/Xml.php
+++ b/core/DataTable/Renderer/Xml.php
@@ -66,11 +66,7 @@ class Xml extends Renderer
             return $out;
         }
         if ($table instanceof Simple) {
-            if (is_array($array)) {
-                $out = $this->renderDataTableSimple($array);
-            } else {
-                $out = $array;
-            }
+            $out = $this->renderDataTableSimple($array);
             if ($returnOnlyDataTableXml) {
                 return $out;
             }
@@ -403,10 +399,6 @@ class Xml extends Renderer
      */
     protected function renderDataTableSimple($array, $prefixLine = "")
     {
-        if (!is_array($array)) {
-            $array = array('value' => $array);
-        }
-
         $columnsHaveInvalidChars = $this->areTableLabelsInvalidXmlTagNames($array);
 
         $out = '';


### PR DESCRIPTION
### Description:

This is a start towards fixing https://github.com/matomo-org/matomo/issues/7051

The return value when requesting a single column has now changed.
old: {"value":3161}
new: {"nb_visits":315}

The way I have done that has had some reasonably significant impacts on both JSON and XML output so I am unsure if I'm on the right track.

The core problem is that Renderer::convertDataTableToArray() contains a check for an array of length one. If an array of length 1 is detected its key is discarded and a single value is returned instead of an array. Instead of this array
```
array(1) {
  ["nb_visits"]=>
  float(315)
}
```
you just get this instead `float(315)` meaning that the array key has been discarded. There are then places that check for the single value where there should be an array and wrap that value in an array with key 'value'.

It does seem preferable in my mind for Renderer::convertDataTableToArray() to just return an array regardless of length and let code closer to output generation decide if a single element array requires special handling for display purposes but I could well be off base.

The code as it currently is in this PR has had various effects other than those above.

1) XML output is affected too. For example if you change the requested format from JSON to XML (/index.php?module=API&method=API.get&idSite=1&period=day&date=yesterday&format=XML&token_auth=anonymous&columns=nb_visits) you no longer get `<result>2526</result>` but get this instead.
```
<result>
	<nb_visits>2526</nb_visits>
</result>
```
This is the same format returned when you request multiple columns.

2) I'm not sure if the effects on nested arrays is desirable or not. The below is phpunit test output. Quite a few DataTable tests will require updating if they are to pass against this code (I'm happy to update the tests if this is the behaviour we want)
```
'<?xml version="1.0" encoding="utf-8" ?>\n
 <results>\n
 	<result parentArrayKey="idSite">\n
-		<result testKey="row1">14</result>\n
-		<result testKey="row2">15</result>\n
+		<result testKey="row1">\n
+			<nb_visits>14</nb_visits>\n
+		</result>\n
+		<result testKey="row2">\n
+			<nb_visits>15</nb_visits>\n
+		</result>\n
 		<result testKey="row3" />\n
 	</result>\n
 </results>'
```
```
-'{"idSite":{"row1":14,"row2":15,"row3":[]}}'
+'{"idSite":{"row1":{"nb_visits":14},"row2":{"nb_visits":15},"row3":[]}}'
```
Again, this is the same format that is already return for multi-column queries.

Options:
1) Decide we want the column name preserved everywhere meaning that single column queries will match the format of multi-column queries. Both json and xml outputs will change substantially to bring single column queries in line with multi-column queries and downstream consumers will need to be updated where they expect the single column specific output format.

2) Decide we want the old behaviour in some contexts and I add in code to detect single column arrays and make the output match what it did previously. Make the tests pass essentially with very few test updates.

3) Something else?

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
