### PR TITLE
PHP 8.1 compatibility, fix "Deprecated - explode(): Passing null to parameter"

### DIFF
--- a/core/Site.php
+++ b/core/Site.php
@@ -422,6 +422,10 @@ class Site
      */
     public static function getIdSitesFromIdSitesString($ids, $_restrictSitesToLogin = false)
     {
+        if (empty($ids)) {
+            return [];
+        }
+
         if ($ids === 'all') {
             return API::getInstance()->getSitesIdWithAtLeastViewAccess($_restrictSitesToLogin);
         }

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -56,8 +56,12 @@ class CoreArchiver extends ConsoleCommand
         $archiveFilter->setForceReport($input->getOption('force-report'));
 
         $segmentIds = $input->getOption('force-idsegments');
-        $segmentIds = explode(',', $segmentIds);
-        $segmentIds = array_map('trim', $segmentIds);
+        if (!empty($segmentIds)) {
+            $segmentIds = explode(',', $segmentIds);
+            $segmentIds = array_map('trim', $segmentIds);
+        } else {
+            $segmentIds = [];
+        }
         $archiveFilter->setSegmentsToForceFromSegmentIds($segmentIds);
 
         $archiver->setArchiveFilter($archiveFilter);


### PR DESCRIPTION
see https://github.com/matomo-org/matomo/issues/17686

`$ids` can be null because of

https://github.com/matomo-org/matomo/blob/1fcc10569378263775a1f8a3e2429406da9423ce/plugins/CoreConsole/Commands/CoreArchiver.php#L44

https://github.com/matomo-org/matomo/blob/1fcc10569378263775a1f8a3e2429406da9423ce/plugins/CoreConsole/Commands/CoreArchiver.php#L68-L71

when no command line arg is passed.

I'm not completely sure if this is the correct fix, but it seems reasonable to me.

Also changed a similar case with `$segmentIds`. 

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
