### PR TITLE
Added code to filter metadata response before xml comparison

### DIFF
--- a/tests/PHPUnit/Framework/TestRequest/Response.php
+++ b/tests/PHPUnit/Framework/TestRequest/Response.php
@@ -39,6 +39,11 @@ class Response
         return $this->processedResponseText;
     }
 
+    public function updateResponseText($responseText)
+    {
+        $this->processedResponseText = $responseText;
+    }
+
     public function save($path)
     {
         file_put_contents($path, $this->processedResponseText);


### PR DESCRIPTION
### Description:

Added code to filter metadata response before XML comparison.

The previous code changes added to filter metadata response was breaking other API tests like `API.get` which internally tries to call `API.getSegmentsMetadata`. The result of `API.getSegmentsMetadata` gets filtered out for `API.get` and system testcases starts to fail.

To solve the issue, will be filtering the XML response just before we compare the processed and expected output.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
