### PR TITLE
Ensure DNS records are only requested for IP allowlist when needed

### DIFF
--- a/plugins/CoreHome/tests/Integration/LoginAllowlistTest.php
+++ b/plugins/CoreHome/tests/Integration/LoginAllowlistTest.php
@@ -138,7 +138,13 @@ class LoginAllowlistTest extends IntegrationTestCase
     public function test_getAllowlistedLoginIps_shouldResolveIpv6Only()
     {
         $this->setGeneralConfig('login_allowlist_ip', ['192.168.33.1', 'integration-test.matomo.org', '127.0.0.1']);
-        $this->assertSame(['192.168.33.1', 'integration-test.matomo.org', '::1', '127.0.0.1'], $this->allowlist->getAllowlistedLoginIps());
+        $this->assertSame(['192.168.33.1', '::1', '127.0.0.1'], $this->allowlist->getAllowlistedLoginIps());
+    }
+
+    public function test_getAllowlistedLoginIps_shouldReturnRanges()
+    {
+        $this->setGeneralConfig('login_allowlist_ip', ['192.168.33.1', '204.93.177.0/25', '2001:db9::/48', '127.0.0.1']);
+        $this->assertSame(['192.168.33.1', '204.93.177.0/25', '2001:db9::/48', '127.0.0.1'], $this->allowlist->getAllowlistedLoginIps());
     }
 
     public function test_getAllowlistedLoginIps_shouldNotBeCheckedIfOnlyEmptyEntries()


### PR DESCRIPTION
### Description:

- only request dns records if it's not an IP range
- cache DNS results for 30 seconds to reduce DNS requests

Note: Tracking requests never go through the allow-list, as that's excluded here: https://github.com/matomo-org/matomo/blob/bc75f9dafc9287a7864f3ecd556a5ae6b699546a/plugins/CoreHome/CoreHome.php#L78-L81

fixes #18244

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
