### PR TITLE
Add info about custom segments in archiving setting

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -16,6 +16,7 @@
         "Apply": "Apply",
         "ArchivingInlineHelp": "For medium to high traffic websites, it is recommended to disable Matomo archiving to trigger from the browser. Instead, we recommend that you setup a cron job to process Matomo reports every hour.",
         "ArchivingTriggerDescription": "Recommended for larger Matomo installs, you need to %1$ssetup a cron job%2$s to process the reports automatically.",
+        "ArchivingTriggerSegment": "Using Custom Segments will still trigger processing of archives.",
         "AuthenticationMethodSmtp": "Authentication method for SMTP",
         "AverageOrderValue": "Average Order Value",
         "AveragePrice": "Average Price",

--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -299,6 +299,7 @@ class Controller extends ControllerAdmin
         $view->todayArchiveTimeToLive = $todayArchiveTimeToLive;
         $view->todayArchiveTimeToLiveDefault = Rules::getTodayArchiveTimeToLiveDefault();
         $view->enableBrowserTriggerArchiving = $enableBrowserTriggerArchiving;
+        $view->showSegmentArchiveTriggerInfo = !((bool) Config::getInstance()->General['browser_archiving_disabled_enforce']);
 
         $mail = Config::getInstance()->mail;
         $mail['noreply_email_address'] = Config::getInstance()->General['noreply_email_address'];

--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -299,7 +299,7 @@ class Controller extends ControllerAdmin
         $view->todayArchiveTimeToLive = $todayArchiveTimeToLive;
         $view->todayArchiveTimeToLiveDefault = Rules::getTodayArchiveTimeToLiveDefault();
         $view->enableBrowserTriggerArchiving = $enableBrowserTriggerArchiving;
-        $view->showSegmentArchiveTriggerInfo = !((bool) Config::getInstance()->General['browser_archiving_disabled_enforce']);
+        $view->showSegmentArchiveTriggerInfo = Rules::isBrowserArchivingAvailableForSegments();
 
         $mail = Config::getInstance()->mail;
         $mail['noreply_email_address'] = Config::getInstance()->General['noreply_email_address'];

--- a/plugins/CoreAdminHome/templates/generalSettings.twig
+++ b/plugins/CoreAdminHome/templates/generalSettings.twig
@@ -33,7 +33,10 @@
                                name="enableBrowserTriggerArchiving"
                                 {% if enableBrowserTriggerArchiving==0 %} checked="checked"{% endif %} />
                         <span>{{ 'General_No'|translate }}</span>
-                        <span class="form-description">{{ 'General_ArchivingTriggerDescription'|translate("<a target='_blank' rel='noreferrer noopener' href='https://matomo.org/docs/setup-auto-archiving/'>","</a>")|raw }}</span>
+                        <span class="form-description">
+                            {{ 'General_ArchivingTriggerDescription'|translate("<a target='_blank' rel='noreferrer noopener' href='https://matomo.org/docs/setup-auto-archiving/'>","</a>")|raw }}
+                            {% if showSegmentArchiveTriggerInfo %}{{ 'General_ArchivingTriggerSegment'|translate }}{% endif %}
+                        </span>
                     </label>
                     </p>
                 </div><div class="col s12 m6">

--- a/tests/UI/expected-screenshots/UIIntegrationTest_admin_settings_general.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_admin_settings_general.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c4f737256e9aee194958114171bcfff3218a0db611d21afb4c52f7ce15c6fbd
-size 1340640
+oid sha256:567c7311d8ffca9cc94a58f98fec294cdbe21fca6fc405f01e9f4668fb3ed5da
+size 1344697


### PR DESCRIPTION
… triggered archiving will not prevent processing of archives when Custom Segments are used, if config browser_archiving_disabled_enforce=0

### Description:

Fixes #17479 

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
