### PR TITLE
Make password reset use a secure hash to create reset token

### DIFF
--- a/plugins/Login/PasswordResetter.php
+++ b/plugins/Login/PasswordResetter.php
@@ -347,7 +347,7 @@ class PasswordResetter
      */
     protected function hashData($data)
     {
-        return Common::hash($data);
+        return $this->passwordHelper->hash($data);
     }
 
     /**

--- a/plugins/Login/tests/Integration/PasswordResetterTest.php
+++ b/plugins/Login/tests/Integration/PasswordResetterTest.php
@@ -195,7 +195,8 @@ class PasswordResetterTest extends IntegrationTestCase
                 ['Test.Mail.send', \DI\value(function (PHPMailer $mail) {
                     $body = $mail->createBody();
                     $body = preg_replace("/=[\r\n]+/", '', $body);
-                    preg_match('/resetToken=[\s]*3D([a-zA-Z0-9=\s]+)<\/p>/', $body, $matches);
+                    // This regex should include the range of characters Piwik\Auth\Password->hash() might return.
+                    preg_match('/resetToken=[\s]*3D([^<]+)<\/p>/', $body, $matches);
                     if (!empty($matches[1])) {
                         $capturedToken = $matches[1];
                         $capturedToken = preg_replace('/=\s*/', '', $capturedToken);


### PR DESCRIPTION
Fix issue #15278 Secure Hash is not secure. Use passwordHelper->hash() which uses the Password::preferredAlgorithm() hash.