### PR TITLE
Fix menu dropdown spacing

### DIFF
--- a/plugins/CoreHome/angularjs/menudropdown/menudropdown.directive.less
+++ b/plugins/CoreHome/angularjs/menudropdown/menudropdown.directive.less
@@ -52,11 +52,11 @@
       display: block;
       color: @theme-color-text !important;
       text-decoration: none !important;
-      padding: 6px 25px 6px 6px !important;
+      padding: 12px 25px 12px 6px !important;
       font-size: 11px;
       float: none;
       text-align: left;
-      line-height: 30px;
+      line-height: 16px;
 
       &:hover {
         background: @theme-color-background-tinyContrast;


### PR DESCRIPTION
Fixes #17786. I tested the styles on https://demo.matomo.cloud (the language picker is a `menuDropdown`).