### PR TITLE
Also try to remove hidden files on update

### DIFF
--- a/core/Filesystem.php
+++ b/core/Filesystem.php
@@ -294,8 +294,17 @@ class Filesystem
      */
     public static function directoryDiff($source, $target)
     {
-        $sourceFiles = self::globr($source, '*');
-        $targetFiles = self::globr($target, '*');
+        $flags = 0;
+        $pattern = '*';
+
+        if (defined('GLOB_BRACE')) {
+            // The GLOB_BRACE flag is not available on some non GNU systems, like Solaris or Alpine Linux.
+            $flags = GLOB_BRACE;
+            $pattern = '{,.}*[!.]*'; // matches all files and folders, including those starting with ".", but excludes "." and ".."
+        }
+
+        $sourceFiles = self::globr($source, $pattern, $flags);
+        $targetFiles = self::globr($target, $pattern, $flags);
 
         $sourceFiles = array_map(function ($file) use ($source) {
             return str_replace($source, '', $file);


### PR DESCRIPTION
### Description:

Hidden files were not removed correctly on update. The reason is the `glob` we are using to create a diff for the directories.

refs #18435 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
