### PR TITLE
Fix sorting of Geolocation providers

### DIFF
--- a/plugins/UserCountry/LocationProvider.php
+++ b/plugins/UserCountry/LocationProvider.php
@@ -311,16 +311,17 @@ abstract class LocationProvider
             $info['isVisible'] = $provider->isVisible();
             $info['usageWarning'] = $provider->getUsageWarning();
 
-            $allInfo[$info['order']] = $info;
+            $allInfo[$info['id']] = $info;
         }
 
-        ksort($allInfo);
+        uasort($allInfo, function($a, $b) {
+            if ($a['order'] == $b['order']) {
+                return strcmp($a['id'], $b['id']);
+            }
+            return $a['order'] - $b['order'];
+        });
 
-        $result = array();
-        foreach ($allInfo as $info) {
-            $result[$info['id']] = $info;
-        }
-        return $result;
+        return $allInfo;
     }
 
     /**

--- a/plugins/UserCountry/tests/Integration/LocationProviderTest.php
+++ b/plugins/UserCountry/tests/Integration/LocationProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\UserCountry\tests\Integration;
+
+use Piwik\Plugins\GeoIp2\LocationProvider\GeoIp2\Php;
+use Piwik\Plugins\GeoIp2\LocationProvider\GeoIp2\ServerModule;
+use Piwik\Plugins\UserCountry\LocationProvider;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+
+/**
+ * @group UserCountry
+ * @group LocationProvider
+ */
+class LocationProviderTest extends IntegrationTestCase
+{
+    public function testGetAllProviderInfo()
+    {
+        $allProviders = LocationProvider::getAllProviderInfo();
+
+        // We currently have 3 Providers shipped with core
+        $this->assertSame(3, count($allProviders));
+        $this->assertEquals(['default', 'geoip2php', 'geoip2server'], array_keys($allProviders));
+    }
+
+    public function testGetAllProviderInfoWithDuplicateOrder()
+    {
+        \Piwik\Tests\Framework\Mock\LocationProvider::$locations = [
+            [
+                LocationProvider::CITY_NAME_KEY    => 'Manchaster',
+                LocationProvider::REGION_CODE_KEY  => '15',
+                LocationProvider::COUNTRY_CODE_KEY => 'US',
+                LocationProvider::LATITUDE_KEY     => '12',
+                LocationProvider::LONGITUDE_KEY    => '11',
+                LocationProvider::ISP_KEY          => 'Facebook',
+            ],
+        ];
+
+        LocationProvider::$providers = [
+            new LocationProvider\DefaultProvider(),
+            new Php(),
+            new ServerModule(),
+            new \Piwik\Tests\Framework\Mock\LocationProvider(),
+        ];
+
+        $allProviders = LocationProvider::getAllProviderInfo();
+
+        $this->assertSame(4, count($allProviders));
+        $this->assertEquals(['default', 'geoip2php', 'mock_provider', 'geoip2server'], array_keys($allProviders));
+    }
+}

--- a/tests/PHPUnit/Framework/Mock/LocationProvider.php
+++ b/tests/PHPUnit/Framework/Mock/LocationProvider.php
@@ -45,7 +45,7 @@ class LocationProvider extends CountryLocationProvider
 
     public function getInfo()
     {
-        return array('id' => self::ID, 'title' => 'mock provider', 'description' => 'mock provider', 'order' => 10);
+        return array('id' => self::ID, 'title' => 'mock provider', 'description' => 'mock provider', 'order' => 2);
     }
 
     public function isAvailable()


### PR DESCRIPTION
### Description:

Geolocation providers can be defined together with an `order`. This flag is used to sort the providers to generate the list of all providers. Currently when two providers have the same order flag, the second provider will replace the first on in the list. Currently this can cause problems when installing a new provider (like IP2Location), as the currently used geoip2php suddenly gets unavailable.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
