### PR TITLE
do not try and set mysqli ssl option through mysqli_options since it is set later via mysqli_ssl_set

### DIFF
--- a/libs/Zend/Db/Adapter/Mysqli.php
+++ b/libs/Zend/Db/Adapter/Mysqli.php
@@ -313,6 +313,7 @@ class Zend_Db_Adapter_Mysqli extends Zend_Db_Adapter_Abstract
                 if(array_key_exists($option, $ssl_options)) {
                     $ssl_options[$option] = $value;
                     $enable_ssl = true;
+                    continue; // these options are set below in mysqli_ssl_set
                 } elseif(is_string($option)) {
                     // Suppress warnings here
                     // Ignore it if it's not a valid constant


### PR DESCRIPTION
### Description:

Fixes #17782

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
