### PR TITLE
Fix preselection in site selector form fields

### DIFF
--- a/plugins/CoreHome/angularjs/siteselector/siteselector.directive.js
+++ b/plugins/CoreHome/angularjs/siteselector/siteselector.directive.js
@@ -65,10 +65,6 @@
                 }
 
                 return function (scope, element, attrs, ngModel) {
-                    if (attrs.siteid && attrs.sitename) {
-                        scope.selectedSite = {id: attrs.siteid, name: attrs.sitename};
-                    }
-
                     scope.model.onlySitesWithAdminAccess = scope.onlySitesWithAdminAccess;
 
                     if (ngModel) {
@@ -103,6 +99,10 @@
                     });
 
                     $timeout(function () {
+                        if (attrs.siteid && attrs.sitename) {
+                            scope.selectedSite = {id: attrs.siteid, name: piwik.helper.htmlDecode(attrs.sitename)};
+                        }
+
                         initTopControls();
                     });
                 };

--- a/plugins/CorePluginsAdmin/angularjs/form-field/field-site.html
+++ b/plugins/CorePluginsAdmin/angularjs/form-field/field-site.html
@@ -3,6 +3,8 @@
     <div piwik-siteselector
          class="sites_autocomplete"
          ng-model="formField.value"
+         siteid="{{ formField.value.id }}"
+         sitename="{{ formField.value.name }}"
          id="{{ formField.name }}"
          show-all-sites-item="formField.uiControlAttributes.showAllSitesItem || false"
          switch-site-on-select="false"


### PR DESCRIPTION
### Description:

Currently the selected site (form field value) is not correctly passed to the site selector field, resulting in a selection of the default site.

fixes https://github.com/matomo-org/plugin-CustomAlerts/issues/53

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
