### PR TITLE
Temporarily let update test fail directly to avoid aborted tests on PHP7.4 and above

### DIFF
--- a/plugins/CoreUpdater/tests/Integration/Commands/UpdateTest.php
+++ b/plugins/CoreUpdater/tests/Integration/Commands/UpdateTest.php
@@ -102,6 +102,8 @@ class UpdateTest extends ConsoleCommandTestCase
 
     public function test_UpdateCommand_ReturnsCorrectExitCode_WhenErrorOccurs()
     {
+        $this->fail('This test currently lets PHPUnit fatal completely. Please investigate!');
+
         // create a blob table, then drop it manually so update 2.10.0-b10 will fail
         $tableName = ArchiveTableCreator::getBlobTable(Date::factory('2015-01-01'));
         Db::exec("DROP TABLE $tableName");


### PR DESCRIPTION
till someone has some time to work on #17721 
