### PR TITLE
Don't browser archive when segment is set to be pre-processed

### DIFF
--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -208,45 +208,39 @@ class Rules
 
     public static function isArchivingEnabledFor(array $idSites, Segment $segment, $periodLabel)
     {
-        return !self::isArchivingDisabledFor($idSites, $segment, $periodLabel);
-    }
-
-    public static function isArchivingDisabledFor(array $idSites, Segment $segment, $periodLabel)
-    {
         $generalConfig = Config::getInstance()->General;
 
-        if ($periodLabel == 'range') {
-            if (!isset($generalConfig['archiving_range_force_on_browser_request'])
-                || $generalConfig['archiving_range_force_on_browser_request'] != false
+        if ($periodLabel === 'range') {
+            if (isset($generalConfig['archiving_range_force_on_browser_request'])
+                && $generalConfig['archiving_range_force_on_browser_request'] == false
             ) {
                 return false;
             }
 
             Log::debug("Not forcing archiving for range period.");
-            $processOneReportOnly = false;
-
-        } else {
-            $processOneReportOnly = !self::shouldProcessReportsAllPlugins($idSites, $segment, $periodLabel);
+            return true;
         }
 
         $isArchivingEnabled = self::isRequestAuthorizedToArchive() && !self::$archivingDisabledByTests;
+        if ($segment->isEmpty()) {
+            // viewing "All Visits"
+            return $isArchivingEnabled;
+        }
 
-        if ($processOneReportOnly)  {
-            // When there is a segment, we disable archiving when browser_archiving_disabled_enforce applies
-            if (!$segment->isEmpty()
-                && !$isArchivingEnabled
-                && !self::isBrowserArchivingAvailableForSegments()
-                && !SettingsServer::isArchivePhpTriggered() // Only applies when we are not running core:archive command
-            ) {
-                Log::debug("Archiving is disabled because of config setting browser_archiving_disabled_enforce=1");
-                return true;
-            }
-
-            // Always allow processing one report
+        if (!$isArchivingEnabled
+            && (!self::isBrowserArchivingAvailableForSegments() || self::isSegmentPreProcessed($idSites, $segment))
+            && !SettingsServer::isArchivePhpTriggered() // Only applies when we are not running core:archive command
+        ) {
+            Log::debug("Archiving is disabled because of config setting browser_archiving_disabled_enforce=1");
             return false;
         }
 
-        return !$isArchivingEnabled;
+        return true;
+    }
+
+    public static function isArchivingDisabledFor(array $idSites, Segment $segment, $periodLabel)
+    {
+        return !self::isArchivingEnabledFor($idSites, $segment, $periodLabel);
     }
 
     public static function isRequestAuthorizedToArchive(Parameters $params = null)

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -214,10 +214,10 @@ class Rules
             if (isset($generalConfig['archiving_range_force_on_browser_request'])
                 && $generalConfig['archiving_range_force_on_browser_request'] == false
             ) {
+                Log::debug("Not forcing archiving for range period.");
                 return false;
             }
 
-            Log::debug("Not forcing archiving for range period.");
             return true;
         }
 
@@ -231,7 +231,7 @@ class Rules
             && (!self::isBrowserArchivingAvailableForSegments() || self::isSegmentPreProcessed($idSites, $segment))
             && !SettingsServer::isArchivePhpTriggered() // Only applies when we are not running core:archive command
         ) {
-            Log::debug("Archiving is disabled because of config setting browser_archiving_disabled_enforce=1");
+            Log::debug("Archiving is disabled because of config setting browser_archiving_disabled_enforce=1 or because the segment is selected to be pre-processed.");
             return false;
         }
 

--- a/core/ArchiveProcessor/Rules.php
+++ b/core/ArchiveProcessor/Rules.php
@@ -208,6 +208,8 @@ class Rules
 
     public static function isArchivingEnabledFor(array $idSites, Segment $segment, $periodLabel)
     {
+        $isArchivingEnabled = self::isRequestAuthorizedToArchive() && !self::$archivingDisabledByTests;
+
         $generalConfig = Config::getInstance()->General;
 
         if ($periodLabel === 'range') {
@@ -215,13 +217,12 @@ class Rules
                 && $generalConfig['archiving_range_force_on_browser_request'] == false
             ) {
                 Log::debug("Not forcing archiving for range period.");
-                return false;
+                return $isArchivingEnabled;
             }
 
             return true;
         }
 
-        $isArchivingEnabled = self::isRequestAuthorizedToArchive() && !self::$archivingDisabledByTests;
         if ($segment->isEmpty()) {
             // viewing "All Visits"
             return $isArchivingEnabled;


### PR DESCRIPTION
### Description:

While commenting on https://github.com/matomo-org/matomo/issues/17941 I noticed that a segment that is selected to be pre-processed would still be archived when it's viewed from browser even though it's set to be preprocessed. When a segment is selected to be pre-processed then it should be only processed during cron archiving no matter the if browser archiving for segments is available or not.

I'm meaning this setting: 
![image](https://user-images.githubusercontent.com/273120/136717188-5d6311b9-683a-4d57-a983-e6583a3c7ec3.png)

When it's currently set to be pre-processed, it would be still archived during day time. Users confirm this makes Matomo slow!

The logic for whether archiving is enabled / disabled or not is currently where complicated IMO:

![image](https://user-images.githubusercontent.com/273120/136717232-17f962a2-0e37-4349-8cad-c0ae555ec037.png)

I'm thinking this new logic is more clear and less prone to side effects from when the `shouldProcessReportsAllPlugins` is shown.

![image](https://user-images.githubusercontent.com/273120/136717623-bd080e40-c9bc-453e-831b-f2b90a17fc92.png)


## Behaviour to be specified

There's also one other issue I noticed in the implementation. When setting `archiving_range_force_on_browser_request=0` in config, then we were still archiving ranges in some cases. Like if browser archiving is enabled (as described in the config setting for it) or  if the `range` is requested during CLI archiving. Not sure if that's on purpuse but I kept this logic. 
![image](https://user-images.githubusercontent.com/273120/136717646-39cfeddb-9754-4aff-aa9f-934231d55833.png)


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
