### PR TITLE
Couple of fixes in QuickForm2 for PHP8.1 compatibility

### DIFF
--- a/libs/HTML/QuickForm2/Container.php
+++ b/libs/HTML/QuickForm2/Container.php
@@ -323,7 +323,7 @@ abstract class HTML_QuickForm2_Container extends HTML_QuickForm2_Node
     *
     * @return    HTML_QuickForm2_ContainerIterator
     */
-    public function getIterator()
+    public function getIterator(): HTML_QuickForm2_ContainerIterator
     {
         return new HTML_QuickForm2_ContainerIterator($this);
     }
@@ -334,7 +334,7 @@ abstract class HTML_QuickForm2_Container extends HTML_QuickForm2_Node
     * @param    int     mode passed to RecursiveIteratorIterator
     * @return   RecursiveIteratorIterator
     */
-    public function getRecursiveIterator($mode = RecursiveIteratorIterator::SELF_FIRST)
+    public function getRecursiveIterator($mode = RecursiveIteratorIterator::SELF_FIRST): RecursiveIteratorIterator
     {
         return new RecursiveIteratorIterator(
                         new HTML_QuickForm2_ContainerIterator($this), $mode
@@ -346,7 +346,7 @@ abstract class HTML_QuickForm2_Container extends HTML_QuickForm2_Node
     *
     * @return    int
     */
-    public function count()
+    public function count(): int
     {
         return count($this->elements);
     }

--- a/libs/HTML/QuickForm2/Container.php
+++ b/libs/HTML/QuickForm2/Container.php
@@ -48,6 +48,34 @@
  */
 // require_once 'HTML/QuickForm2/Node.php';
 
+
+/**
+ * Implements a recursive iterator for the container elements
+ *
+ * @category   HTML
+ * @package    HTML_QuickForm2
+ * @author     Alexey Borzov <avb@php.net>
+ * @author     Bertrand Mansion <golgote@mamasam.com>
+ * @version    Release: @package_version@
+ */
+class HTML_QuickForm2_ContainerIterator extends RecursiveArrayIterator implements RecursiveIterator
+{
+    public function __construct(HTML_QuickForm2_Container $container)
+    {
+        parent::__construct($container->getElements());
+    }
+
+    public function hasChildren()
+    {
+        return $this->current() instanceof HTML_QuickForm2_Container;
+    }
+
+    public function getChildren()
+    {
+        return new HTML_QuickForm2_ContainerIterator($this->current());
+    }
+}
+
 /**
  * Abstract base class for simple QuickForm2 containers
  *
@@ -454,33 +482,6 @@ abstract class HTML_QuickForm2_Container extends HTML_QuickForm2_Node
             }
         }
         return 'qf.form.getContainerValue(' . implode(', ', $args) . ')';
-    }
-}
-
-/**
- * Implements a recursive iterator for the container elements
- *
- * @category   HTML
- * @package    HTML_QuickForm2
- * @author     Alexey Borzov <avb@php.net>
- * @author     Bertrand Mansion <golgote@mamasam.com>
- * @version    Release: @package_version@
- */
-class HTML_QuickForm2_ContainerIterator extends RecursiveArrayIterator implements RecursiveIterator
-{
-    public function __construct(HTML_QuickForm2_Container $container)
-    {
-        parent::__construct($container->getElements());
-    }
-
-    public function hasChildren()
-    {
-        return $this->current() instanceof HTML_QuickForm2_Container;
-    }
-
-    public function getChildren()
-    {
-        return new HTML_QuickForm2_ContainerIterator($this->current());
     }
 }
 

--- a/libs/HTML/QuickForm2/Controller.php
+++ b/libs/HTML/QuickForm2/Controller.php
@@ -500,7 +500,7 @@ class HTML_QuickForm2_Controller implements IteratorAggregate
     *
     * @return   ArrayIterator
     */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->pages);
     }

--- a/libs/HTML/QuickForm2/Element/InputFile.php
+++ b/libs/HTML/QuickForm2/Element/InputFile.php
@@ -224,7 +224,7 @@ class HTML_QuickForm2_Element_InputFile extends HTML_QuickForm2_Element_Input
     */
     protected function validate()
     {
-        if (strlen($this->error)) {
+        if (strlen($this->error ?? '')) {
             return false;
         }
         if (isset($this->value['error']) &&

--- a/libs/HTML/QuickForm2/Element/Select.php
+++ b/libs/HTML/QuickForm2/Element/Select.php
@@ -48,6 +48,30 @@
  */
 // require_once 'HTML/QuickForm2/Element.php';
 
+/**
+ * Implements a recursive iterator for options arrays
+ *
+ * @category   HTML
+ * @package    HTML_QuickForm2
+ * @author     Alexey Borzov <avb@php.net>
+ * @author     Bertrand Mansion <golgote@mamasam.com>
+ * @version    Release: @package_version@
+ */
+class HTML_QuickForm2_Element_Select_OptionIterator extends RecursiveArrayIterator
+    implements RecursiveIterator
+{
+    public function hasChildren()
+    {
+        return $this->current() instanceof HTML_QuickForm2_Element_Select_OptionContainer;
+    }
+
+    public function getChildren()
+    {
+        return new HTML_QuickForm2_Element_Select_OptionIterator(
+            $this->current()->getOptions()
+        );
+    }
+}
 
 /**
  * Collection of <option>s and <optgroup>s
@@ -254,31 +278,6 @@ class HTML_QuickForm2_Element_Select_Optgroup
         $linebreak = self::getOption('linebreak');
         return $indent . '<optgroup' . $this->getAttributes(true) . '>' .
                $linebreak . parent::__toString() . $indent . '</optgroup>' . $linebreak;
-    }
-}
-
-/**
- * Implements a recursive iterator for options arrays
- *
- * @category   HTML
- * @package    HTML_QuickForm2
- * @author     Alexey Borzov <avb@php.net>
- * @author     Bertrand Mansion <golgote@mamasam.com>
- * @version    Release: @package_version@
- */
-class HTML_QuickForm2_Element_Select_OptionIterator extends RecursiveArrayIterator
-    implements RecursiveIterator
-{
-    public function hasChildren()
-    {
-        return $this->current() instanceof HTML_QuickForm2_Element_Select_OptionContainer;
-    }
-
-    public function getChildren()
-    {
-        return new HTML_QuickForm2_Element_Select_OptionIterator(
-            $this->current()->getOptions()
-        );
     }
 }
 

--- a/libs/HTML/QuickForm2/Element/Select.php
+++ b/libs/HTML/QuickForm2/Element/Select.php
@@ -187,7 +187,7 @@ class HTML_QuickForm2_Element_Select_OptionContainer extends HTML_Common2
     *
     * @return   HTML_QuickForm2_Element_Select_OptionIterator
     */
-    public function getIterator()
+    public function getIterator(): HTML_QuickForm2_Element_Select_OptionIterator
     {
         return new HTML_QuickForm2_Element_Select_OptionIterator($this->options);
     }
@@ -197,7 +197,7 @@ class HTML_QuickForm2_Element_Select_OptionContainer extends HTML_Common2
     *
     * @return   RecursiveIteratorIterator
     */
-    public function getRecursiveIterator()
+    public function getRecursiveIterator(): RecursiveIteratorIterator
     {
         return new RecursiveIteratorIterator(
             new HTML_QuickForm2_Element_Select_OptionIterator($this->options),
@@ -210,7 +210,7 @@ class HTML_QuickForm2_Element_Select_OptionContainer extends HTML_Common2
     *
     * @return   int
     */
-    public function count()
+    public function count(): int
     {
         return count($this->options);
     }

--- a/libs/HTML/QuickForm2/Node.php
+++ b/libs/HTML/QuickForm2/Node.php
@@ -585,14 +585,14 @@ abstract class HTML_QuickForm2_Node extends HTML_Common2
     protected function validate()
     {
         foreach ($this->rules as $rule) {
-            if (strlen($this->error)) {
+            if (strlen($this->error ?? '')) {
                 break;
             }
             if ($rule[1] & HTML_QuickForm2_Rule::RUNAT_SERVER) {
                 $rule[0]->validate();
             }
         }
-        return !strlen($this->error);
+        return !strlen($this->error ?? '');
     }
 
    /**


### PR DESCRIPTION
### Description:

fixes #18117

Note: QuickForm2 would meanwhile also be available via composer, so we could switch using that instead. Unfortunately QuickForm2 is compatible with PHP 5.4+, which makes it impossible to have it compatible with PHP 8.1
 as well. I first created an approach using composer and forked the QuickForm2 repos to adjust the fixes (see https://github.com/matomo-org/matomo/compare/quickform_composer), but guess they might not be merged upstream because of the PHP requirement maybe. So guess simply adjusting the code here would be the simplest solution for now.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
