### PR TITLE
fix usort() in SQL Profiler

### DIFF
--- a/core/Profiler.php
+++ b/core/Profiler.php
@@ -100,12 +100,18 @@ class Profiler
 
     private static function maxSumMsFirst($a, $b)
     {
-        return $a['sum_time_ms'] < $b['sum_time_ms'];
+        if ($a['sum_time_ms'] == $b['sum_time_ms']) {
+            return 0;
+        }
+        return ($a['sum_time_ms'] < $b['sum_time_ms']) ? -1 : 1;
     }
 
     private static function sortTimeDesc($a, $b)
     {
-        return $a['sumTimeMs'] < $b['sumTimeMs'];
+        if ($a['sumTimeMs'] == $b['sumTimeMs']) {
+            return 0;
+        }
+        return ($a['sumTimeMs'] < $b['sumTimeMs']) ? -1 : 1;
     }
 
     /**


### PR DESCRIPTION
reported in https://forum.matomo.org/t/deprecated-uasort-returning-bool-from-comparison-function-is-deprecated-return-an-integer-less-than-equal-to-or-greater-than-zero-matomo-4-2-1/42125

> core\Profiler.php(80): Deprecated - uasort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero

I didn't test this, but the fix seems obvious from https://www.php.net/manual/en/function.uasort.php

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
