### PR TITLE
If a usable archive exists and the invalidation is for a specific plugin, delete the invalidation

### DIFF
--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -238,7 +238,7 @@ class QueueConsumer
             if ($isUsableExists) {
                 $now = Date::now()->getDatetime();
                 $this->addInvalidationToExclude($invalidatedArchive);
-                if (is_null($invalidatedArchive['plugin'])) {
+                if (empty($invalidatedArchive['plugin'])) {
                     $this->logger->debug("Found invalidation with usable archive (not yet outdated, ts_archived of existing = $archivedTime, now = $now) skipping until archive is out of date: $invalidationDesc");
                 } else {
                     $this->logger->debug("Found invalidation with usable archive (not yet outdated, ts_archived of existing = $archivedTime, now = $now) ignoring and deleting: $invalidationDesc");

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -237,8 +237,13 @@ class QueueConsumer
             list($isUsableExists, $archivedTime) = $this->usableArchiveExists($invalidatedArchive);
             if ($isUsableExists) {
                 $now = Date::now()->getDatetime();
-                $this->logger->debug("Found invalidation with usable archive (not yet outdated, ts_archived of existing = $archivedTime, now = $now) skipping until archive is out of date: $invalidationDesc");
                 $this->addInvalidationToExclude($invalidatedArchive);
+                if (is_null($invalidatedArchive['plugin'])) {
+                    $this->logger->debug("Found invalidation with usable archive (not yet outdated, ts_archived of existing = $archivedTime, now = $now) skipping until archive is out of date: $invalidationDesc");
+                } else {
+                    $this->logger->debug("Found invalidation with usable archive (not yet outdated, ts_archived of existing = $archivedTime, now = $now) ignoring: $invalidationDesc");
+                    $this->model->deleteInvalidations([$invalidatedArchive]);
+                }
                 continue;
             } else {
                 $now = Date::now()->getDatetime();

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -241,7 +241,7 @@ class QueueConsumer
                 if (is_null($invalidatedArchive['plugin'])) {
                     $this->logger->debug("Found invalidation with usable archive (not yet outdated, ts_archived of existing = $archivedTime, now = $now) skipping until archive is out of date: $invalidationDesc");
                 } else {
-                    $this->logger->debug("Found invalidation with usable archive (not yet outdated, ts_archived of existing = $archivedTime, now = $now) ignoring: $invalidationDesc");
+                    $this->logger->debug("Found invalidation with usable archive (not yet outdated, ts_archived of existing = $archivedTime, now = $now) ignoring and deleting: $invalidationDesc");
                     $this->model->deleteInvalidations([$invalidatedArchive]);
                 }
                 continue;

--- a/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
@@ -504,6 +504,82 @@ class QueueConsumerTest extends IntegrationTestCase
         $this->assertEquals(0, $count);
     }
 
+
+
+    public function test_pluginInvalidationDeletedIfUsableArchiveExists()
+    {
+        Fixture::createWebsite('2015-02-03');
+
+        // force archiving so we don't skip those without visits
+        Piwik::addAction('Archiving.getIdSitesToArchiveWhenNoVisits', function (&$idSites) {
+            $idSites[] = 1;
+        });
+
+        $cronArchive = new MockCronArchive();
+        $cronArchive->init();
+
+        $archiveFilter = $this->makeTestArchiveFilter();
+
+        $queueConsumer = new QueueConsumer(
+            StaticContainer::get(LoggerInterface::class),
+            new FixedSiteIds([1]),
+            3,
+            24,
+            new Model(),
+            new SegmentArchiving('beginning_of_time'),
+            $cronArchive,
+            new RequestParser(true),
+            $archiveFilter
+        );
+
+        Date::$now = strtotime('2018-03-04 01:00:00');
+
+        $invalidations = [
+            ['idarchive' => 1, 'name' => "done.Actions", 'idsite' => 1, 'date1' => '2018-03-04', 'date2' => '2018-03-04', 'period' => 1, 'report' => null],
+            ['idarchive' => 1, 'name' => 'done', 'idsite' => 1, 'date1' => '2018-03-04', 'date2' => '2018-03-04', 'period' => 3, 'report' => null],
+        ];
+
+        shuffle($invalidations);
+
+        $this->insertInvalidations($invalidations);
+
+        $usableArchive = ['idarchive' => 1, 'name' => 'done', 'idsite' => 1, 'date1' => '2018-03-04', 'date2' => '2018-03-04', 'period' => 1, 'ts_archived' => Date::now()->getDatetime(), 'value' => 3.0];
+        $this->insertArchive($usableArchive);
+
+        $iteratedInvalidations = [];
+        while (true) {
+            $next = $queueConsumer->getNextArchivesToProcess();
+            if ($next === null) {
+                break;
+            }
+
+            foreach ($next as &$item) {
+                $this->simulateJobStart($item['idinvalidation']);
+
+                unset($item['periodObj']);
+                unset($item['idinvalidation']);
+                unset($item['ts_invalidated']);
+            }
+
+            $iteratedInvalidations[] = $next;
+        }
+
+        $expectedInvalidationsFound = [
+            array(
+                ['idarchive' => '1', 'idsite' => '1', 'date1' => '2018-03-04', 'date2' => '2018-03-04', 'period' => '3', 'name' => 'done', 'report' => null, 'plugin' => null, 'segment' => '', 'ts_started' => null, 'status' => '0']
+            ),
+            array()
+        ];
+
+        $this->assertEquals($expectedInvalidationsFound, $iteratedInvalidations, "Invalidations inserted:\n" . var_export($invalidations, true));
+
+        // check that segment hash 2 is no longer in the invalidations table
+        $count = Db::fetchOne('SELECT COUNT(*) FROM ' . Common::prefixTable('archive_invalidations') . ' WHERE name = ?', [
+            "done.Actions",
+        ]);
+        $this->assertEquals(0, $count);
+    }
+
     public function test_skipSegmentsToday()
     {
         Date::$now = strtotime('2018-03-04 01:00:00');
@@ -678,6 +754,25 @@ class QueueConsumerTest extends IntegrationTestCase
             Db::query("INSERT INTO `$table` (idarchive, name, idsite, date1, date2, period, ts_invalidated, report, status)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)", $bind);
         }
+    }
+
+    private function insertArchive(array $archive)
+    {
+        $table = ArchiveTableCreator::getNumericTable(Date::now());
+
+        $bind = [
+            $archive['idarchive'],
+            $archive['name'],
+            $archive['idsite'],
+            $archive['date1'],
+            $archive['date2'],
+            $archive['period'],
+            $archive['ts_archived'],
+            $archive['value']
+        ];
+
+        Db::query("INSERT INTO `$table` (idarchive, name, idsite, date1, date2, period, ts_archived, value)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)", $bind);
     }
 
     public function test_canSkipArchiveBecauseNoPoint_returnsTrueIfDateRangeHasNoVisits()

--- a/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
+++ b/tests/PHPUnit/Integration/CronArchive/QueueConsumerTest.php
@@ -573,7 +573,7 @@ class QueueConsumerTest extends IntegrationTestCase
 
         $this->assertEquals($expectedInvalidationsFound, $iteratedInvalidations, "Invalidations inserted:\n" . var_export($invalidations, true));
 
-        // check that segment hash 2 is no longer in the invalidations table
+        // check that our plugin invalidation is no longer in the invalidations table
         $count = Db::fetchOne('SELECT COUNT(*) FROM ' . Common::prefixTable('archive_invalidations') . ' WHERE name = ?', [
             "done.Actions",
         ]);


### PR DESCRIPTION


### Description:

Delete plugin invalidations that are ignored because a newer archive exists, otherwise invalidations get stuck there indefinitely.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
