### PR TITLE
Disable logme functionality by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The Product Changelog at **[matomo.org/changelog](https://matomo.org/changelog)*
 
 ### Breaking Changes
 
+* The `logme` method for automatic logins is now disabled by default for new installations. For existing installations it will be enabled automatically on update. If you do not need it please consider disabling it again for security reasons by setting `login_allow_logme = 0` in `General` section of `config.ini.php`.
 * The redirect using the `url` param for the automatic login action `logme`, will no longer do redirects to untrusted hosts. If you need to do redirects to other URLs on purpose, please add the according hosts as `trusted_hosts` entry in `config.ini.php`
 
 ### Changes to events

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -482,6 +482,10 @@ login_allowlist_apply_to_reporting_api_requests = 1
 ; Uncomment the next line to set a URL to redirect the user to after they log out of Matomo.
 ; login_logout_url = http://...
 
+; By default the logme functionality to automatically log in users using url params is disabled
+; You can enable that by setting this to "1". See https://matomo.org/faq/how-to/faq_30/ for more details
+login_allow_logme = 0
+
 ; Set to 1 to disable the framebuster on standard Non-widgets pages (a click-jacking countermeasure).
 ; Default is 0 (i.e., bust frames on all non Widget pages such as Login, API, Widgets, Email reports, etc.).
 enable_framed_pages = 0

--- a/core/Updates/4.4.0-b1.php
+++ b/core/Updates/4.4.0-b1.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Updates;
+
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+/**
+ * Update for version 4.4.0-b1.
+ */
+class Updates_4_4_0_b1 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    public function getMigrations(Updater $updater)
+    {
+        $migrations = [];
+        $migrations[] = $this->migration->config->set('General', 'login_allow_logme', '1');
+        return $migrations;
+    }
+
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+}

--- a/core/Version.php
+++ b/core/Version.php
@@ -20,7 +20,7 @@ final class Version
      * The current Matomo version.
      * @var string
      */
-    const VERSION = '4.3.1';
+    const VERSION = '4.4.0-b1';
     const MAJOR_VERSION = 4;
 
     public function isStableVersion($version)

--- a/plugins/Login/Controller.php
+++ b/plugins/Login/Controller.php
@@ -237,6 +237,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
      */
     function logme()
     {
+        if (Config::getInstance()->General['login_allow_logme'] == 0) {
+            throw new Exception('This functionality has been disabled in config');
+        }
+
         $password = Common::getRequestVar('password', null, 'string');
 
         $login = Common::getRequestVar('login', null, 'string');

--- a/plugins/Login/tests/UI/Login_spec.js
+++ b/plugins/Login/tests/UI/Login_spec.js
@@ -189,9 +189,21 @@ describe("Login", function () {
         await page.waitForSelector('#dashboard');
     });
 
-    it("should login successfully when formless login used", async function() {
+    it("should show error when formless login used, but disabled", async function () {
+        testEnvironment.overrideConfig('General', 'login_allow_logme', '0')
+        testEnvironment.save();
         await page.click("nav .right .icon-sign-out");
         await page.waitForNetworkIdle();
+
+        await page.goto(formlessLoginUrl);
+
+        expect(await page.screenshot({ fullPage: true })).to.matchImage('logme_disabled');
+    });
+
+    it("should login successfully when formless login used", async function() {
+        testEnvironment.overrideConfig('General', 'login_allow_logme', '1')
+        testEnvironment.save();
+        await page.goto("about:blank");
         await page.goto(formlessLoginUrl);
 
         // check dashboard is shown

--- a/plugins/Login/tests/UI/expected-screenshots/Login_logme_disabled.png
+++ b/plugins/Login/tests/UI/expected-screenshots/Login_logme_disabled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f65dfc6e14865782065da6c644112ca2bfa50c16966b42e963a999e4ab97610
+size 41859

--- a/plugins/TwoFactorAuth/tests/UI/TwoFactorAuth_spec.js
+++ b/plugins/TwoFactorAuth/tests/UI/TwoFactorAuth_spec.js
@@ -25,6 +25,9 @@ describe("TwoFactorAuth", function () {
 
     async function loginUser(username, doAuth)
     {
+        testEnvironment.overrideConfig('General', 'login_allow_logme', '1')
+        testEnvironment.save();
+
         // make sure to log out previous session
         await page.goto(logoutUrl);
 
@@ -70,6 +73,7 @@ describe("TwoFactorAuth", function () {
         delete testEnvironment.requireTwoFa;
         delete testEnvironment.restoreRecoveryCodes;
         delete testEnvironment.fakeCorrectAuthCode;
+        delete testEnvironment.configOverride;
         testEnvironment.testUseMockAuth = 1;
         testEnvironment.save();
     });
@@ -106,6 +110,9 @@ describe("TwoFactorAuth", function () {
     });
 
     it('when logging in through logme and verifying screen it works to access ui', async function () {
+        testEnvironment.overrideConfig('General', 'login_allow_logme', '1')
+        testEnvironment.save();
+
         await page.type('.loginTwoFaForm #login_form_authcode', '123456');
         await page.evaluate(function(){
             $('.loginTwoFaForm #login_form_submit').click();

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_diagnostics_configfile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94a7dd514ab0c6706a45db218b9e02294340d35c21d4ce1c54183208c0bcfdbb
-size 4975287
+oid sha256:3a1d75f489ae0fb47ea4c3c23c1b22be612461d7f8cb606a0f6fb0e4e24e4693
+size 4993514


### PR DESCRIPTION
### Description:

Logme functionality will be disabled for new installs by default now. For existing installs an update script should automatically enable it in config to keep bc.

Note: Once this has been merge we need to update the FAQ here https://matomo.org/faq/how-to/faq_30/ and maybe also some other places.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
