### PR TITLE
Ensure login is correctly detected for brute force detection when using logme feature

### DIFF
--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -221,11 +221,12 @@ class Login extends \Piwik\Plugin
         $login = StaticContainer::get(\Piwik\Auth::class)->getLogin();
         if (empty($login) || $login == 'anonymous') {
             $login = Common::getRequestVar('form_login', false);
+            $action = Common::getRequestVar('action', false);
+            if ($action == 'logme') {
+                $login = Common::getRequestVar('login', $login);
+            }
         }
-        $action = Common::getRequestVar('action', false);
-        if ((empty($login) || $login == 'anonymous') && $action == 'logme') {
-            $login = Common::getRequestVar('login', false);
-        }
+
         return $login;
     }
 

--- a/plugins/Login/Login.php
+++ b/plugins/Login/Login.php
@@ -219,10 +219,12 @@ class Login extends \Piwik\Plugin
     private function getUsernameUsedInPasswordLogin()
     {
         $login = StaticContainer::get(\Piwik\Auth::class)->getLogin();
-        if (empty($login)
-            || $login == 'anonymous'
-        ) {
+        if (empty($login) || $login == 'anonymous') {
             $login = Common::getRequestVar('form_login', false);
+        }
+        $action = Common::getRequestVar('action', false);
+        if ((empty($login) || $login == 'anonymous') && $action == 'logme') {
+            $login = Common::getRequestVar('login', false);
         }
         return $login;
     }


### PR DESCRIPTION
### Description:

When using logme feature the brute force detection on login level might not work correctly.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
