### PR TITLE
Add possiblity to open sites manager and directly edit a specific site using URL parameter

### DIFF
--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
@@ -41,10 +41,9 @@
                 } else {
                     $scope.currentType = {name: $scope.site.type};
                 }
-                var search = String(window.location.search);
-                var searchParams = piwik.helper.getArrayFromQueryString(search);
-                if (searchParams.editsiteid
-                    && $scope.site.idsite == searchParams.editsiteid) {
+
+                var forcedEditSiteId = sitesManagerTypeModel.getEditSiteIdParameter();
+                if (forcedEditSiteId && $scope.site.idsite == forcedEditSiteId) {
                     editSite();
                 }
             });
@@ -165,6 +164,8 @@
                         }
                     });
                 });
+
+                sitesManagerTypeModel.removeEditSiteIdParameterFromHash();
             });
         };
 

--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager-site.controller.js
@@ -41,6 +41,12 @@
                 } else {
                     $scope.currentType = {name: $scope.site.type};
                 }
+                var search = String(window.location.search);
+                var searchParams = piwik.helper.getArrayFromQueryString(search);
+                if (searchParams.editsiteid
+                    && $scope.site.idsite == searchParams.editsiteid) {
+                    editSite();
+                }
             });
         };
 

--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager-type-model.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager-type-model.js
@@ -14,10 +14,23 @@
             typesById: {},
             fetchTypeById: fetchTypeById,
             fetchAvailableTypes: fetchAvailableTypes,
-            hasMultipleTypes: hasMultipleTypes
+            hasMultipleTypes: hasMultipleTypes,
+            removeEditSiteIdParameterFromHash: removeEditSiteIdParameterFromHash,
+            getEditSiteIdParameter: getEditSiteIdParameter
         };
 
         return model;
+
+        function getEditSiteIdParameter() {
+            var search = String(window.location.hash).substr('#/'.length);
+            var searchParams = piwik.helper.getArrayFromQueryString(search);
+            if (searchParams.editsiteid && $.isNumeric(searchParams.editsiteid)) {
+                return searchParams.editsiteid;
+            }
+        }
+        function removeEditSiteIdParameterFromHash() {
+            window.location.hash = window.location.hash.replace(/editsiteid=\d+/g, '');
+        }
 
         function hasMultipleTypes(typeId)
         {

--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
@@ -104,11 +104,12 @@
             var search = String(window.location.search);
             var searchParams = piwik.helper.getArrayFromQueryString(search);
 
+            var forcedEditSiteId = sitesManagerTypeModel.getEditSiteIdParameter();
 
             if(searchParams.showaddsite == 1) {
                 addNewEntity();
-            } else if(searchParams.editsiteid && $.isNumeric(searchParams.editsiteid)) {
-                adminSites.search = parseInt(searchParams.editsiteid, 10);
+            } else if(forcedEditSiteId) {
+                adminSites.search = parseInt(forcedEditSiteId, 10);
                 adminSites.searchSite(adminSites.search);
             }
         };
@@ -238,6 +239,7 @@
                     siteElement[0].scrollIntoView();
                 }
             }
+            sitesManagerTypeModel.removeEditSiteIdParameterFromHash();
         };
 
         var lookupCurrentEditSite = function () {

--- a/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
+++ b/plugins/SitesManager/angularjs/sites-manager/sites-manager.controller.js
@@ -102,9 +102,15 @@
 
         var triggerAddSiteIfRequested = function() {
             var search = String(window.location.search);
+            var searchParams = piwik.helper.getArrayFromQueryString(search);
 
-            if(piwik.helper.getArrayFromQueryString(search).showaddsite == 1)
+
+            if(searchParams.showaddsite == 1) {
                 addNewEntity();
+            } else if(searchParams.editsiteid && $.isNumeric(searchParams.editsiteid)) {
+                adminSites.search = parseInt(searchParams.editsiteid, 10);
+                adminSites.searchSite(adminSites.search);
+            }
         };
 
         var initUtcTime = function() {

--- a/plugins/SitesManager/tests/UI/SitesManager_spec.js
+++ b/plugins/SitesManager/tests/UI/SitesManager_spec.js
@@ -91,6 +91,9 @@ describe("SitesManager", function () {
     it("should be able to open and edit a site directly based on url parameter", async function() {
         await assertScreenshotEquals("site_edit_url", async function () {
             await page.goto(url + '#/editsiteid=23');
+            await page.evaluate(function () {
+                $('.form-help:contains(UTC time is)').hide();
+            });
         });
     });
 });

--- a/plugins/SitesManager/tests/UI/SitesManager_spec.js
+++ b/plugins/SitesManager/tests/UI/SitesManager_spec.js
@@ -87,4 +87,10 @@ describe("SitesManager", function () {
             });
         });
     });
+
+    it("should be able to open and edit a site directly based on url parameter", async function() {
+        await assertScreenshotEquals("site_edit_url", async function () {
+            await page.goto(url + '&editsiteid=23');
+        });
+    });
 });

--- a/plugins/SitesManager/tests/UI/SitesManager_spec.js
+++ b/plugins/SitesManager/tests/UI/SitesManager_spec.js
@@ -90,7 +90,7 @@ describe("SitesManager", function () {
 
     it("should be able to open and edit a site directly based on url parameter", async function() {
         await assertScreenshotEquals("site_edit_url", async function () {
-            await page.goto(url + '&editsiteid=23');
+            await page.goto(url + '#/editsiteid=23');
         });
     });
 });

--- a/plugins/SitesManager/tests/UI/expected-screenshots/SitesManager_site_edit_url.png
+++ b/plugins/SitesManager/tests/UI/expected-screenshots/SitesManager_site_edit_url.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:50d7a50082c5a2ad047e97d32d262f5d86eaa5d304fbd91b6fc7aab6eb7053de
-size 344677
+oid sha256:3e0350c0722f80f1f34f543e33983ef1b76f2e94f762b66564b325de0ace4340
+size 331773

--- a/plugins/SitesManager/tests/UI/expected-screenshots/SitesManager_site_edit_url.png
+++ b/plugins/SitesManager/tests/UI/expected-screenshots/SitesManager_site_edit_url.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe784923227434261405f87a84c4bdd260d7c94ea5f817636bb19fa458da3b34
-size 380063
+oid sha256:50d7a50082c5a2ad047e97d32d262f5d86eaa5d304fbd91b6fc7aab6eb7053de
+size 344677

--- a/plugins/SitesManager/tests/UI/expected-screenshots/SitesManager_site_edit_url.png
+++ b/plugins/SitesManager/tests/UI/expected-screenshots/SitesManager_site_edit_url.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe784923227434261405f87a84c4bdd260d7c94ea5f817636bb19fa458da3b34
+size 380063


### PR DESCRIPTION
### Description:

Needed for some plugin. Adding `&editsiteid=\d+` should open the specified site directly. There may be edge cases where multiple sites match a searched number maybe but that be edge case as it likely would be only an issue if > 10 sites matched the specified number. Basically, the URL parameter triggers a search for that number / idsite and the site will be opened directly.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
