### PR TITLE
Set proper permissions for github actions

### DIFF
--- a/.github/workflows/buildtrackerjs.yml
+++ b/.github/workflows/buildtrackerjs.yml
@@ -4,6 +4,18 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  actions: read
+  checks: none
+  contents: write
+  deployments: none
+  issues: read
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildtrackerjs.yml
+++ b/.github/workflows/buildtrackerjs.yml
@@ -56,6 +56,8 @@ jobs:
         java-version: 9
       if: steps.vars.outputs.branch != ''
     - uses: actions/checkout@v2
+      permissions:
+        contents: read
       with:
         ref: ${{ steps.vars.outputs.branch }}
         lfs: false

--- a/.github/workflows/buildtrackerjs.yml
+++ b/.github/workflows/buildtrackerjs.yml
@@ -50,6 +50,8 @@ jobs:
         echo ::set-output name=branch::$REF
       if: github.event.comment.body == 'build js'
     - uses: actions/setup-java@v1
+      permissions:
+        contents: none
       with:
         java-version: 9
       if: steps.vars.outputs.branch != ''

--- a/.github/workflows/follow-up-reviews.yml
+++ b/.github/workflows/follow-up-reviews.yml
@@ -3,6 +3,18 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  actions: read
+  checks: none
+  contents: read
+  deployments: none
+  issues: write
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/inactive-prs-closing-message.yaml
+++ b/.github/workflows/inactive-prs-closing-message.yaml
@@ -3,6 +3,18 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  actions: read
+  checks: none
+  contents: read
+  deployments: none
+  issues: write
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/inactive-prs.yaml
+++ b/.github/workflows/inactive-prs.yaml
@@ -3,6 +3,18 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  actions: read
+  checks: none
+  contents: read
+  deployments: none
+  issues: write
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: composer install --dev --prefer-dist --no-progress --no-suggest
       - name: PHPCS check
-        uses: chekalsky/phpcs-action@v1
+        uses: chekalsky/phpcs-action@e269c2f264f400adcda7c6b24c8550302350d495
         with:
           phpcs_bin_path: './vendor/bin/phpcs'
           enable_warnings: true

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -2,6 +2,18 @@ name: PHPCS check
 
 on: pull_request
 
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  deployments: none
+  issues: read
+  packages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: read
+
 jobs:
   phpcs:
     name: PHPCS

--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -5,6 +5,18 @@ on:
   schedule:
   - cron: "0 2 * * 5"
 
+permissions:
+  actions: read
+  checks: none
+  contents: write
+  deployments: none
+  issues: read
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build:
 

--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      permissions:
+        contents: read
       with:
         ref: '4.x-dev'
         lfs: false

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -40,6 +40,8 @@ jobs:
       with:
         php-version: '7.3'
     - uses: actions/checkout@v2
+      permissions:
+        contents: read
       with:
         ref: '4.x-dev'
         lfs: false

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -35,6 +35,8 @@ jobs:
 
     steps:
     - uses: shivammathur/setup-php@v2
+      permissions:
+        contents: none
       with:
         php-version: '7.3'
     - uses: actions/checkout@v2

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -34,7 +34,7 @@ jobs:
 
 
     steps:
-    - uses: shivammathur/setup-php@v2
+    - uses: shivammathur/setup-php@36cb9fb0fccf887130d6c5a3d40a3b3479310026
       permissions:
         contents: none
       with:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -5,6 +5,18 @@ on:
   schedule:
   - cron: "0 2 * * 6"
 
+permissions:
+  actions: read
+  checks: none
+  contents: write
+  deployments: none
+  issues: read
+  packages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   build:
 


### PR DESCRIPTION
### Description:

Actually I'm not totally sure if the changes might be to restrictive or if we could restrict some actions a bit more. Maybe write access to pull requests/issues would not be needed, if only commits are added and no comments. 

Note: Setting permissions to `none` would actually not be needed, as that's the default as soon as another permission is set. I left them in, so it's clear which permissions are available and set.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
