### PR TITLE
Add Regex check on customer dimensions

### DIFF
--- a/plugins/CustomDimensions/Dimension/Extraction.php
+++ b/plugins/CustomDimensions/Dimension/Extraction.php
@@ -16,6 +16,7 @@ use Piwik\Url;
 use Piwik\UrlHelper;
 use Piwik\Piwik;
 use Exception;
+use Piwik\Validators\Regex;
 
 class Extraction
 {
@@ -52,14 +53,8 @@ class Extraction
         }
 
         //validate pattern
-        try {
-            // for unit test purpose, need a try catch there.
-            if (preg_match($this->formatPattern(), '') === false) {
-                throw new Exception();
-            }
-        } catch (Exception $ex) {
-            throw new Exception("The pattern " . $this->pattern . " has an invalid format");
-        }
+        $validator = new Regex();
+        $validator->validate($this->formatPattern());
     }
 
     public static function getSupportedDimensions()

--- a/plugins/CustomDimensions/Dimension/Extraction.php
+++ b/plugins/CustomDimensions/Dimension/Extraction.php
@@ -52,7 +52,7 @@ class Extraction
             }
         }
 
-        //validate pattern
+        //validate regex pattern
         $validator = new Regex();
         $validator->validate($this->formatPattern());
     }

--- a/plugins/CustomDimensions/Dimension/Extraction.php
+++ b/plugins/CustomDimensions/Dimension/Extraction.php
@@ -50,6 +50,16 @@ class Extraction
                 throw new Exception("You need to group exactly one part of the regular expression inside round brackets, eg 'index_(.+).html'");
             }
         }
+
+        //validate pattern
+        try {
+            // for unit test purpose, need a try catch there.
+            if (preg_match($this->formatPattern(), '') === false) {
+                throw new Exception();
+            }
+        } catch (Exception $ex) {
+            throw new Exception("The pattern " . $this->pattern . " has an invalid format");
+        }
     }
 
     public static function getSupportedDimensions()
@@ -104,6 +114,20 @@ class Extraction
             return null;
         }
 
+        $regex = $this->formatPattern();
+
+        if (preg_match($regex, (string) $value, $matches)) {
+            // we could improve performance here I reckon by combining all patterns of all configs see eg http://nikic.github.io/2014/02/18/Fast-request-routing-using-regular-expressions.html
+
+            if (array_key_exists(1, $matches)) {
+                return $matches[1];
+            }
+        }
+    }
+
+    // format pattern to matomo format
+    private function formatPattern () {
+
         $pattern = $this->pattern;
         if ($this->dimension === 'urlparam') {
             $pattern = '\?.*' . $pattern . '=([^&]*)';
@@ -114,12 +138,6 @@ class Extraction
             $regex .= 'i';
         }
 
-        if (preg_match($regex, (string) $value, $matches)) {
-            // we could improve performance here I reckon by combining all patterns of all configs see eg http://nikic.github.io/2014/02/18/Fast-request-routing-using-regular-expressions.html
-
-            if (array_key_exists(1, $matches)) {
-                return $matches[1];
-            }
-        }
+        return $regex;
     }
 }

--- a/plugins/CustomDimensions/tests/Integration/Dimension/ExtractionTest.php
+++ b/plugins/CustomDimensions/tests/Integration/Dimension/ExtractionTest.php
@@ -8,6 +8,7 @@
 
 namespace Piwik\Plugins\CustomDimensions\tests\Integration\Dimension;
 
+use Piwik\Piwik;
 use Piwik\Plugins\CustomDimensions\Dimension\Extraction;
 use Piwik\Tests\Framework\Fixture;
 use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
@@ -187,9 +188,10 @@ class ExtractionTest extends IntegrationTestCase
 
     public function test_check_shouldFailWhenInvalidRegGiven()
     {
+        $check = '/foo(*)/';
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('The pattern /foo(*)/ has an invalid format');
-        $this->buildExtraction('url', '/foo(*)/')->check();
+        $this->expectExceptionMessage(Piwik::translate('General_ValidatorErrorNoValidRegex', array($check)));
+        $this->buildExtraction('url', $check)->check();
     }
 
     /**

--- a/plugins/CustomDimensions/tests/Integration/Dimension/ExtractionTest.php
+++ b/plugins/CustomDimensions/tests/Integration/Dimension/ExtractionTest.php
@@ -185,6 +185,13 @@ class ExtractionTest extends IntegrationTestCase
         $this->buildExtraction('anyInvalid', '/ref(.+)')->check();
     }
 
+    public function test_check_shouldFailWhenInvalidRegGiven()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The pattern /foo(*)/ has an invalid format');
+        $this->buildExtraction('url', '/foo(*)/')->check();
+    }
+
     /**
      * @dataProvider getInvalidPatterns
      */

--- a/plugins/CustomDimensions/tests/Integration/Dimension/ExtractionTest.php
+++ b/plugins/CustomDimensions/tests/Integration/Dimension/ExtractionTest.php
@@ -208,8 +208,9 @@ class ExtractionTest extends IntegrationTestCase
     public function test_check_shouldNotFailWhenValidCombinationsAreGiven()
     {
         $this->expectNotToPerformAssertions();
-        $this->buildExtraction('url', 'index_(+).html')->check();
-        $this->buildExtraction('action_name', 'index_(+).html')->check();
+        $this->buildExtraction('urlparam', 'index')->check(); // does not have to contain brackets
+        $this->buildExtraction('url', 'index_(.+).html')->check();
+        $this->buildExtraction('action_name', 'index_(.+).html')->check();
         $this->buildExtraction('url', '')->check(); // empty value is allowed
         $this->buildExtraction('urlparam', 'index')->check(); // does not have to contain brackets
     }


### PR DESCRIPTION
### Description:

Fixes:#16153

Add Regex check on customer dimensions. 

Just Extraction test below changed from `index_(+).html` to`index_(.+).html` to passed validation. Let me know if that's wrong.



### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
