### PR TITLE
Fixes some UI issues in anonymise data

### DIFF
--- a/plugins/PrivacyManager/angularjs/anonymize-log-data/anonymize-log-data.directive.less
+++ b/plugins/PrivacyManager/angularjs/anonymize-log-data/anonymize-log-data.directive.less
@@ -5,7 +5,6 @@
   }
 
   .innerFormField {
-    margin-left: -0.75rem;
     .form-group.row {
       margin-top: 2px;
       margin-bottom: 2px;
@@ -14,5 +13,6 @@
 
   .innerFormField {
     width: 100%;
+    width: ~"calc(100% - 0.75rem)";
   }
 }

--- a/plugins/PrivacyManager/angularjs/anonymize-log-data/anonymize-log-data.directive.less
+++ b/plugins/PrivacyManager/angularjs/anonymize-log-data/anonymize-log-data.directive.less
@@ -1,6 +1,7 @@
 .anonymizeLogData {
   .icon-minus {
     cursor: pointer;
+    z-index: 10;
   }
 
   .innerFormField {

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizeip_and_visit_column_cancelled.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizeip_and_visit_column_cancelled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:638e813c43505b2d715de1e299770b964990fd0c3c18c3788e4ece77aa8bce47
-size 215963
+oid sha256:110ede9d6e2e3bf1f85bd7aef80a40704908409abef55b9cf485613af51a864d
+size 215955

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizeip_and_visit_column_confirmed.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizeip_and_visit_column_confirmed.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06495f98a6b727d1da6bbc84921e6559b9cfcb8290a906d42e46cc9cd57dfcdb
-size 220870
+oid sha256:53b9bf0a3774be088f4431db505b546a282fe774ab7ddbeeb2fa71eca69a43e5
+size 220871

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizeip_and_visit_column_prefilled.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizeip_and_visit_column_prefilled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:638e813c43505b2d715de1e299770b964990fd0c3c18c3788e4ece77aa8bce47
-size 215963
+oid sha256:110ede9d6e2e3bf1f85bd7aef80a40704908409abef55b9cf485613af51a864d
+size 215955

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizelocation_anduserid_and_action_column_confirmed.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizelocation_anduserid_and_action_column_confirmed.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:193b062a5a058a6955ce2ef7d66580aa898aee2de16b8484b02cdd68647d0572
-size 233321
+oid sha256:2086d228b348fca1c839fa8e0d7b744ba3c9a838c634318cc7fce9387aa13b9c
+size 233322

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizelocation_anduserid_and_action_column_prefilled.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_anonymizelocation_anduserid_and_action_column_prefilled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c6da3e4e4b69ca9e75de221171d5993ec26b5eb5debade3fb0b1e9975ca02621
-size 229863
+oid sha256:90d41c865723166ea39bca2f099bc79ae829f1de8366f3cb9019308decd81a78
+size 229870

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_one_site_and_custom_date_confirmed.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_one_site_and_custom_date_confirmed.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87084a49a3174ba506c19cebb0fc3a6ce91ce26836e79c9db1c88e9d3edcb56b
-size 241565
+oid sha256:36dd853772182993b9f61ac90fff19489c59d2f176b1933b0fab3df6480d9c13
+size 241566

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_one_site_and_custom_date_prefilled.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_anonymizelogdata_one_site_and_custom_date_prefilled.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:631206c6bba4d1c65179c171de3f34aed6efab4d05f9f7008385576adbc1eaa0
-size 232923
+oid sha256:4c4d7e2ea01b39bbd3e0f86761b9854b12d8e367495909f25fa9dc6820c6ee9b
+size 232924

--- a/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_privacy_settings_default.png
+++ b/plugins/PrivacyManager/tests/UI/expected-screenshots/PrivacyManager_privacy_settings_default.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39b338e165b7fe1ef7333d1ad3a2be3285fb5a899e1d29eb4dc5fbd4b4daa700
+oid sha256:ddb7a2f94f148f8e9079ac14b723df46f051f37d7d1064103f702691b12820c0
 size 545154


### PR DESCRIPTION
### Description:

Found a few UI issues while testing some other stuff.

* The remove icon (appearing when fields are added) was not really clickable as the input field had an higher z-index
* The select fields were slightly misplaced

Note: There are currently a lot UI tests failing due to the fact, that the new version was tagged on another branch, but the changes are not yet included here...

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
