### PR TITLE
Remove checking for /proc existence

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -236,10 +236,6 @@ class Process
             $reasons[] = 'awk is not available or did not run as we would expect it to';
         }
 
-        if (!self::isProcFSMounted() && !SettingsServer::isMac()) {
-            $reasons[] = 'procfs is not mounted';
-        }
-
         return $reasons;
     }
 
@@ -285,21 +281,6 @@ class Process
         $returnCode = @shell_exec($exec);
         $returnCode = trim($returnCode);
         return 0 == (int) $returnCode;
-    }
-
-    /**
-     * ps -e requires /proc
-     * @return bool
-     */
-    private static function isProcFSMounted()
-    {
-        if (is_resource(@fopen('/proc', 'r'))) {
-            return true;
-        }
-        // Testing if /proc is a resource with @fopen fails on systems with open_basedir set.
-        // by using stat we not only test the existence of /proc but also confirm it's a 'proc' filesystem
-        $type = @shell_exec('stat -f -c "%T" /proc 2>/dev/null');
-        return strpos($type, 'proc') === 0;
     }
 
     public static function getListOfRunningProcesses()


### PR DESCRIPTION
### Description:

Currently the '-e' option in `ps` is not used and looks like /proc is no more needed to detect a running process.
The change can make CliMulti usable on some systems like FreeBSD, OpenBSD or macOS.

Tested on FreeBSD without /proc mounted.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
