### PR TITLE
Allow scheduled report emails to be differentiated from other emails

### DIFF
--- a/plugins/ScheduledReports/ReportEmailGenerator.php
+++ b/plugins/ScheduledReports/ReportEmailGenerator.php
@@ -15,7 +15,7 @@ abstract class ReportEmailGenerator
 {
     public function makeEmail(GeneratedReport $report, $customReplyTo = null)
     {
-        $mail = new Mail();
+        $mail = new ScheduledReportEmail();
         $mail->setDefaultFromPiwik();
         $mail->setSubject($report->getReportDescription());
 

--- a/plugins/ScheduledReports/ScheduledReportEmail.php
+++ b/plugins/ScheduledReports/ScheduledReportEmail.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace Piwik\Plugins\ScheduledReports;
+
+use Piwik\Mail;
+
+class ScheduledReportEmail extends Mail
+{
+
+}

--- a/plugins/ScheduledReports/ScheduledReportEmail.php
+++ b/plugins/ScheduledReports/ScheduledReportEmail.php
@@ -11,6 +11,10 @@ namespace Piwik\Plugins\ScheduledReports;
 
 use Piwik\Mail;
 
+/**
+ * This class exists so that scheduled report emails can
+ * be identified by plugins that listen to Mail events.
+ */
 class ScheduledReportEmail extends Mail
 {
 


### PR DESCRIPTION
### Description:

**Isssue:** dev-2253

This PR adds a new class `ScheduledReportEmail` which extends the base `Mail` class and enables us to differentiate scheduled report emails from other emails.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
