### PR TITLE
Added method to unset categorylist to reset the list in ReportsProvider Class

### DIFF
--- a/core/Plugin/ReportsProvider.php
+++ b/core/Plugin/ReportsProvider.php
@@ -272,4 +272,10 @@ class ReportsProvider
     {
         return Plugin\Manager::getInstance()->findMultipleComponents('Reports', '\\Piwik\\Plugin\\Report');
     }
+
+    //Added this to trigger reset of category list as the list never gets rest after setting up due to isset check and affects testcases
+    public function unsetCategoryList()
+    {
+        unset($this->categoryList);
+    }
 }


### PR DESCRIPTION
Added method to unset categorylist to reset the list in ReportsProvider Class
Fixes: #18139 

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
