### PR TITLE
for AWS Aurora users and when using a DB Reader: new INI setting to enable aurora read replica read committed for fixing purge lag performance issue

### DIFF
--- a/core/Db.php
+++ b/core/Db.php
@@ -184,6 +184,10 @@ class Db
 
         $db = @Adapter::factory($dbConfig['adapter'], $dbConfig);
 
+        if (!empty($dbConfig['aurora_readonly_read_committed'])) {
+            $db->exec('set session aurora_read_replica_read_committed = ON;set session transaction isolation level read committed;');
+        }
+
         self::$readerConnection = $db;
     }
 


### PR DESCRIPTION
### Description:

Allows enabling aurora read replica read committed

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
