### PR TITLE
Revert "if not comparing, set show_limit_control to true for Evolution Report"

### DIFF
--- a/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
+++ b/plugins/CoreVisualizations/Visualizations/JqplotGraph/Evolution.php
@@ -48,7 +48,6 @@ class Evolution extends JqplotGraph
     {
         if (!$this->isComparing()) {
             $this->calculateEvolutionDateRange();
-            $this->config->show_limit_control = true;
         }
 
         parent::beforeLoadDataTable();

--- a/tests/UI/expected-screenshots/Comparison_row_evolution.png
+++ b/tests/UI/expected-screenshots/Comparison_row_evolution.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e074defaa9ef14cbfdc4b5a8ada840f4c1bd6bf36fd3eb6d63201ab2e0a857e4
-size 73170
+oid sha256:d4665e537c3e986c62edf5d5988344b6fe33882bab743e86c36c7970f8ab532d
+size 72789

--- a/tests/UI/expected-screenshots/UIIntegrationTest_goals_individual_row_evolution.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_goals_individual_row_evolution.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6fa8eb9fe92f45054973d474a76f2385527083a395c9c6916ec10aad81fb168a
-size 65721
+oid sha256:600ae76a2c5561c3b2aac2fac3417c197a42a7011e2e96a6b405ba7e108c26e9
+size 65379


### PR DESCRIPTION
Reverts matomo-org/matomo#17987

This made it impossible to overwrite the value in reports as the `beforeRender` method is called after the method that is normally used to configure the view.