### PR TITLE
Link to Drupal or WebFlow Matomo FAQ when the website is detected to use it

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -175,6 +175,14 @@ return array(
         return $ipsResolved;
     },
 
+    /**
+     * This defines a list of hostnames Matomo's Http class will deny requests to. Wildcards (*) can be used in the
+     * beginning to match any subdomain level or in the end to match any tlds
+     */
+    'http.blocklist.hosts' => DI\add([
+        '*.amazonaws.com'
+    ]),
+
     'Piwik\Tracker\VisitorRecognizer' => DI\autowire()
         ->constructorParameter('trustCookiesOnly', DI\get('ini.Tracker.trust_visitors_cookies'))
         ->constructorParameter('visitStandardLength', DI\get('ini.Tracker.visit_standard_length'))

--- a/plugins/SitesManager/Controller.php
+++ b/plugins/SitesManager/Controller.php
@@ -12,6 +12,7 @@ use Exception;
 use Piwik\API\Request;
 use Piwik\API\ResponseBuilder;
 use Piwik\Common;
+use Piwik\Container\StaticContainer;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\Piwik;
 use Piwik\Plugin\Manager;
@@ -25,6 +26,7 @@ use Piwik\View;
 use Piwik\Http;
 use Piwik\Plugins\SitesManager\GtmSiteTypeGuesser;
 use Matomo\Cache\Lazy;
+use Psr\Log\LoggerInterface;
 
 /**
  *
@@ -184,6 +186,10 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
                     $response = Http::sendHttpRequest($mainUrl, 5, null, null, 0, false, false, true);
                 }
             } catch (Exception $e) {
+                StaticContainer::get(LoggerInterface::class)->info('Unable to fetch site type for host "{host}": {exception}', [
+                    'host' => $parsedUrl['host'] ?? 'unknown',
+                    'exception' => $e,
+                ]);
             }
 
             $guesser = new GtmSiteTypeGuesser();

--- a/plugins/SitesManager/GtmSiteTypeGuesser.php
+++ b/plugins/SitesManager/GtmSiteTypeGuesser.php
@@ -8,8 +8,6 @@
  */
 namespace Piwik\Plugins\SitesManager;
 
-use Piwik\Plugins\SitesManager\SitesManager;
-
 class GtmSiteTypeGuesser
 {
     public function guessSiteTypeFromResponse($response)
@@ -47,6 +45,22 @@ class GtmSiteTypeGuesser
         $needle = 'content="Microsoft SharePoint';
         if (strpos($response['data'], $needle) !== false) {
             return SitesManager::SITE_TYPE_SHAREPOINT;
+        }
+
+        $needle = '<meta name="Generator" content="Drupal';
+        if (strpos($response['data'], $needle) !== false) {
+            return SitesManager::SITE_TYPE_DRUPAL;
+        }
+
+        // https://github.com/drupal/drupal/blob/9.2.x/core/includes/install.core.inc#L1054
+        // Birthday of Dries Buytaert, the founder of Drupal is on 19 November 1978 - https://en.wikipedia.org/wiki/Drupal
+        if (isset($response['headers']['expires']) && $response['headers']['expires'] === 'Sun, 19 Nov 1978 05:00:00 GMT') {
+            return SitesManager::SITE_TYPE_DRUPAL;
+        }
+
+        $pattern = '/data-wf-(?:domain|page)=/i';
+        if (preg_match($pattern, $response['data']) === 1) {
+            return SitesManager::SITE_TYPE_WEBFLOW;
         }
 
         return SitesManager::SITE_TYPE_UNKNOWN;

--- a/plugins/SitesManager/SitesManager.php
+++ b/plugins/SitesManager/SitesManager.php
@@ -39,6 +39,8 @@ class SitesManager extends \Piwik\Plugin
     const SITE_TYPE_SHAREPOINT = 'sharepoint';
     const SITE_TYPE_JOOMLA = 'joomla';
     const SITE_TYPE_SHOPIFY = 'shopify';
+    const SITE_TYPE_WEBFLOW = 'webflow';
+    const SITE_TYPE_DRUPAL = 'drupal';
 
     /**
      * @see \Piwik\Plugin::registerEvents
@@ -367,6 +369,8 @@ class SitesManager extends \Piwik\Plugin
             self::SITE_TYPE_SQUARESPACE => 'https://matomo.org/faq/new-to-piwik/how-do-i-integrate-matomo-with-squarespace-website',
             self::SITE_TYPE_WIX => 'https://matomo.org/faq/new-to-piwik/how-do-i-install-the-matomo-analytics-tracking-code-on-wix',
             self::SITE_TYPE_WORDPRESS => 'https://matomo.org/faq/new-to-piwik/how-do-i-install-the-matomo-tracking-code-on-wordpress',
+            self::SITE_TYPE_DRUPAL => 'https://matomo.org/faq/new-to-piwik/how-to-integrate-with-drupal/',
+            self::SITE_TYPE_WEBFLOW => 'https://matomo.org/faq/new-to-piwik/how-do-i-install-the-matomo-tracking-code-on-webflow',
         ];
 
         return $map[$siteType] ? $map[$siteType] : false;


### PR DESCRIPTION
### Description:

Besides wordpress and other already detected site types, Matomo will now also detect pages based on Drupal and WebFlow and will automatically link to the correct guide how to integrate Matomo there.

In addition requests to localhost and plane IPs will be avoided for site detection and there is a new DI config for completely blocking certain hosts for requests through Matomo's Http class.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
