### PR TITLE
clear EventDispatcher cache in tests

### DIFF
--- a/core/EventDispatcher.php
+++ b/core/EventDispatcher.php
@@ -176,9 +176,17 @@ class EventDispatcher
     public function postPendingEventsTo($plugin)
     {
         foreach ($this->pendingEvents as $eventInfo) {
-            list($eventName, $eventParams) = $eventInfo;
+            [$eventName, $eventParams] = $eventInfo;
             $this->postEvent($eventName, $eventParams, $pending = false, array($plugin));
         }
+    }
+
+    /**
+     * @internal  For testing purpose only
+     */
+    public function clearCache()
+    {
+        $this->pluginHooks = [];
     }
 
     private function getCallbackFunctionAndGroupNumber($hookInfo)

--- a/tests/PHPUnit/Framework/Fixture.php
+++ b/tests/PHPUnit/Framework/Fixture.php
@@ -24,6 +24,7 @@ use Piwik\DataTable\Manager as DataTableManager;
 use Piwik\Date;
 use Piwik\Db;
 use Piwik\DbHelper;
+use Piwik\EventDispatcher;
 use Piwik\FrontController;
 use Matomo\Ini\IniReader;
 use Piwik\Log;
@@ -405,6 +406,7 @@ class Fixture extends \PHPUnit\Framework\Assert
         PiwikCache::getEagerCache()->flushAll();
         PiwikCache::getLazyCache()->flushAll();
         ArchiveTableCreator::clear();
+        EventDispatcher::getInstance()->clearCache();
         \Piwik\Plugins\ScheduledReports\API::$cache = array();
         Singleton::clearAll();
         PluginsArchiver::$archivers = array();

--- a/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/IntegrationTestCase.php
@@ -9,13 +9,11 @@
 namespace Piwik\Tests\Framework\TestCase;
 
 use Piwik\Access;
-use Piwik\Config;
+use Piwik\Cache as PiwikCache;
 use Piwik\Db;
-use Piwik\DbHelper;
-use Piwik\Menu\MenuAbstract;
+use Piwik\EventDispatcher;
 use Piwik\Option;
 use Piwik\Tests\Framework\Fixture;
-use Piwik\Cache as PiwikCache;
 use Piwik\Tests\Framework\TestingEnvironmentVariables;
 
 /**
@@ -90,8 +88,11 @@ abstract class IntegrationTestCase extends SystemTestCase
             self::restoreDbTables(self::$tableData);
         }
 
+        // Note: we can't clear all in memory caches at this point
+        // Otherwise fixtures can't be used to e.g. manipulate static instances
         PiwikCache::getEagerCache()->flushAll();
         PiwikCache::getTransientCache()->flushAll();
+        EventDispatcher::getInstance()->clearCache();
         Option::clearCache();
     }
 

--- a/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
+++ b/tests/PHPUnit/Unit/DataAccess/LogQueryBuilder/JoinTablesTest.php
@@ -6,7 +6,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  *
  */
-namespace Piwik\Tests\Unit\DataAccess;
+namespace Piwik\Tests\Unit\DataAccess\LogQueryBuilder;
 
 use Piwik\DataAccess\LogQueryBuilder\JoinTables;
 use Piwik\Tests\Framework\Mock\Plugin\LogTablesProvider;


### PR DESCRIPTION
### Description:

Was writing some tests that require the ActivityLog plugin but failed to get them working. The reason actually was, that the ActivityLog plugin dynamically tries to register hooks. To get that working in tests it's required to clear the registered hooks that might have been cached previously.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
