### PR TITLE
Fix for misaligned evolution trend icons

### DIFF
--- a/plugins/MultiSites/angularjs/dashboard/dashboard.directive.less
+++ b/plugins/MultiSites/angularjs/dashboard/dashboard.directive.less
@@ -277,6 +277,10 @@
     border-bottom: 5px solid @theme-color-brand;
   }
 
+  .multisites_icon {
+    display:inline-block;vertical-align:middle;
+  }
+
   div.sparkline {
     float:none;
   }

--- a/plugins/MultiSites/angularjs/dashboard/dashboard.directive.less
+++ b/plugins/MultiSites/angularjs/dashboard/dashboard.directive.less
@@ -278,7 +278,8 @@
   }
 
   .multisites_icon {
-    display:inline-block;vertical-align:middle;
+    display: inline-block;
+    vertical-align: middle;
   }
 
   div.sparkline {

--- a/plugins/MultiSites/angularjs/site/site.directive.html
+++ b/plugins/MultiSites/angularjs/site/site.directive.html
@@ -22,9 +22,9 @@
 
     <td ng-if="period != 'range'" class="multisites-evolution" title="{{ website.tooltip }}">
         <div class="visits value" ng-if="!website.isGroup">
-            <span ng-show="website[evolutionMetric+'_trend'] == 1"><img src="plugins/MultiSites/images/arrow_up.png" alt="" /> <span style="color: green;">{{ website[evolutionMetric] }}</span></span>
-            <span ng-show="website[evolutionMetric+'_trend'] == 0"><img src="plugins/MultiSites/images/stop.png" alt="" /> <span>{{ website[evolutionMetric] }}</span></span>
-            <span ng-show="website[evolutionMetric+'_trend'] == -1"><img src="plugins/MultiSites/images/arrow_down.png" alt="" /> <span style="color: red;">{{ website[evolutionMetric] }}</span></span>
+            <span ng-show="website[evolutionMetric+'_trend'] == 1"><img class="multisites_icon" src="plugins/MultiSites/images/arrow_up.png" alt="" /> <span style="color: green;">{{ website[evolutionMetric] }}</span></span>
+            <span ng-show="website[evolutionMetric+'_trend'] == 0"><img class="multisites_icon" src="plugins/MultiSites/images/stop.png" alt="" /> <span>{{ website[evolutionMetric] }}</span></span>
+            <span ng-show="website[evolutionMetric+'_trend'] == -1"><img class="multisites_icon" src="plugins/MultiSites/images/arrow_down.png" alt="" /> <span style="color: red;">{{ website[evolutionMetric] }}</span></span>
         </div>
     </td>
 

--- a/plugins/MultiSites/lang/en.json
+++ b/plugins/MultiSites/lang/en.json
@@ -8,11 +8,9 @@
         "AllWebsitesDashboardDocumentation": "This report gives you an informational overview for each of your websites, containing the most general metrics about your visitors.",
         "EvolutionComparisonIncomplete": "The currently selected time period is %1$s complete.",
         "EvolutionComparisonProportional": "When the previous period was also %1$s complete, there would have been an estimated %2$s %3$s\n (out of a total of %4$s %3$s in the previous period).",
-        "EvolutionComparisonDay": "%1$s %2$s this day compared to %3$s %2$s in the previous period (%4$s) Evolution: %5$s",
-        "EvolutionComparisonWeek": "%1$s %2$s this week compared to %3$s %2$s in the previous period (%4$s) Evolution: %5$s",
-        "EvolutionComparisonMonth": "%1$s %2$s this month compared to %3$s %2$s in the previous period (%4$s) Evolution: %5$s",
-        "EvolutionComparisonYear": "%1$s %2$s this year compared to %3$s %2$s in the previous period (%4$s) Evolution: %5$s"
-
-
+        "EvolutionComparisonDay": "%1$s %2$s this day compared to %3$s %2$s in the previous partial period (%4$s) Evolution: %5$s",
+        "EvolutionComparisonWeek": "%1$s %2$s this week compared to %3$s %2$s in the previous partial period (%4$s) Evolution: %5$s",
+        "EvolutionComparisonMonth": "%1$s %2$s this month compared to %3$s %2$s in the previous partial period (%4$s) Evolution: %5$s",
+        "EvolutionComparisonYear": "%1$s %2$s this year compared to %3$s %2$s in the previous partial period (%4$s) Evolution: %5$s"
     }
 }


### PR DESCRIPTION
### Description:

Fixes #18322

All websites evolution trend icons should now be properly vertically aligned. The proportional tooltip text has also been tweaked.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
