### PR TITLE
Fix error cannot read property "replace" of undefined in quick search

### DIFF
--- a/plugins/CoreHome/angularjs/quick-access/quick-access.directive.js
+++ b/plugins/CoreHome/angularjs/quick-access/quick-access.directive.js
@@ -58,9 +58,12 @@
                 }
 
                 scope.quickAccessTitle = translate('CoreHome_QuickAccessTitle', searchAreasTitle);
-
+              
                 function trim(str) {
-                    return str.replace(/^\s+|\s+$/g,'');
+                    if (str) {
+                      return str.replace(/^\s+|\s+$/g,'');
+                    }
+                    return str;
                 }
 
                 scope.getTopMenuItems = function()
@@ -74,12 +77,9 @@
                     $rootElement.find('nav .sidenav li > a').each(function (index, element) {
                         var $element = $(element);
 
-                        var text = '';
-                        if ($element.text()) {
-                          text = trim($element.text());
-                        }
+                        var text = trim($element.text());
 
-                        if (!text && $element.attr('title')) {
+                        if (!text) {
                             text = trim($element.attr('title')); // possibly a icon, use title instead
                         }
 
@@ -109,10 +109,7 @@
 
                         $element.find('li .item').each(function (i, element) {
                             var $element = angular.element(element);
-                            var text = '';
-                            if ($element.text()) {
-                                text = trim($element.text());
-                            }
+                            var text = trim($element.text());
                             if (text) {
                                 leftMenuItems.push({name: text, category: category, index: ++menuIndex});
                                 $element.attr('quick_access', menuIndex);

--- a/plugins/CoreHome/angularjs/quick-access/quick-access.directive.js
+++ b/plugins/CoreHome/angularjs/quick-access/quick-access.directive.js
@@ -74,9 +74,12 @@
                     $rootElement.find('nav .sidenav li > a').each(function (index, element) {
                         var $element = $(element);
 
-                        var text = trim($element.text());
+                        var text = '';
+                        if ($element.text()) {
+                          text = trim($element.text());
+                        }
 
-                        if (!text) {
+                        if (!text && $element.attr('title')) {
                             text = trim($element.attr('title')); // possibly a icon, use title instead
                         }
 
@@ -106,8 +109,10 @@
 
                         $element.find('li .item').each(function (i, element) {
                             var $element = angular.element(element);
-                            var text = trim($element.text());
-
+                            var text = '';
+                            if ($element.text()) {
+                                text = trim($element.text());
+                            }
                             if (text) {
                                 leftMenuItems.push({name: text, category: category, index: ++menuIndex});
                                 $element.attr('quick_access', menuIndex);


### PR DESCRIPTION
### Description:

See below error in `getTopMenuItems`.

`$element.attr(...)` may return `undefined` and then it tries to call `undefined.replace()` which won't work.

![image](https://user-images.githubusercontent.com/273120/137220660-6f483ce6-5c3b-443e-bf52-7e5e849be912.png)


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
