### PR TITLE
PHP 8.1 compatibility, fix "Warning - foreach() argument must be of type"

### DIFF
--- a/core/Option.php
+++ b/core/Option.php
@@ -181,7 +181,7 @@ class Option
         }
 
         $value = Db::fetchOne('SELECT option_value FROM `' . Common::prefixTable('option') . '` ' .
-                              'WHERE option_name = ?', $name);
+                              'WHERE option_name = ?', [$name]);
 
         $this->all[$name] = $value;
         return $value;


### PR DESCRIPTION
refs #17686

fixes 
> WARNING [2021-06-17 22:11:46] 311625  /home/lukas/public_html/matomophp8/core/Db.php(829): Warning - foreach() argument must be of type array|object, string given - Matomo 4.4.0-b1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)

in php 8.1


I think 
https://github.com/matomo-org/matomo/blob/77f607d49fb632a87c53c3513a2f5fcf7c66a185/core/Tracker/Db/Pdo/Mysql.php#L226-L227

makes sure it worked correctly nevertheless, but the logging of the SQL query doesn't seem to contain such code.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
