### PR TITLE
Fix possible notice when no user is set

### DIFF
--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -176,7 +176,7 @@ class Piwik
     public static function getCurrentUserEmail()
     {
         $user = APIUsersManager::getInstance()->getUser(Piwik::getCurrentUserLogin());
-        return $user['email'];
+        return $user['email'] ?? '';
     }
 
     /**


### PR DESCRIPTION
### Description:

Especially in tests it might be possible that a user is actually not set. If for any reason `Piwik::getCurrentUserEmail()` is then called a notice might be triggered causing a test to fail.

In theory there might also be other use cases where that could happen. Like using a custom login plugin, that actually does not use the users stored in database.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
