### PR TITLE
Remove cache clearing from forget invalidations loop.

### DIFF
--- a/core/Archive/ArchiveInvalidator.php
+++ b/core/Archive/ArchiveInvalidator.php
@@ -222,7 +222,6 @@ class ArchiveInvalidator
         // The process pid is added to the end of the entry in order to support multiple concurrent transactions.
         //  So this must be a deleteLike call to get all the entries, where there used to only be one.
         $this->deleteOptionLike($id);
-        Cache::clearCacheGeneral();
     }
 
     private function deleteOptionLike($id)


### PR DESCRIPTION
### Description:

issue: d2405

There has been a lot of tracker general cache invalidation occurring seemingly needlessly. It seems to come down to the archive invalidation clearing out the cache when trying to forget (remove) the remembered dates that need to be reArchived. This appears to be an accidental regression based off the comment.

I've removed the cache clearing from inside `forgetRememberedArchivedReportsToInvalidate` method. Both uses of this method will clear the general cache just after this method anyway.

I can't think of any cases that this should cause a problem. The only think I can think is that doing it perhaps only moments later (after the loop) might increase the probability of clearing out something that was just cached. Even if it was the case but picking a time between the two seems arbitrary. In that case it would be preferable to clear the cache before the loop.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
