### PR TITLE
Make anchor links on Admin General Settings page work

### DIFF
--- a/plugins/CoreHome/angularjs/anchorLinkFix.js
+++ b/plugins/CoreHome/angularjs/anchorLinkFix.js
@@ -112,4 +112,12 @@
     handleScrollToAnchorAfterPageLoad();
     $(handleScrollToAnchorIfPresentOnPageLoad);
 
+    window.anchorLinkFix = {
+        scrollToAnchorInUrl: function () {
+            // may be called when page is only fully loaded after some additional requests
+            // timeout needed to ensure angular rendered fully
+            var $timeout = piwikHelper.getAngularDependency('$timeout');
+            $timeout(handleScrollToAnchorIfPresentOnPageLoad);
+        }
+    };
 })();

--- a/plugins/CorePluginsAdmin/angularjs/plugin-settings/plugin-settings.controller.js
+++ b/plugins/CorePluginsAdmin/angularjs/plugin-settings/plugin-settings.controller.js
@@ -28,6 +28,8 @@
         piwikApi.fetch({method: apiMethod}).then(function (settings) {
             self.isLoading = false;
             self.settingsPerPlugin = settings;
+
+            window.anchorLinkFix.scrollToAnchorInUrl();
         }, function () {
             self.isLoading = false;
         });


### PR DESCRIPTION
### Description:

Currently, links with anchors mostly don't work when linking to a different URL. That's because often the page is loaded async and it's unknown to the system when it's fully loaded. Therefore it is impossible to for example deep link to a specific system setting like https://mydomain/index.php?module=CoreAdminHome&action=generalSettings&editsiteid=5&period=day&date=yesterday&idSite=1#/HeatmapSessionRecording

This logic would make it work to make use of anchor links on the general settings page. There might be a generic solution to it but it's very tricky because the system can never really know whether it should/needs to wait for more requests to finish or whether some more might be coming etc. In many cases using again the `globalAjaxQueue` could work though instead as soon as there are 0 requests active after the load event then trigger this method. Such a solution may be quite tricky though as might then need to factor in whether user maybe already started scrolling etc. Could create a new issue to fix this properly maybe?

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
