### PR TITLE
Allow plugins to abort sending emails via 'Mail.send' event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This is the Developer Changelog for Matomo platform developers. All changes in o
 
 The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)** lets you see more details about any Matomo release, such as the list of new guides and FAQs, security fixes, and links to all closed issues. 
 
+## Matomo 4.4.0
+
+### Changes to events
+
+* It is now possible via the Mail.send event to abort sending emails. Set the `$mail` event parameter to null to do this.
+
 ## Matomo 4.3.1
 
 ### New commands

--- a/core/Mail.php
+++ b/core/Mail.php
@@ -270,7 +270,7 @@ class Mail
     /**
      * Sends the mail
      *
-     * @return bool
+     * @return bool|null returns null if sending the mail was aborted by the Mail.send event
      * @throws \DI\NotFoundException
      */
     public function send()
@@ -285,9 +285,14 @@ class Mail
          * This event is posted right before an email is sent. You can use it to customize the email by, for example, replacing
          * the subject/body, changing the from address, etc.
          *
-         * @param Mail $mail The Mail instance that is about to be sent.
+         * @param Mail &$mail The Mail instance that is about to be sent. Set it to null to stop the email from
+         *                    being sent.
          */
-        Piwik::postEvent('Mail.send', [$mail]);
+        Piwik::postEvent('Mail.send', [&$mail]);
+
+        if (empty($mail)) {
+            return null;
+        }
 
         return StaticContainer::get('Piwik\Mail\Transport')->send($mail);
     }


### PR DESCRIPTION
### Description:

Refs DEV-2158

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
