### PR TITLE
Use team mention for github stale actions

### DIFF
--- a/.github/workflows/follow-up-reviews.yml
+++ b/.github/workflows/follow-up-reviews.yml
@@ -16,5 +16,5 @@ jobs:
           only-pr-labels: Needs Review
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          stale-pr-message: This issue is in "needs review" but there has been no activity for 7 days. ping @tsteur @justinvelluppillai @sgiehl @diosmosis
+          stale-pr-message: This issue is in "needs review" but there has been no activity for 7 days. ping @matomo-org/core-reviewers
           stale-pr-label: Stale

--- a/.github/workflows/inactive-prs-closing-message.yaml
+++ b/.github/workflows/inactive-prs-closing-message.yaml
@@ -16,5 +16,5 @@ jobs:
           days-before-issue-stale: -1
           days-before-issue-close: -1
           exempt-pr-labels: Do not close
-          stale-pr-message: This PR was last updated more than one month ago, maybe it's time to close it. Please check if there is anything we still can do or close this PR. ping @tsteur @justinvelluppillai @sgiehl @diosmosis
+          stale-pr-message: This PR was last updated more than one month ago, maybe it's time to close it. Please check if there is anything we still can do or close this PR. ping @matomo-org/core-reviewers
           stale-pr-label: Stale for long


### PR DESCRIPTION
### Description:

use @matomo-org/core-reviewers to make it easier to update the list of mentioned people

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
