### PR TITLE
Determine the first date to show feedback question banner more randomly

### DIFF
--- a/core/Piwik.php
+++ b/core/Piwik.php
@@ -180,7 +180,7 @@ class Piwik
     }
 
 
-    public static function getCurrentUserCreationData()
+    public static function getCurrentUserCreationDate()
     {
         $user = APIUsersManager::getInstance()->getUser(Piwik::getCurrentUserLogin());
         return $user['date_registered'] ?? '';

--- a/plugins/Feedback/Feedback.php
+++ b/plugins/Feedback/Feedback.php
@@ -129,7 +129,7 @@ class Feedback extends \Piwik\Plugin
             // if user was created within the last 6 months, we set the date to 6 months after his creation date
             $userCreatedDate = Piwik::getCurrentUserCreationDate();
             if (!empty($userCreatedDate) && Date::factory($userCreatedDate)->addMonth(6)->getTimestamp() > $now) {
-                $nextReminder = Date::now()->getStartOfDay()->subDay(1)->toString('Y-m-d');
+                $nextReminder = Date::factory($userCreatedDate)->addMonth(6)->toString('Y-m-d');
                 $feedbackReminder->setUserOption($nextReminder);
                 return false;
             }

--- a/plugins/Feedback/Feedback.php
+++ b/plugins/Feedback/Feedback.php
@@ -127,7 +127,7 @@ class Feedback extends \Piwik\Plugin
         if ($nextReminderDate === false || $nextReminderDate <= 0) {
 
             // if user was created within the last 6 months, we set the date to 6 months after his creation date
-            $userCreatedDate = Piwik::getCurrentUserCreationData();
+            $userCreatedDate = Piwik::getCurrentUserCreationDate();
             if (!empty($userCreatedDate) && Date::factory($userCreatedDate)->addMonth(6)->getTimestamp() > $now) {
                 $nextReminder = Date::now()->getStartOfDay()->subDay(1)->toString('Y-m-d');
                 $feedbackReminder->setUserOption($nextReminder);


### PR DESCRIPTION
### Description:

This should randomize the first time the feedback banner is shown

@tsteur is this random enough?

follow-up to #18308

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
