### PR TITLE
Prevent error message in dev mode no date is defined in segment

### DIFF
--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -406,7 +406,7 @@ class API extends \Piwik\Plugin\API
         foreach ($segments as &$segmentInfo) {
             $idSites = !empty($segmentInfo['enable_only_idsite']) ? [(int) $segmentInfo['enable_only_idsite']] : $allIdSites;
             try {
-                $segmentObj = new Segment($segmentInfo['definition'], $idSites);
+                $segmentObj = new Segment($segmentInfo['definition'], $idSites, Date::yesterday(), Date::now());
                 $segmentInfo['hash'] = $segmentObj->getHash();
             } catch (\Exception $ex) {
                 $segmentInfo['hash'] = 'INVALID SEGMENT';

--- a/plugins/SegmentEditor/API.php
+++ b/plugins/SegmentEditor/API.php
@@ -401,18 +401,6 @@ class API extends \Piwik\Plugin\API
 
         $segments = $this->sortSegmentsCreatedByUserFirst($segments);
 
-        $model = new \Piwik\Plugins\SitesManager\Model();
-        $allIdSites = $model->getSitesId();
-        foreach ($segments as &$segmentInfo) {
-            $idSites = !empty($segmentInfo['enable_only_idsite']) ? [(int) $segmentInfo['enable_only_idsite']] : $allIdSites;
-            try {
-                $segmentObj = new Segment($segmentInfo['definition'], $idSites, Date::yesterday(), Date::now());
-                $segmentInfo['hash'] = $segmentObj->getHash();
-            } catch (\Exception $ex) {
-                $segmentInfo['hash'] = 'INVALID SEGMENT';
-            }
-        }
-
         return $segments;
     }
 


### PR DESCRIPTION
Have been getting this notification many times every time I fetch a screen and always receive heaps of notifications (when dev mode enabled). This should fix it. Shouldn't be needed in the 4.3 release but selected 4.3 so it later gets converted maybe to 4.4

> WARNING: Avoiding segment subquery due to missing start date and/or an end date. Please ensure a start date and/or end date is set when initializing a segment if it's used to build a query. Stacktrace: #0 /piwik/core/Segment.php(266): Piwik\Segment-&gt;doesSegmentNeedSubquery('!=', 'eventCategory') #1 /piwik/core/Segment.php(241): Piwik\Segment-&gt;getExpressionsWithUnionsResolved(Array) #2 /piwik/core/Segment.php(150): Piwik\Segment-&gt;initializeSegment('eventCategory!=...', Array) #3 /piwik/plugins/SegmentEditor/API.php(409): Piwik\Segment-&gt;__construct('eventCategory!=...', Array) #4 [internal function]: Piwik\Plugins\SegmentEditor\API-&gt;getAll('1') #5 /piwik/core/API/Proxy.php(244): call_user_func_array(Array, Array) #6 /piwik/core/Context.php(28): Piwik\API\Proxy-&gt;Piwik\API\{closure}() #7 /piwik/core/API/Proxy.php(335): Piwik\Context::executeWithQueryParameters(Array, Object(Closure)) #8 /piwik/core/API/Request.php(266): Piwik\API\Proxy-&gt;call('\\Piwik\\Plugins\\...', 'getAll', Array) #9 /piwik/core/API/Request.php(559): Piwik\API\Request-&gt;process() #10 /piwik/plugins/SegmentEditor/SegmentEditor.php(356): Piwik\API\Request::processRequest('SegmentEditor.g...', Array, Array) #11 /piwik/core/Segment.php(624): Piwik\Plugins\SegmentEditor\SegmentEditor::getAllSegmentsForSite(1) #12 /piwik/core/Archive/DataTableFactory.php(588): Piwik\Segment-&gt;getStoredSegmentName(1) #13 /piwik/core/Archive/DataTableFactory.php(288): Piwik\Archive\DataTableFactory-&gt;setPrettySegmentMetadata(Object(Piwik\DataTable)) #14 /piwik/core/Archive/DataTableFactory.php(259): Piwik\Archive\DataTableFactory-&gt;makeDataTableFromSingleBlob(Array, Array) #15 /piwik/core/Archive/DataTableFactory.php(375): Piwik\Archive\DataTableFactory-&gt;makeFromBlobRow(Array, Array) #16 /piwik/core/Archive/DataTableFactory.php(347): Piwik\Archive\DataTableFactory-&gt;createDataTable(Array, Array) #17 /piwik/core/Archive/DataTableFactory.php(188): Piwik\Archive\DataTableFactory-&gt;createDataTableMapFromIndex(Array, Array, Array) #18 /piwik/core/Archive/DataCollection.php(289): Piwik\Archive\DataTableFactory-&gt;make(Array, Array) #19 /piwik/core/Archive.php(386): Piwik\Archive\DataCollection-&gt;getExpandedDataTable(Array, NULL, NULL, false) #20 /piwik/core/ArchiveProcessor.php(346): Piwik\Archive-&gt;getDataTableExpanded('Goals_ItemsSku', NULL, NULL, false) #21 /piwik/core/ArchiveProcessor.php(213): Piwik\ArchiveProcessor-&gt;aggregateDataTableRecord('Goals_ItemsSku', NULL, NULL) #22 /piwik/plugins/Goals/Archiver.php(436): Piwik\ArchiveProcessor-&gt;aggregateDataTableRecords(Array, NULL, NULL, NULL, NULL, NULL, Array) #23 /piwik/core/Plugin/Archiver.php(103): Piwik\Plugins\Goals\Archiver-&gt;aggregateMultipleReports() #24 /piwik/core/ArchiveProcessor/PluginsArchiver.php(168): Piwik\Plugin\Archiver-&gt;callAggregateMultipleReports() #25 /piwik/core/ArchiveProcessor/Loader.php(228): Piwik\ArchiveProcessor\PluginsArchiver-&gt;callAggregateAllPlugins(2, 0, false) #26 /piwik/core/ArchiveProcessor/Loader.php(163): Piwik\ArchiveProcessor\Loader-&gt;prepareAllPluginsArchive(2, 0) #27 /piwik/core/ArchiveProcessor/Loader.php(101): Piwik\ArchiveProcessor\Loader-&gt;prepareArchiveImpl('Goals') #28 /piwik/core/Context.php(75): Piwik\ArchiveProcessor\Loader-&gt;Piwik\ArchiveProcessor\{closure}() #29 /piwik/core/ArchiveProcessor/Loader.php(105): Piwik\Context::changeIdSite(1, Object(Closure)) #30 /piwik/core/ArchiveProcessor.php(668): Piwik\ArchiveProcessor\Loader-&gt;prepareArchive('Goals') #31 /piwik/plugins/Goals/Archiver.php(485): Piwik\ArchiveProcessor-&gt;processDependentArchive('Goals', 'visitorType%3D%...') #32 /piwik/core/Plugin/Archiver.php(103): Piwik\Plugins\Goals\Archiver-&gt;aggregateMultipleReports() #33 /piwik/core/ArchiveProcessor/PluginsArchiver.php(168): Piwik\Plugin\Archiver-&gt;callAggregateMultipleReports() #34 /piwik/core/ArchiveProcessor/Loader.php(228): Piwik\ArchiveProcessor\PluginsArchiver-&gt;callAggregateAllPlugins(2, 0, false) #35 /piwik/core/ArchiveProcessor/Loader.php(163): Piwik\ArchiveProcessor\Loader-&gt;prepareAllPluginsArchive(2, 0) #36 /piwik/core/ArchiveProcessor/Loader.php(101): Piwik\ArchiveProcessor\Loader-&gt;prepareArchiveImpl('VisitsSummary') #37 /piwik/core/Context.php(75): Piwik\ArchiveProcessor\Loader-&gt;Piwik\ArchiveProcessor\{closure}() #38 /piwik/core/ArchiveProcessor/Loader.php(105): Piwik\Context::changeIdSite(1, Object(Closure)) #39 /piwik/plugins/CoreAdminHome/API.php(278): Piwik\ArchiveProcessor\Loader-&gt;prepareArchive('VisitsSummary') #40 /piwik/core/Archive.php(825): Piwik\Plugins\CoreAdminHome\API-&gt;archiveReports(1, Object(Piwik\Period\Week), '2021-05-10', '', 'VisitsSummary', NULL) #41 /piwik/core/Archive.php(624): Piwik\Archive-&gt;prepareArchive(Array, Object(Piwik\Site), Object(Piwik\Period\Week)) #42 /piwik/core/Archive.php(571): Piwik\Archive-&gt;cacheArchiveIdsAfterLaunching(Array, Array) #43 /piwik/core/Archive.php(497): Piwik\Archive-&gt;getArchiveIds(Array) #44 /piwik/core/Archive.php(312): Piwik\Archive-&gt;get(Array, 'numeric') #45 /piwik/core/ArchiveProcessor.php(606): Piwik\Archive-&gt;getDataTableFromNumeric(Array) #46 /piwik/core/ArchiveProcessor.php(252): Piwik\ArchiveProcessor-&gt;getAggregatedNumericMetrics(Array, false) #47 /piwik/core/ArchiveProcessor/PluginsArchiver.php(306): Piwik\ArchiveProcessor-&gt;aggregateNumericMetrics(Array) #48 /piwik/core/ArchiveProcessor/PluginsArchiver.php(104): Piwik\ArchiveProcessor\PluginsArchiver-&gt;aggregateMultipleVisitsMetrics() #49 /piwik/core/ArchiveProcessor/Loader.php(222): Piwik\ArchiveProcessor\PluginsArchiver-&gt;callAggregateCoreMetrics() #50 /piwik/core/ArchiveProcessor/Loader.php(163): Piwik\ArchiveProcessor\Loader-&gt;prepareAllPluginsArchive(6, 1) #51 /piwik/core/ArchiveProcessor/Loader.php(101): Piwik\ArchiveProcessor\Loader-&gt;prepareArchiveImpl('VisitsSummary') #52 /piwik/core/Context.php(75): Piwik\ArchiveProcessor\Loader-&gt;Piwik\ArchiveProcessor\{closure}() #53 /piwik/core/ArchiveProcessor/Loader.php(105): Piwik\Context::changeIdSite(1, Object(Closure)) #54 /piwik/plugins/CoreAdminHome/API.php(278): Piwik\ArchiveProcessor\Loader-&gt;prepareArchive('VisitsSummary') #55 /piwik/core/Archive.php(825): Piwik\Plugins\CoreAdminHome\API-&gt;archiveReports(1, Object(Piwik\Period\Month), '2021-05-01', '', 'VisitsSummary', NULL) #56 /piwik/core/Archive.php(624): Piwik\Archive-&gt;prepareArchive(Array, Object(Piwik\Site), Object(Piwik\Period\Month)) #57 /piwik/core/Archive.php(571): Piwik\Archive-&gt;cacheArchiveIdsAfterLaunching(Array, Array) #58 /piwik/core/Archive.php(497): Piwik\Archive-&gt;getArchiveIds(Array) #59 /piwik/core/Archive.php(312): Piwik\Archive-&gt;get(Array, 'numeric') #60 /piwik/plugins/VisitsSummary/API.php(36): Piwik\Archive-&gt;getDataTableFromNumeric(Array) #61 [internal function]: Piwik\Plugins\VisitsSummary\API-&gt;get('1', 'month', 'yesterday', false, Array) #62 /piwik/core/API/Proxy.php(244): call_user_func_array(Array, Array) #63 /piwik/core/Context.php(28): Piwik\API\Proxy-&gt;Piwik\API\{closure}() #64 /piwik/core/API/Proxy.php(335): Piwik\Context::executeWithQueryParameters(Array, Object(Closure)) #65 /piwik/core/API/Request.php(266): Piwik\API\Proxy-&gt;call('\\Piwik\\Plugins\\...', 'get', Array) #66 /piwik/core/API/Request.php(559): Piwik\API\Request-&gt;process() #67 /piwik/plugins/CoreHome/Columns/UserId.php(119): Piwik\API\Request::processRequest('VisitsSummary.g...', Array, Array) #68 /piwik/plugins/CoreHome/Columns/UserId.php(104): Piwik\Plugins\CoreHome\Columns\UserId-&gt;isUsedInSite('1', 'month', 'yesterday') #69 /piwik/plugins/CoreHome/Columns/UserId.php(89): Piwik\Plugins\CoreHome\Columns\UserId-&gt;isUsedInSiteCached('1', 'month', 'yesterday') #70 /piwik/plugins/VisitsSummary/Reports/Get.php(181): Piwik\Plugins\CoreHome\Columns\UserId-&gt;isUsedInAtLeastOneSite(Array, 'month', 'yesterday') #71 /piwik/plugins/VisitsSummary/Reports/Get.php(87): Piwik\Plugins\VisitsSummary\Reports\Get-&gt;addSparklineColumns(Object(Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines)) #72 /piwik/core/Plugin/ViewDataTable.php(239): Piwik\Plugins\VisitsSummary\Reports\Get-&gt;configureView(Object(Piwik\Plugins\CoreVisualizations\Visualizations\Sparklines)) #73 /piwik/core/ViewDataTable/Factory.php(243): Piwik\Plugin\ViewDataTable-&gt;__construct('get', 'VisitsSummary.g...', Array) #74 /piwik/core/ViewDataTable/Factory.php(156): Piwik\ViewDataTable\Factory::createViewDataTableInstance('Piwik\\Plugins\\C...', 'VisitsSummary.g...', 'VisitsSummary.g...', Array) #75 /piwik/core/Plugin/Report.php(318): Piwik\ViewDataTable\Factory::build('sparklines', 'VisitsSummary.g...', 'VisitsSummary.g...', 1) #76 /piwik/plugins/CoreHome/Controller.php(58): Piwik\Plugin\Report-&gt;render() #77 [internal function]: Piwik\Plugins\CoreHome\Controller-&gt;renderReportWidget(Object(Piwik\Plugins\VisitsSummary\Reports\Get)) #78 /piwik/core/FrontController.php(615): call_user_func_array(Array, Array) #79 /piwik/core/FrontController.php(167): Piwik\FrontController-&gt;doDispatch('VisitsSummary', 'get', Array) #80 /piwik/core/dispatch.php(32): Piwik\FrontController-&gt;dispatch() #81 /piwik/index.php(25): require_once('/Users/thomasst...') #82 {main} (Module: API, Action: get, Method: SegmentEditor.getAll, In CLI mode: false)

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
