### PR TITLE
Allow more img sources when embedding page in an iframe

### DIFF
--- a/core/View/SecurityPolicy.php
+++ b/core/View/SecurityPolicy.php
@@ -113,6 +113,7 @@ class SecurityPolicy
      */
     public function allowEmbedPage() {
         $this->overridePolicy('default-src', self::RULE_EMBEDDED_FRAME);
+        $this->overridePolicy('img-src', self::RULE_EMBEDDED_FRAME);
         $this->addPolicy('script-src', self::RULE_DEFAULT);
     }
 }


### PR DESCRIPTION
Noticed this while testing changes in the heatmaps plugin. Was otherwise getting this error: 

![image](https://user-images.githubusercontent.com/273120/131934730-b714c845-39f6-4da9-8c0d-bd53798b20da.png)

It's needed because we now set `img-src` in the beginning:

![image](https://user-images.githubusercontent.com/273120/131934753-f3c4e6a5-253f-412a-aa26-cbf2c9214c01.png)


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
