### PR TITLE
provide console command for version information (#17755)

### DIFF
--- a/plugins/CoreAdminHome/Commands/VersionInfo.php
+++ b/plugins/CoreAdminHome/Commands/VersionInfo.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\CoreAdminHome\Commands;
+
+use Piwik\Plugin\ConsoleCommand;
+use Piwik\Version;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class VersionInfo extends ConsoleCommand
+{
+    protected function configure()
+    {
+        $this->setName('core:version');
+        $this->setDescription('Returns the current version information of this Matomo instance.');
+        $this->setHelp("This command can be used to set get the version information of the current Matomo instance.");
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln(Version::VERSION);
+    }
+}


### PR DESCRIPTION
### Description:

Adds a new console command core:version which outputs only the bare version information (#17755).


### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
