### PR TITLE
In Diagnostics, fix edge case "Warning - trim() expects parameter 1 to be string, array given"

### DIFF
--- a/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
+++ b/plugins/Diagnostics/Diagnostic/RequiredPrivateDirectories.php
@@ -135,11 +135,11 @@ class RequiredPrivateDirectories implements Diagnostic
                     return true;
                 }
 
-                if (trim($response) === $publicIfResponseEquals) {
+                if (trim($response['data']) === $publicIfResponseEquals) {
                     // we assume it is publicly accessible because either the exact expected content is returned or because we don't check for content match
                     $result->addItem(new DiagnosticResultItem(DiagnosticResult::STATUS_ERROR, $testUrl));
                     return true;
-                } elseif (strpos($response, $publicIfResponseContains) !== false) {
+                } elseif (strpos($response['data'], $publicIfResponseContains) !== false) {
                     // we assume it is publicly accessible because a unique content is included in the response or because we don't check for content contains
                     $result->addItem(new DiagnosticResultItem(DiagnosticResult::STATUS_ERROR, $testUrl));
                     return true;


### PR DESCRIPTION
### Description:

As title.

reported in https://forum.matomo.org/t/warning-required-private-directories/42158

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
