### PR TITLE
Fix for incorrect multisite dashboard Urls behind reverse proxy

### DIFF
--- a/plugins/MultiSites/angularjs/dashboard/dashboard.directive.html
+++ b/plugins/MultiSites/angularjs/dashboard/dashboard.directive.html
@@ -89,7 +89,7 @@
             <td colspan="8" class="paging" ng-hide="model.numberOfPages() <= 1">
                 <div class="row">
                     <div class="col s3 add_new_site">
-                        <a ng-if="hasSuperUserAccess" href="{{ url }}?module=SitesManager&action=index&showaddsite=1&period={{ period }}&date={{ date }}&idSite={{ idSite }}">
+                        <a ng-if="hasSuperUserAccess" href="index.php?module=SitesManager&action=index&showaddsite=1&period={{ period }}&date={{ date }}&idSite={{ idSite }}">
                             <span class="icon-add"></span> {{ 'SitesManager_AddSite'|translate }}
                         </a>
                     </div>

--- a/plugins/MultiSites/angularjs/site/site.controller.js
+++ b/plugins/MultiSites/angularjs/site/site.controller.js
@@ -27,7 +27,7 @@
         }
 
         function dashboardUrl(website){
-            return piwik.piwik_url + 'index.php?module=CoreHome&action=index&date=' + $scope.date + '&period=' + $scope.period + '&idSite=' + website.idsite + tokenParam();
+            return 'index.php?module=CoreHome&action=index&date=' + $scope.date + '&period=' + $scope.period + '&idSite=' + website.idsite + tokenParam();
         }
 
         function sparklineImage(website){
@@ -45,7 +45,7 @@
                     break;
             }
 
-            return piwik.piwik_url + 'index.php?module=MultiSites&action=getEvolutionGraph&period=' + $scope.period + '&date=' + $scope.dateSparkline + '&evolutionBy=' + metric + '&columns=' + metric + '&idSite=' + website.idsite + '&idsite=' + website.idsite + '&viewDataTable=sparkline' + tokenParam() + '&colors=' + encodeURIComponent(JSON.stringify(piwik.getSparklineColors()));
+            return 'index.php?module=MultiSites&action=getEvolutionGraph&period=' + $scope.period + '&date=' + $scope.dateSparkline + '&evolutionBy=' + metric + '&columns=' + metric + '&idSite=' + website.idsite + '&idsite=' + website.idsite + '&viewDataTable=sparkline' + tokenParam() + '&colors=' + encodeURIComponent(JSON.stringify(piwik.getSparklineColors()));
         }
     }
 })();


### PR DESCRIPTION
### Description:

Fixes #17945 

When Matomo is running behind a reverse proxy server that forwards traffic to a directory path (eg. `proxy.com/matomo/`) but Matomo itself is installed in a different path (eg. `someotherhost.com/` or `someotherhost.com/differentpath`) then incorrect paths are used for links in the Multi Sites page, specifically: site selection, the evolution sparklines and add a new website.

This PR is a simple fix to remove the calculated piwik_url from these links and use relative paths instead.

Tested with three docker images: mariadb:latest, matomo:4.5.0 official docker and nginx:latest

nginx configured with
```
location /matomo/ {
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Uri /matomo/;
        proxy_pass http://<matomo container ip>/;
        proxy_read_timeout 90;
    }
```
Matomo config.ini.php
```
[General]
assume_secure_protocol = 0
proxy_client_headers[] = "HTTP_X_FORWARDED_FOR"
proxy_host_headers[] = "HTTP_X_FORWARDED_HOST"
trusted_hosts[] = "<nginx container ip>"
```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
