### PR TITLE
When reading IP address, do not ignore remote_addr if reading the last ip in proxy header lists

### DIFF
--- a/core/IP.php
+++ b/core/IP.php
@@ -78,9 +78,11 @@ class IP
             $proxyIps = array();
         }
 
-        $proxyIps[] = $default;
-
         $shouldReadLastProxyIp = Config::getInstance()->General['proxy_ip_read_last_in_list'] == 1;
+
+        if (!$shouldReadLastProxyIp) {
+            $proxyIps[] = $default;
+        }
 
         // examine proxy headers
         foreach ($proxyHeaders as $proxyHeader) {

--- a/tests/PHPUnit/Unit/IPTest.php
+++ b/tests/PHPUnit/Unit/IPTest.php
@@ -18,6 +18,18 @@ use Piwik\IP;
  */
 class IPTest extends \PHPUnit\Framework\TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::getInstance()->General['proxy_ip_read_last_in_list'] = 0;
+    }
+
+    protected function tearDown(): void
+    {
+        Config::getInstance()->General['proxy_ip_read_last_in_list'] = 0;
+        parent::tearDown();
+    }
+
     /**
      * Dataprovider for long2ip test
      */
@@ -92,6 +104,16 @@ class IPTest extends \PHPUnit\Framework\TestCase
         Config::getInstance()->General['proxy_client_headers'] = array($test[2]);
         Config::getInstance()->General['proxy_ips'] = array($test[3]);
         $this->assertEquals($test[4], IP::getIpFromHeader(), $description);
+    }
+
+    public function testGetIpFromHeader_DoesNotIgnoreRemoteAddr_ifReadingFromLast()
+    {
+        $_SERVER['REMOTE_ADDR'] = '234.50.50.23';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '192.32.45.66,234.50.50.23,90.09.12.34';
+        Config::getInstance()->General['proxy_client_headers'] = array('HTTP_X_FORWARDED_FOR');
+        Config::getInstance()->General['proxy_ips'] = array('90.09.12.34');
+        Config::getInstance()->General['proxy_ip_read_last_in_list'] = 1;
+        $this->assertEquals('234.50.50.23', IP::getIpFromHeader());
     }
 
     /**


### PR DESCRIPTION
### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
