### PR TITLE
Fix uncaught exception when running system tests for plugins

### DIFF
--- a/plugins/API/tests/System/expected/test_AutoSuggestAPITest_browserName__API.getSuggestedValuesForSegment.xml
+++ b/plugins/API/tests/System/expected/test_AutoSuggestAPITest_browserName__API.getSuggestedValuesForSegment.xml
@@ -4,6 +4,7 @@
 	<row>2345 Browser</row>
 	<row>360 Phone Browser</row>
 	<row>360 Browser</row>
+	<row>7654 Browser</row>
 	<row>Avant Browser</row>
 	<row>ABrowse</row>
 	<row>ANT Fresco</row>
@@ -121,6 +122,7 @@
 	<row>GOG Galaxy</row>
 	<row>HasBrowser</row>
 	<row>Hawk Turbo Browser</row>
+	<row>Helio</row>
 	<row>hola! Browser</row>
 	<row>HotJava</row>
 	<row>Huawei Browser</row>
@@ -197,6 +199,7 @@
 	<row>Opera Mini iOS</row>
 	<row>Obigo</row>
 	<row>Odin</row>
+	<row>OceanHero</row>
 	<row>Odyssey Web Browser</row>
 	<row>Off By One</row>
 	<row>OhHai Browser</row>
@@ -235,6 +238,7 @@
 	<row>PolyBrowser</row>
 	<row>PrivacyWall</row>
 	<row>Microsoft Edge</row>
+	<row>Qazweb</row>
 	<row>QQ Browser Lite</row>
 	<row>QQ Browser Mini</row>
 	<row>QQ Browser</row>

--- a/plugins/API/tests/System/expected/test_AutoSuggestAPITest_operatingSystemName__API.getSuggestedValuesForSegment.xml
+++ b/plugins/API/tests/System/expected/test_AutoSuggestAPITest_operatingSystemName__API.getSuggestedValuesForSegment.xml
@@ -18,6 +18,7 @@
 	<row>Debian</row>
 	<row>Deepin</row>
 	<row>DragonFly</row>
+	<row>DVKBuntu</row>
 	<row>Fedora</row>
 	<row>Fenix</row>
 	<row>Firefox OS</row>
@@ -38,6 +39,7 @@
 	<row>Kubuntu</row>
 	<row>GNU/Linux</row>
 	<row>Lubuntu</row>
+	<row>Lumin OS</row>
 	<row>VectorLinux</row>
 	<row>Mac</row>
 	<row>Maemo</row>

--- a/plugins/CoreHome/Columns/VisitorId.php
+++ b/plugins/CoreHome/Columns/VisitorId.php
@@ -44,12 +44,18 @@ class VisitorId extends VisitDimension
 
     public function configureSegments(SegmentsList $segmentsList, DimensionSegmentFactory $dimensionSegmentFactory)
     {
-        $systemSettings = new SystemSettings();
-        $a = $systemSettings->disableVisitorProfile->getValue();
-        $b = $systemSettings->disableVisitorLog->getValue();
+        try {
+            $systemSettings        = new SystemSettings();
+            $visitorProfileEnabled = $systemSettings->disableVisitorProfile->getValue() === false
+                && $systemSettings->disableVisitorLog->getValue() === false;
+        } catch (\Zend_Db_Exception $e) {
+            // when running tests the db might not yet be set up when fetching available segments
+            if (!defined('PIWIK_TEST_MODE') || !PIWIK_TEST_MODE) {
+                throw $e;
+            }
+            $visitorProfileEnabled = true;
+        }
 
-        $visitorProfileEnabled = $systemSettings->disableVisitorProfile->getValue() === false
-            && $systemSettings->disableVisitorLog->getValue() === false;
         if ($visitorProfileEnabled) {
             parent::configureSegments($segmentsList, $dimensionSegmentFactory);
         }


### PR DESCRIPTION
### Description:

When running system tests for plugins there is currently an uncaught exception when the tests starts running.
See eg. https://travis-ci.com/github/matomo-org/matomo/jobs/507308739#L732

This is caused by a dataprovider that tries to fetch available segments before the database is actually set up. As the visitor id segment tries to check for a system settings this fails.

This actually caused the AutoSuggestAPI test not to run anymore

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
