### PR TITLE
[Vue] add test to make sure umd module files are production builds

### DIFF
--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -41,6 +41,30 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
     }
 
+    public function test_umdModulesAreProductionBuilds()
+    {
+        $strToLookFor = 'eval("__webpack_require__';
+
+        $umdModulesWithDevelopmentBuilds = [];
+
+        $files = Filesystem::globr(PIWIK_INCLUDE_PATH . '/plugins', 'vue/dist/*.umd*.js');
+        foreach ($files as $filePath) {
+            $content = file_get_contents($filePath);
+
+            $plugin = substr($filePath, strlen(PIWIK_INCLUDE_PATH . '/plugins/'));
+            $plugin = substr($plugin, 0, strpos($plugin, '/'));
+
+            if (strpos($content, $strToLookFor) !== false) {
+                $umdModulesWithDevelopmentBuilds[] = $plugin;
+            }
+        }
+
+        $umdModulesWithDevelopmentBuilds = array_unique($umdModulesWithDevelopmentBuilds);
+
+        $this->assertEmpty($umdModulesWithDevelopmentBuilds, "Found plugins with development UMD builds: " . implode(', ', $umdModulesWithDevelopmentBuilds)
+            . ". Please run './console vue:build " . implode(' ', $umdModulesWithDevelopmentBuilds) . "'.");
+    }
+
     public function test_CustomVariablesAndProviderPluginCanBeUninstalledOnceNoLongerIncludedInPackage()
     {
         $pluginsToTest = ['CustomVariables', 'Provider'];

--- a/tests/PHPUnit/Integration/ReleaseCheckListTest.php
+++ b/tests/PHPUnit/Integration/ReleaseCheckListTest.php
@@ -18,6 +18,7 @@ use Piwik\Filesystem;
 use Piwik\Http;
 use Piwik\Plugin;
 use Piwik\Plugin\Manager;
+use Piwik\Plugins\CoreConsole\Commands\ComputeJsAssetSize;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Tracker;
 use RecursiveDirectoryIterator;
@@ -43,23 +44,7 @@ class ReleaseCheckListTest extends \PHPUnit\Framework\TestCase
 
     public function test_umdModulesAreProductionBuilds()
     {
-        $strToLookFor = 'eval("__webpack_require__';
-
-        $umdModulesWithDevelopmentBuilds = [];
-
-        $files = Filesystem::globr(PIWIK_INCLUDE_PATH . '/plugins', 'vue/dist/*.umd*.js');
-        foreach ($files as $filePath) {
-            $content = file_get_contents($filePath);
-
-            $plugin = substr($filePath, strlen(PIWIK_INCLUDE_PATH . '/plugins/'));
-            $plugin = substr($plugin, 0, strpos($plugin, '/'));
-
-            if (strpos($content, $strToLookFor) !== false) {
-                $umdModulesWithDevelopmentBuilds[] = $plugin;
-            }
-        }
-
-        $umdModulesWithDevelopmentBuilds = array_unique($umdModulesWithDevelopmentBuilds);
+        $umdModulesWithDevelopmentBuilds = ComputeJsAssetSize::findAnyUmdModulesWithDevelopmentBuilds();
 
         $this->assertEmpty($umdModulesWithDevelopmentBuilds, "Found plugins with development UMD builds: " . implode(', ', $umdModulesWithDevelopmentBuilds)
             . ". Please run './console vue:build " . implode(' ', $umdModulesWithDevelopmentBuilds) . "'.");


### PR DESCRIPTION
### Description:

To catch when someone pushes a development build of a UMD module (as I did in the alert PR).

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
