### PR TITLE
before trying to invalidate parent period, make sure period is enabled in INI config

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -211,6 +211,11 @@ enable_processing_unique_visitors_multiple_sites = 0
 ; Example use case: custom date range requests are processed in real time,
 ; so they may take a few minutes on very high traffic website: you may remove "range" below to disable this period
 enabled_periods_UI = "day,week,month,year,range"
+
+; The list of periods that are available in through the API. This also controls the list of periods that are allowed
+; to be archived. You can disable some of them if you have a high traffic website and archiving is too compute heavy.
+; NOTE: if you disable a period in the API, it's parent periods are effectively disabled as well. For example, if
+; month periods are disabled, then year periods can no longer be computed, so they are effectively disabled as well.
 enabled_periods_API = "day,week,month,year,range"
 
 ; whether to enable segment archiving cache

--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -392,6 +392,7 @@ class ArchiveInvalidator
     {
         if ($period->getLabel() == 'year'
             || $period->getLabel() == 'range'
+            || !Period\Factory::isPeriodEnabledForAPI($period->getParentPeriodLabel())
         ) {
             return;
         }

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -986,6 +986,13 @@ class CronArchive
                 continue;
             }
 
+            // period is disabled in API
+            if (!PeriodFactory::isPeriodEnabledForAPI($label)
+                || PeriodFactory::isAnyLowerPeriodDisabledForAPI($label)
+            ) {
+                continue;
+            }
+
             // archive is for week that is over two months, we don't need to care about the month
             if ($label == 'month'
                 && Date::factory($archiveToProcess['date1'])->toString('m') != Date::factory($archiveToProcess['date2'])->toString('m')

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -348,7 +348,7 @@ class QueueConsumer
 
             $periodLabel = $this->periodIdsToLabels[$nextArchive['period']];
             if (!PeriodFactory::isPeriodEnabledForAPI($periodLabel)
-                || $this->isAnyLowerPeriodDisabledForAPI($periodLabel)
+                || PeriodFactory::isAnyLowerPeriodDisabledForAPI($periodLabel)
             ) {
                 $this->logger->info("Found invalidation for period that is disabled in the API, skipping and removing: {$nextArchive['idinvalidation']}");
                 $this->model->deleteInvalidations([$nextArchive]);
@@ -611,30 +611,5 @@ class QueueConsumer
     public function getIdSite()
     {
         return $this->idSite;
-    }
-
-    private function isAnyLowerPeriodDisabledForAPI($periodLabel)
-    {
-        $parentPeriod = null;
-        switch ($periodLabel) {
-            case 'week':
-                $parentPeriod = 'day';
-                break;
-            case 'month':
-                $parentPeriod = 'week';
-                break;
-            case 'year':
-                $parentPeriod = 'month';
-                break;
-            default:
-                break;
-        }
-
-        if ($parentPeriod === null) {
-            return false;
-        }
-
-        return !PeriodFactory::isPeriodEnabledForAPI($parentPeriod)
-            || $this->isAnyLowerPeriodDisabledForAPI($parentPeriod);
     }
 }

--- a/core/Period/Factory.php
+++ b/core/Period/Factory.php
@@ -195,4 +195,29 @@ abstract class Factory
         $periodValidator = new PeriodValidator();
         return $periodValidator->getPeriodsAllowedForAPI();
     }
+
+    public static function isAnyLowerPeriodDisabledForAPI($periodLabel)
+    {
+        $parentPeriod = null;
+        switch ($periodLabel) {
+            case 'week':
+                $parentPeriod = 'day';
+                break;
+            case 'month':
+                $parentPeriod = 'week';
+                break;
+            case 'year':
+                $parentPeriod = 'month';
+                break;
+            default:
+                break;
+        }
+
+        if ($parentPeriod === null) {
+            return false;
+        }
+
+        return !self::isPeriodEnabledForAPI($parentPeriod)
+            || self::isAnyLowerPeriodDisabledForAPI($parentPeriod);
+    }
 }


### PR DESCRIPTION
### Description:

Fixes #17872 

This has the consequence where if a week period is disabled, but the month period is enabled, the month will not archive. Which I think is expected since the month period depends on the week.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
