### PR TITLE
Remove no longer needed version check for confirmPassword parameter in setSystemSettings API

### DIFF
--- a/plugins/CorePluginsAdmin/API.php
+++ b/plugins/CorePluginsAdmin/API.php
@@ -55,10 +55,7 @@ class API extends \Piwik\Plugin\API
     {
         Piwik::checkUserHasSuperUserAccess();
 
-        $skipPasswordConfirm = $passwordConfirmation === false && version_compare(Version::VERSION, '4.4.0-b1', '<');
-        if (!$skipPasswordConfirm) {
-            $this->confirmCurrentUserPassword($passwordConfirmation);
-        }
+        $this->confirmCurrentUserPassword($passwordConfirmation);
 
         $pluginsSettings = $this->settingsProvider->getAllSystemSettings();
 


### PR DESCRIPTION


Just saw this code and noticed it shouldn't be needed anymore as the version is now always > 4.4.0-b1.

It was initially added in 4.3.0 and enforced with Matomo 4.4.0 to give users time to adjust to this new parameter.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
