### PR TITLE
Fix some PHP8.1 deprecation warnings occurred while running tests

### DIFF
--- a/core/API/Request.php
+++ b/core/API/Request.php
@@ -127,7 +127,7 @@ class Request
 
         foreach ($requestArray as &$element) {
             if (!is_array($element)) {
-                $element = trim($element);
+                $element = trim((string) $element);
             }
         }
         return $requestArray;

--- a/core/Common.php
+++ b/core/Common.php
@@ -298,7 +298,7 @@ class Common
     {
         try {
             // phpcs:ignore Generic.PHP.ForbiddenFunctions
-            return unserialize($string, ['allowed_classes' => empty($allowedClasses) ? false : $allowedClasses]);
+            return unserialize($string ?? '', ['allowed_classes' => empty($allowedClasses) ? false : $allowedClasses]);
         } catch (\Throwable $e) {
             if ($rethrow) {
                 throw $e;
@@ -743,8 +743,12 @@ class Common
 
     public static function stringEndsWith($haystack, $needle)
     {
-        if ('' === $needle) {
+        if (empty($needle)) {
             return true;
+        }
+
+        if (empty($haystack)) {
+            return false;
         }
 
         $lastCharacters = substr($haystack, -strlen($needle));

--- a/core/Common.php
+++ b/core/Common.php
@@ -743,11 +743,11 @@ class Common
 
     public static function stringEndsWith($haystack, $needle)
     {
-        if (empty($needle)) {
+        if (strlen(strval($needle)) === 0) {
             return true;
         }
 
-        if (empty($haystack)) {
+        if (strlen(strval($haystack)) === 0) {
             return false;
         }
 

--- a/core/DataArray.php
+++ b/core/DataArray.php
@@ -286,10 +286,10 @@ class DataArray
 
         $newRowToAdd[Metrics::INDEX_EVENT_SUM_EVENT_VALUE] = round($newRowToAdd[Metrics::INDEX_EVENT_SUM_EVENT_VALUE], static::EVENT_VALUE_PRECISION);
         $oldRowToUpdate[Metrics::INDEX_EVENT_SUM_EVENT_VALUE] += $newRowToAdd[Metrics::INDEX_EVENT_SUM_EVENT_VALUE];
-        $oldRowToUpdate[Metrics::INDEX_EVENT_MAX_EVENT_VALUE] = round(max($newRowToAdd[Metrics::INDEX_EVENT_MAX_EVENT_VALUE], $oldRowToUpdate[Metrics::INDEX_EVENT_MAX_EVENT_VALUE]), static::EVENT_VALUE_PRECISION);
+        $oldRowToUpdate[Metrics::INDEX_EVENT_MAX_EVENT_VALUE] = round(max(0, $newRowToAdd[Metrics::INDEX_EVENT_MAX_EVENT_VALUE], $oldRowToUpdate[Metrics::INDEX_EVENT_MAX_EVENT_VALUE]), static::EVENT_VALUE_PRECISION);
 
         // Update minimum only if it is set
-        if ($newRowToAdd[Metrics::INDEX_EVENT_MIN_EVENT_VALUE] !== false) {
+        if ($newRowToAdd[Metrics::INDEX_EVENT_MIN_EVENT_VALUE] !== false && $newRowToAdd[Metrics::INDEX_EVENT_MIN_EVENT_VALUE] !== null) {
             if ($oldRowToUpdate[Metrics::INDEX_EVENT_MIN_EVENT_VALUE] === false) {
                 $oldRowToUpdate[Metrics::INDEX_EVENT_MIN_EVENT_VALUE] = round($newRowToAdd[Metrics::INDEX_EVENT_MIN_EVENT_VALUE], static::EVENT_VALUE_PRECISION);
             } else {

--- a/core/DataTable/Renderer/Csv.php
+++ b/core/DataTable/Renderer/Csv.php
@@ -489,7 +489,7 @@ class Csv extends Renderer
     protected function removeFirstPercentSign($value)
     {
         $needle = '%';
-        $posPercent = strpos($value, $needle);
+        $posPercent = strpos($value ?? '', $needle);
         if ($posPercent !== false) {
             return substr_replace($value, '', $posPercent, strlen($needle));
         }

--- a/core/DataTable/Renderer/Xml.php
+++ b/core/DataTable/Renderer/Xml.php
@@ -381,7 +381,7 @@ class Xml extends Renderer
 
                     list($tagStart, $tagEnd) = $this->getTagStartAndEndFor($name, $columnsHaveInvalidChars);
 
-                    if (strlen($value) == 0) {
+                    if (strlen((string) $value) == 0) {
                         $out .= $prefixLine . "\t\t<$tagStart />\n";
                     } else {
                         $out .= $prefixLine . "\t\t<$tagStart>" . $value . "</$tagEnd>\n";

--- a/core/Mail.php
+++ b/core/Mail.php
@@ -192,9 +192,9 @@ class Mail
      * Add Bcc address
      *
      * @param string $email
-     * @param null|string $name
+     * @param string $name
      */
-    public function addBcc($email, $name = null)
+    public function addBcc($email, $name = '')
     {
         $this->bccs[$email] = $name;
     }
@@ -222,9 +222,9 @@ class Mail
      * Add Reply-To address
      *
      * @param string $email
-     * @param null|string $name
+     * @param string $name
      */
-    public function addReplyTo($email, $name = null)
+    public function addReplyTo($email, $name = '')
     {
         $this->replyTos[$this->parseDomainPlaceholderAsPiwikHostName($email)] = $name;
     }
@@ -235,7 +235,7 @@ class Mail
      * @param string $email
      * @param string $name
      */
-    public function setReplyTo($email, $name = null)
+    public function setReplyTo($email, $name = '')
     {
         $this->replyTos = [];
         $this->addReplyTo($email, $name);

--- a/core/Metrics/Formatter.php
+++ b/core/Metrics/Formatter.php
@@ -71,7 +71,7 @@ class Formatter
             } else {    
                 $time    = sprintf(Piwik::translate('Intl_NDays'), $days) . " " . sprintf("%02s", $hours) . ':' . sprintf("%02s", $minutes) . ':' . sprintf("%02s", $seconds);
             }
-            $centiSeconds = ($numberOfSeconds * 100) % 100;
+            $centiSeconds = intval($numberOfSeconds * 100) % 100;
             if ($centiSeconds) {
                 $time .= '.' . sprintf("%02s", $centiSeconds);
             }

--- a/core/Plugin.php
+++ b/core/Plugin.php
@@ -530,7 +530,7 @@ class Plugin
      */
     public static function getPluginNameFromNamespace($namespaceOrClassName)
     {
-        if (preg_match("/Piwik\\\\Plugins\\\\([a-zA-Z_0-9]+)\\\\/", $namespaceOrClassName, $matches)) {
+        if ($namespaceOrClassName && preg_match("/Piwik\\\\Plugins\\\\([a-zA-Z_0-9]+)\\\\/", $namespaceOrClassName, $matches)) {
             return $matches[1];
         } else {
             return false;

--- a/core/Plugin/Dependency.php
+++ b/core/Plugin/Dependency.php
@@ -65,7 +65,7 @@ class Dependency
 
     public function getMissingVersions($currentVersion, $requiredVersion)
     {
-        $currentVersion = trim($currentVersion);
+        $currentVersion = trim($currentVersion ?? '');
 
         $missingVersions = array();
 

--- a/core/Tracker/Visit.php
+++ b/core/Tracker/Visit.php
@@ -452,8 +452,8 @@ class Visit implements VisitInterface
     private function printVisitorInformation()
     {
         $debugVisitInfo = $this->visitProperties->getProperties();
-        $debugVisitInfo['idvisitor'] = bin2hex($debugVisitInfo['idvisitor']);
-        $debugVisitInfo['config_id'] = bin2hex($debugVisitInfo['config_id']);
+        $debugVisitInfo['idvisitor'] = isset($debugVisitInfo['idvisitor']) ? bin2hex($debugVisitInfo['idvisitor']) : '';
+        $debugVisitInfo['config_id'] = isset($debugVisitInfo['config_id']) ? bin2hex($debugVisitInfo['config_id']) : '';
         $debugVisitInfo['location_ip'] = IPUtils::binaryToStringIP($debugVisitInfo['location_ip']);
         Common::printDebug($debugVisitInfo);
     }

--- a/core/Url.php
+++ b/core/Url.php
@@ -668,13 +668,17 @@ class Url
      */
     public static function getHostFromUrl($url)
     {
-        $parsedUrl = parse_url($url);
-
-        if (empty($parsedUrl['host'])) {
-            return;
+        if (empty($url)) {
+            return null;
         }
 
-        return mb_strtolower($parsedUrl['host']);
+        $urlHost = parse_url($url, PHP_URL_HOST);
+
+        if (empty($urlHost)) {
+            return null;
+        }
+
+        return mb_strtolower($urlHost);
     }
 
     /**

--- a/core/Url.php
+++ b/core/Url.php
@@ -668,7 +668,7 @@ class Url
      */
     public static function getHostFromUrl($url)
     {
-        if (empty($url)) {
+        if (!is_string($url)) {
             return null;
         }
 

--- a/core/UrlHelper.php
+++ b/core/UrlHelper.php
@@ -141,7 +141,7 @@ class UrlHelper
      */
     public static function isLookLikeUrl($url)
     {
-        return preg_match('~^(([[:alpha:]][[:alnum:]+.-]*)?:)?//(.*)$~D', $url, $matches) !== 0
+        return $url && preg_match('~^(([[:alpha:]][[:alnum:]+.-]*)?:)?//(.*)$~D', $url, $matches) !== 0
             && strlen($matches[3]) > 0
             && !preg_match('/^(javascript:|vbscript:|data:)/i', $matches[1])
             ;

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -621,15 +621,15 @@ class API extends \Piwik\Plugin\API
         $coreProperties = $this->setSettingValue('ecommerce', $ecommerce, $coreProperties, $settingValues);
         $coreProperties = $this->setSettingValue('group', $group, $coreProperties, $settingValues);
         $coreProperties = $this->setSettingValue('sitesearch', $siteSearch, $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('sitesearch_keyword_parameters', explode(',', $searchKeywordParameters), $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('sitesearch_category_parameters', explode(',', $searchCategoryParameters), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('sitesearch_keyword_parameters', explode(',', $searchKeywordParameters ?? ''), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('sitesearch_category_parameters', explode(',', $searchCategoryParameters ?? ''), $coreProperties, $settingValues);
         $coreProperties = $this->setSettingValue('keep_url_fragment', $keepURLFragments, $coreProperties, $settingValues);
         $coreProperties = $this->setSettingValue('exclude_unknown_urls', $excludeUnknownUrls, $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('excluded_ips', explode(',', $excludedIps), $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('excluded_parameters', explode(',', $excludedQueryParameters), $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('excluded_user_agents', explode(',', $excludedUserAgents), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('excluded_ips', explode(',', $excludedIps ?? ''), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('excluded_parameters', explode(',', $excludedQueryParameters ?? ''), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('excluded_user_agents', explode(',', $excludedUserAgents ?? ''), $coreProperties, $settingValues);
 
-        $timezone = trim($timezone);
+        $timezone = trim($timezone ?? '');
         if (empty($timezone)) {
             $timezone = $this->getDefaultTimezone();
         }

--- a/plugins/SitesManager/API.php
+++ b/plugins/SitesManager/API.php
@@ -1252,13 +1252,13 @@ class API extends \Piwik\Plugin\API
         $coreProperties = $this->setSettingValue('group', $group, $coreProperties, $settingValues);
         $coreProperties = $this->setSettingValue('ecommerce', $ecommerce, $coreProperties, $settingValues);
         $coreProperties = $this->setSettingValue('sitesearch', $siteSearch, $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('sitesearch_keyword_parameters', explode(',', $searchKeywordParameters), $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('sitesearch_category_parameters', explode(',', $searchCategoryParameters), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('sitesearch_keyword_parameters', explode(',', $searchKeywordParameters ?? ''), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('sitesearch_category_parameters', explode(',', $searchCategoryParameters ?? ''), $coreProperties, $settingValues);
         $coreProperties = $this->setSettingValue('keep_url_fragment', $keepURLFragments, $coreProperties, $settingValues);
         $coreProperties = $this->setSettingValue('exclude_unknown_urls', $excludeUnknownUrls, $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('excluded_ips', explode(',', $excludedIps), $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('excluded_parameters', explode(',', $excludedQueryParameters), $coreProperties, $settingValues);
-        $coreProperties = $this->setSettingValue('excluded_user_agents', explode(',', $excludedUserAgents), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('excluded_ips', explode(',', $excludedIps ?? ''), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('excluded_parameters', explode(',', $excludedQueryParameters ?? ''), $coreProperties, $settingValues);
+        $coreProperties = $this->setSettingValue('excluded_user_agents', explode(',', $excludedUserAgents ?? ''), $coreProperties, $settingValues);
 
         if (isset($currency)) {
             $currency = trim($currency);

--- a/plugins/UserCountry/Archiver.php
+++ b/plugins/UserCountry/Archiver.php
@@ -102,7 +102,7 @@ class Archiver extends \Piwik\Plugin\Archiver
     {
         // remove the location separator from the region/city/country we get from the query
         foreach ($this->dimensions as $column) {
-            $row[$column] = str_replace(self::LOCATION_SEPARATOR, '', $row[$column]);
+            $row[$column] = str_replace(self::LOCATION_SEPARATOR, '', $row[$column] ?? '');
         }
 
         // set city first, as containing region might be manipulated afterwards if not empty

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_flat__API.getProcessedReport_day.xml
@@ -530,7 +530,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>28.32</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getCategory_lastN__API.getProcessedReport_day.xml
@@ -54,7 +54,7 @@
 				<nb_events>28</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -63,7 +63,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -92,7 +92,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>1</nb_events_with_value>
 				<sum_event_value>9.66</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -101,7 +101,7 @@
 				<nb_events>7</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -173,7 +173,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>28.32</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_flat__API.getProcessedReport_day.xml
@@ -608,7 +608,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>28.32</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_Events.getName_lastN__API.getProcessedReport_day.xml
@@ -54,7 +54,7 @@
 				<nb_events>16</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -63,7 +63,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -119,7 +119,7 @@
 				<nb_events>8</nb_events>
 				<nb_events_with_value>1</nb_events_with_value>
 				<sum_event_value>9.66</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -128,7 +128,7 @@
 				<nb_events>7</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>
@@ -269,7 +269,7 @@
 		<nb_events>69</nb_events>
 		<nb_events_with_value>14</nb_events_with_value>
 		<sum_event_value>137.96</sum_event_value>
-		<min_event_value>9.66</min_event_value>
+		<min_event_value>28.32</min_event_value>
 		<max_event_value>52.32</max_event_value>
 	</reportTotal>
 </result>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -131,7 +131,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getCategory_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>42</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>39</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -130,7 +130,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents__Events.getName_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>24</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -108,7 +108,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -131,7 +131,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventCategoryOrNameMatch__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>22</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -120,7 +120,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_eventValueMatch__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -131,7 +131,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getCategory_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>42</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>39</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -130,7 +130,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventAction__Events.getName_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>24</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -108,7 +108,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -19,7 +19,7 @@
 				<nb_events>16</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -32,7 +32,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>
@@ -44,7 +44,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventCategory__Events.getName_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>24</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,7 +18,7 @@
 				<nb_events>24</nb_events>
 				<nb_events_with_value>3</nb_events_with_value>
 				<sum_event_value>28.98</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.66</avg_event_value>
@@ -31,7 +31,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -43,7 +43,7 @@
 				<nb_events>21</nb_events>
 				<nb_events_with_value>6</nb_events_with_value>
 				<sum_event_value>57</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>28</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -19,7 +19,7 @@
 				<nb_events>16</nb_events>
 				<nb_events_with_value>2</nb_events_with_value>
 				<sum_event_value>19.32</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<avg_event_value>9.66</avg_event_value>
 			</row>
@@ -65,7 +65,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>
@@ -77,7 +77,7 @@
 				<nb_events>14</nb_events>
 				<nb_events_with_value>4</nb_events_with_value>
 				<sum_event_value>38</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<avg_event_value>9.5</avg_event_value>
 			</row>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_month.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_secondaryDimensionIsEventName__Events.getCategory_month.xml
@@ -6,7 +6,7 @@
 		<nb_events>42</nb_events>
 		<nb_events_with_value>3</nb_events_with_value>
 		<sum_event_value>28.98</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<sum_daily_nb_uniq_visitors>39</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.66</avg_event_value>
@@ -18,7 +18,7 @@
 				<nb_events>24</nb_events>
 				<nb_events_with_value>3</nb_events_with_value>
 				<sum_event_value>28.98</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9.66</min_event_value>
 				<max_event_value>9.66</max_event_value>
 				<sum_daily_nb_uniq_visitors>24</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.66</avg_event_value>
@@ -64,7 +64,7 @@
 		<nb_events>21</nb_events>
 		<nb_events_with_value>6</nb_events_with_value>
 		<sum_event_value>57</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 		<avg_event_value>9.5</avg_event_value>
@@ -76,7 +76,7 @@
 				<nb_events>21</nb_events>
 				<nb_events_with_value>6</nb_events_with_value>
 				<sum_event_value>57</sum_event_value>
-				<min_event_value>0</min_event_value>
+				<min_event_value>9</min_event_value>
 				<max_event_value>10</max_event_value>
 				<sum_daily_nb_uniq_visitors>18</sum_daily_nb_uniq_visitors>
 				<avg_event_value>9.5</avg_event_value>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getCategory_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getCategory_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>22</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventCategory==Movie</segment>
@@ -120,7 +120,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventCategory==Music</segment>

--- a/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getName_day.xml
+++ b/tests/PHPUnit/System/expected/test_CustomEvents_segmentMatchesEventActionPlay__Events.getName_day.xml
@@ -7,7 +7,7 @@
 		<nb_events>16</nb_events>
 		<nb_events_with_value>2</nb_events_with_value>
 		<sum_event_value>19.32</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9.66</min_event_value>
 		<max_event_value>9.66</max_event_value>
 		<avg_event_value>9.66</avg_event_value>
 		<segment>eventName==Spirited+Away+%28%E5%8D%83%E3%81%A8%E5%8D%83%E5%B0%8B%E3%81%AE%E7%A5%9E%E9%9A%A0%E3%81%97%29</segment>
@@ -109,7 +109,7 @@
 		<nb_events>14</nb_events>
 		<nb_events_with_value>4</nb_events_with_value>
 		<sum_event_value>38</sum_event_value>
-		<min_event_value>0</min_event_value>
+		<min_event_value>9</min_event_value>
 		<max_event_value>10</max_event_value>
 		<avg_event_value>9.5</avg_event_value>
 		<segment>eventName==La+fianc%C3%A9e+de+l%26%23039%3Beau</segment>


### PR DESCRIPTION
### Description:

Tried running the tests locally and a couple of deprecation warnings showed up. Not sure if they would occur normally. But should be good to fix them nevertheless.

refs #17686 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
