### PR TITLE
Cache translated timezone name in enrichSite

### DIFF
--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -81,7 +81,7 @@ class API extends \Piwik\Plugin\API
      */
     private $translator;
 
-    private static $timezoneNameCache = [];
+    private $timezoneNameCache = [];
 
     public function __construct(SettingsProvider $provider, SettingsMetadata $settingsMetadata, Translator $translator)
     {
@@ -542,11 +542,11 @@ class API extends \Piwik\Plugin\API
     private function enrichSite(&$site)
     {
         $cacheKey = $site['timezone'] . $this->translator->getCurrentLanguage();
-        if (!isset(self::$timezoneNameCache[$cacheKey])) {
+        if (!isset($this->timezoneNameCache[$cacheKey])) {
             //cached as this can be called VERY often and getTimezoneName is quite slow
-            self::$timezoneNameCache[$cacheKey] = $this->getTimezoneName($site['timezone']);
+            $this->timezoneNameCache[$cacheKey] = $this->getTimezoneName($site['timezone']);
         }
-        $site['timezone_name'] = self::$timezoneNameCache[$cacheKey];
+        $site['timezone_name'] = $this->timezoneNameCache[$cacheKey];
 
         $key = 'Intl_Currency_' . $site['currency'];
         $name = $this->translator->translate($key);

--- a/plugins/SitesManager/tests/Integration/ApiTest.php
+++ b/plugins/SitesManager/tests/Integration/ApiTest.php
@@ -560,11 +560,9 @@ class ApiTest extends IntegrationTestCase
         API::getInstance()->addSite("site2", array("http://piwik.com/test/"));
         API::getInstance()->addSite("site3", array("http://piwik.org"), null, null, null, null, null, null, 'Asia/Tokyo');
 
-        Fixture::loadAllTranslations();
-
         $resultWanted = array(
-            0 => array("idsite" => 1, "name" => "site1", "main_url" => "http://piwik.net", "ecommerce" => 0, "excluded_ips" => "", 'sitesearch' => 1, 'sitesearch_keyword_parameters' => '', 'sitesearch_category_parameters' => '', 'excluded_parameters' => '', 'excluded_user_agents' => '', 'timezone' => 'UTC', 'timezone_name' => 'UTC', 'currency' => 'USD', 'group' => '', 'keep_url_fragment' => 0, 'type' => 'website', 'exclude_unknown_urls' => 0, 'currency_name' => 'US Dollar'),
-            1 => array("idsite" => 3, "name" => "site3", "main_url" => "http://piwik.org", "ecommerce" => 0, "excluded_ips" => "", 'sitesearch' => 1, 'sitesearch_keyword_parameters' => '', 'sitesearch_category_parameters' => '', 'excluded_parameters' => '', 'excluded_user_agents' => '', 'timezone' => 'Asia/Tokyo', 'timezone_name' => 'Japan', 'currency' => 'USD', 'group' => '', 'keep_url_fragment' => 0, 'type' => 'website', 'exclude_unknown_urls' => 0, 'currency_name' => 'US Dollar'),
+            0 => array("idsite" => 1, "name" => "site1", "main_url" => "http://piwik.net", "ecommerce" => 0, "excluded_ips" => "", 'sitesearch' => 1, 'sitesearch_keyword_parameters' => '', 'sitesearch_category_parameters' => '', 'excluded_parameters' => '', 'excluded_user_agents' => '', 'timezone' => 'UTC', 'timezone_name' => 'SitesManager_Format_Utc', 'currency' => 'USD', 'group' => '', 'keep_url_fragment' => 0, 'type' => 'website', 'exclude_unknown_urls' => 0, 'currency_name' => 'USD'),
+            1 => array("idsite" => 3, "name" => "site3", "main_url" => "http://piwik.org", "ecommerce" => 0, "excluded_ips" => "", 'sitesearch' => 1, 'sitesearch_keyword_parameters' => '', 'sitesearch_category_parameters' => '', 'excluded_parameters' => '', 'excluded_user_agents' => '', 'timezone' => 'Asia/Tokyo', 'timezone_name' => 'Intl_Country_JP', 'currency' => 'USD', 'group' => '', 'keep_url_fragment' => 0, 'type' => 'website', 'exclude_unknown_urls' => 0, 'currency_name' => 'USD'),
         );
 
         FakeAccess::setIdSitesAdmin(array(1, 3));


### PR DESCRIPTION
### Description:

Noticed the `getTimezoneName` method can be very slow and CPU consuming. Especially `new DateTimeZone($timezone);` etc. Could technically cache the `getTimezoneName` method itself but figured it's a bit easier to only cache it for now in `enrichSite` as we then don't need to worry about cache key for different getTimezoneName parameters etc.  The method isn't a concern when called from other places. Often most sites have the same timezone so this will be an improvement. On cloud we're calling getAllSites etc more often and we noticed it had a performance impact.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
