### PR TITLE
Make sure summary row subtables are included in the serialized representaion of a datatable tree.

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1317,10 +1317,10 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
         $consecutiveSubtableIds = array();
         $forcedId = $subtableId;
 
-        // For each row, get the serialized row
+        // For each row (including the summary row), get the serialized row
         // If it is associated to a sub table, get the serialized table recursively ;
         // but returns all serialized tables and subtable in an array of 1 dimension
-        foreach ($this->rows as $id => $row) {
+        foreach ($this->getRows() as $id => $row) {
             $subTable = $row->getSubtable();
             if ($subTable) {
                 $consecutiveSubtableIds[$id] = ++$subtableId;

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -453,6 +453,26 @@ class DataTableTest extends \PHPUnit\Framework\TestCase
         $table->getSerialized();
     }
 
+    public function test_getSerialized_SerializesSubtablesOfSummaryRows()
+    {
+        $table = new DataTable;
+        $table->addRowFromArray(array(Row::COLUMNS => array('label' => 'dimval1', 'visits' => 245)));
+
+        $summaryRow = new Row([Row::COLUMNS => ['label' => 'others', 'visits' => 500]]);
+
+        $summaryRowSubtable = new DataTable;
+        $summaryRowSubtable->addRow(new Row([Row::COLUMNS => ['label' => 'subtabledimension', 'visits' => 100]]));
+        $summaryRow->setSubtable($summaryRowSubtable);
+
+        $table->addSummaryRow($summaryRow);
+
+        $results = $table->getSerialized();
+
+        $this->assertCount(2, $results);
+        $this->assertStringContainsString('dimval1', $results[0]);
+        $this->assertStringContainsString('subtabledimension', $results[1]);
+    }
+
     /**
      * Test queing filters
      */


### PR DESCRIPTION
### Description:

If a summary row has a subtable, it will not be serialized because we go over the `$rows` property, but the summary row is held in a different property. Fixed by including it.

This was causing the strange "Row with label '%s' (columns = %s) has already a subtable" errors. The summary row subtable couldn't be loaded from the DB, just the ID, so when summing them, we'd trigger this warning.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
