### PR TITLE
Fix transition popover for page titles

### DIFF
--- a/plugins/Transitions/javascripts/transitions.js
+++ b/plugins/Transitions/javascripts/transitions.js
@@ -603,7 +603,10 @@ Piwik_Transitions.prototype.renderOpenGroup = function (groupName, side, onlyBg)
             } else {
                 onClick = (function (url) {
                     return function () {
-                        self.reloadPopover(url.replace(/^(?!http)/, 'http://'));
+                        if (self.actionType == 'url') {
+                            url = url.replace(/^(?!http)/, 'http://');
+                        }
+                        self.reloadPopover(url);
                     };
                 })(label);
             }


### PR DESCRIPTION
### Description:

It didn't work correctly to click through the following pages in the transition overlay for page titles. Reason was that a `http://` was prepended, which only make sense for urls.

fixes #17853

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
