### PR TITLE
Fix few bugs in sparklines visualisation when there is no row

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/Sparklines.php
+++ b/plugins/CoreVisualizations/Visualizations/Sparklines.php
@@ -122,7 +122,11 @@ class Sparklines extends ViewDataTable
         }
 
         $firstRow = $data->getFirstRow();
-        $comparisons = $firstRow->getComparisons();
+        if ($firstRow) {
+            $comparisons = $firstRow->getComparisons();
+        } else {
+            $comparisons = null;
+        }
 
         $originalDate = Common::getRequestVar('date');
         $originalPeriod = Common::getRequestVar('period');
@@ -257,7 +261,7 @@ class Sparklines extends ViewDataTable
         $table->applyQueuedFilters();
     }
 
-    private function getValuesAndDescriptions(DataTable\Row $firstRow, $columns, $evolutionColumnNameSuffix = null)
+    private function getValuesAndDescriptions($firstRow, $columns, $evolutionColumnNameSuffix = null)
     {
         if (!is_array($columns)) {
             $columns = array($columns);
@@ -270,7 +274,10 @@ class Sparklines extends ViewDataTable
         $evolutions = [];
 
         foreach ($columns as $col) {
-            $value = $firstRow->getColumn($col);
+            $value = 0;
+            if ($firstRow) {
+                $value = $firstRow->getColumn($col);
+            }
 
             if ($value === false) {
                 $value = 0;

--- a/tests/UI/expected-screenshots/UIIntegrationTest_exampleui_sparklines_no_matching_row.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_exampleui_sparklines_no_matching_row.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e4f11eca27076f917f3b528d2cc8c716a3811ac05a9b44a8cd44195296f86d1
+size 20108

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -672,6 +672,14 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
             pageWrap = await page.$('.pageWrap');
             expect(await pageWrap.screenshot()).to.matchImage('exampleui_treemap');
         });
+
+        it('should load sparklines view correctly even when there is no matching row', async function () {
+            await page.goto('?forceView=1&viewDataTable=sparklines&module=ExampleUI&action=getTemperaturesEvolution&label=example32323.matomo.org'+generalParams+'&segment=&showtitle=1');
+            await page.waitForNetworkIdle();
+
+            pageWrap = await page.$('body');
+            expect(await pageWrap.screenshot()).to.matchImage('exampleui_sparklines_no_matching_row');
+        });
     });
 
     describe("WidgetizePages", function () {

--- a/tests/UI/specs/UIIntegration_spec.js
+++ b/tests/UI/specs/UIIntegration_spec.js
@@ -674,7 +674,7 @@ describe("UIIntegrationTest", function () { // TODO: Rename to Piwik?
         });
 
         it('should load sparklines view correctly even when there is no matching row', async function () {
-            await page.goto('?forceView=1&viewDataTable=sparklines&module=ExampleUI&action=getTemperaturesEvolution&label=example32323.matomo.org'+generalParams+'&segment=&showtitle=1');
+            await page.goto('?forceView=1&viewDataTable=sparklines&module=ExampleUI&action=getTemperaturesEvolution&label=example32323.matomo.org&'+generalParams+'&segment=&showtitle=1');
             await page.waitForNetworkIdle();
 
             pageWrap = await page.$('body');


### PR DESCRIPTION
### Description:

Fixes two issues for sparklines visualisation when no row is found. Seems so far we did not have this use case in core:

First error:

* `Call to a member function getComparisons() on bool in plugins/CoreVisualizations/Visualizations/Sparklines.php line 125`
* `Call to a member function getColumn() on bool in plugins/CoreVisualizations/Visualizations/Sparklines.php line 275`

Before:
![image](https://user-images.githubusercontent.com/273120/123884838-43c65c00-d9a0-11eb-8b1b-41b17a28ea16.png)

After:
![image](https://user-images.githubusercontent.com/273120/123884820-3ad58a80-d9a0-11eb-8f70-2c4a433c48d4.png)

You can reproduce this for example using such a URL:

* /index.php?forceView=1&viewDataTable=sparklines&module=ExampleUI&action=getTemperaturesEvolution&label=example32323.matomo.org&idSite=1&period=month&date=2021-06-17&segment=&showtitle=1&random=7773&widget=1

![image](https://user-images.githubusercontent.com/273120/123885836-62c5ed80-d9a2-11eb-9c2b-f709cdf08d3f.png)

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
