### PR TITLE
JS Tracker: new setPageViewId function to override the pageviewid and not have it auto generated 

### DIFF
--- a/js/piwik.js
+++ b/js/piwik.js
@@ -63,7 +63,7 @@
     setCustomVariable, getCustomVariable, deleteCustomVariable, storeCustomVariablesInCookie, setCustomDimension, getCustomDimension,
     deleteCustomVariables, deleteCustomDimension, setDownloadExtensions, addDownloadExtensions, removeDownloadExtensions,
     setDomains, setIgnoreClasses, setRequestMethod, setRequestContentType, setGenerationTimeMs,
-    setReferrerUrl, setCustomUrl, setAPIUrl, setDocumentTitle, getPiwikUrl, getMatomoUrl, getCurrentUrl,
+    setReferrerUrl, setCustomUrl, setAPIUrl, setDocumentTitle, setPageViewId, getPiwikUrl, getMatomoUrl, getCurrentUrl,
     setDownloadClasses, setLinkClasses,
     setCampaignNameKey, setCampaignKeywordKey,
     getConsentRequestsQueue, requireConsent, getRememberedConsent, hasRememberedConsent, isConsentRequired,

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -5607,7 +5607,7 @@ if (typeof window.Matomo !== 'object') {
              */
             this.setPageViewId = function (pageView) {
                 configIdPageView = pageView;
-            }
+            };
 
             /**
              * Set the URL of the Matomo API. It is used for Page Overlay.

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -3894,7 +3894,9 @@ if (typeof window.Matomo !== 'object') {
              * Log the page view / visit
              */
             function logPageView(customTitle, customData, callback) {
-                configIdPageView = generateUniqueId();
+                if (!configIdPageView) {
+                    configIdPageView = generateUniqueId();
+                }
 
                 var request = getRequest('action_name=' + encodeWrapper(titleFixup(customTitle || configTitle)), customData, 'log');
 
@@ -5597,6 +5599,15 @@ if (typeof window.Matomo !== 'object') {
             this.setDocumentTitle = function (title) {
                 configTitle = title;
             };
+
+            /**
+             * Override PageView id
+             *
+             * @param string pageView
+             */
+            this.setPageViewId = function (pageView) {
+                configIdPageView = pageView;
+            }
 
             /**
              * Set the URL of the Matomo API. It is used for Page Overlay.

--- a/js/piwik.js
+++ b/js/piwik.js
@@ -2368,6 +2368,8 @@ if (typeof window.Matomo !== 'object') {
                 domainHash,
 
                 configIdPageView,
+                // Boolean indicating that a page view ID has been set manually
+                configIdPageViewSetManually = false,
 
                 // we measure how many pageviews have been tracked so plugins can use it to eg detect if a
                 // pageview was already tracked or not
@@ -3894,7 +3896,7 @@ if (typeof window.Matomo !== 'object') {
              * Log the page view / visit
              */
             function logPageView(customTitle, customData, callback) {
-                if (!configIdPageView) {
+                if (!configIdPageViewSetManually) {
                     configIdPageView = generateUniqueId();
                 }
 
@@ -5607,6 +5609,7 @@ if (typeof window.Matomo !== 'object') {
              */
             this.setPageViewId = function (pageView) {
                 configIdPageView = pageView;
+                configIdPageViewSetManually = true;
             };
 
             /**


### PR DESCRIPTION
### Description:

This Pull Request solves the issue mentioned in the following issue: https://github.com/matomo-org/matomo/issues/16942

It would allow for a combination of the PHP tracker (to track 100% of the PageViews) and the JavaScript tracker (to track screen size, plugins, …) by first generating a page view id on the PHP side and setting it after page generation using JavaScript.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
