### PR TITLE
Improve purge log data logic to improve speed, and avoid locks in some cases

### DIFF
--- a/core/LogDeleter.php
+++ b/core/LogDeleter.php
@@ -9,7 +9,6 @@
 namespace Piwik;
 
 use Piwik\DataAccess\RawLogDao;
-use Piwik\Db\TransactionLevel;
 use Piwik\Plugin\LogTablesProvider;
 use Piwik\Plugins\SitesManager\Model;
 

--- a/core/LogDeleter.php
+++ b/core/LogDeleter.php
@@ -9,6 +9,7 @@
 namespace Piwik;
 
 use Piwik\DataAccess\RawLogDao;
+use Piwik\Db\TransactionLevel;
 use Piwik\Plugin\LogTablesProvider;
 use Piwik\Plugins\SitesManager\Model;
 
@@ -96,7 +97,8 @@ class LogDeleter
         $logsDeleted = 0;
         $logPurger = $this;
         $this->rawLogDao->forAllLogs('log_visit', $fields, $conditions, $iterationStep, function ($logs) use ($logPurger, &$logsDeleted, $afterChunkDeleted) {
-            $ids = array_map(function ($row) { return reset($row); }, $logs);
+            $ids = array_map(function ($row) { return (int) (reset($row)); }, $logs);
+            sort($ids);
             $logsDeleted += $logPurger->deleteVisits($ids);
 
             if (!empty($afterChunkDeleted)) {

--- a/plugins/PrivacyManager/LogDataPurger.php
+++ b/plugins/PrivacyManager/LogDataPurger.php
@@ -13,6 +13,7 @@ use Piwik\Container\StaticContainer;
 use Piwik\DataAccess\RawLogDao;
 use Piwik\Date;
 use Piwik\Db;
+use Piwik\Db\TransactionLevel;
 use Piwik\Log;
 use Piwik\LogDeleter;
 use Piwik\Piwik;
@@ -66,7 +67,13 @@ class LogDataPurger
     public function purgeData($deleteLogsOlderThan, $deleteUnusedLogActions)
     {
         $dateUpperLimit = Date::factory("today")->subDay($deleteLogsOlderThan);
+
+        $transactionLevel = new TransactionLevel(Db::get());
+        $transactionLevel->setUncommitted();
+
         $this->logDeleter->deleteVisitsFor($start = null, $dateUpperLimit->getDatetime());
+
+        $transactionLevel->restorePreviousStatus();
 
         $logTables = self::getDeleteTableLogTables();
 


### PR DESCRIPTION
### Description:

see https://stackoverflow.com/questions/23193761/delete-operation-locks-whole-table-in-innodb/23194154

Deletes may be faster or less locking when they are in descending order. Also added a transaction uncommitted in the hope for this to be less locking and making it faster. This should be fine because we usually delete only older visits anyway and they wouldn't be included in current reports or something.

Problem was that we noticed some locks around the time when the delete visits statement ran even though InnoDB was used.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
