### PR TITLE
make sure summary rows are serialized with their in-db subtable ID and not in memory one

### DIFF
--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1345,7 +1345,23 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
         // we then serialize the rows and store them in the serialized dataTable
         $rows = array();
-        foreach ($this->getRows() as $id => $row) {
+        foreach ($this->rows as $id => $row) {
+            if (isset($consecutiveSubtableIds[$id])) {
+                $backup = $row->subtableId;
+                $row->subtableId = $consecutiveSubtableIds[$id];
+                $rows[$id] = $row->export();
+                $row->subtableId = $backup;
+            } else {
+                $rows[$id] = $row->export();
+            }
+        }
+
+        if (isset($this->summaryRow)) {
+            $id = self::ID_SUMMARY_ROW;
+            $row = $this->summaryRow;
+
+            // duplicating code above so we don't create a new array w/ getRows() above in this function which is
+            // used heavily in matomo.
             if (isset($consecutiveSubtableIds[$id])) {
                 $backup = $row->subtableId;
                 $row->subtableId = $consecutiveSubtableIds[$id];

--- a/core/DataTable.php
+++ b/core/DataTable.php
@@ -1345,7 +1345,7 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
 
         // we then serialize the rows and store them in the serialized dataTable
         $rows = array();
-        foreach ($this->rows as $id => $row) {
+        foreach ($this->getRows() as $id => $row) {
             if (isset($consecutiveSubtableIds[$id])) {
                 $backup = $row->subtableId;
                 $row->subtableId = $consecutiveSubtableIds[$id];
@@ -1354,10 +1354,6 @@ class DataTable implements DataTableInterface, \IteratorAggregate, \ArrayAccess
             } else {
                 $rows[$id] = $row->export();
             }
-        }
-
-        if (isset($this->summaryRow)) {
-            $rows[self::ID_SUMMARY_ROW] = $this->summaryRow->export();
         }
 
         if (!empty($metadata)) {

--- a/tests/PHPUnit/Unit/DataTableTest.php
+++ b/tests/PHPUnit/Unit/DataTableTest.php
@@ -471,6 +471,15 @@ class DataTableTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(2, $results);
         $this->assertStringContainsString('dimval1', $results[0]);
         $this->assertStringContainsString('subtabledimension', $results[1]);
+
+        $tableUnserialized = DataTable::fromSerializedArray($results[0]);
+        $this->assertEquals(1, $tableUnserialized->getSummaryRow()->getIdSubDataTable());
+
+        $expectedResults = [
+            'a:2:{i:0;a:3:{i:0;a:2:{s:5:"label";s:7:"dimval1";s:6:"visits";i:245;}i:1;a:0:{}i:3;N;}i:-1;a:3:{i:0;a:2:{s:5:"label";s:6:"others";s:6:"visits";i:500;}i:1;a:0:{}i:3;i:1;}}',
+            'a:1:{i:0;a:3:{i:0;a:2:{s:5:"label";s:17:"subtabledimension";s:6:"visits";i:100;}i:1;a:0:{}i:3;N;}}',
+        ];
+        $this->assertEquals($expectedResults, $results);
     }
 
     /**


### PR DESCRIPTION
### Description:

As title, for summary rows we are currently serializing the row with the incorrect subtable ID, causing it not to load w/ the subtable.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
