### PR TITLE
unify duplicated translation string

### DIFF
--- a/plugins/UserId/Reports/GetUsers.php
+++ b/plugins/UserId/Reports/GetUsers.php
@@ -61,7 +61,7 @@ class GetUsers extends Base
         $view->config->show_related_reports = false;
         $view->config->show_insights = false;
         $view->config->show_pivot_by_subtable = false;
-        $view->config->no_data_message = Piwik::translate('UserId_ThereIsNoDataForThisReport') . '<br><br>'
+        $view->config->no_data_message = Piwik::translate('CoreHome_ThereIsNoDataForThisReport') . '<br><br>'
           . sprintf(Piwik::translate('UserId_ThereIsNoDataForThisReportHelp'),
             "<a target='_blank' rel='noreferrer noopener' href='https://matomo.org/docs/user-id/'>", "</a>");
 

--- a/plugins/UserId/lang/en.json
+++ b/plugins/UserId/lang/en.json
@@ -5,6 +5,5 @@
         "UserReportDocumentation": "This report shows visits and other general metrics for every individual User ID.",
         "PluginDescription": "Shows user reports",
         "VisitorsUserSubcategoryHelp": "The User IDs report shows visits associated with all of your registered and logged in users. You can use this section to understand website usage by specific users and identify who your most and least active users are.",
-        "ThereIsNoDataForThisReport": "There is no data for this report.",
         "ThereIsNoDataForThisReportHelp" : "%1$sLearn more about how to generate data for this report in our user guide.%2$s"    }
 }


### PR DESCRIPTION
#18077 created a new translation string for a text that already exists in Matomo causing translators to translate the same text again (and potentially differently this time)

This should remove that string again.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
