### PR TITLE
Fix parameters of UsersManager.addUser.end event

### DIFF
--- a/plugins/UsersManager/API.php
+++ b/plugins/UsersManager/API.php
@@ -745,12 +745,12 @@ class API extends \Piwik\Plugin\API
         $this->model->addUser($userLogin, $passwordTransformed, $email, Date::now()->getDatetime());
 
         $container = StaticContainer::getContainer();
-        $email = $container->make(UserCreatedEmail::class, array(
+        $mail = $container->make(UserCreatedEmail::class, array(
             'login' => Piwik::getCurrentUserLogin(),
             'emailAddress' => Piwik::getCurrentUserEmail(),
             'userLogin' => $userLogin
         ));
-        $email->safeSend();
+        $mail->safeSend();
 
         // we reload the access list which doesn't yet take in consideration this new user
         Access::getInstance()->reloadAccess();


### PR DESCRIPTION
### Description:

The event `UsersManager.addUser.end` used to receive the email address of the newly created user, but now receives an email object.

regression from #17531

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
