### PR TITLE
Fix redirect link not working after plugin activation

### DIFF
--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -9,29 +9,27 @@
 namespace Piwik\Plugins\CorePluginsAdmin;
 
 use Exception;
-use Piwik\Access;
-use Piwik\API\Request;
+use Piwik\API\ResponseBuilder;
+use Piwik\ArchiveProcessor\Rules;
 use Piwik\Common;
-use Piwik\Container\StaticContainer;
-use Piwik\Exception\MissingFilePermissionException;
-use Piwik\Filechecks;
-use Piwik\Filesystem;
-use Piwik\Nonce;
-use Piwik\Notification;
+use Piwik\Config;
+use Piwik\Mail;
+use Piwik\Menu\MenuTop;
 use Piwik\Piwik;
 use Piwik\Plugin;
-use Piwik\Plugins\CorePluginsAdmin\Model\TagManagerTeaser;
-use Piwik\Plugins\Login\PasswordVerifier;
-use Piwik\Plugins\Marketplace\Controller as MarketplaceController;
+use Piwik\Plugin\ControllerAdmin;
+use Piwik\Plugins\CorePluginsAdmin\CorePluginsAdmin;
 use Piwik\Plugins\Marketplace\Marketplace;
-use Piwik\Plugins\Marketplace\Plugins;
-use Piwik\SettingsPiwik;
-use Piwik\SettingsServer;
+use Piwik\Plugins\CustomVariables\CustomVariables;
+use Piwik\Plugins\LanguagesManager\LanguagesManager;
+use Piwik\Plugins\PrivacyManager\DoNotTrackHeaderChecker;
+use Piwik\Plugins\SitesManager\API as APISitesManager;
+use Piwik\Site;
 use Piwik\Translation\Translator;
 use Piwik\Url;
-use Piwik\Version;
 use Piwik\View;
-
+use Piwik\Widget\WidgetsList;
+use Piwik\SettingsPiwik;
 class Controller extends Plugin\ControllerAdmin
 {
     const ACTIVATE_NONCE = 'CorePluginsAdmin.activatePlugin';

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -13,7 +13,6 @@ use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
-use Piwik\ErrorHandler;
 use Piwik\Exception\MissingFilePermissionException;
 use Piwik\Filechecks;
 use Piwik\Filesystem;
@@ -23,10 +22,9 @@ use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Plugins\CorePluginsAdmin\Model\TagManagerTeaser;
 use Piwik\Plugins\Login\PasswordVerifier;
-use Piwik\Plugins\Marketplace\Marketplace;
 use Piwik\Plugins\Marketplace\Controller as MarketplaceController;
+use Piwik\Plugins\Marketplace\Marketplace;
 use Piwik\Plugins\Marketplace\Plugins;
-use Piwik\Settings\Storage\Backend\PluginSettingsTable;
 use Piwik\SettingsPiwik;
 use Piwik\SettingsServer;
 use Piwik\Translation\Translator;
@@ -77,8 +75,8 @@ class Controller extends Plugin\ControllerAdmin
      * @param Plugins $marketplacePlugins
      * @param PasswordVerifier $passwordVerify
      */
-    public function __construct(Translator $translator, 
-                                Plugin\SettingsProvider $settingsProvider, 
+    public function __construct(Translator $translator,
+                                Plugin\SettingsProvider $settingsProvider,
                                 PluginInstaller $pluginInstaller,
                                 PasswordVerifier $passwordVerify,
                                 $marketplacePlugins = null
@@ -350,7 +348,7 @@ class Controller extends Plugin\ControllerAdmin
         if (ob_get_length()) {
             ob_clean();
         }
-        
+
         $this->tryToRepairPiwik();
 
         if (empty($lastError) && defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE) {
@@ -432,7 +430,7 @@ class Controller extends Plugin\ControllerAdmin
             'action' => 'activate',
             'pluginName' => Common::getRequestVar('pluginName'),
             'nonce' => Common::getRequestVar('nonce'),
-            'redirectTo' => Common::getRequestVar('redirectTo'),
+            'redirectTo' => Common::getRequestVar('redirectTo', '', 'string'),
             'referrer' => urlencode(Url::getReferrer()),
         ];
 
@@ -446,7 +444,7 @@ class Controller extends Plugin\ControllerAdmin
 
         if ($redirectAfter) {
             $message = $this->translator->translate('CorePluginsAdmin_SuccessfullyActicated', array($pluginName));
-            
+
             if ($this->settingsProvider->getSystemSettings($pluginName)) {
                 $target   = sprintf('<a href="index.php%s#%s">',
                     Url::getCurrentQueryStringWithParametersModified(array('module' => 'CoreAdminHome', 'action' => 'generalSettings')),
@@ -545,7 +543,7 @@ class Controller extends Plugin\ControllerAdmin
     public function showLicense()
     {
         Piwik::checkUserHasSomeViewAccess();
-        
+
         $pluginName = Common::getRequestVar('pluginName', null, 'string');
 
         if (!Plugin\Manager::getInstance()->isPluginInFilesystem($pluginName)) {

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -9,27 +9,31 @@
 namespace Piwik\Plugins\CorePluginsAdmin;
 
 use Exception;
-use Piwik\API\ResponseBuilder;
-use Piwik\ArchiveProcessor\Rules;
+use Piwik\Access;
+use Piwik\API\Request;
 use Piwik\Common;
-use Piwik\Config;
-use Piwik\Mail;
-use Piwik\Menu\MenuTop;
+use Piwik\Container\StaticContainer;
+use Piwik\ErrorHandler;
+use Piwik\Exception\MissingFilePermissionException;
+use Piwik\Filechecks;
+use Piwik\Filesystem;
+use Piwik\Nonce;
+use Piwik\Notification;
 use Piwik\Piwik;
 use Piwik\Plugin;
-use Piwik\Plugin\ControllerAdmin;
-use Piwik\Plugins\CorePluginsAdmin\CorePluginsAdmin;
+use Piwik\Plugins\CorePluginsAdmin\Model\TagManagerTeaser;
+use Piwik\Plugins\Login\PasswordVerifier;
 use Piwik\Plugins\Marketplace\Marketplace;
-use Piwik\Plugins\CustomVariables\CustomVariables;
-use Piwik\Plugins\LanguagesManager\LanguagesManager;
-use Piwik\Plugins\PrivacyManager\DoNotTrackHeaderChecker;
-use Piwik\Plugins\SitesManager\API as APISitesManager;
-use Piwik\Site;
+use Piwik\Plugins\Marketplace\Controller as MarketplaceController;
+use Piwik\Plugins\Marketplace\Plugins;
+use Piwik\Settings\Storage\Backend\PluginSettingsTable;
+use Piwik\SettingsPiwik;
+use Piwik\SettingsServer;
 use Piwik\Translation\Translator;
 use Piwik\Url;
+use Piwik\Version;
 use Piwik\View;
-use Piwik\Widget\WidgetsList;
-use Piwik\SettingsPiwik;
+
 class Controller extends Plugin\ControllerAdmin
 {
     const ACTIVATE_NONCE = 'CorePluginsAdmin.activatePlugin';


### PR DESCRIPTION
reported in https://forum.matomo.org/t/i-get-an-error-when-i-click-to-activate-the-plugin/42173/2

It turns out unlike the regular "activate plugin" buttons, the ones shown after uploading a plugin zip don't have a `redirectTo` GET parameter set. 

https://github.com/matomo-org/matomo/blob/587cc39e0362719332d410b7a4d5ddcc68788eeb/plugins/CorePluginsAdmin/templates/uploadPlugin.twig#L29

This should not matter as an empty value means redirecting to the plugin or theme list (which is what we want.

https://github.com/matomo-org/matomo/blob/792bc0cfd5bc9365351097e07710f3148f3b3f32/plugins/CorePluginsAdmin/Controller.php#L469-L476

But https://github.com/matomo-org/matomo/pull/17345 added a section that reads the parameters, but forgot to set a default value for `redirectTo` in case it is missing, throwing the error reported on the forum

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
