### PR TITLE
Ensure javascript of a datatable only initializes itself

### DIFF
--- a/plugins/CoreHome/angularjs/widget-bydimension-container/widget-bydimension-container.directive.less
+++ b/plugins/CoreHome/angularjs/widget-bydimension-container/widget-bydimension-container.directive.less
@@ -14,6 +14,7 @@
         .dimensionReport {
             float: left;
             min-width: 500px;
+            max-width: 100%;
         }
 
         table.dataTable tr td.label {

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -40,7 +40,7 @@ function DataTable(element) {
 DataTable._footerIconHandlers = {};
 
 DataTable.initNewDataTables = function (reportId) {
-    var selector = reportId ? '[data-report="'+reportId+'"]' : 'div.dataTable';
+    var selector = typeof reportId === 'string' ? '[data-report='+JSON.stringify(reportId)+']' : 'div.dataTable';
     $(selector).each(function () {
         if (!$(this).attr('id')) {
             var tableType = $(this).attr('data-table-type') || 'DataTable',

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -39,8 +39,9 @@ function DataTable(element) {
 
 DataTable._footerIconHandlers = {};
 
-DataTable.initNewDataTables = function () {
-    $('div.dataTable').each(function () {
+DataTable.initNewDataTables = function (reportId) {
+    var selector = reportId ? '[data-report="'+reportId+'"]' : 'div.dataTable';
+    $(selector).each(function () {
         if (!$(this).attr('id')) {
             var tableType = $(this).attr('data-table-type') || 'DataTable',
                 klass = require('piwik/UI')[tableType] || require(tableType);
@@ -376,7 +377,7 @@ $.extend(DataTable.prototype, UIControl.prototype, {
         self.handleSearchBox(domElem);
         self.handleColumnDocumentation(domElem);
         self.handleRowActions(domElem);
-		self.handleCellTooltips(domElem);
+        self.handleCellTooltips(domElem);
         self.handleRelatedReports(domElem);
         self.handleTriggeredEvents(domElem);
         self.handleColumnHighlighting(domElem);

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -1956,17 +1956,13 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                     // ensure the tooltips of parent elements are hidden when the action tooltip is shown
                     // otherwise it can happen that tooltips for subtable rows are shown as well.
                     open: function() {
-                        var tooltip = $(this).parents().filter(function() {
-                            return jQuery.hasData(this) && $(this).data('ui-tooltip');
-                        }).tooltip('instance');
+                        var tooltip = $(this).parents('[piwik-widget]').tooltip('instance');
                         if (tooltip) {
                             tooltip.disable();
                         }
                     },
                     close: function() {
-                        var tooltip = $(this).parents().filter(function() {
-                            return jQuery.hasData(this) && $(this).data('ui-tooltip');
-                        }).tooltip('instance');
+                        var tooltip = $(this).parents('[piwik-widget]').tooltip('instance');
                         if (tooltip) {
                             tooltip.enable();
                         }

--- a/plugins/CoreHome/javascripts/dataTable.js
+++ b/plugins/CoreHome/javascripts/dataTable.js
@@ -426,14 +426,6 @@ $.extend(DataTable.prototype, UIControl.prototype, {
             $domElem.width('');
             parentDataTable.width('');
 
-            var $table = $('table.dataTable', domElem);
-            if ($table.closest('.reportsByDimensionView').length) {
-                var requiredTableWidth = $table.width() - 40; // 40 is padding on card content
-                if (domElem.width() > requiredTableWidth) {
-                    domElem.css('max-width', requiredTableWidth + 'px');
-                }
-            }
-
             var tableWidth = getTableWidth(domElem);
 
             if (tableWidth <= maxTableWidth) {
@@ -446,9 +438,9 @@ $.extend(DataTable.prototype, UIControl.prototype, {
 
             if (dataTableInCard && dataTableInCard.length) {
                 // makes sure card has the same width
-                dataTableInCard.width(maxTableWidth);
+                dataTableInCard.css('max-width', maxTableWidth);
             } else {
-                $domElem.width(maxTableWidth);
+                $domElem.css('max-width', maxTableWidth);
             }
 
             if (parentDataTable && parentDataTable.length) {
@@ -456,9 +448,9 @@ $.extend(DataTable.prototype, UIControl.prototype, {
                 // applied in getLabelWidth() since they will have the same size.
 
                 if (dataTableInCard.length) {
-                    dataTableInCard.width(maxTableWidth);
+                    dataTableInCard.css('max-width', maxTableWidth);
                 } else {
-                    parentDataTable.width(maxTableWidth);
+                    parentDataTable.css('max-width', maxTableWidth);
                 }
             }
         }

--- a/plugins/CoreHome/templates/_dataTable.twig
+++ b/plugins/CoreHome/templates/_dataTable.twig
@@ -73,7 +73,7 @@
                 {% include "@CoreHome/_dataTableFooter.twig" %}
             {% endif %}
 
-            {% include "@CoreHome/_dataTableJS.twig" %}
+            {% include "@CoreHome/_dataTableJS.twig" with { reportId: properties.report_id } %}
         {% endif %}
     </div>
 </div>

--- a/plugins/CoreHome/templates/_dataTableJS.twig
+++ b/plugins/CoreHome/templates/_dataTableJS.twig
@@ -1,5 +1,5 @@
 <script type="text/javascript" defer="defer">
     $(document).ready(function () {
-        require('piwik/UI/DataTable').initNewDataTables('{{ reportId }}');
+        require('piwik/UI/DataTable').initNewDataTables({{ reportId|json_encode|raw }});
     });
 </script>

--- a/plugins/CoreHome/templates/_dataTableJS.twig
+++ b/plugins/CoreHome/templates/_dataTableJS.twig
@@ -1,5 +1,5 @@
 <script type="text/javascript" defer="defer">
     $(document).ready(function () {
-        require('piwik/UI/DataTable').initNewDataTables();
+        require('piwik/UI/DataTable').initNewDataTables('{{ reportId }}');
     });
 </script>

--- a/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_overview.png
+++ b/plugins/Goals/tests/UI/expected-screenshots/GoalsPages_overview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23039ef64c1d32ae9149d6cb1fadeb8f133efe350372583c797f160056075199
-size 161691
+oid sha256:47f4954791162c63495b422e2bbf6eef330cd819ecb3f4490d0edc7dc7b9cbca
+size 164421

--- a/tests/UI/expected-screenshots/PivotByDimension_pivoted.png
+++ b/tests/UI/expected-screenshots/PivotByDimension_pivoted.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d86338d2cddaf3be5e191433daf081b8fad5e21ea7e4379a8785acda80c123b
-size 71499
+oid sha256:1f03cc267c565c4c84f8476fd60238bb340ba72e11d93e3a8d042248718bd84a
+size 69333

--- a/tests/UI/expected-screenshots/UIIntegrationTest_ecommerce_products.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_ecommerce_products.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d870cdfc0e8040ae1942eef1137a29593c12eb2f9ff6ded1785860556fd0ff63
-size 55119
+oid sha256:a0814a1ee0355b98d6c8ef81396fe70fd42e56dbb728507f2fdb1d80d35ed442
+size 53649

--- a/tests/UI/expected-screenshots/UIIntegrationTest_ecommerce_sales.png
+++ b/tests/UI/expected-screenshots/UIIntegrationTest_ecommerce_sales.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3e29ca5e758358f795ec28b23e12f587cfdbe7bba0c6e6e208f6ae458c04a67
-size 92245
+oid sha256:6f5e19a61f57c573ea1e7302c530c819182a3b42bf1eba1b98b47974fa59ec24
+size 92901


### PR DESCRIPTION
### Description:

When a report containing some kind of datatable is loaded, the delivered code also includes some javascript to initialize the datatable (see `_dataTableJS.twig `). We used to simply initialize all (new) datatables found on the page. This actually led to #18373. When switching the date range, all reports on the goals page are reloaded. In most cases the evolution chart is finished first. This chart already triggers a datatable initialize. In most cases the detail report below is already loaded but not yet rendered into the page. The javascript already tries to initialize the datatable, resulting in the weird behavior. 

This PR will change this, so only the report contained in the response (based on the reportid) will be initialized.
Locally that seems to work fine for me.

fixes #18373 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
