### PR TITLE
if a failed login attempt comes from an API request, mark it as from the API in the brute force log

### DIFF
--- a/plugins/Login/Security/BruteForceDetection.php
+++ b/plugins/Login/Security/BruteForceDetection.php
@@ -8,6 +8,7 @@
  */
 namespace Piwik\Plugins\Login\Security;
 
+use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Date;
@@ -16,6 +17,7 @@ use Piwik\Option;
 use Piwik\Plugins\Login\Emails\SuspiciousLoginAttemptsInLastHourEmail;
 use Piwik\Plugins\Login\Model;
 use Piwik\Plugins\Login\SystemSettings;
+use Piwik\SettingsServer;
 use Piwik\Updater;
 use Piwik\Version;
 use Psr\Log\LoggerInterface;
@@ -24,6 +26,7 @@ class BruteForceDetection {
 
     const OVERALL_LOGIN_LOCKOUT_THRESHOLD_MIN = 10;
     const TABLE_NAME = 'brute_force_log';
+    const API_LOGIN_PLACEHOLDER = '__API__';
 
     private $minutesTimeRange;
     private $maxLogAttempts;
@@ -68,6 +71,10 @@ class BruteForceDetection {
 
     public function addFailedAttempt($ipAddress, $login = null)
     {
+        if (empty($login) && Request::isRootRequestApiRequest()) {
+            $login = self::API_LOGIN_PLACEHOLDER;
+        }
+
         $now = $this->getNow()->getDatetime();
         $db = Db::get();
         try {


### PR DESCRIPTION
### Description:

For debugging purposes it could be helpful to see what entries are from API requests (as opposed to login requests and tracker API requests).

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
