### PR TITLE
Updated shell_exec recommended message

### DIFF
--- a/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
@@ -73,7 +73,7 @@ class RecommendedFunctionsCheck implements Diagnostic
         );
 
         $translation_params = array(
-            'shell_exec'     => ["<a href='https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/'>", "</a>"]
+            'shell_exec'     => ["<a href='https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/' rel='noopener' target='_blank'>", "</a>"]
         );
 
         return $this->translator->translate($messages[$function], $translation_params[$function] ?? []);

--- a/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
@@ -72,6 +72,10 @@ class RecommendedFunctionsCheck implements Diagnostic
             'gzopen'         => 'Installation_SystemCheckZlibHelp',
         );
 
-        return $this->translator->translate($messages[$function]);
+        $translation_params = array(
+            'shell_exec'     => ["<a href='https://matomo.org/faq/troubleshooting/how-to-make-the-diagnostic-managing-processes-via-cli-to-display-ok/'>", "</a>"]
+        );
+
+        return $this->translator->translate($messages[$function], $translation_params[$function] ?? []);
     }
 }

--- a/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
+++ b/plugins/Diagnostics/Diagnostic/RecommendedFunctionsCheck.php
@@ -64,7 +64,7 @@ class RecommendedFunctionsCheck implements Diagnostic
     private function getHelpMessage($function)
     {
         $messages = array(
-            'shell_exec'     => 'Installation_SystemCheckFunctionHelp',
+            'shell_exec'     => 'Installation_SystemCheckShellExecHelp',
             'set_time_limit' => 'Installation_SystemCheckTimeLimitHelp',
             'mail'           => 'Installation_SystemCheckMailHelp',
             'parse_ini_file' => 'Installation_SystemCheckParseIniFileHelp',

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -88,7 +88,7 @@
         "SystemCheckFileIntegrity": "File integrity",
         "SystemCheckFilterHelp": "You need to configure and rebuild PHP with \"filter\" support enabled (don't use --disable-filter).",
         "SystemCheckFunctions": "Required functions",
-        "SystemCheckFunctionHelp": "We recommend you enable this PHP built-in function. %1$sRead this to learn more.%2$s",
+        "SystemCheckShellExecHelp": "We recommend you enable this PHP built-in function. %1$sRead this to learn more.%2$s",
         "SystemCheckGDFreeType": "GD > 2.x + Freetype (graphics)",
         "SystemCheckGDHelp": "The sparklines (small graphs) and image graphs (in Matomo Mobile app and Email reports) will not work.",
         "SystemCheckGlobHelp": "This built-in function has been disabled on your host. Matomo will attempt to emulate this function but may encounter further security restrictions. Functionality may be impacted.",

--- a/plugins/Installation/lang/en.json
+++ b/plugins/Installation/lang/en.json
@@ -88,7 +88,7 @@
         "SystemCheckFileIntegrity": "File integrity",
         "SystemCheckFilterHelp": "You need to configure and rebuild PHP with \"filter\" support enabled (don't use --disable-filter).",
         "SystemCheckFunctions": "Required functions",
-        "SystemCheckFunctionHelp": "You need to enable this built-in function.",
+        "SystemCheckFunctionHelp": "We recommend you enable this PHP built-in function. %1$sRead this to learn more.%2$s",
         "SystemCheckGDFreeType": "GD > 2.x + Freetype (graphics)",
         "SystemCheckGDHelp": "The sparklines (small graphs) and image graphs (in Matomo Mobile app and Email reports) will not work.",
         "SystemCheckGlobHelp": "This built-in function has been disabled on your host. Matomo will attempt to emulate this function but may encounter further security restrictions. Functionality may be impacted.",


### PR DESCRIPTION
### Description:

Resolves #14782 by changing the shell_exec missing message from "You need to" to "We recommend you", also adding a link to the reasons for shell_exec being used in Matomo.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
