### PR TITLE
Revert "more private Referrer-Policy: use strict-origin-when-cross-origin "

### DIFF
--- a/core/View.php
+++ b/core/View.php
@@ -296,7 +296,7 @@ class View implements ViewInterface
                 Common::sendHeader('Referrer-Policy: same-origin');
             } else {
                 // always send explicit default header
-                Common::sendHeader('Referrer-Policy: strict-origin-when-cross-origin');
+                Common::sendHeader('Referrer-Policy: no-referrer-when-downgrade');
             }
         }
 


### PR DESCRIPTION
Reverts matomo-org/matomo#17382

Otherwise it may break the overlay if overlay is loaded cross origin (eg a different domain) as it would only receive the origin referrer but not path and subquery. 