### PR TITLE
Only set requests in tracking request set when correct value is given

### DIFF
--- a/core/Tracker/RequestSet.php
+++ b/core/Tracker/RequestSet.php
@@ -33,6 +33,10 @@ class RequestSet
     {
         $this->requests = array();
 
+        if (empty($requests)|| !is_array($requests)) {
+            return;
+        }
+        
         foreach ($requests as $request) {
             if (empty($request) && !is_array($request)) {
                 continue;


### PR DESCRIPTION
refs https://github.com/matomo-org/plugin-QueuedTracking/issues/153#issuecomment-896856651

fix https://github.com/matomo-org/plugin-QueuedTracking/issues/153

Possible warning:

>  /usr/share/piwik/core/Tracker/RequestSet.php(36): Warning - Invalid argument supplied for foreach() -

Not sure how this would happen and it might hide an actual error maybe. I've been looking through code for a while and couldn't really see where this might happen.  The only one I could find was bulk tracking a wrong JSON being set. Maybe we should throw an invalid tracking parameter exception when `requests` is not an array? https://github.com/matomo-org/matomo/blob/4.4.1/plugins/BulkTracking/Tracker/Requests.php#L78

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
