### PR TITLE
Fix error where no data is shown on campaign with segments and periods

### DIFF
--- a/plugins/SegmentEditor/SegmentEditor.php
+++ b/plugins/SegmentEditor/SegmentEditor.php
@@ -252,7 +252,7 @@ class SegmentEditor extends \Piwik\Plugin
         // check if segment archive does not exist
         $processorParams = new \Piwik\ArchiveProcessor\Parameters(new Site($idSite), $period, $segment);
         $archiveIdAndStats = ArchiveSelector::getArchiveIdAndVisits($processorParams, null);
-        if (!empty($archiveIdAndStats[0])) {
+        if (!empty($archiveIdAndStats[0]) || !empty($archiveIdAndStats[1])) {
             return null;
         }
 


### PR DESCRIPTION
### Description:
L3: https://innocraft.atlassian.net/browse/L3-199
fix error no data notification.  
Show on the `campaign` with data show. 
To reproduce it, need to select a period, and require a segment. The request is that one, in my case.  
```
segment=visitorType==returning&date=2021-09-01,2021-09-15&module=MarketingCampaignsReporting&format=html&action=getGroup&period=range&idSite=1&widget=&showtitle=1&random=2789 
```

The code runs into here https://github.com/matomo-org/matomo/blob/1aec00ff0affa727ef134e230b465091b97e6863/core/DataAccess/ArchiveSelector.php#L102-L107


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
