### PR TITLE
Improve Vue Build action

### DIFF
--- a/.github/workflows/buildvue.yml
+++ b/.github/workflows/buildvue.yml
@@ -41,12 +41,7 @@ jobs:
             exit 0;
           fi
 
-          if [[ $BASE != $GITHUB_REPOSITORY ]]
-          then
-            echo "It's only possible to update local branches"
-            exit 1;
-          fi
-
+          echo ::set-output name=islocalbranch::$BASE == $GITHUB_REPOSITORY
           echo ::set-output name=branch::$REF
           echo ::set-output name=base::$BASE_SHA
       - uses: actions/checkout@v2
@@ -64,7 +59,7 @@ jobs:
           if [[ $VUE_FILES_MODIFIED == "0" ]]
           then
             echo "No vue files modified"
-            exit;
+            exit 0;
           fi
 
           echo ::set-output name=vue_modified::1
@@ -126,12 +121,32 @@ jobs:
         run: php ./console vue:build
         if: steps.vars.outputs.branch != '' && steps.vuecheck.outputs.vue_modified == '1'
       - name: Push changes
+        id: push
         run: |
           if [[ $( git diff --numstat plugins/*/vue/dist/*.js ) ]]
           then
-            cd $GITHUB_WORKSPACE
-            git add plugins/*/vue/dist/*.js plugins/*/vue/dist/*.json
-            git commit -m "built vue files"
-            git push
+            if [[ ! ${{ steps.vars.outputs.islocalbranch }} ]]
+            then
+              echo "It's only possible to update local branches automatically. Adding a comment instead."
+              echo ::set-output name=failure::1
+            else
+              cd $GITHUB_WORKSPACE
+              git add plugins/*/vue/dist/*.js plugins/*/vue/dist/*.json
+              git commit -m "built vue files"
+              git push
+            fi
           fi
         if: steps.vars.outputs.branch != '' && steps.vuecheck.outputs.vue_modified == '1'
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Vue files are not up to date. Please build the files using `./console vue:build` locally and push them to your branch.'
+            })
+        if: steps.push.outputs.failure == '1'
+      - name: Fail if not up to date
+        run: exit 1
+        if: steps.push.outputs.failure == '1'


### PR DESCRIPTION
### Description:

Currently when a build runs for a PR coming from a fork, the action fails. 

This will change the process, so it succeeds if vue files are still up to date, or leave a PR comment if the files need to be updated:

![image](https://user-images.githubusercontent.com/1579355/142999905-50350bee-8d08-4e0a-824b-0a255605eeda.png)


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
