### PR TITLE
Matomo application logs can now be written in syslog and errorlog

### DIFF
--- a/plugins/Monolog/config/config.php
+++ b/plugins/Monolog/config/config.php
@@ -17,6 +17,8 @@ return array(
         'file'     => 'Piwik\Plugins\Monolog\Handler\FileHandler',
         'screen'   => 'Piwik\Plugins\Monolog\Handler\WebNotificationHandler',
         'database' => 'Piwik\Plugins\Monolog\Handler\DatabaseHandler',
+        'syslog' => 'Piwik\Plugins\Monolog\Handler\SyslogHandler',
+        'errorlog' => 'Piwik\Plugins\Monolog\Handler\ErrorLogHandler',
     ),
     'log.handlers' => DI\factory(function (\DI\Container $c) {
         if ($c->has('ini.log.log_writers')) {
@@ -98,6 +100,14 @@ return array(
         ->constructor(DI\get('log.file.filename'), DI\get('log.level.file'))
         ->method('setFormatter', DI\get('log.lineMessageFormatter.file')),
 
+    'Piwik\Plugins\Monolog\Handler\SyslogHandler' => DI\create()
+        ->constructor('matomo', null, DI\get('log.level.syslog'))
+        ->method('setFormatter', DI\get('log.lineMessageFormatter.file')),
+
+    'Piwik\Plugins\Monolog\Handler\ErrorLogHandler' => DI\create()
+        ->constructor(null, DI\get('log.level.errorlog'))
+        ->method('setFormatter', DI\get('log.lineMessageFormatter.file')),
+
     'Piwik\Plugins\Monolog\Handler\DatabaseHandler' => DI\create()
         ->constructor(DI\get('log.level.database'))
         ->method('setFormatter', DI\get('log.lineMessageFormatter')),
@@ -140,6 +150,26 @@ return array(
     'log.level.database' => DI\factory(function (ContainerInterface $c) {
         if ($c->has('ini.log.log_level_database')) {
             $level = Log::getMonologLevelIfValid($c->get('ini.log.log_level_database'));
+            if ($level !== null) {
+                return $level;
+            }
+        }
+        return $c->get('log.level');
+    }),
+
+    'log.level.syslog' => DI\factory(function (ContainerInterface $c) {
+        if ($c->has('ini.log.log_level_syslog')) {
+            $level = Log::getMonologLevelIfValid($c->get('ini.log.log_level_syslog'));
+            if ($level !== null) {
+                return $level;
+            }
+        }
+        return $c->get('log.level');
+    }),
+
+    'log.level.errorlog' => DI\factory(function (ContainerInterface $c) {
+        if ($c->has('ini.log.log_level_errorlog')) {
+            $level = Log::getMonologLevelIfValid($c->get('ini.log.log_level_errorlog'));
             if ($level !== null) {
                 return $level;
             }


### PR DESCRIPTION
Issue #9400

### Description:

Add log handlers syslog and errorlog

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
