### PR TITLE
delete old log_* table data also without idvisit

### DIFF
--- a/core/Common.php
+++ b/core/Common.php
@@ -1225,4 +1225,40 @@ class Common
         }
         return $validLanguages;
     }
+
+    /**
+     * compare 2 strings by strcmp but putting longer strings first
+     * @param string $a compare subject left
+     * @param string $b compare subject right
+     * @return int
+     */
+    public static function longerStrCmp(string $a, string $b)
+    {
+        $alen = strlen($a);
+        $blen = strlen($b);
+        $len = $alen - $blen;
+        if ($len === 0) {
+            return strcmp($a, $b);
+        }
+        if ($len < 0) {
+            $bshort = substr($b, 0, $alen);
+            $cmp = strcmp($a, $bshort);
+        } else {
+            $bshort = substr($b, 0, $alen);
+            $cmp = strcmp($a, $bshort);
+        }
+        if ($cmp === 0) {
+            return -$len;
+        }
+        return $cmp;
+    }
+
+    /**
+     * sort an array by strcmp but longer strings first
+     * @param array &$arr to sort (by ref)
+     */
+    public static function sortByLongerString(array &$arr)
+    {
+        usort($arr, [Common::class, 'longerStrCmp']);
+    }
 }

--- a/tests/PHPUnit/Unit/CommonTest.php
+++ b/tests/PHPUnit/Unit/CommonTest.php
@@ -498,4 +498,40 @@ class CommonTest extends TestCase
     {
         $this->assertEquals($expected, Common::extractLanguageCodeFromBrowserLanguage($browserLanguage, $validLanguages), "test with {$browserLanguage} failed, expected {$expected}");
     }
+
+    public function testSortByLongerString()
+    {
+        $arr = [
+            'matomo_log_action',
+            'matomo_log_conversion',
+            'matomo_log_conversion_item',
+            'matomo_log_hsr',
+            'matomo_log_hsr_blob',
+            'matomo_log_hsr_event',
+            'matomo_log_hsr_site',
+            'matomo_log_form',
+            'matomo_log_form_field',
+            'matomo_log_form_page',
+            'matomo_log_link_visit_action',
+            'matomo_log_profiling',
+            'matomo_log_visit',
+        ];
+        $expected = [
+            'matomo_log_action',
+            'matomo_log_conversion_item',
+            'matomo_log_conversion',
+            'matomo_log_form_field',
+            'matomo_log_form_page',
+            'matomo_log_form',
+            'matomo_log_hsr_blob',
+            'matomo_log_hsr_event',
+            'matomo_log_hsr_site',
+            'matomo_log_hsr',
+            'matomo_log_link_visit_action',
+            'matomo_log_profiling',
+            'matomo_log_visit',
+        ];
+        Common::sortByLongerString($arr);
+        $this->assertSame($expected, $arr);
+    }
 }


### PR DESCRIPTION
fixes #16529

### Description:

I know and realise I have been reinventing the wheel here a bit and there is redundant code here. Also, I know already there are better ways of doing things. But I thought I'd spent a bit of time and some of it might still be useful at some point.

I guess we could find dependent tables in the sort function I wrote somehow and then join on `log_visit`'s idcolumn.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
