### PR TITLE
if not comparing, set show_limit_control to true for Evolution Report

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
+++ b/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
@@ -48,6 +48,7 @@ class Evolution extends JqplotGraph
     {
         if (!$this->isComparing()) {
             $this->calculateEvolutionDateRange();
+            $this->config->show_limit_control = true;
         }
 
         parent::beforeLoadDataTable();

--- a/tests/UI/expected-screenshots/Comparison_row_evolution.png
+++ b/tests/UI/expected-screenshots/Comparison_row_evolution.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4665e537c3e986c62edf5d5988344b6fe33882bab743e86c36c7970f8ab532d
-size 72789
+oid sha256:e074defaa9ef14cbfdc4b5a8ada840f4c1bd6bf36fd3eb6d63201ab2e0a857e4
+size 73170

--- a/tests/UI/expected-screenshots/UIIntegrationTest_goals_individual_row_evolution.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_goals_individual_row_evolution.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:600ae76a2c5561c3b2aac2fac3417c197a42a7011e2e96a6b405ba7e108c26e9
-size 65379
+oid sha256:6fa8eb9fe92f45054973d474a76f2385527083a395c9c6916ec10aad81fb168a
+size 65721


### PR DESCRIPTION
fixes #17965

### Description:

Assumes we want the report to show_limit_control in all cases but when comparing.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
