### PR TITLE
Do not send idGoal=0 parameter for goals overview since 0 is for orders

### DIFF
--- a/plugins/Goals/Reports/Base.php
+++ b/plugins/Goals/Reports/Base.php
@@ -45,7 +45,7 @@ abstract class Base extends \Piwik\Plugin\Report
         } else {
             $this->name = $goalNameFormatter(['name' => Piwik::translate('Goals_GoalsOverview')]);
         }
-        $this->parameters = ['idGoal' => 0];
+        $this->parameters = [];
         $this->order = $this->orderGoal;
         $availableReports[] = $this->buildReportMetadata();
 


### PR DESCRIPTION
### Description:

Fixes #17502

In the past the UI controller method that outputted the goals overview used idGoal=0 to signify it was handling the overview. It would not pass that parameter on to the API, since the API treats idGoal=0 as IDGOAL_ORDER.

This means, currently, we are displaying order goal information in place of the goals overview for scheduled reports. To fix this, we can just not send the idGoal to the API.

The tests are failing, most seem like they are expected. The TSV test however changes the name of the report in the output (though this doesn't happen locally for me).

cc @tsteur for prioritization

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
