### PR TITLE
check plugin exists in the filesystem on plugin activate command

### DIFF
--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1185,10 +1185,6 @@ class Manager
             return $this->loadedPlugins[$pluginName];
         }
 
-        if (!$this->isPluginInFilesystem($pluginName)) {
-            throw new \Exception("Plugin $pluginName does not exist.");
-        }
-
         $newPlugin = $this->makePluginClass($pluginName);
 
         $this->addLoadedPlugin($pluginName, $newPlugin);

--- a/core/Plugin/Manager.php
+++ b/core/Plugin/Manager.php
@@ -1184,6 +1184,11 @@ class Manager
         if (isset($this->loadedPlugins[$pluginName])) {
             return $this->loadedPlugins[$pluginName];
         }
+
+        if (!$this->isPluginInFilesystem($pluginName)) {
+            throw new \Exception("Plugin $pluginName does not exist.");
+        }
+
         $newPlugin = $this->makePluginClass($pluginName);
 
         $this->addLoadedPlugin($pluginName, $newPlugin);

--- a/plugins/CorePluginsAdmin/Commands/ActivatePlugin.php
+++ b/plugins/CorePluginsAdmin/Commands/ActivatePlugin.php
@@ -38,6 +38,11 @@ class ActivatePlugin extends ConsoleCommand
                 continue;
             }
 
+            if (!$pluginManager->isPluginInFilesystem($plugin)) {
+                $output->writeln("<error>Cannot find plugin files for $plugin.</error>");
+                continue;
+            }
+
             if ($dependencies = $pluginManager->loadPlugin($plugin)->getMissingDependenciesAsString()) {
                 $output->writeln("<error>$dependencies</error>");
                 continue;

--- a/plugins/CorePluginsAdmin/Commands/DeactivatePlugin.php
+++ b/plugins/CorePluginsAdmin/Commands/DeactivatePlugin.php
@@ -38,6 +38,11 @@ class DeactivatePlugin extends ConsoleCommand
                 continue;
             }
 
+            if (!$pluginManager->isPluginInFilesystem($plugin)) {
+                $output->writeln("<error>Cannot find plugin files for $plugin.</error>");
+                continue;
+            }
+
             $pluginManager->deactivatePlugin($plugin);
 
             $output->writeln("Deactivated plugin <info>$plugin</info>");

--- a/plugins/CorePluginsAdmin/Commands/DeactivatePlugin.php
+++ b/plugins/CorePluginsAdmin/Commands/DeactivatePlugin.php
@@ -38,11 +38,6 @@ class DeactivatePlugin extends ConsoleCommand
                 continue;
             }
 
-            if (!$pluginManager->isPluginInFilesystem($plugin)) {
-                $output->writeln("<error>Cannot find plugin files for $plugin.</error>");
-                continue;
-            }
-
             $pluginManager->deactivatePlugin($plugin);
 
             $output->writeln("Deactivated plugin <info>$plugin</info>");


### PR DESCRIPTION
### Description:

If a plugin doesn't have a Plugin class, the plugin manager just uses `new Plugin($pluginName)`. Calling `getMissingDependencies()` immediately after triggers the plugin install code path, which adds the nonexistent plugin to the INI config. Now we check and provide a clear error message in the commands, and make sure we only try to load plugins that exist in the filesystem.

Fixes #17770

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
