### PR TITLE
Changes to keep sorting order consistent across all PHP versions for Live.getLastVisitsDetails API

### DIFF
--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -306,7 +306,7 @@ class Visitor implements VisitorInterface
                 }
             }
 
-            return 0;
+            return -1;
         });
 
         return $actions;

--- a/plugins/Live/Visitor.php
+++ b/plugins/Live/Visitor.php
@@ -297,7 +297,7 @@ class Visitor implements VisitorInterface
 
     private static function sortActionDetails($actions)
     {
-        usort($actions, function ($a, $b) {
+        usort($actions, function ($a, $b) use ($actions) {
             $fields = array('serverTimePretty', 'idlink_va', 'type', 'title', 'url', 'pageIdAction', 'goalId');
             foreach ($fields as $field) {
                 $sort = VisitorLog::sortByActionsOnPageColumn($a, $b, $field);
@@ -306,7 +306,10 @@ class Visitor implements VisitorInterface
                 }
             }
 
-            return -1;
+            $indexA = array_search($a, $actions);
+            $indexB = array_search($b, $actions);
+
+            return $indexA > $indexB ? 1 : -1;
         });
 
         return $actions;


### PR DESCRIPTION
### Description:

Changes to keep sorting order consistent across all php versions.
Fixes: #18234 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
