### PR TITLE
Added config option for custom tracking image

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -996,6 +996,11 @@ innodb_lock_wait_timeout = 0
 ; For a list of tracking parameters you can use on the left side view https://developer.matomo.org/api-reference/tracking-api
 exclude_requests = ""
 
+; Custom image to return when tracker URL includes &image=1
+; Overrides the default 1x1 transparent gif
+; This should either be the full path to the image file or a base64 encoded image string wrapped in quotes
+custom_image =
+
 [Segments]
 ; Reports with segmentation in API requests are processed in real time.
 ; On high traffic websites it is recommended to pre-process the data

--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -999,6 +999,7 @@ exclude_requests = ""
 ; Custom image to return when tracker URL includes &image=1
 ; Overrides the default 1x1 transparent gif
 ; This should either be the full path to the image file or a base64 encoded image string wrapped in quotes
+; For both image files and base64 encoded strings supported image types are gif, jpg and png
 custom_image =
 
 [Segments]

--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -198,26 +198,8 @@ class Response
 
         // Must have valid image data and a valid mime type to proceed
         if ($img && $size && isset($size['mime'])  && in_array($size['mime'], $supportedMimeTypes)) {
-
-            // Recreate the image to improve security
-            $newImg = imagecreatefromstring($img);
-            if ($newImg === false) {
-                return false;
-            }
-
             Common::sendHeader('Content-Type: '.$size['mime']);
-            switch ($size['mime']) {
-                case 'image/png':
-                    imagepng($newImg);
-                    break;
-                case 'image/jpeg':
-                    imagejpeg($newImg);
-                    break;
-                case 'image/gif':
-                    imagegif($newImg);
-                    break;
-            }
-
+            echo $img;
             return true;
         }
 

--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -153,9 +153,8 @@ class Response
 
         // Check for a custom tracking image
         $customImage = Config::getInstance()->Tracker['custom_image'];
-        if (!empty($customImage)) {
-            if ($this->outputCustomImage($customImage))
-                return;
+        if (!empty($customImage) && $this->outputCustomImage($customImage)) {
+            return;
         }
 
         // No custom image defined, so output the default 1x1 base64 transparent gif

--- a/core/Tracker/Response.php
+++ b/core/Tracker/Response.php
@@ -181,7 +181,7 @@ class Response
     private function outputCustomImage(string $customImage): bool
     {
 
-        if (strlen($customImage) > 2 && substr($customImage, strlen($customImage)-2, 2) == '==') {
+        if (strlen($customImage) > 2 && substr($customImage, -2) == '==') {
 
             $transGifBase64 = $customImage;
             Common::sendHeader('Content-Type: image/gif');

--- a/tests/PHPUnit/Unit/Tracker/ResponseTest.php
+++ b/tests/PHPUnit/Unit/Tracker/ResponseTest.php
@@ -176,7 +176,6 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         // Initialise the custom_image setting
         $config = Config::getInstance();
         $trackerSettings = $config->Tracker;
-        //$trackerSettings['custom_image'] = '/var/www/matomo/plugins/Morpheus/images/logo.png';
         $trackerSettings['custom_image'] = $base64Image; 
         $config->Tracker = $trackerSettings;
 


### PR DESCRIPTION
### Description:

fixes #2672 Custom image to replace default 1x1 GIF image

Added a new config option which may be used to specify a custom image to override the default 1x1 transparent gif. 
Either a image file location (with full path) or a base64 image string may be used.

`
[Tracker]
custom_image = /path/to/my_custom_image.png
`
or
`
[Tracker]
custom_image = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAIAAAACDbGyAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH5QgLFiABlwQnpwAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAUSURBVAjXY/wjLMyABJgYUAGpfABbJQEsALGyNgAAAABJRU5ErkJggg=="
`

Two unit tests are included which set the config option for both an image file and base64 image string, then check the respective tracker responses against the original image data.

### Review

* [x] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [x] Code review done
* [x] Tests were added if useful/possible
* [x] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
