### PR TITLE
Add option to allow skipping logic that exits w/ an error code if warnings are detected in the output

### DIFF
--- a/core/Console.php
+++ b/core/Console.php
@@ -55,7 +55,7 @@ class Console extends Application
         $this->getDefinition()->addOption($option);
 
         $option = new InputOption('ignore-warn', null, InputOption::VALUE_NONE,
-            'Return 0 exit code even if there are warnings detected.');
+            'Return 0 exit code even if there are warning logs or error logs detected in the command output.');
 
         $this->getDefinition()->addOption($option);
     }

--- a/core/Console.php
+++ b/core/Console.php
@@ -53,6 +53,11 @@ class Console extends Application
         );
 
         $this->getDefinition()->addOption($option);
+
+        $option = new InputOption('ignore-warn', null, InputOption::VALUE_NONE,
+            'Return 0 exit code even if there are warnings detected.');
+
+        $this->getDefinition()->addOption($option);
     }
 
     public function renderException($e, $output)
@@ -132,7 +137,10 @@ class Console extends Application
         }
 
         $importantLogDetector = StaticContainer::get(FailureLogMessageDetector::class);
-        if ($exitCode === 0 && $importantLogDetector->hasEncounteredImportantLog()) {
+        if (!$input->getOption('ignore-warn')
+            && $exitCode === 0
+            && $importantLogDetector->hasEncounteredImportantLog()
+        ) {
             $output->writeln("Error: error or warning logs detected, exit 1");
             $exitCode = 1;
         }

--- a/core/Console.php
+++ b/core/Console.php
@@ -137,7 +137,7 @@ class Console extends Application
         }
 
         $importantLogDetector = StaticContainer::get(FailureLogMessageDetector::class);
-        if (!$input->getOption('ignore-warn')
+        if (!$input->hasParameterOption('ignore-warn')
             && $exitCode === 0
             && $importantLogDetector->hasEncounteredImportantLog()
         ) {

--- a/core/Console.php
+++ b/core/Console.php
@@ -137,7 +137,7 @@ class Console extends Application
         }
 
         $importantLogDetector = StaticContainer::get(FailureLogMessageDetector::class);
-        if (!$input->hasParameterOption('ignore-warn')
+        if (!$input->hasParameterOption('--ignore-warn')
             && $exitCode === 0
             && $importantLogDetector->hasEncounteredImportantLog()
         ) {


### PR DESCRIPTION
### Description:

This is for automation for the vue migration, specifically being able to run vue:build and tell if there is a legitimate error in the file.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
