### PR TITLE
Filter metadata API response only when the test is executed for allowed metadata API

### DIFF
--- a/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
+++ b/tests/PHPUnit/Framework/TestCase/SystemTestCase.php
@@ -81,6 +81,8 @@ abstract class SystemTestCase extends TestCase
         ),
     );
 
+    private static $shouldFilterApiResponse = false;
+
     public function setGroups(array $groups): void
     {
         $pluginName = explode('\\', get_class($this));
@@ -131,7 +133,7 @@ abstract class SystemTestCase extends TestCase
                 } else if ($apiValue['filterKey'] === 'category') {
                     $filterValues = self::getAllowedCategoriesToFilterApiResponse($api);
                 }
-                if ($filterValues) {
+                if ($filterValues && self::$shouldFilterApiResponse) {
                     self::filterReportsCallback($reports, $info, $api, $apiValue['filterKey'], $filterValues);
                 }
             });
@@ -494,6 +496,10 @@ abstract class SystemTestCase extends TestCase
         unset($_GET['serialize']);
 
         $onlyCheckUnserialize = !empty($params['onlyCheckUnserialize']);
+
+        $apiIdExploded = explode('_', str_replace('.xml', '', $apiId));
+        $api = $apiIdExploded[0];
+        self::$shouldFilterApiResponse = !empty(self::$apisToFilterResponse[$api]);
 
         $processedResponse = Response::loadFromApi($params, $requestUrl, $normailze = !$onlyCheckUnserialize);
         if (empty($compareAgainst)) {


### PR DESCRIPTION
Filter metadata API response only when the test is executed for allowed metadata API

### Description:

The previous code changes added to filter metadata response was breaking other API tests like API.get which internally tries to call `API.getSegmentsMetadata`. The result of `API.getSegmentsMetadata` gets filtered out for API.get and system test cases starts to fail.

To solve the issue, before calling the API, we check if its the allowed metadata API and will filter only if its true.
This solves the metadata response getting filtered for other APIs like `API.get`

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
