### PR TITLE
Log archiving query timeouts

### DIFF
--- a/core/DataAccess/ArchivingDbAdapter.php
+++ b/core/DataAccess/ArchivingDbAdapter.php
@@ -13,6 +13,7 @@ use Piwik\Config;
 use Piwik\Db\AdapterInterface;
 use Piwik\DbHelper;
 use Psr\Log\LoggerInterface;
+use Exception;
 
 class ArchivingDbAdapter
 {
@@ -48,7 +49,7 @@ class ArchivingDbAdapter
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this->wrapped, __FUNCTION__], func_get_args());
+        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
     }
 
     public function query($sql)
@@ -56,7 +57,7 @@ class ArchivingDbAdapter
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this->wrapped, __FUNCTION__], func_get_args());
+        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
     }
 
     public function fetchAll($sql)
@@ -64,7 +65,7 @@ class ArchivingDbAdapter
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this->wrapped, __FUNCTION__], func_get_args());
+        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
     }
 
     public function fetchRow($sql)
@@ -72,7 +73,7 @@ class ArchivingDbAdapter
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this->wrapped, __FUNCTION__], func_get_args());
+        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
     }
 
     public function fetchOne($sql)
@@ -80,7 +81,7 @@ class ArchivingDbAdapter
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this->wrapped, __FUNCTION__], func_get_args());
+        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
     }
 
     public function fetchAssoc($sql)
@@ -88,7 +89,19 @@ class ArchivingDbAdapter
         $sql = DbHelper::addMaxExecutionTimeHintToQuery($sql, $this->maxExecutionTime);
         $this->logSql($sql);
 
-        return call_user_func_array([$this->wrapped, __FUNCTION__], func_get_args());
+        return call_user_func_array([$this, "callFunction"], array_merge([__FUNCTION__], func_get_args()));
+    }
+
+    /**
+     * Test error number
+     *
+     * @param Exception $e
+     * @param string $errno
+     * @return bool
+     */
+    public function isErrNo($e, $errno)
+    {
+        return $this->wrapped->isErrNo($e, $errno);
     }
 
     private function logSql($sql)
@@ -98,4 +111,26 @@ class ArchivingDbAdapter
             $this->logger->debug($sql);
         }
     }
+
+    private function callFunction($function) {
+
+        $args = func_get_args();
+        unset($args[0]);
+
+        try {
+            return call_user_func_array([$this->wrapped, $function], $args);
+        } catch (\Exception $e) {
+            if ($this->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_MAX_EXECUTION_TIME_EXCEEDED_QUERY_INTERRUPTED) ||
+                $this->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_MAX_EXECUTION_TIME_EXCEEDED_SORT_ABORTED)
+            )
+            {
+                $this->logger->info('Archiver query exceeded maximum execution time: {details}',
+                    ['details' => json_encode($args, true)]);
+
+            } else {
+                throw $e;
+            }
+        }
+    }
+
 }

--- a/core/DataAccess/ArchivingDbAdapter.php
+++ b/core/DataAccess/ArchivingDbAdapter.php
@@ -127,9 +127,8 @@ class ArchivingDbAdapter
                 $this->logger->info('Archiver query exceeded maximum execution time: {details}',
                     ['details' => json_encode($args, true)]);
 
-            } else {
-                throw $e;
             }
+            throw $e;
         }
     }
 

--- a/core/DataAccess/ArchivingDbAdapter.php
+++ b/core/DataAccess/ArchivingDbAdapter.php
@@ -124,7 +124,7 @@ class ArchivingDbAdapter
                 $this->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_MAX_EXECUTION_TIME_EXCEEDED_SORT_ABORTED)
             )
             {
-                $this->logger->info('Archiver query exceeded maximum execution time: {details}',
+                $this->logger->warning('Archiver query exceeded maximum execution time: {details}',
                     ['details' => json_encode($args, true)]);
 
             }


### PR DESCRIPTION
### Description:

Fixes #18025 

Added an exception handler to the archiving db adapter which will catch any exceptions thrown because of the max_execution_time hint and log the exception and query details.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
