### PR TITLE
Improve I/O performance by not writing placeholder files when they already exist

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -563,7 +563,9 @@ class Filesystem
             $path . '/index.php'
         );
         foreach ($filesToCreate as $file) {
-            @file_put_contents($file, 'Nothing to see here.');
+            if (!is_file($file)) {
+                @file_put_contents($file, 'Nothing to see here.');
+            }
         }
     }
 }


### PR DESCRIPTION
fixes #17870 

### Description:

When matomo checks if directories are writeable it puts empty index files in the directories to prevent directory listing. This causes a few unnecessary writes. This fix checks if the file exists to potentially skip writing and reduce IO.

Note: We use is_file not file_exists as slightly faster: https://github.com/matomo-org/matomo/issues/16552

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
