### PR TITLE
Scheduled tasks: Always read timetable from the database and not from memory

### DIFF
--- a/core/Scheduler/Scheduler.php
+++ b/core/Scheduler/Scheduler.php
@@ -102,6 +102,7 @@ class Scheduler
 
         // for every priority level, starting with the highest and concluding with the lowest
         $executionResults = array();
+        $readFromOption = true;
         for ($priority = Task::HIGHEST_PRIORITY; $priority <= Task::LOWEST_PRIORITY; ++$priority) {
             $this->logger->debug("Executing tasks with priority {priority}:", array('priority' => $priority));
 
@@ -112,13 +113,20 @@ class Scheduler
                     continue;
                 }
                 
-                // because other jobs might execute the scheduled tasks as well we have to read the up to date time table to not handle the same task twice
-                $this->timetable->readFromOption();
+                if ($readFromOption) {
+                    // because other jobs might execute the scheduled tasks as well we have to read the up to date time table to not handle the same task twice
+                    // ideally we would read from option every time but using $readFromOption as a minor performance tweak. There can be easily 100 tasks 
+                    // of which we only execute very few and it's unlikely that the timetable changes too much in between while iterating over the loop and triggering the event.
+                    // this way we only read from option when we actually execute or reschedule a task as this can take a few seconds.
+                    $this->timetable->readFromOption();
+                    $readFromOption = false;
+                }
 
                 $taskName = $task->getName();
                 $shouldExecuteTask = $this->timetable->shouldExecuteTask($taskName);
 
                 if ($this->timetable->taskShouldBeRescheduled($taskName)) {
+                    $readFromOption = true;
                     $rescheduledDate = $this->timetable->rescheduleTask($task);
 
                     $this->logger->debug("Task {task} is scheduled to run again for {date}.", array('task' => $taskName, 'date' => $rescheduledDate));
@@ -136,6 +144,7 @@ class Scheduler
                 Piwik::postEvent('ScheduledTasks.shouldExecuteTask', array(&$shouldExecuteTask, $task));
 
                 if ($shouldExecuteTask) {
+                    $readFromOption = true;
                     $message = $this->executeTask($task);
 
                     $executionResults[] = array('task' => $taskName, 'output' => $message);

--- a/core/Scheduler/Scheduler.php
+++ b/core/Scheduler/Scheduler.php
@@ -111,7 +111,8 @@ class Scheduler
                 if ($task->getPriority() != $priority) {
                     continue;
                 }
-
+                
+                // because other jobs might execute the scheduled tasks as well we have to read the up to date time table to not handle the same task twice
                 $this->timetable->readFromOption();
 
                 $taskName = $task->getName();

--- a/core/Scheduler/Timetable.php
+++ b/core/Scheduler/Timetable.php
@@ -143,6 +143,7 @@ class Timetable
 
     public function readFromOption()
     {
+        Option::clearCachedOption(self::TIMETABLE_OPTION_STRING);
         $optionData = Option::get(self::TIMETABLE_OPTION_STRING);
         $unserializedTimetable = Common::safe_unserialize($optionData);
 


### PR DESCRIPTION
… memory

I was reviewing another issue and then saw that we actually read always the cached option entry for the scheduled tasks timetable by the looks. This is executed in https://github.com/matomo-org/matomo/blob/4.4.1/core/Scheduler/Scheduler.php#L105-L115

Because it is normal to have 2 or many more archivers running in parallel it's not uncommon that multiple archivers might execute the task runner at the same time.  They would all fetch the timetable (the entries of what scheduled tasks to execute when) and they would all have a different version of it and work on this version constantly. However, because it can take a long time (from seconds up to hours) to execute all tasks, there's a high risk that some tasks may be executed multiple times if we don't always read the timetable from the database. It will cause quite a few additional queries but should reduce some concurrency issues.

Currently, there was already code to always read the DB value again. However, `Option::get` would always first return a cached result from memory and not fetch the DB again. 

Basically this is how it currently looks like:

```
job 1: load tasks, returns [a,b,c,d]
job 1: work task a
job 2: load tasks, returns [b,c,d]
job 1: work task b 
job 2: work task b
job 1: work task c
job 2: work task c
...
```

The task runner logic is still far from being thread safe but this should improve it quite a bit.

Consequence of all this is a lot of added load as several tasks may be executed multiple times, potentially some scheduled reports or custom alerts may be sent multiple times (I remember seeing such reports), etc.

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
