### PR TITLE
invalidate-report-data console to show a timestamp in the output

### DIFF
--- a/plugins/CoreAdminHome/Commands/InvalidateReportData.php
+++ b/plugins/CoreAdminHome/Commands/InvalidateReportData.php
@@ -85,6 +85,8 @@ class InvalidateReportData extends ConsoleCommand
         $dateRanges = $this->getDateRangesToInvalidateFor($input);
         $segments = $this->getSegmentsToInvalidateFor($input, $sites, $output);
 
+        $logger = StaticContainer::get(LoggerInterface::class);
+
         foreach ($periodTypes as $periodType) {
             if ($periodType === 'range') {
                 continue; // special handling for range below
@@ -93,7 +95,7 @@ class InvalidateReportData extends ConsoleCommand
                 foreach ($segments as $segment) {
                     $segmentStr = $segment ? $segment->getString() : '';
 
-                    $output->writeln("Invalidating $periodType periods in $dateRange [segment = $segmentStr]...");
+                    $logger->info("Invalidating $periodType periods in $dateRange [segment = $segmentStr]...");
 
                     $dates = $this->getPeriodDates($periodType, $dateRange);
 
@@ -104,13 +106,13 @@ class InvalidateReportData extends ConsoleCommand
                         if (!empty($plugin)) {
                             $message .= ", plugin = [ $plugin ]";
                         }
-                        $output->writeln($message);
+                        $logger->info($message);
                     } else {
                         $invalidationResult = $invalidator->markArchivesAsInvalidated($sites, $dates, $periodType, $segment, $cascade,
                             false, $plugin, $ignoreLogDeletionLimit);
 
                         if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
-                            $output->writeln($invalidationResult->makeOutputLogs());
+                            $logger->info($invalidationResult->makeOutputLogs());
                         }
                     }
                 }
@@ -134,7 +136,7 @@ class InvalidateReportData extends ConsoleCommand
                     $segmentStr = $segment ? $segment->getString() : '';
                     if ($dryRun) {
                         $dateRangeStr = implode(';', $dateRanges);
-                        $output->writeln("Invalidating range periods overlapping $dateRangeStr [segment = $segmentStr]...");
+                        $logger->info("Invalidating range periods overlapping $dateRangeStr [segment = $segmentStr]...");
                     } else {
                         $invalidator->markArchivesOverlappingRangeAsInvalidated($sites, $rangeDates, $segment);
                     }

--- a/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/InvalidateReportDataTest.php
@@ -8,10 +8,12 @@
 
 namespace Piwik\Plugins\CoreAdminHome\tests\Integration\Commands;
 
+use Monolog\Handler\AbstractProcessingHandler;
 use Piwik\ArchiveProcessor\Rules;
 use Piwik\Plugins\SegmentEditor\API;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\ConsoleCommandTestCase;
+use Psr\Log\LoggerInterface;
 
 /**
  * @group CoreAdminHome
@@ -19,6 +21,8 @@ use Piwik\Tests\Framework\TestCase\ConsoleCommandTestCase;
  */
 class InvalidateReportDataTest extends ConsoleCommandTestCase
 {
+    private static $captureHandler;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
@@ -28,6 +32,18 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         Fixture::createWebsite('2012-01-01 00:00:00');
 
         API::getInstance()->add('test segment', 'browserCode==IE', $idSite);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        self::$captureHandler->messages = [];
+    }
+
+    protected function tearDown(): void
+    {
+        self::$captureHandler->messages = [];
+        parent::tearDown();
     }
 
     /**
@@ -45,7 +61,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalid date or date range specifier", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalid date or date range specifier", $this->getLogOutput());
     }
 
     public function getInvalidDateRanges()
@@ -71,7 +87,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalid period type", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalid period type", $this->getLogOutput());
     }
 
     public function getInvalidPeriodTypes()
@@ -96,7 +112,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalid --sites value", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalid --sites value", $this->getLogOutput());
     }
 
     public function getInvalidSiteLists()
@@ -121,7 +137,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("The segment condition 'ablksdjfdslkjf' is not valid", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("The segment condition 'ablksdjfdslkjf' is not valid", $this->getLogOutput());
     }
 
     /**
@@ -149,7 +165,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
 
         foreach ($expectedOutputs as $output) {
-            self::assertStringContainsString($output, $this->applicationTester->getDisplay());
+            self::assertStringContainsString($output, $this->getLogOutput());
         }
     }
 
@@ -165,7 +181,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
     }
 
     public function test_Command_InvalidateDateRange_invalidDate()
@@ -180,7 +196,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("The date '2019-01-01,2019-01--09' is not a correct date range", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("The date '2019-01-01,2019-01--09' is not a correct date range", $this->getLogOutput());
     }
 
     public function test_Command_InvalidateDateRange_onlyOneDate()
@@ -195,7 +211,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("The date '2019-01-01' is not a correct date range", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("The date '2019-01-01' is not a correct date range", $this->getLogOutput());
     }
 
     public function test_Command_InvalidateDateRange_tooManyDatesInRange()
@@ -210,7 +226,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertNotEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("The date '2019-01-01,2019-01-09,2019-01-12,2019-01-15' is not a correct date range", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("The date '2019-01-01,2019-01-09,2019-01-12,2019-01-15' is not a correct date range", $this->getLogOutput());
     }
 
     public function test_Command_InvalidateDateRange_multipleDateRanges()
@@ -225,7 +241,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-15", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-15", $this->getLogOutput());
     }
 
     public function test_Command_InvalidateDateRange_invalidateAllPeriodTypesSkipsRangeWhenNotRangeDAte()
@@ -240,8 +256,8 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringNotContainsString("range", $this->applicationTester->getDisplay());
-        self::assertStringNotContainsString("Range", $this->applicationTester->getDisplay());
+        self::assertStringNotContainsString("range", $this->getLogOutput());
+        self::assertStringNotContainsString("Range", $this->getLogOutput());
     }
 
     public function test_Command_InvalidateDateRange_invalidateAllPeriodTypes()
@@ -256,11 +272,11 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating day periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
-        self::assertStringContainsString("Invalidating week periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
-        self::assertStringContainsString("Invalidating month periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
-        self::assertStringContainsString("Invalidating year periods in 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating day periods in 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating week periods in 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating month periods in 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating year periods in 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09 [segment = ]", $this->getLogOutput());
     }
 
     public function test_Command_InvalidateAll_multipleDateRanges()
@@ -275,7 +291,7 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
         ));
 
         $this->assertEquals(0, $code, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-13 [segment = ]", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Invalidating range periods overlapping 2019-01-01,2019-01-09;2019-01-12,2019-01-13 [segment = ]", $this->getLogOutput());
     }
 
     public function getTestDataForSuccessTests()
@@ -415,5 +431,30 @@ class InvalidateReportDataTest extends ConsoleCommandTestCase
                 ],
             ],
         );
+    }
+
+    public static function provideContainerConfigBeforeClass()
+    {
+        if (empty(self::$captureHandler)) {
+            self::$captureHandler = new class extends AbstractProcessingHandler {
+                public $messages = [];
+
+                protected function write(array $record)
+                {
+                    $this->messages[] = (string)$record['formatted'];
+                }
+            };
+        }
+
+        return [
+            'ini.tests.enable_logging' => 1,
+            'Tests.log.allowAllHandlers' => true,
+            'log.handlers' => [self::$captureHandler],
+        ];
+    }
+
+    private function getLogOutput()
+    {
+        return implode("\n", self::$captureHandler->messages);
     }
 }


### PR DESCRIPTION
…timestamp in the output

As requested by support

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
