### PR TITLE
Use originalString when returning the Segment definition string

### DIFF
--- a/core/Archive.php
+++ b/core/Archive.php
@@ -827,7 +827,7 @@ class Archive implements ArchiveQuery
             $this->initializeArchiveIdCache($doneFlag);
 
             $prepareResult = $coreAdminHomeApi->archiveReports(
-                $site->getId(), $period->getLabel(), $periodDateStr, $this->params->getSegment()->getString(),
+                $site->getId(), $period->getLabel(), $periodDateStr, $this->params->getSegment()->getOriginalString(),
                 $plugin, $requestedReport);
 
             if (!empty($prepareResult)

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -553,7 +553,7 @@ class ArchiveInvalidator
                 'pluginName' => $pluginName,
                 'report' => $report,
                 'startDate' => $startDate ? $startDate->getTimestamp() : null,
-                'segment' => $segment ? $segment->getString() : null,
+                'segment' => $segment ? $segment->getOriginalString() : null,
             ]));
         } catch (\Throwable $ex) {
             $this->logger->info("Failed to schedule rearchiving of past reports for $pluginName plugin.");

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -446,7 +446,7 @@ class Segment
      */
     public function getString()
     {
-        return $this->originalString;
+        return $this->string;
     }
 
     /**
@@ -642,5 +642,10 @@ class Segment
         }
 
         return $this->isSegmentEncoded ? urldecode($segment) : $segment;
+    }
+
+    public function getOriginalString()
+    {
+        return $this->originalString;
     }
 }

--- a/core/Segment.php
+++ b/core/Segment.php
@@ -446,7 +446,7 @@ class Segment
      */
     public function getString()
     {
-        return $this->string;
+        return $this->originalString;
     }
 
     /**

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -60,7 +60,7 @@ class SegmentTest extends IntegrationTestCase
         $hash = $segment->getHash();
         $this->assertEquals($segmentInfo['hash'], $hash);
 
-        $segmentStringFromObject = $segment->getString();
+        $segmentStringFromObject = $segment->getOriginalString();
         $segment2 = new Segment($segmentStringFromObject, []);
 
         $hash = $segment2->getHash();

--- a/tests/PHPUnit/Integration/SegmentTest.php
+++ b/tests/PHPUnit/Integration/SegmentTest.php
@@ -16,6 +16,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\Http;
+use Piwik\Plugins\SegmentEditor\API;
 use Piwik\Segment;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\Mock\FakeAccess;
@@ -46,6 +47,24 @@ class SegmentTest extends IntegrationTestCase
         Config::getInstance()->General['enable_browser_archiving_triggering'] = 1;
         self::$fixture->getTestEnvironment()->overrideConfig('General', 'enable_browser_archiving_triggering', 1);
         self::$fixture->getTestEnvironment()->save();
+    }
+
+    public function test_getHash_returnsCorrectHashWhenDefinitionIsFromGetStringFromSegmentTableDefinition()
+    {
+        // definition is encoded as it would be in the URL
+        $idSegment = API::getInstance()->add('test segment', 'pageUrl%3D%3Dhttps%25253A%25252F%25252Fserenity.org%25252Fparticipate%25252F');
+        $segmentInfo = API::getInstance()->get($idSegment);
+
+        $segment = new Segment($segmentInfo['definition'], []);
+
+        $hash = $segment->getHash();
+        $this->assertEquals($segmentInfo['hash'], $hash);
+
+        $segmentStringFromObject = $segment->getString();
+        $segment2 = new Segment($segmentStringFromObject, []);
+
+        $hash = $segment2->getHash();
+        $this->assertEquals($segmentInfo['hash'], $hash);
     }
 
     static public function removeExtraWhiteSpaces($valueToFilter)


### PR DESCRIPTION
### Description:

Fixes #17583

The string definition passed into Segment will sometimes be decoded before being saved in Segment::$string. So if we reuse the string to create a new Segment, the new segment's hash will be different. This PR changes getString() to return the original string so we're always using the definition we started with.

EDIT: Modified this PR to not change Segment::getString(), since that resulted in a test failure that looked like a regression. Instead there's a new method. We can replace every occurrence if desired in 4.4.0.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
