### PR TITLE
Do not log a failed login if a valid app token_auth is sent

### DIFF
--- a/core/Access.php
+++ b/core/Access.php
@@ -170,14 +170,11 @@ class Access
             $auth = StaticContainer::get(SessionAuth::class);
             $auth->setTokenAuth($tokenAuth);
             $result = $auth->authenticate();
-            if (!$result->wasAuthenticationSuccessful()) {
-                /**
-                 * Ensures brute force logic to be executed
-                 * @ignore
-                 * @internal
-                 */
-                Piwik::postEvent('API.Request.authenticate.failed');
-            }
+            // Note: We do not post a failed login event at this point on purpose
+            // If using the SessionAuth doesn't work, the FrontController will try to reload the Auth using
+            // the token_auth only. If that works everything is "fine" and the `force_api_session` parameter was
+            // unneeded. If that fails as well it will trigger the failed login event
+            // See FrontController::init() or Request::reloadAuthUsingTokenAuth()
             Session::close();
             // if not successful, we will fallback to regular auth
         }


### PR DESCRIPTION
### Description:

Currently when sending a valid token_auth with any API request, a failed login is logged when the `force_api_session` parameter is set in the request as well.

refs L3-131

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
