### PR TITLE
Improves Geolocation diagnostics

### DIFF
--- a/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
+++ b/plugins/Diagnostics/tests/UI/expected-screenshots/Diagnostics_page.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8809c4c3142064eb43329a7c9dddaeaaf8edf97c78c8e55b4615a0324562be29
-size 452174
+oid sha256:fcc30ea2194c731a6aaa48f51316ec58015cb1d14adf2025ade229dbc953b204
+size 460614

--- a/plugins/UserCountry/Diagnostic/GeolocationDiagnostic.php
+++ b/plugins/UserCountry/Diagnostic/GeolocationDiagnostic.php
@@ -71,6 +71,9 @@ class GeolocationDiagnostic implements Diagnostic
             return [DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_WARNING, $providerWarning)];
         }
 
-        return [DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_OK)];
+        $availableInfo = LocationProvider::getProviderById($currentProviderId)->getSupportedLocationInfo();
+        $message = sprintf("%s (%s)", $currentProviderId, implode(', ', array_keys(array_filter($availableInfo))));
+
+        return [DiagnosticResult::singleResult($label, DiagnosticResult::STATUS_OK, $message)];
     }
 }


### PR DESCRIPTION
### Description:

When geolocation is configured and a provider other than the default is used, the diagnostic might currently only show a green tick. For support and debugging purpose it might be useful to directly know which provider is currently used and which location properties are available. This might help us to better answer support requests or issues on github where people are having problems with geolocation and post the diagnostic result. 

![image](https://user-images.githubusercontent.com/1579355/118491939-c8765700-b71f-11eb-8725-609b11af88a7.png)


### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
