### PR TITLE
Provide console command for adding a marketplace license key (#18070)

### DIFF
--- a/plugins/Marketplace/Commands/SetLicenseKey.php
+++ b/plugins/Marketplace/Commands/SetLicenseKey.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Marketplace\Commands;
+
+use Piwik\Plugin\ConsoleCommand;
+use Piwik\Plugins\Marketplace\LicenseKey;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Piwik\Plugins\Marketplace\Api;
+
+/**
+ * marketplace:set-license-key console command
+ */
+class SetLicenseKey extends ConsoleCommand
+{
+    protected function configure()
+    {
+        $this->setName('marketplace:set-license-key');
+        $this->setDescription('Sets a marketplace license key');
+        $this->addOption('license-key', null, InputOption::VALUE_REQUIRED, 'Your license key:');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $licenseKey = $input->getOption('license-key');
+
+        if (empty(trim($licenseKey))) {
+            Api::getInstance()->deleteLicenseKey();
+            $output->writeln("License key removed.");
+            return;
+        }
+
+        Api::getInstance()->saveLicenseKey($licenseKey);
+        $output->writeln("License key set.");
+    }
+}


### PR DESCRIPTION
### Description:

Adds a new console command marketplace:add-license-key which adds a marketplace license key (Fixes #18070)

This is the first draft. It does not implement any checks like it's done in the Marketplace API: https://github.com/matomo-org/matomo/blob/2ac2bc1aeaf8efce6bb9af92506311da99e1757f/plugins/Marketplace/API.php#L69-L95

I'd need some pointers for further implementing this, if checking the license key this is deemed necessary.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
