### PR TITLE
Ignore performance metrics that are obviously too high

### DIFF
--- a/plugins/PagePerformance/Columns/Base.php
+++ b/plugins/PagePerformance/Columns/Base.php
@@ -37,6 +37,12 @@ abstract class Base extends ActionDimension
             throw new InvalidRequestParameterException(sprintf('Value for %1$s can\'t be negative.', $this->getRequestParam()));
         }
 
+        // ignore obviously incorrect values (nothing should take more than 1 hour to load)
+        // refs https://github.com/matomo-org/matomo/issues/17035
+        if ($time > 3600000) {
+            return false;
+        }
+
         return $time;
     }
 }

--- a/plugins/PagePerformance/Columns/Base.php
+++ b/plugins/PagePerformance/Columns/Base.php
@@ -37,9 +37,9 @@ abstract class Base extends ActionDimension
             throw new InvalidRequestParameterException(sprintf('Value for %1$s can\'t be negative.', $this->getRequestParam()));
         }
 
-        // ignore obviously incorrect values (nothing should take more than 1 hour to load)
+        // ignore values that are too high to be stored in column (unsigned mediumint)
         // refs https://github.com/matomo-org/matomo/issues/17035
-        if ($time > 3600000) {
+        if ($time > 16777215) {
             return false;
         }
 

--- a/plugins/PagePerformance/tests/Integration/Tracker/PerformanceDataProcessorTest.php
+++ b/plugins/PagePerformance/tests/Integration/Tracker/PerformanceDataProcessorTest.php
@@ -88,6 +88,24 @@ class PerformanceDataProcessorTest extends IntegrationTestCase
         $this->checkActionHasTimings($tracker->idPageview, 0, 66, 445, 1025, 12, 111);
     }
 
+    public function test_shouldNotUseObviouslyTooHighNumbers()
+    {
+        $tracker = Fixture::getTracker(1, Date::now()->toString('Y-m-d H:i:s'));
+        $tracker->setUrl('http://example.org/test');
+        Fixture::checkResponse($tracker->doTrackPageView('My Page'));
+
+        $idPageView = $tracker->idPageview;
+
+        $this->checkActionHasTimings($idPageView);
+
+        $tracker->setPerformanceTimings(6525265942, 6525265942, 6525265942, 6525265942, 6525265942, 111);
+        $tracker->setUrl('http://example.org/test2');
+        Fixture::checkResponse($tracker->doTrackPageView('Another Page'));
+
+        $this->checkActionHasTimings($idPageView);
+        $this->checkActionHasTimings($tracker->idPageview, null, null, null, null, null, 111);
+    }
+
     protected function checkActionHasTimings($pageViewId, $network = null, $server = null, $transfer = null, $domProcessing = null, $domCompletion = null, $onload = null)
     {
         $result = Db::fetchRow(


### PR DESCRIPTION
### Description:

Added a check for one hour for now. Might be even fine to check for 10 minutes or so, as no website performance metric should contain a number higher that this. 

refs #17035

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
