### PR TITLE
[Vue] use .development suffix for watch files and gitignore them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ docker-compose.yml
 /plugins/*/vue/dist/demo.html
 /plugins/*/vue/dist/*.common.js
 /plugins/*/vue/dist/*.map
+/plugins/*/vue/dist/*.development.*

--- a/core/AssetManager/UIAssetFetcher/JScriptUIAssetFetcher.php
+++ b/core/AssetManager/UIAssetFetcher/JScriptUIAssetFetcher.php
@@ -98,7 +98,7 @@ class JScriptUIAssetFetcher extends UIAssetFetcher
     private function addUmdFilesIfDetected($plugins)
     {
         foreach ($plugins as $plugin) {
-            $devUmd = "plugins/$plugin/vue/dist/$plugin.umd.js";
+            $devUmd = "plugins/$plugin/vue/dist/$plugin.development.umd.js";
             $minifiedUmd = "plugins/$plugin/vue/dist/$plugin.umd.min.js";
 
             if (Development::isEnabled() && is_file(PIWIK_INCLUDE_PATH . '/' . $devUmd)) {

--- a/plugins/CoreVue/Commands/Build.php
+++ b/plugins/CoreVue/Commands/Build.php
@@ -88,7 +88,7 @@ class Build extends ConsoleCommand
     private function watch($plugins, $printBuildCommand, OutputInterface $output)
     {
         $commandSingle = "FORCE_COLOR=1 MATOMO_CURRENT_PLUGIN=%1\$s " . self::getVueCliServiceBin() . ' build --mode=development --target lib --name '
-            . "%1\$s ./plugins/%1\$s/vue/src/index.ts --dest ./plugins/%1\$s/vue/dist --watch &";
+            . "%1\$s --filename=%1\$s.development --no-clean ./plugins/%1\$s/vue/src/index.ts --dest ./plugins/%1\$s/vue/dist --watch &";
 
         $command = '';
         foreach ($plugins as $plugin) {


### PR DESCRIPTION
### Description:

I noticed in the Vue workflow, when running vue:build --watch, the UMD files are overwritten. This causes git to notice and requires a vue:build before a dev can push. This PR changes the output file name of files built with --watch to have a .development suffix and adds paths like these to the .gitignore so rebuilding JS locally before pushing isn't always needed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
