### PR TITLE
Support downloading system tests from plugins

### DIFF
--- a/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
+++ b/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
@@ -34,6 +34,10 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
         $this->setDescription('For Piwik core devs. Copies processed system tests from travis artifacts to local processed directories');
         $this->addArgument('buildnumber', InputArgument::REQUIRED, 'Travis build number you want to sync, eg "14820".');
         $this->addOption('expected', 'e', InputOption::VALUE_NONE, 'If given file will be copied in expected directories instead of processed');
+        $this->addOption('repository', 'r', InputOption::VALUE_OPTIONAL, 'Repository name you want to sync screenshots for.', 'matomo-org/matomo');
+        $this->addOption('http-user', '', InputOption::VALUE_OPTIONAL, 'the HTTP AUTH username (for premium plugins where artifacts are protected)');
+        $this->addOption('http-password', '', InputOption::VALUE_OPTIONAL, 'the HTTP AUTH password (for premium plugins where artifacts are protected)');
+
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -56,9 +60,22 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
             $buildNumber = substr($buildNumber, 0, -2);
         }
 
+        $httpUser = $input->getOption('http-user');
+        $httpPassword = $input->getOption('http-password');
+
+        $repository = $input->getOption('repository');
         $filename = sprintf('system.%s.tar.bz2', $buildNumber);
-        $urlBase  = sprintf('https://builds-artifacts.matomo.org/matomo-org/matomo/%s', $filename);
-        $tests    = Http::sendHttpRequest($urlBase, $timeout = 120);
+        $urlBase  = sprintf('https://builds-artifacts.matomo.org/%s/%s', $repository, $filename);
+        $tests    = Http::sendHttpRequest($urlBase, $timeout = 120,
+            $userAgent = null,
+            $destinationPath = null,
+            $followDepth = 0,
+            $acceptLanguage = false,
+            $byteRange = false,
+            $getExtendedInfo = false,
+            $httpMethod = 'GET',
+            $httpUser,
+            $httpPassword);
 
         $tarFile = $tmpDir . $filename;
         file_put_contents($tarFile, $tests);

--- a/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
+++ b/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
@@ -37,7 +37,7 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
         $this->addOption('repository', 'r', InputOption::VALUE_OPTIONAL, 'Repository name you want to sync screenshots for.', 'matomo-org/matomo');
         $this->addOption('http-user', '', InputOption::VALUE_OPTIONAL, 'the HTTP AUTH username (for premium plugins where artifacts are protected)');
         $this->addOption('http-password', '', InputOption::VALUE_OPTIONAL, 'the HTTP AUTH password (for premium plugins where artifacts are protected)');
-
+        $this->addOption('plugin', 'p', InputOption::VALUE_OPTIONAL, 'Name of the plugin the files shall be synced to');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -54,6 +54,14 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
         $buildNumber = $input->getArgument('buildnumber');
         $expected    = $input->getOption('expected');
         $targetDir   = sprintf(PIWIK_INCLUDE_PATH . '/tests/PHPUnit/System/%s', $expected ? 'expected' : 'processed');
+        $repository = $input->getOption('repository');
+
+        if ($input->getOption('plugin')) {
+            $targetDir   = sprintf(PIWIK_INCLUDE_PATH . '/plugins/%s/tests/System/%s/', $input->getOption('plugin'), $expected ? 'expected' : 'processed');
+        } else if (preg_match('/plugin-([a-z0-9]{3,40})$/i', $repository, $match)) {
+            $targetDir   = sprintf(PIWIK_INCLUDE_PATH . '/plugins/%s/tests/System/%s/', $match[1], $expected ? 'expected' : 'processed');
+        }
+
         $tmpDir      = StaticContainer::get('path.tmp') . '/';
 
         $this->validate($buildNumber, $targetDir, $tmpDir);
@@ -66,7 +74,6 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
         $httpUser = $input->getOption('http-user');
         $httpPassword = $input->getOption('http-password');
 
-        $repository = $input->getOption('repository');
         $filename = sprintf('system.%s.tar.bz2', $buildNumber);
         $urlBase  = sprintf('https://builds-artifacts.matomo.org/%s/%s', $repository, $filename);
         $tests    = Http::sendHttpRequest($urlBase, $timeout = 120,

--- a/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
+++ b/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
@@ -44,7 +44,7 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
     {
         $this->updateCoreFiles($input, $output);
 
-        if (!$input->getOption('repository')) {
+        if ($input->getOption('repository') === 'matomo-org/matomo') {
             $this->updatePluginsFiles($input, $output);
         }
     }

--- a/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
+++ b/plugins/CoreConsole/Commands/DevelopmentSyncProcessedSystemTests.php
@@ -43,7 +43,10 @@ class DevelopmentSyncProcessedSystemTests extends ConsoleCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->updateCoreFiles($input, $output);
-        $this->updatePluginsFiles($input, $output);
+
+        if (!$input->getOption('repository')) {
+            $this->updatePluginsFiles($input, $output);
+        }
     }
 
     protected function updateCoreFiles(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
### Description:

Works same way as syncing UI test screenshots.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
