### PR TITLE
Add option to specify the max number of websites to process by archiver.

### DIFF
--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -403,15 +403,15 @@ class CronArchive
             }
 
             if (empty($archivesToProcess)) {
-                if ($this->maxArchivesToProcess && $numArchivesFinished >= $this->maxArchivesToProcess) {
-                    $this->logger->info("Maximum number of archives to process per execution has been reached.");
-                    break;
-                }
                 continue;
             }
 
             $successCount = $this->launchArchivingFor($archivesToProcess, $queueConsumer);
             $numArchivesFinished += $successCount;
+            if ($this->maxArchivesToProcess && $numArchivesFinished >= $this->maxArchivesToProcess) {
+                $this->logger->info("Maximum number of archives to process per execution has been reached.");
+                break;
+            }
         }
 
         $this->disconnectDb();

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -169,6 +169,16 @@ class CronArchive
      */
     public $maxSitesToProcess = null;
 
+    /**
+     * Maximum number of archives to process during a single execution of the archiver.
+     *
+     * Note that this is not a hard limit as the limit is only checked after all
+     * archives for a site have been processed.
+     *
+     * @var int|null
+     */
+    public $maxArchivesToProcess = null;
+
     private $archivingStartingTime;
 
     private $formatter;
@@ -393,6 +403,10 @@ class CronArchive
             }
 
             if (empty($archivesToProcess)) {
+                if ($this->maxArchivesToProcess && $numArchivesFinished >= $this->maxArchivesToProcess) {
+                    $this->logger->info("Maximum number of archives to process per execution has been reached.");
+                    break;
+                }
                 continue;
             }
 
@@ -1125,14 +1139,17 @@ class CronArchive
         }
 
         if ($this->maxSitesToProcess) {
-            $this->logger->info("- Maximum {$this->maxSitesToProcess} websites will be processed");
+            $this->logger->info("- Maximum {$this->maxSitesToProcess} websites will be processed.");
+        }
+        if ($this->maxArchivesToProcess) {
+            $this->logger->info("- Maximum {$this->maxArchivesToProcess} archives will be processed (soft limit).");
         }
 
         // Try and not request older data we know is already archived
         if ($this->lastSuccessRunTimestamp !== false) {
             $dateLast = time() - $this->lastSuccessRunTimestamp;
             $this->logger->info("- Archiving was last executed without error "
-                . $this->formatter->getPrettyTimeFromSeconds($dateLast, true) . " ago");
+                . $this->formatter->getPrettyTimeFromSeconds($dateLast, true) . " ago.");
         }
     }
 

--- a/core/CronArchive.php
+++ b/core/CronArchive.php
@@ -162,6 +162,13 @@ class CronArchive
      */
     public $maxConcurrentArchivers = false;
 
+    /**
+     * Maximum number of sites to process during a single execution of the archiver.
+     *
+     * @var int|null
+     */
+    public $maxSitesToProcess = null;
+
     private $archivingStartingTime;
 
     private $formatter;
@@ -359,6 +366,8 @@ class CronArchive
 
         $queueConsumer = new QueueConsumer($this->logger, $this->websiteIdArchiveList, $countOfProcesses, $pid,
             $this->model, $this->segmentArchiving, $this, $this->cliMultiRequestParser, $this->archiveFilter);
+
+        $queueConsumer->setMaxSitesToProcess($this->maxSitesToProcess);
 
         while (true) {
             if ($this->isMaintenanceModeEnabled()) {
@@ -1113,6 +1122,10 @@ class CronArchive
                 $this->logger->info("- Reports for the current $period will be processed at most every " . $ttl
                     . " seconds. You can change this value in config/config.ini.php by editing 'time_before_" . $period . "_archive_considered_outdated' in the '[General]' section.");
             }
+        }
+
+        if ($this->maxSitesToProcess) {
+            $this->logger->info("- Maximum {$this->maxSitesToProcess} websites will be processed");
         }
 
         // Try and not request older data we know is already archived

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -136,6 +136,15 @@ class QueueConsumer
         $this->periodIdsToLabels = array_flip(Piwik::$idPeriods);
     }
 
+    /**
+     * Get next archives to process.
+     *
+     * Returns either an array of archives to process for the current site (may be
+     * empty if there are no more archives to process for it) or null when there are
+     * no more sites to process.
+     *
+     * @return null|array
+     */
     public function getNextArchivesToProcess()
     {
         if (empty($this->idSite)) {

--- a/core/CronArchive/QueueConsumer.php
+++ b/core/CronArchive/QueueConsumer.php
@@ -115,9 +115,9 @@ class QueueConsumer
 
     private $processedSiteCount = 0;
 
-    public function __construct(LoggerInterface $logger, $websiteIdArchiveList, $countOfProcesses, $pid,
-                                Model $model, SegmentArchiving $segmentArchiving, CronArchive $cronArchive,
-                                RequestParser $cliMultiRequestParser, ArchiveFilter $archiveFilter = null)
+    public function __construct(LoggerInterface $logger, $websiteIdArchiveList, $countOfProcesses, $pid, Model $model,
+                                SegmentArchiving $segmentArchiving, CronArchive $cronArchive, RequestParser $cliMultiRequestParser,
+                                ArchiveFilter $archiveFilter = null)
     {
         $this->logger = $logger;
         $this->websiteIdArchiveList = $websiteIdArchiveList;

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -46,6 +46,7 @@ class CoreArchiver extends ConsoleCommand
         $archiver->concurrentRequestsPerWebsite = $input->getOption('concurrent-requests-per-website');
         $archiver->maxConcurrentArchivers = $input->getOption('concurrent-archivers');
         $archiver->shouldArchiveAllSites = $input->getOption('force-all-websites');
+        $archiver->maxSitesToProcess = $input->getOption('max-websites-to-process');
         $archiver->setUrlToPiwik($url);
 
         $archiveFilter = new CronArchive\ArchiveFilter();
@@ -111,6 +112,8 @@ class CoreArchiver extends ConsoleCommand
             "When processing a website and its segments, number of requests to process in parallel", CronArchive::MAX_CONCURRENT_API_REQUESTS);
         $command->addOption('concurrent-archivers', null, InputOption::VALUE_OPTIONAL,
             "The number of max archivers to run in parallel. Depending on how you start the archiver as a cronjob, you may need to double the amount of archivers allowed if the same process appears twice in the `ps ex` output.", false);
+        $command->addOption('max-websites-to-process', null, InputOption::VALUE_REQUIRED,
+            "Maximum number of websites to process during a single execution of the archiver. Can be used to limit the process lifetime e.g. to avoid increasing memory usage.");
         $command->addOption('disable-scheduled-tasks', null, InputOption::VALUE_NONE,
             "Skips executing Scheduled tasks (sending scheduled reports, db optimization, etc.).");
         $command->addOption('accept-invalid-ssl-certificate', null, InputOption::VALUE_NONE,

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -47,6 +47,7 @@ class CoreArchiver extends ConsoleCommand
         $archiver->maxConcurrentArchivers = $input->getOption('concurrent-archivers');
         $archiver->shouldArchiveAllSites = $input->getOption('force-all-websites');
         $archiver->maxSitesToProcess = $input->getOption('max-websites-to-process');
+        $archiver->maxArchivesToProcess = $input->getOption('max-archives-to-process');
         $archiver->setUrlToPiwik($url);
 
         $archiveFilter = new CronArchive\ArchiveFilter();
@@ -114,6 +115,8 @@ class CoreArchiver extends ConsoleCommand
             "The number of max archivers to run in parallel. Depending on how you start the archiver as a cronjob, you may need to double the amount of archivers allowed if the same process appears twice in the `ps ex` output.", false);
         $command->addOption('max-websites-to-process', null, InputOption::VALUE_REQUIRED,
             "Maximum number of websites to process during a single execution of the archiver. Can be used to limit the process lifetime e.g. to avoid increasing memory usage.");
+        $command->addOption('max-archives-to-process', null, InputOption::VALUE_REQUIRED,
+            "Preferred number of archives to process during a single execution of the archiver. Can be used to limit the process lifetime e.g. to avoid increasing memory usage. Note that execution will only stop after all archives for a website have been processed, so the limit may be exceeded.");
         $command->addOption('disable-scheduled-tasks', null, InputOption::VALUE_NONE,
             "Skips executing Scheduled tasks (sending scheduled reports, db optimization, etc.).");
         $command->addOption('accept-invalid-ssl-certificate', null, InputOption::VALUE_NONE,

--- a/plugins/CoreConsole/Commands/CoreArchiver.php
+++ b/plugins/CoreConsole/Commands/CoreArchiver.php
@@ -116,7 +116,7 @@ class CoreArchiver extends ConsoleCommand
         $command->addOption('max-websites-to-process', null, InputOption::VALUE_REQUIRED,
             "Maximum number of websites to process during a single execution of the archiver. Can be used to limit the process lifetime e.g. to avoid increasing memory usage.");
         $command->addOption('max-archives-to-process', null, InputOption::VALUE_REQUIRED,
-            "Preferred number of archives to process during a single execution of the archiver. Can be used to limit the process lifetime e.g. to avoid increasing memory usage. Note that execution will only stop after all archives for a website have been processed, so the limit may be exceeded.");
+            "Maximum number of archives to process during a single execution of the archiver. Can be used to limit the process lifetime e.g. to avoid increasing memory usage.");
         $command->addOption('disable-scheduled-tasks', null, InputOption::VALUE_NONE,
             "Skips executing Scheduled tasks (sending scheduled reports, db optimization, etc.).");
         $command->addOption('accept-invalid-ssl-certificate', null, InputOption::VALUE_NONE,


### PR DESCRIPTION

### Description:

This change makes it possible to limit the process lifetime to avoid excessive memory usage (possibly due to PHP bugs such as 79519).

#### Rationale:

We have an issue with the archiver and a large number (~3900) of sites where the archiver process runs out of memory. We have tried to increase memory_limit up to 12 GB to no avail, so this is an attempt to limit the lifetime of the archiver to avoid this excessive memory usage.

As a sidenote there seem to be some static or long-living arrays that consume memory during archiving, such as the transient cache, but they don't seem to explain everything. I suspect PHP issues such as [79519](https://bugs.php.net/bug.php?id=79519) contribute to this.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
