### PR TITLE
Dashboards per site

### DIFF
--- a/plugins/Dashboard/API.php
+++ b/plugins/Dashboard/API.php
@@ -9,6 +9,7 @@ namespace Piwik\Plugins\Dashboard;
 
 use Piwik\API\Request;
 use Piwik\Piwik;
+use Piwik\Common;
 
 /**
  * This API is the <a href='http://matomo.org/docs/analytics-api/reference/' rel='noreferrer' target='_blank'>Dashboard API</a>: it gives information about dashboards.
@@ -36,15 +37,16 @@ class API extends \Piwik\Plugin\API
      *
      * @return array[]
      */
-    public function getDashboards($login = '', $returnDefaultIfEmpty = true)
+    public function getDashboards($login = '', $returnDefaultIfEmpty = true )
     {
         $login = $login ? $login : Piwik::getCurrentUserLogin();
+        $idSite = Common::getRequestVar('idSite');
 
         $dashboards = [];
 
         if (!Piwik::isUserIsAnonymous()) {
             Piwik::checkUserHasSuperUserAccessOrIsTheUser($login);
-            $dashboards = $this->getUserDashboards($login);
+            $dashboards = $this->getUserDashboards($login,$idSite);
         }
 
         if (empty($dashboards) && $returnDefaultIfEmpty) {
@@ -74,8 +76,9 @@ class API extends \Piwik\Plugin\API
         if ($addDefaultWidgets) {
             $layout = $this->dashboard->getDefaultLayout();
         }
+        $idSite = Common::getRequestVar('idSite');
 
-        return $this->model->createNewDashboardForUser($login, $dashboardName, $layout);
+        return $this->model->createNewDashboardForUser($login, $dashboardName, $layout,$idSite);
     }
 
     /**

--- a/plugins/Dashboard/API.php
+++ b/plugins/Dashboard/API.php
@@ -37,10 +37,9 @@ class API extends \Piwik\Plugin\API
      *
      * @return array[]
      */
-    public function getDashboards($login = '', $returnDefaultIfEmpty = true )
+    public function getDashboards($login = '', $returnDefaultIfEmpty = true, $idSite = 0 )
     {
         $login = $login ? $login : Piwik::getCurrentUserLogin();
-        $idSite = Common::getRequestVar('idSite');
 
         $dashboards = [];
 
@@ -67,7 +66,7 @@ class API extends \Piwik\Plugin\API
      * @param bool $addDefaultWidgets  whether to add the current default widget collection or not
      * @return int|string
      */
-    public function createNewDashboardForUser($login, $dashboardName = '', $addDefaultWidgets = true)
+    public function createNewDashboardForUser($login, $dashboardName = '', $addDefaultWidgets = true, $idSite = 0)
     {
         Piwik::checkUserHasSuperUserAccessOrIsTheUser($login);
 
@@ -76,7 +75,6 @@ class API extends \Piwik\Plugin\API
         if ($addDefaultWidgets) {
             $layout = $this->dashboard->getDefaultLayout();
         }
-        $idSite = Common::getRequestVar('idSite');
 
         return $this->model->createNewDashboardForUser($login, $dashboardName, $layout,$idSite);
     }

--- a/plugins/Dashboard/Dashboard.php
+++ b/plugins/Dashboard/Dashboard.php
@@ -211,7 +211,9 @@ class Dashboard extends \Piwik\Plugin
 
     public function getAllDashboards($login)
     {
-        $dashboards = $this->getModel()->getAllDashboardsForUser($login);
+        $idSite = Common::getRequestVar('idSite');
+
+        $dashboards = $this->getModel()->getAllDashboardsForUser($login,$idSite);
 
         $nameless = 1;
         foreach ($dashboards as &$dashboard) {

--- a/plugins/Dashboard/Model.php
+++ b/plugins/Dashboard/Model.php
@@ -41,10 +41,10 @@ class Model
         return $layouts;
     }
 
-    public function getAllDashboardsForUser($login)
+    public function getAllDashboardsForUser($login, $idSite)
     {
         $dashboards = Db::fetchAll('SELECT iddashboard, name, layout FROM ' . $this->table .
-                                   ' WHERE login = ? ORDER BY iddashboard', array($login));
+                                   ' WHERE login = ? and (idSite = ? OR idSite=0) ORDER BY iddashboard', array($login,$idSite));
 
         return $dashboards;
     }
@@ -81,12 +81,12 @@ class Model
      * Creates a new dashboard for the current user
      * User needs to be logged in
      */
-    public function createNewDashboardForUser($login, $name, $layout)
+    public function createNewDashboardForUser($login, $name, $layout,$idSite)
     {
         $nextId = $this->getNextIdDashboard($login);
 
-        $query = sprintf('INSERT INTO %s (login, iddashboard, name, layout) VALUES (?, ?, ?, ?)', $this->table);
-        $bind  = array($login, $nextId, $name, $layout);
+        $query = sprintf('INSERT INTO %s (login, iddashboard, name, layout, idSite) VALUES (?, ?, ?, ?,?)', $this->table);
+        $bind  = array($login, $nextId, $name, $layout,$idSite);
         Db::query($query, $bind);
 
         return $nextId;
@@ -133,10 +133,10 @@ class Model
     public static function install()
     {
         $dashboard = "login VARCHAR( 100 ) NOT NULL ,
-					  iddashboard INT NOT NULL ,
-					  name VARCHAR( 100 ) NULL DEFAULT NULL ,
-					  layout TEXT NOT NULL,
-					  PRIMARY KEY ( login , iddashboard )";
+                      iddashboard INT NOT NULL ,
+                      name VARCHAR( 100 ) NULL DEFAULT NULL ,
+                      layout TEXT NOT NULL,
+                      PRIMARY KEY ( login , iddashboard )";
 
         DbHelper::createTable(self::$rawPrefix, $dashboard);
     }

--- a/plugins/Dashboard/Model.php
+++ b/plugins/Dashboard/Model.php
@@ -136,7 +136,7 @@ class Model
                       iddashboard INT NOT NULL ,
                       name VARCHAR( 100 ) NULL DEFAULT NULL ,
                       layout TEXT NOT NULL,
-                      idsite bigint(20) NOT NULL ,
+                      idsite int(11) NOT NULL ,
                       PRIMARY KEY ( login , iddashboard )";
 
         DbHelper::createTable(self::$rawPrefix, $dashboard);

--- a/plugins/Dashboard/Model.php
+++ b/plugins/Dashboard/Model.php
@@ -136,6 +136,7 @@ class Model
                       iddashboard INT NOT NULL ,
                       name VARCHAR( 100 ) NULL DEFAULT NULL ,
                       layout TEXT NOT NULL,
+                      idsite bigint(20) NOT NULL ,
                       PRIMARY KEY ( login , iddashboard )";
 
         DbHelper::createTable(self::$rawPrefix, $dashboard);

--- a/plugins/Dashboard/Updates/4.7.0.php
+++ b/plugins/Dashboard/Updates/4.7.0.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link    https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\Dashboard;
+
+use Piwik\Updater;
+use Piwik\Updates as PiwikUpdates;
+use Piwik\Updater\Migration;
+use Piwik\Updater\Migration\Factory as MigrationFactory;
+
+/**
+ * Update for version 1.0.8-beta.
+ */
+class Updates_4_7_0 extends PiwikUpdates
+{
+    /**
+     * @var MigrationFactory
+     */
+    private $migration;
+
+    public function __construct(MigrationFactory $factory)
+    {
+        $this->migration = $factory;
+    }
+
+    /**
+     * Return database migrations to be executed in this update.
+     *
+     * Database migrations should be defined here, instead of in `doUpdate()`, since this method is used
+     * in the `core:update` command when displaying the queries an update will run. If you execute
+     * migrations directly in `doUpdate()`, they won't be displayed to the user. Migrations will be executed in the
+     * order as positioned in the returned array.
+     *
+     * @param  Updater $updater
+     * @return Migration\Db[]
+     */
+    public function getMigrations(Updater $updater)
+    {
+        return array(
+            $this->migration->db->addColumn('idSite', 'description', 'bigint(20) NOT NULL DEFAULT 0', 'layout'),
+        );
+    }
+
+    /**
+     * Perform the incremental version update.
+     *
+     * This method should perform all updating logic. If you define queries in the `getMigrations()` method,
+     * you must call {@link Updater::executeMigrations()} here.
+     *
+     * @param Updater $updater
+     */
+    public function doUpdate(Updater $updater)
+    {
+        $updater->executeMigrations(__FILE__, $this->getMigrations($updater));
+    }
+}


### PR DESCRIPTION
### Description:
This branch adds the feature to make Dashboards connected to specific idSites. 
This is important especially if we work with plugins like Custom reports where reports are bound to specific idSites so if we add a custom report to a Dashboard it will generate errors to the users on all other sites.

I added support for All sites (0) in the db and logic but there is not yes a GUI for users to manage this (we will always set. the siteId of the site you are currently viewing when you create a new dashboard.

**Note**: This still needs more testing I have created the DB updates but these are not tested yet for instance.

I would really need some help testing this. 
