### PR TITLE
Take archive TTL time into consideration for today when browser archiving is enabled

### DIFF
--- a/core/ArchiveProcessor/Loader.php
+++ b/core/ArchiveProcessor/Loader.php
@@ -507,7 +507,7 @@ class Loader
             if ($minDatetimeArchiveProcessedUTC
                 && Date::factory($tsArchived)->isEarlier($minDatetimeArchiveProcessedUTC)
             ) {
-                return false;
+                return true;
             }
         }
 


### PR DESCRIPTION
### Description:

While we looked into the goal range issue this looked potentially like a bug to me. 

There is a `return false;` but at the end of the method also a `return false;` so I was wondering why the check was there in the first place as it would return false anyway.

Then looked at the check `$minDatetimeArchiveProcessedUTC  && Date::factory($tsArchived)->isEarlier($minDatetimeArchiveProcessedUTC)` and if I read this right, if the archive was created before the minimum date, then it doesn't force archive invalidation but probably it should.

Could maybe someone have a look that this PR looks correct? Could think about adding a test but this might be tricky. I haven't even tried to reproduce the issue due to lack of time. I would think that

* If browser archiving is enabled
* And you view an older period
* And you are viewing today
* And there is already an archive that is older than the configured `[General]time_before_today_archive_considered_outdated` setting

Then I would expect that maybe Matomo falsely isn't archiving again meaning effectively Matomo will only archive again if the report is being requested the next day again. But only max once per day maybe.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
