### PR TITLE
If no archives names are requested when querying archive data, do not initiate archiving.

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -493,6 +493,9 @@ class Archive implements ArchiveQuery
 
         $result = new Archive\DataCollection(
             $dataNames, $archiveDataType, $this->params->getIdSites(), $this->params->getPeriods(), $this->params->getSegment(), $defaultRow = null);
+        if (empty($archiveNames)) {
+            return $result; // NOTE: note posting Archive.noArchivedData here, because there might be archive data, someone just requested nothing
+        }
 
         $archiveIds = $this->getArchiveIds($archiveNames);
         if (empty($archiveIds)) {

--- a/core/Archive.php
+++ b/core/Archive.php
@@ -476,6 +476,8 @@ class Archive implements ArchiveQuery
             $archiveNames = array($archiveNames);
         }
 
+        $archiveNames = array_filter($archiveNames);
+
         // apply idSubtable
         if ($idSubtable !== null
             && $idSubtable !== self::ID_SUBTABLE_LOAD_ALL_SUBTABLES
@@ -493,7 +495,7 @@ class Archive implements ArchiveQuery
 
         $result = new Archive\DataCollection(
             $dataNames, $archiveDataType, $this->params->getIdSites(), $this->params->getPeriods(), $this->params->getSegment(), $defaultRow = null);
-        if (empty($archiveNames)) {
+        if (empty($dataNames)) {
             return $result; // NOTE: note posting Archive.noArchivedData here, because there might be archive data, someone just requested nothing
         }
 

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -15,6 +15,7 @@ use Piwik\ArchiveProcessor\Rules;
 use Piwik\Common;
 use Piwik\Config;
 use Piwik\CronArchive;
+use Piwik\DataAccess\ArchiveTableCreator;
 use Piwik\DataAccess\ArchiveWriter;
 use Piwik\Date;
 use Piwik\Db;
@@ -32,6 +33,27 @@ class ArchiveTest extends IntegrationTestCase
         parent::setUp();
 
         Fixture::createWebsite('2014-05-06');
+    }
+
+    public function test_queryingForNoData_doesNotCreateEmptyArchive()
+    {
+        $tracker = Fixture::getTracker(1, '2014-05-07 07:00:00');
+        $tracker->setUrl('http://matomo.net/page/1');
+        Fixture::checkResponse($tracker->doTrackPageView('a page'));
+
+        $tracker->setForceVisitDateTime('2014-05-08 09:00:00');
+        $tracker->setUrl('http://matomo.net/page/2');
+        Fixture::checkResponse($tracker->doTrackPageView('a page'));
+
+        // the table may not be created if we skip archiving logic, so make sure it's created here
+        ArchiveTableCreator::getNumericTable(Date::factory('2014-05-07'));
+
+        $archive = Archive::factory(new Segment('', [1]), [Factory::build('range', '2014-05-07,2014-05-08')], [1]);
+        $data = $archive->getDataTableFromNumeric([]);
+        $this->assertEquals([], $data->getRows());
+
+        $archiveRows = Db::fetchAll('SELECT * FROM ' . Common::prefixTable('archive_numeric_2014_05') . ' WHERE idsite = 1 AND period = 5');
+        $this->assertEquals([], $archiveRows);
     }
 
     public function test_pluginSpecificArchiveUsed_EvenIfAllArchiveExists_IfThereAreNoDataInAllArchive()

--- a/tests/PHPUnit/Integration/ArchiveTest.php
+++ b/tests/PHPUnit/Integration/ArchiveTest.php
@@ -52,6 +52,12 @@ class ArchiveTest extends IntegrationTestCase
         $data = $archive->getDataTableFromNumeric([]);
         $this->assertEquals([], $data->getRows());
 
+        $data = $archive->getDataTableFromNumeric(null);
+        $this->assertEquals([], $data->getRows());
+
+        $data = $archive->getDataTableFromNumeric(['']);
+        $this->assertEquals([], $data->getRows());
+
         $archiveRows = Db::fetchAll('SELECT * FROM ' . Common::prefixTable('archive_numeric_2014_05') . ' WHERE idsite = 1 AND period = 5');
         $this->assertEquals([], $archiveRows);
     }


### PR DESCRIPTION
### Description:

This solves a very convoluted bug involving CustomReports:

- user creates a custom report with just unique visitors and places it in the visitors overview
- user views a large range (eg, 2021-01-01,2021-03-31)
- the first request on the page, for visits summary data succeeds creating plugin specific range archives with data
- the custom report request is triggered
- the custom report data is successfully requested
- since its for a range, CustomReports decides we're not allowed to archive unique visitors (because of an INI config setting) and removes it from the columns_to_display
- Visualization tries to get the site summary to build totals data
- this issues an API request to API.get for a range, using columns_to_display, which is empty
- API.get issues a request to VisitsSummary.get w/ 0 columns
- VisitsSummary.get creates an Archive instance and calls getDataTableFromNumeric() with an empty array for $names
- since it's a range, Archive.php tries to launch archiving. since no data is requested, there is no specific plugin to load, so we assume it's the all plugins archive. so we create a 'done' archive.
- PluginsArchiver does nothing, since there is nothing being requested
- then we finalize the 'done' archive w/ the DONE_OK flag
- now on the next request, all archive requests to got the new 'done' archive for the range, even though it contains nothing
- the user sees 0 for all metrics for the range

This is fixed in this PR by not launching archiving if nothing is requested in Archive.php.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
