### PR TITLE
delete old log_* table data also without idvisit

### DIFF
--- a/core/DataAccess/RawLogDao.php
+++ b/core/DataAccess/RawLogDao.php
@@ -145,22 +145,6 @@ class RawLogDao
     }
 
     /**
-     * Deletes conversions for the supplied visit IDs from log_conversion. This method does not cascade, so
-     * conversion items will not be deleted.
-     *
-     * @param int[] $visitIds
-     * @return int The number of deleted rows.
-     */
-    public function deleteFromLogTable($tableName, $visitIds)
-    {
-        $sql = "DELETE FROM `" . Common::prefixTable($tableName) . "` WHERE idvisit IN "
-             . $this->getInFieldExpressionWithInts($visitIds);
-
-        $statement = Db::query($sql);
-        return $statement->rowCount();
-    }
-
-    /**
      * Deletes conversion items for the supplied visit IDs from log_conversion_item.
      *
      * @param int[] $visitIds

--- a/core/LogDeleter.php
+++ b/core/LogDeleter.php
@@ -48,7 +48,7 @@ class LogDeleter
         $deleteCounts = StaticContainer::get(DataSubjects::class)->deleteDataSubjectsWithoutInvalidatingArchives(array_map(function($visitid) {
             return ['idvisit' => $visitid];
         }, $visitIds));
-        return array_sum($deleteCounts);
+        return $deleteCounts['log_visit'];
     }
 
     /**

--- a/core/LogDeleter.php
+++ b/core/LogDeleter.php
@@ -45,9 +45,11 @@ class LogDeleter
      */
     public function deleteVisits($visitIds)
     {
-        $deleteCounts = StaticContainer::get(DataSubjects::class)->deleteDataSubjectsWithoutInvalidatingArchives(array_map(function($visitid) {
+        $visitIds = array_map(function($visitid) {
             return ['idvisit' => $visitid];
-        }, $visitIds));
+        }, $visitIds);
+        $dataSubjects = StaticContainer::get(DataSubjects::class);
+        $deleteCounts = $dataSubjects->deleteDataSubjectsWithoutInvalidatingArchives($visitIds);
         return $deleteCounts['log_visit'];
     }
 

--- a/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
@@ -128,7 +128,7 @@ class DeleteLogsDataTest extends ConsoleCommandTestCase
         ), $options);
 
         $this->assertEquals(0, $result, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Successfully deleted 57 visits", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Successfully deleted 19 visits", $this->applicationTester->getDisplay());
     }
 
     private function setCommandInput($value)

--- a/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
+++ b/plugins/CoreAdminHome/tests/Integration/Commands/DeleteLogsDataTest.php
@@ -128,7 +128,7 @@ class DeleteLogsDataTest extends ConsoleCommandTestCase
         ), $options);
 
         $this->assertEquals(0, $result, $this->getCommandDisplayOutputErrorMessage());
-        self::assertStringContainsString("Successfully deleted 19 visits", $this->applicationTester->getDisplay());
+        self::assertStringContainsString("Successfully deleted 57 visits", $this->applicationTester->getDisplay());
     }
 
     private function setCommandInput($value)

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -456,10 +456,10 @@ class DataSubjects
     {
         $where = array();
         $bind = array();
+        $in = array();
         foreach ($visits as $visit) {
             if (empty($visit['idsite'])) {
-                $where[] = '(' . $tableToSelect . '.idvisit = ?)';
-                $bind[] = $visit['idvisit'];
+                $in[] = (int) $visit['idvisit'];
             } else {
                 $where[] = '(' . $tableToSelect . '.idsite = ? AND ' . $tableToSelect . '.idvisit = ?)';
                 $bind[] = $visit['idsite'];
@@ -467,6 +467,12 @@ class DataSubjects
             }
         }
         $where = implode(' OR ', $where);
+        if (!empty($in)) {
+            if (!empty($where)) {
+                $where .= ' OR ';
+            }
+            $where .= $tableToSelect . '.idvisit in (' . implode(',',$in) . ')';
+        }
 
         return array($where, $bind);
     }

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -457,12 +457,12 @@ class DataSubjects
         $where = array();
         $bind = array();
         foreach ($visits as $visit) {
-            if (isset($visit['idsite']) && $visit['idsite'] != null) {
-                $where[] = '(' . $tableToSelect . '.idsite = ? AND ' . $tableToSelect . '.idvisit = ?)';
-                $bind[] = $visit['idsite'];
+            if (empty($visit['idsite'])) {
+                $where[] = '(' . $tableToSelect . '.idvisit = ?)';
                 $bind[] = $visit['idvisit'];
             } else {
-                $where[] = '(' . $tableToSelect . '.idvisit = ?)';
+                $where[] = '(' . $tableToSelect . '.idsite = ? AND ' . $tableToSelect . '.idvisit = ?)';
+                $bind[] = $visit['idsite'];
                 $bind[] = $visit['idvisit'];
             }
         }

--- a/plugins/PrivacyManager/Model/DataSubjects.php
+++ b/plugins/PrivacyManager/Model/DataSubjects.php
@@ -461,9 +461,8 @@ class DataSubjects
             if (empty($visit['idsite'])) {
                 $in[] = (int) $visit['idvisit'];
             } else {
-                $where[] = '(' . $tableToSelect . '.idsite = ? AND ' . $tableToSelect . '.idvisit = ?)';
-                $bind[] = $visit['idsite'];
-                $bind[] = $visit['idvisit'];
+                $where[] = sprintf('(%s.idsite = %d AND %s.idvisit = %d)',
+                    $tableToSelect, (int) $visit['idsite'], $tableToSelect, (int) $visit['idvisit']);
             }
         }
         $where = implode(' OR ', $where);

--- a/plugins/PrivacyManager/tests/Integration/Model/DataSubjectsTest.php
+++ b/plugins/PrivacyManager/tests/Integration/Model/DataSubjectsTest.php
@@ -66,6 +66,43 @@ class DataSubjectsTest extends IntegrationTestCase
         $this->theFixture->trackingTime = $this->originalTrackingTime;
     }
 
+    public function test_deleteExport_deleteOneVisitWithoutIdsite()
+    {
+        $this->theFixture->setUpWebsites();
+        $this->theFixture->trackVisits($idSite = 1, 1);
+
+        $this->assertNotEmpty($this->getVisit(1, 1));
+        $this->assertNotEmpty($this->getLinkAction(1, 1));
+        $this->assertNotEmpty($this->getConversion(1, 1));
+        $this->assertNotEmpty($this->getOneVisit(1, 1, TestLogFoo::TABLE));
+
+        $this->assertNotEmpty($this->getVisit(1, 2));
+        $this->assertNotEmpty($this->getLinkAction(1, 2));
+        $this->assertNotEmpty($this->getOneVisit(1, 2, TestLogFoo::TABLE));
+
+        $visits = array(array('idvisit' => 1));
+        $result = $this->dataSubjects->deleteDataSubjectsWithoutInvalidatingArchives($visits);
+
+        $this->assertEquals(array(
+            'log_conversion' => 1,
+            'log_conversion_item' => 0,
+            'log_link_visit_action' => 11,
+            'log_visit' => 1,
+            'log_foo_bar_baz' => 2,
+            'log_foo_bar' => 2,
+            'log_foo' => 2
+        ), $result);
+
+        $this->assertEmpty($this->getVisit(1, 1));
+        $this->assertEmpty($this->getLinkAction(1, 1));
+        $this->assertEmpty($this->getConversion(1, 1));
+        $this->assertEmpty($this->getOneVisit(1, 1, TestLogFoo::TABLE));
+
+        // idvisit 2 still exists
+        $this->assertNotEmpty($this->getVisit(1, 2));
+        $this->assertNotEmpty($this->getLinkAction(1, 2));
+        $this->assertNotEmpty($this->getOneVisit(1, 2, TestLogFoo::TABLE));
+    }
     public function test_deleteExport_deleteOneVisit()
     {
         $this->theFixture->setUpWebsites();

--- a/plugins/PrivacyManager/tests/Integration/Model/DataSubjectsTest.php
+++ b/plugins/PrivacyManager/tests/Integration/Model/DataSubjectsTest.php
@@ -66,7 +66,7 @@ class DataSubjectsTest extends IntegrationTestCase
         $this->theFixture->trackingTime = $this->originalTrackingTime;
     }
 
-    public function test_deleteExport_deleteOneVisitWithoutIdsite()
+    public function test_deleteDataSubjectsWithoutInvalidatingArchives_deleteVisitsWithoutIdsite()
     {
         $this->theFixture->setUpWebsites();
         $this->theFixture->trackVisits($idSite = 1, 1);
@@ -76,18 +76,22 @@ class DataSubjectsTest extends IntegrationTestCase
         $this->assertNotEmpty($this->getConversion(1, 1));
         $this->assertNotEmpty($this->getOneVisit(1, 1, TestLogFoo::TABLE));
 
+        $this->assertNotEmpty($this->getVisit(1, 3));
+        $this->assertNotEmpty($this->getLinkAction(1, 3));
+        $this->assertNotEmpty($this->getConversion(1, 3));
+
         $this->assertNotEmpty($this->getVisit(1, 2));
         $this->assertNotEmpty($this->getLinkAction(1, 2));
         $this->assertNotEmpty($this->getOneVisit(1, 2, TestLogFoo::TABLE));
 
-        $visits = array(array('idvisit' => 1));
+        $visits = array(array('idvisit' => 1),array('idvisit' => 3),array('idvisit' => 999));
         $result = $this->dataSubjects->deleteDataSubjectsWithoutInvalidatingArchives($visits);
 
         $this->assertEquals(array(
-            'log_conversion' => 1,
+            'log_conversion' => 2,
             'log_conversion_item' => 0,
-            'log_link_visit_action' => 11,
-            'log_visit' => 1,
+            'log_link_visit_action' => 12,
+            'log_visit' => 2,
             'log_foo_bar_baz' => 2,
             'log_foo_bar' => 2,
             'log_foo' => 2
@@ -98,11 +102,63 @@ class DataSubjectsTest extends IntegrationTestCase
         $this->assertEmpty($this->getConversion(1, 1));
         $this->assertEmpty($this->getOneVisit(1, 1, TestLogFoo::TABLE));
 
+        $this->assertEmpty($this->getVisit(1, 3));
+        $this->assertEmpty($this->getLinkAction(1, 3));
+        $this->assertEmpty($this->getConversion(1, 3));
+        $this->assertEmpty($this->getOneVisit(1, 3, TestLogFoo::TABLE));
+
         // idvisit 2 still exists
         $this->assertNotEmpty($this->getVisit(1, 2));
         $this->assertNotEmpty($this->getLinkAction(1, 2));
         $this->assertNotEmpty($this->getOneVisit(1, 2, TestLogFoo::TABLE));
     }
+
+    public function test_deleteDataSubjectsWithoutInvalidatingArchives_deleteVisitWithAndWithoutIdSite()
+    {
+        $this->theFixture->setUpWebsites();
+        $this->theFixture->trackVisits($idSite = 1, 1);
+
+        $this->assertNotEmpty($this->getVisit(1, 1));
+        $this->assertNotEmpty($this->getLinkAction(1, 1));
+        $this->assertNotEmpty($this->getConversion(1, 1));
+        $this->assertNotEmpty($this->getOneVisit(1, 1, TestLogFoo::TABLE));
+
+        $this->assertNotEmpty($this->getVisit(1, 3));
+        $this->assertNotEmpty($this->getLinkAction(1, 3));
+        $this->assertNotEmpty($this->getConversion(1, 3));
+
+        $this->assertNotEmpty($this->getVisit(1, 2));
+        $this->assertNotEmpty($this->getLinkAction(1, 2));
+        $this->assertNotEmpty($this->getOneVisit(1, 2, TestLogFoo::TABLE));
+
+        $visits = array(array('idvisit' => 1),array('idvisit' => 3, 'idsite' => 1),array('idvisit' => 999),array('idvisit' => 999, 'idsite' => 999));
+        $result = $this->dataSubjects->deleteDataSubjectsWithoutInvalidatingArchives($visits);
+
+        $this->assertEquals(array(
+            'log_conversion' => 2,
+            'log_conversion_item' => 0,
+            'log_link_visit_action' => 12,
+            'log_visit' => 2,
+            'log_foo_bar_baz' => 2,
+            'log_foo_bar' => 2,
+            'log_foo' => 2
+        ), $result);
+
+        $this->assertEmpty($this->getVisit(1, 1));
+        $this->assertEmpty($this->getLinkAction(1, 1));
+        $this->assertEmpty($this->getConversion(1, 1));
+        $this->assertEmpty($this->getOneVisit(1, 1, TestLogFoo::TABLE));
+
+        $this->assertEmpty($this->getVisit(1, 3));
+        $this->assertEmpty($this->getLinkAction(1, 3));
+        $this->assertEmpty($this->getConversion(1, 3));
+
+        // idvisit 2 still exists
+        $this->assertNotEmpty($this->getVisit(1, 2));
+        $this->assertNotEmpty($this->getLinkAction(1, 2));
+        $this->assertNotEmpty($this->getOneVisit(1, 2, TestLogFoo::TABLE));
+    }
+
     public function test_deleteExport_deleteOneVisit()
     {
         $this->theFixture->setUpWebsites();


### PR DESCRIPTION
fixes #16529

### Description:

Reuse logic from DataSubject and refactor into core.

To test this manually, please see https://github.com/matomo-org/test-examples/blob/trackingformlogs/logdeleter/general/index.php . You can configure it with https://github.com/matomo-org/test-examples/blob/trackingformlogs/config/config.example.php .

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
