### PR TITLE
Multisite links to reports now pass token_auth

### DIFF
--- a/plugins/MultiSites/angularjs/site/site.controller.js
+++ b/plugins/MultiSites/angularjs/site/site.controller.js
@@ -13,6 +13,7 @@
 
         $scope.period = piwik.period;
         $scope.date   = piwik.broadcast.getValueFromUrl('date');
+        $scope.dashboardUrl = dashboardUrl;
         $scope.sparklineImage = sparklineImage;
         $scope.website.label  = piwik.helper.htmlDecode($scope.website.label);
 
@@ -20,13 +21,16 @@
             return $scope.website;
         };
 
-        function sparklineImage(website){
-            var append = '';
+        function tokenParam() {
             var token_auth = piwik.broadcast.getValueFromUrl('token_auth');
-            if (token_auth.length) {
-                append = '&token_auth=' + token_auth;
-            }
+            return token_auth.length ? '&token_auth=' + token_auth : '';
+        }
 
+        function dashboardUrl(website){
+            return piwik.piwik_url + 'index.php?module=CoreHome&action=index&date=' + $scope.date + '&period=' + $scope.period + '&idSite=' + website.idsite + tokenParam();
+        }
+
+        function sparklineImage(website){
             var metric = $scope.metric;
 
             switch ($scope.evolutionMetric) {
@@ -41,7 +45,7 @@
                     break;
             }
 
-            return piwik.piwik_url + 'index.php?module=MultiSites&action=getEvolutionGraph&period=' + $scope.period + '&date=' + $scope.dateSparkline + '&evolutionBy=' + metric + '&columns=' + metric + '&idSite=' + website.idsite + '&idsite=' + website.idsite + '&viewDataTable=sparkline' + append + '&colors=' + encodeURIComponent(JSON.stringify(piwik.getSparklineColors()));
+            return piwik.piwik_url + 'index.php?module=MultiSites&action=getEvolutionGraph&period=' + $scope.period + '&date=' + $scope.dateSparkline + '&evolutionBy=' + metric + '&columns=' + metric + '&idSite=' + website.idsite + '&idsite=' + website.idsite + '&viewDataTable=sparkline' + tokenParam() + '&colors=' + encodeURIComponent(JSON.stringify(piwik.getSparklineColors()));
         }
     }
 })();

--- a/plugins/MultiSites/angularjs/site/site.directive.html
+++ b/plugins/MultiSites/angularjs/site/site.directive.html
@@ -1,6 +1,6 @@
 <tr ng-class="{'groupedWebsite': website.group, 'website': !website.group, 'group': website.isGroup}">
     <td ng-if="!website.isGroup" class="multisites-label label">
-        <a title="View reports" ng-href="index.php?module=CoreHome&action=index&date={{ date }}&period={{ period }}&idSite={{ website.idsite }}" class="value truncated-text-line">{{ website.label }}</a>
+        <a title="View reports" ng-href="{{ dashboardUrl(website) }}" class="value truncated-text-line">{{ website.label }}</a>
 
         <span>
             <a rel="noreferrer noopener" target="_blank" title="{{ 'General_GoTo'|translate:website.main_url }}" ng-href="{{ website.main_url }}">
@@ -30,7 +30,7 @@
 
     <td ng-if="showSparklines" style="width:180px;">
         <div ng-if="!website.isGroup" class="sparkline" style="width: 100px; margin: auto;">
-            <a rel="noreferrer noopener" target="_blank" ng-href="index.php?module=CoreHome&action=index&date={{ date }}&period={{ period }}&idSite={{ website.idsite }}"
+            <a rel="noreferrer noopener" target="_blank" ng-href="{{ dashboardUrl(website) }}"
                title="{{ 'General_GoTo'|translate:('Dashboard_DashboardOf'|translate:website.label) }}">
                 <img alt="" ng-src="{{ sparklineImage(website) }}" width="100" height="25" />
             </a>


### PR DESCRIPTION


### Description:

Fixes #17001 

Pass token_auth parameter so embedded widget links log user in to their matomo dashboard when they click to view full reports.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
