### PR TITLE
Action permissions can't be set on step level

### DIFF
--- a/.github/workflows/buildtrackerjs.yml
+++ b/.github/workflows/buildtrackerjs.yml
@@ -50,14 +50,10 @@ jobs:
         echo ::set-output name=branch::$REF
       if: github.event.comment.body == 'build js'
     - uses: actions/setup-java@v1
-      permissions:
-        contents: none
       with:
         java-version: 9
       if: steps.vars.outputs.branch != ''
     - uses: actions/checkout@v2
-      permissions:
-        contents: read
       with:
         ref: ${{ steps.vars.outputs.branch }}
         lfs: false

--- a/.github/workflows/submodules.yml
+++ b/.github/workflows/submodules.yml
@@ -24,8 +24,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      permissions:
-        contents: read
       with:
         ref: '4.x-dev'
         lfs: false

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -35,13 +35,9 @@ jobs:
 
     steps:
     - uses: shivammathur/setup-php@36cb9fb0fccf887130d6c5a3d40a3b3479310026
-      permissions:
-        contents: none
       with:
         php-version: '7.3'
     - uses: actions/checkout@v2
-      permissions:
-        contents: read
       with:
         ref: '4.x-dev'
         lfs: false


### PR DESCRIPTION
### Description:

as per title. Would only be possible on job level, but we are only having one job each with multiple steps.

follow up to #17809

will merge this directly to prevent further fails of running actions

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
