### PR TITLE
Support for Tracker INI settings to be set for each website

### DIFF
--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -150,7 +150,7 @@ class Request
      */
     protected function authenticateTrackingApi($tokenAuth)
     {
-        $shouldAuthenticate = TrackerConfig::getConfigValue('tracking_requests_require_authentication', $this->getIdSite());
+        $shouldAuthenticate = TrackerConfig::getConfigValue('tracking_requests_require_authentication', $this->getIdSiteIfExists());
 
         if ($shouldAuthenticate) {
             try {

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -73,7 +73,6 @@ class Request
         $this->tokenAuth = $tokenAuth;
         $this->timestamp = time();
         $this->isEmptyRequest = empty($params);
-        $this->customTimestampDoesNotRequireTokenauthWhenNewerThan = (int) TrackerConfig::getConfigValue('tracking_requests_require_authentication_when_custom_timestamp_newer_than');
 
         // When the 'url' and referrer url parameter are not given, we might be in the 'Simple Image Tracker' mode.
         // The URL can default to the Referrer, which will be in this case
@@ -90,6 +89,8 @@ class Request
 
         // check for 4byte utf8 characters in all tracking params and replace them with � if not support by database
         $this->params = $this->replaceUnsupportedUtf8Chars($this->params);
+
+        $this->customTimestampDoesNotRequireTokenauthWhenNewerThan = (int) TrackerConfig::getConfigValue('tracking_requests_require_authentication_when_custom_timestamp_newer_than', $this->getIdSite());
     }
 
     protected function replaceUnsupportedUtf8Chars($value, $key=false)
@@ -148,7 +149,7 @@ class Request
      */
     protected function authenticateTrackingApi($tokenAuth)
     {
-        $shouldAuthenticate = TrackerConfig::getConfigValue('tracking_requests_require_authentication');
+        $shouldAuthenticate = TrackerConfig::getConfigValue('tracking_requests_require_authentication', $this->getIdSite());
 
         if ($shouldAuthenticate) {
             try {
@@ -685,22 +686,22 @@ class Request
 
     protected function getCookieName()
     {
-        return TrackerConfig::getConfigValue('cookie_name');
+        return TrackerConfig::getConfigValue('cookie_name', $this->getIdSite());
     }
 
     protected function getCookieExpire()
     {
-        return $this->getCurrentTimestamp() + TrackerConfig::getConfigValue('cookie_expire');
+        return $this->getCurrentTimestamp() + TrackerConfig::getConfigValue('cookie_expire', $this->getIdSite());
     }
 
     protected function getCookiePath()
     {
-        return TrackerConfig::getConfigValue('cookie_path');
+        return TrackerConfig::getConfigValue('cookie_path', $this->getIdSite());
     }
 
     protected function getCookieDomain()
     {
-        return TrackerConfig::getConfigValue('cookie_domain');
+        return TrackerConfig::getConfigValue('cookie_domain', $this->getIdSite());
     }
 
     /**
@@ -716,7 +717,7 @@ class Request
     {
         $found = false;
 
-        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid')) {
+        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $this->getIdSite())) {
             // If User ID is set it takes precedence
             $userId = $this->getForcedUserId();
             if ($userId) {

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -239,11 +239,10 @@ class Request
 
     public function isRequestExcluded()
     {
-        $config = Config::getInstance();
-        $tracker = $config->Tracker;
+        $excludedRequests = TrackerConfig::getConfigValue('exclude_requests', $this->getIdSite());
 
-        if (!empty($tracker['exclude_requests'])) {
-            $excludedRequests = explode(',', $tracker['exclude_requests']);
+        if (!empty($excludedRequests)) {
+            $excludedRequests = explode(',', $excludedRequests);
             $pattern = '/^(.+?)('.SegmentExpression::MATCH_EQUAL.'|'
                 .SegmentExpression::MATCH_NOT_EQUAL.'|'
                 .SegmentExpression::MATCH_CONTAINS.'|'
@@ -626,7 +625,7 @@ class Request
 
     public function shouldUseThirdPartyCookie()
     {
-        return (bool)Config::getInstance()->Tracker['use_third_party_id_cookie'];
+        return TrackerConfig::getConfigValue('use_third_party_id_cookie', $this->getIdSite());
     }
 
     public function getThirdPartyCookieVisitorId()

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -90,7 +90,8 @@ class Request
         // check for 4byte utf8 characters in all tracking params and replace them with � if not support by database
         $this->params = $this->replaceUnsupportedUtf8Chars($this->params);
 
-        $this->customTimestampDoesNotRequireTokenauthWhenNewerThan = (int) TrackerConfig::getConfigValue('tracking_requests_require_authentication_when_custom_timestamp_newer_than', $this->getIdSite());
+        $this->customTimestampDoesNotRequireTokenauthWhenNewerThan = (int) TrackerConfig::getConfigValue('tracking_requests_require_authentication_when_custom_timestamp_newer_than',
+            $this->getIdSiteIfExists());
     }
 
     protected function replaceUnsupportedUtf8Chars($value, $key=false)
@@ -585,6 +586,15 @@ class Request
          */
         Piwik::postEvent('Tracker.Request.getIdSite', array(&$idSite, $this->params));
         return $idSite;
+    }
+
+    public function getIdSiteIfExists()
+    {
+        try {
+            return $this->getIdSite();
+        } catch (UnexpectedWebsiteFoundException $ex) {
+            return null;
+        }
     }
 
     public function getIdSite()

--- a/core/Tracker/Request.php
+++ b/core/Tracker/Request.php
@@ -240,7 +240,7 @@ class Request
 
     public function isRequestExcluded()
     {
-        $excludedRequests = TrackerConfig::getConfigValue('exclude_requests', $this->getIdSite());
+        $excludedRequests = TrackerConfig::getConfigValue('exclude_requests', $this->getIdSiteIfExists());
 
         if (!empty($excludedRequests)) {
             $excludedRequests = explode(',', $excludedRequests);
@@ -635,7 +635,7 @@ class Request
 
     public function shouldUseThirdPartyCookie()
     {
-        return TrackerConfig::getConfigValue('use_third_party_id_cookie', $this->getIdSite());
+        return TrackerConfig::getConfigValue('use_third_party_id_cookie', $this->getIdSiteIfExists());
     }
 
     public function getThirdPartyCookieVisitorId()
@@ -695,22 +695,22 @@ class Request
 
     protected function getCookieName()
     {
-        return TrackerConfig::getConfigValue('cookie_name', $this->getIdSite());
+        return TrackerConfig::getConfigValue('cookie_name', $this->getIdSiteIfExists());
     }
 
     protected function getCookieExpire()
     {
-        return $this->getCurrentTimestamp() + TrackerConfig::getConfigValue('cookie_expire', $this->getIdSite());
+        return $this->getCurrentTimestamp() + TrackerConfig::getConfigValue('cookie_expire', $this->getIdSiteIfExists());
     }
 
     protected function getCookiePath()
     {
-        return TrackerConfig::getConfigValue('cookie_path', $this->getIdSite());
+        return TrackerConfig::getConfigValue('cookie_path', $this->getIdSiteIfExists());
     }
 
     protected function getCookieDomain()
     {
-        return TrackerConfig::getConfigValue('cookie_domain', $this->getIdSite());
+        return TrackerConfig::getConfigValue('cookie_domain', $this->getIdSiteIfExists());
     }
 
     /**
@@ -726,7 +726,7 @@ class Request
     {
         $found = false;
 
-        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $this->getIdSite())) {
+        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $this->getIdSiteIfExists())) {
             // If User ID is set it takes precedence
             $userId = $this->getForcedUserId();
             if ($userId) {

--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -25,7 +25,7 @@ class Response
     {
         ob_start(); // we use ob_start only because of Common::printDebug, we should actually not really use ob_start
 
-        if ($tracker->isDebugModeEnabled() && TrackerConfig::getConfigValue('enable_sql_profiler')) {
+        if ($tracker->isDebugModeEnabled() && TrackerConfig::getConfigValue('enable_sql_profiler', $this->getIdSite())) {
             $this->timer = new Timer();
 
             TrackerDb::enableProfiling();

--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -25,7 +25,7 @@ class Response
     {
         ob_start(); // we use ob_start only because of Common::printDebug, we should actually not really use ob_start
 
-        if ($tracker->isDebugModeEnabled() && TrackerConfig::getConfigValue('enable_sql_profiler', $this->getIdSite())) {
+        if ($tracker->isDebugModeEnabled() && TrackerConfig::getConfigValue('enable_sql_profiler')) {
             $this->timer = new Timer();
 
             TrackerDb::enableProfiling();

--- a/core/Tracker/TrackerConfig.php
+++ b/core/Tracker/TrackerConfig.php
@@ -25,14 +25,24 @@ class TrackerConfig
         Config::getInstance()->Tracker = $section;
     }
 
-    public static function getConfigValue($name)
+    public static function getConfigValue($name, $idSite = null)
     {
         $config = self::getConfig();
+        if (!empty($idSite)) {
+            $siteSpecificConfig = self::getSiteSpecificConfig($idSite);
+            $config = array_merge($config, $siteSpecificConfig);
+        }
         return $config[$name];
     }
 
     private static function getConfig()
     {
         return Config::getInstance()->Tracker;
+    }
+
+    private static function getSiteSpecificConfig($idSite)
+    {
+        $key = 'Tracker_' . $idSite;
+        return Config::getInstance()->$key;
     }
 }

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -586,7 +586,7 @@ class Visit implements VisitInterface
             $valuesToUpdate['idvisitor'] = $this->request->getVisitorId(); 
         }
 
-        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $this->request->getIdSite())) {
+        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $this->request->getIdSiteIfExists())) {
             // User ID takes precedence and overwrites idvisitor value
             $userId = $this->request->getForcedUserId();
             if ($userId) {

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -586,7 +586,7 @@ class Visit implements VisitInterface
             $valuesToUpdate['idvisitor'] = $this->request->getVisitorId(); 
         }
 
-        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid')) {
+        if (TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $this->request->getIdSite())) {
             // User ID takes precedence and overwrites idvisitor value
             $userId = $this->request->getForcedUserId();
             if ($userId) {

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -104,7 +104,7 @@ class VisitorRecognizer
         $shouldMatchOneFieldOnly  = $this->shouldLookupOneVisitorFieldOnly($isVisitorIdToLookup, $request);
         list($timeLookBack, $timeLookAhead) = $this->getWindowLookupThisVisit($request);
 
-        $maxActions = TrackerConfig::getConfigValue('create_new_visit_after_x_actions', $request->getIdSite());
+        $maxActions = TrackerConfig::getConfigValue('create_new_visit_after_x_actions', $request->getIdSiteIfExists());
 
         $visitRow = $this->model->findVisitor($idSite, $configId, $idVisitor, $userId, $persistedVisitAttributes, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead);
 

--- a/core/Tracker/VisitorRecognizer.php
+++ b/core/Tracker/VisitorRecognizer.php
@@ -104,7 +104,7 @@ class VisitorRecognizer
         $shouldMatchOneFieldOnly  = $this->shouldLookupOneVisitorFieldOnly($isVisitorIdToLookup, $request);
         list($timeLookBack, $timeLookAhead) = $this->getWindowLookupThisVisit($request);
 
-        $maxActions = TrackerConfig::getConfigValue('create_new_visit_after_x_actions');
+        $maxActions = TrackerConfig::getConfigValue('create_new_visit_after_x_actions', $request->getIdSite());
 
         $visitRow = $this->model->findVisitor($idSite, $configId, $idVisitor, $userId, $persistedVisitAttributes, $shouldMatchOneFieldOnly, $isVisitorIdToLookup, $timeLookBack, $timeLookAhead);
 

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -184,7 +184,7 @@ class VisitRequestProcessor extends RequestProcessor
         }
 
         $wasLastActionYesterday = $this->wasLastActionNotToday($visitProperties, $request, $lastKnownVisit);
-        $forceNewVisitAtMidnight = (bool) Config::getInstance()->Tracker['create_new_visit_after_midnight'];
+        $forceNewVisitAtMidnight = (bool) TrackerConfig::getConfigValue('create_new_visit_after_midnight', $request->getIdSite());
 
         if ($wasLastActionYesterday && $forceNewVisitAtMidnight) {
             Common::printDebug("Visitor detected, but last action was yesterday...");

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -192,7 +192,7 @@ class VisitRequestProcessor extends RequestProcessor
             return true;
         }
 
-        if (!TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid')
+        if (!TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $request->getIdSite())
             && !$this->lastUserIdWasSetAndDoesMatch($visitProperties, $request)) {
             Common::printDebug("Visitor detected, but last user_id does not match...");
             return true;

--- a/plugins/CoreHome/Tracker/VisitRequestProcessor.php
+++ b/plugins/CoreHome/Tracker/VisitRequestProcessor.php
@@ -184,7 +184,7 @@ class VisitRequestProcessor extends RequestProcessor
         }
 
         $wasLastActionYesterday = $this->wasLastActionNotToday($visitProperties, $request, $lastKnownVisit);
-        $forceNewVisitAtMidnight = (bool) TrackerConfig::getConfigValue('create_new_visit_after_midnight', $request->getIdSite());
+        $forceNewVisitAtMidnight = (bool) TrackerConfig::getConfigValue('create_new_visit_after_midnight', $request->getIdSiteIfExists());
 
         if ($wasLastActionYesterday && $forceNewVisitAtMidnight) {
             Common::printDebug("Visitor detected, but last action was yesterday...");
@@ -192,7 +192,7 @@ class VisitRequestProcessor extends RequestProcessor
             return true;
         }
 
-        if (!TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $request->getIdSite())
+        if (!TrackerConfig::getConfigValue('enable_userid_overwrites_visitorid', $request->getIdSiteIfExists())
             && !$this->lastUserIdWasSetAndDoesMatch($visitProperties, $request)) {
             Common::printDebug("Visitor detected, but last user_id does not match...");
             return true;

--- a/plugins/Referrers/Columns/Campaign.php
+++ b/plugins/Referrers/Columns/Campaign.php
@@ -23,13 +23,7 @@ class Campaign extends Base
      *
      * @var bool
      */
-    protected $createNewVisitWhenCampaignChanges;
     protected $nameSingular = 'Referrers_ColumnCampaign';
-
-    public function __construct()
-    {
-        $this->createNewVisitWhenCampaignChanges = TrackerConfig::getConfigValue('create_new_visit_when_campaign_changes') == 1;
-    }
 
     /**
      * If we should create a new visit when the campaign changes, check if the campaign info changed and if so
@@ -42,7 +36,7 @@ class Campaign extends Base
      */
     public function shouldForceNewVisit(Request $request, Visitor $visitor, Action $action = null)
     {
-        if (!$this->createNewVisitWhenCampaignChanges) {
+        if (TrackerConfig::getConfigValue('create_new_visit_when_campaign_changes', $request->getIdSite()) != 1) {
             return false;
         }
 

--- a/plugins/Referrers/Columns/Campaign.php
+++ b/plugins/Referrers/Columns/Campaign.php
@@ -36,7 +36,7 @@ class Campaign extends Base
      */
     public function shouldForceNewVisit(Request $request, Visitor $visitor, Action $action = null)
     {
-        if (TrackerConfig::getConfigValue('create_new_visit_when_campaign_changes', $request->getIdSite()) != 1) {
+        if (TrackerConfig::getConfigValue('create_new_visit_when_campaign_changes', $request->getIdSiteIfExists()) != 1) {
             return false;
         }
 

--- a/plugins/Referrers/Columns/Website.php
+++ b/plugins/Referrers/Columns/Website.php
@@ -22,7 +22,7 @@ class Website extends Base
 
     public function shouldForceNewVisit(Request $request, Visitor $visitor, Action $action = null)
     {
-        if (TrackerConfig::getConfigValue('create_new_visit_when_website_referrer_changes', $request->getIdSite()) != 1) {
+        if (TrackerConfig::getConfigValue('create_new_visit_when_website_referrer_changes', $request->getIdSiteIfExists()) != 1) {
             return false;
         }
 

--- a/plugins/Referrers/Columns/Website.php
+++ b/plugins/Referrers/Columns/Website.php
@@ -20,22 +20,9 @@ class Website extends Base
     protected $type = self::TYPE_TEXT;
     protected $nameSingular = 'General_Website';
 
-    /**
-     * Set using the `[Tracker] create_new_visit_when_website_referrer_changes` INI config option.
-     * If true, will force new visits if the referrer website changes.
-     *
-     * @var bool
-     */
-    protected $createNewVisitWhenWebsiteReferrerChanges;
-
-    public function __construct()
-    {
-        $this->createNewVisitWhenWebsiteReferrerChanges = TrackerConfig::getConfigValue('create_new_visit_when_website_referrer_changes') == 1;
-    }
-
     public function shouldForceNewVisit(Request $request, Visitor $visitor, Action $action = null)
     {
-        if (!$this->createNewVisitWhenWebsiteReferrerChanges) {
+        if (TrackerConfig::getConfigValue('create_new_visit_when_website_referrer_changes', $request->getIdSite()) != 1) {
             return false;
         }
 

--- a/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
+++ b/tests/PHPUnit/Unit/Tracker/RequestSetTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Tests\Unit\Tracker;
 
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
 use Piwik\Tracker\Request;
 use Piwik\Tracker\RequestSet;
 
@@ -15,7 +16,7 @@ use Piwik\Tracker\RequestSet;
  * @group RequestSetTest
  * @group Tracker
  */
-class RequestSetTest extends \PHPUnit\Framework\TestCase
+class RequestSetTest extends UnitTestCase
 {
     /**
      * @var TestRequestSet

--- a/tests/PHPUnit/Unit/Tracker/TrackerConfigTest.php
+++ b/tests/PHPUnit/Unit/Tracker/TrackerConfigTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Tests\Unit\Tracker;
+
+use Piwik\Config;
+use Piwik\Tests\Framework\TestCase\UnitTestCase;
+use Piwik\Tracker\TrackerConfig;
+
+class TrackerConfigTest extends UnitTestCase
+{
+    public function test_getConfigValue_returnsTrackerConfigValue_ifNoSiteSpecificValue()
+    {
+        Config::getInstance()->Tracker['setting'] = 1;
+        Config::getInstance()->Tracker_10['setting'] = 0;
+
+        $this->assertEquals(1, TrackerConfig::getConfigValue('setting', 5));
+    }
+
+    public function test_getConfigValue_returnsSiteSpecificConfigValue_ifOneIsSpecified()
+    {
+        Config::getInstance()->Tracker['setting'] = 1;
+        Config::getInstance()->Tracker_10['setting'] = 0;
+
+        $this->assertEquals(0, TrackerConfig::getConfigValue('setting', 10));
+    }
+}


### PR DESCRIPTION
### Description:

This change allows INI config sections like `[Tracker_$idSite]` to be added which will override some Tracker config for individual sites. Config that should be applied overall (or in places where we don't know what the idSite is), cannot be overridden.

### Review

* [x] Functional review done
* [x] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [x] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [x] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] Code review done
* [ ] Tests were added if useful/possible
* [x] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [x] Documentation added if needed
* [x] Existing documentation updated if needed
