### PR TITLE
Corrected paths mentioning "piwik/" to "/path/to/matomo/".

### DIFF
--- a/core/Plugin/Controller.php
+++ b/core/Plugin/Controller.php
@@ -892,7 +892,7 @@ abstract class Controller
                                                                                        '</a>'
                                                                                   ));
             }
-            $view->invalidHostMessageHowToFix = '<p><b>How do I fix this problem and how do I login again?</b><br/> The Matomo Super User can manually edit the file piwik/config/config.ini.php
+            $view->invalidHostMessageHowToFix = '<p><b>How do I fix this problem and how do I login again?</b><br/> The Matomo Super User can manually edit the file /path/to/matomo/config/config.ini.php
 						and add the following lines: <pre>[General]' . "\n" . 'trusted_hosts[] = "' . $invalidHost . '"</pre>After making the change, you will be able to login again.</p>
 						<p>You may also <i>disable this security feature (not recommended)</i>. To do so edit config/config.ini.php and add:
 						<pre>[General]' . "\n" . 'enable_trusted_host_check=0</pre>';

--- a/libs/jqplot/build_minified_script.sh
+++ b/libs/jqplot/build_minified_script.sh
@@ -1,5 +1,5 @@
 # build jqplot-custom.min.js
-# the yuicompressor needs to be set up in piwik/js (see piwik/js/README.md)
+# the yuicompressor needs to be set up in /path/to/matomo/js (see /path/to/matomo/js/README.md)
 
 cat jqplot.core.js > jqplot-custom.min.js-temp 
 cat jqplot.linearAxisRenderer.js >> jqplot-custom.min.js-temp

--- a/plugins/CorePluginsAdmin/Controller.php
+++ b/plugins/CorePluginsAdmin/Controller.php
@@ -297,7 +297,7 @@ class Controller extends Plugin\ControllerAdmin
                 // If the plugin has been renamed, we do not show message to ask user to update plugin
                 list($pluginNameRenamed, $methodName) = Request::getRenamedModuleAndAction($pluginName, 'index');
                 if ($pluginName != $pluginNameRenamed) {
-                    $suffix = "You may uninstall the plugin or manually delete the files in piwik/plugins/$pluginName/";
+                    $suffix = "You may uninstall the plugin or manually delete the files in /path/to/matomo/plugins/$pluginName/";
                 }
 
                 if ($this->pluginManager->isPluginInFilesystem($pluginName)) {

--- a/tests/resources/yuicompressor/How to.md
+++ b/tests/resources/yuicompressor/How to.md
@@ -1,2 +1,2 @@
 * Download latest version from https://github.com/yui/yuicompressor/releases/download/v2.4.8/yuicompressor-2.4.8.zip
-* extract the yuicompressor.jar in the piwik/tests/resources/yuicompressor folder
+* extract the yuicompressor.jar in the /path/to/matomo/tests/resources/yuicompressor folder


### PR DESCRIPTION
Updated some old paths mentioning "piwik/" to read "/path/to/matomo/". I did this because during matomo installation I was presented with the following, which I found confusing:

> The Matomo Super User can manually edit the file piwik/config/config.ini.php and add the following lines:
