### PR TITLE
Improve password handling in SMTP configuration

### DIFF
--- a/plugins/CoreAdminHome/Controller.php
+++ b/plugins/CoreAdminHome/Controller.php
@@ -160,8 +160,8 @@ class Controller extends ControllerAdmin
             $mail['username'] = Common::unsanitizeInputValue(Common::getRequestVar('mailUsername', ''));
             $mail['password'] = Common::unsanitizeInputValue(Common::getRequestVar('mailPassword', ''));
 
-            if (!array_key_exists('mailPassword', $_POST)) {
-                // use old password if it wasn't set in request
+            if (!array_key_exists('mailPassword', $_POST) && Config::getInstance()->mail['password'] !== $mail['host']) {
+                // use old password if it wasn't set in request (and the host wasn't changed)
                 $mail['password'] = Config::getInstance()->mail['password'];
             }
 

--- a/plugins/CoreAdminHome/templates/generalSettings.twig
+++ b/plugins/CoreAdminHome/templates/generalSettings.twig
@@ -96,6 +96,7 @@
 
                 <div piwik-field uicontrol="text" name="mailHost"
                      ng-model="mailSettings.mailHost"
+                     ng-change="mailSettings.passwordChanged || ((mailSettings.mailPassword = '') || (mailSettings.passwordChanged = true))"
                      data-title="{{ 'General_SmtpServerAddress'|translate|e('html_attr') }}"
                      value="{{ mail.host|e('html_attr') }}">
                 </div>
@@ -128,6 +129,7 @@
                 <div piwik-field uicontrol="password" name="mailPassword"
                      ng-model="mailSettings.mailPassword"
                      ng-change="mailSettings.passwordChanged = true"
+                     ng-click="!mailSettings.passwordChanged && $event.target.select();"
                      data-title="{{ 'General_SmtpPassword'|translate|e('html_attr') }}"
                      value="{{ mail.password ? '******' }}" inline-help="{{ help|e('html_attr') }}"
                      autocomplete="off">


### PR DESCRIPTION
### Description:

This PR contains the following changes to the Mail configuration UI:

- As soon as the hostname is changed, the password will be cleared (unless the password has already been changed before)
- Focusing the password field will automatically select all it's content (if the password hadn't been changed already)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
