### PR TITLE
Ensure redirects from logme method are only done to trusted hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ## Matomo 4.4.0
 
+### Breaking Changes
+
+* The redirect using the `url` param for the automatic login action `logme`, will no longer do redirects to untrusted hosts. If you need to do redirects to other URLs on purpose, please add the according hosts as `trusted_hosts` entry in `config.ini.php`
+
 ### Changes to events
 
 * It is now possible via the Mail.send event to abort sending emails. Set the `$mail` event parameter to null to do this.

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -315,7 +315,7 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
         // only use redirect url if host is trusted
         if (!empty($parsedUrl['host']) && !Url::isValidHost($parsedUrl['host'])) {
-            $e = new \Piwik\Exception\Exception('The redirect URL host is not valid, it is not a trusted host. If this URL is trusted, you can allow this in your config.ini.php file by adding the line <i>trusted_hosts[] = "'.$parsedUrl['host'].'"</i> under <i>[General]</i>');
+            $e = new \Piwik\Exception\Exception('The redirect URL host is not valid, it is not a trusted host. If this URL is trusted, you can allow this in your config.ini.php file by adding the line <i>trusted_hosts[] = "'.Common::sanitizeInputValue($parsedUrl['host']).'"</i> under <i>[General]</i>');
             $e->setIsHtmlMessage();
             throw $e;
         }

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -311,6 +311,15 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
         // remove password reset entry if it exists
         $this->passwordResetter->removePasswordResetInfo($login);
 
+        $parsedUrl = parse_url($urlToRedirect);
+
+        // only use redirect url if host is trusted
+        if (!empty($parsedUrl['host']) && !Url::isValidHost($parsedUrl['host'])) {
+            $e = new \Piwik\Exception\Exception('The redirect URL host is not valid, it is not a trusted host. If this URL is trusted, you can allow this in your config.ini.php file by adding the line <i>trusted_hosts[] = "'.$parsedUrl['host'].'"</i> under <i>[General]</i>');
+            $e->setIsHtmlMessage();
+            throw $e;
+        }
+
         if (empty($urlToRedirect)) {
             $redirect = Common::unsanitizeInputValue(Common::getRequestVar('form_redirect', false));
             $redirectParams = UrlHelper::getArrayFromQueryString(UrlHelper::getQueryFromUrl($redirect));

--- a/plugins/Login/tests/UI/Login_spec.js
+++ b/plugins/Login/tests/UI/Login_spec.js
@@ -34,6 +34,7 @@ describe("Login", function () {
         delete testEnvironment.bruteForceBlockIps;
         delete testEnvironment.bruteForceBlockThisIp;
         delete testEnvironment.queryParamOverride;
+        delete testEnvironment.configOverride.General;
         testEnvironment.save();
 
         await page.clearCookies();
@@ -44,6 +45,7 @@ describe("Login", function () {
         delete testEnvironment.bruteForceBlockIps;
         delete testEnvironment.bruteForceBlockThisIp;
         delete testEnvironment.queryParamOverride;
+        delete testEnvironment.configOverride.General;
         testEnvironment.save();
     });
 
@@ -254,5 +256,26 @@ describe("Login", function () {
         await page.goto(formlessLoginUrl);
 
         expect(await page.screenshot({ fullPage: true })).to.matchImage('bruteforcelog_blockedlogme');
+    });
+
+    it("should show invalid host warning if redirect url is not trusted in logme", async function () {
+        testEnvironment.testUseMockAuth = 0;
+        testEnvironment.save();
+
+        await page.goto(formlessLoginUrl + "&url="+encodeURIComponent("https://www.matomo.org/security"));
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('logme_redirect_invalid');
+    });
+
+    it("should redirect if host is trusted in logme", async function () {
+        testEnvironment.testUseMockAuth = 0;
+        testEnvironment.configOverride.General = {
+            "trusted_hosts": ["matomo.org"]
+        };
+        testEnvironment.save();
+
+        await page.goto(formlessLoginUrl + "&url="+encodeURIComponent("https://matomo.org/security/"));
+
+        expect(await page.getWholeCurrentUrl()).to.equal("https://matomo.org/security/");
     });
 });

--- a/plugins/Login/tests/UI/expected-screenshots/Login_logme_redirect_invalid.png
+++ b/plugins/Login/tests/UI/expected-screenshots/Login_logme_redirect_invalid.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:882e9ee5db5d65cba04c14b34f56058625c631df67d45b1dce3e46ac0231283b
+size 62022


### PR DESCRIPTION
### Description:



### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
