### PR TITLE
Add option to skip log purging check when invalidating archives in the rare cases it is needed.

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -265,7 +265,7 @@ class ArchiveInvalidator
      * @throws \Exception
      */
     public function markArchivesAsInvalidated(array $idSites, array $dates, $period, Segment $segment = null, $cascadeDown = false,
-                                              $forceInvalidateNonexistantRanges = false, $name = null)
+                                              $forceInvalidateNonexistantRanges = false, $name = null, $ignorePurgeLogDataDate = false)
     {
         $plugin = null;
         if ($name && strpos($name, '.') !== false) {
@@ -318,7 +318,7 @@ class ArchiveInvalidator
         // might not have this segment meaning we avoid a possible error. For the workflow to work, any added or removed
         // idSite does not need to be added to $segment.
 
-        $datesToInvalidate = $this->removeDatesThatHaveBeenPurged($dates, $period, $invalidationInfo);
+        $datesToInvalidate = $this->removeDatesThatHaveBeenPurged($dates, $period, $invalidationInfo, $ignorePurgeLogDataDate);
 
         $allPeriodsToInvalidate = $this->getAllPeriodsByYearMonth($period, $datesToInvalidate, $cascadeDown);
 
@@ -699,7 +699,7 @@ class ArchiveInvalidator
      * @param InvalidationResult $invalidationInfo
      * @return \Piwik\Date[]
      */
-    private function removeDatesThatHaveBeenPurged($dates, $period, InvalidationResult $invalidationInfo)
+    private function removeDatesThatHaveBeenPurged($dates, $period, InvalidationResult $invalidationInfo, $ignorePurgeLogDataDate)
     {
         $this->findOlderDateWithLogs($invalidationInfo);
 
@@ -709,6 +709,7 @@ class ArchiveInvalidator
 
             // we should only delete reports for dates that are more recent than N days
             if ($invalidationInfo->minimumDateWithLogs
+                && !$ignorePurgeLogDataDate
                 && ($periodObj->getDateEnd()->isEarlier($invalidationInfo->minimumDateWithLogs)
                     || $periodObj->getDateStart()->isEarlier($invalidationInfo->minimumDateWithLogs))
             ) {

--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -62,6 +62,10 @@ class InvalidateReportData extends ConsoleCommand
         $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'For tests. Runs the command w/o actually '
             . 'invalidating anything.');
         $this->addOption('plugin', null, InputOption::VALUE_REQUIRED, 'To invalidate data for a specific plugin only.');
+        $this->addOption('ignore-log-deletion-limit', null, InputOption::VALUE_NONE,
+            'Ignore the log purging limit when invalidating archives. If a date is older than the log purging threshold (which means '
+            . 'there should be no log data for it), we normally skip invalidating it in order to prevent losing any report data. In some cases, '
+            . 'however it is useful, if, for example, your site was imported from Google, and there is never any log data.');
         $this->setHelp('Invalidate archived report data by date range, site and period. Invalidated archive data will '
             . 'be re-archived during the next core:archive run. If your log data has changed for some reason, this '
             . 'command can be used to make sure reports are generated using the new, changed log data.');
@@ -74,6 +78,7 @@ class InvalidateReportData extends ConsoleCommand
         $cascade = $input->getOption('cascade');
         $dryRun = $input->getOption('dry-run');
         $plugin = $input->getOption('plugin');
+        $ignoreLogDeletionLimit = $input->getOption('ignore-log-deletion-limit');
 
         $sites = $this->getSitesToInvalidateFor($input);
         $periodTypes = $this->getPeriodTypesToInvalidateFor($input);
@@ -102,7 +107,7 @@ class InvalidateReportData extends ConsoleCommand
                         $output->writeln($message);
                     } else {
                         $invalidationResult = $invalidator->markArchivesAsInvalidated($sites, $dates, $periodType, $segment, $cascade,
-                            false, $plugin);
+                            false, $plugin, $ignoreLogDeletionLimit);
 
                         if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
                             $output->writeln($invalidationResult->makeOutputLogs());


### PR DESCRIPTION
### Description:

For use in the GoogleAnalyticsImporter, if log purging is enabled, then we'll never be able to invalidate to dates before it. However, the importer can definitely import dates before it and uses archiving to fill up week, month and year periods. The flag would fix this.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
