### PR TITLE
Improve handling of NotSupportedBrowserException

### DIFF
--- a/core/Exception/NotSupportedBrowserException.php
+++ b/core/Exception/NotSupportedBrowserException.php
@@ -8,6 +8,11 @@
  */
 namespace Piwik\Exception;
 
-class NotSupportedBrowserException extends Exception
+class NotSupportedBrowserException extends \Piwik\Exception\Exception
 {
+    public function __construct($message)
+    {
+        // Use HTTP code 400 to avoid server-provided 403 error page.
+        parent::__construct($message, $code = 400);
+    }
 }

--- a/core/ExceptionHandler.php
+++ b/core/ExceptionHandler.php
@@ -72,7 +72,7 @@ class ExceptionHandler
     {
         // Set an appropriate HTTP response code.
         switch (true) {
-            case ( ($exception instanceof \Piwik\Exception\HttpCodeException || $exception instanceof \Piwik\Exception\NotSupportedBrowserException) && $exception->getCode() > 0):
+            case ( ($exception instanceof \Piwik\Http\HttpCodeException || $exception instanceof \Piwik\Exception\NotSupportedBrowserException) && $exception->getCode() > 0):
                 // For these exception types, use the exception-provided error code.
                 http_response_code($exception->getCode());
                 break;


### PR DESCRIPTION
### Description:

fixes #17738 Don't log an error when not supported browser is used

To reproduce the error (before the changes in this ticket):

- Monitor the server (e.g. Apache) error log, e.g. `tail -f error_log` 
- Do a GET on matomo with an unsupported browser version e.g. Firefox < version 32, e.g.
`wget -U "Mozilla/5.0 (Windows NT 5.1; rv:2.0) Gecko/20100101 Firefox/4.0" --no-check-certificate https://127.0.0.1/matomo/`

To test the fix:

- Repeat the steps to reproduce above - you should not see the message in the error log.
- In config.ini.php, set loglevel=DEBUG (the default is WARN):
```
[log]
log_level = DEBUG
```
- Repeat the steps to reproduce above - you should now see the message in the error log.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
