### PR TITLE
When using PDO to connect to the database, a failed connection might trigger a PDOException

### DIFF
--- a/core/Tracker.php
+++ b/core/Tracker.php
@@ -223,7 +223,9 @@ class Tracker
             try {
                 self::$db = TrackerDb::connectPiwikTrackerDb();
             } catch (Exception $e) {
-                throw new DbException($e->getMessage(), $e->getCode());
+                $code = $e->getCode();
+                // Note: PDOException might return a string as code, but we can't use this for DbException
+                throw new DbException($e->getMessage(), is_int($code) ? $code : 0);
             }
         }
 


### PR DESCRIPTION
### Description:

When using PDO to connect to the database, a failed connection might trigger a PDOException. Other than the base exception class, the `getCode()` of PDO exception returns a string (like `HY000`). As the php exception class (and DbException, which directly extends php's Exception), requires the code to be an integer, we can't simply use the return value.

fixes L3-109

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
