### PR TITLE
Make the Twig cache template path more configurable with a DI entry

### DIFF
--- a/config/global.php
+++ b/config/global.php
@@ -29,6 +29,8 @@ return array(
         return $root . $tmp . $instanceId;
     },
 
+    'path.tmp.templates' => DI\string('{path.tmp}/templates_c'),
+
     'path.cache' => DI\string('{path.tmp}/cache/tracker/'),
 
     'Matomo\Cache\Eager' => function (ContainerInterface $c) {

--- a/core/Twig.php
+++ b/core/Twig.php
@@ -153,7 +153,7 @@ class Twig
         $chainLoader = new ChainLoader($loaders);
 
         // Create new Twig Environment and set cache dir
-        $templatesCompiledPath = StaticContainer::get('path.tmp') . '/templates_c';
+        $templatesCompiledPath = StaticContainer::get('path.tmp.templates');
 
         $this->twig = new Environment($chainLoader,
             array(


### PR DESCRIPTION
### Description:

issue: DEV-2356

This is a small change to help make the Twig templates cache path more configurable. 

At the moment only the path is configurable only by changing the `path.tmp` value.

This change supplies a more specific configuration value (`path.tmp.templates`), while preserving the original as the default.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
