### PR TITLE
Update container factory to allow for sorting plugins

### DIFF
--- a/core/Container/ContainerFactory.php
+++ b/core/Container/ContainerFactory.php
@@ -118,6 +118,11 @@ class ContainerFactory
 
         // add plugin environment configs
         $plugins = $this->pluginList->getActivatedPlugins();
+
+        if ($this->shouldSortPlugins()) {
+            $plugins = $this->sortPlugins($plugins);
+        }
+
         foreach ($plugins as $plugin) {
             $baseDir = Manager::getPluginDirectory($plugin);
 
@@ -132,6 +137,10 @@ class ContainerFactory
     {
         $plugins = $this->pluginList->getActivatedPlugins();
 
+        if ($this->shouldSortPlugins()) {
+            $plugins = $this->sortPlugins($plugins);
+        }
+
         foreach ($plugins as $plugin) {
             $baseDir = Manager::getPluginDirectory($plugin);
 
@@ -140,6 +149,25 @@ class ContainerFactory
                 $builder->addDefinitions($file);
             }
         }
+    }
+
+    /**
+     * This method is required for Matomo Cloud to allow for custom sorting of plugin order
+     *
+     * @return bool
+     */
+    private function shouldSortPlugins()
+    {
+        return isset($GLOBALS['MATOMO_SORT_PLUGINS']) && is_callable($GLOBALS['MATOMO_SORT_PLUGINS']);
+    }
+
+    /**
+     * @param array $plugins
+     * @return array
+     */
+    private function sortPlugins(array $plugins)
+    {
+        return call_user_func($GLOBALS['MATOMO_SORT_PLUGINS'], $plugins);
     }
 
     private function isDevelopmentModeEnabled()

--- a/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
+++ b/tests/PHPUnit/Framework/TestingEnvironmentManipulator.php
@@ -33,6 +33,15 @@ class FakePluginList extends PluginList
         $section['Plugins'] = $this->plugins;
         $globalSettingsProvider->setSection('Plugins', $section);
     }
+
+    public function sortPlugins(array $plugins)
+    {
+        if (isset($GLOBALS['MATOMO_SORT_PLUGINS']) && is_callable($GLOBALS['MATOMO_SORT_PLUGINS'])) {
+            return call_user_func($GLOBALS['MATOMO_SORT_PLUGINS'], parent::sortPlugins($plugins));
+        }
+
+        return parent::sortPlugins($plugins);
+    }
 }
 
 /**

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -25,6 +25,10 @@ if (!defined('PIWIK_INCLUDE_PATH')) {
     define('PIWIK_INCLUDE_PATH', PIWIK_PATH_TEST_TO_ROOT);
 }
 
+if (file_exists(PIWIK_DOCUMENT_ROOT . '/bootstrap.php')) {
+    require_once PIWIK_DOCUMENT_ROOT . '/bootstrap.php';
+}
+
 if (!defined('PIWIK_INCLUDE_SEARCH_PATH')) {
     define('PIWIK_INCLUDE_SEARCH_PATH', get_include_path()
         . PATH_SEPARATOR . PIWIK_INCLUDE_PATH . '/vendor/bin'


### PR DESCRIPTION
### Description:

Issue: dev-2082

This PR updates a test helper class and the container factory to enable plugin sorting. This is required for cloud plugins.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
