### PR TITLE
Fix issue "Call to a member function getMainUrl() on null" in permission checks in siteWithoutData method

### DIFF
--- a/plugins/SitesManager/Controller.php
+++ b/plugins/SitesManager/Controller.php
@@ -128,16 +128,11 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
 
     public function siteWithoutData()
     {
+        $this->checkSitePermission();
+
         $javascriptGenerator = new TrackerCodeGenerator();
         $javascriptGenerator->forceMatomoEndpoint();
         $piwikUrl = Url::getCurrentUrlWithoutFileName();
-
-        if (!$this->site && Piwik::hasUserSuperUserAccess()) {
-            throw new UnexpectedWebsiteFoundException('Invalid site ' . $this->idSite);
-        } elseif (!$this->site) {
-            // redirect to login form
-            Piwik::checkUserHasViewAccess($this->idSite);
-        }
 
         $jsTag = Request::processRequest('SitesManager.getJavascriptTag', array('idSite' => $this->idSite, 'piwikUrl' => $piwikUrl));
 
@@ -169,6 +164,8 @@ class Controller extends \Piwik\Plugin\ControllerAdmin
     }
 
     public function siteWithoutDataTabs() {
+        $this->checkSitePermission();
+
         $mainUrl = $this->site->getMainUrl();
         $typeCacheId = 'guessedtype_' . md5($mainUrl);
         $gtmCacheId = 'guessedgtm_' . md5($mainUrl);


### PR DESCRIPTION
### Description:

fixes L3-112

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
