### PR TITLE
SEO ranking Plugin tests update

### DIFF
--- a/plugins/SEO/tests/Integration/SEOTest.php
+++ b/plugins/SEO/tests/Integration/SEOTest.php
@@ -72,7 +72,7 @@ class SEOTest extends IntegrationTestCase
         $renderer->setTable($dataTable);
         $ranks = json_decode($renderer->render(), true);
         foreach ($ranks as $rank) {
-            if ($rank['rank'] == 0 && $counter <= 3) {
+            if ($rank['rank'] === 0 ) {
                 $this->apiFunction($counter++);
             }
         }

--- a/plugins/SEO/tests/Integration/SEOTest.php
+++ b/plugins/SEO/tests/Integration/SEOTest.php
@@ -42,7 +42,6 @@ class SEOTest extends IntegrationTestCase
     public function test_API()
     {
         $ranks = $this->apiFunction();
-        $this->assertNotEmpty($ranks, 'Exceed 3 times, maximum tried');
         foreach ($ranks as $rank) {
             if ($rank['rank'] == Piwik::translate('General_Error')) {
                 $this->markTestSkipped('An exception raised when fetching data. Skipping this test for now.');
@@ -62,10 +61,10 @@ class SEOTest extends IntegrationTestCase
     /**
      * this function rerun the API 3 times, to reduce the chance of failing.
      */
-    private function apiFunction($counter = 0)
+    private function apiFunction($counter = 0, $ranks = [])
     {
         if ($counter > 3) {
-            return [];
+            return $ranks;
         }
         $dataTable = API::getInstance()->getRank('http://matomo.org/');
         $renderer = Renderer::factory('json');
@@ -73,7 +72,7 @@ class SEOTest extends IntegrationTestCase
         $ranks = json_decode($renderer->render(), true);
         foreach ($ranks as $rank) {
             if ($rank['rank'] === 0 ) {
-                $this->apiFunction($counter++);
+                $this->apiFunction($counter++, $ranks);
             }
         }
         return $ranks;

--- a/plugins/SEO/tests/Integration/SEOTest.php
+++ b/plugins/SEO/tests/Integration/SEOTest.php
@@ -41,19 +41,26 @@ class SEOTest extends IntegrationTestCase
      */
     public function test_API()
     {
-        $dataTable = API::getInstance()->getRank('http://www.microsoft.com/');
-        $renderer = Renderer::factory('json');
-        $renderer->setTable($dataTable);
-        $ranks = json_decode($renderer->render(), true);
+        $ranks = $this->apiFunction();
         foreach ($ranks as $rank) {
-            if ($rank['rank'] == Piwik::translate('General_Error')) {
-                $this->markTestSkipped('An exception raised when fetching data. Skipping this test for now.');
-                continue;
-            }
+
             $this->assertNotEmpty($rank['rank'], $rank['id'] . ' expected non-zero rank, got [' . $rank['rank'] . ']');
         }
     }
 
+    private function apiFunction($counter = 0)
+    {
+        $dataTable = API::getInstance()->getRank('http://matomo.org/');
+        $renderer = Renderer::factory('json');
+        $renderer->setTable($dataTable);
+        $ranks = json_decode($renderer->render(), true);
+        foreach ($ranks as $rank) {
+            if (!$rank['rank'] && $counter <= 3) {
+                $this->apiFunction($counter++);
+            }
+        }
+        return $ranks;
+    }
     public function provideContainerConfig()
     {
         return array(


### PR DESCRIPTION
### Description:

Fixes: #17919 

SEO test is failed randomly, normally a rerun will get it passed. 

Call a recluse to rerun the SEO test 3 times inside of the tests to reduce the chance of failing. 

Instead of test Microsoft, test matomo.org.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
