### PR TITLE
Ensure 2FA is not loaded when safemode is triggered

### DIFF
--- a/plugins/TwoFactorAuth/TwoFactorAuth.php
+++ b/plugins/TwoFactorAuth/TwoFactorAuth.php
@@ -172,6 +172,10 @@ class TwoFactorAuth extends \Piwik\Plugin
             return false;
         }
 
+        if ($module === 'CorePluginsAdmin' && strtolower($action) === 'safemode') {
+            return false;
+        }
+
         if ($module === 'CoreUpdater' && $action !== 'newVersionAvailable' && $action !== 'oneClickUpdate') {
             return false;
         }


### PR DESCRIPTION
### Description:

While testing another PR including some db schema changes I observed some weird issue, where while loading the update page the page for setting up 2FA was displayed.

The reason for that took me a while to figure out:

When opening Matomo the updater was triggered due to the version change. While the update is being prepared those components not having an update file are already updated (e.g. version is adjusted in option table). That update triggers an event, which causes the TagManager to update the containers. In my case updating the containers ran into a `maximum execution time exceeded error`. That error should then actually be displayed in the safemode screen. But as this error happened within a method running within `Access::doAsSuperUser`, the login was temporary set to `super user was set`. This caused the `2FA is forced` screen to be rendered instead (as I had force 2FA enabled).

Steps to reproduce the error on `4.x-dev`

* Setup 2FA for super user account
* Enable `Enforce 2FA`
* Logout from Matomo
* switch to a branch containing database & version update, or simulate that by running a db query like `UPDATE matomo_option SET option_value='4.5.0-b1' WHERE option_value='4.7.0-b1'`
* Adjust `plugins\TagManager\TagManager.php` and add this lines somewhere within `Access::doAsSuperUser` (around line 270)
   ```
   set_time_limit(1);
   sleep(2);
   ```
* Open Matomo, which should trigger the Updater
* The above added lines will trigger an execution time error causing 2FA setup to be displayed

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
