### PR TITLE
[PHP 8.1 compatibility] don't pass null to PDOStatement::fetch()

### DIFF
--- a/libs/Zend/Db/Statement/Pdo.php
+++ b/libs/Zend/Db/Statement/Pdo.php
@@ -246,7 +246,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      * @return mixed Array, object, or scalar depending on fetch mode.
      * @throws Zend_Db_Statement_Exception
      */
-    public function fetch($style = \PDO::FETCH_BOTH, $cursor = \PDO::FETCH_ORI_NEXT, $offset = 0)
+    public function fetch($style = null, $cursor = \PDO::FETCH_ORI_NEXT, $offset = 0)
     {
         if ($style === null) {
             $style = $this->_fetchMode;

--- a/libs/Zend/Db/Statement/Pdo.php
+++ b/libs/Zend/Db/Statement/Pdo.php
@@ -246,7 +246,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      * @return mixed Array, object, or scalar depending on fetch mode.
      * @throws Zend_Db_Statement_Exception
      */
-    public function fetch($style = null, $cursor = null, $offset = null)
+    public function fetch($style = \PDO::FETCH_DEFAULT, $cursor = \PDO::FETCH_ORI_NEXT, $offset = 0)
     {
         if ($style === null) {
             $style = $this->_fetchMode;

--- a/libs/Zend/Db/Statement/Pdo.php
+++ b/libs/Zend/Db/Statement/Pdo.php
@@ -246,7 +246,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      * @return mixed Array, object, or scalar depending on fetch mode.
      * @throws Zend_Db_Statement_Exception
      */
-    public function fetch($style = \PDO::FETCH_DEFAULT, $cursor = \PDO::FETCH_ORI_NEXT, $offset = 0)
+    public function fetch($style = \PDO::FETCH_BOTH, $cursor = \PDO::FETCH_ORI_NEXT, $offset = 0)
     {
         if ($style === null) {
             $style = $this->_fetchMode;


### PR DESCRIPTION
refs #17686 

fixes

> WARNING [2021-06-17 22:27:06] 321855  /home/lukas/public_html/matomophp8/libs/Zend/Db/Statement/Pdo.php(257): Deprecated - PDOStatement::fetch(): Passing null to parameter #2 ($cursorOrientation) of type int is deprecated - Matomo 4.4.0-b1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)
> WARNING [2021-06-17 22:28:30] 322336  /home/lukas/public_html/matomophp8/libs/Zend/Db/Statement/Pdo.php(257): Deprecated - PDOStatement::fetch(): Passing null to parameter #3 ($cursorOffset) of type int is deprecated - Matomo 4.4.0-b1 - Please report this message in the Matomo forums: https://forum.matomo.org (please do a search first as it might have been reported already)

in php 8.1

defaults were taken from https://www.php.net/manual/de/pdostatement.fetch.php (the style one didn't output an error, but I changed it nevertheless)

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
