### PR TITLE
Ignore invalid capabilities instead of throwing an exception

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -1448,8 +1448,13 @@ class API extends \Piwik\Plugin\API
             if ($this->roleProvider->isValidRole($entry)) {
                 $roles[] = $entry;
             } else {
-                $this->checkAccessType($entry);
-                $capabilities[] = $entry;
+                try {
+                    $this->checkAccessType($entry);
+                    $capabilities[] = $entry;
+                } catch (\Exception $e) {
+                    // if capability does not exist any longer (e.g. removed plugin) an exception might be thrown
+                    // we ignore that capability in that case
+                }
             }
         }
         return [$roles, $capabilities];

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -366,7 +366,7 @@ class API extends \Piwik\Plugin\API
                 return [];
 
             } else {
-                list($users, $totalResults) = $this->model->getUsersWithRole($idSite, $limit, $offset, $filter_search, $filter_access, $loginsToLimit);
+                [$users, $totalResults] = $this->model->getUsersWithRole($idSite, $limit, $offset, $filter_search, $filter_access, $loginsToLimit);
 
                 foreach ($users as &$user) {
                     $user['superuser_access'] = $user['superuser_access'] == 1;
@@ -374,7 +374,7 @@ class API extends \Piwik\Plugin\API
                         $user['role'] = 'superuser';
                         $user['capabilities'] = [];
                     } else {
-                        list($user['role'], $user['capabilities']) = $this->getRoleAndCapabilitiesFromAccess($user['access']);
+                        [$user['role'], $user['capabilities']] = $this->getRoleAndCapabilitiesFromAccess($user['access']);
                         $user['role'] = empty($user['role']) ? 'noaccess' : reset($user['role']);
                     }
 
@@ -592,9 +592,9 @@ class API extends \Piwik\Plugin\API
             }
         }
 
-        list($sites, $totalResults) = $this->model->getSitesAccessFromUserWithFilters($userLogin, $limit, $offset, $filter_search, $filter_access, $idSites);
+        [$sites, $totalResults] = $this->model->getSitesAccessFromUserWithFilters($userLogin, $limit, $offset, $filter_search, $filter_access, $idSites);
         foreach ($sites as &$siteAccess) {
-            list($siteAccess['role'], $siteAccess['capabilities']) = $this->getRoleAndCapabilitiesFromAccess($siteAccess['access']);
+            [$siteAccess['role'], $siteAccess['capabilities']] = $this->getRoleAndCapabilitiesFromAccess($siteAccess['access']);
             $siteAccess['role'] = empty($siteAccess['role']) ? 'noaccess' : reset($siteAccess['role']);
             unset($siteAccess['access']);
         }
@@ -1102,7 +1102,7 @@ class API extends \Piwik\Plugin\API
 
         if (is_array($access)) {
             // we require one role, and optionally multiple capabilities
-            list($roles, $capabilities) = $this->getRoleAndCapabilitiesFromAccess($access);
+            [$roles, $capabilities] = $this->getRoleAndCapabilitiesFromAccess($access);
 
             if (count($roles) < 1) {
                 $ids = implode(', ', $this->roleProvider->getAllRoleIds());
@@ -1175,7 +1175,7 @@ class API extends \Piwik\Plugin\API
             $this->capabilityProvider->checkValidCapability($entry);
         }
 
-        list($sitesIdWithRole, $sitesIdWithCapability) = $this->getRolesAndCapabilitiesForLogin($userLogin);
+        [$sitesIdWithRole, $sitesIdWithCapability] = $this->getRolesAndCapabilitiesForLogin($userLogin);
 
         foreach ($capabilities as $entry) {
             $cap = $this->capabilityProvider->getCapability($entry);

--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -472,7 +472,7 @@ class API extends \Piwik\Plugin\API
 
         foreach ($access as $entry) {
             if (!in_array($entry, $list, true)) {
-                throw new Exception(Piwik::translate("UsersManager_ExceptionAccessValues", implode(", ", $list), $entry));
+                throw new Exception(Piwik::translate("UsersManager_ExceptionAccessValues", [implode(", ", $list), $entry]));
             }
         }
     }


### PR DESCRIPTION
### Description:

When the database contains an access entry with an capability that is no longer present (e.g. TagManager capability, but TagManager gets disabled), the user admin currently does not show any users, but also no error.

The missing error is caused by the incorrect Piwik::translate, which actually triggers a warning. The error itself is caused by the exception thrown when a capability does not exist.

fixes L3-108

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
