### PR TITLE
limit the size of product reports

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -567,6 +567,12 @@ datatable_archiving_maximum_rows_events = 500
 ; maximum number of rows for sub-tables of the Events tables (eg. for the subtables Categories>Actions or Categories>Names).
 datatable_archiving_maximum_rows_subtable_events = 500
 
+; maximum number of rows for sub-tables of the Products reports
+datatable_archiving_maximum_rows_products = 500
+
+; maximum number of rows for sub-tables of the Products reports
+datatable_archiving_maximum_rows_subtable_products = 500
+
 ; maximum number of rows for other tables (Providers, User settings configurations)
 datatable_archiving_maximum_rows_standard = 500
 

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -567,11 +567,8 @@ datatable_archiving_maximum_rows_events = 500
 ; maximum number of rows for sub-tables of the Events tables (eg. for the subtables Categories>Actions or Categories>Names).
 datatable_archiving_maximum_rows_subtable_events = 500
 
-; maximum number of rows for sub-tables of the Products reports
-datatable_archiving_maximum_rows_products = 500
-
-; maximum number of rows for sub-tables of the Products reports
-datatable_archiving_maximum_rows_subtable_products = 500
+; maximum number of rows for the Products reports
+datatable_archiving_maximum_rows_products = 10000
 
 ; maximum number of rows for other tables (Providers, User settings configurations)
 datatable_archiving_maximum_rows_standard = 500

--- a/plugins/Goals/Archiver.php
+++ b/plugins/Goals/Archiver.php
@@ -9,6 +9,9 @@
 
 namespace Piwik\Plugins\Goals;
 
+use Piwik\ArchiveProcessor;
+use Piwik\Common;
+use Piwik\Config;
 use Piwik\DataAccess\LogAggregator;
 use Piwik\DataArray;
 use Piwik\DataTable;
@@ -93,6 +96,25 @@ class Archiver extends \Piwik\Plugin\Archiver
      * @var DataArray[][]
      */
     protected $itemReports = [];
+
+    /**
+     * @var int
+     */
+    private $productReportsMaximumRows;
+
+    /**
+     * @var int
+     */
+    private $productReportsMaximumRowsForSubtables;
+
+    public function __construct(ArchiveProcessor $processor)
+    {
+        parent::__construct($processor);
+
+        $general = Config::getInstance()->General;
+        $this->productReportsMaximumRows = $general['datatable_archiving_maximum_rows_products'];
+        $this->productReportsMaximumRowsForSubtables = $general['datatable_archiving_maximum_rows_subtable_products'];
+    }
 
     public function aggregateDayReport()
     {
@@ -284,7 +306,11 @@ class Archiver extends \Piwik\Plugin\Archiver
                     $recordName = self::getItemRecordNameAbandonedCart($recordName);
                 }
                 $table = $itemAggregate->asDataTable();
-                $this->getProcessor()->insertBlobRecord($recordName, $table->getSerialized());
+                $blobData = $table->getSerialized($this->productReportsMaximumRows, $this->productReportsMaximumRowsForSubtables,
+                    Metrics::INDEX_ECOMMERCE_ITEM_REVENUE);
+                $this->getProcessor()->insertBlobRecord($recordName, $blobData);
+
+                Common::destroy($table);
             }
         }
     }

--- a/plugins/Goals/Archiver.php
+++ b/plugins/Goals/Archiver.php
@@ -102,18 +102,12 @@ class Archiver extends \Piwik\Plugin\Archiver
      */
     private $productReportsMaximumRows;
 
-    /**
-     * @var int
-     */
-    private $productReportsMaximumRowsForSubtables;
-
     public function __construct(ArchiveProcessor $processor)
     {
         parent::__construct($processor);
 
         $general = Config::getInstance()->General;
         $this->productReportsMaximumRows = $general['datatable_archiving_maximum_rows_products'];
-        $this->productReportsMaximumRowsForSubtables = $general['datatable_archiving_maximum_rows_subtable_products'];
     }
 
     public function aggregateDayReport()
@@ -306,7 +300,7 @@ class Archiver extends \Piwik\Plugin\Archiver
                     $recordName = self::getItemRecordNameAbandonedCart($recordName);
                 }
                 $table = $itemAggregate->asDataTable();
-                $blobData = $table->getSerialized($this->productReportsMaximumRows, $this->productReportsMaximumRowsForSubtables,
+                $blobData = $table->getSerialized($this->productReportsMaximumRows, $this->productReportsMaximumRows,
                     Metrics::INDEX_ECOMMERCE_ITEM_REVENUE);
                 $this->getProcessor()->insertBlobRecord($recordName, $blobData);
 

--- a/plugins/Goals/Archiver.php
+++ b/plugins/Goals/Archiver.php
@@ -448,9 +448,9 @@ class Archiver extends \Piwik\Plugin\Archiver
         $columnsAggregationOperation = null;
 
         $this->getProcessor()->aggregateDataTableRecords($dataTableToSum,
-            $maximumRowsInDataTableLevelZero = null,
-            $maximumRowsInSubDataTable = null,
-            $columnToSortByBeforeTruncation = null,
+            $maximumRowsInDataTableLevelZero = $this->productReportsMaximumRows,
+            $maximumRowsInSubDataTable = $this->productReportsMaximumRows,
+            $columnToSortByBeforeTruncation = Metrics::INDEX_ECOMMERCE_ITEM_REVENUE,
             $columnsAggregationOperation,
             $columnsToRenameAfterAggregation = null,
             $countRowsRecursive = array());


### PR DESCRIPTION
### Description:

Applying row limits to product reports as we do to most other reports. This PR does not include the use of ranking query, just two new INI config options to limit the report sizes.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
