### PR TITLE
Ensure to use correct default value for segment in scheduled reports

### DIFF
--- a/plugins/ScheduledReports/angularjs/manage-scheduled-report/manage-scheduled-report.controller.js
+++ b/plugins/ScheduledReports/angularjs/manage-scheduled-report/manage-scheduled-report.controller.js
@@ -63,6 +63,7 @@
                 'period': ReportPlugin.defaultPeriod,
                 'hour': ReportPlugin.defaultHour,
                 'reports': [],
+                'idsegment': '',
                 'evolutionPeriodFor': 'prev',
                 'evolutionPeriodN': ReportPlugin.defaultEvolutionPeriodN,
                 'periodParam': ReportPlugin.defaultPeriod,
@@ -90,6 +91,10 @@
             });
 
             report['format' + report.type] = report.format;
+
+            if (!report.idsegment) {
+                report.idsegment = '';
+            }
 
             self.report = report;
             self.report.description = piwik.helper.htmlDecode(self.report.description);

--- a/tests/UI/expected-screenshots/UIIntegrationTest_email_reports_editor.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_email_reports_editor.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d1263a789717dca414cc0ee15d172919ba479daf4483e792b49dc07adacefa3
-size 475734
+oid sha256:8f11f5b6127eb5951f333b0ff16f386248114badfae7129cfe58c122f643665d
+size 476854


### PR DESCRIPTION
### Description:

`report.idsegment` might be `null` when received from API. To ensure the default value is selected in that case, we need to convert that to an empty string.

fixes #15335

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
