### PR TITLE
Deprecate passing null to non-nullable arguments of internal functions

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -160,7 +160,7 @@ class Access
         $forceApiSessionPost = Common::getRequestVar('force_api_session', 0, 'int', $_POST);
         $forceApiSessionGet = Common::getRequestVar('force_api_session', 0, 'int', $_GET);
         $isApiRequest = Piwik::getModule() === 'API' && (Piwik::getAction() === 'index' || !Piwik::getAction());
-        $apiMethod = Request::getMethodIfApiRequest(null);
+        $apiMethod = Request::getMethodIfApiRequest(null) ?? '';
         $isGetApiRequest = 1 === substr_count($apiMethod, '.') && strpos($apiMethod, '.get') > 0;
 
         if (($forceApiSessionPost && $isApiRequest) || ($forceApiSessionGet && $isApiRequest && $isGetApiRequest)) {


### PR DESCRIPTION
Issue #17686 Deprecate passing null to non-nullable arguments of internal functions

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
