### PR TITLE
When processing a dependent archive for a range, then only process the requested plugin, not all plugins

### DIFF
--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -66,6 +66,9 @@ class Rules
             return false;
         }
 
+        if ($periodLabel === 'range' && !Rules::isBrowserArchivingAvailableForSegments() && !SettingsServer::isArchivePhpTriggered()) {
+            return false;
+        }
         if ($segment->isEmpty() && ($periodLabel != 'range' || SettingsServer::isArchivePhpTriggered())) {
             return true;
         }

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -66,13 +66,14 @@ class Rules
             return false;
         }
 
-        if ($periodLabel === 'range' && !Rules::isBrowserArchivingAvailableForSegments() && !SettingsServer::isArchivePhpTriggered()) {
-            return false;
-        }
         if ($segment->isEmpty() && ($periodLabel != 'range' || SettingsServer::isArchivePhpTriggered())) {
             return true;
         }
-
+        
+        if ($periodLabel === 'range' && !SettingsServer::isArchivePhpTriggered()) {
+            return false;
+        }
+        
         return self::isSegmentPreProcessed($idSites, $segment);
     }
 


### PR DESCRIPTION
### Description:

Say you are viewing the goals overview page for a range period. What happens is 

* because it is range it will only archive goals archive see https://github.com/matomo-org/matomo/blob/4.5.0-b1/core/ArchiveProcessor/Rules.php#L65-L73
* then it will call `processDependentArchive` with a segment in https://github.com/matomo-org/matomo/blob/4.5.0-b1/plugins/Goals/Archiver.php#L505
* then it will next time think it needs to process all reports because in https://github.com/matomo-org/matomo/blob/4.5.0-b1/core/ArchiveProcessor/Rules.php#L69-L71 the segment is no longer empty .
* and when then the customer then has eg a segment defined `visitorType==returning` then it would suddenly process all archives because `isSegmentPreProcessed($segment)===true`. Or when requesting a segment that is being pre-processed.

Generally, for ranges when triggered from the browser (not archive), we always only want to archive the specific plugin. 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
