### PR TITLE
Optimise tables separately

### DIFF
--- a/core/Db.php
+++ b/core/Db.php
@@ -420,7 +420,7 @@ class Db
      * @param string|array $tables The name of the table to optimize or an array of tables to optimize.
      *                             Table names must be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @param bool $force If true, the `OPTIMIZE TABLE` query will be run even if InnoDB tables are being used.
-     * @return bool|\Zend_Db_Statement
+     * @return bool
      */
     public static function optimizeTables($tables, $force = false)
     {

--- a/core/Db.php
+++ b/core/Db.php
@@ -420,7 +420,7 @@ class Db
      * @param string|array $tables The name of the table to optimize or an array of tables to optimize.
      *                             Table names must be prefixed (see {@link Piwik\Common::prefixTable()}).
      * @param bool $force If true, the `OPTIMIZE TABLE` query will be run even if InnoDB tables are being used.
-     * @return \Zend_Db_Statement
+     * @return bool|\Zend_Db_Statement
      */
     public static function optimizeTables($tables, $force = false)
     {
@@ -461,7 +461,16 @@ class Db
         }
 
         // optimize the tables
-        return self::query("OPTIMIZE TABLE " . implode(',', $tables));
+        $success = true;
+        foreach ($tables as &$t) {
+            $ok = self::query('OPTIMIZE TABLE ' . $t);
+            if (!$ok) {
+                $success = false;
+            }
+        }
+
+        return $success;
+
     }
 
     private static function getTableStatus()


### PR DESCRIPTION
### Description:

Fixes #14719

Rather than optimizing all tables in a single query, the optimize tables task will run each table optimization separately to allow breathing space for replicating servers.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
