### PR TITLE
[Hotfix] update a test translation failed

### DIFF
--- a/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__API.getProcessedReport_year.xml
+++ b/tests/PHPUnit/System/expected/test_apiGetReportMetadata_year__API.getProcessedReport_year.xml
@@ -21,7 +21,7 @@
 			<nb_actions_per_visit>Nombre moyen d'actions (affichages de page, recherches, téléchargements ou liens sortants) qui ont été effectuées durant les visites.</nb_actions_per_visit>
 			<avg_time_on_site>Durée moyenne d'une visite.</avg_time_on_site>
 			<bounce_rate>Pourcentage de visites qui ont eu un affichage unique de page. Cela signifie que le visiteur a quitté le site directement depuis la page d'entrée.</bounce_rate>
-			<conversion_rate>Pourcentage de visites qui ont déclenché une conversion d'objectif.</conversion_rate>
+			<conversion_rate>Le Pourcentage de visites qui ont déclenché une conversion d'objectif.</conversion_rate>
 		</metricsDocumentation>
 		<processedMetrics>
 			<nb_actions_per_visit>Actions par visite</nb_actions_per_visit>


### PR DESCRIPTION
### Description:

update a test translation failed

```
-      <conversion_rate>Pourcentage de visites qui ont d&#xE9;clench&#xE9; une conversion d'objectif.</conversion_rate>
+      <conversion_rate>Le Pourcentage de visites qui ont d&#xE9;clench&#xE9; une conversion d'objectif.</conversion_rate>

```

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
