### PR TITLE
Load sparkline images only once they are near  view port

### DIFF
--- a/core/Twig.php
+++ b/core/Twig.php
@@ -116,7 +116,7 @@ class PiwikTwigFilterExtension extends \Twig\Extension\AbstractExtension
  */
 class Twig
 {
-    const SPARKLINE_TEMPLATE = '<img alt="" data-src="%s" width="%d" height="%d" />
+    const SPARKLINE_TEMPLATE = '<img loading="lazy" alt="" data-src="%s" width="%d" height="%d" />
     <script type="text/javascript">$(function() { piwik.initSparklines(); });</script>';
 
     /**


### PR DESCRIPTION
### Description: 

fix https://github.com/matomo-org/matomo/issues/17774

Test locally and worked nicely. Had 11 goals and on my screen it loaded the first 9 goals right away and the other ones while scrolling. This way, if someone has say 25 goals, then we won't issue like 80 requests at the same time on goals overview or funnels overview page which can cause issues in the web server as well as database.

This won't impact reports like Visitors overview etc. where the sparklines are visible right away.

Works in modern browsers. 

FYI @mattab 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
