### PR TITLE
Include another local file if present in UI tests to allow extending the screenshot testing lib.

### DIFF
--- a/tests/lib/screenshot-testing/.gitignore
+++ b/tests/lib/screenshot-testing/.gitignore
@@ -1,3 +1,3 @@
 /node_modules/
 /*-debug.log
-
+/local-extras.js

--- a/tests/lib/screenshot-testing/mocha-super-suite.js
+++ b/tests/lib/screenshot-testing/mocha-super-suite.js
@@ -1,2 +1,8 @@
 app.init();
 app.loadTestModules();
+
+try {
+  require('./local-extras');
+} catch (e) {
+  // ignore
+}


### PR DESCRIPTION
### Description:

Using this locally to add an extra `afterEach()` hook to every test suite that outputs the HTML on the page to a directory. Diffing these makes it quicker to resolve certain issues encountered in the vue migration. (The logic is not actually useful outside of the vue migration so doesn't need to be in core.)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
