### PR TITLE
Stronger condition to check NFS

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -152,6 +152,7 @@ class Filesystem
             // check if filesystem is NFS
             if ($returnCode == 0
                 && count($output) > 1
+                && preg_match('/\bnfs\d?\b/', implode("\n", $output))
             ) {
                 return true;
             }
@@ -161,9 +162,11 @@ class Filesystem
             $output = @shell_exec($command);
             if ($output) {
                 $commandFailed = (false !== strpos($output, "no file systems processed"));
-                $output = explode("\n", trim($output));
+                $output = trim($output);
+                $outputArray = explode("\n", $output);
                 if (!$commandFailed
-                    && count($output) > 1) {
+                    && count($outputArray) > 1
+                    && preg_match('/\bnfs\d?\b/', $output)) {
                     // check if filesystem is NFS
                     return true;
                 }


### PR DESCRIPTION
### Description:

Issue: #12217 - in the system check page, filesystems like btrfs subvolumes are wrongly recognised as NFS.

NFS filesystems are identified as 'nfs' or 'nfs4' by `df -T`, so the added condition tests the existence of `' nfs'`.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
