### PR TITLE
Improve performance of Process::isSupported by caching it

### DIFF
--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -184,7 +184,12 @@ class Process
         return @file_get_contents($this->pidFile);
     }
 
-    private function writePidFileContent($content)
+    /**
+     * Tests only
+     * @internal
+     * @param $content
+     */
+    public function writePidFileContent($content)
     {
         file_put_contents($this->pidFile, $content);
     }

--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -8,6 +8,7 @@
 namespace Piwik\CliMulti;
 
 use Piwik\CliMulti;
+use Piwik\Common;
 use Piwik\Container\StaticContainer;
 use Piwik\Filesystem;
 use Piwik\SettingsServer;
@@ -132,7 +133,7 @@ class Process
             return false;
         }
 
-        if (!$this->pidFileSizeIsNormal()) {
+        if (!$this->pidFileSizeIsNormal($content)) {
             $this->finishProcess();
             return false;
         }
@@ -148,9 +149,9 @@ class Process
         return false;
     }
 
-    private function pidFileSizeIsNormal()
+    private function pidFileSizeIsNormal($content)
     {
-        $size = Filesystem::getFileSize($this->pidFile);
+        $size = Common::mb_strlen($content);
 
         return $size !== null && $size < 500;
     }

--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -28,7 +28,7 @@ class Process
     private $finished = null;
     private $pidFile = '';
     private $timeCreation = null;
-    private $isSupported = null;
+    private static $isSupported = null;
     private $pid = null;
     private $started = null;
 
@@ -41,7 +41,6 @@ class Process
         $pidDir = CliMulti::getTmpPath();
         Filesystem::mkdir($pidDir);
 
-        $this->isSupported  = self::isSupported();
         $this->pidFile      = $pidDir . '/' . $pid . '.pid';
         $this->timeCreation = time();
         $this->pid = $pid;
@@ -169,7 +168,7 @@ class Process
 
     private function isProcessStillRunning($content)
     {
-        if (!$this->isSupported) {
+        if (!self::isSupported()) {
             return true;
         }
 
@@ -191,8 +190,11 @@ class Process
 
     public static function isSupported()
     {
-        $reasons = self::isSupportedWithReason();
-        return empty($reasons);
+        if (!isset(self::$isSupported)) {
+            $reasons = self::isSupportedWithReason();
+            self::$isSupported = empty($reasons);
+        }
+        return self::$isSupported;
     }
 
     public static function isSupportedWithReason()

--- a/core/CliMulti/Process.php
+++ b/core/CliMulti/Process.php
@@ -153,7 +153,7 @@ class Process
     {
         $size = Common::mb_strlen($content);
 
-        return $size !== null && $size < 500;
+        return $size < 500;
     }
 
     public function finishProcess()

--- a/tests/PHPUnit/Integration/CliMulti/ProcessTest.php
+++ b/tests/PHPUnit/Integration/CliMulti/ProcessTest.php
@@ -106,7 +106,7 @@ class ProcessTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($this->process->isRunning());
         $this->assertFalse($this->process->hasFinished());
 
-        File::setFileSize(505);
+        $this->process->writePidFileContent(str_pad('1', 505,'1'));
 
         $this->assertFalse($this->process->isRunning());
         $this->assertTrue($this->process->hasFinished());


### PR DESCRIPTION
### Description:

This can improve archiving using CLI by approx 1-2%. We're calling isSupported very often. Ideally we would cache this across core:archive commands to have a bigger impact but then we would need to clear the cache when viewing system check etc and didn't want to make code too complicated for this.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
