### PR TITLE
[Vue] fix generate vue component command (new subfolder organization was not updated there)

### DIFF
--- a/plugins/CoreVue/Commands/GenerateVueComponent.php
+++ b/plugins/CoreVue/Commands/GenerateVueComponent.php
@@ -51,8 +51,9 @@ class GenerateVueComponent extends GenerateAngularConstructBase
         $allowlistFiles = array(
             '/vue',
             '/vue/src',
-            '/vue/src/ExampleComponent.vue',
-            '/vue/src/ExampleComponent.adapter.ts',
+            '/vue/src/ExampleComponent',
+            '/vue/src/ExampleComponent/ExampleComponent.vue',
+            '/vue/src/ExampleComponent/ExampleComponent.adapter.ts',
         );
 
         $this->copyTemplateToPlugin($exampleFolder, $pluginName, $replace, $allowlistFiles);
@@ -61,7 +62,7 @@ class GenerateVueComponent extends GenerateAngularConstructBase
         if (!file_exists($indexFile)) {
             file_put_contents($indexFile, '');
         }
-        file_put_contents($indexFile, "export { default as $adapterFunctionName } from './$component.adapter';\n", FILE_APPEND);
+        file_put_contents($indexFile, "export { default as $adapterFunctionName } from './$component/$component.adapter';\n", FILE_APPEND);
 
         // TODO: generate a less file as well?
 


### PR DESCRIPTION
### Description:

The generate command wasn't referencing the per-component subfolders of ExampleComponent when generating. Fixed in this PR.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
