### PR TITLE
Make error messages not leak potentially sensitive information when db connection fails

### DIFF
--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -9,6 +9,7 @@
 namespace Piwik\Db;
 
 use Zend_Db_Table;
+use Piwik\Piwik;
 
 /**
  */
@@ -145,8 +146,8 @@ class Adapter
     {
         $safeMessageMap = array(
             // add any exception search terms and their replacement message here
-            'MySQL server has gone away'    => 'Database server has gone away',
-            'Access denied'                 => 'Database access denied'
+            'MySQL server has gone away'    => Piwik::translate('General_ExceptionDatabaseUnavailable'),
+            'Access denied'                 => Piwik::translate('General_ExceptionDatabaseAccess')
         );
 
         foreach ($safeMessageMap as $search_term => $safeMessage) {

--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -57,14 +57,12 @@ class Adapter
                 $adapter->resetConfig();
             } catch(\Exception $e) {
                 // we don't want certain exceptions to leak information
-                $msg = self::safeExceptionMessage($e->getMessage());
-
-                if ($msg !== $e->getMessage()) {
+                $msg = self::overriddenExceptionMessage($e->getMessage());
+                if ('' !== $msg) {
                     throw new \Exception($msg);
                 }
 
                 throw $e;
-
             }
         }
 
@@ -148,7 +146,7 @@ class Adapter
      * @param string $message
      * @return string
      */
-    public static function safeExceptionMessage($message)
+    public static function overriddenExceptionMessage($message)
     {
         $safeMessageMap = array(
             // add any exception search terms and their replacement message here
@@ -164,6 +162,6 @@ class Adapter
             }
         }
 
-        return $message;
+        return '';
     }
 }

--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -56,9 +56,15 @@ class Adapter
                 // we don't want the connection information to appear in the logs
                 $adapter->resetConfig();
             } catch(\Exception $e) {
-                // we don't want the exception to leak information
+                // we don't want certain exceptions to leak information
                 $msg = self::safeExceptionMessage($e->getMessage());
-                throw new \Exception($msg);
+
+                if ($msg !== $e->getMessage()) {
+                    throw new \Exception($msg);
+                }
+
+                throw $e;
+
             }
         }
 
@@ -146,10 +152,10 @@ class Adapter
     {
         $safeMessageMap = array(
             // add any exception search terms and their replacement message here
-            'MySQL server has gone away'    => Piwik::translate('General_ExceptionDatabaseUnavailable'),
             '[2006]'                        => Piwik::translate('General_ExceptionDatabaseUnavailable'),
-            'Access denied'                 => Piwik::translate('General_ExceptionDatabaseAccess'),
-            '[1698]'                        => Piwik::translate('General_ExceptionDatabaseAccess')
+            'MySQL server has gone away'    => Piwik::translate('General_ExceptionDatabaseUnavailable'),
+            '[1698]'                        => Piwik::translate('General_ExceptionDatabaseAccess'),
+            'Access denied'                 => Piwik::translate('General_ExceptionDatabaseAccess')
         );
 
         foreach ($safeMessageMap as $search_term => $safeMessage) {

--- a/core/Db/Adapter.php
+++ b/core/Db/Adapter.php
@@ -147,7 +147,9 @@ class Adapter
         $safeMessageMap = array(
             // add any exception search terms and their replacement message here
             'MySQL server has gone away'    => Piwik::translate('General_ExceptionDatabaseUnavailable'),
-            'Access denied'                 => Piwik::translate('General_ExceptionDatabaseAccess')
+            '[2006]'                        => Piwik::translate('General_ExceptionDatabaseUnavailable'),
+            'Access denied'                 => Piwik::translate('General_ExceptionDatabaseAccess'),
+            '[1698]'                        => Piwik::translate('General_ExceptionDatabaseAccess')
         );
 
         foreach ($safeMessageMap as $search_term => $safeMessage) {

--- a/lang/en.json
+++ b/lang/en.json
@@ -177,6 +177,8 @@
         "ExceptionDatabaseVersion": "Your %1$s version is %2$s but Matomo requires at least %3$s.",
         "ExceptionDatabaseVersionNewerThanCodebase": "Your Matomo codebase is running the old version %1$s and we have detected that your Matomo Database has already been upgraded to the newer version %2$s.",
         "ExceptionDatabaseVersionNewerThanCodebaseWait": "Maybe your Matomo administrators are currently finishing the upgrade process. Please try again in a few minutes.",
+        "ExceptionDatabaseUnavailable": "Database server has gone away",
+        "ExceptionDatabaseAccess": "Database access denied",
         "ExceptionFileIntegrity": "Integrity check failed: %s",
         "ExceptionFilesizeMismatch": "File size mismatch: %1$s (expected length: %2$s, found: %3$s)",
         "ExceptionIncompatibleClientServerVersions": "Your %1$s client version is %2$s which is incompatible with server version %3$s.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -177,7 +177,7 @@
         "ExceptionDatabaseVersion": "Your %1$s version is %2$s but Matomo requires at least %3$s.",
         "ExceptionDatabaseVersionNewerThanCodebase": "Your Matomo codebase is running the old version %1$s and we have detected that your Matomo Database has already been upgraded to the newer version %2$s.",
         "ExceptionDatabaseVersionNewerThanCodebaseWait": "Maybe your Matomo administrators are currently finishing the upgrade process. Please try again in a few minutes.",
-        "ExceptionDatabaseUnavailable": "Database server has gone away",
+        "ExceptionDatabaseUnavailable": "MySQL server has gone away",
         "ExceptionDatabaseAccess": "Database access denied",
         "ExceptionFileIntegrity": "Integrity check failed: %s",
         "ExceptionFilesizeMismatch": "File size mismatch: %1$s (expected length: %2$s, found: %3$s)",

--- a/plugins/Installation/tests/System/APITest.php
+++ b/plugins/Installation/tests/System/APITest.php
@@ -47,7 +47,7 @@ class APITest extends SystemTestCase
         $data = str_replace("\n", "", $response['data']);
 
         $this->assertStringStartsWith('<?xml version="1.0" encoding="utf-8" ?><result>	<error message=', $data);
-        self::assertStringContainsString('Access denied', $data);
+        self::assertStringContainsString('Database access denied', $data);
         $this->assertStringEndsWith('</result>', $data);
     }
 
@@ -58,7 +58,7 @@ class APITest extends SystemTestCase
         $data = str_replace("\n", "", $response['data']);
 
         $this->assertStringStartsWith('{"result":"error","message":"', $data);
-        self::assertStringContainsString('Access denied', $data);
+        self::assertStringContainsString('Database access denied', $data);
     }
 
     public function test_shouldReturnEmptyResultWhenNotInstalledAndDispatchIsDisabled()

--- a/tests/PHPUnit/Unit/Tracker/CacheTest.php
+++ b/tests/PHPUnit/Unit/Tracker/CacheTest.php
@@ -54,7 +54,7 @@ class CacheTest extends UnitTestCase
     public function provideContainerConfig()
     {
         $mockLazyCache = $this->getMockBuilder(Lazy::class)
-            ->onlyMethods(['flushAll', 'delete'])
+            ->onlyMethods(['flushAll', 'fetch', 'save', 'delete'])
             ->disableOriginalConstructor()
             ->getMock();
         $mockLazyCache
@@ -64,6 +64,12 @@ class CacheTest extends UnitTestCase
         $mockLazyCache->method('delete')->willReturnCallback(function ($key) {
                 $this->methodsCalled[] = 'delete.' . $key;
             });
+        $mockLazyCache->method('save')->willReturnCallback(function ($id, $data) {
+            $this->methodsCalled[] = 'save.' . $id . $data;
+        });
+        $mockLazyCache->method('fetch')->willReturnCallback(function ($id) {
+            $this->methodsCalled[] = 'fetch.' . $id;
+        });
 
         return [
             Lazy::class => $mockLazyCache,

--- a/tests/UI/expected-screenshots/UIIntegrationTest_db_connect_error.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_db_connect_error.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c66b67f954aaa21a5ef577189220cd2018e210cdbbda219a9af0adae1698634
-size 75052
+oid sha256:67b00cbec9103edce15aee9ba01ff977f285063434b5d9f6dba66efc0fb407e5
+size 62482


### PR DESCRIPTION
### Description:

Improve DB connection issue messages and provide framework for later improvements if any.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
