### PR TITLE
Fix fetching Alexa rank

### DIFF
--- a/plugins/SEO/Metric/Alexa.php
+++ b/plugins/SEO/Metric/Alexa.php
@@ -36,10 +36,15 @@ class Alexa implements MetricsProvider
         $value = null;
         try {
             $response = Http::sendHttpRequest(self::URL . urlencode($domain), $timeout = 10, @$_SERVER['HTTP_USER_AGENT']);
+            libxml_use_internal_errors(true); // suppress errors
             $dom = new \DomDocument();
             $dom->loadHTML($response);
-            $nodes = (new \DomXPath($dom))->query("//div[contains(@class, 'data')]");
+            libxml_clear_errors();
+            $nodes = (new \DomXPath($dom))->query("//div[contains(@class, 'ACard')]//section//a");
             if (isset($nodes[0]->nodeValue)) {
+                foreach( $nodes[0]->childNodes as $node) {
+                    $nodes[0]->removeChild($node); // remove the span tags with additional info
+                }
                 $globalRanking = (int) str_replace(array(',', '.'), '', $nodes[0]->nodeValue);
                 $value = NumberFormatter::getInstance()->formatNumber($globalRanking);
             }


### PR DESCRIPTION
### Description:

Seems Alexa has changes the site were we fetch the rank from. It now contains a lot javascript which can't be parsed correctly, resulting in a lot warnings. Added `libxml_use_internal_errors(true)` to ignore them.
Also the markup changed so I tried to adjust the xpath handing to fetch the correct value again.

fixes https://github.com/matomo-org/matomo/issues/17578

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
