### PR TITLE
Fixes HTML_QuickForm2_ContainerIterator for PHP8.1

### DIFF
--- a/libs/HTML/QuickForm2/Container.php
+++ b/libs/HTML/QuickForm2/Container.php
@@ -65,12 +65,12 @@ class HTML_QuickForm2_ContainerIterator extends RecursiveArrayIterator implement
         parent::__construct($container->getElements());
     }
 
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return $this->current() instanceof HTML_QuickForm2_Container;
     }
 
-    public function getChildren()
+    public function getChildren(): HTML_QuickForm2_ContainerIterator
     {
         return new HTML_QuickForm2_ContainerIterator($this->current());
     }

--- a/libs/HTML/QuickForm2/Element/Select.php
+++ b/libs/HTML/QuickForm2/Element/Select.php
@@ -60,12 +60,12 @@
 class HTML_QuickForm2_Element_Select_OptionIterator extends RecursiveArrayIterator
     implements RecursiveIterator
 {
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return $this->current() instanceof HTML_QuickForm2_Element_Select_OptionContainer;
     }
 
-    public function getChildren()
+    public function getChildren(): HTML_QuickForm2_Element_Select_OptionIterator
     {
         return new HTML_QuickForm2_Element_Select_OptionIterator(
             $this->current()->getOptions()


### PR DESCRIPTION
### Description:

missed that in https://github.com/matomo-org/matomo/pull/18309

fixes #18374 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
