### PR TITLE
turn on github actions

### DIFF
--- a/.github/workflows/follow-up-reviews.yml
+++ b/.github/workflows/follow-up-reviews.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          debug-only: true
+          debug-only: false
           start-date: 2021-03-01T00:00:00Z
           days-before-pr-stale: 7
           days-before-pr-close: -1

--- a/.github/workflows/inactive-prs-closing-message.yaml
+++ b/.github/workflows/inactive-prs-closing-message.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          debug-only: true
+          debug-only: false
           start-date: 2021-03-01T00:00:00Z
           days-before-pr-stale: 42
           days-before-pr-close: -1

--- a/.github/workflows/inactive-prs.yaml
+++ b/.github/workflows/inactive-prs.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          debug-only: true
+          debug-only: false
           start-date: 2021-03-01T00:00:00Z
           days-before-pr-stale: 14
           days-before-pr-close: -1


### PR DESCRIPTION
### Description:

Turn off the debug mode so the stale PR actions will run in live mode.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
