### PR TITLE
Don't try to send security email when no email is provided

### DIFF
--- a/plugins/CoreAdminHome/Emails/SecurityNotificationEmail.php
+++ b/plugins/CoreAdminHome/Emails/SecurityNotificationEmail.php
@@ -81,5 +81,13 @@ abstract class SecurityNotificationEmail extends Mail
         return $view;
     }
 
+    public function send()
+    {
+        if (!empty($this->emailAddress)) {
+            return parent::send();
+        }
+        return false;
+    }
+
     abstract protected function getBody();
 }


### PR DESCRIPTION
### Description:

Which happens mostly when eg a user is added on CLI.

We noticed this on cloud that it's causing issues and it's trying to add a user, tokens etc. and tries to send emails. The `safeSend` method is catching exceptions however it is logging data as warning. In CLI this causes the return value of an executed CLI command to not be `0` as our console treats any warning as an error.

I checked and generally on CLI the email should be an empty string.

There are also other approaches to fixing this. 

* We could not send the email  on `cli` but generally if there is a user it be better to send it.
* We could develop the check for each individual email but seems like a lot of duplicate code for everything

```
+        $email = Piwik::getCurrentUserEmail();
+        if (!empty($email)) {
+            $mail = $container->make(UserCreatedEmail::class, array(
+                'login' => Piwik::getCurrentUserLogin(),
+                'emailAddress' => Piwik::getCurrentUserEmail(),
+                'userLogin' => $userLogin
+            ));
+            $mail->safeSend();
+        }
```

* We could potentially listen to the "shouldSendMail" event and disable it there in the cloud plugin but this will later again cause issues in core.
* etc.

Generally we wouldn't want to send any such mail while creating a Matomo instance.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
