### PR TITLE
PHP 8.1 compatibility: fix "Deprecated - glob(): Passing null to parameter #2 ($flags) of type int is deprecated"

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -41,7 +41,7 @@ class Filesystem
         TrackerCache::deleteTrackerCache();
         PiwikCache::flushAll();
         self::clearPhpCaches();
-        
+
         $pluginManager = Plugin\Manager::getInstance();
         $plugins = $pluginManager->getLoadedPlugins();
         foreach ($plugins as $plugin) {
@@ -184,7 +184,7 @@ class Filesystem
      * @return array The list of paths that match the pattern.
      * @api
      */
-    public static function globr($sDir, $sPattern, $nFlags = null)
+    public static function globr($sDir, $sPattern, $nFlags = 0)
     {
         if (($aFiles = \_glob("$sDir/$sPattern", $nFlags)) == false) {
             $aFiles = array();

--- a/tests/PHPUnit/System/CliMultiTest.php
+++ b/tests/PHPUnit/System/CliMultiTest.php
@@ -248,8 +248,8 @@ class CliMultiTest extends SystemTestCase
     {
         $dir = PIWIK_INCLUDE_PATH . '/tmp';
 
-        $files = \_glob($dir . "/*", null);
-        $subFiles = \_glob($dir . "/*/*", null);
+        $files = \_glob($dir . "/*");
+        $subFiles = \_glob($dir . "/*/*");
 
         $files = array_merge($files, $subFiles);
 


### PR DESCRIPTION
refs #17686

fixes
>  WARNING [2021-06-17 21:51:48] 298624 /home/lukas/public_html/matomophp8/libs/upgradephp/upgrade.php(260): Deprecated - glob(): Passing null to parameter #2 ($flags) of type int is deprecated - Matomo 4.0.0-b3 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)

in php 8.1

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
